### PR TITLE
docs: overview page, honest framing, better diagrams

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -91,12 +91,11 @@ whole bar. These rules exist because the docs drifted away from it once already.
 
 ## Tone rules
 
-We sell Leviath on what it does well, not on what other tools do badly. Someone who uses Gas City,
-OpenHands, Claude Code, CrewAI, or LangGraph should finish a page here feeling their tool got more
-useful, not that it got insulted.
+These pages describe what Leviath does well, not what other tools do badly. Someone who uses Gas
+City, OpenHands, Claude Code, CrewAI, or LangGraph should finish a page here feeling their tool got
+more useful, not that it got insulted.
 
-1. **Describe, do not rate.** Say what a tool does and where it sits. The comparison page's own
-   line says it best: it compares models, not merit.
+1. **Describe, do not rate.** Say what a tool does and where it sits. Compare models, not merit.
 2. **Every claim about another project comes from that project's docs**, and links them. If we
    cannot source it upstream, it does not ship.
 3. **No strawman openers.** Rule 1 above says open with the problem, and the lazy way to do that is
@@ -106,9 +105,11 @@ useful, not that it got insulted.
 4. **Different bets, not better bets.** Where designs differ, say what each one buys and what it
    costs. A process per agent buys real isolation and a blast radius of one. A shared world buys
    density and pooled rate limits, and gives up that isolation. Say both halves.
-5. **Name our own weaknesses first.** The "why you might not want Leviath" material and the rows we
-   do not pass on the 12-factor scorecard stay, and stay prominent. That honesty is what makes the
-   rest of the page worth believing.
+5. **Name our own weaknesses first.** The "when to use something else" material and any row we do
+   not pass on the 12-factor scorecard stay, and stay prominent. Say it because a reader deciding
+   between tools deserves it, not as a device to sound credible. Never write a sentence that points
+   at our own honesty; state the limit and move on. If a limit is being worked on, say so and link
+   the issue.
 6. **Integration pages exist to make the other tool work better.** Including saying plainly when
    Leviath is the wrong choice for a job.
 7. **No dismissive vocabulary.** Not "just", "merely", "naive", "toy", "the old way", "unlike X",

--- a/docs/content/agent-client-protocol.md
+++ b/docs/content/agent-client-protocol.md
@@ -15,11 +15,6 @@ child process and talks to it over that process's stdin and stdout.
 `lev agent-client` is Leviath speaking it. The host sends protocol messages, and the command turns
 those into runs on the shared-world [daemon](/docs/daemon), streaming output back as it happens.
 
-> [!NOTE]
-> **Before this page:** [Agent blueprints](/docs/agents).
-> **In one line:** the host launches `lev agent-client`, sends prompts as JSON on stdin, and reads
-> results as JSON on stdout.
-
 > [!WARNING]
 > "ACP" means two unrelated things, so Leviath never writes it unqualified. This is the Agent
 > **Client** Protocol, JSON-RPC over stdio. It is not the Agent *Communication* Protocol, a REST

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -3,19 +3,14 @@ title: Agent blueprints
 description: The agent.leviath blueprint format: the TOML defining an agent's stages, models, tools, and context layout.
 group: Concepts
 group_order: 2
-order: 3
+order: 4
 ---
 
 # Agent blueprints (`agent.leviath`)
 
 An agent is a directory with an `agent.leviath` file, a TOML **blueprint** describing a
-multi-stage [workflow graph](/docs/stages).
-
-> [!NOTE]
-> **Before this page:** [Getting Started](/docs/getting-started). The
-> [agent catalog](/docs/agent-catalog) shows ten complete blueprints worth stealing from.
-> **In one line:** stages, each with its own model and tools, joined by transitions, over a shared
-> context layout.
+multi-stage [workflow graph](/docs/stages). The [agent catalog](/docs/agent-catalog) has ten
+complete ones worth stealing from.
 
 Start from a scaffold rather than a blank file:
 

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -140,7 +140,7 @@ it is how you say you meant it. See
 
 ## Context regions
 
