### PR TITLE
fix(context): a region can refuse to be paraphrased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,22 @@ same list.
   and one where it was asked twice and moved on both finished `complete` with
   nothing to tell them apart. Its counterpart `flags.gates_forced` already
   counted forced transitions.
+- New: `summarizable = false` on a region keeps an edge `transform = "compact"`
+  from handing it to the summarizer (#369). A bare `compact` reads as
+  "summarize the transcript on the way out" and means "summarize every region
+  that is not pinned", which includes the ones holding the run's results -
+  figures that survive a paraphrase are no longer figures. The flag protects a
+  region wherever it is used rather than at each of the N edges that might touch
+  it, and it wins over an explicit `compact` list, saying so when it refuses
+  one. `clear` is unaffected: this says "do not paraphrase my content", not
+  "keep it forever".
+- New: `lev validate` warns when a bare `compact` edge would summarize a region
+  declared `required` - the closest thing a blueprint has to "this is a
+  deliverable" - and names the flag that fixes it.
+- Changed: an edge compaction that does not happen says why. It was dropped
+  silently when the compaction provider was not registered or the pool had no
+  permit, so a declared transform was advisory: the same blueprint corrupted its
+  results only when a permit happened to be free, with no signal either way.
 
 - Breaking: a blueprint value that is not one of the spellings a setting
   accepts is refused, naming what is valid. Four settings took anything and

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -530,3 +530,68 @@ pub(super) fn lint_models(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lin
 
     findings
 }
+
+/// A bare `compact` edge that would summarize a region holding a deliverable.
+///
+/// `transform = "compact"` reads as "summarize the transcript on the way out"
+/// and means "summarize every region that is not pinned", which includes the
+/// ones holding the run's results. Figures that survive a paraphrase are no
+/// longer figures, and nothing about the blueprint is malformed, so the only
+/// place to say so is here (#369).
+///
+/// Scoped to regions declared `required` rather than every region a bare
+/// compact touches. `required` is the author saying "a stage must populate
+/// this", which is the closest thing a blueprint has to "this is a
+/// deliverable" - warning on all of them would fire on every agent that ever
+/// wrote `transform = "compact"` and teach people to ignore it.
+pub(super) fn lint_compacted_deliverables(blueprint: &Blueprint) -> Vec<LintFinding> {
+    use leviath_core::blueprint::EdgeTransform;
+
+    // Named once per region, however many edges would summarize it: the fix is
+    // on the region, so repeating it per edge is noise.
+    let mut at_risk: Vec<&str> = Vec::new();
+    for stage in &blueprint.stages {
+        let layout = stage
+            .context_layout
+            .as_ref()
+            .unwrap_or(&blueprint.context_layout);
+        let bare_compact = stage
+            .transitions
+            .iter()
+            .flat_map(|edges| edges.values())
+            .any(|e| matches!(e.transform, EdgeTransform::Compact { .. }));
+        if !bare_compact {
+            continue;
+        }
+        for region in &layout.regions {
+            if region.required
+                && region.summarizable
+                && leviath_runtime::is_stage_specific(&region.kind)
+                && !at_risk.contains(&region.name.as_str())
+            {
+                at_risk.push(region.name.as_str());
+            }
+        }
+    }
+
+    at_risk
+        .into_iter()
+        .map(|region| {
+            LintFinding::new(
+                LintSeverity::Warning,
+                "compact-summarizes-deliverable",
+                format!(
+                    "region '{region}' is declared required - a stage must populate it - \
+                     and a `transform = \"compact\"` edge would hand it to the summarizer \
+                     on the way out, so whatever the stage wrote reaches later stages \
+                     paraphrased"
+                ),
+            )
+            .with_fix(format!(
+                "add summarizable = false to [context.regions] {region} if its content \
+                 does not survive a rewrite, or name the regions to summarize with \
+                 transform = \"custom\""
+            ))
+        })
+        .collect()
+}

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -271,6 +271,7 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
     findings.extend(lint_graph(blueprint));
     findings.extend(lint_output_reachable(blueprint));
     findings.extend(lint_dead_end_possible(blueprint));
+    findings.extend(lint_compacted_deliverables(blueprint));
 
     let agent_permissions = blueprint.agent_tool_permissions();
 

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -1697,3 +1697,130 @@ fn requiring_an_output_without_the_submit_tool_is_an_error() {
     assert_eq!(missing.len(), 1, "{:?}", codes(&findings));
     assert_eq!(missing[0].severity, LintSeverity::Error);
 }
+
+// ─── compact-summarizes-deliverable (#369) ───────────────────────────────────
+
+/// The reported shape: a `required` region and a bare `compact` edge, which
+/// together mean the stage's own deliverable is paraphrased on the way out.
+#[test]
+fn a_bare_compact_over_a_required_region_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.verify]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+[stages.verify.transitions.answer]
+transform = "compact"
+
+[stages.answer]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    )
+    .replace(
+        "conversation = { kind = \"sliding_window\", max_items = 50, max_tokens = 10000 }",
+        "conversation = { kind = \"sliding_window\", max_items = 50, max_tokens = 10000 }\n\
+         results = { kind = \"sliding_window\", max_items = 20, max_tokens = 8000, required = true }",
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    let found = with_code(&findings, "compact-summarizes-deliverable");
+    assert_eq!(found.len(), 1, "{:?}", codes(&findings));
+    assert!(found[0].message.contains("results"), "{}", found[0].message);
+}
+
+/// Silenced by the flag that fixes it, or the warning would be advice nobody
+/// can act on.
+#[test]
+fn a_region_declared_not_summarizable_is_not_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.verify]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+[stages.verify.transitions.answer]
+transform = "compact"
+
+[stages.answer]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    )
+    .replace(
+        "conversation = { kind = \"sliding_window\", max_items = 50, max_tokens = 10000 }",
+        "conversation = { kind = \"sliding_window\", max_items = 50, max_tokens = 10000 }\n\
+         results = { kind = \"sliding_window\", max_items = 20, max_tokens = 8000, required = true, summarizable = false }",
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(
+        with_code(&findings, "compact-summarizes-deliverable").is_empty(),
+        "{:?}",
+        codes(&findings)
+    );
+}
+
+/// A pinned region is never handed to the summarizer in the first place, so
+/// warning about one would be noise.
+#[test]
+fn a_pinned_required_region_is_not_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.verify]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+[stages.verify.transitions.answer]
+transform = "compact"
+
+[stages.answer]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    )
+    .replace(
+        "system = { kind = \"pinned\", max_tokens = 1000 }",
+        "system = { kind = \"pinned\", max_tokens = 1000, required = true }",
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(
+        with_code(&findings, "compact-summarizes-deliverable").is_empty(),
+        "{:?}",
+        codes(&findings)
+    );
+}
+
+/// No compact edge, nothing to say - so the check is about the pairing rather
+/// than about declaring a required region at all.
+#[test]
+fn a_required_region_with_no_compact_edge_is_not_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.verify]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+[stages.verify.transitions.answer]
+transform = "direct"
+
+[stages.answer]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    )
+    .replace(
+        "conversation = { kind = \"sliding_window\", max_items = 50, max_tokens = 10000 }",
+        "conversation = { kind = \"sliding_window\", max_items = 50, max_tokens = 10000 }\n\
+         results = { kind = \"sliding_window\", max_items = 20, max_tokens = 8000, required = true }",
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(
+        with_code(&findings, "compact-summarizes-deliverable").is_empty(),
+        "{:?}",
+        codes(&findings)
+    );
+}

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -30,6 +30,11 @@ use serde::{Deserialize, Serialize};
 /// exactly, so this costs no existing agent anything.
 pub const STAGE_INSTRUCTIONS_REGION: &str = "stage_instructions";
 
