### PR TITLE
chore(deps): accept the smartstring unmaintained advisory, with its reasoning

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,19 @@ ignore = [
     #   { id = "RUSTSEC-0000-0000", reason = "why this is acceptable here" },
     # Every entry needs a reason. An ignore with no justification is a silent
     # acceptance of risk, which is what this file exists to prevent.
+    # smartstring is unmaintained: the repository was archived on 2026-05-03.
+    #
+    # Accepted 2026-08-10, because nothing on our side can remove it. It is a
+    # hard, non-optional dependency of rhai, no rhai feature turns it off, and
+    # 1.25.1 is the latest release. rhai cannot swap it without a breaking
+    # change of its own, because SmartString appears in rhai's public API; the
+    # maintainer is weighing `ecow` in rhaiscript/rhai#816.
+    #
+    # Watch that issue rather than this advisory. It also covers a soundness
+    # concern in smartstring whose fix sits in an unmerged PR against the now
+    # archived repo, and that is the part that would actually matter to us.
+    # Revisit when rhai ships a release without smartstring.
+    { id = "RUSTSEC-2026-0249", reason = "unmaintained; transitive via rhai, no upgrade path, tracked in rhaiscript/rhai#816" },
 ]
 
 [licenses]


### PR DESCRIPTION
`RUSTSEC-2026-0249` marks **smartstring** unmaintained (repository archived 2026-05-03). It fails the Supply chain job on every PR, including docs-only ones.

## Why an ignore rather than a fix

Nothing on our side can remove it:

- smartstring is a **hard, non-optional dependency of rhai** (`[dependencies.smartstring]`, no `optional = true`). No rhai feature turns it off, so every rhai build links it.
- **rhai 1.25.1 is the newest release**, so there is no upgrade that escapes it.
- rhai cannot swap it without a breaking change of its own: `SmartString` appears in rhai's **public API**. The maintainer is weighing `ecow` in [rhaiscript/rhai#816](https://github.com/rhaiscript/rhai/issues/816), with no committed plan.
- A `[patch.crates-io]` fork would not clear this either, since the advisory is against the crate regardless of where it is sourced from.

Dropping rhai is not proportionate: it is the whole scripting surface (providers, tools, hooks, regions, validators).

## What to actually watch

rhai#816 is titled "smartstring is unsound and has UB", and the soundness fix sits in an unmerged PR against the now-archived repo. **That** is the part that would matter to us, not the unmaintained notice, so the ignore entry names the issue rather than just the advisory id. Revisit when rhai ships a release without smartstring.

`cargo deny check` passes locally: advisories ok, bans ok, licenses ok, sources ok.
