### PR TITLE
feat(gates): a gate that can require a region, and a record when one gives up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ same list.
   and says to use a path inside it. "Denied" on its own sends an agent looking
   for a different way out, and the turns it spends doing that are charged to the
   stage's iteration budget.
+- New: `gate = { require_regions = ["plan"] }` holds an edge until every named
+  region has content, ANDed with the gate's other conditions (#371). `region`
+  reads as though it says this and does not: it is one of several *alternative*
+  ways to satisfy `require_modifications`, so a stage that wrote any file at all
+  satisfied it with the named region still empty. That is the right shape for
+  what `region` is for - a restart-durable stand-in for per-stage counters - and
+  there was no way to express the conjunction.
+- New: `flags.required_regions_abandoned` in `meta.json` names any
+  `required = true` region a stage gave up on after its re-run budget (#371).
+  The mechanism logged and recorded nothing, so a run whose agent wrote its plan
+  and one where it was asked twice and moved on both finished `complete` with
+  nothing to tell them apart. Its counterpart `flags.gates_forced` already
+  counted forced transitions.
 
 - Breaking: a blueprint value that is not one of the spellings a setting
   accepts is refused, naming what is valid. Four settings took anything and

--- a/crates/leviath-core/src/blueprint/transition.rs
+++ b/crates/leviath-core/src/blueprint/transition.rs
@@ -177,6 +177,26 @@ pub struct TransitionGate {
     /// entered, so "changed" means changed by *this* pass.
     #[serde(default)]
     pub require_region_updated: Option<String>,
+
+    /// Regions that must all hold content before this edge may be taken.
+    ///
+    /// Conjunctive, and that is the point. [`Self::region`] reads as though it
+    /// says this and does not: it is one of several *alternative* ways to
+    /// satisfy [`Self::require_modifications`], so
+    /// `{ require_modifications = true, region = "plan" }` is met by writing
+    /// any file anywhere while `plan` stays empty (#371). That is the right
+    /// shape for what `region` is for - a restart-durable stand-in for
+    /// per-stage counters, which do not survive a daemon restart - and the
+    /// wrong shape for "this stage does not leave without writing X". This key
+    /// is the second thing, ANDed with every other condition on the gate.
+    ///
+    /// A name the window does not hold passes with a warning rather than
+    /// blocking: `lev validate` refuses a gate naming a region no stage
+    /// declares, so reaching that at runtime means a layout moved underneath
+    /// the edge, and stranding a run over it would be worse than the missing
+    /// check. Saying nothing is what made the old behaviour hard to find.
+    #[serde(default)]
+    pub require_regions: Vec<String>,
     /// Checklist region that must have no open items before this edge is taken.
     ///
     /// The other gates ask whether a region has content, which cannot tell a

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -72,6 +72,7 @@ const GATE_KEYS: &[&str] = &[
     "require_modifications",
     "require_no_open_items",
     "require_region_updated",
+    "require_regions",
     "tools",
 ];
 
@@ -1033,6 +1034,12 @@ pub(super) fn parse_transition_gate(
     }
     if let Some(region) = table.get("require_region_updated").and_then(|v| v.as_str()) {
         gate.require_region_updated = Some(region.to_string());
+    }
+    if let Some(regions) = table.get("require_regions").and_then(|v| v.as_array()) {
+        gate.require_regions = regions
+            .iter()
+            .filter_map(|v| v.as_str().map(str::to_string))
+            .collect();
     }
     if let Some(region) = table.get("require_no_open_items").and_then(|v| v.as_str()) {
         gate.require_no_open_items = Some(region.to_string());

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -4047,11 +4047,11 @@ fn parse_manifest_rejects_an_unknown_tool_routing_key() {
 #[test]
 fn parse_manifest_rejects_an_unknown_gate_key() {
     let err = parse_manifest(&keys_fixture(
-        "[stages.work.transitions.work]\ncondition = \"always\"\ngate = { require_regions = \"bulk\" }",
+        "[stages.work.transitions.work]\ncondition = \"always\"\ngate = { require_writes = \"bulk\" }",
     ))
     .unwrap_err()
     .to_string();
-    assert!(err.contains("unknown key 'require_regions'"), "got: {err}");
+    assert!(err.contains("unknown key 'require_writes'"), "got: {err}");
 }
 
 #[test]
@@ -4491,6 +4491,43 @@ mode = "autonomous"
     assert_eq!(gate.require_region_updated.as_deref(), Some("plan"));
     assert_eq!(gate.message.as_deref(), Some("Change it first."));
     // And it does not silently turn on the other gate.
+    assert!(!gate.require_modifications);
+}
+
+/// `require_regions` parses onto the edge gate as a list.
+///
+/// The key exists because `region` reads as though it says this and does not:
+/// it is one of several *alternative* ways to satisfy `require_modifications`,
+/// so a stage that wrote any file at all satisfied it with the named region
+/// still empty (#371).
+#[test]
+fn parse_manifest_reads_a_required_regions_gate() {
+    let toml = r#"
+[agent]
+name = "planning"
+
+[context.regions]
+plan = { kind = "pinned", max_tokens = 2000 }
+risks = { kind = "pinned", max_tokens = 2000 }
+
+[stages.plan]
+mode = "autonomous"
+
+[stages.plan.transitions.compute]
+gate = { require_regions = ["plan", "risks"] }
+
+[stages.compute]
+mode = "autonomous"
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let gate = bp
+        .find_stage("plan")
+        .and_then(|s| s.transitions.as_ref())
+        .and_then(|t| t.get("compute"))
+        .and_then(|e| e.gate.as_ref())
+        .expect("the gate survives");
+    assert_eq!(gate.require_regions, vec!["plan", "risks"]);
+    // And it does not silently turn on the condition it exists to replace.
     assert!(!gate.require_modifications);
 }
 

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -264,6 +264,18 @@ pub struct RunFlags {
     /// gate's re-run budget ran out.
     #[serde(default)]
     pub gates_forced: usize,
+    /// Regions declared `required` that were still empty when the stage that
+    /// owed them gave up and moved on, in the order they were abandoned.
+    ///
+    /// The mechanism re-runs the stage a bounded number of times and then
+    /// proceeds with a log line, which nothing downstream reads: a run whose
+    /// agent wrote its plan and a run where we asked twice and moved on both
+    /// finished `complete`, with the second silently missing the artifact every
+    /// later stage's prompt says to work from (#371). Names rather than a count
+    /// because knowing *which* region was abandoned is what makes it
+    /// actionable, and a run cannot abandon many.
+    #[serde(default)]
+    pub required_regions_abandoned: Vec<String>,
     /// The working directory disappeared mid-run.
     #[serde(default)]
     pub workspace_lost: bool,

--- a/crates/leviath-runtime/src/pipeline/requirements.rs
+++ b/crates/leviath-runtime/src/pipeline/requirements.rs
@@ -168,6 +168,7 @@ type ContextRegionQuery = (
     &'static mut ContextWindow,
     Option<&'static RequiredReentries>,
     Option<&'static StageOutcome>,
+    Option<&'static mut crate::persistence::RunOutcomeFlags>,
 );
 
 /// Required-region gate: before a normally-completed stage transitions, if it can
@@ -181,7 +182,7 @@ pub fn require_context_regions(
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
-    for (entity, bp, cursor, mut window, reentries, outcome) in agents.iter_mut() {
+    for (entity, bp, cursor, mut window, reentries, outcome, flags) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         if outcome.is_some() {
             continue; // error / max-iterations transition takes precedence
@@ -201,6 +202,23 @@ pub fn require_context_regions(
                 attempts = cap,
                 "required context regions still empty after re-run attempts; proceeding"
             );
+            // Recorded as well as logged. A log line is not readable after the
+            // fact, so "the agent wrote its plan" and "we asked twice and moved
+            // on" both finished `complete` and nothing downstream could tell
+            // them apart - which is how this went unnoticed across four
+            // benchmark rounds (#371).
+            if let Some(mut flags) = flags {
+                for name in &names {
+                    if !flags
+                        .0
+                        .required_regions_abandoned
+                        .iter()
+                        .any(|seen| seen == name)
+                    {
+                        flags.0.required_regions_abandoned.push((*name).to_string());
+                    }
+                }
+            }
             continue; // proceed with the transition despite the unmet regions
         }
         inject_required_region_nudges(&mut window, &unmet);

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -8307,6 +8307,7 @@ fn gate(region: Option<&str>, message: Option<&str>) -> leviath_core::blueprint:
         tools: Vec::new(),
         max_attempts: None,
         require_region_updated: None,
+        require_regions: Vec::new(),
         require_no_open_items: None,
     }
 }
@@ -13107,5 +13108,271 @@ fn a_pointer_to_a_hidden_region_says_it_cannot_be_read_here() {
             .iter()
             .any(|e| e.content.contains("the manual's full text")),
         "the result is kept for whoever can see it"
+    );
+}
+
+// ─── A gate that can actually require a region (#371) ────────────────────────
+
+/// A gate that asks only for regions, so these tests isolate the new condition
+/// from `require_modifications`. The two together are covered separately.
+fn requiring_gate(regions: &[&str]) -> leviath_core::blueprint::TransitionGate {
+    leviath_core::blueprint::TransitionGate {
+        require_regions: regions.iter().map(|s| (*s).to_string()).collect(),
+        require_modifications: false,
+        ..gate(None, None)
+    }
+}
+
+/// A window holding `regions`, each empty unless named in `filled`.
+fn gate_window(regions: &[&str], filled: &[&str]) -> ContextWindow {
+    let mut window = ContextWindow::new(100_000);
+    for name in regions {
+        window.add_region(leviath_core::Region::new(
+            (*name).to_string(),
+            leviath_core::RegionKind::Pinned,
+            10_000,
+        ));
+    }
+    for name in filled {
+        window
+            .add_to_region(name, "written".to_string(), 2)
+            .expect("fits");
+    }
+    window
+}
+
+/// The heart of #371: `require_modifications` with `region` is satisfied by any
+/// write anywhere, so the named region can still be empty. `require_regions` is
+/// the conjunction that was missing - it holds whatever else the gate is happy
+/// about.
+#[test]
+fn require_regions_blocks_even_when_the_stage_wrote_files() {
+    let stage = writing_stage("plan", Vec::new());
+    let window = gate_window(&["plan"], &[]);
+    let progress = StageProgress {
+        // A file write, which alone satisfies `require_modifications`.
+        modifying_tool_calls: 3,
+        ..Default::default()
+    };
+
+    // The old shape: passes, with `plan` still empty.
+    let old = gate_blocks(Some(&gate(Some("plan"), None)), &stage, &progress, &window);
+    assert!(
+        matches!(old, GateDecision::Pass),
+        "the alternative-condition gate still passes on any write: {old:?}"
+    );
+
+    // The new one does not.
+    let decision = gate_blocks(Some(&requiring_gate(&["plan"])), &stage, &progress, &window);
+    let GateDecision::Block(nudge) = decision else {
+        panic!("an empty required region must hold the stage: {decision:?}");
+    };
+    assert!(
+        nudge.contains("plan"),
+        "the nudge names the region: {nudge}"
+    );
+}
+
+/// And lets the stage go once the region has content, or it would be a wall
+/// rather than a gate.
+#[test]
+fn require_regions_passes_once_the_region_is_written() {
+    let stage = writing_stage("plan", Vec::new());
+    let window = gate_window(&["plan"], &["plan"]);
+    let decision = gate_blocks(
+        Some(&requiring_gate(&["plan"])),
+        &stage,
+        &StageProgress::default(),
+        &window,
+    );
+    assert!(matches!(decision, GateDecision::Pass), "{decision:?}");
+}
+
+/// Every named region, not just the first.
+#[test]
+fn require_regions_holds_until_all_of_them_are_written() {
+    let stage = writing_stage("plan", Vec::new());
+    let gate = requiring_gate(&["plan", "risks"]);
+
+    let half = gate_window(&["plan", "risks"], &["plan"]);
+    let decision = gate_blocks(Some(&gate), &stage, &StageProgress::default(), &half);
+    let GateDecision::Block(nudge) = decision else {
+        panic!("one written region is not all of them: {decision:?}");
+    };
+    assert!(nudge.contains("risks"), "names what is missing: {nudge}");
+    assert!(
+        !nudge.contains("plan,") && !nudge.contains("plan "),
+        "and not what is already there: {nudge}"
+    );
+
+    let both = gate_window(&["plan", "risks"], &["plan", "risks"]);
+    assert!(matches!(
+        gate_blocks(Some(&gate), &stage, &StageProgress::default(), &both),
+        GateDecision::Pass
+    ));
+}
+
+/// It shares the one `max_attempts` budget, so it cannot wedge a run.
+#[test]
+fn require_regions_gives_up_with_the_shared_budget() {
+    let stage = writing_stage("plan", Vec::new());
+    let window = gate_window(&["plan"], &[]);
+    let progress = StageProgress {
+        gate_reentries: leviath_core::blueprint::DEFAULT_GATE_ATTEMPTS,
+        ..Default::default()
+    };
+    let decision = gate_blocks(Some(&requiring_gate(&["plan"])), &stage, &progress, &window);
+    assert!(
+        matches!(decision, GateDecision::Forced),
+        "a gate that could block forever would strand the run: {decision:?}"
+    );
+}
+
+/// A region the window does not hold passes rather than stranding the run.
+/// `lev validate` refuses a gate naming a region no stage declares, so reaching
+/// this means a layout moved underneath the edge.
+#[test]
+fn require_regions_passes_when_the_window_does_not_hold_the_region() {
+    let stage = writing_stage("plan", Vec::new());
+    let window = gate_window(&["plan"], &["plan"]);
+    let decision = gate_blocks(
+        Some(&requiring_gate(&["nowhere"])),
+        &stage,
+        &StageProgress::default(),
+        &window,
+    );
+    assert!(matches!(decision, GateDecision::Pass), "{decision:?}");
+}
+
+/// The two conditions are ANDed. A stage that wrote files but not the region is
+/// held, which is the case `region` could not express; a stage that wrote the
+/// region but no files is held too, by the other half.
+#[test]
+fn require_regions_and_require_modifications_must_both_hold() {
+    let stage = writing_stage("plan", Vec::new());
+    let both = leviath_core::blueprint::TransitionGate {
+        require_regions: vec!["plan".to_string()],
+        ..gate(None, None) // require_modifications: true
+    };
+
+    let wrote_files_only = gate_blocks(
+        Some(&both),
+        &stage,
+        &StageProgress {
+            modifying_tool_calls: 2,
+            ..Default::default()
+        },
+        &gate_window(&["plan"], &[]),
+    );
+    assert!(
+        matches!(wrote_files_only, GateDecision::Block(_)),
+        "files written but the region empty: {wrote_files_only:?}"
+    );
+
+    let wrote_region_only = gate_blocks(
+        Some(&both),
+        &stage,
+        &StageProgress::default(),
+        &gate_window(&["plan"], &["plan"]),
+    );
+    assert!(
+        matches!(wrote_region_only, GateDecision::Block(_)),
+        "region written but no file modifications: {wrote_region_only:?}"
+    );
+
+    let did_both = gate_blocks(
+        Some(&both),
+        &stage,
+        &StageProgress {
+            modifying_tool_calls: 2,
+            ..Default::default()
+        },
+        &gate_window(&["plan"], &["plan"]),
+    );
+    assert!(matches!(did_both, GateDecision::Pass), "{did_both:?}");
+}
+
+/// Giving up on a required region is recorded, not just logged.
+///
+/// A log line cannot be read after the fact, so a run whose agent wrote its
+/// plan and one where we asked twice and moved on both finished `complete` and
+/// nothing downstream could tell them apart (#371).
+#[test]
+fn abandoning_a_required_region_is_recorded_in_the_run() {
+    let mut world = World::new();
+    let capped = world
+        .spawn((
+            required_bp(&["context_write"], None),
+            StageCursor { index: 0 },
+            window_with_plan(false),
+            RequiredReentries(DEFAULT_REQUIRED_REENTRY_CAP),
+            crate::persistence::RunOutcomeFlags::default(),
+            ResolveTransition,
+        ))
+        .id();
+    run_require(&mut world);
+
+    let flags = world
+        .get::<crate::persistence::RunOutcomeFlags>(capped)
+        .expect("flags");
+    assert_eq!(
+        flags.0.required_regions_abandoned,
+        vec!["plan".to_string()],
+        "the abandoned region is named in the run record"
+    );
+    // Still proceeds: this records what happened, it does not strand the run.
+    assert!(world.get::<ResolveTransition>(capped).is_some());
+}
+
+/// A stage that satisfies its required regions records nothing, or the field
+/// would be noise rather than a signal.
+#[test]
+fn meeting_a_required_region_records_nothing() {
+    let mut world = World::new();
+    let met = world
+        .spawn((
+            required_bp(&["context_write"], None),
+            StageCursor { index: 0 },
+            window_with_plan(true),
+            crate::persistence::RunOutcomeFlags::default(),
+            ResolveTransition,
+        ))
+        .id();
+    run_require(&mut world);
+    assert!(
+        world
+            .get::<crate::persistence::RunOutcomeFlags>(met)
+            .expect("flags")
+            .0
+            .required_regions_abandoned
+            .is_empty()
+    );
+}
+
+/// The same region abandoned by two stages is listed once. A run that loops
+/// should not grow the field without bound.
+#[test]
+fn a_region_abandoned_twice_is_listed_once() {
+    let mut world = World::new();
+    let capped = world
+        .spawn((
+            required_bp(&["context_write"], None),
+            StageCursor { index: 0 },
+            window_with_plan(false),
+            RequiredReentries(DEFAULT_REQUIRED_REENTRY_CAP),
+            crate::persistence::RunOutcomeFlags::default(),
+            ResolveTransition,
+        ))
+        .id();
+    run_require(&mut world);
+    run_require(&mut world);
+
+    assert_eq!(
+        world
+            .get::<crate::persistence::RunOutcomeFlags>(capped)
+            .expect("flags")
+            .0
+            .required_regions_abandoned,
+        vec!["plan".to_string()]
     );
 }

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -331,6 +331,48 @@ pub(crate) fn gate_blocks(
             }));
         }
     }
