### PR TITLE
feat(serve): a route for the per-stage ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ same list.
 
 ## Unreleased
 
+- New: `GET /api/agents/{id}/stages` serves a run's per-stage ledger - what each
+  stage cost, the cache read/write split, `region_tokens`, and whether the stage
+  was entered at all (#388). It was the one thing the runtime records per run
+  that no route exposed, so a client over HTTP had to reconstruct it by diffing
+  `context/history` snapshots: expensive, and blind to a stage that ran and
+  wrote nothing to any region. Advertised as the `runs.stages` capability.
+
 ## 0.3.3 - 2026-08-11
 
 - Changed: the outbound-request policy moved out of `leviath-core` into a new

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -720,6 +720,34 @@ pub(super) async fn agent_result(
     }))
 }
 
+/// `GET /api/agents/{id}/stages`: the run's per-stage ledger.
+///
+/// Read-only, and read through the same `stages.json` reader `lev stages`
+/// uses, so the CLI and the API cannot disagree about a run.
+///
+/// A missing or unreadable index is an empty list rather than a 404: the run
+/// exists - `read_meta` would have failed otherwise - and a run that has not
+/// reached its first stage boundary legitimately has no records yet. Reporting
+/// that as "no such run" would send a client back to re-ask a question that has
+/// already been answered.
+pub(super) async fn agent_stages(
+    AxumPath(id): AxumPath<String>,
+) -> Result<Json<RunStagesResp>, (StatusCode, Json<ErrorResponse>)> {
+    let meta = runstate::read_meta(&id).map_err(|_| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorResponse {
+                error: format!("Agent run '{}' not found", id),
+            }),
+        )
+    })?;
+
+    Ok(Json(RunStagesResp {
+        stages: runstate::read_stages_index(&id),
+        run_id: meta.run_id,
+    }))
+}
+
 /// `DELETE /api/agents/{id}`: cancel a run in the shared-world daemon. The
 /// daemon cancels the agent (cascading to its sub-agents in the one world) and
 /// persists the terminal status.
@@ -3344,6 +3372,153 @@ system_prompt = "Plan the work"
             assert!(v["next_offset"].is_null(), "nothing more to fetch");
 
             let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