+/// Serde default for a flag that is on unless a blueprint turns it off.
+fn default_true() -> bool {
+    true
+}
+
 /// How a region's token ceiling is expressed before it is resolved against a
 /// concrete model context window.
 ///
@@ -502,6 +507,21 @@ pub struct RegionDefinition {
     #[serde(default)]
     pub required: bool,
 
+    /// Whether an edge transform may hand this region to the summarizer.
+    ///
+    /// `transform = "compact"` reads as "summarize the transcript on the way
+    /// out" and means "summarize every region that is not pinned", which
+    /// includes the ones holding the run's results. Figures that survive a
+    /// paraphrase are no longer figures: a `results` region carrying computed
+    /// values was rewritten into prose before the stage that reports them saw
+    /// it (#369).
+    ///
+    /// Setting this false protects the region wherever it is used, rather than
+    /// at each of the N edges that might touch it. `clear` still applies - this
+    /// says "do not paraphrase my content", not "keep it forever".
+    #[serde(default = "default_true")]
+    pub summarizable: bool,
+
     /// Optional custom message shown to the agent when this region is required
     /// but empty. Falls back to a generated default when `None`.
     #[serde(default)]
@@ -531,6 +551,7 @@ impl RegionDefinition {
             description: None,
             required: false,
             required_message: None,
+            summarizable: true,
             seed: None,
         }
     }

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -202,6 +202,13 @@ pub(super) fn parse_region_layout(
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
 
+        // Default on: a region is summarizable unless its author says the
+        // content does not survive a paraphrase.
+        let summarizable = region_value
+            .get("summarizable")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(true);
+
         let seed = parse_region_seed(region_name, region_value.get("seed"));
 
         // Percentage regions contribute their (unknown) size at resolution, so
@@ -213,6 +220,7 @@ pub(super) fn parse_region_layout(
         let mut def = RegionDefinition::new(region_name.clone(), kind, provisional_max_tokens)
             .with_budget(budget)
             .with_required(required, required_message);
+        def.summarizable = summarizable;
         if let Some(f) = compact_at_field {
             def = def.with_compact_at(f);
         }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -4735,3 +4735,48 @@ read_file = "codebase"
     bp.validate()
         .expect("routing into a declared region is fine");
 }
+
+// ─── Regions an edge transform must not paraphrase (#369) ────────────────────
+
+/// `summarizable = false` parses, and the default is on.
+///
+/// A region is summarizable unless its author says the content does not survive
+/// a paraphrase, so the flag has to be readable and its absence has to mean
+/// "yes" - a default of false would quietly stop `compact` doing the thing it
+/// is for.
+#[test]
+fn parse_manifest_reads_the_summarizable_flag() {
+    let toml = r#"
+[agent]
+name = "figures"
+
+[context.regions]
+results = { kind = "sliding_window", max_items = 20, summarizable = false }
+notes = { kind = "sliding_window", max_items = 20 }
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let region = |name: &str| {
+        bp.context_layout
+            .regions
+            .iter()
+            .find(|r| r.name == name)
+            .unwrap_or_else(|| panic!("{name} declared"))
+    };
+    assert!(!region("results").summarizable, "the flag is read");
+    assert!(region("notes").summarizable, "and defaults to on");
+}
+
+/// A region definition written before this field existed deserializes as
+/// summarizable, so an archived layout does not come back protected by
+/// accident - or, worse, unprotected when it was not.
+#[test]
+fn a_region_definition_without_the_field_deserializes_as_summarizable() {
+    let json = serde_json::json!({
+        "name": "notes",
+        "kind": "Temporary",
+        "max_tokens": 1000,
+    });
+    let def: crate::layout::RegionDefinition =
+        serde_json::from_value(json).expect("an older definition still loads");
+    assert!(def.summarizable);
+}

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -448,6 +448,19 @@ pub struct Region {
     /// performs the compaction externally (requires an LLM call).
     #[serde(default)]
     pub needs_message_compaction: bool,
+
+    /// Whether an edge transform may hand this region to the summarizer.
+    ///
+    /// Carried from the region's declaration so the transform can consult it
+    /// without the layout: `transform = "compact"` summarizes by region *kind*,
+    /// and kind cannot tell a transcript from a table of results (#369).
+    #[serde(default = "crate::region::default_true")]
+    pub summarizable: bool,
+}
+
+/// Serde default for a flag that is on unless a blueprint turns it off.
+pub(crate) fn default_true() -> bool {
+    true
 }
 
 impl Region {
@@ -462,6 +475,7 @@ impl Region {
             schema: None,
             taint: None,
             needs_message_compaction: false,
+            summarizable: true,
         }
     }
 

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -25,11 +25,12 @@ pub fn init_window_seeded(
     seeds: &HashMap<String, String>,
 ) {
     for region_def in &blueprint.context_layout.regions {
-        let region = Region::new(
+        let mut region = Region::new(
             region_def.name.clone(),
             region_def.kind.clone(),
             region_def.max_tokens,
         );
+        region.summarizable = region_def.summarizable;
         window.add_region(region);
     }
 
@@ -160,6 +161,7 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
             region_def.kind.clone(),
             region_def.max_tokens,
         );
+        new_region.summarizable = region_def.summarizable;
 
         if let Some(existing) = window.get_region(&region_def.name) {
             // Carry entries verbatim - kind, metadata, key, timestamp survive
@@ -216,6 +218,7 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
             existing.kind.clone(),
             existing.max_tokens,
         );
+        carried.summarizable = existing.summarizable;
         // Verbatim, exactly as above: these are the regions whose typed turns
         // a rebuild would flatten.
         for entry in &existing.content {

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -112,7 +112,7 @@ pub use host::{ControlOp, SpawnArgs, WorldEvent, WorldHost};
 pub use inference_bridge::RetryPolicy;
 pub use inference_pool::{InferencePoolConfig, InferencePools};
 pub use interaction_hub::InteractionHub;
-pub use pipeline::{ModelDefaults, ResolvedStage, ToolService};
+pub use pipeline::{ModelDefaults, ResolvedStage, ToolService, is_stage_specific};
 pub use provider_creds::{ProviderCreds, build_provider_registry};
 pub use providers::ProviderRegistry;
 pub use taint::TaintGate;

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -242,7 +242,7 @@ pub struct PendingEdgeCompact(pub Vec<String>);
 /// Whether a region kind is "stage-specific" - eligible for an edge transform to
 /// clear or compact. The always-preserved kinds (pinned identity, compaction
 /// history, hashmap stores, persistent custom regions) are never touched.
-pub(crate) fn is_stage_specific(kind: &leviath_core::RegionKind) -> bool {
+pub fn is_stage_specific(kind: &leviath_core::RegionKind) -> bool {
     !matches!(
         kind,
         leviath_core::RegionKind::Pinned
@@ -276,10 +276,13 @@ pub(crate) fn apply_edge_transform(
             window.current_tokens = window.calculate_tokens();
             Vec::new()
         }
+        // Kind cannot tell a transcript from a table of results, so a region
+        // whose author said its content does not survive a paraphrase is left
+        // alone however the edge is spelled (#369).
         EdgeTransform::Compact { .. } => window
             .regions
             .iter()
-            .filter(|r| is_stage_specific(&r.kind) && !r.content.is_empty())
+            .filter(|r| is_stage_specific(&r.kind) && r.summarizable && !r.content.is_empty())
             .map(|r| r.name.clone())
             .collect(),
         EdgeTransform::Custom {
@@ -301,7 +304,25 @@ pub(crate) fn apply_edge_transform(
             compact
                 .iter()
                 .filter(|n| !carry.contains(n))
-                .filter(|n| window.get_region(n).is_some_and(|r| !r.content.is_empty()))
+                .filter(|n| {
+                    // The region-level flag wins over an explicit list: it is
+                    // there so a deliverable is protected wherever it is used,
+                    // rather than at each of the N edges that might touch it.
+                    // Said out loud, because refusing an explicit instruction
+                    // silently is the thing this issue is about.
+                    match window.get_region(n) {
+                        Some(r) if !r.summarizable => {
+                            tracing::warn!(
+                                region = %n,
+                                "edge asks to compact a region declared \
+                                 summarizable = false; leaving it as written"
+                            );
+                            false
+                        }
+                        Some(r) => !r.content.is_empty(),
+                        None => false,
+                    }
+                })
                 .cloned()
                 .collect()
         }
@@ -338,12 +359,33 @@ pub fn dispatch_edge_compact(
         if state.status != AgentStatus::Active {
             continue; // paused / waiting / cancelled - don't start new work
         }
+        // Each way this can decline says which one it was. A declared
+        // transform that quietly does nothing is a transform that behaves
+        // differently on different runs of the same blueprint, with no signal
+        // either way - and the un-compacted run looks identical to a compacted
+        // one from outside (#369).
         let started = settings
             .and_then(|s| {
                 let config = &s.0;
                 let requests = build_edge_compact_requests(window, &pending.0, config)?;
-                let provider = providers.0.get(&config.provider)?;
-                let permit = stage.pools.try_acquire(&config.model)?;
+                let Some(provider) = providers.0.get(&config.provider) else {
+                    tracing::warn!(
+                        provider = %config.provider,
+                        regions = ?pending.0,
+                        "edge transform asked to compact, but its compaction provider is \
+                         not registered; carrying the regions as written"
+                    );
+                    return None;
+                };
+                let Some(permit) = stage.pools.try_acquire(&config.model) else {
+                    tracing::warn!(
+                        model = %config.model,
+                        regions = ?pending.0,
+                        "edge transform asked to compact, but the compaction pool is full; \
+                         carrying the regions as written"
+                    );
+                    return None;
+                };
                 spawn_supervised_compaction(
                     &stage,
                     entity,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -13376,3 +13376,110 @@ fn a_region_abandoned_twice_is_listed_once() {
         vec!["plan".to_string()]
     );
 }
+
+// ─── A deliverable region survives a bare compact (#369) ─────────────────────
+
+/// A window with a transcript and a results region, both non-pinned.
+fn compact_window(results_summarizable: bool) -> ContextWindow {
+    let mut window = ContextWindow::new(100_000);
+    let mut conversation = leviath_core::Region::new(
+        "conversation".to_string(),
+        leviath_core::RegionKind::SlidingWindow {
+            max_items: 50,
+            eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+        },
+        50_000,
+    );
+    conversation.summarizable = true;
+    window.add_region(conversation);
+
+    let mut results = leviath_core::Region::new(
+        "results".to_string(),
+        leviath_core::RegionKind::SlidingWindow {
+            max_items: 50,
+            eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+        },
+        20_000,
+    );
+    results.summarizable = results_summarizable;
+    window.add_region(results);
+
+    window
+        .add_to_region("conversation", "chatter".to_string(), 2)
+        .expect("fits");
+    window
+        .add_to_region("results", "fee = 12.375%".to_string(), 4)
+        .expect("fits");
+    window
+}
+
+fn bare_compact() -> leviath_core::blueprint::EdgeTransform {
+    leviath_core::blueprint::EdgeTransform::Compact { prompt: None }
+}
+
+/// The bug: a bare `compact` hands every non-pinned region to the summarizer,
+/// including the one holding the run's figures. Figures that survive a
+/// paraphrase are no longer figures.
+#[test]
+fn a_bare_compact_summarizes_a_results_region_by_default() {
+    let mut window = compact_window(true);
+    let to_compact = apply_edge_transform(&mut window, &bare_compact());
+    assert!(
+        to_compact.contains(&"results".to_string()),
+        "unchanged default: {to_compact:?}"
+    );
+}
+
+/// Declaring the region not-summarizable protects it, and leaves the
+/// transcript - the thing `compact` is actually for - still summarized.
+#[test]
+fn a_region_declared_not_summarizable_is_left_alone() {
+    let mut window = compact_window(false);
+    let to_compact = apply_edge_transform(&mut window, &bare_compact());
+    assert!(
+        !to_compact.contains(&"results".to_string()),
+        "the deliverable must not be paraphrased: {to_compact:?}"
+    );
+    assert!(
+        to_compact.contains(&"conversation".to_string()),
+        "and the transcript still is: {to_compact:?}"
+    );
+}
+
+/// The region-level flag wins over an edge that names it explicitly: it exists
+/// so a deliverable is protected wherever it is used, rather than at each of
+/// the N edges that might touch it.
+#[test]
+fn a_custom_compact_list_cannot_override_the_region_flag() {
+    let _guard = leviath_testkit::tracing_guard();
+    let mut window = compact_window(false);
+    let custom = leviath_core::blueprint::EdgeTransform::Custom {
+        carry: Vec::new(),
+        compact: vec!["results".to_string(), "conversation".to_string()],
+        clear: Vec::new(),
+        compact_prompt: None,
+    };
+    let to_compact = apply_edge_transform(&mut window, &custom);
+    assert_eq!(
+        to_compact,
+        vec!["conversation".to_string()],
+        "the named-but-protected region is refused, the other still compacts"
+    );
+}
+
+/// `clear` is a different question from `compact`: the flag says "do not
+/// paraphrase my content", not "keep it forever".
+#[test]
+fn not_summarizable_does_not_protect_a_region_from_clear() {
+    let mut window = compact_window(false);
+    let cleared = apply_edge_transform(&mut window, &leviath_core::blueprint::EdgeTransform::Clear);
+    assert!(cleared.is_empty(), "clear compacts nothing");
+    assert!(
+        window
+            .get_region("results")
+            .expect("region")
+            .content
+            .is_empty(),
+        "clear still clears it"
+    );
+}

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -143,6 +143,7 @@ on the first attempt, which looks exactly like a stage that finished its work.
 | `min_tokens` | unset | A floor for a percentage budget, so the region stays usable on a small model |
 | `seed` | unset | What the region starts with. See below |
 | `required` | `false` | The stage re-runs rather than moving on while this region is empty |
+| `summarizable` | `true` | Set false to keep an edge `transform = "compact"` from paraphrasing this region. See [transforms](/docs/stages#carrying-context-across-an-edge) |
 | `required_message` | generated | What the model is told when a required region is empty. Supports `{region}` |
 
 **Resolved budget** is the phrase used for the number a region actually gets, once the percentage

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -159,7 +159,19 @@ transform = "compact"        # direct | clear | compact | summarize | custom
 - `direct` is the default and carries everything as-is.
 - `clear` drops stage-specific regions and keeps pinned ones.
 - `compact`, and its alias `summarize`, sends the stage's content through a summarization pass
-  before the next stage starts.
+  before the next stage starts. **It summarizes every region that is not pinned**, not just the
+  transcript - including the ones holding your results. A region whose content does not survive a
+  rewrite should say so:
+
+  ```toml
+  [context.regions]
+  results = { kind = "sliding_window", budget = "20%", summarizable = false }
+  ```
+
+  That protects it wherever it is used, rather than at each of the edges that might touch it, and it
+  wins over an explicit `compact` list. `lev validate` warns when a bare `compact` edge would
+  summarize a region declared `required`, which is the closest thing a blueprint has to "this is a
+  deliverable".
 - `custom` takes a `transform_config` that names regions one at a time:
 
 ```toml

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -371,6 +371,7 @@
         "max_tokens": { "type": "integer", "minimum": 1, "default": 5000 },
         "min_tokens": { "type": "integer", "minimum": 0 },
         "required": { "type": "boolean", "default": false },
+          "summarizable": { "type": "boolean", "default": true, "description": "Set false to keep an edge transform = \"compact\" from handing this region to the summarizer. Protects the region wherever it is used, and wins over an explicit compact list." },
         "required_message": {
           "type": "string",
           "description": "Shown when a required region is empty. `{region}` interpolates."


### PR DESCRIPTION
Closes #369.

`transform = "compact"` decides what to summarize by region **kind**, and kind
cannot tell a transcript from a table of results. So a `sliding_window` holding
the run's figures gets summarized, and so does a `compacting` region holding the
scripts that produced them. Figures that survive a paraphrase are no longer
figures.

Three of your four suggestions are here. The fourth is a default change and I
want your call on it — see the end.

## 1. A region can refuse to be paraphrased

```toml
[context.regions]
results = { kind = "sliding_window", budget = "20%", summarizable = false }
```

Protects the region **wherever it is used**, rather than at each of the N edges
that might touch it — which is the shape of the problem you described. It also
wins over an edge that names the region in an explicit `compact` list, and says
so when it refuses one: declining an explicit instruction in silence is the
thing this issue is about.

`clear` is untouched. The flag says "do not paraphrase my content", not "keep it
forever", and there's a test pinning that distinction.

## 2. `lev validate` warns

```
WARN region 'results' is declared required - a stage must populate it - and a
     `transform = "compact"` edge would hand it to the summarizer on the way
     out, so whatever the stage wrote reaches later stages paraphrased
     [compact-summarizes-deliverable]
     add summarizable = false to [context.regions] results if its content does
     not survive a rewrite, or name the regions to summarize with
     transform = "custom"
```

Scoped to regions declared `required` rather than every region a bare compact
touches. `required` is the author saying "a stage must populate this", which is
the closest thing a blueprint has to "this is a deliverable"; warning on all of
them would fire on every agent that ever wrote `transform = "compact"` and teach
people to ignore it. Adding the flag silences it — verified both ways through
the real CLI.

## 3. A compaction that doesn't happen says why

This is the part that explains your 20 runs with no compaction event and every
region raw. `dispatch_edge_compact` dropped the request silently when the
compaction provider wasn't registered or the pool had no permit, so a declared
transform was advisory — the same blueprint corrupted its results only when a
permit happened to be free, with no signal either way. Both now warn, naming the
regions that were carried as written.

I did not make it *fail* the run. A compaction that can't get a permit is
transient and failing the run over it trades a quiet wrong answer for a loud
lost one; the warning makes it visible, which is what the loaded-gun problem
needed.

## 4. The default — your call

You suggested bare `compact` should mean `compact = ["conversation"]`. I agree
that's the right end state and I have **not** done it here, because it changes
what every existing blueprint does and the cost lands on runs nobody is
watching. Concretely, narrowing it means regions that were being summarized are
now carried verbatim: safer for correctness, and a context/token increase for
agents that were relying on the wide behaviour to stay under budget.

Say the word and it's a small follow-up — the machinery is all here. I'd ship it
as an explicitly breaking change with the changelog entry spelling out the
migration (`transform = "custom"` with an explicit `compact` list restores the
old scope).

## Verification

- `cargo test --workspace` — 0 failures
- `cargo xtask coverage` — `leviath-core`, `leviath-runtime`, `leviath-cli` all exit 0
- live: the lint fires on your shape and goes quiet with the flag
- tests cover the unchanged default, the opt-out, the explicit-list override,
  and that `clear` still clears
