### PR TITLE
fix(blueprint): a stage may only route results where it can read them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ same list.
   tool-less output stage came to look like it had written 153,983 tokens. Stage
   records also carry `entered`, so a consumer can tell the two apart without the
   "empty map means it did not run" heuristic.
+- Breaking: a stage that routes a tool result into a region its own
+  `[context.regions]` omits is refused by `lev validate` (#370). Omitting a
+  region hides it, so the result was written where that stage could not read it
+  - and the pointer left in `conversation` told the model to go and read it
+  anyway. Measured on a scoped agent: a `verify` stage instructed to check rules
+  against the documentation tried in 6 of 20 runs, and the manual landed out of
+  view every time. The message names the region and how to fix it. The four
+  regions the runtime always carries stay valid targets, and a stage that
+  declares no layout of its own is judged against the blueprint's.
+- Changed: when a result does land in a region the stage does not carry, the
+  pointer says so instead of instructing the model to read it. The content is
+  still stored, for a later stage that declares the region.
 
 - Breaking: a blueprint value that is not one of the spellings a setting
   accepts is refused, naming what is valid. Four settings took anything and

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -11,6 +11,20 @@ use crate::lifecycle::CompactionConfig;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Regions every stage can see, whatever its own `[context.regions]` says.
+///
+/// The runtime adds the first three when a blueprint declares none, and carries
+/// all four visible through a stage's layout swap: the first two hold the typed
+/// tool_use/tool_result turns, an answer submitted early has to survive to the
+/// end, and the last holds the instructions of the stage being entered. Mirrors
+/// `context_setup::apply_layout`, which is where the rule is enforced.
+const ALWAYS_VISIBLE_REGIONS: [&str; 4] = [
+    "conversation",
+    "tool_results",
+    "final_output",
+    crate::layout::STAGE_INSTRUCTIONS_REGION,
+];
+
 /// An agent blueprint - the complete definition of an agent type.
 ///
 /// Includes stages, model selection, tools, AND context layout. A blueprint
@@ -315,7 +329,26 @@ impl Blueprint {
         }
         // Added by `setup_context_window` when a blueprint does not declare
         // them, so they are always addressable.
-        names.extend(["conversation", "tool_results", "final_output"]);
+        names.extend(ALWAYS_VISIBLE_REGIONS);
+        names
+    }
+
+    /// The regions `stage` can actually see while it runs.
+    ///
+    /// Its own `[context.regions]` when it declares one, the blueprint's
+    /// otherwise, plus the regions the runtime carries visible whatever a stage
+    /// says. Narrower than [`known_region_names`](Self::known_region_names),
+    /// which asks only whether a name exists somewhere - the difference is the
+    /// whole of #370: a region another stage declares exists, and is still not
+    /// readable from here.
+    fn regions_visible_to<'a>(&'a self, stage: &'a Stage) -> std::collections::HashSet<&'a str> {
+        let layout = stage
+            .context_layout
+            .as_ref()
+            .unwrap_or(&self.context_layout);
+        let mut names: std::collections::HashSet<&str> =
+            layout.regions.iter().map(|r| r.name.as_str()).collect();
+        names.extend(ALWAYS_VISIBLE_REGIONS);
         names
     }
 