+        })
+        .await;
+    }
+
+    // ─── GET /api/agents/{id}/stages (#388) ──────────────────────────────────
+
+    /// Build a ledger with one stage that ran, one the run stepped over, and
+    /// one still ahead of it.
+    fn ledger_fixture() -> Vec<leviath_core::run_meta::StageRecord> {
+        use leviath_core::run_meta::{StageRecord, StageRunStatus};
+        let mut plan = StageRecord::new("plan".to_string(), 0);
+        plan.status = StageRunStatus::Complete;
+        plan.entered = true;
+        plan.prompt_tokens = 900;
+        plan.completion_tokens = 120;
+        plan.cached_tokens = 400;
+        plan.cache_write_tokens = 60;
+        plan.region_tokens.insert("task".to_string(), 24);
+        plan.region_tokens.insert("data_preview".to_string(), 4004);
+        plan.runaway_warned = true;
+
+        let mut recovery = StageRecord::new("error_recovery".to_string(), 1);
+        recovery.status = StageRunStatus::Skipped;
+
+        let answer = StageRecord::new("answer".to_string(), 2);
+        vec![plan, recovery, answer]
+    }
+
+    /// The route the issue asks for: the per-stage ledger, served as recorded.
+    #[tokio::test]
+    async fn agent_stages_serves_the_per_stage_ledger() {
+        crate::runstate::with_isolated_runs_dir_async("agent_stages_serves", |_d| async move {
+            let run_id = unique_run_id("stages-ledger");
+            create_run(&make_run(&run_id)).unwrap();
+            runstate::write_stages_index(&run_id, &ledger_fixture()).unwrap();
+
+            let app = Router::new()
+                .route("/api/agents/{id}/stages", get(agent_stages))
+                .with_state(test_state());
+            let req = Request::builder()
+                .uri(format!("/api/agents/{}/stages", run_id))
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert_eq!(body["run_id"], run_id);
+
+            let stages = body["stages"].as_array().expect("an array of stages");
+            assert_eq!(stages.len(), 3);
+
+            // The costs no other route can answer.
+            assert_eq!(stages[0]["name"], "plan");
+            assert_eq!(stages[0]["prompt_tokens"], 900);
+            assert_eq!(stages[0]["cache_write_tokens"], 60);
+            assert_eq!(stages[0]["region_tokens"]["data_preview"], 4004);
+            assert_eq!(stages[0]["runaway_warned"], true);
+
+            // The distinction that cannot be reconstructed from context/history:
+            // a stage the run stepped over, versus one still ahead of it.
+            assert_eq!(stages[1]["entered"], false);
+            assert_eq!(stages[2]["entered"], false);
+        })
+        .await;
+    }
+
+    /// The wire spelling is snake_case, and pinned here because the issue is
+    /// right that this has drifted before: `RunMeta` serializes snake_case
+    /// while the result and tree routes render a PascalCase `Display`, and that
+    /// asymmetry has already cost one filter bug.
+    #[tokio::test]
+    async fn agent_stages_spells_status_in_snake_case() {
+        crate::runstate::with_isolated_runs_dir_async("agent_stages_spelling", |_d| async move {
+            let run_id = unique_run_id("stages-spelling");
+            create_run(&make_run(&run_id)).unwrap();
+            runstate::write_stages_index(&run_id, &ledger_fixture()).unwrap();
+
+            let app = Router::new()
+                .route("/api/agents/{id}/stages", get(agent_stages))
+                .with_state(test_state());
+            let req = Request::builder()
+                .uri(format!("/api/agents/{}/stages", run_id))
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+
+            assert_eq!(body["stages"][0]["status"], "complete");
+            assert_eq!(
+                body["stages"][1]["status"], "skipped",
+                "the status #372 added has to reach the wire under the name the \
+                 schema advertises"
+            );
+            assert_eq!(body["stages"][2]["status"], "pending");
+        })
+        .await;
+    }
+
+    /// A run that has not reached its first stage boundary has no records yet.
+    /// That is an empty list, not a 404 - the run exists, and answering "no
+    /// such run" would send a client back to re-ask a settled question.
+    #[tokio::test]
+    async fn agent_stages_of_a_run_with_no_index_is_empty() {
+        crate::runstate::with_isolated_runs_dir_async("agent_stages_empty", |_d| async move {
+            let run_id = unique_run_id("stages-empty");
+            create_run(&make_run(&run_id)).unwrap();
+
+            let app = Router::new()
+                .route("/api/agents/{id}/stages", get(agent_stages))
+                .with_state(test_state());
+            let req = Request::builder()
+                .uri(format!("/api/agents/{}/stages", run_id))
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+            assert!(body["stages"].as_array().expect("an array").is_empty());
+        })
+        .await;
+    }
+
+    /// A run that does not exist is still a 404, or the empty-list answer above
+    /// would swallow a typo'd id.
+    #[tokio::test]
+    async fn agent_stages_of_an_unknown_run_is_not_found() {
+        crate::runstate::with_isolated_runs_dir_async("agent_stages_unknown", |_d| async move {
+            let app = Router::new()
+                .route("/api/agents/{id}/stages", get(agent_stages))
+                .with_state(test_state());
+            let req = Request::builder()
+                .uri("/api/agents/no-such-run/stages")
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
         })
         .await;
     }

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -100,6 +100,7 @@ fn api_router() -> Router<AppState> {
         .route("/api/agents/{id}/files", get(agents::agent_file))
         .route("/api/agents/{id}/logs", get(agents::agent_logs))
         .route("/api/agents/{id}/result", get(agents::agent_result))
+        .route("/api/agents/{id}/stages", get(agents::agent_stages))
         .route("/api/agents/{id}/tree-status", get(tree::agent_tree_status))
         .route("/api/agents/{id}/pause", post(agents::pause_agent))
         .route("/api/agents/{id}/resume", post(agents::resume_agent))

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -763,6 +763,28 @@ pub(super) enum FileOrListing {
     Listing(Box<RunFileListing>),
 }
 
+/// Response of `GET /api/agents/{id}/stages`: the run's per-stage ledger.
+///
+/// The one thing the runtime records per run that no route served. Everything
+/// here is already on disk in `stages.json` and already read by `lev stages`;
+/// a client over HTTP had to reconstruct the interesting part by diffing
+/// `context/history` snapshots, which is expensive and cannot see a stage that
+/// ran and wrote nothing (#388).
+///
+/// Not paginated. The list is bounded by the blueprint's stage count - a dozen
+/// at the top end - so a cursor would be ceremony over a short array. The
+/// records themselves are open-ended in width because `region_tokens` has one
+/// entry per region, which is the reason this is its own route rather than a
+/// field on the run listing.
+#[derive(Debug, Serialize)]
+pub(super) struct RunStagesResp {
+    /// The run these stages belong to, echoed so a response is self-describing
+    /// when it has been passed around.
+    pub(super) run_id: String,
+    /// Per-stage records in blueprint order, exactly as recorded.
+    pub(super) stages: Vec<leviath_core::run_meta::StageRecord>,
+}
+
 /// Response of `GET /api/agents/{id}/files` with no file named.
 #[derive(Debug, Serialize)]
 pub(super) struct RunFileListing {
@@ -988,6 +1010,7 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     "runs.since",
     "runs.files.listing",
     "runs.files.workdir",
+    "runs.stages",
     "logs.stage",
     "logs.stream",
     "context.history.page",

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -164,6 +164,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/agents/{id}/result` · `/context` | The run's answer and log tail · current context window |
 | `GET /api/agents/{id}/logs?stage=&stream=&tail=` | A run's logs. `stage` takes an index or `all`, defaulting to the current stage; `stream` is `output` (the assistant's text) or `logs` (tool calls, token counts, errors); `tail` is a byte budget |
 | `GET /api/agents/{id}/context/history` | How the context window changed over the run, paginated |
+| `GET /api/agents/{id}/stages` | The per-stage ledger: what each stage cost, which regions it carried, and whether it ran at all. See [below](#where-a-runs-cost-went) |
 | `GET /api/agents/{id}/files` | List a run's files, or read one with `?path=`. `offset` pages a large one. See [below](#a-runs-files) |
 | `GET /api/agents/tree` · `/{id}/tree-status` · `/{id}/children` | Sub-agent tree + token roll-ups |
 | `POST /api/agents/{id}/pause` · `/resume` | Pause a run · resume it |
@@ -239,6 +240,58 @@ One honest limit: the deep sources match the raw JSON on disk, so a query contai
 a backslash or a newline may not match text that does contain it.
 
 ## A run's files
+
+## Where a run's cost went
+
+`GET /api/agents/{id}/stages` returns one record per declared stage, in blueprint
+order:
+
+```json
+{
+  "run_id": "analyst-1786409275-d17e8f82",
+  "stages": [
+    { "name": "plan",           "status": "complete", "entered": true,
+      "prompt_tokens": 8420, "completion_tokens": 610,
+      "cached_tokens": 6100, "cache_write_tokens": 240,
+      "region_tokens": { "task": 24, "data_preview": 4004 },
+      "runaway_warned": false },
+    { "name": "error_recovery", "status": "skipped",  "entered": false },
+    { "name": "answer",         "status": "complete", "entered": true }
+  ]
+}
+```
+
+Three things here are not derivable from any other route.
+
+**`entered` says whether the run was ever in that stage.** The alternative is to
+fetch `context/history` and diff consecutive snapshots to see which stages
+produced entries, which is expensive - every point carries a whole context
+window - and wrong in the case that matters: a stage that ran and wrote nothing
+to any region leaves no trace to find. `status: "skipped"` is the same fact
+stated from the other side, and means the run finished without reaching this
+stage, as distinct from `"pending"` on a run that is still going.
+
+**The per-stage cost split.** The run-level totals are on the run record; which
+stage spent them, and the cache read/write split within a stage, are only here.
+A stage showing no cache reads cannot be told apart from one paying to write a
+prefix nothing reuses without `cache_write_tokens`.
+
+**`region_tokens` is what decides whether a region is earning its place** - the
+largest each region reached while that stage was active. This is the number to
+look at before trimming a layout.
+
+`runaway_warned` is set when a stage's per-call prompt passed four times its
+first call, which is the shape of a region accumulating without a cap.
+
+The list is bounded by the blueprint's stage count, so it is not paginated. A run
+that has not reached its first stage boundary returns an empty list rather than a
+404 - the run exists, it just has nothing to report yet.
+
+> [!NOTE]
+> `entered` is `false` for every stage of a run recorded before Leviath tracked
+> it, because the field simply is not in those files. Read it together with
+> `status`: a stage recorded `complete` with tokens against its name ran,
+> whatever `entered` says on an old run.
 
 `GET /api/agents/{id}/files` answers two different questions, and neither substitutes for the other.
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1085,6 +1085,42 @@
           }
         }
       }
+    },
+    "/api/agents/{id}/stages": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Id"
+        }
+      ],
+      "get": {
+        "tags": [
+          "agents"
+        ],
+        "summary": "The run's per-stage ledger",
+        "description": "What each stage cost and which regions it carried. Not derivable from the other routes: a stage that ran and wrote nothing to any region leaves no trace in context/history, so `entered` is the only way to tell it from a stage that was never reached.",
+        "responses": {
+          "200": {
+            "description": "Stage records in blueprint order. Empty for a run that has not reached its first stage boundary.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunStagesResp"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No run with that id.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1353,6 +1389,113 @@
         "properties": {
           "error": {
             "type": "string"
+          }
+        }
+      },
+      "RunStagesResp": {
+        "type": "object",
+        "required": [
+          "run_id",
+          "stages"
+        ],
+        "properties": {
+          "run_id": {
+            "type": "string"
+          },
+          "stages": {
+            "type": "array",
+            "description": "One record per declared stage, in blueprint order.",
+            "items": {
+              "$ref": "#/components/schemas/StageRecord"
+            }
+          }
+        }
+      },
+      "StageRecord": {
+        "type": "object",
+        "required": [
+          "name",
+          "index",
+          "status",
+          "entered",
+          "prompt_tokens",
+          "completion_tokens"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The stage's key under [stages]."
+          },
+          "index": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Position in the blueprint's stage list. Not a progress measure: stages loop and revisit."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "active",
+              "waiting_input",
+              "complete",
+              "error",
+              "skipped"
+            ],
+            "description": "`skipped` means the run finished without ever entering this stage, which is distinct from `pending` (not yet, on a live run)."
+          },
+          "entered": {
+            "type": "boolean",
+            "description": "Whether the run has ever been in this stage. Position cannot answer this - a graph reaches its stages in whatever order its edges describe. False for every stage of a run recorded before Leviath tracked this, because the field is not in those files; read it together with `status`."
+          },
+          "prompt_tokens": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "cached_tokens": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "cache_write_tokens": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Without this a stage showing no cache reads cannot be told apart from one paying to write a prefix nothing reuses."
+          },
+          "region_tokens": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "minimum": 0
+            },
+            "description": "The largest each region reached while this stage was active, by region name. The number that decides whether a region is earning its place."
+          },
+          "first_call_prompt_tokens": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "minimum": 0
+          },
+          "runaway_warned": {
+            "type": "boolean",
+            "description": "The stage's per-call prompt passed four times its first call - the shape of a region accumulating without a cap."
+          },
+          "started_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Unix seconds; null until the stage is entered."
+          },
+          "ended_at": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Unix seconds; null until the stage is left."
           }
         }
       }


### PR DESCRIPTION
Closes #388.

```
GET /api/agents/{id}/stages  ->  { run_id, stages: [StageRecord, ...] }
```

Verified against a real `lev serve` over HTTP, on a run written by this build:

```
plan             status=complete  entered=true   prompt=10  regions=4
error_recovery   status=skipped   entered=false  prompt=0   regions=0
answer           status=complete  entered=true   prompt=10  regions=4
```

The middle row is the thing the issue is about. It is not reconstructible from
`context/history` — a stage that ran and wrote nothing to any region leaves no
snapshot to diff, and `error_recovery` here was never entered at all.

## Decisions

**Not paginated.** The list is bounded by the blueprint's stage count, so a
cursor would be ceremony over a short array. You're right that `region_tokens`
makes each record open-ended in width, and that's exactly why this is its own
route rather than a field on the run listing — the listing stays cheap.

**Empty index → empty list, not 404.** The run exists (`read_meta` would have
failed otherwise); a run that hasn't reached its first stage boundary just has
nothing to report yet. Answering "no such run" would send a client back to
re-ask a settled question. An unknown id is still a 404, and there's a test for
each, so the empty answer can't swallow a typo.

**Read through the same reader `lev stages` uses**, so the CLI and the API can't
disagree about a run.

## On the wire spelling

Already pinned — `StageRunStatus` carries `rename_all = "snake_case"` just like
`RunStatus`, so it was not inheriting whatever it happened to serialize as.
There's now a test asserting the exact strings, including the `skipped` variant
#372 added, so the two can't drift apart quietly later.

## One caveat found by testing, not by reading

Running the probe against an *older* run first gave `entered: false` on stages
that were `complete` with tokens against their name. That's not a bug in the
route: those files predate #372 and have no `entered` key at all, so serde's
default fills in `false`. I only trusted the fresh-run result after confirming
the old file's key set.

Documented on both the schema property and the API page, with the advice to read
`entered` beside `status` — a stage recorded `complete` with billed tokens ran,
whatever `entered` says on an old run.

## Also

- Capability `runs.stages`, so clients gate rather than probe.
- `docs/content/api.md` gets a route row and a "Where a run's cost went" section.
- `docs/schema/openapi.json` gets the route plus `RunStagesResp` and
  `StageRecord` schemas. Not optional paperwork here: a test pins the spec to
  exactly the routes the router serves, so an undocumented route fails CI — which
  is how I found out I needed it.

## Verification

- `cargo test --workspace` — 0 failures
- `cargo xtask coverage --package leviath-cli` — exit 0
- live: real server, real run, over HTTP, plus the 404 path
- clippy, fmt, `cargo xtask docs --check` clean