+    // Conjunctive, and checked before `require_modifications` so it holds
+    // whatever else the gate asks for. `gate.region` below is one of several
+    // *alternative* ways to satisfy `require_modifications`, which is why it
+    // cannot express "do not leave without writing this" (#371).
+    let missing: Vec<&str> = gate
+        .require_regions
+        .iter()
+        .filter(|name| {
+            match window.get_region(name) {
+                Some(region) => region.content.is_empty(),
+                // Not held by the window at all. `lev validate` refuses a gate
+                // naming a region no stage declares, so this means a layout
+                // moved underneath the edge; blocking would strand the run over
+                // something no amount of work could satisfy.
+                None => {
+                    tracing::warn!(
+                        stage = %stage.name,
+                        region = %name,
+                        "gate requires a region this stage's window does not hold; \
+                         letting the transition through"
+                    );
+                    false
+                }
+            }
+        })
+        .map(String::as_str)
+        .collect();
+    if !missing.is_empty() {
+        let listed = missing.join(", ");
+        return spend_gate_attempt(
+            gate,
+            stage,
+            progress,
+            gate.message.clone().unwrap_or_else(|| {
+                format!(
+                    "This stage is not finished: the `{listed}` region is still empty. \
+                     Write it with context_write before moving on - later stages read \
+                     from it, and there is nothing there yet."
+                )
+            }),
+        );
+    }
     if !gate.require_modifications {
         return GateDecision::Pass;
     }

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -190,11 +190,43 @@ gate = { require_modifications = true, max_attempts = 3 }
 | Field | Default | Meaning |
 |---|---|---|
 | `require_modifications` | `false` | Require at least one successful file-modifying tool call in the stage being left |
