### PR TITLE
docs: write the engine page for someone who has never met an ECS

### DIFF
--- a/docs/content/comparison.md
+++ b/docs/content/comparison.md
@@ -61,9 +61,11 @@ description comes from that project's own documentation.
 We would rather you pick the right tool than pick ours, so here is where Leviath is the wrong
 answer and what to reach for instead.
 
-**Use a coding agent like Claude Code or Codex** when you want to sit down and work with something
-polished and interactive. They are better at that than Leviath is, and it is not close. Leviath can
-even run *on top of* Claude Code as a transport, so this is not either/or.
+**Use a coding agent like Claude Code or Codex** when you want the familiar thing: a chat in your
+terminal or editor, aimed squarely at writing code, that you steer turn by turn. That interactive
+loop is what they are built around, and it is the experience most people want most days. Leviath
+asks you to describe the work up front instead, which pays off on a task with distinct phases and
+gets in the way of a quick edit.
 
 **Use CrewAI or LangGraph** when your orchestration already lives in Python or TypeScript and you
 want the workflow expressed in code, with your own types and your own tests around it. A Leviath
@@ -71,18 +73,11 @@ agent is a TOML blueprint plus optional Rhai script tools, so if you want agent 
 language against an SDK, that model is not here. Other languages drive Leviath through the
 [REST API](/docs/api) instead.
 
