### PR TITLE
fix(config): a setting that does nothing says so, wherever it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ same list.
 
 ## Unreleased
 
+- Breaking: a blueprint value that is not one of the spellings a setting
+  accepts is refused, naming what is valid. Four settings took anything and
+  quietly used a default instead: `tool_permissions` values, `on_worker_failure`,
+  an interaction point's `style`, and a sliding window's `strategy`. The first
+  is the sharp one - anything unrecognised resolved to `ask`, so a misspelled
+  `deny` produced a prompt where a refusal was written, and a prompt can be
+  answered by a session grant or `--yolo`. The same typo in `config.toml` has
+  always been refused, because that side deserializes into an enum; this closes
+  the gap the other way round.
+- Fixed: an unknown key in `config.toml` is reported wherever it sits, not only
+  at the top level (#365). `[limits] max_concurrent_tool` used to be accepted in
+  silence. Keys are now judged by asking serde - deserialize, serialize back,
+  and report what did not survive - so this needs no list to maintain and stays
+  right as fields come and go. It also leaves `[model_providers.<name>]` alone,
+  which deliberately forwards unrecognised keys to a Rhai script.
+- New: `lev doctor` reports the same unread keys, for when the start-up warning
+  scrolls past, and names a `[rate_limits.<provider>]` entry whose provider does
+  not exist - a case the key check cannot see, since that table accepts any name
+  and a misspelled provider simply throttles nothing.
+
 - Breaking: a blueprint key the parser does not read is now refused, naming
   what is valid, in `[stages.X]`, `[stages.X.context]`,
   `[stages.X.tool_routing]`, a transition edge and its `gate` (#362). The

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -210,6 +210,30 @@ pub fn format_report(checks: &[Check]) -> String {
 
 // ─── Check 1: config ──────────────────────────────────────────────────────────
 
+/// `[rate_limits.<name>]` entries naming no provider that exists.
+///
+/// The unknown-key check cannot see these: the table is a map with arbitrary
+/// keys, so `[rate_limits.anthropc]` deserializes perfectly and simply throttles
+/// nothing. The set of names that mean anything here is closed - script
+/// providers set theirs under `[model_providers.<name>] rate_limit` instead -
+/// and the wizard's catalog is already the one list of it, so this needs no
+/// second list to fall out of date.
+fn misdirected_rate_limits(config: &Config) -> Vec<String> {
+    let known: Vec<&str> = crate::commands::setup::catalog::providers()
+        .iter()
+        .map(|p| p.id)
+        .collect();
+    let mut misdirected: Vec<String> = config
+        .rate_limits
+        .keys()
+        .filter(|name| !known.contains(&name.as_str()))
+        .map(|name| format!("rate_limits.{name}"))
+        .collect();
+    // A map iterates in arbitrary order; the report should not.
+    misdirected.sort_unstable();
+    misdirected
+}
+
 /// Report what the config named and what the registry ended up holding.
 ///
 /// Only native providers can be listed - a Rhai script provider is resolved by
@@ -222,11 +246,30 @@ fn config_check(config: &Config, registry: &ProviderRegistry) -> Check {
         true => "none".to_string(),
         false => names.join(", "),
     };
+    let detail = format!(
+        "default_provider={}; registered: {} (script providers resolve by name)",
+        config.default_provider, registered
+    );
+
+    // "Which keys were ignored" was previously only answerable by catching the
+    // start-up warning as it scrolled past, and only if you were looking. A
+    // note on an OK line rather than a failure, matching how the `resolve`
+    // check reports a config that works but probably is not what was meant:
+    // the rest of the file still applies, so this is not broken wiring.
+    let mut unread = Config::unread_keys_at(&Config::config_path());
+    unread.extend(misdirected_rate_limits(config));
+    if unread.is_empty() {
+        return Check::ok("config", detail);
+    }
+    let subject = match unread.len() {
+        1 => "1 key in config.toml is",
+        n => &format!("{n} keys in config.toml are"),
+    };
     Check::ok(
         "config",
         format!(
-            "default_provider={}; registered: {} (script providers resolve by name)",
-            config.default_provider, registered
+            "{detail}  (note: {subject} read by nothing - check the spelling: {})",
+            unread.join(", ")
         ),
     )
 }

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -216,6 +216,79 @@ fn config_check_says_none_when_nothing_is_registered() {
     );
 }
 
+/// A `[rate_limits]` entry naming no provider throttles nothing, and the
+/// unknown-key check cannot see it: the table takes arbitrary keys, so the
+/// typo deserializes perfectly.
+#[test]
+fn config_check_names_a_rate_limit_for_a_provider_that_does_not_exist() {
+    let mut config = Config::default();
+    let limit = leviath_providers::RateLimitConfig {
+        requests_per_minute: 10,
+        tokens_per_minute: 1000,
+    };
+    config
+        .rate_limits
+        .insert("anthropc".to_string(), limit.clone());
+    // The control: the correctly spelled one beside it must stay quiet, or the
+    // note would just be reporting every rate limit anyone set.
+    config.rate_limits.insert("anthropic".to_string(), limit);
+
+    let check = config_check(&config, &ProviderRegistry::new());
+    assert_eq!(check.status, CheckStatus::Ok, "not broken wiring");
+    assert!(
+        check.detail.contains("rate_limits.anthropc"),
+        "got: {}",
+        check.detail
+    );
+    assert!(
+        !check.detail.contains("rate_limits.anthropic,")
+            && !check.detail.ends_with("rate_limits.anthropic"),
+        "the real provider must not be reported: {}",
+        check.detail
+    );
+}
+
+/// Two of them read as two, not as "1 key".
+#[test]
+fn config_check_counts_more_than_one_unread_key() {
+    let mut config = Config::default();
+    for name in ["anthropc", "opennai"] {
+        config.rate_limits.insert(
+            name.to_string(),
+            leviath_providers::RateLimitConfig {
+                requests_per_minute: 10,
+                tokens_per_minute: 1000,
+            },
+        );
+    }
+    let check = config_check(&config, &ProviderRegistry::new());
+    assert!(
+        check
+            .detail
+            .contains("2 keys in config.toml are read by nothing"),
+        "got: {}",
+        check.detail
+    );
+}
+
+#[test]
+fn config_check_is_quiet_when_every_rate_limit_names_a_real_provider() {
+    let mut config = Config::default();
+    config.rate_limits.insert(
+        "openrouter".to_string(),
+        leviath_providers::RateLimitConfig {
+            requests_per_minute: 10,
+            tokens_per_minute: 1000,
+        },
+    );
+    let check = config_check(&config, &ProviderRegistry::new());
+    assert!(
+        !check.detail.contains("read by nothing"),
+        "got: {}",
+        check.detail
+    );
+}
+
 // ─── resolve_check ────────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -18,40 +18,36 @@ pub use providers::*;
 mod security;
 pub use security::*;
 
-/// Every top-level key `config.toml` may set.
+/// Record every dotted path in `found` that is missing from `kept`.
 ///
-/// One entry per [`Config`] field. Kept beside the struct so the two are read
-/// together, and held to the shipped example by
-/// `every_config_section_is_a_known_key`.
-const KNOWN_CONFIG_KEYS: &[&str] = &[
-    "agent_paths",
-    "agent_read_paths",
-    "agent_safe_commands",
-    "agent_tool_permissions",
-    "batch_tool_hint",
-    "default_model",
-    "default_provider",
-    "limits",
-    "mcp_servers",
-    "model_capabilities",
-    "model_providers",
-    "nudge",
-    "observability",
-    "ollama_base_url",
-    "openrouter_api_key",
-    "providers",
-    "rate_limits",
-    "request_timeout_secs",
-    "safe_commands",
-    "sandbox",
-    "security",
-    "shell_hint",
-    "taint_tracking",
-    "title",
-    "tool_permissions",
-    "tool_script_permissions",
-    "webhook",
-];
+/// `kept` is what survived a deserialize/serialize round trip, so a path that
+/// is absent from it is one nothing read. Recurses only where both sides are
+/// tables: a value serde rewrote (an enum, a duration) is still a value it
+/// understood, and only the *keys* are being judged here.
+fn collect_dropped_keys(
+    found: &toml::value::Table,
+    kept: &toml::value::Table,
+    prefix: &str,
+    out: &mut Vec<String>,
+) {
+    for (key, value) in found {
+        let path = if prefix.is_empty() {
+            key.clone()
+        } else {
+            format!("{prefix}.{key}")
+        };
+        match kept.get(key) {
+            None => out.push(path),
+            Some(kept_value) => {
+                if let (Some(found_table), Some(kept_table)) =
+                    (value.as_table(), kept_value.as_table())
+                {
+                    collect_dropped_keys(found_table, kept_table, &path, out);
+                }
+            }
+        }
+    }
+}
 
 /// CLI configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -452,12 +448,8 @@ impl Config {
     /// over one stale key would take the whole CLI down rather than the one
     /// thing that key was meant to affect.
     ///
-    /// The known set is spelled out below rather than derived by serializing
-    /// the default, which was the first attempt: TOML cannot represent null,
-    /// so every `Option` field still at `None` vanishes from the serialized
-    /// form and five real keys would have been reported as unknown.
-    /// `every_config_section_is_a_known_key` holds this list against the
-    /// shipped example, which sets every section.
+    /// Reported at every depth, so `[limits] max_concurrent_tool` is named as
+    /// readily as a whole unknown table (#365).
     fn warn_unknown_config_keys(content: &str) {
         let unknown = Self::unknown_config_keys(content);
         if !unknown.is_empty() {
@@ -469,9 +461,22 @@ impl Config {
             tracing::warn!(
                 %keys,
                 "config.toml has keys nothing reads; they are being ignored. \
-                 Check the spelling against `lev config schema`."
+                 `lev doctor` reports them too, if this scrolls past."
             );
         }
+    }
+
+    /// Keys in the config file at `path` that nothing reads.
+    ///
+    /// The same answer the start-up warning gives, available to anyone who
+    /// wants to *ask* rather than having to catch it scrolling past - which is
+    /// what `lev doctor` does with it. An unreadable or absent file has no
+    /// unread keys, because that is a different problem and one the caller has
+    /// already reported.
+    pub fn unread_keys_at(path: &std::path::Path) -> Vec<String> {
+        std::fs::read_to_string(path)
+            .map(|content| Self::unknown_config_keys(&content))
+            .unwrap_or_default()
     }
 
     /// The decision behind [`Self::warn_unknown_config_keys`], as data.
@@ -485,15 +490,48 @@ impl Config {
     /// `toml::from_str::<Table>` and not `content.parse::<toml::Value>()`: the
     /// latter parses a bare TOML *value*, so a document failed at the first
     /// `=` and this returned empty every time.
+    ///
+    /// # How a key is judged unknown
+    ///
+    /// By asking serde, rather than by consulting a list somebody has to
+    /// remember to update: deserialize the file into [`Config`], serialize that
+    /// straight back to TOML, and report any path in the input that did not
+    /// survive the round trip. Serde keeps what it understands and drops what
+    /// it does not, so the round trip *is* the definition of "read".
+    ///
+    /// Three things fall out of that for free:
+    ///
+    /// - It works at any depth, without knowing the shape of anything.
+    /// - It stays true as fields come and go, with nothing to maintain.
+    /// - It respects `#[serde(flatten)]`. `[model_providers.<name>]`
+    ///   deliberately absorbs unrecognised keys and forwards them to a Rhai
+    ///   script, and those keys round-trip, so they are not reported. Where
+    ///   serde keeps the data, this stays quiet.
+    ///
+    /// An earlier attempt compared against `Config::default()` instead, which
+    /// was wrong in a way worth recording: TOML cannot represent null, so every
+    /// `Option` still at `None` vanishes from the *default's* serialized form
+    /// and five real keys read as unknown. Round-tripping the user's own config
+    /// does not have that problem, because a field they set is a field that
+    /// serializes.
     fn unknown_config_keys(content: &str) -> Vec<String> {
         let Ok(found) = toml::from_str::<toml::value::Table>(content) else {
             return Vec::new();
         };
-        found
-            .keys()
-            .filter(|k| !KNOWN_CONFIG_KEYS.contains(&k.as_str()))
-            .cloned()
-            .collect()
+        // A file that is TOML but not a config has no *unknown* keys to report
+        // - it has a type error, which whoever asked for it reports instead.
+        let Ok(config) = toml::from_str::<Self>(content) else {
+            return Vec::new();
+        };
+        // Infallible, and said with `expect` rather than a branch nothing can
+        // reach: every field of `Config` is plain data with a derived
+        // `Serialize`, and a struct always serializes to a table.
+        let kept = toml::Value::try_from(config).expect("a Config is plain data and serializes");
+        let kept = kept.as_table().expect("a struct serializes to a table");
+
+        let mut unknown = Vec::new();
+        collect_dropped_keys(&found, kept, "", &mut unknown);
+        unknown
     }
 
     /// Core of `load()`, parameterized by path so it can be exercised in
@@ -1310,24 +1348,86 @@ mod tests {
             .collect()
     }
 
-    /// A key the warning does not know is a key it reports, so a field added
-    /// to `Config` and left out of `KNOWN_CONFIG_KEYS` would tell every user
-    /// who sets it that it does nothing. The shipped example exercises every
-    /// section, which makes it the right thing to hold the list against.
+    /// An unknown key is reported wherever it sits, not only at the top level.
+    ///
+    /// The reported case (#365) was `[limits] max_concurrent_tool`, a
+    /// misspelling one level down, which the first version of this check could
+    /// not see: it compared top-level keys only, so a whole bogus table was
+    /// named and a bogus key inside a real table was not.
     #[test]
-    fn every_config_section_is_a_known_key() {
-        // Straight to `Table` rather than `Value` + a match: the match's other
-        // arm can never run, and an arm that cannot run is a coverage hole.
-        let example: toml::value::Table =
-            toml::from_str(CONFIG_EXAMPLE).expect("the example is a TOML table");
-        let unreported: Vec<&str> = example
-            .keys()
-            .filter(|k| !KNOWN_CONFIG_KEYS.contains(&k.as_str()))
-            .map(String::as_str)
-            .collect();
+    fn an_unknown_key_is_reported_at_any_depth() {
+        let content = "\
+default_provider = \"anthropic\"
+
+[cache]
+ttl = \"banana\"
+
+[limits]
+max_concurrent_tool = 3
+
+[providers]
+anthropic_api_key = \"x\"
+anthropic_cach_ttl = \"1h\"
+";
+        let unknown = Config::unknown_config_keys(content);
+        assert!(unknown.contains(&"cache".to_string()), "{unknown:?}");
         assert!(
-            unreported.is_empty(),
-            "the shipped example sets keys the warning would call unknown: {unreported:?}"
+            unknown.contains(&"limits.max_concurrent_tool".to_string()),
+            "a key one level down is named by its path: {unknown:?}"
+        );
+        assert!(
+            unknown.contains(&"providers.anthropic_cach_ttl".to_string()),
+            "{unknown:?}"
+        );
+        // And the real keys beside them are not reported.
+        assert!(
+            !unknown.iter().any(|k| k == "default_provider"),
+            "{unknown:?}"
+        );
+        assert!(
+            !unknown.iter().any(|k| k == "providers.anthropic_api_key"),
+            "{unknown:?}"
+        );
+    }
+
+    /// A file that is TOML but not a config reports no unknown keys: it has a
+    /// type error, and saying "every key here is unread" on top of that would
+    /// bury the message that actually explains it.
+    #[test]
+    fn a_file_that_is_not_a_config_reports_no_unknown_keys() {
+        // Parses as a table, fails as a `Config`: the provider is a number.
+        assert!(Config::unknown_config_keys("default_provider = 42").is_empty());
+    }
+
+    /// `unread_keys_at` answers for a path, and a path that is not there is a
+    /// question about a file rather than about its keys.
+    #[test]
+    fn unread_keys_of_a_missing_file_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(Config::unread_keys_at(&dir.path().join("nope.toml")).is_empty());
+    }
+
+    #[test]
+    fn unread_keys_at_reads_the_file_it_is_given() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "[cache]\nttl = \"banana\"\n").unwrap();
+        assert_eq!(Config::unread_keys_at(&path), vec!["cache".to_string()]);
+    }
+
+    /// `[model_providers.<name>]` forwards whatever it does not recognise to a
+    /// Rhai script through `#[serde(flatten)]`, so those keys *are* read and
+    /// must stay quiet. This is the case a hand-maintained key list gets wrong.
+    #[test]
+    fn keys_a_flatten_field_absorbs_are_not_reported() {
+        let content = "\
+[model_providers.groq]
+script = \"groq.rhai\"
+some_custom_thing = \"forwarded to the script\"
+";
+        assert!(
+            Config::unknown_config_keys(content).is_empty(),
+            "a key serde keeps is a key nothing should complain about"
         );
     }
 

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -597,6 +597,14 @@ fn by_any_spelling<'a, V>(map: &'a HashMap<String, V>, tool_name: &str) -> Optio
     leviath_tools::tool_name_spellings(tool_name).find_map(|name| map.get(name))
 }
 