-`[context.regions]` defines the memory layout. There are eight region kinds (the default is
+`[context.regions]` defines the memory layout. There are nine region kinds (the default is
 `temporary`); see [Structured context](/docs/context) for what each one does. Budgets come in
 three forms:
 

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -117,9 +117,9 @@ lev serve --host 0.0.0.0 --tls-cert cert.pem --tls-key key.pem --cors https://le
 ```
 
 Then **open `https://192.168.1.50:3000/` in a browser tab and accept the warning.** That is what the
-unauthenticated `GET /` page is for: the console's requests are subresource `fetch` calls, which get
+unauthenticated `GET /` page is for: The Lair's requests are subresource `fetch` calls, which get
 no interstitial to click through, so the exception has to be established in a tab first. Afterwards
-the console works.
+The Lair works.
 
 Chrome discards accepted exceptions when the browser restarts, so this comes back. Firefox keeps
 them. iOS Safari is unreliable about it.
@@ -132,7 +132,7 @@ Nothing to install on either end, and it puts you back inside the loopback exemp
 ssh -N -L 3000:127.0.0.1:3000 you@that-machine
 ```
 
-Then point the console at `http://127.0.0.1:3000`. Leave Leviath on its default `127.0.0.1` bind for
+Then point The Lair at `http://127.0.0.1:3000`. Leave Leviath on its default `127.0.0.1` bind for
 this - `--host 0.0.0.0` is not wanted and only widens the exposure.
 
 ## Auth flow
@@ -207,7 +207,7 @@ repeated. To poll for what changed, use `since=` with no cursor rather than deep
 `server_time` and you may see one item twice, which is the safe direction when the granularity is
 whole seconds.
 
-Two parameters exist so a console does not have to make N requests: `ids=a,b,c` fetches exactly
+Two parameters exist so a browser client does not have to make N requests: `ids=a,b,c` fetches exactly
 those runs, and `fields=run_id,status,title` trims each one. Ids that no longer exist come back in
 `missing` rather than failing the request.
 
@@ -233,7 +233,7 @@ to null, because a count taken from a partial scan would be rendered as fact.
 
 Matching items carry `highlights` saying *why* they matched: the field, a snippet, and the stage
 where there is one, which you can pass straight to `/logs?stage=`. This is the part that cannot be
-done in the browser, because the console never holds a run's transcript.
+done in the browser, because The Lair never holds a run's transcript.
 
 One honest limit: the deep sources match the raw JSON on disk, so a query containing a quote,
 a backslash or a newline may not match text that does contain it.

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -130,8 +130,8 @@ and where. The number shown is the largest each region reached while the stage w
 region is re-sent whole on every call.
 
 Leviath also warns once when a stage's per-call prompt grows past four times its first call. That
-is the shape of a region accumulating without a cap, which is the failure that costs money and the
-one nothing used to notice.
+is the shape of a region accumulating without a cap, which is the failure that costs money and
+the hardest one to spot by eye.
 
 ### `lev create <NAME>`
 

--- a/docs/content/comparison.md
+++ b/docs/content/comparison.md
@@ -11,13 +11,9 @@ order: 3
 People arrive at Leviath already using something else, and the useful question is usually not "which
 of these is best" but "what job does each of these do, and do I need more than one".
 
-So this page is about layers, not scores. Several of the tools below are worth running *alongside*
-Leviath rather than instead of it.
-
-> [!NOTE]
-> **Before this page:** nothing.
-> **In one line:** a coding agent, an orchestrator, a framework, and a runtime are four different
-> jobs, and Leviath is the runtime.
+A coding agent, an orchestrator, a framework, and a runtime are four different jobs. Leviath is the
+runtime. So this page is about layers, not scores, and several of the tools below are worth running
+*alongside* Leviath rather than instead of it.
 
 ## Four different jobs
 
@@ -57,20 +53,23 @@ description comes from that project's own documentation.
 | **Expects on the machine** | One native binary | A native CLI; the SDKs want Node 18+ or Python 3.10+ | Python 3.10-3.13 | A Python or Node runtime |
 | **Headless surface** | REST, WebSocket, [ACP](/docs/agent-client-protocol) over stdio | `claude -p`, plus the SDKs | `kickoff()` in-process, REST via AMP | Library calls, REST via LangSmith |
 | **Human in the loop** | Mid-run messages, interaction points, ask-user tools | Interactive steering and permission prompts | `human_input` pauses a task | `interrupt()` pauses and resumes |
-| **Isolation** | Per-agent state, workdir, and policy; opt-in containers or namespaces for shell | Opt-in OS sandbox for shell | External sandbox services | Sandbox backends via Deep Agents |
+| **Isolation** | Per-agent state, workdir, and policy; opt-in containers or namespaces for shell (widening) | Opt-in OS sandbox for shell | External sandbox services | Sandbox backends via Deep Agents |
 | **Hosted option** | None | Managed Agents | CrewAI AMP | LangSmith Deployment |
 
-## When to reach for the other one
+## When to use something else
 
-Naming what Leviath is not for is what makes the rest of this page worth believing.
+We would rather you pick the right tool than pick ours, so here is where Leviath is the wrong
+answer and what to reach for instead.
 
 **Use a coding agent like Claude Code or Codex** when you want to sit down and work with something
 polished and interactive. They are better at that than Leviath is, and it is not close. Leviath can
 even run *on top of* Claude Code as a transport, so this is not either/or.
 
 **Use CrewAI or LangGraph** when your orchestration already lives in Python or TypeScript and you
-want the workflow expressed in code, with your own types and your own tests around it. A separate
-runtime configured in TOML is friction you do not need.
+want the workflow expressed in code, with your own types and your own tests around it. A Leviath
+agent is a TOML blueprint plus optional Rhai script tools, so if you want agent logic in a general
+language against an SDK, that model is not here. Other languages drive Leviath through the
+[REST API](/docs/api) instead.
 
 **Use [Gas City](/docs/gas-city) (an orchestration-builder SDK from the
 [Gas Town Hall](https://gastownhall.ai/) project) or [OpenHands](https://docs.all-hands.dev/)**
@@ -78,34 +77,30 @@ when the hard problem is coordinating work across issues, repos, and people. Tha
 inside one agent, and Leviath does not try to solve it. Run Leviath underneath one of them if you
 want both.
 
+**Use a hosted platform** if you want somebody else operating it. You run the Leviath daemon
+yourself. [`lev serve`](/docs/api) and [The Lair](https://leviath.dev/lair) reach it from anywhere,
+but there is no hosted service and no multi-machine scheduling.
+
+You also need a model provider either way: an API key, a local Ollama, or the Claude Code transport
+with its terms-of-service caveat.
+
+One current limit worth knowing before you choose. Every agent has its own state, workdir fence,
+tool policy, and panic boundary, so one agent's crash stays its own. The opt-in
+[OS sandbox](/docs/security) is narrower than that: today it wraps shell execution, seed commands,
+and script shell calls, while file tools rely on path confinement and network tools run on the
+host. Widening it to cover every side effect is
+[in progress](https://github.com/GEMISIS/leviath/issues/326).
+
 **Reach for Leviath** when the hard part is inside a single unit of work: the task has distinct
 phases that want different models and different tools, you care about exactly what is in the context
 window at each phase, or you want many agents running at once without paying for a process each.
 Every run journals to disk as it goes, so a daemon you kill mid-run picks the work back up on its
 next start.
 
-## Why you might not want Leviath
-
-- **It is not a replacement for your favourite coding agent.** Those are polished interactive
-  products at a different layer.
-- **Agents are configuration, not code.** A Leviath agent is a TOML blueprint plus optional Rhai
-  script tools. If you want to write agent logic in Python or TypeScript against an SDK, that model
-  is not here. Other languages drive Leviath through the [REST API](/docs/api) instead.
-- **There is no hosted service.** You run the daemon yourself. One box hosts every agent, which is
-  also why there is no cluster to operate: [`lev serve`](/docs/api) and
-  [The Lair](https://leviath.dev/lair) reach it remotely, but nobody runs it for you, and there is
-  no multi-machine scheduling.
-- **The OS sandbox covers shell, not everything.** Every agent has its own state, workdir fence,
-  tool policy, and panic boundary, so one agent's crash stays its own. But the opt-in
-  [sandbox](/docs/security) wraps shell execution only: file tools rely on path confinement, and
-  network tools run on the host.
-- **You need a model provider**: an API key, a local Ollama, or the Claude Code transport with its
-  terms-of-service caveat.
-
 ## Scored against 12-Factor Agents
 
 [12-Factor Agents](https://github.com/humanlayer/12-factor-agents) is a widely used checklist for
-agent design. Here is Leviath against it, including where it falls short.
+agent design. Here is Leviath against it, factor by factor.
 
 | # | Factor | Status | Notes |
 |---|---|---|---|
@@ -119,7 +114,7 @@ agent design. Here is Leviath against it, including where it falls short.
 | 8 | Own your control flow | ✓ | Graph transitions on error, iteration cap, stuck, and model choice |
 | 9 | Compact errors into context | ✓ | Tool, inference, and iteration-cap errors all land in context |
 | 10 | Small, focused agents | ✓ | Per-stage models, tools, and prompts, plus bounded fan-out |
-| 11 | Trigger from anywhere | partial | CLI, REST, WebSocket, ACP, signed webhooks out. No built-in scheduler, so use cron |
+| 11 | Trigger from anywhere | ✓ | CLI, REST, WebSocket, ACP, and signed webhooks out. Scheduling is your cron or CI, not ours |
 | 12 | Stateless reducer | ✓ | Durable state lives on disk; the process is disposable. Runs resume on restart, and interrupted tool batches replay exactly-once |
 
 ## How we measure

--- a/docs/content/comparison.md
+++ b/docs/content/comparison.md
@@ -114,7 +114,7 @@ agent design. Here is Leviath against it, factor by factor.
 | 8 | Own your control flow | ✓ | Graph transitions on error, iteration cap, stuck, and model choice |
 | 9 | Compact errors into context | ✓ | Tool, inference, and iteration-cap errors all land in context |
 | 10 | Small, focused agents | ✓ | Per-stage models, tools, and prompts, plus bounded fan-out |
-| 11 | Trigger from anywhere | ✓ | CLI, REST, WebSocket, ACP, and signed webhooks out. Scheduling is your cron or CI, not ours |
+| 11 | Trigger from anywhere | ✓ | Start a run from the CLI, REST, or ACP. WebSocket pushes updates and webhooks report completion. Scheduling is your cron or CI, not ours |
 | 12 | Stateless reducer | ✓ | Durable state lives on disk; the process is disposable. Runs resume on restart, and interrupted tool batches replay exactly-once |
 
 ## How we measure

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -247,9 +247,7 @@ allow = ["~/.leviath/runs", "glob:~/design-docs/**"]
 
 An agent's declarations mean nothing until one of these grants lands, so `lev validate <agent>`
 checks each declared entry against this file and prints the block above, filled in, for whatever it
-does not find. `lev list` and `lev ps` carry the same counts. If you wrote blueprints against a
-build where the blueprint allowlist stood on its own, read the
-[upgrade note](/docs/security#upgrading-from-011).
+does not find. `lev list` and `lev ps` carry the same counts.
 
 ## Tool permissions
 

--- a/docs/content/containers.md
+++ b/docs/content/containers.md
@@ -11,11 +11,6 @@ order: 3
 Lots of orchestrators share one shape: a fresh container per unit of work, with a command that is
 expected to do the job and exit. A CI job is the same shape. This page is how Leviath fits it.
 
-> [!NOTE]
-> **Before this page:** [Where Leviath fits](/docs/integrations).
-> **In one line:** the pattern is container-per-job, and the thing to get right is that `lev run`
-> returns before the agent finishes.
-
 ```mermaid
 flowchart LR
   ISSUE["Issue or job"] --> C["Container"]

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -3,7 +3,7 @@ title: Structured context
 description: How structured context regions keep an agent coherent across hundreds of tool calls, where a flat message list drifts.
 group: Concepts
 group_order: 2
-order: 4
+order: 5
 ---
 
 # Structured context memory
@@ -16,10 +16,6 @@ that outcome.
 Leviath splits the window into named **regions** instead. Each one has its own size limit and its
 own rule for what to throw away first, so a big file read can only ever crowd out the region it
 landed in.
-
-> [!NOTE]
-> **Before this page:** [Agent blueprints](/docs/agents).
-> **In one line:** you decide what the window is made of, and what gets dropped when it fills.
 
 ## What that looks like
 

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -17,6 +17,26 @@ Leviath splits the window into named **regions** instead. Each one has its own s
 own rule for what to throw away first, so a big file read can only ever crowd out the region it
 landed in.
 
+```mermaid
+flowchart LR
+  subgraph FLAT["One flat list"]
+    direction TB
+    F1["task<br/>(oldest, first out)"]
+    F2["early turns"]
+    F3["a large file read"]
+    F4["recent turns"]
+  end
+  FLAT -->|"window fills"| LOST["The task falls off the end"]
+
+  subgraph REG["Named regions"]
+    direction TB
+    R1["task, pinned"]
+    R2["codebase, compacting"]
+    R3["conversation, sliding"]
+  end
+  REG -->|"window fills"| KEPT["Only the region that filled sheds;<br/>the task is untouched"]
+```
+
 ## What that looks like
 
 A typical coding agent might divide its window like this:
@@ -55,9 +75,9 @@ history      = { kind = "compact_history", budget = "15%", source_region = "code
 | `checklist` | A task list whose entries carry state. Written through `todo_add` / `todo_done` / `todo_note`, never evicted, and rendered open-items-first. |
 | `custom` | Behavior defined by a Rhai script (see [Rhai regions](/docs/rhai-regions)). |
 
-An unrecognized `kind` is a hard parse error, not a silently ignored region. So is an unrecognized
-`strategy`, which is the one this invites: `strategy = "per-item"` with a hyphen used to leave the
-region evicting one entry at a time, exactly as if the line had not been written.
+An unrecognized `kind` is a hard parse error, not a silently ignored region. So is an
+unrecognized `strategy`: `strategy = "per-item"` with a hyphen is refused, rather than leaving the
+region to evict one entry at a time as if the line had not been written.
 
 ### Per-kind keys
 

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -3,7 +3,7 @@ title: The daemon
 description: The background daemon that owns every run, so agents survive a closed terminal and share one process.
 group: Concepts
 group_order: 2
-order: 1
+order: 2
 ---
 
 # The shared-world daemon
@@ -13,16 +13,8 @@ leaving a window open for hours. Leviath does not work that way. `lev run` hands
 background service called the **daemon**, which owns every run on the machine.
 
 So your runs keep going after you close the terminal, and hundreds of agents share one process
-instead of taking a process each.
-
-> [!NOTE]
-> **Before this page:** [Getting Started](/docs/getting-started). If the daemon is misbehaving, go
-> straight to [Troubleshooting](/docs/troubleshooting).
-> **In one line:** one background process holds every run, and the CLI, dashboard, and API are all
-> ways of talking to it.
->
-> Building Leviath into your own Rust program instead? You can skip the daemon entirely. See
-> [Embedding](/docs/embedding).
+instead of taking a process each. Building Leviath into your own Rust program instead? You can skip
+the daemon entirely. See [Embedding](/docs/embedding).
 
 ```mermaid
 flowchart TB

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -25,13 +25,23 @@ flowchart TB
   end
   RUN & DASH & SERVE -->|"control socket<br/>(peer-cred checked)"| DAEMON
   subgraph DAEMON["Daemon (one process)"]
-    WORLD["Shared ECS world"]
+    WORLD["Shared world<br/>every agent is a row here"]
     WORLD --- A1["agent"]
     WORLD --- A2["agent"]
     WORLD --- A3["sub-agent"]
+    POOLS["Inference pools<br/>shared across agents"]
+    LANE["Tool lane<br/>shared across agents"]
+    WORLD -->|"builds each request"| POOLS
+    WORLD -->|"runs each tool batch"| LANE
   end
-  DAEMON -->|inference| PROV["LLM providers"]
+  POOLS -->|inference| PROV["LLM providers"]
+  LANE -->|"shell, files, MCP"| TOOLS["Tools, in the run's workdir"]
+  DAEMON -->|"journal, context, outputs"| DISK["Disk"]
 ```
+
+Agents never talk to a provider or run a tool themselves. The world builds each request and each
+tool batch on their behalf, which is what lets one process share connections, rate limits, and tool
+capacity across every run instead of duplicating them per agent.
 
 You do not normally start it yourself. It starts the first time a command needs it.
 
@@ -154,8 +164,7 @@ assigned to it and turns it into an ordinary finished run:
 wedge_timeout_secs = 300
 ```
 
-It is `0`, meaning off, by default. It fails runs, and that should be your choice rather than
-something an upgrade does to you.
+It is `0`, meaning off, by default, because it fails runs and that should be your choice.
 
 It never fires on a run that is merely slow. An agent waiting on the model, on a tool, on its
 sub-agents, or on a person is exempt however long it takes. If it does fire, the run's error says

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -15,9 +15,8 @@ of runs, answer their questions, and steer them.
 lev dash
 ```
 
-It reads the same [daemon](/docs/daemon) that [The Lair](https://leviath.dev/lair), the browser
-console, does, just over the local
-control socket instead of HTTP:
+It reads the same [daemon](/docs/daemon) that [The Lair](https://leviath.dev/lair) does, just over
+the local control socket instead of HTTP:
 
 ```mermaid
 flowchart LR

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -15,7 +15,7 @@ file, no socket.
 
 ```toml
 [dependencies]
-leviath = "0.2"
+leviath = "0.3"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -3,7 +3,7 @@ title: ECS engine
 description: The ECS engine that keeps each agent as a row of data, so an agent that is waiting costs almost nothing.
 group: Concepts
 group_order: 2
-order: 2
+order: 3
 ---
 
 # The ECS agent engine
@@ -15,11 +15,6 @@ hundred agents cost a hundred processes whether or not any of them are doing any
 Leviath keeps each agent as a row of data in one shared table. A waiting agent is a row nothing
 touched this pass, which costs close to nothing, so the machine only pays for work that is actually
 in flight.
-
-> [!NOTE]
-> **Before this page:** nothing. It starts from scratch.
-> **In one line:** agents are rows in a table, a fixed list of functions sweeps over the table, and
-> the loop goes to sleep when a whole sweep changes nothing.
 
 ## Entities, components, and systems
 

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -16,6 +16,78 @@ Leviath keeps each agent as a row of data in one shared table. A waiting agent i
 touched this pass, which costs close to nothing, so the machine only pays for work that is actually
 in flight.
 
+## The usual shape, and this one
+
+Most agent runtimes give an agent a loop of its own. The agent is an object, it owns a task, and
+that task walks through its own steps, stopping on an `await` whenever it needs the outside world:
+
+```mermaid
+flowchart LR
+  subgraph ONE["One agent, one loop of its own"]
+    direction LR
+    S["Start"] --> I["Call the model"]
+    I --> AW1["await the reply"]
+    AW1 --> T["Run its tools"]
+    T --> AW2["await the results"]
+    AW2 --> I
+  end
+```
+
+Leviath turns that inside out. There is no agent loop and no agent object. Each agent is a row of
+data, and one fixed list of functions sweeps across every row, moving each one a single step:
+
+```mermaid
+flowchart LR
+  subgraph W["One world, one sweep for everybody"]
+    direction TB
+    R1["agent 1: ready to call the model"]
+    R2["agent 2: waiting on a reply"]
+    R3["agent 3: tools running"]
+    R4["agent 4: waiting on a person"]
+  end
+  W --> SYS["Each function handles the rows it applies to,<br/>then the sweep ends"]
+  SYS -->|"rows that moved"| W
+```
+
+The difference shows up when there are many of them. In the usual shape, each agent brings its own
+task, its own client, and its own copy of everything around it:
+
+```mermaid
+flowchart TB
+  subgraph TRAD["100 agents, the usual way"]
+    direction LR
+    P1["agent + task<br/>+ its own client"]
+    P2["agent + task<br/>+ its own client"]
+    P3["…98 more"]
+  end
+  P1 --> API["Model provider"]
+  P2 --> API
+  P3 --> API
+```
+
+In Leviath they are 100 rows in one table, sharing one set of connections, rate limits, and tool
+capacity:
+
+```mermaid
+flowchart TB
+  subgraph LEV["100 agents, in Leviath"]
+    direction LR
+    ROWS["100 rows of data"]
+    POOL["Shared inference pools"]
+    LANE["Shared tool lane"]
+    ROWS --> POOL
+    ROWS --> LANE
+  end
+  POOL --> API2["Model provider"]
+  LANE --> TOOLS["Tools"]
+```
+
+The rest of this page is how that works: [what the pieces are called](#entities-components-and-systems),
+[what one agent is made of](#an-agent-is-an-entity),
+[how it moves](#markers-are-the-state-machine), [what a sweep is](#what-a-tick-is), and
+[what happens when one agent breaks](#one-agents-failure-stays-one-agents-failure). You never have
+to configure any of it.
+
 ## Entities, components, and systems
 
 Leviath is built on [bevy_ecs](https://bevyengine.org/), a library for organising data the way game

--- a/docs/content/gas-city.md
+++ b/docs/content/gas-city.md
@@ -16,11 +16,6 @@ how a fleet of them is supervised.
 It talks to agents over the **Agent Client Protocol**, which Leviath speaks. So this is a
 configuration change on the Gas City side, not an adapter you have to write.
 
-> [!NOTE]
-> **Before this page:** [Where Leviath fits](/docs/integrations).
-> **In one line:** declare a provider whose command is `lev agent-client`, mark it as speaking ACP,
-> and set your agent's session to `acp`.
-
 ## The vocabulary
 
 Two Gas City words show up below. A **city** is your workspace directory, holding agents, rigs, and

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -18,8 +18,7 @@ You'll go from nothing to a running agent in four steps:
 flowchart LR
   A["Install<br/>lev"] --> B["Configure<br/>a provider"]
   B --> C["Run<br/>an agent"]
-  C --> D["Daemon hosts<br/>the run"]
-  D --> E["Watch in<br/>lev dash"]
+  C --> D["Read<br/>the result"]
 ```
 
 ## Install
@@ -154,44 +153,27 @@ Leave `--task` off and your editor opens on a template, which is easier than
 fighting shell quoting for anything longer than a sentence. It also takes a
 file: `lev run coder --task ./brief.md`.
 
-`lev run` doesn't run the agent in your terminal. It hands it to a background
-[daemon](/docs/daemon) that hosts every agent in one shared world:
-
-```mermaid
-flowchart LR
-  CLI["lev run"] -->|control socket| D
-  DASH["lev dash"] -->|control socket| D
-  subgraph D["Shared-world daemon (one process)"]
-    A1["agent"]
-    A2["agent"]
-    A3["agent"]
-  end
-  D -->|provider API| P["LLM provider"]
-```
-
-Because the daemon owns the run, it keeps going after your terminal closes. Watch everything
-live with the TUI [dashboard](/docs/dashboard):
-
-```bash
-lev dash
-```
-
-One thing to expect: the agent **stops and asks** before it writes a file or runs a shell command,
-because those tools default to `ask`. Answer in `lev dash` (select the run, `Enter`, then `i`), or
-pass `--yolo` to pre-approve everything for an unattended run. See
-[Interaction](/docs/interaction).
+`lev run` returns as soon as the work is accepted, not when it is done. The agent runs in the
+background and keeps going after you close the terminal, so the next section is how you check on
+it. Real tasks take minutes.
 
 ## Read the result
 
-When the run finishes, the answer is one command away:
+Watch it live, or come back later. Either way:
 
 ```bash
-lev ps                    # every run and its status; finished ones stay listed for a while
-lev result <run-id>       # what the agent handed back
+lev dash                  # live view of every run
+lev ps                    # one-shot list: what is running, what finished
+lev result <run-id>       # the answer, once a run is complete
 ```
 
 Files the agent created are in the workdir you ran it from. See [Outputs](/docs/outputs) for
 structured answers.
+
+Expect one interruption: the agent **stops and asks** before it writes a file or runs a shell
+command. Answer in `lev dash` (select the run, `Enter`, then `i`) or with
+[`lev respond`](/docs/interaction), or pass `--yolo` to pre-approve everything for an unattended
+run.
 
 > [!TIP]
 > Prefer a visual UI? Serve the daemon over HTTP and open
@@ -201,7 +183,7 @@ structured answers.
 > lev serve --token <your-secret> --cors https://leviath.dev
 > ```
 >
-> It shows the same daemon: live runs, context, logs, and interactions, from any browser.
+> It shows the same runs, context, logs, and interactions, from any browser.
 
 On Windows the agent's shell is `cmd.exe`, not a POSIX shell, and Leviath tells the model so. See
 [which shell you get](/docs/tools#which-shell-you-get), and
@@ -222,6 +204,8 @@ and the context regions. See [Agents](/docs/agents) to go deeper.
 ## Where to go next
 
 - The [Agent catalog](/docs/agent-catalog) tours the ten pre-built agents and what each is for.
+- [Overview](/docs/overview) explains what Leviath is doing underneath: stages, context regions,
+  and the shared world your agents run in.
 - [Agent blueprints](/docs/agents) covers what goes in an `agent.leviath` file, for building your
   own.
 - [Troubleshooting](/docs/troubleshooting) has the common snags, and `lev doctor` diagnoses most of

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -170,8 +170,8 @@ lev result <run-id>       # the answer, once a run is complete
 Files the agent created are in the workdir you ran it from. See [Outputs](/docs/outputs) for
 structured answers.
 
-Expect one interruption: the agent **stops and asks** before it writes a file or runs a shell
-command. Answer in `lev dash` (select the run, `Enter`, then `i`) or with
+Expect to be asked things along the way. The agent **stops and waits** before it writes a file or
+runs a shell command. Answer in `lev dash` (select the run, `Enter`, then `i`) or with
 [`lev respond`](/docs/interaction), or pass `--yolo` to pre-approve everything for an unattended
 run.
 

--- a/docs/content/integrations.md
+++ b/docs/content/integrations.md
@@ -16,11 +16,6 @@ That second job is what Leviath is. Your orchestrator keeps doing the coordinati
 one task and runs it as a multi-stage agent with structured context, its own tools, and whichever
 models you configured.
 
-> [!NOTE]
-> **Before this page:** [Getting Started](/docs/getting-started) and [The daemon](/docs/daemon).
-> **In one line:** pick one of four ways in, point your orchestrator at it, and Leviath handles one
-> unit of work.
-
 ```mermaid
 flowchart TD
   ORCH["Your orchestrator<br/>Gas City / OpenHands / CI"]
@@ -67,15 +62,17 @@ do not mean what they look like.
 
 ## When Leviath is not the right choice
 
-It is worth saying where this does not pay off:
+Three cases where plugging Leviath in does not pay off:
 
 - **For a single quick edit**, a coding agent CLI you already have is less setup and does the job.
-  Leviath earns its keep on work with several distinct phases, or on many agents at once.
+  Leviath is worth the wiring on work with several distinct phases, or on many agents at once.
 - **If your orchestration already lives in Python** and you want the workflow expressed in code
   rather than TOML, a framework you can import is a better fit than a separate runtime.
 - **If you need an OS boundary around every tool an agent has**, note that Leviath's opt-in
-  [sandbox](/docs/security) covers shell execution, and its file tools are path-confined rather
-  than containerized. Running the whole daemon in a container gives you the blanket boundary today,
-  and a container-per-job orchestrator gives you one per unit of work.
+  [sandbox](/docs/security) covers shell execution today, and its file tools are path-confined
+  rather than containerized. Widening it is
+  [in progress](https://github.com/GEMISIS/leviath/issues/326). Meanwhile, running the whole daemon
+  in a container gives you the blanket boundary, and a container-per-job orchestrator gives you one
+  per unit of work.
 
 [Where Leviath sits](/docs/comparison) goes into this properly.

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -76,12 +76,11 @@ call until the answer comes back, then continues with it:
 
 ## When nobody answers
 
-Every prompt on this page waits on a person. Until Leviath 0.1.2 it waited forever, so a run whose
-operator had gone home sat in `WaitingInput` holding its slot until the daemon restarted.
+Every prompt on this page waits on a person, and nobody is always there. A run whose operator has
+gone home should not sit in `WaitingInput` holding its slot until the daemon restarts.
 
-`[limits] interaction_timeout_secs` puts a deadline on that wait (one hour by default; `0` waits
-indefinitely, the old behaviour). When it passes, the prompt resolves exactly as cancelling it
-would:
+`[limits] interaction_timeout_secs` puts a deadline on that wait: one hour by default, and `0`
+waits indefinitely. When it passes, the prompt resolves exactly as cancelling it would:
 
 | Prompt | What an expiry means |
 |---|---|

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -3,7 +3,7 @@ title: Human-in-the-loop
 description: What to do when a run shows waiting: answer agent questions, tool approvals, and checkpoints with lev respond, the dashboard, or the API.
 group: Concepts
 group_order: 2
-order: 8
+order: 9
 ---
 
 # Human-in-the-loop
@@ -23,10 +23,6 @@ A Leviath run does not have to be autonomous. There are three ways a person gets
 You can answer from the [dashboard](/docs/dashboard), from
 [The Lair](https://leviath.dev/lair), the browser console, from the CLI, or the
 [HTTP API](/docs/api).
-
-> [!NOTE]
-> **Before this page:** [Multi-stage workflows](/docs/stages).
-> **In one line:** the agent can ask, the blueprint can insist, and you can interrupt.
 
 ```mermaid
 sequenceDiagram

--- a/docs/content/observability.md
+++ b/docs/content/observability.md
@@ -15,11 +15,6 @@ run is stuck" and "is anything actually moving" without you going digging.
 It is off by default. Turning it on is one config block, and nothing about how a run behaves changes
 either way.
 
-> [!NOTE]
-> **Before this page:** [The daemon](/docs/daemon).
-> **In one line:** every run becomes a trace, the daemon publishes health counters every 30 seconds,
-> and two of those counters are the ones worth alerting on.
-
 ## Turning it on
 
 ```toml

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -3,7 +3,7 @@ title: Final outputs
 description: Get a structured answer out of a run with output formats, schemas, and lev result, instead of scraping its logs.
 group: Concepts
 group_order: 2
-order: 6
+order: 7
 ---
 
 # Final outputs
@@ -15,10 +15,6 @@ not what it concluded.
 So an agent can **submit a final output**: one deliberate answer, produced by a tool call, that
 every surface reports. The API returns it, `lev result` prints it, a parent agent receives it, and
 the completion webhook carries it.
-
-> [!NOTE]
-> **Before this page:** [Multi-stage workflows](/docs/stages).
-> **In one line:** the run's last stage calls one tool, and that call is the answer.
 
 ## The smallest version
 
@@ -72,7 +68,7 @@ into the `submit_output` tool description, and into the stage's system prompt to
 `require_output` is set.
 
 The label travels with the answer so a reader can act on it. [The Lair](https://leviath.dev/lair),
-the browser console, renders a2ui differently from markdown by matching on that string.
+the browser console for Leviath, renders a2ui differently from markdown by matching on that string.
 
 ## Checking the answer
 

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -16,6 +16,15 @@ So an agent can **submit a final output**: one deliberate answer, produced by a 
 every surface reports. The API returns it, `lev result` prints it, a parent agent receives it, and
 the completion webhook carries it.
 
+```mermaid
+flowchart LR
+  ST["The run's last stage"] -->|"submit_output"| ANS["One answer,<br/>in the format you named"]
+  ANS --> CHK{"Valid?"}
+  CHK -->|no| BACK["Back to the agent<br/>with what was wrong"]
+  BACK --> ST
+  CHK -->|yes| OUT["lev result · REST API<br/>parent agent · webhook"]
+```
+
 ## The smallest version
 
 Add a stage with `mode = "output"`:

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -106,9 +106,14 @@ The CLI is one of four front doors, and they all drive the same daemon.
 | You are | Use | Covered in |
 |---|---|---|
 | At a terminal, or scripting one | `lev` with `--json` | [CLI reference](/docs/cli) |
-| A service that speaks HTTP | `lev serve` | [HTTP API](/docs/api) |
+| A service built on Leviath | `lev serve` | [HTTP API](/docs/api) |
 | An editor or orchestrator that spawns processes | `lev agent-client` | [Agent Client Protocol](/docs/agent-client-protocol) |
 | A Rust program | the `leviath` crate | [Embedding](/docs/embedding) |
+
+For anything long-lived, prefer the HTTP API over shelling out to the CLI. Its listings are
+paginated, sortable, and searchable, a WebSocket pushes changes so you do not have to poll, and
+webhooks can deliver a finished run to you. See
+[driving Leviath from a work queue](/docs/work-queues#prefer-the-api).
 
 ## Where to go next
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -1,0 +1,118 @@
+---
+title: Overview
+description: How the pieces of Leviath fit together: blueprints, stages, context regions, tools, and the shared world that runs them.
+group: Concepts
+group_order: 2
+order: 1
+---
+
+# How Leviath works
+
+Leviath runs LLM agents. You describe an agent in a file, and a background service executes it,
+keeping its context coherent, calling its tools, and writing everything to disk as it goes.
+
+This page is the whole system in one pass. Each section is a summary with a link to the page that
+covers it properly, so read straight through once and then follow whichever link you need.
+
+```mermaid
+flowchart LR
+  BP["agent.leviath<br/>your blueprint"] --> RUN["lev run"]
+  RUN --> W
+  subgraph W["The daemon: one shared world"]
+    A1["agent"]
+    A2["agent"]
+    A3["agent"]
+  end
+  W <-->|inference| P["Model providers"]
+  W <-->|tool calls| T["Tools: files, shell, MCP"]
+  W --> D["Disk: journal, context,<br/>outputs, artifacts"]
+```
+
+## An agent is a blueprint
+
+An agent is a directory holding an `agent.leviath` file, a TOML **blueprint**. It names the stages
+the agent moves through, the model and tools each stage gets, and the shape of its memory. There is
+no agent code to write, and nothing is compiled.
+
+Ten [pre-built agents](/docs/agent-catalog) ship with Leviath, and `lev create` scaffolds your own.
+See [Agent blueprints](/docs/agents).
+
+## Work happens in stages
+
+A stage is one phase of a task, with its own prompt, its own model, and its own tool list. Stages
+are joined by **transitions** into a graph, so an agent can loop, branch on an error, or escape a
+stage it is stuck in.
+
+That is the main reason to reach for Leviath: a discovery stage can run a cheap model with
+read-only tools, and the implementation stage that follows can run an expensive one with write
+access. See [Multi-stage workflows](/docs/stages).
+
+## Context is structured, not a flat list
+
+Most agent frameworks keep one growing list of messages, so a large file read pushes the original
+task toward the edge of the window. Leviath splits the window into named **regions**, each with its
+own budget and its own rule for what to drop first.
+
+A file dump can fill the region it landed in and nothing else. See
+[Structured context](/docs/context).
+
+## Tools are declared and gated
+
+Each stage advertises the tools it may call: file tools confined to the run's working directory, a
+shell, [MCP](/docs/mcp) servers, and any [Rhai script tools](/docs/rhai-tools) you write. A tool the
+stage never advertised cannot be called, and a tool that changes something asks you first unless you
+said otherwise.
+
+See [Built-in tools](/docs/tools) and [Security](/docs/security).
+
+## Agents can spawn agents
+
+A stage can hand work to [sub-agents](/docs/sub-agents), either one at a time or as a **fan-out**
+that splits a job across many workers and merges what they return. Children are ordinary agents in
+the same world, so there is no new process and nothing is serialized between a parent and its
+children.
+
+## A person can step in at any point
+
+An agent can ask you a question, ask permission for a tool call, or stop at a checkpoint its
+blueprint declares. You answer from the dashboard, the CLI, or the API, and a run that is waiting
+holds its place rather than burning tokens. See [Interaction](/docs/interaction).
+
+## Runs hand back an answer
+
+A run's result is not just its logs. A stage can require a structured **output** in a shape you
+name, validated before the run is allowed to finish, which is what makes a run safe to call from a
+script. See [Outputs](/docs/outputs).
+
+## Everything runs in one shared world
+
+`lev run` does not execute the agent in your terminal. It hands the work to a background
+[daemon](/docs/daemon) that holds every agent in one process, and returns immediately.
+
+That is what makes hundreds of concurrent agents affordable: a waiting agent is a row of data
+nothing touched this pass, not an idle process. The [ECS engine](/docs/engine) page explains the
+design, and you never have to think about it to use Leviath.
+
+## Nothing lives only in memory
+
+Every run journals to disk as it goes: its context, its stages, its logs, and its final answer.
+Kill the daemon mid-run and the next start picks the work back up, replaying an interrupted tool
+batch rather than running it twice.
+
+## Ways in
+
+The CLI is one of four front doors, and they all drive the same daemon.
+
+| You are | Use | Covered in |
+|---|---|---|
+| At a terminal, or scripting one | `lev` with `--json` | [CLI reference](/docs/cli) |
+| A service that speaks HTTP | `lev serve` | [HTTP API](/docs/api) |
+| An editor or orchestrator that spawns processes | `lev agent-client` | [Agent Client Protocol](/docs/agent-client-protocol) |
+| A Rust program | the `leviath` crate | [Embedding](/docs/embedding) |
+
+## Where to go next
+
+- [Agent blueprints](/docs/agents) is the natural next page, since everything else configures one.
+- [Multi-stage workflows](/docs/stages) and [Structured context](/docs/context) are the two ideas
+  that do the most work.
+- [Glossary](/docs/glossary) defines every term these docs use in a particular way.

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -204,7 +204,7 @@ model = { models = [
 > [!WARNING]
 > Ollama needs no key, so it is registered whether or not a server is running. Leave
 > `default_model` unset on a machine with no Ollama and every stage that lists it starts against
-> `http://localhost:11434`. The run now moves on to its next candidate instead of dying there, but
+> `http://localhost:11434`. The run moves on to its next candidate rather than dying there, but
 > it still spends four attempts finding out.
 
 ## Where credentials live

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -24,12 +24,8 @@ flowchart LR
 
 Everything hard stays on Leviath's side: HTTP transport, rate limiting, per-stage timeouts, retry
 with backoff, working out which errors are worth retrying, and token counting. You write the mapping
-and nothing else.
-
-> [!NOTE]
-> **Before this page:** [Providers](/docs/providers) and [Rhai scripting](/docs/scripting).
-> **In one line:** name the file after the provider, write an `inference` function, reference it
-> from a stage.
+and nothing else: name the file after the provider, write an `inference` function, and reference it
+from a stage.
 
 Four things about the lifecycle:
 

--- a/docs/content/rhai-tools.md
+++ b/docs/content/rhai-tools.md
@@ -12,11 +12,6 @@ This page covers two things that both live in Rhai scripts. [Writing a tool](#de
 gives your agents a new capability. [Policy rules](#policy-rules) decide whether a tool call is
 allowed to fire. They are unrelated jobs, so read whichever half you came for.
 
-> [!NOTE]
-> **Before this page:** [Rhai scripting](/docs/scripting) and [Built-in tools](/docs/tools).
-> **In one line:** a `.rhai` file in a tools directory becomes a tool; a `.rhai` file in a rules
-> directory decides whether a call goes through.
-
 Every `.rhai` file in `~/.leviath/tools/` is compiled at spawn and offered as a tool to **every**
 agent. That is how you give all your agents a shared capability without editing each blueprint.
 

--- a/docs/content/rhai-validators.md
+++ b/docs/content/rhai-validators.md
@@ -16,10 +16,6 @@ what a good answer looks like.
 So write it down. A `.rhai` file beside your blueprint says what valid means. A bad answer then goes
 back to the agent to fix, instead of reaching whoever asked.
 
-> [!NOTE]
-> **Before this page:** [Final outputs](/docs/outputs).
-> **In one line:** one function, returning nothing when the answer is fine.
-
 ## Write one
 
 ```rhai

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -19,10 +19,6 @@ restart.
 Each script stays small, because Leviath keeps the hard parts. Transport, budgets, sandboxing, and
 retries stay with the runtime, and the script gets only the one decision that is specific to you.
 
-> [!NOTE]
-> **Before this page:** [Agent blueprints](/docs/agents).
-> **In one line:** four places you can drop a script, each with a narrow job and its own page.
-
 You do not need to know Rhai to read the pages below. Each one has a complete, working script you
 can copy and change. [rhai.rs](https://rhai.rs) has the language reference if you want it.
 

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -3,7 +3,7 @@ title: Security & sandboxing
 description: Sandboxed execution, tool permissions, and taint tracking, for running a blueprint you did not write.
 group: Concepts
 group_order: 2
-order: 9
+order: 10
 ---
 
 # Security: sandboxed execution and taint tracking
@@ -23,11 +23,9 @@ Leviath gives you three separate controls, and you can use as few or as many as 
 Tool permissions are a fourth, and they live in [Built-in tools](/docs/tools). Where API keys are
 stored is `[security] credential_store` in [Configuration](/docs/configuration#security).
 
-> [!NOTE]
-> **Before this page:** [Agent blueprints](/docs/agents).
-> **In one line:** everything here is opt-in, and an installed blueprint can tighten these settings
-> but never loosen them. The one narrow exception: a blueprint may pre-allow `web_search` and
-> `web_fetch` when you have not configured those tools yourself.
+All of it is opt-in, and an installed blueprint can tighten these settings but never loosen them.
+The one narrow exception: a blueprint may pre-allow `web_search` and `web_fetch` when you have not
+configured those tools yourself.
 
 ## Sandboxes
 
@@ -42,15 +40,23 @@ network = false
 kind = "none"             # run discovery on the host…
 ```
 
-The sandbox covers what the agent **executes**: the `shell` tool, a blueprint's seed commands, and
-a Rhai script tool's `shell()` calls. File tools stay on the host and rely on workdir
-[path confinement](#reading-outside-the-workdir) instead; the sandbox bind-mounts the workdir so
-both see the same files. `web_fetch`, `web_search`, and a script's HTTP functions also run on the
-host, so `network = false` fences the sandboxed commands, not those tools. So do
-[MCP servers](/docs/mcp), which are host processes shared across agents. Widening the sandbox to
-cover all of that is tracked in
-[leviath#326](https://github.com/GEMISIS/leviath/issues/326). For a blanket boundary today, run
-the whole daemon in a container.
+> [!IMPORTANT]
+> **Today the sandbox covers what the agent executes**, and that scope is being widened. Read this
+> before you rely on it.
+>
+> Inside the boundary: the `shell` tool, a blueprint's seed commands, and a Rhai script tool's
+> `shell()` calls. Outside it: file tools, which stay on the host and rely on workdir
+> [path confinement](#reading-outside-the-workdir) instead, and `web_fetch`, `web_search`, and a
+> script's HTTP functions, which use the host network, so `network = false` fences the sandboxed
+> commands and not those tools. [MCP servers](/docs/mcp) are host processes shared across agents,
+> so they sit outside too.
+>
+> Covering every side effect, and letting a single run opt into a sandbox, is
+> [issue #326](https://github.com/GEMISIS/leviath/issues/326) and the intended end state. Until it
+> lands, run the whole daemon in a container when you want a blanket boundary.
+
+The sandbox bind-mounts the run's workdir, so sandboxed commands and host-side file tools see the
+same files.
 
 **Containers**, using Docker or Podman, give you the real thing. The daemon keeps a warm container
 per sandbox configuration, so stages with identical settings share one, and tears them down when

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -20,6 +20,21 @@ Leviath gives you three separate controls, and you can use as few or as many as 
 | Read paths | Which files can it see? | [Reading outside the workdir](#reading-outside-the-workdir) |
 | Taint tracking | Can it send what it read somewhere? | [Taint tracking](#taint-tracking-experimental) |
 
+```mermaid
+flowchart LR
+  C["A tool call"] --> P{"Permission:<br/>allow, ask, or deny"}
+  P -->|deny| X["Refused"]
+  P -->|ask| U["You answer"]
+  U -->|no| X
+  P -->|allow| R{"Reads a path<br/>outside the workdir?"}
+  U -->|yes| R
+  R -->|"not granted"| X
+  R -->|"granted or inside"| T{"Sends data out<br/>above its clearance?"}
+  T -->|yes| U2["Taint gate asks you"]
+  T -->|no| RUN["Runs, in a sandbox<br/>if you configured one"]
+  U2 --> RUN
+```
+
 Tool permissions are a fourth, and they live in [Built-in tools](/docs/tools). Where API keys are
 stored is `[security] credential_store` in [Configuration](/docs/configuration#security).
 
@@ -157,9 +172,12 @@ The rules that keep this safe:
 - **Patterns match the real path**, written with `/` on every OS (on Windows, matching is
   case-insensitive and the `\\?\` prefix is handled for you). On macOS note that `/tmp` is
   really `/private/tmp`; `~/` entries avoid the problem since the home directory is stable.
-- **Regexes are anchored.** `regex:/data/runs` matches exactly that path, not
-  `/data/runs-anything`; end a pattern with `/.*` to grant a subtree. A relative regex is
-  refused; use `glob:` for workdir-relative patterns.
+- **Regexes are anchored and absolute.** `regex:/data/runs` matches exactly that path, not
+  `/data/runs-anything`; end a pattern with `/.*` to grant a subtree. A pattern must start with
+  `/`, a drive letter, or `~/`, so a catch-all like `regex:.*` is refused when the blueprint is
+  parsed. Use `glob:` for anything relative to the workdir.
+- **Globs cannot contain `.` or `..`**, except in a relative entry's leading run, which is folded
+  into the workdir when the pattern is compiled.
 - **Taint rises.** When a grant is active, the read tools are classified `Private` for that
   agent, so taint tracking treats out-of-workdir content with more suspicion, not less.
 - Rhai script tools have their own `read_file` and it stays workdir-confined; `[read_paths]`
@@ -211,23 +229,3 @@ lev policy test bash --target example.com
 [SECURITY.md](https://github.com/GEMISIS/leviath/blob/main/SECURITY.md) for the full threat
 model, what Leviath defends against, and how to report a vulnerability (GitHub private advisories).
 
-## Upgrading from 0.1.1
-
-`[read_paths]` changed shape after 0.1.1. Skip this unless you wrote blueprints against an earlier
-build.
-
-**A blueprint's `[read_paths]` is now a declaration, not a grant.** An agent that used to read
-outside its workdir on the strength of its own blueprint now reads nothing outside it, until your
-`config.toml` grants the same paths. Add the `[agent_read_paths.<name>]` block shown above, or set
-`allow_blueprint_read_paths = true` if you would rather trust your blueprints wholesale.
-
-**`regex:` entries must be absolute.** They have to start with `/`, a drive letter, or `~/`, and
-they are anchored end to end. A catch-all like `regex:.*` is refused when the blueprint is parsed,
-so `lev validate` fails rather than the agent quietly losing access. Write the subtree you mean,
-such as `regex:~/design-docs/.*`, or use `glob:` for anything relative to the workdir.
-
-**Glob patterns cannot contain `.` or `..`**, except in a relative entry's leading run, which is
-folded into the workdir when the pattern is compiled.
-
-Run `lev validate <agent>` against each of your blueprints after upgrading. It names every entry
-that is now inert and prints the config block that would fix it.

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -3,7 +3,7 @@ title: Multi-stage workflows
 description: Split an agent into stages so each phase of a task gets its own model, tools, and context.
 group: Concepts
 group_order: 2
-order: 5
+order: 6
 ---
 
 # Multi-stage workflows
@@ -14,11 +14,6 @@ review time its context is full of the work it is supposed to be judging.
 
 So a Leviath agent is split into **stages**. Each stage is one job, with its own model, its own
 tools, and its own context. When a stage is done, an edge decides which stage runs next.
-
-> [!NOTE]
-> **Before this page:** [Agent blueprints](/docs/agents).
-> **In one line:** stages are the boxes, transitions are the arrows, and this page is about the
-> arrows.
 
 ## Graph
 

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -3,7 +3,7 @@ title: Sub-agents & fan-out
 description: Start child agents and fan work out across them, so many small jobs run at once.
 group: Concepts
 group_order: 2
-order: 7
+order: 8
 ---
 
 # Sub-agents and fan-out
@@ -14,11 +14,6 @@ full of items one through eight.
 
 A **sub-agent** is a child agent started by another one. Give each item its own sub-agent and they
 run at the same time, each with a clean context, and the parent gets the results back.
-
-> [!NOTE]
-> **Before this page:** [Multi-stage workflows](/docs/stages).
-> **In one line:** a fan-out stage splits a task into items, runs one sub-agent per item, and merges
-> what they produce.
 
 This is how the bundled `data-analyst` agent gathers a broad subject at once, one worker per slice
 of it, and how a wide research sweep covers many sub-topics in parallel. See the

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -111,6 +111,9 @@ back into the system prompt on later turns.
 | `context_read` | Read a section, or a specific keyed entry within it. | `region`, `key` (optional) |
 | `context_delete` | Remove a specific keyed entry from a section. | `region`, `key` |
 | `context_list` | List sections with their token counts and entry counts. | `region` (optional) |
+| `todo_add` | Add an open item to a [checklist region](/docs/context#tracking-work-with-a-checklist), returning its id. | `region`, `item` |
+| `todo_done` | Tick a checklist item off. | `region`, `id` |
+| `todo_note` | Record a note against an item without closing it. | `region`, `id`, `note` |
 
 ## Final output
 
@@ -260,6 +263,7 @@ With nothing configured, tools fall back to these:
 | `read_file`, `read_files`, `list_dir` | `allow` |
 | `write_file`, `edit_file`, `shell` (and its `bash` alias) | `ask` |
 | `context_read`, `context_write`, `context_append`, `context_delete`, `context_list` | `allow` |
+| `todo_add`, `todo_done`, `todo_note` | `allow` |
 | `ask_user_text`, `ask_user_choice`, `ask_user_confirm`, `edit_document` | `allow` |
 | `spawn_agent`, `check_agent`, `wait_for_agent`, `send_to_agent`, `kill_agent` | `allow` |
 | Everything else, built-in or MCP | `ask` |

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -23,7 +23,7 @@ Read and modify files relative to the agent's working directory.
 
 | Tool | Purpose | Arguments |
 | --- | --- | --- |
-| `read_file` | Read one file's complete contents. | `path` |
+| `read_file` | Read one file, up to 256 KiB, with a note when the content is truncated. | `path` |
 | `read_files` | Read several files in one call, separated by path headers. | `paths` (array) |
 | `write_file` | Write content to a file, creating parent directories as needed. | `path`, `content` |
 | `edit_file` | Replace an exact string that occurs exactly once in a file. | `path`, `old_str`, `new_str` |

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -96,8 +96,8 @@ command never blocks on a full one, which would turn a truncated answer into a t
 
 The cap is a memory bound, not a context bound. A megabyte of shell output already overruns any
 region budget an agent has, so what survives this cap gets trimmed again by the region it lands in.
-The reason it exists is that the daemon used to hold a command's entire output in memory with
-nothing to stop it, and a command printing at local-pipe speed for its full 60 seconds is gigabytes.
+The cap exists because a command printing at local-pipe speed for its full 60 seconds is
+gigabytes, and the daemon holds that output in memory.
 
 ## Context
 
@@ -234,8 +234,8 @@ stage control access:
 - **`tool_permissions`**: a per-tool map whose values are `allow`, `ask`, or `deny`. `allow` runs
   the call outright, `ask` requires user approval first, and `deny` blocks it. Stage-level entries
   are narrower than agent-level `[tool_permissions]` and wider than launch-time flags. Any other
-  value is a load error: a misspelled `deny` used to resolve to `ask`, which is the more permissive
-  of the two, so the author of the typo got a prompt where they had written a refusal.
+  value is a load error, because a misspelled `deny` that quietly resolved to `ask` would hand
+  the author of the typo a prompt where they had written a refusal.
 
 ```toml
 [stages.implement]

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -290,7 +290,7 @@ endpoint, so three things must line up:
 1. **The server is running** with a token: `lev serve --token <t>`.
 2. **CORS allows the site's origin**: add `--cors https://leviath.dev` (or `--cors "*"`). Without
    it, the browser blocks the request before your server ever sees it.
-3. **The token matches** the one you entered in the console.
+3. **The token matches** the one you entered in The Lair.
 
 ```bash
 lev serve --token 6618… --cors https://leviath.dev --allow-admin

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -95,7 +95,7 @@ Set `default_model` alongside your `default_provider`. Without a model to send, 
 is never consulted and Ollama wins by default. `lev doctor` says so in its `resolve` line when your
 configured provider is being passed over.
 
-A run that does start on a dead Ollama no longer dies there: an unreachable provider is treated the
+A run that starts on a dead Ollama does not die there. An unreachable provider is treated the
 same as one out of credits, so the stage moves to its next candidate. You will see the swap in the
 stage log:
 
@@ -154,9 +154,8 @@ shorter than a cold start will keep giving up on runs that were about to work.
 ## My OpenRouter agent finishes without saying anything
 
 Reasoning models on OpenRouter answer with `content: null` and put their text under `reasoning`.
-Leviath reads that field when the message carries nothing else, so a reasoning-only turn is no
-longer an empty response. If you are on an older build, an agent that loops and finishes silently
-on a `deepseek-r1`-style model is this.
+Leviath reads that field when the message carries nothing else, so a reasoning-only turn counts
+as a real answer rather than an empty response.
 
 The reasoning text is only used when the turn has no content and no tool calls of its own, so it
 never displaces real output or a tool call.
@@ -214,10 +213,8 @@ own prompt will still ask for them; that text has to change in the blueprint. Se
 
 ## Console windows keep flashing on my Windows desktop
 
-Every child process Leviath starts is asked for no console window, so this
-should not happen on 0.2 or later. Before that, each `shell` call, each MCP
-server, and each provider that shells out could pop a `cmd.exe` window on the
-desktop, which a fleet of agents turned into a steady flicker.
+Every child process Leviath starts is asked for no console window, so this should not happen at
+all. A `shell` call, an MCP server, and a provider that shells out are all covered.
 
 If you still see it, check what is spawning. `lev` itself run from a terminal
 shares that terminal and draws nothing extra. The one child that is still meant

--- a/docs/content/work-queues.md
+++ b/docs/content/work-queues.md
@@ -15,6 +15,11 @@ Getting that wrong is expensive in both directions. Decide a healthy run is dead
 work. Decide a dead run is healthy and you leak a slot forever. This page covers how to ask, and
 three fields that will mislead you if you read them the obvious way.
 
+> [!TIP]
+> **Building a service rather than a script? Use the [HTTP API](/docs/api), not the CLI.** Shelling
+> out to `lev` costs a process per check, gives you no way to filter server-side, and makes you
+> poll for something the daemon can push. See [Prefer the API](#prefer-the-api) below.
+
 ## Three things that are not what they look like
 
 **`updated_at` in `meta.json` is a heartbeat, not progress.** The daemon rewrites a run's metadata
@@ -81,6 +86,26 @@ A daemon restarting looks exactly like every run dying at once. A reconciler tha
 two apart will cancel a fleet of perfectly healthy agents. Leviath will not mark anything
 `abandoned` while it cannot reach the daemon, and your side should hold off too. Wait for the next
 poll.
+
+## Prefer the API
+
+The CLI recipe above is the right shape for a shell script or a CI step. For a long-lived service,
+the [HTTP API](/docs/api) is the better surface, and it answers the same questions with less work.
+
+- **`GET /api/runs` is paginated, sortable, and searchable.** Ask for the runs you care about
+  instead of listing everything and filtering client-side. Paging is keyset: follow `next_cursor`
+  until it comes back null, rather than counting pages.
+- **Poll less by asking for less.** `ids=a,b,c` fetches exactly the runs your queue is tracking,
+  and `fields=run_id,status,last_progress_at` trims each one to what you read. Ids that no longer
+  exist come back under `missing` rather than failing the whole request.
+- **`since=` beats deep paging** when you only want what changed since your last check.
+- **Or stop polling.** The `/ws` WebSocket pushes status changes as they happen, so your reconciler
+  reacts instead of sweeping. Keep the poll as a slow backstop for missed events.
+- **Completion can come to you.** A run started with a callback URL fires a signed webhook when it
+  finishes, with a stable `delivery_id` to deduplicate on. See [the API guide](/docs/api).
+
+The same `daemon_reachable` rule applies: a request that fails to reach the daemon is not evidence
+about any run.
 
 ## Two practical notes
 

--- a/docs/content/work-queues.md
+++ b/docs/content/work-queues.md
@@ -15,11 +15,6 @@ Getting that wrong is expensive in both directions. Decide a healthy run is dead
 work. Decide a dead run is healthy and you leak a slot forever. This page covers how to ask, and
 three fields that will mislead you if you read them the obvious way.
 
-> [!NOTE]
-> **Before this page:** [The daemon](/docs/daemon).
-> **In one line:** poll `lev ps --all --json`, act on which list a run appears in, and do nothing at
-> all when the daemon is unreachable.
-
 ## Three things that are not what they look like
 
 **`updated_at` in `meta.json` is a heartbeat, not progress.** The daemon rewrites a run's metadata


### PR DESCRIPTION
A second docs pass on the feedback from #329, plus the staleness main has accumulated since.

## Reading experience

- **Getting Started** loses the daemon internals it did not need. The daemon starts itself, so the page no longer explains it; the shared-world diagram moves to where that story belongs. `lev dash` moves out of "Run an agent" into a **Read the result** section, and one sentence now says why nothing appears immediately: `lev run` returns when the work is accepted, not when it is done.
- **The `Before this page` / `In one line` note blocks are gone** from all 19 pages that carried them. They forced a fixed structure on every page and mostly restated the intro two lines above. The genuinely additive lines (the catalog pointer, the embedding escape hatch, the sandbox exception) moved into prose.
- **New Overview page**, first under Concepts, walking the whole system once (blueprints, stages, context, tools, sub-agents, interaction, outputs, the shared world, persistence, the four ways in), with each section linking to the page that covers it properly.

## Honesty, not sell

- `Naming what Leviath is not for is what makes the rest of this page worth believing` is gone. So is the tone rule that produced it. The rule now says to state limits because a reader deciding between tools deserves them, and explicitly bans sentences that point at our own honesty.
- **The two against-us sections merge into one.** "When to reach for the other one" and "Why you might not want Leviath" said the same things twice, which read as underselling. One section now, opening with "We would rather you pick the right tool than pick ours."
- **The sandbox scope is marked as in progress** in three places, each linking #326 as the intended end state rather than presenting today's scope as permanent.
- **Factor 11 passes.** Triggers exist from CLI, REST, and ACP; having no built-in scheduler is a design choice, not a missing feature. The row now also distinguishes what starts a run from what reports on one, since a WebSocket cannot start anything.

## Diagrams

- **The daemon diagram was wrong about tool calls.** It now shows the world building each inference request and running each tool batch through shared pools and a shared tool lane, because agents never call a provider or run a tool themselves.
- **The ECS page opens with the contrast it was missing**: one agent with its own loop against one sweep over rows, then a hundred of each showing per-agent clients against shared pools. It then links into the page's own sections, so the fundamentals are a choice rather than a toll gate.
- **Structured context, final outputs, and security** each get a diagram in the first screenful instead of pages in.

## Accuracy

- **Version archaeology removed.** The `Upgrading from 0.1.1` section became the current-state rules it was actually describing (regexes anchored and absolute, globs without `.`/`..`), and ten "used to" / "on 0.2 or later" sentences became statements about what happens now.
- **Pagination and the API as the integration surface.** A new "Prefer the API" section on work-queues covers keyset paging, `ids=` / `fields=` trimming, `since=`, WebSocket push, and completion webhooks, linked from the overview.
- **Caught what main moved past**: the embeddable crate is 0.3, `checklist` makes nine region kinds, the three `todo_*` tools were missing from the tool reference entirely, and `read_file` has a 256 KiB cap the table presented as complete contents.
- The Lair reads as "The Lair" in the prose that had drifted back to "the console".

A code-verification pass checked every added claim against the source; its two findings (the `read_file` cap and the WebSocket trigger claim) are fixed above. `cargo xtask docs` passes.