-**Use [Gas City](/docs/gas-city) (an orchestration-builder SDK from the
-[Gas Town Hall](https://gastownhall.ai/) project) or [OpenHands](https://docs.all-hands.dev/)**
-when the hard problem is coordinating work across issues, repos, and people. That is a different problem from what happens
-inside one agent, and Leviath does not try to solve it. Run Leviath underneath one of them if you
-want both.
-
 **Use a hosted platform** if you want somebody else operating it. You run the Leviath daemon
 yourself. [`lev serve`](/docs/api) and [The Lair](https://leviath.dev/lair) reach it from anywhere,
 but there is no hosted service and no multi-machine scheduling.
 
-You also need a model provider either way: an API key, a local Ollama, or the Claude Code transport
-with its terms-of-service caveat.
+You also need a model provider either way: an API key or a local Ollama.
 
 One current limit worth knowing before you choose. Every agent has its own state, workdir fence,
 tool policy, and panic boundary, so one agent's crash stays its own. The opt-in

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -1,20 +1,34 @@
 ---
-title: ECS engine
-description: The ECS engine that keeps each agent as a row of data, so an agent that is waiting costs almost nothing.
+title: The agent engine
+description: How one process runs many agents at once: each is a row of data in an Entity Component System, so a waiting agent costs almost nothing.
 group: Concepts
 group_order: 2
 order: 3
 ---
 
-# The ECS agent engine
+# The agent engine
 
 Most of the agents you run are waiting. Waiting on a model to reply, on a tool to finish, on a
 person to answer a question. If every waiting agent costs you an operating system process, then a
 hundred agents cost a hundred processes whether or not any of them are doing anything.
 
-Leviath keeps each agent as a row of data in one shared table. A waiting agent is a row nothing
-touched this pass, which costs close to nothing, so the machine only pays for work that is actually
-in flight.
+So Leviath does not give an agent a process, a thread, or even a task of its own. It keeps each
+agent as a **row of data** in one shared table, and runs a fixed list of functions across the whole
+table over and over. An agent with nothing to do is a row those functions skipped, which costs
+close to nothing.
+
+That arrangement has a name: an **Entity Component System**, usually shortened to **ECS**. Game
+engines use it to move thousands of objects every frame, for the same reason it suits agents. The
+three words are the three pieces, and this page explains each one as it goes:
+
+| Word | Means here |
+|---|---|
+| **Entity** | One agent. Really just a row number, with no code attached to it. |
+| **Component** | One piece of an agent's data, such as its context window or which stage it is on. |
+| **System** | One function that runs across every agent in a given state and moves it along. |
+
+You never configure any of this. It is here because "hundreds of agents in one process" is a claim
+worth being able to check.
 
 ## The usual shape, and this one
 
@@ -33,21 +47,29 @@ flowchart LR
   end
 ```
 
-Leviath turns that inside out. There is no agent loop and no agent object. Each agent is a row of
-data, and one fixed list of functions sweeps across every row, moving each one a single step:
+Leviath turns that inside out. The loop belongs to the engine, not to any agent, and it is a
+pipeline: a fixed sequence of phases that runs start to finish, over and over. Each phase is one
+function, and it acts on whichever agents happen to be sitting at that phase right now.
 
 ```mermaid
 flowchart LR
-  subgraph W["One world, one sweep for everybody"]
-    direction TB
-    R1["agent 1: ready to call the model"]
-    R2["agent 2: waiting on a reply"]
-    R3["agent 3: tools running"]
-    R4["agent 4: waiting on a person"]
-  end
-  W --> SYS["Each function handles the rows it applies to,<br/>then the sweep ends"]
-  SYS -->|"rows that moved"| W
+  P1["Phase 1<br/>Ask the model<br/>· agent 1 · agent 7"]
+  P2["Phase 2<br/>Take replies that arrived<br/>· agent 2 · agent 6 still waiting"]
+  P3["Phase 3<br/>Start tool calls<br/>· agent 4"]
+  P4["Phase 4<br/>Take finished tool results<br/>· agent 3"]
+  P5["Phase 5<br/>Choose the next stage<br/>· agent 5"]
+  P1 --> P2 --> P3 --> P4 --> P5
+  P5 -.->|"run it again"| P1
 ```
+
+Read one pass of that left to right. Agents 1 and 7 have a request ready, so the first phase sends
+both. Agent 2's reply has landed, so the second phase takes it, while agent 6 is still waiting on
+the provider and is skipped at no cost. Agent 4's turn asked for tools, so the third phase starts
+them. Agent 3's tools have come back. Agent 5 finished its stage and needs an edge chosen.
+
+Nobody was blocked and nothing was waited on. An agent's position in the pipeline **is** a piece of
+its data, so the phase that acts on it finds it by looking, and an agent waiting on the outside
+world is simply not in any phase's list this pass.
 
 The difference shows up when there are many of them. In the usual shape, each agent brings its own
 task, its own client, and its own copy of everything around it:
@@ -56,13 +78,13 @@ task, its own client, and its own copy of everything around it:
 flowchart TB
   subgraph TRAD["100 agents, the usual way"]
     direction LR
-    P1["agent + task<br/>+ its own client"]
-    P2["agent + task<br/>+ its own client"]
-    P3["…98 more"]
+    T1["agent + task<br/>+ its own client"]
+    T2["agent + task<br/>+ its own client"]
+    T3["…98 more"]
   end
-  P1 --> API["Model provider"]
-  P2 --> API
-  P3 --> API
+  T1 --> API["Model provider"]
+  T2 --> API
+  T3 --> API
 ```
 
 In Leviath they are 100 rows in one table, sharing one set of connections, rate limits, and tool
@@ -82,17 +104,15 @@ flowchart TB
   LANE --> TOOLS["Tools"]
 ```
 
-The rest of this page is how that works: [what the pieces are called](#entities-components-and-systems),
-[what one agent is made of](#an-agent-is-an-entity),
-[how it moves](#markers-are-the-state-machine), [what a sweep is](#what-a-tick-is), and
-[what happens when one agent breaks](#one-agents-failure-stays-one-agents-failure). You never have
-to configure any of it.
+The rest of this page fills that in: [what the three words mean precisely](#entities-components-and-systems),
+[what one agent is made of](#an-agent-is-an-entity), [how it moves between phases](#markers-are-the-state-machine),
+[what one pass costs](#what-a-tick-is), and
+[what happens when one agent breaks](#one-agents-failure-stays-one-agents-failure).
 
 ## Entities, components, and systems
 
-Leviath is built on [bevy_ecs](https://bevyengine.org/), a library for organising data the way game
-engines do: an Entity Component System. An ECS turns an agent inside out. Instead of one object
-with its own methods and its own task, parked on an `await`, there are three separate things:
+Leviath gets this from [bevy_ecs](https://bevyengine.org/), a library built for game engines and
+used here unchanged. Precisely:
 
 - An **entity** is just an id. No data, no methods. Think of it as a row number.
 - A **component** is a plain struct attached to an entity. `AgentState` is a component,
@@ -100,8 +120,8 @@ with its own methods and its own task, parked on an `await`, there are three sep
 - A **system** is an ordinary function that runs over every entity carrying some particular set of
   components. It asks for what it needs and changes it in place.
 
-So there is no agent object that knows how to run itself. There is agent-shaped **data**, and a
-fixed list of functions that sweep across all of it. Nothing sits on an `await`, because nothing
+So there is no agent object that knows how to run itself. There is agent-shaped **data**, and the
+pipeline of functions above running across all of it. Nothing sits on an `await`, because nothing
 owns a call stack. A blocked agent is just a row that this pass skipped.
 
 That trade is aimed at running many agents at once:

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -18,8 +18,13 @@ table over and over. An agent with nothing to do is a row those functions skippe
 close to nothing.
 
 That arrangement has a name: an **Entity Component System**, usually shortened to **ECS**. Game
-engines use it to move thousands of objects every frame, for the same reason it suits agents. The
-three words are the three pieces, and this page explains each one as it goes:
+engines use it to move thousands of objects per frame, and Leviath borrows the storage and
+iteration rather than the reason: games want cache locality in a tight frame budget, while an agent
+runtime wants a way to hold state for something that is mostly waiting. If you have written a
+reactor with a state machine per connection, this will feel familiar. The ECS supplies the table
+and the sweep so Leviath does not hand-roll them.
+
+The three words are the three pieces, and this page explains each one as it goes:
 
 | Word | Means here |
 |---|---|
@@ -27,8 +32,12 @@ three words are the three pieces, and this page explains each one as it goes:
 | **Component** | One piece of an agent's data, such as its context window or which stage it is on. |
 | **System** | One function that runs across every agent in a given state and moves it along. |
 
-You never configure any of this. It is here because "hundreds of agents in one process" is a claim
-worth being able to check.
+Two words from elsewhere in the docs turn up throughout. A **stage** is one phase of the agent's
+own workflow, with its own prompt, model, and tools, described in
+[Multi-stage workflows](/docs/stages). The **world** is the single table this page keeps talking
+about: one per daemon, holding every agent on the machine.
+
+You never configure any of this.
 
 ## The usual shape, and this one
 
@@ -51,6 +60,10 @@ Leviath turns that inside out. The loop belongs to the engine, not to any agent,
 pipeline: a fixed sequence of phases that runs start to finish, over and over. Each phase is one
 function, and it acts on whichever agents happen to be sitting at that phase right now.
 
+Here is the spine of it. The real pipeline has about forty-five functions; these five are the ones
+that move an ordinary turn, and the rest handle summarizing context, spotting a stuck agent,
+iteration caps, checkpoints, fan-out, telemetry, and writing to disk.
+
 ```mermaid
 flowchart LR
   P1["Phase 1<br/>Ask the model<br/>· agent 1 · agent 7"]
@@ -63,23 +76,29 @@ flowchart LR
 ```
 
 Read one pass of that left to right. Agents 1 and 7 have a request ready, so the first phase sends
-both. Agent 2's reply has landed, so the second phase takes it, while agent 6 is still waiting on
-the provider and is skipped at no cost. Agent 4's turn asked for tools, so the third phase starts
-them. Agent 3's tools have come back. Agent 5 finished its stage and needs an edge chosen.
+both and moves on. Agent 2's reply has come back, so the second phase takes it. Agent 6 is in that
+same phase but its reply has not arrived, so the function looks at it, finds nothing to do, and
+leaves it there. Agent 4's turn asked for tools, so the third phase starts them. Agent 3's tools
+have finished. Agent 5 reached the end of its stage and needs its next one chosen.
 
-Nobody was blocked and nothing was waited on. An agent's position in the pipeline **is** a piece of
-its data, so the phase that acts on it finds it by looking, and an agent waiting on the outside
-world is simply not in any phase's list this pass.
+Two things to take from that. **Nothing blocked**: sending a request and collecting its reply are
+different phases, so an agent that asks the model in one pass is collected in some *later* pass,
+whenever the answer actually arrives. And **an agent with nothing to do costs a glance**. Agent 6
+was looked at and skipped; no thread was parked on it, and no work was queued behind it.
 
-The difference shows up when there are many of them. In the usual shape, each agent brings its own
-task, its own client, and its own copy of everything around it:
+An agent's position in the pipeline is itself a piece of its data, which is what lets each phase
+find its agents by looking rather than by being told.
+
+The difference shows up when there are many of them. Give each agent its own task and the runtime
+has 100 things it must schedule, each holding a turn's worth of stack, and any budget you want to
+apply across all of them has to be coordinated between them:
 
 ```mermaid
 flowchart TB
-  subgraph TRAD["100 agents, the usual way"]
+  subgraph TRAD["100 agents, one task each"]
     direction LR
-    T1["agent + task<br/>+ its own client"]
-    T2["agent + task<br/>+ its own client"]
+    T1["agent + its own task"]
+    T2["agent + its own task"]
     T3["…98 more"]
   end
   T1 --> API["Model provider"]
@@ -87,8 +106,8 @@ flowchart TB
   T3 --> API
 ```
 
-In Leviath they are 100 rows in one table, sharing one set of connections, rate limits, and tool
-capacity:
+In Leviath they are 100 rows in one table, and the budgets live in one place because there is only
+one place to put them:
 
 ```mermaid
 flowchart TB
@@ -104,7 +123,25 @@ flowchart TB
   LANE --> TOOLS["Tools"]
 ```
 
-The rest of this page fills that in: [what the three words mean precisely](#entities-components-and-systems),
+### The cost that is left
+
+Being straight about what this does and does not buy. It removes the per-agent task and the
+per-agent scheduling, which is the part that scales badly. It does **not** make an agent free,
+because the expensive thing an idle agent holds is its context window, and that stays in memory
+while the run is live. A hundred idle agents with large windows cost real memory, whatever the
+concurrency model.
+
+Two cases reclaim it. A **paused** run is written to disk and dropped from the world entirely, then
+rebuilt when you resume it. A **fan-out worker** whose result has been merged and persisted has its
+window, blueprint, and stage tables removed while its record stays. Everything else keeps its
+window until the run ends.
+
+Every system also runs on one thread, in a fixed order, so a pass is serial in the number of agents
+that have something to do. Idle agents cost a glance each, and a pass where nothing changed puts
+the loop to sleep entirely, which is the [fixed point](#what-a-tick-is) below.
+
+From here the page gets specific:
+[what the three words mean precisely](#entities-components-and-systems),
 [what one agent is made of](#an-agent-is-an-entity), [how it moves between phases](#markers-are-the-state-machine),
 [what one pass costs](#what-a-tick-is), and
 [what happens when one agent breaks](#one-agents-failure-stays-one-agents-failure).
@@ -224,30 +261,33 @@ flowchart TD
 2. **`collect_inference`** picks up whatever came back and moves the agent to `ProcessResponse`.
 3. **`process_response`** reads the reply. Tool calls go down the tool path; plain text goes toward
    a transition.
-4. **`dispatch_tools`** enforces the stage's `available_tools` (a tool the stage never advertised is
-   refused, not merely hidden), runs the taint and permission checks, applies `context_*` tools
-   immediately, and sends everything else to the tool lane.
+4. **`dispatch_tools`** checks each requested call before it runs. A tool the stage never
+   advertised in `available_tools` is refused rather than hidden, [permissions](/docs/tools) decide
+   whether the call needs you, and [taint tracking](/docs/security#taint-tracking-experimental)
+   blocks a call that would carry sensitive data somewhere it should not go. Calls that only edit
+   the agent's own context apply here; the rest go to the tool lane.
 5. **`collect_tools`** merges the results back into the order the model asked for them, files each
-   into a context region per the stage's tool routing, and returns the agent to `ReadyToInfer`.
-6. **`resolve_transition`** ends the stage with one of six answers: `Terminal` (done),
-   `TerminalError` (failed with no `error` edge to catch it), `Next` (take this edge), `Choose`
-   (ask the model which edge), `Resume` (a `stuck` interrupt fired with no `stuck` edge, so keep
-   going), or `DeadEnd` (every outgoing edge is exhausted, which routes down the `error` edge or
-   fails the run rather than faking a completion).
+   into the [context region](/docs/context) the stage routes it to, and returns the agent to
+   `ReadyToInfer`.
+6. **`resolve_transition`** picks what happens at the end of a stage. A stage's outgoing edges are
+   its [transitions](/docs/stages), including ones that fire on an error or when the agent is
+   detected going in circles. There are six answers: `Terminal` (done), `TerminalError` (failed,
+   with no `error` edge to catch it), `Next` (take this edge), `Choose` (ask the model which edge),
+   `Resume` (the agent looked stuck, but the stage has no edge for that, so carry on), and
+   `DeadEnd` (every edge out is exhausted, which routes to the `error` edge or fails the run rather
+   than reporting a completion that did not happen).
 
-Those are six of roughly forty-five systems. The rest handle compaction, stuck detection,
-iteration caps, interaction points, fan-out, telemetry, and persistence, all in a fixed order every
-pass. See [Multi-stage workflows](/docs/stages) for the transition conditions and
-[Structured context](/docs/context) for the regions.
+Those are six of the roughly forty-five. See [Multi-stage workflows](/docs/stages) for what the
+transition conditions mean and [Structured context](/docs/context) for what the regions do.
 
 ## What a tick is
 
 A **tick** is one pass of that whole system list over every agent in the world. The systems run
 one after another in a fixed order, so no two ever overlap, and no system ever awaits. A dispatch
 system starts async work and swaps in an `Awaiting*` marker; a collect system on a later tick
-picks the result up. That one rule is what makes "hundreds of agents in one process" true, and it
-gives you backpressure for free: a full pool just means an agent stays `ReadyToInfer` until a later
-tick finds it a slot.
+picks the result up. That one rule is what keeps a pass short no matter how many agents are
+waiting, and it gives you backpressure for free: a full pool just means an agent stays
+`ReadyToInfer` until a later tick finds it a slot.
 
 At the end of a tick, Leviath counts how many agents carry each of the twelve markers. Those
 counts are the world's **fingerprint**. The loop does not do its work on a clock. It ticks for as
@@ -327,5 +367,5 @@ is the guarantee separate processes would give you and this design does not.
 
 > [!NOTE]
 > The engine is not something you usually configure. You describe *what* an agent does in its
-> [blueprint](/docs/agents), and the engine works out how to run it. This page exists so that
-> "hundreds of agents in one process" is not a black box.
+> [blueprint](/docs/agents), and the engine works out how to run it. This page exists so the
+> design is inspectable rather than something you have to take on trust.

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -90,8 +90,8 @@ script. See [Outputs](/docs/outputs).
 [daemon](/docs/daemon) that holds every agent in one process, and returns immediately.
 
 That is what makes hundreds of concurrent agents affordable: a waiting agent is a row of data
-nothing touched this pass, not an idle process. The [ECS engine](/docs/engine) page explains the
-design, and you never have to think about it to use Leviath.
+nothing touched this pass, not an idle process. [The agent engine](/docs/engine) explains how, and
+you never have to think about it to use Leviath.
 
 ## Nothing lives only in memory
 


### PR DESCRIPTION
Two things from a read-through of the merged docs.

## Where Leviath sits: three claims that were wrong

- **"They are better at that than Leviath is, and it is not close"** about Claude Code and Codex. That is not the useful distinction and it undersells for no reason. They are now described as what they are: the familiar interactive loop, in your terminal or editor, aimed squarely at coding, steered turn by turn. Leviath asks you to describe the work up front, which pays off across phases and gets in the way of a quick edit.
- **Gas City and OpenHands are gone from that section entirely.** They are not alternatives to Leviath, they sit above it, which the layers diagram at the top of the same page already says. Listing them as things to use *instead* contradicted it.
- **The Claude Code transport mention is gone** from this page. It still lives on [Providers](/docs/providers), which is where someone looking for it would be.

## The agent engine page: written for someone who has never met an ECS

The page was called "ECS engine" and said "ECS" throughout, which tells a skeptical reader nothing. Now:

- **The mechanism arrives before the label.** An agent is a row of data in a shared table, functions sweep the table, then the name for that arrangement is given as **Entity Component System**, with a table of what each of the three words means here.
- **The page is retitled** to "The agent engine", since "ECS" in a sidebar is a wall rather than a signpost. Slug unchanged.
- **The second diagram is drawn as the pipeline it is**: five phases in order, each labelled with the agents sitting at it, with an agent that gets skipped for free shown in place.
- **Stage and world are defined** before the page leans on them, and the walkthrough no longer drops taint, `stuck` edges, `error` edges, and context tools on a reader with no gloss and no link.

I also ran the revised page past a fresh reader playing a backend engineer who is skeptical of "hundreds of agents in one process" and has never used a game engine. Four things they caught, all fixed:

1. **The diagram contradicted the prose.** Agent 6 was drawn inside phase 2 while the text said waiting agents are in no phase's list. The diagram was right; the prose now matches it.
2. **Left-to-right implied dispatch and collect happen in one pass.** That correction used to be 190 lines away. It is now next to the diagram.
3. **Five phases, forty-five systems.** The page never admitted the picture was a simplification, so discovering it later undercut the rest. It says so up front now.
4. **The game-engine analogy was a category error**: games want cache locality in a frame budget, agents are IO-bound over large buffers. It now says Leviath borrows the storage and iteration, not the reason, and names the reactor pattern for readers who would recognise it.

Also removed a strawman (every alternative runtime drawn with "its own client", when connection pooling is standard everywhere) and the habit of quoting our own "hundreds of agents in one process" line back as evidence for itself.

**And the cost the page kept dodging**: a live agent holds its context window, which is what actually costs memory, not the process. Only a paused run (paged out to disk) and a merged fan-out worker (window, blueprint, and stage tables dropped after its final snapshot persists) give it back. Both verified in `host/mod.rs` and `fanout.rs`.

`cargo xtask docs` passes.
