### PR TITLE
Update Version to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ same list.
 
 ## Unreleased
 
+## 0.3.3 - 2026-08-11
+
 - Changed: the outbound-request policy moved out of `leviath-core` into a new
   `leviath-net` crate. `leviath-core` describes itself as plain serializable
   data with no async dependencies and pulled a full HTTP client, so depending on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.2" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.2" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.2" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.2" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.2" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.2" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.2" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.2" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.2" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.2" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.2" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.2" }
+leviath = { path = "crates/leviath", version = "0.3.3" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.3" }
+leviath-net = { path = "crates/leviath-net", version = "0.3.3" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.3" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.3" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.3" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.3" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.3" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.3" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.3" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.3" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.3" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.2", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.3", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }


### PR DESCRIPTION
## What & why

<!-- What does this PR change, and what problem does it solve?
     Link the issue it addresses, if there is one: Fixes #NNN -->

## How it was tested

<!-- Beyond `cargo test`: if the change affects runtime behavior, describe the
     live run you did (`lev run ...`, `lev dash`, daemon restart, ...).
     CI-green alone is not evidence a behavior change works. -->

## Checklist

- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org) (`feat:`, `fix:`, `docs:`, ...)
- [ ] `cargo test --workspace` and `cargo clippy --workspace` pass locally (the pre-commit hook enforces this)
- [ ] New code is fully covered — CI gates at 100% lines/regions/functions with no opt-out
- [ ] Docs updated if user-facing behavior changed (`README.md`, `docs/content/`)
- [ ] `CHANGELOG.md` updated under `## Unreleased` if this is user-visible
- [ ] Version bumped only if this PR is meant to ship — use `cargo xtask version <X.Y.Z>`, and apply the `allow-version-bump` label (see [CONTRIBUTING](../CONTRIBUTING.md#cutting-a-release))
