### PR TITLE
feat(context): stage instructions get a region with a name on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ same list.
   scrolls past, and names a `[rate_limits.<provider>]` entry whose provider does
   not exist - a case the key check cannot see, since that table accepts any name
   and a misspelled provider simply throttles nothing.
+- New: a region named `stage_instructions` receives the entering stage's
+  `system_prompt`, if a blueprint declares one (#366). Stage instructions have
+  always been pinned context, but the region holding them was chosen by
+  accident - whichever pinned region was declared first - so its tokens were
+  charged to that region's name in the stage ledger, it could not be sized or
+  scoped, and it sat wherever that region sat in the cacheable prefix. Measured
+  on a two-stage agent: `task` reported 65 tokens where 63 of them were the
+  stage prompt, and 2 were the task. Declared, the same run reports `task` 2 and
+  `stage_instructions` 63. The region is also assembled after every other pinned
+  block whatever order it was declared in, so the prefix in front of it is
+  byte-identical across a transition rather than being rewritten at the head on
+  every stage change. A blueprint that declares nothing by that name behaves
+  exactly as before.
 
 - Breaking: a blueprint key the parser does not read is now refused, naming
   what is valid, in `[stages.X]`, `[stages.X.context]`,

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -9,6 +9,27 @@ use crate::error::ValidationError;
 use crate::region::{RegionKind, RegionSchema};
 use serde::{Deserialize, Serialize};
 
+/// The region a stage's `system_prompt` is written into, when a blueprint
+/// declares one by this name.
+///
+/// Stage instructions have always been pinned context - that is why they read
+/// as instruction rather than history - but the region holding them was chosen
+/// by accident: whichever pinned region happened to be declared first. That
+/// region then carried the prompt's tokens in the stage ledger under its own
+/// name, could not be sized or scoped, and sat wherever it sat in the cached
+/// prefix (#366).
+///
+/// Declaring a region by this name gives the prompt a handle:
+///
+/// ```toml
+/// [context.regions]
+/// stage_instructions = { kind = "pinned", budget = "3%" }
+/// ```
+///
+/// A blueprint that declares nothing by this name keeps the old behaviour
+/// exactly, so this costs no existing agent anything.
+pub const STAGE_INSTRUCTIONS_REGION: &str = "stage_instructions";
+
 /// How a region's token ceiling is expressed before it is resolved against a
 /// concrete model context window.
 ///

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -194,10 +194,17 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
     // hiding them would strand a message history the next stage's own turns
     // have to attach to. An answer submitted early has to survive to the end
     // for the same reason.
+    // `stage_instructions` joins them for a different reason: it holds the
+    // prompt of the stage being entered, which is written straight after this
+    // runs. Hiding it because a stage's own `[context.regions]` did not list it
+    // would silently drop that stage's instructions - the region is the
+    // runtime's to fill, not something an author has to remember to re-declare
+    // in every stage.
     let always_visible = [
         "conversation",
         "tool_results",
         crate::output_tool::FINAL_OUTPUT_REGION,
+        leviath_core::layout::STAGE_INSTRUCTIONS_REGION,
     ];
     let mut hidden = std::collections::HashSet::new();
     for existing in &window.regions {

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -12706,3 +12706,196 @@ fn on_stage_exit_skips_an_out_of_range_stage_and_a_stage_that_declared_none() {
     assert!(status_message(&world, out_of_range).is_none());
     assert!(status_message(&world, undeclared).is_none());
 }
+
+// ─── Stage instructions get a region of their own (#366) ─────────────────────
+
+/// Build a window whose pinned regions are `names`, in that order.
+fn instructions_window(names: &[&str]) -> ContextWindow {
+    let mut window = ContextWindow::new(100_000);
+    for name in names {
+        window.add_region(leviath_core::Region::new(
+            (*name).to_string(),
+            leviath_core::RegionKind::Pinned,
+            10_000,
+        ));
+    }
+    window
+}
+
+fn setup_carrying_prompt(prompt: &str) -> StageSetup {
+    StageSetup {
+        system_prompt: Some(prompt.to_string()),
+        ..setup()
+    }
+}
+
+/// Without a declared region the prompt still lands in the first pinned one, so
+/// every blueprint written before this keeps working unchanged.
+#[test]
+fn stage_instructions_still_land_in_the_first_pinned_region_by_default() {
+    let mut window = instructions_window(&["task", "notes"]);
+    apply_stage_context(&setup_carrying_prompt("do the thing"), &mut window).expect("fits");
+
+    let task = window.get_region("task").expect("task region");
+    assert!(
+        task.content
+            .iter()
+            .any(|e| e.content.contains("do the thing")),
+        "the historical target still receives it"
+    );
+}
+
+/// Declared, it goes there instead - so its tokens stop being charged to
+/// whichever region an author happened to declare first, which is what made the
+/// per-region numbers in the stage ledger untrustworthy.
+#[test]
+fn a_declared_stage_instructions_region_receives_the_prompt() {
+    let mut window = instructions_window(&["task", "stage_instructions"]);
+    apply_stage_context(&setup_carrying_prompt("do the thing"), &mut window).expect("fits");
+
+    let instructions = window
+        .get_region("stage_instructions")
+        .expect("the declared region");
+    assert!(
+        instructions
+            .content
+            .iter()
+            .any(|e| e.content.contains("do the thing")),
+        "the prompt lands in the region named for it"
+    );
+    let task = window.get_region("task").expect("task region");
+    assert!(
+        task.content.is_empty(),
+        "and `task` is no longer charged for it: {:?}",
+        task.content
+    );
+}
+
+/// It renders last among the pinned blocks however it was declared, so the
+/// prefix in front of it is byte-identical across a stage change. That prefix is
+/// what a provider caches; a per-stage string in front of it invalidates
+/// everything behind it on every transition.
+#[test]
+fn stage_instructions_render_after_every_other_pinned_block() {
+    // Declared *first*, which is the arrangement that used to poison the prefix.
+    let mut window = instructions_window(&["stage_instructions", "task", "notes"]);
+    window
+        .add_to_region("task", "the task".to_string(), 2)
+        .expect("fits");
+    window
+        .add_to_region("notes", "some notes".to_string(), 2)
+        .expect("fits");
+
+    apply_stage_context(&setup_carrying_prompt("stage one"), &mut window).expect("fits");
+    let first = window.assemble();
+    apply_stage_context(&setup_carrying_prompt("stage two"), &mut window).expect("fits");
+    let second = window.assemble();
+
+    assert!(
+        first
+            .system_blocks
+            .last()
+            .expect("a system block")
+            .text
+            .contains("stage one"),
+        "instructions are the final system block: {:?}",
+        first.system_blocks.last()
+    );
+    assert!(
+        second
+            .system_blocks
+            .last()
+            .expect("a system block")
+            .text
+            .contains("stage two"),
+        "and still are after a transition"
+    );
+
+    // The point of the ordering: everything in front of them is unchanged.
+    let head = |c: &crate::components::AssembledContext| -> Vec<String> {
+        c.system_blocks[..c.system_blocks.len() - 1]
+            .iter()
+            .map(|b| b.text.clone())
+            .collect()
+    };
+    assert_eq!(
+        head(&first),
+        head(&second),
+        "the cacheable prefix in front of the instructions must not move"
+    );
+}
+
+/// The previous stage's instructions go and nothing else does. The shared-region
+/// fallback has to find its own entries by their opening words, which takes any
+/// author content starting the same way with it; a region of its own is emptied
+/// outright.
+#[test]
+fn a_declared_region_is_replaced_not_prefix_matched() {
+    let mut window = instructions_window(&["stage_instructions"]);
+    apply_stage_context(&setup_carrying_prompt("first"), &mut window).expect("fits");
+    apply_stage_context(&setup_carrying_prompt("second"), &mut window).expect("fits");
+
+    let region = window.get_region("stage_instructions").expect("region");
+    assert_eq!(region.content.len(), 1, "one stage's worth, not two");
+    assert!(region.content[0].content.contains("second"));
+}
+
+/// A stage with no prompt clears the previous stage's rather than leaving it
+/// standing as if it still applied.
+#[test]
+fn a_stage_without_a_prompt_clears_the_previous_one() {
+    let mut window = instructions_window(&["stage_instructions"]);
+    apply_stage_context(&setup_carrying_prompt("first"), &mut window).expect("fits");
+    apply_stage_context(&setup(), &mut window).expect("fits");
+
+    let region = window.get_region("stage_instructions").expect("region");
+    assert!(
+        region.content.is_empty(),
+        "instructions from a stage that has been left do not linger: {:?}",
+        region.content
+    );
+}
+
+/// A stage whose own `[context.regions]` does not list `stage_instructions`
+/// still shows them.
+///
+/// Omitting a region hides it, which is right for an author's data and wrong
+/// for this one: the runtime writes the entering stage's prompt into it
+/// immediately afterwards, so hiding it would drop that stage's instructions
+/// with nothing said. Found by reading the hiding rule rather than by a failing
+/// run, which is why the test exists.
+#[test]
+fn stage_instructions_survive_a_stage_layout_that_does_not_declare_them() {
+    use leviath_core::{ContextLayout, RegionDefinition};
+
+    let mut window = instructions_window(&["stage_instructions", "task"]);
+    // A stage layout naming only `task`.
+    let layout = ContextLayout::new(
+        vec![RegionDefinition::new(
+            "task".to_string(),
+            leviath_core::RegionKind::Pinned,
+            10_000,
+        )],
+        10_000,
+    );
+    let setup = StageSetup {
+        context_layout: Some(layout),
+        ..setup_carrying_prompt("still visible")
+    };
+
+    apply_stage_context(&setup, &mut window).expect("fits");
+
+    assert!(
+        !window.hidden.contains("stage_instructions"),
+        "the region the runtime fills is never hidden"
+    );
+    let assembled = window.assemble();
+    assert!(
+        assembled
+            .system_blocks
+            .iter()
+            .any(|b| b.text.contains("still visible")),
+        "the stage's own instructions reach the model: {:?}",
+        assembled.system_blocks
+    );
+}

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -802,6 +802,37 @@ pub(crate) fn emit_stage_transition(
     }
 }
 
+/// Which region a stage's instructions are written into.
+///
+/// A declared [`STAGE_INSTRUCTIONS_REGION`] when there is one, and it is moved
+/// to the end of the region list so it renders after every other pinned block.
+/// That ordering is the point: pinned regions carry `CacheHint::Always` and are
+/// assembled in list order, so instructions sitting anywhere but last put a
+/// per-stage string *in front of* the shared prefix - and changing stage then
+/// rewrites the head of the prefix and invalidates everything behind it. Last
+/// means the bytes in front stay identical across a transition.
+///
+/// Otherwise the historical target: the first pinned region, or `conversation`
+/// when a layout declares no pinned region at all.
+///
+/// [`STAGE_INSTRUCTIONS_REGION`]: leviath_core::layout::STAGE_INSTRUCTIONS_REGION
+fn stage_instructions_target(window: &mut ContextWindow) -> String {
+    let declared = leviath_core::layout::STAGE_INSTRUCTIONS_REGION;
+    if let Some(at) = window.regions.iter().position(|r| r.name == declared) {
+        if at + 1 < window.regions.len() {
+            let region = window.regions.remove(at);
+            window.regions.push(region);
+        }
+        return declared.to_string();
+    }
+    window
+        .regions
+        .iter()
+        .find(|r| matches!(r.kind, leviath_core::RegionKind::Pinned))
+        .map(|r| r.name.clone())
+        .unwrap_or_else(|| "conversation".to_string())
+}
+
 /// Apply a stage's context setup to a window: swap to the stage's layout (if any)
 /// and (re)inject its system prompt as pinned `[Stage instructions: …]` context,
 /// clearing any previous stage's first. Returns `Err` only when the prompt
@@ -815,16 +846,18 @@ pub(crate) fn apply_stage_context(
         crate::context_setup::apply_layout(window, layout);
     }
 
-    // Inject stage instructions into the first pinned region (cacheable), or the
-    // conversation region if there is none - clearing any prior stage's first.
-    let target = window
-        .regions
-        .iter()
-        .find(|r| matches!(r.kind, leviath_core::RegionKind::Pinned))
-        .map(|r| r.name.clone())
-        .unwrap_or_else(|| "conversation".to_string());
+    let target = stage_instructions_target(window);
     if let Some(region) = window.regions.iter_mut().find(|r| r.name == target) {
-        region.remove_entries_by_prefix("[Stage instructions:");
+        if target == leviath_core::layout::STAGE_INSTRUCTIONS_REGION {
+            // The whole region is ours, so the previous stage's prompt goes by
+            // emptying it. The fallback below cannot do that - it shares a
+            // region with the author's own content - and has to identify its
+            // own entries by their prefix, which silently removes any author
+            // content that happens to start with the same words.
+            region.clear();
+        } else {
+            region.remove_entries_by_prefix("[Stage instructions:");
+        }
     }
     if let Some(sp) = &setup.system_prompt {
         let content = format!("[Stage instructions: {sp}]");

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -219,6 +219,41 @@ Scripts are stricter and have no `[read_paths]` escape: a stage hook, a custom-r
 output validator must all live inside the blueprint's own directory. A script is code the agent
 ships, and there is no such thing as loading your logic from somewhere else on purpose.
 
+## Where a stage's own instructions live
+
+A stage's `system_prompt` is pinned context - that is why it reads as instruction rather than
+history - and it goes into a region like everything else. By default that region is *whichever
+pinned region you declared first*, which costs three things: its tokens are charged to that region's
+name in the [stage ledger](/docs/cli#lev-stages-run-id), you cannot size or scope it, and it lands wherever
+that region sits in the cacheable prefix.
+
+Name a region for it and all three go away:
+
+```toml
+[context.regions]
+stage_instructions = { kind = "pinned", budget = "3%" }
+```
+
+The runtime writes the entering stage's prompt there, replacing the previous stage's. It is always
+assembled **after** every other pinned block, however you declared it, so the content in front of it
+stays byte-identical when the stage changes - and that content is what a provider's prompt cache
+matches on. Instructions sitting in front of the shared prefix rewrite its head on every transition,
+which invalidates everything behind them.
+
+Measured on a two-stage agent whose prompts are about 63 tokens each:
+
+| Region | Without the declaration | With it |
+|---|---|---|
+| `task` | 65 | 2 |
+| `stage_instructions` | not present | 63 |
+
+The 65 is the whole problem in one number: two tokens of task and sixty-three of somebody else's
+instructions, under a heading that says `task`.
+
+A blueprint that declares no such region keeps the old behaviour exactly, so this costs nothing to
+ignore. The region is never hidden by a stage that omits it from its own `[context.regions]`: it
+holds the instructions of the stage being entered, so hiding it would drop that stage's prompt.
+
 ## Eviction is deterministic
 
 When a region crosses its threshold, the runtime acts by the region's *kind*, never by pushing out


### PR DESCRIPTION
Closes #366.

The diagnosis in the issue is right, including the part about why the mechanism
itself is sensible: stage instructions genuinely are pinned context. What was
wrong is that the region holding them was chosen by accident of declaration
order and had no name anyone could use.

```toml
[context.regions]
stage_instructions = { kind = "pinned", budget = "3%" }
```

Declaring nothing by that name keeps today's behaviour exactly, so no existing
blueprint changes.

## The accounting, measured

A real daemon run against a mock provider, two stages with ~63-token prompts,
reading the per-region ledger back with `lev stages --regions`. The control is
the same agent with the one line deleted:

| Region | Without the declaration | With it |
|---|---|---|
| `task` | **65** | **2** |
| `stage_instructions` | not present | **63** |

65 = 2 + 63. `task` really was reporting sixty-three tokens of somebody else's
instructions under its own heading — which is exactly the "one number that lies"
the issue names, now with the arithmetic closed on both sides.

## The cache prefix

The region is assembled **after every other pinned block**, however it was
declared. Pinned blocks carry `CacheHint::Always` and are sorted with a stable
sort, so a region's position in the list decides its position in the prefix.
Instructions anywhere but last put a per-stage string in front of the shared
content, so changing stage rewrites the head of the prefix and invalidates
everything behind it.

Proven by mutation rather than assertion: deleting the reorder makes the test
that compares the blocks in front of the instructions across a transition fail.

I have **not** claimed a cache-rate improvement here. The issue measures 26% vs
64% on a real suite and attributes most of the gap to this; that is plausible and
this removes the mechanism, but I have not reproduced that measurement, and a
mock provider cannot.

## Two things that fell out

**The prefix surgery is gone on the declared path.** A region of its own is
emptied outright, so `remove_entries_by_prefix("[Stage instructions:")` — which
silently removes any author content starting with those words — is only used by
the fallback that still shares a region.

**The region is never hidden.** A stage whose own `[context.regions]` omits it
would otherwise have the instructions written into an invisible region and lose
that stage's prompt with nothing said. It joins `conversation`, `tool_results`
and `final_output` for the same reason they are there. I found this by reading
the hiding rule while writing the change, not from a failing test, so it has its
own mutation-checked test.

## One deliberate non-change

The `[Stage instructions: …]` wrapper stays on both paths. With a dedicated
region it is no longer needed to identify the entries, but dropping it changes
what the model reads, and this change is about where the block lives rather than
what it says. Happy to drop it if you'd rather.

## Verification

- `cargo test --workspace` — 0 failures
- `cargo xtask coverage` — `leviath-runtime` and `leviath-core` both exit 0
- two mutation checks (the ordering, and the never-hidden rule) both kill their test
- live: two-stage run plus a control, ledger read back through the CLI
- clippy, fmt, `cargo xtask docs --check` clean