+/// A blueprint's policy string as a [`ToolPolicy`].
+///
+/// The fallback is defensive rather than load-bearing: the manifest parser
+/// refuses a spelling that is not `allow`/`ask`/`deny`, so the only string that
+/// reaches the last arm is `ask` itself. It was load-bearing, and wrong -
+/// anything unrecognised became `ask`, so a misspelled `deny` resolved to the
+/// more permissive of the two and could then be approved by a session grant or
+/// `--yolo`.
 fn parse_policy_str(s: &str) -> ToolPolicy {
     match s.to_lowercase().as_str() {
         "allow" => ToolPolicy::Allow,

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -163,7 +163,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     if let Some(tp_table) = parsed.get("tool_permissions").and_then(|v| v.as_table()) {
         blueprint
             .metadata
-            .extend(tool_permission_metadata(tp_table));
+            .extend(tool_permission_metadata(tp_table)?);
     }
 
     // Parse file tracking config: [context.file_tracking]

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -98,7 +98,16 @@ pub(super) fn parse_region_layout(
                             .unwrap_or(10) as usize;
                         EvictionStrategy::Compact { compact_count }
                     }
-                    _ => EvictionStrategy::PerItem,
+                    Some("per_item") | None => EvictionStrategy::PerItem,
+                    // Unknown used to mean per_item, so `strategy = "per-item"`
+                    // or a mistyped `compact` left the region evicting one
+                    // entry at a time with no sign the setting was read.
+                    Some(other) => {
+                        return Err(Error::Other(format!(
+                            "region '{region_name}': strategy \"{other}\" is not \
+                             valid (valid: per_item, bulk, compact)"
+                        )));
+                    }
                 };
                 RegionKind::SlidingWindow {
                     max_items,

--- a/crates/leviath-core/src/manifest/sections.rs
+++ b/crates/leviath-core/src/manifest/sections.rs
@@ -78,19 +78,30 @@ pub(super) fn parse_safe_commands(
 }
 
 /// Flatten `[tool_permissions]` into the `tool_perm:<tool>` metadata keys the
-/// permission layer reads. A non-string policy is dropped rather than rejected:
-/// the value's meaning is validated where it is resolved.
+/// permission layer reads.
+///
+/// This used to drop a value it could not read and say "the value's meaning is
+/// validated where it is resolved". It was not: resolution maps anything it
+/// does not recognise to `ask`, so a misspelled `deny` became a prompt.
 pub(super) fn tool_permission_metadata(
     table: &toml::value::Table,
-) -> impl Iterator<Item = (String, serde_json::Value)> + use<'_> {
-    table.iter().filter_map(|(tool_name, policy_val)| {
-        policy_val.as_str().map(|policy| {
-            (
+) -> Result<Vec<(String, serde_json::Value)>> {
+    table
+        .iter()
+        .map(|(tool_name, policy_val)| {
+            let policy = policy_val.as_str().ok_or_else(|| {
+                Error::Other(format!(
+                    "[tool_permissions]: {tool_name} must be one of {}",
+                    TOOL_POLICIES.join(", ")
+                ))
+            })?;
+            validate_tool_policy("[tool_permissions]", tool_name, policy)?;
+            Ok((
                 format!("tool_perm:{}", tool_name),
                 serde_json::Value::String(policy.to_string()),
-            )
+            ))
         })
-    })
+        .collect()
 }
 
 /// Parse `[context.file_tracking]`. Tracking both directions into a `files`

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -88,6 +88,30 @@ const EDGE_KEYS: &[&str] = &[
     "transform_config",
 ];
 
+/// The three policies a `tool_permissions` entry may name.
+pub(super) const TOOL_POLICIES: &[&str] = &["allow", "ask", "deny"];
+
+/// Refuse a policy nothing will act on.
+///
+/// Resolution maps any unrecognised spelling to `ask`, so `shell = "denied"`
+/// read as a prompt rather than a refusal - and `ask` is the *more* permissive
+/// of the two, approvable by a session grant or `--yolo`. An author who
+/// misspells a denial gets the opposite of what they wrote, in the layer where
+/// that matters most.
+///
+/// The same typo in `config.toml` has always been refused, because that side
+/// deserializes into an enum. This closes the gap the other way round.
+pub(super) fn validate_tool_policy(where_: &str, tool: &str, policy: &str) -> Result<()> {
+    if TOOL_POLICIES.contains(&policy.to_lowercase().as_str()) {
+        return Ok(());
+    }
+    Err(Error::Other(format!(
+        "{where_}: tool_permissions.{tool} = \"{policy}\" is not a policy \
+         (valid: {})",
+        TOOL_POLICIES.join(", ")
+    )))
+}
+
 /// Refuse a key the parser does not read.
 ///
 /// The manifest parser walks the TOML by hand, so every unrecognised key was
@@ -444,11 +468,17 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
         .and_then(|v| v.as_table())
     {
         for (tool_name, policy_val) in tp_table {
-            if let Some(policy_str) = policy_val.as_str() {
-                stage
-                    .tool_permissions
-                    .insert(tool_name.clone(), policy_str.to_string());
-            }
+            let policy_str = policy_val.as_str().ok_or_else(|| {
+                Error::Other(format!(
+                    "stage '{stage_name}': tool_permissions.{tool_name} must be \
+                     one of {}",
+                    TOOL_POLICIES.join(", ")
+                ))
+            })?;
+            validate_tool_policy(&format!("stage '{stage_name}'"), tool_name, policy_str)?;
+            stage
+                .tool_permissions
+                .insert(tool_name.clone(), policy_str.to_string());
         }
     }
 
@@ -652,7 +682,18 @@ pub(super) fn apply_stage_mode(
                             crate::blueprint::InteractionStyle::MultipleChoice
                         }
                         Some("confirm") => crate::blueprint::InteractionStyle::Confirm,
-                        _ => crate::blueprint::InteractionStyle::FreeText,
+                        Some("free_text") | None => crate::blueprint::InteractionStyle::FreeText,
+                        // Its neighbour `unattended` has always rejected an
+                        // unknown value; this arm quietly turned a mistyped
+                        // `confirm` into a free-text question with the options
+                        // still listed and nothing enforcing them.
+                        Some(other) => {
+                            return Err(Error::Other(format!(
+                                "stage '{stage_name}': interaction point style \
+                                 \"{other}\" is not valid (valid: free_text, \
+                                 multiple_choice, confirm)"
+                            )));
+                        }
                     };
                     // Accept either "options" or "choices" key
                     let pt_options: Vec<String> = pt
@@ -735,8 +776,17 @@ pub(super) fn apply_stage_mode(
                 .and_then(|v| v.as_str())
             {
                 Some("fail_all") => crate::blueprint::WorkerFailurePolicy::FailAll,
-                // "continue" / missing / unknown all mean continue.
-                _ => crate::blueprint::WorkerFailurePolicy::Continue,
+                Some("continue") | None => crate::blueprint::WorkerFailurePolicy::Continue,
+                // Unknown used to mean continue, so a misspelled `fail_all`
+                // let a fan-out swallow every worker failure - the opposite of
+                // what was written, and invisible in a run that then merged
+                // nothing.
+                Some(other) => {
+                    return Err(Error::Other(format!(
+                        "stage '{stage_name}': on_worker_failure = \"{other}\" \
+                         is not a policy (valid: continue, fail_all)"
+                    )));
+                }
             };
             let config = crate::blueprint::FanOutConfig {
                 worker_agent: str_field("worker_agent"),

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -3009,7 +3009,7 @@ mode = "interactive_points"
 /// Per-stage tool_permissions with a non-string policy value - the inner
 /// `if let Some(policy_str) = policy_val.as_str()` should be skipped.
 #[test]
-fn parse_manifest_stage_tool_permissions_non_string_value_skipped() {
+fn parse_manifest_stage_tool_permissions_non_string_value_is_rejected() {
     let toml = r#"
 [agent]
 name = "non-string-perm"
@@ -3020,10 +3020,8 @@ mode = "autonomous"
 [stages.main.tool_permissions]
 bash = 123
 "#;
-    let bp = parse_manifest(toml).unwrap();
-    let stage = bp.find_stage("main").unwrap();
-    // Non-string value for "bash" is silently skipped.
-    assert!(stage.tool_permissions.is_empty());
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("bash"), "names the tool: {err}");
 }
 
 /// Compaction config without `provider` - covers the None-branch at line ~460.
@@ -3101,7 +3099,10 @@ name = "no-security"
 /// Agent-level tool_permissions with a non-string value - the inner
 /// `if let Some(policy_str) = policy_val.as_str()` should be skipped.
 #[test]
-fn parse_manifest_agent_tool_permissions_non_string_value_skipped() {
+fn parse_manifest_agent_tool_permissions_non_string_value_is_rejected() {
+    // Skipped, until it wasn't worth it: a permission that does not survive
+    // parsing is a permission nobody enforces, and the tool falls back to a
+    // default that may be looser than what was written.
     let toml = r#"
 [agent]
 name = "agent-non-string-perm"
@@ -3110,15 +3111,8 @@ name = "agent-non-string-perm"
 bash = 42
 read_file = "allow"
 "#;
-    let bp = parse_manifest(toml).unwrap();
-    // Non-string "bash" is skipped; "read_file" is kept.
-    assert!(!bp.metadata.contains_key("tool_perm:bash"));
-    assert_eq!(
-        bp.metadata
-            .get("tool_perm:read_file")
-            .and_then(|v| v.as_str()),
-        Some("allow")
-    );
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("bash"), "names the tool: {err}");
 }
 
 // ─── Models list & allow_user_default tests ─────────────────────────────
@@ -3829,6 +3823,166 @@ grep = 500
     let err = parse_manifest(toml).unwrap_err().to_string();
     assert!(err.contains("read_file"), "names the offending tool: {err}");
     assert!(err.contains("must be a number"), "got: {err}");
+}
+
+// ─── Values that quietly became a default ────────────────────────────────────
+//
+// Each of these parsed clean and resolved to something the author did not
+// write. Same class as the unknown keys below: a line that does nothing and
+// says nothing. The policy one is the sharp one - it resolved *looser* than
+// what was asked for.
+
+/// A misspelled `deny` used to resolve to `ask`, which is the more permissive
+/// of the two: approvable by a session grant or `--yolo`. The author wrote a
+/// refusal and got a prompt.
+#[test]
+fn parse_manifest_rejects_a_misspelled_stage_tool_policy() {
+    let toml = r#"
+[agent]
+name = "typo"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_permissions]
+shell = "denied"
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("\"denied\""), "quotes what was written: {err}");
+    assert!(err.contains("valid: allow, ask, deny"), "got: {err}");
+}
+
+#[test]
+fn parse_manifest_rejects_a_misspelled_agent_tool_policy() {
+    let toml = r#"
+[agent]
+name = "typo"
+
+[tool_permissions]
+shell = "denny"
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("valid: allow, ask, deny"), "got: {err}");
+}
+
+/// Case is not the mistake - `Deny` has always resolved, and still must.
+#[test]
+fn parse_manifest_accepts_a_tool_policy_in_any_case() {
+    let toml = r#"
+[agent]
+name = "cased"
+
+[stages.work]
+mode = "autonomous"
+
+[stages.work.tool_permissions]
+shell = "Deny"
+write_file = "ALLOW"
+"#;
+    let bp = parse_manifest(toml).expect("case is not a typo");
+    let stage = bp.find_stage("work").expect("stage");
+    assert_eq!(
+        stage.tool_permissions.get("shell").map(String::as_str),
+        Some("Deny")
+    );
+}
+
+/// A misspelled `fail_all` let a fan-out swallow every worker failure.
+#[test]
+fn parse_manifest_rejects_an_unknown_worker_failure_policy() {
+    let toml = r#"
+[agent]
+name = "fan"
+
+[stages.split]
+mode = "fan_out"
+worker_stage = "work"
+on_worker_failure = "failall"
+
+[stages.work]
+mode = "autonomous"
+allow_as_worker = true
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("valid: continue, fail_all"), "got: {err}");
+}
+
+#[test]
+fn parse_manifest_accepts_both_worker_failure_policies() {
+    for policy in ["continue", "fail_all"] {
+        let toml = format!(
+            r#"
+[agent]
+name = "fan"
+
+[stages.split]
+mode = "fan_out"
+worker_stage = "work"
+on_worker_failure = "{policy}"
+
+[stages.work]
+mode = "autonomous"
+allow_as_worker = true
+"#
+        );
+        parse_manifest(&toml).unwrap_or_else(|e| panic!("{policy} is valid: {e}"));
+    }
+}
+
+/// Its neighbour `unattended` has always rejected an unknown value; `style`
+/// turned a mistyped `confirm` into a free-text question with the options
+/// listed and nothing enforcing them.
+#[test]
+fn parse_manifest_rejects_an_unknown_interaction_style() {
+    let toml = r#"
+[agent]
+name = "ask"
+
+[stages.work]
+mode = "interactive_points"
+
+[[stages.work.interaction_points]]
+name = "approve"
+prompt = "ok?"
+style = "confirmation"
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(
+        err.contains("valid: free_text, multiple_choice, confirm"),
+        "got: {err}"
+    );
+}
+
+/// `strategy = "per-item"` is the hyphen mistake this invites, and it left the
+/// region evicting one entry at a time with no sign the line was read.
+#[test]
+fn parse_manifest_rejects_an_unknown_eviction_strategy() {
+    let toml = r#"
+[agent]
+name = "evict"
+
+[context.regions]
+notes = { kind = "sliding_window", max_items = 20, strategy = "per-item" }
+"#;
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(err.contains("valid: per_item, bulk, compact"), "got: {err}");
+    assert!(err.contains("notes"), "names the region: {err}");
+}
+
+#[test]
+fn parse_manifest_accepts_every_eviction_strategy() {
+    for strategy in ["per_item", "bulk", "compact"] {
+        let toml = format!(
+            r#"
+[agent]
+name = "evict"
+
+[context.regions]
+notes = {{ kind = "sliding_window", max_items = 20, strategy = "{strategy}" }}
+"#
+        );
+        parse_manifest(&toml).unwrap_or_else(|e| panic!("{strategy} is valid: {e}"));
+    }
 }
 
 // ─── Keys that do not exist (#362) ───────────────────────────────────────────

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -442,6 +442,27 @@ tokens_per_minute   = 40000
 This shapes request *rate*. `[limits] max_concurrent_inferences` bounds *concurrency*. Both apply.
 Script providers configure theirs under `[model_providers.<name>.rate_limit]` instead.
 
