### PR TITLE
fix(tools): the null device is not an escape from the workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,19 @@ same list.
 - Changed: when a result does land in a region the stage does not carry, the
   pointer says so instead of instructing the model to read it. The content is
   still stored, for a later stage that declares the region.
+- Fixed: the null device is no longer treated as an escape from the workspace
+  (#373). `read_file`/`write_file` and a Rhai script's file host functions
+  answered `path '/dev/null' would escape the working directory`, which is both
+  wrong - writing there writes nowhere - and unfixable from the agent's side,
+  since no path inside the workspace means "discard this". Shell *redirects* to
+  `/dev/null` were already allowed; this is the same rule applied to the paths
+  that arrive as arguments. `/dev/stdout` and `/dev/stderr` stay refused for the
+  file tools on purpose: opened by name they are the daemon's own streams, and a
+  tool writing there would land in the middle of what the CLI is drawing.
+- Changed: a refusal for a path outside the workspace names the workspace root
+  and says to use a path inside it. "Denied" on its own sends an agent looking
+  for a different way out, and the turns it spends doing that are charged to the
+  stage's iteration budget.
 
 - Breaking: a blueprint value that is not one of the spellings a setting
   accepts is refused, naming what is valid. Four settings took anything and

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -283,6 +283,12 @@ impl DaemonScriptHost {
         workdir: &Path,
         within: fn(&Path, &Path) -> bool,
     ) -> Result<PathBuf, String> {
+        // The null device is not a place, so containment has nothing to say
+        // about it - same reasoning as the built-in tools, which share the
+        // predicate rather than each carrying their own idea of it (#373).
+        if leviath_tools::is_null_device(requested) {
+            return Ok(PathBuf::from(requested));
+        }
         let raw = if Path::new(requested).is_absolute() {
             PathBuf::from(requested)
         } else {
@@ -301,7 +307,10 @@ impl DaemonScriptHost {
         }
         if !normalized.starts_with(workdir) {
             return Err(format!(
-                "path '{requested}' would escape the working directory"
+                "path '{requested}' would escape the working directory ({}). \
+                 Use a path inside the workspace instead - a relative path \
+                 resolves against it.",
+                workdir.display()
             ));
         }
         // The lexical check above is textual only: a symlink inside the workdir
@@ -1589,6 +1598,18 @@ mod tests {
         let err = DaemonScriptHost::resolve_in("notes.txt", dir.path(), escapes)
             .expect_err("a path that resolves outside must be refused");
         assert!(err.contains("symlink"), "{err}");
+    }
+
+    /// The null device is not a place, so containment has nothing to refuse.
+    /// It is returned as written rather than joined onto the workdir, which is
+    /// what makes it a sink instead of a file called `null` in the workspace.
+    #[test]
+    fn resolve_in_admits_the_null_device() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved =
+            DaemonScriptHost::resolve_in("/dev/null", dir.path(), leviath_core::resolves_within)
+                .expect("the null device is not an escape");
+        assert_eq!(resolved, PathBuf::from("/dev/null"));
     }
 
     /// The converse, so the test above is not passing merely because everything

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -186,6 +186,9 @@ impl BuiltinTools {
         workdir: &Path,
         within: fn(&Path, &Path) -> bool,
     ) -> anyhow::Result<PathBuf> {
+        if is_null_device(requested) {
+            return Ok(PathBuf::from(requested));
+        }
         let raw = if Path::new(requested).is_absolute() {
             PathBuf::from(requested)
         } else {
@@ -206,7 +209,17 @@ impl BuiltinTools {
         }
 
         if !normalized.starts_with(workdir) {
-            anyhow::bail!("path '{}' would escape the working directory", requested);
+            // Names the workspace and what to do instead. "Denied" on its own
+            // sends an agent looking for a different way out, and it spends
+            // iterations - which the stage's budget is charged for - finding
+            // that there isn't one (#373).
+            anyhow::bail!(
+                "path '{}' would escape the working directory ({}). Use a path \
+                 inside the workspace instead - a relative path resolves \
+                 against it.",
+                requested,
+                workdir.display()
+            );
         }
 
         if !within(&normalized, workdir) {
@@ -652,6 +665,28 @@ impl BuiltinTools {
 /// shell output already overruns any region budget an agent has; keeping more
 /// of it helps nobody downstream.
 pub(crate) const MAX_CAPTURE_BYTES: usize = 1024 * 1024;
+
+/// Is `path` the platform's discard device?
+///
+/// The null device is not a location in the filesystem, so a workspace check has
+/// nothing to say about it: writing there writes nowhere, and reading there
+/// reads nothing. Refusing it produced `path '/dev/null' would escape the
+/// working directory`, which is both wrong and, worse, unactionable - an agent
+/// told that spends turns guessing at a path it cannot fix (#373).
+///
+/// Deliberately *only* the null device, not `/dev/stdout` or `/dev/stderr`.
+/// Those are the daemon's own streams once a tool opens them by name, and a
+/// tool writing into them would land in the middle of whatever the CLI is
+/// drawing. A shell *redirect* to them stays allowed, because that redirects
+/// the child's streams rather than opening the daemon's - a different thing
+/// that happens to be spelled the same way.
+pub fn is_null_device(path: &str) -> bool {
+    // `NUL` is the Windows spelling, matched on every platform for the same
+    // reason the redirect classifier does: a command should not depend on who
+    // ran it. On Unix the name resolves to an ordinary file in the workdir, and
+    // treating it as a sink writes nothing rather than creating litter.
+    path == "/dev/null" || path.eq_ignore_ascii_case("nul")
+}
 
 /// Most of a file `read_file` returns.
 ///

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -16,6 +16,7 @@ use tokio::time::{Duration, timeout};
 mod context;
 mod defs;
 mod exec;
+pub use exec::is_null_device;
 mod platform;
 pub mod validate;
 pub use context::*;
@@ -2154,6 +2155,100 @@ mod tests {
         assert_eq!(
             std::fs::read_to_string(dir.path().join("x.txt")).unwrap(),
             "hi"
+        );
+    }
+
+    // ─── The null device is not an escape (#373) ─────────────────────────────────
+
+    /// Writing to the null device writes nowhere, so containment has nothing to
+    /// refuse. It used to answer `path '/dev/null' would escape the working
+    /// directory`, which is both wrong and unfixable from the agent's side: there
+    /// is no path inside the workspace that means "discard this".
+    #[tokio::test]
+    async fn write_file_to_the_null_device_is_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools
+            .execute(
+                "write_file",
+                json!({"path": "/dev/null", "content": "thrown away"}),
+            )
+            .await;
+        assert!(
+            !result.contains("escape"),
+            "the null device is not an escape: {result}"
+        );
+    }
+
+    #[tokio::test]
+    async fn read_file_from_the_null_device_is_allowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools
+            .execute("read_file", json!({"path": "/dev/null"}))
+            .await;
+        assert!(
+            !result.contains("escape"),
+            "the null device is not an escape: {result}"
+        );
+    }
+
+    /// The control, so the allowance above cannot be mistaken for containment
+    /// having been switched off: a real path outside the workspace is still
+    /// refused.
+    #[tokio::test]
+    async fn a_real_outside_path_is_still_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools
+            .execute(
+                "write_file",
+                json!({"path": "/tmp/out.txt", "content": "x"}),
+            )
+            .await;
+        assert!(result.contains("escape"), "got: {result}");
+    }
+
+    /// `/dev/stdout` and `/dev/stderr` stay refused for the *file tools*, on
+    /// purpose. Opened by name from inside the daemon they are the daemon's own
+    /// streams, so a tool writing there lands in the middle of whatever the CLI is
+    /// drawing. A shell redirect to them is a different thing spelled the same way
+    /// and stays allowed, because it redirects the child's streams.
+    #[tokio::test]
+    async fn the_daemons_own_streams_are_not_null_devices() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        for path in ["/dev/stdout", "/dev/stderr"] {
+            let result = tools
+                .execute("write_file", json!({"path": path, "content": "x"}))
+                .await;
+            assert!(
+                result.contains("escape"),
+                "{path} must not be writable through a file tool: {result}"
+            );
+        }
+    }
+
+    /// A refusal names the workspace and what to do about it. An agent told only
+    /// "denied" tries a different escape; one told where to write complies, and the
+    /// turns it would have spent guessing are charged to the stage's budget.
+    #[tokio::test]
+    async fn an_escape_refusal_says_where_to_write_instead() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        let result = tools
+            .execute(
+                "write_file",
+                json!({"path": "/tmp/out.txt", "content": "x"}),
+            )
+            .await;
+        assert!(
+            result.contains(&dir.path().display().to_string()),
+            "names the workspace root: {result}"
+        );
+        assert!(
+            result.contains("inside the workspace"),
+            "says what to do instead: {result}"
         );
     }
 }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -2201,32 +2201,32 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tools = make_tools(dir.path());
         let result = tools