+| `require_regions` | `[]` | Regions that must **all** hold content. ANDed with every other condition here |
 | `require_region_updated` | unset | Require that a named region **changed** during this stage, not merely that it has content. See below |
 | `require_no_open_items` | unset | Name a [checklist region](/docs/context) that must have no open items before this edge is taken |
 | `message` | generated | The nudge shown when the gate blocks |
-| `region` | unset | A region that also satisfies the gate by being non-empty |
+| `region` | unset | An **alternative** way to satisfy `require_modifications`: the gate also passes if this region is non-empty. Not a requirement - see below |
 | `tools` | `[]` | Extra tool names to count as modifying, beyond `write_file` and `edit_file` |
+
+### `region` is an alternative, `require_regions` is a requirement
+
+These two read alike and do opposite things.
+
+`region` is one of several ways to satisfy `require_modifications`, alongside "a file was modified"
+and "a modification was denied by policy". It exists because per-stage counters do not survive a
+daemon restart and a region does, so it is the durable stand-in. It is an **or**:
+
+```toml
+# Passes as soon as the stage writes any file, even with `plan` still empty.
+gate = { require_modifications = true, region = "plan" }
+```
+
+`require_regions` is the conjunction. Every region named must hold content, whatever else the gate
+is satisfied by:
+
+```toml
+# Does not leave until `plan` has been written, full stop.
+gate = { require_regions = ["plan"] }
+
+# And this one wants both: files changed AND the plan written.
+gate = { require_modifications = true, require_regions = ["plan"] }
+```
+
+Like every gate it shares the one `max_attempts` budget, so it re-runs the stage a bounded number of
+times and then lets the edge through with a warning rather than stranding the run. When that
+happens the run records it: `flags.gates_forced` in `meta.json` counts the transitions that went
+through unsatisfied, and `flags.required_regions_abandoned` names any `required = true` region a
+stage gave up on. A run that produced its artifact and one that was asked twice and moved on both
+finish `complete`, and those two fields are how you tell them apart.
 
 ### Requiring a revision, not a repetition
 

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -467,8 +467,24 @@
           "additionalProperties": false,
           "properties": {
             "require_modifications": { "type": "boolean" },
+            "require_regions": {
+              "type": "array",
+              "description": "Regions that must all hold content before this edge may be taken. ANDed with every other condition on the gate, unlike `region`.",
+              "items": { "type": "string" }
+            },
+            "require_region_updated": {
+              "type": "string",
+              "description": "A region that must have changed during this stage, not merely be present. For a revise loop, where re-emitting the same content would satisfy a presence check."
+            },
+            "require_no_open_items": {
+              "type": "string",
+              "description": "A checklist region that must have no open items before this edge is taken."
+            },
             "message": { "type": "string" },
-            "region": { "type": "string" },
+            "region": {
+              "type": "string",
+              "description": "An alternative way to satisfy require_modifications: the gate also passes when this region is non-empty. A restart-durable stand-in for the per-stage counters, not a requirement - use require_regions for that."
+            },
             "tools": { "type": "array", "items": { "type": "string" } },
             "max_attempts": { "type": "integer", "minimum": 1 }
           }