@@ -349,19 +382,31 @@ impl Blueprint {
             };
 
             if let Some(routing) = &stage.tool_result_routing {
-                if !known.contains(routing.default_region.as_str()) {
-                    return Err(bad(format!(
-                        "tool_routing.default_region names region '{}', which no \
-                         stage declares",
-                        routing.default_region
-                    )));
+                // Routing is checked against what *this* stage can see, not
+                // against every name in the blueprint. A stage that omits a
+                // region from its own `[context.regions]` hides it, so a result
+                // routed there is written somewhere the stage cannot read - and
+                // the pointer left in `conversation` tells the model to go read
+                // it. There is no reading of a blueprint where that was
+                // intended (#370).
+                let visible = self.regions_visible_to(stage);
+                let dead_drop = |key: &str, region: &str| ValidationError::Stage {
+                    stage: stage.name.clone(),
+                    message: format!(
+                        "tool_routing.{key} sends results to region '{region}', \
+                             which this stage's context does not include, so it \
+                             could not read them back. Add '{region}' to \
+                             [stages.{}.context.regions], or route somewhere the \
+                             stage can see.",
+                        stage.name
+                    ),
+                };
+                if !visible.contains(routing.default_region.as_str()) {
+                    return Err(dead_drop("default_region", &routing.default_region));
                 }
                 for (tool, region) in &routing.tool_overrides {
-                    if !known.contains(region.as_str()) {
-                        return Err(bad(format!(
-                            "tool_routing.overrides.{tool} names region '{region}', \
-                             which no stage declares"
-                        )));
+                    if !visible.contains(region.as_str()) {
+                        return Err(dead_drop(&format!("overrides.{tool}"), region));
                     }
                 }
             }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -4114,7 +4114,11 @@ fn validate_rejects_a_checklist_gate_on_a_non_checklist_region() {
 /// it rather than destroying it, so this is legitimate and must not be
 /// mistaken for a typo.
 #[test]
-fn validate_allows_a_region_declared_by_another_stage() {
+fn validate_allows_a_gate_on_a_region_declared_by_another_stage() {
+    // A gate is evaluated by the runtime against the region's contents, not by
+    // the model reading it, so a region this stage does not render is still a
+    // sound thing to gate on. Routing is the opposite case and is checked
+    // per-stage; see the #370 tests.
     let toml = r#"
 [agent]
 name = "keys"
@@ -4124,8 +4128,9 @@ entry_stage = "work"
 mode = "autonomous"
 system_prompt = "go"
 
-[stages.work.tool_routing.overrides]
-read_file = "notes"
+[stages.work.transitions.other]
+condition = "always"
+gate = { require_region_updated = "notes" }
 
 [stages.other]
 mode = "autonomous"
@@ -4136,7 +4141,7 @@ notes = { kind = "pinned", max_tokens = 1000 }
 "#;
     let bp = parse_manifest(toml).expect("parses");
     bp.validate()
-        .expect("a cross-stage region reference is fine");
+        .expect("a cross-stage region reference is fine for a gate");
 }
 
 #[test]
@@ -4540,4 +4545,156 @@ on_unavailable = "explode"
         err.contains("unknown on_unavailable 'explode'"),
         "got: {err}"
     );
+}
+
+// ─── Routing into a region the stage cannot see (#370) ───────────────────────
+
+/// The reported shape: a stage scopes its context and routes a tool into a
+/// region it left out. The result is written where the stage cannot read it,
+/// and the pointer left in `conversation` tells the model to go read it.
+#[test]
+fn validate_rejects_routing_into_a_region_the_stage_omits() {
+    let toml = r#"
+[agent]
+name = "scoped"
+entry_stage = "verify"
+
+[context.regions]
+data_preview = { kind = "pinned", max_tokens = 8000 }
+plan = { kind = "pinned", max_tokens = 2000 }
+
+[stages.verify]
+mode = "autonomous"
+system_prompt = "check the rules against the manual"
+
+[stages.verify.context.regions]
+plan = { kind = "pinned", max_tokens = 2000 }
+
+[stages.verify.tool_routing.overrides]
+read_file = "data_preview"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let err = bp.validate().unwrap_err().to_string();
+    assert!(err.contains("data_preview"), "names the region: {err}");
+    assert!(
+        err.contains("could not read them back"),
+        "says what is wrong: {err}"
+    );
+    assert!(
+        err.contains("[stages.verify.context.regions]"),
+        "says how to fix it: {err}"
+    );
+}
+
+/// `scratch` in the report: declared globally, named as a routing target, and
+/// in no stage's layout at all - unreachable by construction for the whole life
+/// of the blueprint.
+#[test]
+fn validate_rejects_a_default_region_no_stage_renders() {
+    let toml = r#"
+[agent]
+name = "scoped"
+entry_stage = "plan"
+
+[context.regions]
+scratch = { kind = "temporary", max_tokens = 4000 }
+notes = { kind = "pinned", max_tokens = 2000 }
+
+[stages.plan]
+mode = "autonomous"
+system_prompt = "go"
+
+[stages.plan.context.regions]
+notes = { kind = "pinned", max_tokens = 2000 }
+
+[stages.plan.tool_routing]
+default_region = "scratch"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let err = bp.validate().unwrap_err().to_string();
+    assert!(err.contains("scratch"), "{err}");
+}
+
+/// A stage that declares no layout of its own sees the blueprint's, so routing
+/// into any global region is fine. Without this the check would reject the
+/// ordinary un-scoped blueprint, which is most of them.
+#[test]
+fn validate_allows_routing_into_a_global_region_from_an_unscoped_stage() {
+    let toml = r#"
+[agent]
+name = "plain"
+entry_stage = "work"
+
+[context.regions]
+codebase = { kind = "compacting", max_tokens = 8000 }
+
+[stages.work]
+mode = "autonomous"
+system_prompt = "go"
+
+[stages.work.tool_routing.overrides]
+read_file = "codebase"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    bp.validate()
+        .expect("an unscoped stage sees the global layout");
+}
+
+/// The regions the runtime carries visible whatever a stage declares are always
+/// legitimate routing targets, or a scoped stage could not route anywhere.
+#[test]
+fn validate_allows_routing_into_the_always_visible_regions() {
+    for target in ["conversation", "tool_results", "final_output"] {
+        let toml = format!(
+            r#"
+[agent]
+name = "scoped"
+entry_stage = "work"
+
+[context.regions]
+notes = {{ kind = "pinned", max_tokens = 2000 }}
+
+[stages.work]
+mode = "autonomous"
+system_prompt = "go"
+
+[stages.work.context.regions]
+notes = {{ kind = "pinned", max_tokens = 2000 }}
+
+[stages.work.tool_routing]
+default_region = "{target}"
+"#
+        );
+        let bp = parse_manifest(&toml).expect("parses");
+        bp.validate()
+            .unwrap_or_else(|e| panic!("{target} is always visible: {e}"));
+    }
+}
+
+/// A stage that scopes its context and routes into a region it *did* declare is
+/// the case this must not touch.
+#[test]
+fn validate_allows_routing_into_a_region_the_stage_declares() {
+    let toml = r#"
+[agent]
+name = "scoped"
+entry_stage = "work"
+
+[context.regions]
+codebase = { kind = "compacting", max_tokens = 8000 }
+notes = { kind = "pinned", max_tokens = 2000 }
+
+[stages.work]
+mode = "autonomous"
+system_prompt = "go"
+
+[stages.work.context.regions]
+codebase = { kind = "compacting", max_tokens = 8000 }
+
+[stages.work.tool_routing.overrides]
+read_file = "codebase"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    bp.validate()
+        .expect("routing into a declared region is fine");
 }

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -12999,3 +12999,113 @@ fn stage_instructions_survive_a_stage_layout_that_does_not_declare_them() {
         assembled.system_blocks
     );
 }
+
+// ─── The pointer tells the truth about a region the stage cannot see (#370) ──
+
+/// Build a window with `regions` plus `conversation`, hiding `hidden`.
+fn routed_window(regions: &[&str], hidden: &[&str]) -> ContextWindow {
+    let mut window = ContextWindow::new(100_000);
+    window.add_region(leviath_core::Region::new(
+        "conversation".to_string(),
+        leviath_core::RegionKind::SlidingWindow {
+            max_items: 50,
+            eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+        },
+        50_000,
+    ));
+    for name in regions {
+        window.add_region(leviath_core::Region::new(
+            (*name).to_string(),
+            leviath_core::RegionKind::Pinned,
+            20_000,
+        ));
+    }
+    window.hidden = hidden.iter().map(|s| (*s).to_string()).collect();
+    window
+}
+
+fn routed_to(region: &str) -> leviath_core::blueprint::ToolResultRouting {
+    leviath_core::blueprint::ToolResultRouting {
+        default_region: region.to_string(),
+        ..Default::default()
+    }
+}
+
+fn one_read_call() -> (Vec<crate::components::ToolCall>, Vec<(String, String)>) {
+    (
+        vec![crate::components::ToolCall {
+            tool_id: "call-1".to_string(),
+            name: "read_file".to_string(),
+            arguments: serde_json::json!({"path": "manual.md"}),
+            thought_signature: None,
+        }],
+        vec![("call-1".to_string(), "the manual's full text".to_string())],
+    )
+}
+
+/// The pointer that reaches the model when the region *is* visible: go and read
+/// it, because it can.
+#[test]
+fn a_pointer_to_a_visible_region_says_to_read_it() {
+    let mut window = routed_window(&["data_preview"], &[]);
+    let (calls, results) = one_read_call();
+    apply_tool_results(
+        &mut window,
+        "",
+        &calls,
+        &results,
+        Some(&routed_to("data_preview")),
+        None,
+    );
+    let conversation = window.get_region("conversation").expect("conversation");
+    let text: String = conversation
+        .content
+        .iter()
+        .map(|e| e.content.clone())
+        .collect();
+    assert!(
+        text.contains("read that region for the full result"),
+        "{text}"
+    );
+}
+
+/// And when it is not visible: say so, rather than instructing the model to
+/// read somewhere it has no access to. `verify` in the report tried exactly
+/// that, in 6 of 20 runs, and the manual landed out of view every time.
+#[test]
+fn a_pointer_to_a_hidden_region_says_it_cannot_be_read_here() {
+    let mut window = routed_window(&["data_preview"], &["data_preview"]);
+    let (calls, results) = one_read_call();
+    apply_tool_results(
+        &mut window,
+        "",
+        &calls,
+        &results,
+        Some(&routed_to("data_preview")),
+        None,
+    );
+    let conversation = window.get_region("conversation").expect("conversation");
+    let text: String = conversation
+        .content
+        .iter()
+        .map(|e| e.content.clone())
+        .collect();
+    assert!(
+        text.contains("cannot be read from here"),
+        "the model must not be told to read a region it does not carry: {text}"
+    );
+    assert!(
+        !text.contains("read that region for the full result"),
+        "and must not also be told the opposite: {text}"
+    );
+    // The content is still written, so a later stage that declares the region
+    // gets it - which is the reason this is not simply dropped.
+    let stored = window.get_region("data_preview").expect("target region");
+    assert!(
+        stored
+            .content
+            .iter()
+            .any(|e| e.content.contains("the manual's full text")),
+        "the result is kept for whoever can see it"
+    );
+}

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -156,9 +156,21 @@ pub(crate) fn apply_tool_results(
             } else {
                 ""
             };
-            let pointer = format!(
-                "[output stored in context region '{target_region}' ({result_tokens} tokens) - read that region for the full result. Preview: {preview}{ellipsis}]"
-            );
+            // A region this stage does not render is one the model cannot go
+            // and read, so telling it to is worse than saying nothing: the
+            // instruction is unfollowable and the model spends turns trying
+            // (#370). `lev validate` refuses a blueprint that routes this way,
+            // so reaching here means a layout swapped underneath a routing rule
+            // rather than an author mistake - but the model still needs to be
+            // told the truth about where its output went.
+            let pointer = match window.hidden.contains(target_region) {
+                false => format!(
+                    "[output stored in context region '{target_region}' ({result_tokens} tokens) - read that region for the full result. Preview: {preview}{ellipsis}]"
+                ),
+                true => format!(
+                    "[output stored in context region '{target_region}' ({result_tokens} tokens), which this stage does not carry - it is kept for a later stage and cannot be read from here. Preview: {preview}{ellipsis}]"
+                ),
+            };
             let pointer_tokens = leviath_core::estimate_tokens(&pointer);
             add_kind(
                 window,

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -291,6 +291,11 @@ read_file = 20000
 Both tables are keyed by tool name, and an alias matches the tool it aliases - writing `bash` covers
 the `shell` the model actually calls.
 
+A stage may only route into a region it can see. Routing a result into a region the stage left out
+of its own `[context.regions]` writes it where that stage cannot read it back, so `lev validate`
+refuses the blueprint and says which region to add. The four the runtime always carries -
+`conversation`, `tool_results`, `final_output` and `stage_instructions` - are always valid targets.
+
 An override entry can also carry both answers at once, which is usually what you mean when a tool
 needs its own region *and* its own ceiling:
 


### PR DESCRIPTION
Closes #370.

You're right that this is always a mistake: there is no reading of a blueprint
where the author wanted a result written somewhere the stage cannot read. So it
is refused at validate time, which is the cheapest place — before any tokens are
spent.

Your exact shape, through the real CLI:

```
Error: ✗ Validation failed: Invalid stage 'verify': tool_routing.overrides.read_file
sends results to region 'data_preview', which this stage's context does not
include, so it could not read them back. Add 'data_preview' to
[stages.verify.context.regions], or route somewhere the stage can see.
```

`scratch` — declared globally, named as a routing target, in no stage's layout —
is caught the same way, by `default_region` rather than an override.

## Why this needed a new check rather than the one from #362

#362 already validates that a routing target names a region that *exists*. That
check asks the union question: is this name declared by any stage. The
difference is the whole of this issue — a region another stage declares exists,
and is still not readable from here.

So routing is now checked against what **this stage** can see. Gates keep the
wider rule, and the test that pinned it now says why: a gate is evaluated by the
runtime against a region's contents, not by the model reading it, so gating on a
region this stage does not render is sound. Routing is the opposite case.

## Two things kept deliberately un-rejected

- **A stage that declares no layout of its own** is judged against the
  blueprint's global layout, so an ordinary un-scoped blueprint — most of them —
  is untouched. There's a test for this, because getting it wrong would reject
  almost every existing agent.
- **The always-visible regions** (`conversation`, `tool_results`,
  `final_output`, `stage_instructions`) stay valid targets. A scoped stage could
  not route anywhere at all otherwise.

## The pointer text

For anything that still reaches the runtime — a layout swapped underneath a
routing rule rather than an author mistake — the pointer now tells the truth:

> `[output stored in context region 'data_preview' (4004 tokens), which this stage does not carry - it is kept for a later stage and cannot be read from here. Preview: ...]`

The content is still written, which is why this isn't simply dropped: a later
stage that declares the region gets it.

## Verification

- `cargo test --workspace` — 0 failures, including the bundled-agent validation
  tests, so none of the ten shipped agents routes this way
- `cargo xtask coverage` — `leviath-core` and `leviath-runtime` both exit 0
- live: your blueprint shape refused through `lev validate`
- tests cover the scoped-omission case, the `scratch` case, the two shapes that
  must stay legal, and both pointer texts