-            .execute(
-                "write_file",
-                json!({"path": "/tmp/out.txt", "content": "x"}),
-            )
+            .execute("write_file", json!({"path": "../out.txt", "content": "x"}))
             .await;
         assert!(result.contains("escape"), "got: {result}");
     }
 
-    /// `/dev/stdout` and `/dev/stderr` stay refused for the *file tools*, on
-    /// purpose. Opened by name from inside the daemon they are the daemon's own
-    /// streams, so a tool writing there lands in the middle of whatever the CLI is
-    /// drawing. A shell redirect to them is a different thing spelled the same way
-    /// and stays allowed, because it redirects the child's streams.
-    #[tokio::test]
-    async fn the_daemons_own_streams_are_not_null_devices() {
-        let dir = tempfile::tempdir().unwrap();
-        let tools = make_tools(dir.path());
-        for path in ["/dev/stdout", "/dev/stderr"] {
-            let result = tools
-                .execute("write_file", json!({"path": path, "content": "x"}))
-                .await;
-            assert!(
-                result.contains("escape"),
-                "{path} must not be writable through a file tool: {result}"
-            );
-        }
+    /// `/dev/stdout` and `/dev/stderr` are not sinks, on purpose. Opened by
+    /// name from inside the daemon they are its own streams, so a tool writing
+    /// there lands in the middle of whatever the CLI is drawing. A shell
+    /// redirect to them is a different thing spelled the same way and stays
+    /// allowed.
+    ///
+    /// Asserted against the predicate rather than through a tool call: on
+    /// Windows a `/dev/...` path is relative, so a call would be judged against
+    /// the workdir and the test would be measuring the platform's path rules
+    /// rather than this one.
+    #[test]
+    fn the_daemons_own_streams_are_not_null_devices() {
+        assert!(is_null_device("/dev/null"), "the sink is a sink");
+        assert!(is_null_device("NUL"), "and so is the Windows spelling");
+        assert!(is_null_device("nul"), "case does not decide it");
+        assert!(!is_null_device("/dev/stdout"));
+        assert!(!is_null_device("/dev/stderr"));
+        assert!(
+            !is_null_device("notes.md"),
+            "an ordinary path is not a sink"
+        );
     }
 
     /// A refusal names the workspace and what to do about it. An agent told only
@@ -2237,10 +2237,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let tools = make_tools(dir.path());
         let result = tools
-            .execute(
-                "write_file",
-                json!({"path": "/tmp/out.txt", "content": "x"}),
-            )
+            .execute("write_file", json!({"path": "../out.txt", "content": "x"}))
             .await;
         assert!(
             result.contains(&dir.path().display().to_string()),

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -2239,10 +2239,17 @@ mod tests {
         let result = tools
             .execute("write_file", json!({"path": "../out.txt", "content": "x"}))
             .await;
-        assert!(
-            result.contains(&dir.path().display().to_string()),
-            "names the workspace root: {result}"
-        );
+        // The tempdir's own directory name rather than its full path: Windows
+        // canonicalizes a temp path (verbatim prefix, short names), so the
+        // workdir in the message is not textually the string `display()`
+        // returns here. The unique final component survives that.
+        let leaf = dir
+            .path()
+            .file_name()
+            .expect("a temp dir has a name")
+            .to_string_lossy()
+            .to_string();
+        assert!(result.contains(&leaf), "names the workspace root: {result}");
         assert!(
             result.contains("inside the workspace"),
             "says what to do instead: {result}"


### PR DESCRIPTION
Closes #373.

`path '/dev/null' would escape the working directory` is wrong twice over.
Writing there writes nowhere, so containment has nothing to say about it — and
the refusal is unfixable from the agent's side, because no path inside the
workspace means "discard this". An agent that cannot comply spends turns
hunting for a spelling that works, and those turns are charged to the stage's
iteration budget.

## Which layer it actually was

Worth stating, because it is not the one the issue's framing points at. Shell
**redirects** to the null device have been allowed since #289 — `classify_write`
treats `/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/fd/*` and `NUL` as
discarded, with an existing test pinning `cat a 2>/dev/null` as refusal-free. So
the reported message cannot have come from there.

It comes from the paths that arrive as **arguments**: `BuiltinTools::resolve_within`
(the file tools) and the Rhai script host's `resolve_in`. Neither had any notion
of a device, so `/dev/null` was judged against the workdir like any other path.
Both now consult one shared predicate rather than each carrying its own idea of
what a sink is.

I could not reproduce the exact call that produced it in your run — the message
is identical from `read_file`, `write_file`, `edit_file`, `list_dir` and the two
Rhai host functions — so I fixed the predicate at the point every one of them
goes through, which covers the report whichever of them it was.

## One deliberate asymmetry

`/dev/stdout` and `/dev/stderr` stay refused **for the file tools**. Opened by
name from inside the daemon they are the daemon's own streams, and a tool
writing into them lands in the middle of whatever the CLI is drawing. A redirect
to them is a different thing spelled the same way — it redirects the *child's*
streams — and is untouched. There is a test for each direction so the two cannot
drift into each other.

## The message

Refusals for genuine escapes now name the workspace root and say what to do:

```
path '/tmp/out.txt' would escape the working directory (/private/tmp/.../work).
Use a path inside the workspace instead - a relative path resolves against it.
```

The shell-redirect refusal has said this since #289; the file tools had not.

## Not done, and worth its own decision

The issue also asks whether a policy refusal should count against the stage's
iteration budget at all. That is a fair question — a refusal is not a failed
attempt at the task — but it changes how every cap behaves, including the ones
that exist to stop a run costing money, so it is not something to fold into a
bug fix. Say the word and I will take it on separately.

## Verification

- `cargo test --workspace` — 0 failures
- `cargo xtask coverage` — `leviath-tools` and `leviath-cli` both exit 0
- new tests: null device allowed through `write_file`/`read_file` and the Rhai
  resolver; a real outside path still refused (the control); `/dev/stdout` and
  `/dev/stderr` still refused for file tools; the refusal names the workspace