### PR DESCRIPTION
Closes #371.

Your reading of `gate_blocks` is exactly right, including the part about *why*
`region` is an alternative — per-stage counters don't survive a daemon restart
and a region does, so it's the durable stand-in. What was missing is the
conjunction.

```toml
# Before: passes as soon as the stage writes any file, `plan` still empty.
gate = { require_modifications = true, region = "plan" }

# Now: does not leave until `plan` has been written, full stop.
gate = { require_regions = ["plan"] }

# And both, when you want both.
gate = { require_modifications = true, require_regions = ["plan"] }
```

`require_regions` is ANDed with every other condition and shares the one
`max_attempts` budget, so it cannot wedge a run. A region the window does not
hold passes with a warning rather than blocking — `lev validate` refuses a gate
naming a region no stage declares, so reaching that means a layout moved
underneath the edge, and stranding a run over it would be worse than the missing
check.

There's a test that asserts the *old* shape still passes on any write, next to
one asserting the new one doesn't, so the difference between them is pinned
rather than described.

## The second half is the one that made this expensive to find

The required-region mechanism gives up after its budget with a `tracing::warn!`
and nothing else. So a run whose agent wrote its plan and one where it was asked
twice and moved on both finish `complete`, with nothing to tell them apart —
which is what you describe going unnoticed across four rounds.