+## Keys nothing reads
+
+A key Leviath does not recognize is named at start-up rather than ignored, wherever it sits:
+
+```
+WARN config.toml has keys nothing reads; they are being ignored.
+     keys=limits.max_concurrent_tool, cache, providers.anthropic_cach_ttl
+```
+
+`lev doctor` reports the same list, for when that scrolls past. It also names a
+`[rate_limits.<provider>]` entry whose provider does not exist, which is a case the key check cannot
+see: that table takes any name, so a misspelled provider deserializes perfectly and throttles
+nothing.
+
+This is a warning, not an error. Every command reads `config.toml`, so one stale key should not take
+the CLI down - unlike a blueprint, which is authored and validated deliberately and fails on an
+unknown key.
+
+The one place unrecognized keys are *kept*: `[model_providers.<name>]` forwards anything it does not
+recognize to the Rhai script, so those are read and never reported.
+
 ## `[model_capabilities.<model_id>]`
 
 Per-model corrections to the provider's built-in capability table. Useful for a local or

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -59,7 +59,9 @@ history      = { kind = "compact_history", budget = "15%", source_region = "code
 | `checklist` | A task list whose entries carry state. Written through `todo_add` / `todo_done` / `todo_note`, never evicted, and rendered open-items-first. |
 | `custom` | Behavior defined by a Rhai script (see [Rhai regions](/docs/rhai-regions)). |
 
-An unrecognized `kind` is a hard parse error, not a silently ignored region.
+An unrecognized `kind` is a hard parse error, not a silently ignored region. So is an unrecognized
+`strategy`, which is the one this invites: `strategy = "per-item"` with a hyphen used to leave the
+region evicting one entry at a time, exactly as if the line had not been written.
 
 ### Per-kind keys
 

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -233,7 +233,9 @@ stage control access:
   not listed here is invisible to the LLM. Names may use aliases (e.g. `bash` for `shell`).
 - **`tool_permissions`**: a per-tool map whose values are `allow`, `ask`, or `deny`. `allow` runs
   the call outright, `ask` requires user approval first, and `deny` blocks it. Stage-level entries
-  are narrower than agent-level `[tool_permissions]` and wider than launch-time flags.
+  are narrower than agent-level `[tool_permissions]` and wider than launch-time flags. Any other
+  value is a load error: a misspelled `deny` used to resolve to `ask`, which is the more permissive
+  of the two, so the author of the typo got a prompt where they had written a refusal.
 
 ```toml
 [stages.implement]


### PR DESCRIPTION
Closes #365.

Two halves, both the shape #362 fixed for blueprint *keys*: a line that is
accepted, does nothing, and says nothing.

## The sweep found four values that quietly became a default

You asked me to check whether other parameters had the same problem. Four did:

| Setting | An unrecognised value became | Consequence |
|---|---|---|
| `tool_permissions` values | `ask` | **a misspelled `deny` became a prompt** |
| `on_worker_failure` | `continue` | a fan-out swallows every worker failure |
| interaction point `style` | `free_text` | options listed, nothing enforcing them |
| sliding window `strategy` | `per_item` | `"per-item"` with a hyphen does nothing |

The first is the sharp one. `ask` is the **more permissive** of the two — it can
be answered by a session grant or `--yolo` — so an author who misspells a
refusal gets the opposite of what they wrote, in the layer where that matters
most. And the same typo in `config.toml` has always been refused, because that
side deserializes into an enum. The gap was blueprint-only.

Reproduced before fixing. This validated clean on main:

```toml
[tool_permissions]
shell = "denied"                       # -> ask
[context.regions]
notes = { kind = "sliding_window", strategy = "per-item" }   # -> per_item
[stages.work.tool_permissions]
write_file = "denny"                   # -> ask
```

```
✓ Blueprint 'typo-policies' is valid.
```

The pattern was already right next door — `unattended` rejects an unknown value
and names the two that work, as do region kinds and transition conditions.
These four never got it.

## Keys nothing reads, at any depth

The existing check compared top-level keys only, so a whole bogus table was
named and a bogus key *inside* a real table was not — which is exactly what you
reported with `[limits] max_concurrent_tool`.

Keys are now judged by **asking serde** instead of consulting a list: parse the
file into `Config`, serialize it straight back, and report any path that did not
survive the round trip. Serde keeps what it understands and drops what it does
not, so the round trip *is* the definition of "read".

Three things fall out of that for free:

- it works at any depth without knowing the shape of anything
- it stays right as fields come and go, with nothing to maintain
- it respects `#[serde(flatten)]` — `[model_providers.<name>]` deliberately
  forwards unrecognised keys to a Rhai script, and those stay quiet

It also let me delete the 27-entry hand-maintained key list it replaces, which
is the better outcome: a list that must be kept in sync is the same class of bug
one level up.

Measured against a built binary:

```
keys=limits.max_concurrent_tool, cache, providers.anthropic_cach_ttl
```

## `lev doctor` answers "which keys were ignored"

Per the issue's ask. The start-up warning is only useful if you happen to be
looking when it goes past:

```
config  OK  default_provider=ollama; registered: ollama  (note: 2 keys in
            config.toml are read by nothing - check the spelling:
            limits.max_concurrent_tool, cache)
```

It also names a `[rate_limits.<provider>]` entry whose provider does not exist —
a case the key check **cannot** see, because that table accepts any name, so a
misspelled provider deserializes perfectly and throttles nothing. The set of
names that mean anything there is closed, and the setup wizard's catalog is
already the one list of it, so this adds no second list.

## Two things I did not do, and why

**The warning used to point at `lev config schema`, which does not exist.** That
is the bug being fixed, inside the fix. It points at `lev doctor` now.

**A `[model_capabilities]` entry for an unused model id is left alone.** Model
ids are an open set, so naming one you have not run yet is ordinary rather than
a mistake, and warning on it would fire for every legitimately pre-configured
model.

## One correction on the report

The `[cache] ttl` example already warns on `c5db4fcc`. I built that commit and
measured it via both `LEVIATH_CONFIG_PATH` and `LEVIATH_HOME`, `lev list` and
`lev validate` — the top-level check landed about forty minutes before the issue
was filed, and the version string is unchanged, so a previously installed binary
is indistinguishable. Nothing rests on this: the substance of the issue is the
nested case, which was real, and everything above is fixed either way.

## Verification

- `cargo test --workspace` — 0 failures
- `cargo xtask coverage` — `leviath-core` and `leviath-cli` both exit 0
- clippy, fmt, `cargo xtask docs --check` clean
- all 10 bundled agents still parse, so none carried a misspelled value
