### PR TITLE
Validate the changelog the site publishes from, and index the docs for search

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,6 +222,25 @@ jobs:
       - name: Check docs/content links and frontmatter
         run: cargo xtask docs
 
+      # leviath.dev reads CHANGELOG.md to name the version beside its install command and
+      # to render that release's notes, and it fails its own deploy rather than publish a
+      # version it cannot verify. Without this that failure lands on the website, after
+      # merging, for somebody who was not editing the website. The checker is the same
+      # parser the site uses, so there is one definition of the format rather than two.
+      - name: Checkout leviath.dev (changelog contract)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          repository: GEMISIS/leviath.dev
+          token: ${{ secrets.DOCS_SSG_TOKEN }}
+          path: site
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+      # No npm ci: the checker and its parser import nothing but node:fs, so tsx on its
+      # own is the whole dependency.
+      - name: Check the changelog the site publishes from
+        run: npx --yes tsx site/tools/check-changelog.ts CHANGELOG.md
+
   # Coverage runs on all three OSes and enforces a hard 100% on regions, lines,
   # and functions. Each (os × package) runner GATES one package with llvm-cov's
   # own thresholds: `cargo xtask coverage --package <pkg>` runs `cargo llvm-cov

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -65,8 +65,31 @@ jobs:
           npm ci
           npm run build --workspace @leviath-dev/docs-ssg
 
+      # DOCS_RENDERER_REV goes into a <meta> on every page. This bundle is built from
+      # leviath.dev's default branch at whatever it is right now, and only when a
+      # channel publishes, so a renderer fix over there can sit unpublished for days
+      # with nothing on the page to say which version rendered it. This makes that
+      # answerable with view-source instead of a guess.
+      - name: Record which renderer is being used
+        id: renderer
+        working-directory: site
+        run: echo "rev=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Render docs
+        env:
+          DOCS_RENDERER_REV: ${{ steps.renderer.outputs.rev }}
         run: node site/packages/docs-ssg/dist/cli.mjs docs/content docs-out "${{ inputs.channel }}"
+
+      # Full-text search. Pagefind indexes the rendered HTML and shards the index, so a
+      # reader fetches only the fragments their query needs rather than one blob of it up
+      # front. It runs after the render and before the sync, and the step also deletes
+      # Pagefind's own search widget, which this site does not use: ~400 KB a channel
+      # that would otherwise be published and never requested.
+      #
+      # Docs published before this step existed simply have no index, and the site falls
+      # back to the title filter it had, so a channel is never broken by being behind.
+      - name: Build the docs search index
+        run: node site/node_modules/.bin/tsx site/tools/build-docs-index.ts docs-out
 
       # The machine-readable half: JSON Schemas for agent.leviath and
       # config.toml, and the OpenAPI spec for `lev serve`. llms.txt links these


### PR DESCRIPTION
Three workflow additions, all serving leviath.dev without giving it a way to break this
repo.

## `ci.yml`: check the changelog on the PR that changes it

leviath.dev reads `CHANGELOG.md` to name the version beside its install command and to
render that release's notes. It fails its own deploy rather than publish a version it
cannot verify — which is the right failure in the wrong place: it lands on the website,
after merging, for somebody who was not editing the website.

The checker is **the same parser the site uses**, so the format has one definition rather
than two, and it prints what the site would publish rather than only whether it errored:

```
CHANGELOG.md: readable by leviath.dev
  9 section(s), 1 unreleased
  newest released: 0.3.3 (2026-08-11), 22 entries
```

No `npm ci` — it and its parser import nothing but `node:fs`, so `tsx` is the whole
dependency. Contract is narrow on purpose: a dated section must exist, every heading dated
or `Unreleased`, no empty releases or entries. Nothing about prose.

## `publish-docs.yml`: stamp the renderer

This bundle is built from leviath.dev's default branch at whatever it happens to be, and
only when a channel publishes — so a fix over there can sit unpublished for days with
nothing on the page to say which version rendered it. That is exactly how a wrong nav
label survived being fixed. `DOCS_RENDERER_REV` now goes into a `<meta>`, so view-source
answers it.

## `publish-docs.yml`: build a search index

Docs search matched titles only, across 93,000 words. Pagefind indexes the rendered HTML
and shards the index, so a reader fetches only the fragments their query needs (~160 KB for
a first query) rather than one blob up front. The step also deletes Pagefind's own search
widget, which the site does not use: ~400 KB per channel that would be published and never
requested.

**A channel published before this step existed simply has no index**, and the site falls
back to the title filter it has today — so nothing breaks by being behind, and stable can
wait for its next release.

Depends on GEMISIS/leviath.dev#22 for `tools/build-docs-index.ts` and the client side.
Pre-commit hooks (fmt, clippy, docs, suppression markers, structure) all passed locally.