`flags.required_regions_abandoned` now names them.

One correction worth making: **`flags.gates_forced` already exists** and counts
transitions that went through unsatisfied. That half of your ask was already
there; it's the required-region path that recorded nothing.

## Measured against a real daemon

A `plan` stage gated on `require_regions = ["plan"]`, driven by a model that
never writes the region:

```
plan     complete   60 prompt tokens     <- re-run, not transitioned
answer   complete   10 prompt tokens
gates_forced: 1
```

The same stage with `plan` declared `required = true` and no gate:

```
status: complete
required_regions_abandoned: ['plan']
```

**My first attempt at that measurement was wrong**, and it's worth recording:
the stage had `max_iterations = 4`, so it hit its iteration cap before the gate
could spend its budget, and `gates_forced` read `0` while the stage looked like
it had been held. The iteration cap and the gate budget are different clocks,
and a fixture that conflates them measures the wrong one.

## Also fixed while here

The published `blueprint.schema.json` was missing `require_region_updated` and
`require_no_open_items` as well — real keys absent from the schema is the same
class of problem, so all three are in now.

## Verification

- `cargo test --workspace` — 0 failures
- `cargo xtask coverage` — `leviath-core` and `leviath-runtime` both exit 0
- live: both mechanisms driven end to end on a real daemon, flags read back from
  `meta.json`
- tests cover the OR-vs-AND difference, all-regions-not-just-the-first, the
  shared budget, a region the window lacks, the interaction with
  `require_modifications`, and the dedup on the abandoned list
