### PR TITLE
docs: fix a schema that rejected shipped features, and add a build-your-first-agent tutorial

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -89,7 +89,14 @@ jobs:
       # Docs published before this step existed simply have no index, and the site falls
       # back to the title filter it had, so a channel is never broken by being behind.
       - name: Build the docs search index
-        run: node site/node_modules/.bin/tsx site/tools/build-docs-index.ts docs-out
+        run: |
+          node site/node_modules/.bin/tsx site/tools/build-docs-index.ts docs-out
+          # The site falls back to a title-only filter when the index is absent,
+          # and says nothing about it, so a channel can publish without search
+          # and look fine. Fail here instead, the way the schemas below do.
+          test -s docs-out/pagefind/pagefind.js || {
+            echo "no search index at docs-out/pagefind/pagefind.js"; exit 1;
+          }
 
       # The machine-readable half: JSON Schemas for agent.leviath and
       # config.toml, the OpenAPI spec for `lev serve`, and the commented example

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -92,13 +92,16 @@ jobs:
         run: node site/node_modules/.bin/tsx site/tools/build-docs-index.ts docs-out
 
       # The machine-readable half: JSON Schemas for agent.leviath and
-      # config.toml, and the OpenAPI spec for `lev serve`. llms.txt links these
+      # config.toml, the OpenAPI spec for `lev serve`, and the commented example
+      # config that Configuration links beside the schema. llms.txt links these
       # by name, and the sync below uses --delete, so anything not copied in
-      # here becomes a 404 that the index still advertises.
+      # here becomes a 404 that the index still advertises. The example is not
+      # a .json, which is exactly how it went missing: the glob did not reach it
+      # and the check below did not name it.
       - name: Add the machine-readable schemas
         run: |
-          cp docs/schema/*.json docs-out/
-          for f in blueprint.schema.json config.schema.json openapi.json; do
+          cp docs/schema/*.json docs/schema/config.example.toml docs-out/
+          for f in blueprint.schema.json config.schema.json openapi.json config.example.toml; do
             test -s "docs-out/$f" || { echo "missing docs-out/$f"; exit 1; }
           done
 

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -492,6 +492,73 @@ mod tests {
     }
 
     #[test]
+    fn the_blueprint_schema_accepts_every_region_kind_the_parser_names() {
+        // The bundled agents between them use only some of the kinds, so the
+        // positive test above cannot notice one the schema forgot. `checklist`
+        // shipped that way: the parser took it, the published schema's closed
+        // enum refused it, and every blueprint using the feature failed to
+        // validate against the file we tell people to validate against.
+        //
+        // The parser's own error message enumerates the valid kinds, so read
+        // the list back from it rather than restating it here and drifting the
+        // same way twice.
+        let err = leviath_core::manifest::parse_manifest(
+            "[agent]\nname = \"a\"\n\n[context.regions]\nx = { kind = \"not-a-kind\" }\n",
+        )
+        .expect_err("an unknown region kind is a load error")
+        .to_string();
+        let listed = err
+            .split("valid kinds:")
+            .nth(1)
+            .expect("the error names the valid kinds")
+            .trim()
+            .trim_end_matches(')')
+            .split(',')
+            .map(str::trim)
+            .filter(|k| !k.is_empty())
+            .collect::<Vec<_>>();
+        assert!(
+            listed.len() > 5,
+            "the error should list every kind: {listed:?}"
+        );
+
+        let schema: serde_json::Value =
+            serde_json::from_str(BLUEPRINT_SCHEMA).expect("the schema is valid JSON");
+        let validator = jsonschema::validator_for(&schema).expect("the schema compiles");
+        for kind in listed {
+            let manifest = format!(
+                "[agent]\nname = \"a\"\n\n[context.regions]\nx = {{ kind = \"{kind}\" }}\n"
+            );
+            let parsed: toml::Value = toml::from_str(&manifest).expect("valid TOML");
+            assert_eq!(
+                schema_problems(&validator, &toml_to_json(&parsed)),
+                Vec::<String>::new(),
+                "the schema rejects region kind \"{kind}\", which the parser accepts"
+            );
+        }
+    }
+
+    #[test]
+    fn the_blueprint_schema_accepts_stage_hooks() {
+        // Same blind spot as the region kinds: no bundled agent declares hooks,
+        // so nothing noticed that the stage object is `additionalProperties:
+        // false` without a `hooks` property. Every blueprint following the Rhai
+        // hooks page was rejected by the published schema.
+        let schema: serde_json::Value =
+            serde_json::from_str(BLUEPRINT_SCHEMA).expect("the schema is valid JSON");
+        let validator = jsonschema::validator_for(&schema).expect("the schema compiles");
+        let manifest = "[agent]\nname = \"a\"\n\n[stages.main.hooks]\n\
+                        on_stage_enter = \"hooks/enter.rhai\"\n\
+                        on_error = \"hooks/error.rhai\"\n";
+        let parsed: toml::Value = toml::from_str(manifest).expect("valid TOML");
+        assert_eq!(
+            schema_problems(&validator, &toml_to_json(&parsed)),
+            Vec::<String>::new(),
+            "the schema rejects [stages.<name>.hooks], which the parser accepts"
+        );
+    }
+
+    #[test]
     fn the_blueprint_schema_rejects_what_the_parser_rejects() {
         // A schema that accepts everything would pass the test above over any
         // input at all. These are the mistakes it exists to catch before a run

--- a/docs/content/agent-client-protocol.md
+++ b/docs/content/agent-client-protocol.md
@@ -65,11 +65,11 @@ Flags (run `lev agent-client --help` for the authoritative list):
 
 | Flag | Purpose |
 |---|---|
-| `--agent <name-or-path>` | Blueprint to serve: an installed [agent](/docs/agents) name, or a path to one. When omitted, the session's working directory is searched for an `agent.leviath`. |
+| `--agent <name-or-path>` | Blueprint to serve: an installed [agent](/docs/agents) name, or a path to one. Omitted, the session's working directory is searched. |
 | `--yolo` | Approve every tool call without prompting. Recommended when the host does not implement `session/request_permission` (e.g. Gas City). |
 | `--allow <tool>` | Allow a tool outright. Repeatable. |
 | `--max-depth <n>` | Override the blueprint's max sub-agent tree depth. |
-| `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions, which run a shell command at spawn, before the first inference, and so before any approval prompt. |
+| `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions, which run at spawn before any approval prompt. |
 | `--output-format <label>` | Ask for the [final output](/docs/outputs) in this shape. Any label works. |
 | `--output-instructions <text>` | Extra guidance about that shape. |
 

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -124,9 +124,9 @@ temperature = 0.2
 max_tokens  = 8000
 ```
 
-Model selection is per stage, and only per stage. There are two ways to get this wrong quietly (a
-top-level `[model]` block, which parses and is read by nothing, and a stage naming no model, which
-silently takes the host default), and `lev validate` reports both. See
+Model selection is per stage, and only per stage. Two mistakes here are quiet ones. A top-level
+`[model]` block parses and is read by nothing, and a stage naming no model takes the host default
+without saying so. `lev validate` reports both. See
 [every stage should name its own model](/docs/stages#every-stage-should-name-its-own-model).
 
 ### Which tools a stage gets
@@ -161,7 +161,7 @@ max_tokens = 2000          # bare max_tokens alone = fixed absolute budget
 
 Percentages are **ceilings, not allocations**. They may sum past 100%, because regions rarely all
 fill at once. With a percentage, `max_tokens` caps and `min_tokens` floors the resolved value;
-without one, `max_tokens` is simply the fixed budget. Compacting regions also take
+without one, `max_tokens` is the fixed budget. Compacting regions also take
 `threshold_tokens`, the fill level that triggers compaction.
 
 A stage can override the whole layout for just itself with `[stages.<name>.context.regions]`. The
@@ -335,8 +335,8 @@ lev test .                        # run the blueprint's tests/ cases (real API c
 lev test . --dry-run              # parse and report them without calling a provider
 ```
 
-Beyond the graph, `lev validate` reports the fields whose absence quietly changes what a run does: a
-stage with no model block, a tool name that matches nothing, an autonomous stage offering a tool
-that waits for a person. Errors exit non-zero, warnings do not, notes never can. The
+Beyond the graph, `lev validate` reports the fields whose absence quietly changes what a run does.
+That covers a stage with no model block, a tool name that matches nothing, and an autonomous stage
+offering a tool that waits for a person. Errors exit non-zero, warnings do not, notes never can. The
 [CLI reference](/docs/cli#lev-validate-path) lists every check. The daemon logs the same findings
 when a run spawns, so a blueprint nobody validated still says what is wrong with it.

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -3,7 +3,7 @@ title: Agent blueprints
 description: The agent.leviath blueprint format: the TOML defining an agent's stages, models, tools, and context layout.
 group: Concepts
 group_order: 2
-order: 4
+order: 5
 ---
 
 # Agent blueprints (`agent.leviath`)
@@ -11,6 +11,9 @@ order: 4
 An agent is a directory with an `agent.leviath` file, a TOML **blueprint** describing a
 multi-stage [workflow graph](/docs/stages). The [agent catalog](/docs/agent-catalog) has ten
 complete ones worth stealing from.
+
+New to this? [Build your first agent](/docs/first-agent) walks through writing one stage by
+stage; this page is the reference for every field it uses.
 
 Start from a scaffold rather than a blank file:
 

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -265,6 +265,26 @@ max_repeat_calls    = 3      # default; identical tool call, back to back
 max_readonly_streak = 10     # default; read-only calls with no modification in between
 ```
 
+## Who does the summarizing
+
+A [`compacting` region](/docs/context) summarizes rather than evicting, and something has to write
+that summary. By default it is Sonnet on Anthropic, whatever the stage itself runs on, because a
+summary is cheap work that does not need the stage's model:
+
+```toml
+[compaction]
+provider           = "anthropic"          # default
+model              = "claude-sonnet-4-6"  # default
+max_summary_tokens = 2000                 # default
+temperature        = 0.2                  # default
+system_prompt      = "..."                # optional; replaces the built-in summarizer prompt
+```
+
+Point it at a provider you have configured if you do not use Anthropic. A run whose compaction
+provider is not registered loses compaction rather than failing, so an unset `[compaction]` on an
+OpenAI-only machine quietly stops summarizing. `lev doctor` reports which providers are
+registered.
+
 ## Discovering tools mid-run
 
 By default a stage advertises a fixed tool set resolved at spawn, and a tool that appears later is

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -61,11 +61,11 @@ The short version: **`http://` only works on loopback.** Everything else needs H
 A browser treats `http://localhost` and `http://127.0.0.1` as potentially trustworthy, which is the
 only reason the default setup works from a page served over HTTPS. Every other address is blocked,
 and **a LAN address is blocked exactly like a public one** - `http://192.168.1.50:3000` fails just as
-`http://34.132.206.6:8080` does:
+`http://203.0.113.10:8080` does:
 
 ```
 Mixed Content: The page at 'https://leviath.dev/lair' was loaded over HTTPS, but requested an
-insecure resource 'http://34.132.206.6:8080/api/config'. This request has been blocked.
+insecure resource 'http://203.0.113.10:8080/api/config'. This request has been blocked.
 ```
 
 Two things that are *not* the problem, because they are what people reach for first:
@@ -239,8 +239,6 @@ done in the browser, because The Lair never holds a run's transcript.
 One honest limit: the deep sources match the raw JSON on disk, so a query containing a quote,
 a backslash or a newline may not match text that does contain it.
 
-## A run's files
-
 ## Where a run's cost went
 
 `GET /api/agents/{id}/stages` returns one record per declared stage, in blueprint
@@ -292,6 +290,8 @@ that has not reached its first stage boundary returns an empty list rather than 
 > it, because the field simply is not in those files. Read it together with
 > `status`: a stage recorded `complete` with tokens against its name ran,
 > whatever `entered` says on an old run.
+
+## A run's files
 
 `GET /api/agents/{id}/files` answers two different questions, and neither substitutes for the other.
 

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -28,13 +28,13 @@ a test, so a client generator or an agent can consume the contract directly.
   (`ps`).
 - **CORS is closed by default.** Pass `--cors <origin>` (e.g. `https://leviath.dev`) or `--cors "*"`
   to allow a browser to call it cross-origin.
-- **Binds to `127.0.0.1`** by default. `--host 0.0.0.0` exposes it on your network - and without
-  `--tls-cert`, puts the bearer token on the wire in cleartext for anyone on that network to read.
+- **Binds to `127.0.0.1`** by default. `--host 0.0.0.0` exposes it on your network. Without
+  `--tls-cert`, that puts the bearer token on the wire in cleartext for anyone on that network to read.
   If the address is publicly routable, that is the open internet. See
   [reaching a Leviath on another machine](#reaching-a-leviath-on-another-machine).
 - **`--tls-cert` / `--tls-key`** serve HTTPS instead of HTTP. Off by default, bring your own
   certificate; Leviath never generates one.
-- **`GET /` needs no token.** It returns a fixed "Leviath is running." page and nothing else - no
+- **`GET /` needs no token.** It returns a fixed "Leviath is running." page and nothing else: no
   version, no run counts, no endpoint list. It exists so a certificate can be accepted in a browser
   tab; see the section below.
 - **`--allow-admin`** mounts the mutating admin routes. `GET /api/config` and
@@ -60,7 +60,7 @@ The short version: **`http://` only works on loopback.** Everything else needs H
 
 A browser treats `http://localhost` and `http://127.0.0.1` as potentially trustworthy, which is the
 only reason the default setup works from a page served over HTTPS. Every other address is blocked,
-and **a LAN address is blocked exactly like a public one** - `http://192.168.1.50:3000` fails just as
+and **a LAN address is blocked exactly like a public one**. `http://192.168.1.50:3000` fails just as
 `http://203.0.113.10:8080` does:
 
 ```
@@ -133,7 +133,7 @@ ssh -N -L 3000:127.0.0.1:3000 you@that-machine
 ```
 
 Then point The Lair at `http://127.0.0.1:3000`. Leave Leviath on its default `127.0.0.1` bind for
-this - `--host 0.0.0.0` is not wanted and only widens the exposure.
+this. `--host 0.0.0.0` is not wanted and only widens the exposure.
 
 ## Auth flow
 
@@ -159,10 +159,10 @@ Base path `/api`; all JSON unless noted.
 | Method · Path | Purpose |
 |---|---|
 | `GET /api/runs` | List runs: paginated, sortable, searchable. See [below](#listing-and-searching-runs) |
-| `GET /api/agents` · `POST /api/agents` | List runs *(deprecated, use `/api/runs`)* · spawn an agent. Reads the persisted records, so unlike `lev ps` it keeps finished runs |
+| `GET /api/agents` · `POST /api/agents` | List runs *(deprecated, use `/api/runs`)* · spawn an agent. Reads the persisted records, so finished runs stay listed |
 | `GET /api/agents/{id}` · `DELETE …` | Get one · cancel |
 | `GET /api/agents/{id}/result` · `/context` | The run's answer and log tail · current context window |
-| `GET /api/agents/{id}/logs?stage=&stream=&tail=` | A run's logs. `stage` takes an index or `all`, defaulting to the current stage; `stream` is `output` (the assistant's text) or `logs` (tool calls, token counts, errors); `tail` is a byte budget |
+| `GET /api/agents/{id}/logs?stage=&stream=&tail=` | A run's logs. `stage`, `stream` and `tail` pick which stage, which stream, and how much |
 | `GET /api/agents/{id}/context/history` | How the context window changed over the run, paginated |
 | `GET /api/agents/{id}/stages` | The per-stage ledger: what each stage cost, which regions it carried, and whether it ran at all. See [below](#where-a-runs-cost-went) |
 | `GET /api/agents/{id}/files` | List a run's files, or read one with `?path=`. `offset` pages a large one. See [below](#a-runs-files) |
@@ -177,6 +177,10 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
 | `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
+
+On `/logs`, `stage` takes a stage index or `all`, and defaults to the current stage. `stream` is
+either `output`, the assistant's own text, or `logs`, which carries tool calls, token counts and
+errors. `tail` is a byte budget for how much of the end you get back.
 
 > [!NOTE]
 > A run object carries both `updated_at` and `last_progress_at`. The first advances on a 30-second
@@ -229,8 +233,8 @@ operators or phrase quoting, and case folding is ASCII-only.
 
 The last three read from disk, which is why they are opt-in. Surface them as a "search inside
 runs" toggle rather than making every keystroke pay for them. They also stop after a bounded number
-of runs, newest first; when that happens the response says `scan_truncated: true` and sets `total`
-to null, because a count taken from a partial scan would be rendered as fact.
+of runs, newest first. When that happens the response says `scan_truncated: true` and sets `total`
+to null, because a count taken from a partial scan would be read as fact.
 
 Matching items carry `highlights` saying *why* they matched: the field, a snippet, and the stage
 where there is one, which you can pass straight to `/logs?stage=`. This is the part that cannot be
@@ -263,9 +267,9 @@ Three things here are not derivable from any other route.
 
 **`entered` says whether the run was ever in that stage.** The alternative is to
 fetch `context/history` and diff consecutive snapshots to see which stages
-produced entries, which is expensive - every point carries a whole context
-window - and wrong in the case that matters: a stage that ran and wrote nothing
-to any region leaves no trace to find. `status: "skipped"` is the same fact
+produced entries. That is expensive, because every point carries a whole context
+window. It is also wrong in the case that matters: a stage that ran and wrote
+nothing to any region leaves no trace to find. `status: "skipped"` is the same fact
 stated from the other side, and means the run finished without reaching this
 stage, as distinct from `"pending"` on a run that is still going.
 
@@ -274,8 +278,8 @@ stage spent them, and the cache read/write split within a stage, are only here.
 A stage showing no cache reads cannot be told apart from one paying to write a
 prefix nothing reuses without `cache_write_tokens`.
 
-**`region_tokens` is what decides whether a region is earning its place** - the
-largest each region reached while that stage was active. This is the number to
+**`region_tokens` is what decides whether a region is earning its place.** It is
+the largest each region reached while that stage was active. This is the number to
 look at before trimming a layout.
 
 `runaway_warned` is set when a stage's per-call prompt passed four times its
@@ -283,11 +287,11 @@ first call, which is the shape of a region accumulating without a cap.
 
 The list is bounded by the blueprint's stage count, so it is not paginated. A run
 that has not reached its first stage boundary returns an empty list rather than a
-404 - the run exists, it just has nothing to report yet.
+404. The run exists and has nothing to report yet.
 
 > [!NOTE]
 > `entered` is `false` for every stage of a run recorded before Leviath tracked
-> it, because the field simply is not in those files. Read it together with
+> it, because the field is not in those files at all. Read it together with
 > `status`: a stage recorded `complete` with tokens against its name ran,
 > whatever `entered` says on an old run.
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -17,7 +17,7 @@ symptom, and `lev doctor` checks the usual causes for you.
 `-v` / `--verbose` is global and works on every subcommand.
 
 Scripting against the CLI? `--json` is on `run`, `ps`, `doctor`, `validate`, `list`, `models list`,
-`context`, `result`, `respond`, `tools`, `approvals safe`, and `mcp list`. Everything else prints
+`context`, `result`, `respond`, `stages`, `tools`, `approvals safe`, and `mcp list`. Everything else prints
 for a person. Warnings go to stderr, so stdout parses on its own. A service that would rather
 speak HTTP should use [`lev serve`](/docs/api) instead.
 
@@ -152,6 +152,7 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 |---|---|---|
 | error | `unknown-tool` | A name in `available_tools` matches no built-in, sub-agent tool, or `tools/*.rhai`. The stage silently advertises one tool fewer, so the model is told it does not exist. MCP names (`server__tool`) are skipped, since they resolve only once that server is installed. |
 | error | `unparseable-safe-command` | A `[safe_commands] shell` entry that is not a bare command prefix, so no call can ever match it. Write a program, optionally with the subcommand that narrows it: `rg`, `cargo test`. |
+| error | `output-missing-submit-tool` | A stage sets `require_output` but never grants `submit_output`, so it is required to produce an answer it has no way to submit. Use `mode = "output"`, which grants the tool. |
 | error | `orphan-stage-permission` | A `[stages.X.tool_permissions]` key names a tool the stage never granted. It reads as a grant and is not one. |
 | warning | `stage-missing-model` | No `[stages.X.model]` block, so the stage runs on whatever your `default_provider` is. |
 | warning | `stage-missing-mode` | No `mode`, so the stage runs as `autonomous`. |
@@ -162,6 +163,7 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 | warning | `implicit-shell-policy` | A shell grant with no policy behind it. The default is `ask`, and an unattended run waits on that prompt rather than being denied. |
 | warning | `unknown-model` | A model this build has not heard of, checked only against providers with a closed catalog. Ollama, OpenRouter and script providers are never checked. |
 | warning | `no-reachable-provider` | Nothing in the stage's models list is configured here, so it falls through to your default model. |
+| warning | `compact-summarizes-deliverable` | A `required` region would be handed to the summarizer by a `transform = "compact"` edge, so a later stage reads a paraphrase of it. Set `summarizable = false` on the region. |
 | warning | `unreachable-stage`, `cycle-without-max-revisits`, `broad-read-path` | Graph and `[read_paths]` shape. |
 | warning | `dead-end-possible` | Every normal edge's target has a `max_revisits` budget, so the run errors once they are spent. Add a `condition = "dead_end"` edge to a stage without one. A `max_iterations` edge does not count: it fires on the iteration cap, never on this path. |
 | warning | `read-paths-not-granted` | The blueprint declares `[read_paths]` your `config.toml` does not grant. Declaring is not granting, so those reads are refused; the fix line carries the stanza to add. |
@@ -250,7 +252,7 @@ Serve an agent over the [Agent Client Protocol](/docs/agent-client-protocol) as 
 
 | Command | Flags | Purpose |
 |---|---|---|
-| `lev list` | `--json` | List installed and bundled blueprints. An agent declaring [`[read_paths]`](/docs/security#reading-outside-the-workdir) also shows how many of its entries your config grants |
+| `lev list` | `--json`, `-f`, `--filter <all\|agents\|blueprints>` | List installed and bundled blueprints. `--filter` narrows to installed agents or to bundled blueprints; an unrecognized value is an error, not a silent ignore. An agent declaring [`[read_paths]`](/docs/security#reading-outside-the-workdir) also shows how many of its entries your config grants |
 | `lev add <PACKAGE>` | | Install a blueprint directory or `.leviath-bundle`. Prints what the package grants itself before installing |
 | `lev remove <NAME>` | | Uninstall a blueprint |
 | `lev pack [PATH]` | `-o`, `--output <FILE>` (default `{name}-{version}.leviath-bundle`) | Bundle a blueprint for [sharing](/docs/packaging) |

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -36,17 +36,23 @@ Spawn an agent into the daemon. `PATH` is an installed agent name, a blueprint d
 |---|---|
 | `-t`, `--task <TEXT\|FILE>` | The task prompt, or the path of a file holding it. Left off, your editor opens |
 | `-m`, `--model <MODEL>` | Model override, as `provider/model` or a bare model name |
-| `--workdir <DIR>` | Working directory for the run. Defaults to where you ran the command. File tools are confined to it, and relative `[read_paths]` entries resolve against it |
+| `--workdir <DIR>` | Working directory for the run, defaulting to where you ran the command. See below |
 | `--yolo` | Run unattended. See below |
 | `--allow <TOOL>` | Allow one tool outright. Repeatable |
 | `--max-depth <N>` | Override the blueprint's maximum sub-agent tree depth |
 | `--no-seed-commands` | Refuse the blueprint's `seed = { command = "..." }` regions for this run |
 | `--count <N>` | Start this many runs of the same agent and task, each under its own run id, from one invocation |
-| `--json` | Print the spawned run as JSON rather than a sentence, for a caller that parses the run id back out. With `--count` above 1 it is an array, one object per run |
+| `--json` | Print the spawned run as JSON rather than a sentence. See below |
 | `--output-format <LABEL>` | Ask for the final output in this shape. See [Final outputs](/docs/outputs) |
 | `--output-instructions <TEXT>` | Extra guidance about that shape |
 | `--output-schema <JSON\|@FILE>` | A JSON Schema the final output must satisfy |
 | `--<region> <TEXT\|@FILE>` | Seed a named context region. See below |
+
+**`--workdir`** decides more than where commands run. File tools are confined to it, and relative
+`[read_paths]` entries resolve against it.
+
+**`--json`** is for a caller that parses the run id back out. With `--count` above 1 it prints an
+array, one object per run.
 
 **`--yolo`** waives approvals, not checkpoints. It approves every tool call, and it takes away the
 tools that wait on a person (`ask_user_*`, `present_for_review`, `edit_document`) so the run does
@@ -72,7 +78,7 @@ lev run reviewer --task "Review the auth module" --standards @./team-standards.m
 A region only accepts a seed if the blueprint declares it as caller input: a string
 `seed = "<key>"` in its `[context.regions]` entry, or being named `task`, which asks for the `task`
 key implicitly. A table seed (`seed = { glob = ... }`, `{ command = ... }`, and so on) fills the
-region from somewhere else and takes no caller input, and a `--<name>` naming any other region is
+region from somewhere else and takes no caller input. A `--<name>` naming any other region is
 dropped.
 
 > [!NOTE]
@@ -96,10 +102,11 @@ your PATH.
 Stdin has to be a terminal for any of this. In a script, a pipeline, or CI, pass `-t` and Leviath
 says so rather than blocking.
 
-`-t` reads a file when the value names one that exists. It is an error when the value looks like a path but no such
-file is there, so a mistyped filename fails instead of quietly becoming the prompt. "Looks like a
-path" means no spaces, plus a `/`, a `\`, or a leading `~`. Region flags work the other way round and want an
-explicit `@` before a path, because a region seed is usually a file while a task is usually a
+`-t` reads a file when the value names one that exists. A value that looks like a path with no
+file behind it is an error, so a mistyped filename fails instead of quietly becoming the prompt.
+"Looks like a path" means no spaces, plus a `/`, a `\`, or a leading `~`. Region flags work the
+other way round and want an explicit `@` before a path, because a region seed is usually a file
+while a task is usually a
 sentence.
 
 ### `lev stages <RUN-ID>`
@@ -150,27 +157,75 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 
 | Level | Code | What it means |
 |---|---|---|
-| error | `unknown-tool` | A name in `available_tools` matches no built-in, sub-agent tool, or `tools/*.rhai`. The stage silently advertises one tool fewer, so the model is told it does not exist. MCP names (`server__tool`) are skipped, since they resolve only once that server is installed. |
-| error | `unparseable-safe-command` | A `[safe_commands] shell` entry that is not a bare command prefix, so no call can ever match it. Write a program, optionally with the subcommand that narrows it: `rg`, `cargo test`. |
-| error | `output-missing-submit-tool` | A stage sets `require_output` but never grants `submit_output`, so it is required to produce an answer it has no way to submit. Use `mode = "output"`, which grants the tool. |
+| error | `unknown-tool` | A name in `available_tools` matches nothing. See below |
+| error | `unparseable-safe-command` | A `[safe_commands] shell` entry no call can ever match. See below |
+| error | `output-missing-submit-tool` | A stage must produce an output and has no way to submit one. See below |
 | error | `orphan-stage-permission` | A `[stages.X.tool_permissions]` key names a tool the stage never granted. It reads as a grant and is not one. |
 | warning | `stage-missing-model` | No `[stages.X.model]` block, so the stage runs on whatever your `default_provider` is. |
 | warning | `stage-missing-mode` | No `mode`, so the stage runs as `autonomous`. |
 | warning | `stage-missing-max-iterations` | Unbounded unless `[limits] default_max_iterations` is set. Fan-out stages are exempt. |
 | warning | `agent-model-block-ignored` | A top-level `[model]` block. Nothing reads it; model selection is per stage. |
-| warning | `region-seed-not-understood` | A region's `seed` is not one of the recognized forms, so it is ignored and the region starts empty. Usually a typo in the table key: it is `{ caller = "task" }`, not `{ caller_input = "task" }`. |
-| warning | `blocking-tool-in-autonomous-stage` | An autonomous stage grants `ask_user_*`, `present_for_review` or `edit_document`. With nobody attached the run parks there until it is killed. Set `allow_blocking_tools = true` on the stage to say you meant it. |
-| warning | `implicit-shell-policy` | A shell grant with no policy behind it. The default is `ask`, and an unattended run waits on that prompt rather than being denied. |
-| warning | `unknown-model` | A model this build has not heard of, checked only against providers with a closed catalog. Ollama, OpenRouter and script providers are never checked. |
+| warning | `region-seed-not-understood` | A region's `seed` is not a recognized form, so the region starts empty. See below |
+| warning | `blocking-tool-in-autonomous-stage` | An autonomous stage grants a tool that waits for a person. See below |
+| warning | `implicit-shell-policy` | A shell grant with no policy behind it. See below |
+| warning | `unknown-model` | A model this build has not heard of. See below |
 | warning | `no-reachable-provider` | Nothing in the stage's models list is configured here, so it falls through to your default model. |
-| warning | `compact-summarizes-deliverable` | A `required` region would be handed to the summarizer by a `transform = "compact"` edge, so a later stage reads a paraphrase of it. Set `summarizable = false` on the region. |
+| warning | `compact-summarizes-deliverable` | A `compact` edge would hand a `required` region to the summarizer. See below |
 | warning | `unreachable-stage`, `cycle-without-max-revisits`, `broad-read-path` | Graph and `[read_paths]` shape. |
-| warning | `dead-end-possible` | Every normal edge's target has a `max_revisits` budget, so the run errors once they are spent. Add a `condition = "dead_end"` edge to a stage without one. A `max_iterations` edge does not count: it fires on the iteration cap, never on this path. |
-| warning | `read-paths-not-granted` | The blueprint declares `[read_paths]` your `config.toml` does not grant. Declaring is not granting, so those reads are refused; the fix line carries the stanza to add. |
+| warning | `dead-end-possible` | Every route out of a stage can run out of budget. See below |
+| warning | `read-paths-not-granted` | The blueprint declares `[read_paths]` your `config.toml` does not grant. See below |
 | warning | `read-paths-grant-invalid` | A `read_paths` grant in your own config will not compile. It is a hard spawn error, named here first. |
-| note | `holds-under-yolo` | A checkpoint that still stops an unattended run for a person: an interaction point declaring `unattended = "ask"`, or a blocking tool a stage keeps in `required_tools`. Deliberate where it appears; noted because `--yolo` reads as "run without me". |
-| note | `safe-commands-declared` | The blueprint declares `[safe_commands]`. Declaring is not granting: it applies only where the user opts in, per agent via `[agent_safe_commands.<name>] allow_blueprint` or globally via `[security] allow_blueprint_safe_commands`. |
-| note | `command-seed`, `read-paths-declared` | What the blueprint will do that you should know about before running it. `read-paths-declared` carries the granted/declared counts and each entry's status. |
+| note | `holds-under-yolo` | A checkpoint that still stops an unattended run for a person. See below |
+| note | `safe-commands-declared` | The blueprint declares `[safe_commands]`. Declaring is not granting. See below |
+| note | `command-seed`, `read-paths-declared` | Things worth knowing before you run the blueprint. See below |
+
+Thirteen of those findings need more than a phrase.
+
+**`unknown-tool`** means the name matches no built-in, no sub-agent tool, and no `tools/*.rhai`
+file. The stage then advertises one tool fewer, so the model is told a tool it was meant to have
+does not exist. MCP names (`server__tool`) are skipped, since they resolve only once that server is
+installed.
+
+**`unparseable-safe-command`** fires on an entry that is not a bare command prefix, so no call can
+ever match it. Write a program, optionally with the subcommand that narrows it: `rg`, `cargo test`.
+
+**`output-missing-submit-tool`** means a stage sets `require_output` but never grants
+`submit_output`. Use `mode = "output"`, which grants the tool.
+
+**`region-seed-not-understood`** is usually a typo in a table key. It is `{ caller = "task" }`, not
+`{ caller_input = "task" }`. An unrecognized seed is ignored, and the region starts empty.
+
+**`blocking-tool-in-autonomous-stage`** fires when an autonomous stage grants `ask_user_*`,
+`present_for_review` or `edit_document`. With nobody attached, the run parks there until it is
+killed. Set `allow_blocking_tools = true` on the stage to say you meant it.
+
+**`implicit-shell-policy`** matters because the default is `ask`. An unattended run waits on that
+prompt rather than being denied.
+
+**`unknown-model`** is checked only against providers with a closed catalog. Ollama, OpenRouter and
+script providers are never checked.
+
+**`compact-summarizes-deliverable`** means a later stage reads a paraphrase of a region you marked
+`required`. Set `summarizable = false` on the region.
+
+**`dead-end-possible`** fires when every normal edge's target has a `max_revisits` budget, so the
+run errors once they are spent. Add a `condition = "dead_end"` edge to a stage without one. A
+`max_iterations` edge does not count, because it fires on the iteration cap rather than on this
+path.
+
+**`read-paths-not-granted`** is the declaring-is-not-granting case. Those reads are refused at
+runtime, and the fix line carries the stanza that would grant them.
+
+**`holds-under-yolo`** names an interaction point declaring `unattended = "ask"`, or a blocking tool
+a stage keeps in `required_tools`. Both are deliberate wherever they appear. It is a note because
+`--yolo` reads as "run without me".
+
+**`safe-commands-declared`** applies only where you opt in. That is per agent via
+`[agent_safe_commands.<name>] allow_blueprint`, or globally via
+`[security] allow_blueprint_safe_commands`.
+
+**`command-seed`** and **`read-paths-declared`** say what the blueprint will do before you run it.
+`read-paths-declared` carries the granted and declared counts, plus each entry's status.
 
 | Flag | Purpose |
 |---|---|
@@ -183,7 +238,7 @@ validated still says what is wrong with it. Nothing there refuses a spawn.
 `[read_paths]` entries are checked against your own `config.toml`, entry by entry, because
 declaring one is not the same as being allowed to read it. Anything your config does not grant is
 named as such, with the stanza that would grant it. The daemon's own lint has no user config to
-consult, so there it stays the plain "these need granting" note - see
+consult, so there it stays the plain "these need granting" note. See
 [reading outside the workdir](/docs/security#reading-outside-the-workdir).
 
 ### `lev test [PATH]`
@@ -215,13 +270,14 @@ max_tokens = 500
 | `name` | Case name. `--filter` matches on it |
 | `input` | Seeded as the task, exactly as `lev run "..."` would |
 | `expect_contains` | Case-insensitive substring the response must contain |
-| `expect_tool_call` | A tool the model must call. Only tools the stage lists in `available_tools` are offered, so a case cannot assert on a tool the stage does not have |
+| `expect_tool_call` | A tool the model must call. It has to be one the stage lists in `available_tools` |
 | `max_tokens` | Caps this case's output. Narrows the ceiling the window and model already impose; it cannot raise it |
 
 **What a case actually runs.** One inference, not a run. `lev test` builds a fresh context
 window from the blueprint's layout, seeds `input` as the task, and assembles the request exactly
-as a live run's *first* turn would - iteration 0, region hooks active, the first stage's model and
-tools. It then calls the provider once and checks the assertions. Nothing executes: a tool call is
+as a live run's *first* turn would. That means iteration 0, region hooks active, and the first
+stage's model and tools. It then calls the provider once and checks the assertions. Nothing
+executes: a tool call is
 asserted on, never performed, so a case can expect `write_file` without a file appearing.
 
 A `tests/*.rhai` file is run instead as a script through the scripting engine, and fails the run if
@@ -231,7 +287,7 @@ it returns `false`.
 
 | Command | Flags |
 |---|---|
-| `lev models list` | `-p/--provider <NAME>`, `-r/--remote` (fetch live from the provider APIs, slower but complete), `-a/--all` (include providers this install has no credential for) |
+| `lev models list` | `-p/--provider <NAME>`, `-r/--remote` (live from the provider APIs, slower), `-a/--all` (include providers with no credential here) |
 | `lev models show <MODEL>` | `-p/--provider <NAME>` (required for a remote lookup), `-r/--remote` |
 
 ### `lev agent-client`
@@ -252,16 +308,21 @@ Serve an agent over the [Agent Client Protocol](/docs/agent-client-protocol) as 
 
 | Command | Flags | Purpose |
 |---|---|---|
-| `lev list` | `--json`, `-f`, `--filter <all\|agents\|blueprints>` | List installed and bundled blueprints. `--filter` narrows to installed agents or to bundled blueprints; an unrecognized value is an error, not a silent ignore. An agent declaring [`[read_paths]`](/docs/security#reading-outside-the-workdir) also shows how many of its entries your config grants |
+| `lev list` | `--json`, `-f`, `--filter <all\|agents\|blueprints>` | List installed and bundled blueprints. See below |
 | `lev add <PACKAGE>` | | Install a blueprint directory or `.leviath-bundle`. Prints what the package grants itself before installing |
 | `lev remove <NAME>` | | Uninstall a blueprint |
 | `lev pack [PATH]` | `-o`, `--output <FILE>` (default `{name}-{version}.leviath-bundle`) | Bundle a blueprint for [sharing](/docs/packaging) |
+
+`lev list --filter` narrows the listing to installed agents or to bundled blueprints. An
+unrecognized value is an error rather than a silent ignore. An agent declaring
+[`[read_paths]`](/docs/security#reading-outside-the-workdir) also shows how many of its entries your
+config grants.
 
 ## Watching and steering
 
 | Command | Flags | Purpose |
 |---|---|---|
-| `lev ps` | `--json`, `--all` | List runs in the daemon with their status. `--all` adds runs on disk the daemon is not hosting, finished ones included. See [below](#reading-lev-ps) |
+| `lev ps` | `--json`, `--all` | List runs in the daemon with their status. `--all` also reads the runs dir. See [below](#reading-lev-ps) |
 | `lev dash` | | Full-screen TUI [dashboard](/docs/dashboard) |
 | `lev msg <AGENT_ID> <CONTENT>` | | Deliver a message into a running agent's context |
 | `lev pause <RUN_ID>` | | Pause a run. It finishes its in-flight step, then holds |
@@ -352,7 +413,7 @@ you are driving Leviath from a scheduler.
 | `active` | Running a turn, or waiting on the model or a tool |
 | `idle` | Spawned, not yet started |
 | `paused` | Paused with `lev pause` |
-| `waiting` | Blocked - the reason follows the colon |
+| `waiting` | Blocked. The reason follows the colon |
 | `complete` | Finished |
 | `cancelled` | Cancelled with `lev cancel` |
 | `error` | Ended with the error shown |
@@ -362,8 +423,8 @@ need to do anything. These are stopped until a person acts:
 
 | Reason | What to do |
 |---|---|
-| `tool approval` | A tool call needs approving - `lev respond` |
-| `user prompt` | The agent asked a question (`ask_user_*`) - answer it |
+| `tool approval` | A tool call needs approving with `lev respond` |
+| `user prompt` | The agent asked a question (`ask_user_*`). Answer it |
 | `taint gate` | A call needs clearance for the data it touches |
 | `checkpoint` | A blueprint stage-boundary review |
 
@@ -472,8 +533,8 @@ Start the [REST and WebSocket API](/docs/api).
 | `--tls-key <PATH>` | unset | PEM private key for `--tls-cert` |
 
 > [!TIP]
-> A browser cannot call an `http://` Leviath that is not on loopback, whatever `--cors` says - not
-> even on a LAN. That is what the TLS flags are for. See
+> A browser cannot call an `http://` Leviath that is not on loopback, whatever `--cors` says. That
+> holds on a LAN too. That is what the TLS flags are for. See
 > [reaching a Leviath on another machine](/docs/api#reaching-a-leviath-on-another-machine).
 
 > [!WARNING]
@@ -515,11 +576,13 @@ the run. Nothing is left in `lev ps` or on disk.
 
 | Flag | Purpose |
 |---|---|
-| `-m`, `--model <MODEL>` | Test a specific model. Takes the same forms as `lev run --model`: `provider/model` picks both, a bare model id pairs with your `default_provider` |
+| `-m`, `--model <MODEL>` | Test a specific model. Takes the same forms as `lev run --model` |
 | `--no-daemon` | Stop after the third check. Contacts no daemon, starts none, and creates no run |
 | `--json` | Print the checks as `{"checks": [...], "passed": bool}` |
 
-`--model provider/model` is the way to reach a [Rhai script provider](/docs/rhai-providers), which
+`--model` takes `provider/model` to pick both, and a bare model id pairs with your
+`default_provider`. `--model provider/model` is the way to reach a
+[Rhai script provider](/docs/rhai-providers), which
 is resolved by name and so cannot be listed. Use it to try a model string before wiring it into a
 blueprint.
 

--- a/docs/content/comparison.md
+++ b/docs/content/comparison.md
@@ -86,9 +86,10 @@ and script shell calls, while file tools rely on path confinement and network to
 host. Widening it to cover every side effect is
 [in progress](https://github.com/GEMISIS/leviath/issues/326).
 
-**Reach for Leviath** when the hard part is inside a single unit of work: the task has distinct
-phases that want different models and different tools, you care about exactly what is in the context
-window at each phase, or you want many agents running at once without paying for a process each.
+**Reach for Leviath** when the hard part is inside a single unit of work. That is the case when a
+task has distinct phases wanting different models and different tools. It is also the case when you
+care about exactly what is in the context window at each phase, or want many agents running at once
+without paying for a process each.
 Every run journals to disk as it goes, so a daemon you kill mid-run picks the work back up on its
 next start.
 
@@ -109,7 +110,7 @@ agent design. Here is Leviath against it, factor by factor.
 | 8 | Own your control flow | ✓ | Graph transitions on error, iteration cap, stuck, and model choice |
 | 9 | Compact errors into context | ✓ | Tool, inference, and iteration-cap errors all land in context |
 | 10 | Small, focused agents | ✓ | Per-stage models, tools, and prompts, plus bounded fan-out |
-| 11 | Trigger from anywhere | ✓ | Start a run from the CLI, REST, or ACP. WebSocket pushes updates and webhooks report completion. Scheduling is your cron or CI, not ours |
+| 11 | Trigger from anywhere | ✓ | Start a run from the CLI, REST, or ACP. WebSocket updates, webhooks on completion. Scheduling is your cron or CI |
 | 12 | Stateless reducer | ✓ | Durable state lives on disk; the process is disposable. Runs resume on restart, and interrupted tool batches replay exactly-once |
 
 ## How we measure

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -45,7 +45,7 @@ shell_hint           = true          # global master switch, see below
 | `request_timeout_secs` | integer | unset | Unset means the 15 minute ceiling. A stage's `[stages.<name>.model] request_timeout_secs` wins for that stage |
 | `taint_tracking` | bool | `false` | Turns on [taint tracking](/docs/security) for every agent. With it off, an agent can still opt in itself |
 | `batch_tool_hint` | bool | `true` | Adds a short hint telling the model it may batch independent tool calls |
-| `shell_hint` | bool | `true` | Adds a short hint describing the shell a stage will get. Only says anything on platforms that need it, today just Windows |
+| `shell_hint` | bool | `true` | Adds a short hint describing the shell a stage will get. Only says anything on Windows today |
 
 All three of those cascade: a stage setting beats an agent setting, which beats this file.
 
@@ -92,8 +92,8 @@ fallback_order      = ["anthropic/claude-sonnet-5", "openai/gpt-5.6-mini"]
 
 `anthropic_cache_ttl` is how long a cached prompt prefix survives. The default `5m` is free; `1h`
 costs more to write and sends the beta header it needs. It is worth the write cost for a staged
-agent: stages routinely take longer than five minutes when one of them is running scripts, so a
-prefix cached at the start of a run is cold by the time a later stage could have reused it.
+agent. Stages routinely take longer than five minutes, especially when one is running scripts. A
+prefix cached at the start of a run is then cold by the time a later stage could have reused it.
 
 `claude_code_enabled` is off unless you turn it on. See
 [Providers](/docs/providers#claude-code-transport) for the terms note that goes with it.
@@ -159,8 +159,8 @@ can see *how* it ended rather than finding it gone. `0` drops it immediately. Th
 memory, so a daemon restart clears it whatever you set.
 
 **`wedge_timeout_secs`** fails a run that is sitting in a state no part of the engine can reach,
-rather than leaving it reported as running. It never fires on a run that is merely slow: an agent
-waiting on the model, a tool, its sub-agents, or a person is exempt however long it takes. It is off
+rather than leaving it reported as running. A slow run never trips it: an agent waiting on the
+model, a tool, its sub-agents, or a person is exempt however long it takes. It is off
 by default because it fails runs, and that should be your decision. `300` is sensible if something
 outside Leviath is tracking your slots. See [External work queues](/docs/work-queues).
 
@@ -178,13 +178,14 @@ never counts as consent. `0` waits indefinitely. See
 <a id="security"></a>
 
 **`max_tool_call_write_bytes`** and **`max_run_write_bytes`** bound how much an agent puts on disk.
-Both are **unset in code and written by `lev setup`**, which is the unusual part and deliberate: how
-much an agent should be allowed to write depends on what you are doing with it, so Leviath imposes
-nothing on a config it did not write. A fresh install gets concrete numbers here, where you can see
-them and **delete the line to remove the limit**.
+Both are **unset in code and written by `lev setup`**, which is the unusual part and is deliberate.
+How much an agent should be allowed to write depends on what you are doing with it, so Leviath
+imposes nothing on a config it did not write. A fresh install gets concrete numbers here, where you
+can see them and **delete the line to remove the limit**.
 
-The incident behind them was a single shell call appending in a loop until the 60-second timeout -
-about 14 GB from one call that looked ordinary - repeated until the disk was full.
+The incident behind them was a single shell call appending in a loop until the 60-second timeout.
+That put about 14 GB on disk from one call that looked ordinary, and it repeated until the disk was
+full.
 
 They work differently because they have to. `write_file` and `edit_file` carry their content as an
 argument, so an oversized one is refused before a byte lands. A shell redirect does not: those bytes
@@ -194,8 +195,8 @@ call. That stops the call after the one that overran, not the one that did.
 Running out of disk is separate and **not configurable**. Leviath refuses any write that would leave
 under a gigabyte free, whatever these two say and whatever `--yolo` says, because filling the disk
 harms every other process on the machine rather than just the run. A filesystem whose free space
-cannot be read is treated as unknown and allowed - a guard that cannot measure has nothing to say -
-and the two ceilings above still apply to it.
+cannot be read is treated as unknown and allowed, because a guard that cannot measure has nothing to
+say. The two ceilings above still apply to it.
 
 ## `[security]`
 
@@ -218,17 +219,36 @@ credential_store           = "file"   # file | keychain
 
 | Key | Default | Notes |
 |---|---|---|
-| `allowed_workdirs` | `[]` | Directories a run's workdir may sit under without being confirmed. Empty asks only about the alarming cases: a home directory or a filesystem root. Listing a path silences the prompt for everything under it |
-| `allow_seed_commands` | `true` | Whether a blueprint's `seed = { command = "..." }` regions may run at all. They execute at spawn, before the first approval prompt, so a seed also has to be covered by `[safe_commands]` - there is nobody to ask in the moment. `--no-seed-commands` refuses them for one run |
-| `allow_local_network` | `false` | Whether agent fetches may reach loopback, private, and link-local addresses. Off, this blocks cloud metadata, your own `lev serve`, and the LAN |
-| `allow_env_vars` | `[]` | Credential-shaped variable names a Rhai script may read through `env_var()`. Matching is exact and case-insensitive, and there is no wildcard |
+| `allowed_workdirs` | `[]` | Directories a run's workdir may sit under without being confirmed. See below |
+| `allow_seed_commands` | `true` | Whether a blueprint's `seed = { command = "..." }` regions may run at all. See below |
+| `allow_local_network` | `false` | Whether agent fetches may reach loopback, private, and link-local addresses. See below |
+| `allow_env_vars` | `[]` | Credential-shaped variable names a Rhai script may read through `env_var()`. Exact and case-insensitive, no wildcards |
 | `allow_blueprint_read_paths` | `false` | Honors every blueprint's `[read_paths]` as written. Prefer a per-agent grant for anything you did not author |
 | `allow_blueprint_safe_commands` | `false` | Honors every blueprint's `[safe_commands]` as written. Off, an installed agent cannot pre-approve its own shell |
-| `allow_blueprint_permissions` | `false` | Honors every blueprint's `[tool_permissions]` even where it exceeds the built-in default for a tool you have not configured. Off, a blueprint may still pre-approve `web_search` and `web_fetch`; anything else is clamped to the default. Name the tool under `[agent_tool_permissions.<agent>]` to grant it per agent instead |
+| `allow_blueprint_permissions` | `false` | Honors every blueprint's `[tool_permissions]`, even above the built-in default. See below |
 | `shell_env` | `"filtered"` | Which of the daemon's environment variables a shell command inherits. See below |
 | `shell_env_withhold` | `[]` | The names `shell_env = "custom"` withholds. Ignored under every other mode |
-| `read_paths` | `[]` | Machine-wide read grants. A grant only applies to a path the blueprint also declares, so listing one here opens nothing by itself |
+| `read_paths` | `[]` | Machine-wide read grants, which apply only where a blueprint declares the path too. See below |
 | `credential_store` | `"file"` | `keychain` moves secrets to the OS credential store. Run `lev auth migrate` after changing it |
+
+Five of those need more than a table cell.
+
+**`allowed_workdirs`** silences the confirm prompt for everything under a listed path. Left empty,
+`lev run` asks only about the alarming cases: a home directory, or a filesystem root.
+
+**`allow_seed_commands`** covers commands that run at spawn, before the first approval prompt.
+Because there is nobody to ask at that moment, a seed command also has to be covered by
+`[safe_commands]`. `--no-seed-commands` refuses seed commands for one run.
+
+**`allow_local_network`** is off by default. Off, an agent's fetches cannot reach cloud metadata
+endpoints, your own `lev serve`, or anything else on your LAN.
+
+**`allow_blueprint_permissions`** off still lets a blueprint pre-approve `web_search` and
+`web_fetch`. Anything else is clamped to the built-in default. To grant one tool to one agent
+instead, name it under `[agent_tool_permissions.<agent>]`.
+
+**`read_paths`** opens nothing on its own. A grant applies only to a path the blueprint also
+declares, so both halves have to name it.
 
 Grant entries (here and in `[agent_read_paths]`) take three forms: an exact path, which grants its
 subtree; `glob:` patterns; and `regex:` patterns, auto-anchored. Both patterns are matched against
@@ -253,8 +273,8 @@ does not find. `lev list` and `lev ps` carry the same counts.
 
 `[tool_permissions]` sets a machine-wide ceiling. A blueprint's own `[tool_permissions]` may
 tighten it but never loosen it. For a tool you have not listed here there is no ceiling to clamp
-against, so a blueprint may raise it no higher than the built-in default - except `web_search` and
-`web_fetch`, which read-only research agents pre-approve. To let a blueprint go further, name the
+against, so a blueprint may raise it no higher than the built-in default. The exceptions are
+`web_search` and `web_fetch`, which read-only research agents pre-approve. To go further, name the
 tool under `[agent_tool_permissions.<agent>]`, or set `[security] allow_blueprint_permissions`.
 
 ```toml
@@ -286,14 +306,15 @@ inherit. All three answer to the same setting, so a script with `shell` is not a
 
 | Mode | What it withholds |
 |---|---|
-| `filtered` (default) | Credential-shaped names, **except `SSH_AUTH_SOCK`** - so `git push` over agent keys still works |
-| `strict` | The same, plus `SSH_AUTH_SOCK`, `AWS_PROFILE`, `AWS_REGION`, `KUBECONFIG`, `NETRC`. Breaks `git push`, `aws` and `kubectl` in a shell tool until you list what you need |
+| `filtered` (default) | Credential-shaped names, **except `SSH_AUTH_SOCK`**, so `git push` over agent keys still works |
+| `strict` | The same, plus `SSH_AUTH_SOCK`, `AWS_PROFILE`, `AWS_REGION`, `KUBECONFIG`, `NETRC`. See below |
 | `custom` | Exactly the names in `shell_env_withhold`, and nothing inferred |
 | `inherit` | Nothing |
 
-Toolchain variables pass through under every mode: `PATH`, `HOME`, `CARGO_HOME`, `JAVA_HOME`,
-`VIRTUAL_ENV`, `NVM_DIR`, `GOPATH`, `DOCKER_HOST`, `TERM`. `allow_env_vars` hands a specific name
-over under every mode too, so one list means one thing whichever surface asks.
+`strict` breaks `git push`, `aws` and `kubectl` inside a shell tool until you list the names those
+commands need. Toolchain variables pass through under every mode: `PATH`, `HOME`, `CARGO_HOME`,
+`JAVA_HOME`, `VIRTUAL_ENV`, `NVM_DIR`, `GOPATH`, `DOCKER_HOST`, `TERM`. `allow_env_vars` hands a
+specific name over under every mode too, so one list means one thing whichever surface asks.
 
 ```toml
 [security]
@@ -304,15 +325,15 @@ allow_env_vars     = ["MY_PROVIDER_KEY"]
 
 Be clear about what this buys. With `cat` and `grep` on the default safe list, a granted shell can
 read `~/.leviath/config.toml` and find the provider key anyway. This is defence in depth against
-accidental leakage - an `env` in tool output, a `printenv` in a log, a subprocess that phones home -
-and it closes the command-seed case, where nothing was ever approved. It is not a boundary. For one,
-use `[sandbox]`.
+accidental leakage: an `env` in tool output, a `printenv` in a log, a subprocess that phones home.
+It also closes the command-seed case, where nothing was ever approved. It is not a boundary. For
+one, use `[sandbox]`.
 
 ## `[safe_commands]` and `[agent_safe_commands.<agent>]`
 
 A permission is per tool name, which for the shell is a choice between a prompt on every `ls` and no
 prompt on `curl evil | sh`. These entries are argument-scoped, and can only turn an `ask` into an
-`allow` - never a configured `deny`.
+`allow`. They never lift a configured `deny`.
 
 ```toml
 [safe_commands]
@@ -327,10 +348,16 @@ allow_blueprint = true          # honour this agent's own [safe_commands]
 
 | Key | Default | Notes |
 |---|---|---|
-| `defaults` | `true` | The shipped read-only verb list. An entry on it must not be able to write a file, run another program, or open a connection under any flag, which is why `find`, `sed`, `awk`, `sort`, `xargs`, `env` and `cargo` are absent - and why `uniq` (writes its second operand), `tree` (`-o`) and `rg` (`--pre` runs a command) were removed. Add any of them back by name if you want them unprompted |
+| `defaults` | `true` | The shipped read-only verb list. See below |
 | `tools` | `[]` | Tools that never prompt whatever their arguments. Built-in names, or MCP names as advertised (`server__tool`) |
 | `shell` | `[]` | A program, optionally with the subcommand that narrows it. `git status`, never `git` or `cargo test --lib`. Also `env:NAME`, below |
 | `allow_blueprint` | `false` | Per-agent only. Honour that agent's own `[safe_commands]` block |
+
+An entry on the `defaults` list has to clear one bar: under any flag, it must not be able to write a
+file, run another program, or open a connection. That is why `find`, `sed`, `awk`, `sort`, `xargs`,
+`env` and `cargo` are absent from it. It is also why `uniq` (it writes its second operand), `tree`
+(`-o`) and `rg` (`--pre` runs a command) were taken off. Add any of them back by name if you want
+them unprompted.
 
 A shell entry covers the program it names with any arguments, so `cat` covers `cat notes.md`. It
 does not cover a line that also runs something else: `cat notes.md && curl evil` still asks, because
@@ -361,7 +388,7 @@ pipefail` is unaffected, since shell options change nothing about which program 
 ### Redirects
 
 `echo x > file` writes a file, and no tool name in the call says so. A shell call that redirects
-output is therefore held to the `write_file` policy as well as the shell's own: where `write_file`
+output is therefore held to the `write_file` policy as well as the shell's own. Where `write_file`
 is `deny` the call is refused, and it is never quieter than a `write_file` call would have been.
 That is what stops a redirect being a spelling of `write_file` that a `deny` never sees.
 
@@ -371,16 +398,17 @@ Each target is also its own key, so an approval names what is being written:
 Allow cat notes.md, >/tmp/report.txt for this run
 ```
 
-Unlike a program, a write cannot be pre-approved in a config file - `[safe_commands] shell` rejects
-any entry beginning with `>`. A write is approved by a person, per target, or not at all.
+A write cannot be pre-approved in a config file the way a program can. `[safe_commands] shell`
+rejects any entry beginning with `>`. A write is approved by a person, per target, or not at all.
 
-Three shapes cost nothing, because they write nothing that outlives the call: `/dev/null`,
-`/dev/stdout`, `/dev/stderr`, `/dev/tty` and `/dev/fd/*`; descriptor duplications such as `2>&1`;
-and read redirects, since a program that can read a file could already read it. So `cargo build >
-/dev/null 2>&1` and `cat notes.md 2>/dev/null` are as quiet as they were.
+Three shapes cost nothing, because they write nothing that outlives the call. The first is the
+throwaway devices: `/dev/null`, `/dev/stdout`, `/dev/stderr`, `/dev/tty` and `/dev/fd/*`. The second
+is a descriptor duplication such as `2>&1`. The third is a read redirect, since a program that can
+read a file could already read it. So `cargo build > /dev/null 2>&1` and `cat notes.md 2>/dev/null`
+are as quiet as they were.
 
 Two shapes cannot be granted at all. A target that only exists after expansion (`> $OUT`) names a
-different file on every run, and bash's `> /dev/tcp/host/port` is a socket rather than a file, which
+different file on every run. Bash's `> /dev/tcp/host/port` is a socket rather than a file, which
 makes the redirect a network channel no program name describes. Both prompt every time.
 
 <a id="tool_script_permissions"></a>
@@ -455,8 +483,8 @@ see: that table takes any name, so a misspelled provider deserializes perfectly 
 nothing.
 
 This is a warning, not an error. Every command reads `config.toml`, so one stale key should not take
-the CLI down - unlike a blueprint, which is authored and validated deliberately and fails on an
-unknown key.
+the CLI down. A blueprint is different: it is authored and validated deliberately, and it fails on
+an unknown key.
 
 The one place unrecognized keys are *kept*: `[model_providers.<name>]` forwards anything it does not
 recognize to the Rhai script, so those are read and never reported.
@@ -503,8 +531,8 @@ Three sources, narrowest first:
    128,000 tokens.
 
 The reason this order matters is that region budgets are percentages of the window. A `budget = "30%"`
-region on a model that really holds 1M tokens is 314,572 tokens if the window is known and 38,400 if
-it fell back, with no error either way - the agent just evicts working material early and looks like
+region on a model that really holds 1M tokens is 314,572 tokens if the window is known, and 38,400
+if it fell back. Neither case raises an error. The agent evicts working material early and reads as
 a worse model.
 
 A provider that cannot be reached at start-up costs nothing but the fallback: Leviath warns, keeps
@@ -513,7 +541,7 @@ the line that fixes it.
 
 > [!NOTE]
 > Region budgets written as percentages resolve against `max_context_tokens`, so a wrong window is
-> not cosmetic: a `budget = "30%"` region on a model assumed to be 128k gets 38 400 tokens instead
+> not cosmetic. A `budget = "30%"` region on a model assumed to be 128k gets 38 400 tokens instead
 > of the 314 572 a 1M-token model would give it. OpenRouter fronts far more models than any built-in
 > table names, so Leviath warns once per model when it falls back to a conservative window and tells
 > you the line to add here.
@@ -624,19 +652,19 @@ Leviath reads a `.env` file from the working directory unless `LEVIATH_SKIP_DOTE
 that one file, never a walk up the tree, and a variable you have already exported always wins.
 
 A cloned repository *is* the working directory, so its `.env` is content somebody else wrote.
-Credentials from it load normally - that is what the feature is for - but the handful of names that
-decide where configuration comes from or what gets executed are ignored, with a warning naming them:
-the `LEVIATH_` namespace, `PATH`, `SHELL`, `EDITOR`, `VISUAL`, the `LD_*` and `DYLD_*` loader
-variables, and the interpreter and tool hook variables that turn a later command into code
-execution (`BASH_ENV`, `GIT_SSH_COMMAND` and the other `GIT_*` hooks, `PAGER`, `NODE_OPTIONS`,
-`PYTHONSTARTUP`, `PYTHONPATH`, `PERL5OPT`, `RUBYOPT`, `JAVA_TOOL_OPTIONS`, `RUSTC_WRAPPER`, and
-their kin). Without that, one line of `LEVIATH_CONFIG_PATH` in a repository you cloned would point
+Credentials from it load normally, which is what the feature is for. The handful of names that
+decide where configuration comes from, or what gets executed, are ignored instead, with a warning
+naming them. That covers the `LEVIATH_` namespace, `PATH`, `SHELL`, `EDITOR`, `VISUAL`, and the
+`LD_*` and `DYLD_*` loader variables. It also covers the interpreter and tool hook variables that
+turn a later command into code execution: `BASH_ENV`, `GIT_SSH_COMMAND` and the other `GIT_*` hooks,
+`PAGER`, `NODE_OPTIONS`, `PYTHONSTARTUP`, `PYTHONPATH`, `PERL5OPT`, `RUBYOPT`, `JAVA_TOOL_OPTIONS`,
+`RUSTC_WRAPPER`, and their kin. Without that, one line of `LEVIATH_CONFIG_PATH` in a repository you cloned would point
 Leviath at a config file of its choosing, with its own MCP server commands and tool permissions.
 Export those yourself if you meant them.
 
 | Variable | Effect |
 |---|---|
-| `LEVIATH_HOME` | Redirects the whole data root. Every home-relative path honors it, which is what makes an isolated test or a second install possible |
+| `LEVIATH_HOME` | Redirects the whole data root. Every home-relative path honors it, so an isolated test or a second install works |
 | `LEVIATH_CONFIG_PATH` | Path to an exact config file, bypassing the default location |
 | `LEVIATH_SKIP_DOTENV` | Set to skip `.env` loading |
 | `LEVIATH_RUNS_DIR` | Overrides where run directories are written |

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -69,7 +69,7 @@ history      = { kind = "compact_history", budget = "15%", source_region = "code
 | `pinned` | Never evicted (architecture, the task). |
 | `sliding_window` | Keeps the most recent entries; the conversation lives here. |
 | `compacting` | Summarizes instead of evicting: file reads and tool results. |
-| `compact_history` | Carries summaries from earlier stages forward, so a later stage knows what happened without holding the raw content. Names the region it summarizes with `source_region`. |
+| `compact_history` | Carries summaries from earlier stages forward, so a later stage skips the raw content. `source_region` names what it summarizes. |
 | `clearable` | Wiped in one shot when space is needed (scratch). |
 | `hashmap` | Keyed entries (alias `hash_map`); a write to a key replaces it. |
 | `checklist` | A task list whose entries carry state. Written through `todo_add` / `todo_done` / `todo_note`, never evicted, and rendered open-items-first. |
@@ -131,11 +131,11 @@ model believes it wrote:
 | `todo_done(region, id)` | Ticks it off |
 | `todo_note(region, id, note)` | Records a note **without** closing it |
 
-It renders as one stable block with open items first, because the value of it being in the system
-section is that it stays in front of the model every turn as instruction rather than history.
+It renders as one stable block with open items first. Sitting in the system section is what keeps it
+in front of the model every turn, as instruction rather than history.
 
-An id is never reused, so a `todo_done` cannot land on a different item than the one it names, and
-an id that matches nothing is an error the model can read rather than a silent no-op.
+An id is never reused, so a `todo_done` cannot land on a different item than the one it names. An id
+that matches nothing is an error the model can read rather than a silent no-op.
 
 The gate is the part that makes any of this enforceable:
 
@@ -147,8 +147,8 @@ gate = { require_no_open_items = "todos",
 
 The nudge names the items that are still open. It shares the same `max_attempts` budget as every
 other gate, so it cannot wedge a run. A gate naming a region no stage declares, or a region that is
-not a `checklist`, is refused by `lev validate`: at runtime it could only ever count zero and pass
-on the first attempt, which looks exactly like a stage that finished its work.
+not a `checklist`, is refused by `lev validate`. At runtime such a gate could only ever count zero
+and pass on the first attempt, which looks exactly like a stage that finished its work.
 
 ### Keys every region accepts
 
@@ -206,8 +206,8 @@ working.
 
 A `seed` that matches none of the forms above is ignored and the region starts empty. `lev validate`
 reports that as `region-seed-not-understood`, which is worth reading before wondering why a region
-came out blank: the table keys are exactly the ones in the left column, so `{ caller_input = "..." }`
-is a typo for `{ caller = "..." }` and seeds nothing. And a blueprint that seeds no region from the
+came out blank. The table keys are exactly the ones in the left column, so `{ caller_input = "..." }`
+is a typo for `{ caller = "..." }` and seeds nothing. A blueprint that seeds no region from the
 task refuses a task outright rather than running without it.
 
 > [!WARNING]
@@ -238,10 +238,10 @@ ships, and there is no such thing as loading your logic from somewhere else on p
 
 ## Where a stage's own instructions live
 
-A stage's `system_prompt` is pinned context - that is why it reads as instruction rather than
-history - and it goes into a region like everything else. By default that region is *whichever
-pinned region you declared first*, which costs three things: its tokens are charged to that region's
-name in the [stage ledger](/docs/cli#lev-stages-run-id), you cannot size or scope it, and it lands wherever
+A stage's `system_prompt` is pinned context, which is why it reads as instruction rather than
+history. It goes into a region like everything else. By default that region is *whichever pinned
+region you declared first*. That costs three things: its tokens are charged to that region's name in
+the [stage ledger](/docs/cli#lev-stages-run-id), you cannot size or scope it, and it lands wherever
 that region sits in the cacheable prefix.
 
 Name a region for it and all three go away:
@@ -253,7 +253,7 @@ stage_instructions = { kind = "pinned", budget = "3%" }
 
 The runtime writes the entering stage's prompt there, replacing the previous stage's. It is always
 assembled **after** every other pinned block, however you declared it, so the content in front of it
-stays byte-identical when the stage changes - and that content is what a provider's prompt cache
+stays byte-identical when the stage changes. That content is what a provider's prompt cache
 matches on. Instructions sitting in front of the shared prefix rewrite its head on every transition,
 which invalidates everything behind them.
 
@@ -305,13 +305,13 @@ read_file = "codebase"
 read_file = 20000
 ```
 
-Both tables are keyed by tool name, and an alias matches the tool it aliases - writing `bash` covers
+Both tables are keyed by tool name, and an alias matches the tool it aliases. Writing `bash` covers
 the `shell` the model actually calls.
 
 A stage may only route into a region it can see. Routing a result into a region the stage left out
 of its own `[context.regions]` writes it where that stage cannot read it back, so `lev validate`
-refuses the blueprint and says which region to add. The four the runtime always carries -
-`conversation`, `tool_results`, `final_output` and `stage_instructions` - are always valid targets.
+refuses the blueprint and says which region to add. The four the runtime always carries are always
+valid targets: `conversation`, `tool_results`, `final_output` and `stage_instructions`.
 
 An override entry can also carry both answers at once, which is usually what you mean when a tool
 needs its own region *and* its own ceiling:
@@ -329,8 +329,8 @@ skipped.
 
 `read_file` also has a hard byte cap of its own, independent of any of this, and says so in the
 result when it applies. Without one, a large file went into its region whole and was either
-truncated or dropped as `[result omitted]` depending on how full the region already was - a cliff
-rather than a limit.
+truncated or dropped as `[result omitted]` depending on how full the region already was. That is a
+cliff rather than a limit.
 
 ## Budgets travel across models
 

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -3,7 +3,7 @@ title: Structured context
 description: How structured context regions keep an agent coherent across hundreds of tool calls, where a flat message list drifts.
 group: Concepts
 group_order: 2
-order: 5
+order: 6
 ---
 
 # Structured context memory

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -3,7 +3,7 @@ title: The daemon
 description: The background daemon that owns every run, so agents survive a closed terminal and share one process.
 group: Concepts
 group_order: 2
-order: 2
+order: 3
 ---
 
 # The shared-world daemon

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -166,7 +166,7 @@ wedge_timeout_secs = 300
 
 It is `0`, meaning off, by default, because it fails runs and that should be your choice.
 
-It never fires on a run that is merely slow. An agent waiting on the model, on a tool, on its
+A slow run never trips it. An agent waiting on the model, on a tool, on its
 sub-agents, or on a person is exempt however long it takes. If it does fire, the run's error says
 so and the daemon logs it at `error` level. That is a bug in Leviath, and worth reporting.
 

--- a/docs/content/embedding.md
+++ b/docs/content/embedding.md
@@ -81,7 +81,7 @@ returning.
 | `fallback_model(provider, model)` | Where a run moves when its provider fails mid-run, so a single-model blueprint survives an outage. |
 | `prompt_hints(hints)` | Turn on the batch-tool and shell hints, which are off by default on the embed path. |
 | `tool_service(arc)` | Replace the built-in tool service with your own (see below). |
-| `state_dir(dir)` | Persist runs on disk in the daemon's layout (`dir/runs/<run_id>/`). Without it the world is fully in memory and never touches disk. |
+| `state_dir(dir)` | Persist runs on disk in the daemon's layout (`dir/runs/<run_id>/`). Without it the world stays in memory. |
 | `inference_pool(config)` | Per-model inference concurrency limits. |
 | `tool_concurrency(n)` | How many tool batches may execute at once (default 4). |
 | `runtime(handle)` | Run on a specific Tokio runtime instead of the ambient one. |

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -18,8 +18,8 @@ table over and over. An agent with nothing to do is a row those functions skippe
 close to nothing.
 
 That arrangement has a name: an **Entity Component System**, usually shortened to **ECS**. Game
-engines use it to move thousands of objects per frame, and Leviath borrows the storage and
-iteration rather than the reason: games want cache locality in a tight frame budget, while an agent
+engines use it to move thousands of objects per frame. Leviath borrows the storage and iteration
+rather than the reason. Games want cache locality in a tight frame budget, while an agent
 runtime wants a way to hold state for something that is mostly waiting. If you have written a
 reactor with a state machine per connection, this will feel familiar. The ECS supplies the table
 and the sweep so Leviath does not hand-roll them.
@@ -28,7 +28,7 @@ The three words are the three pieces, and this page explains each one as it goes
 
 | Word | Means here |
 |---|---|
-| **Entity** | One agent. Really just a row number, with no code attached to it. |
+| **Entity** | One agent. A row number, with no code attached to it. |
 | **Component** | One piece of an agent's data, such as its context window or which stage it is on. |
 | **System** | One function that runs across every agent in a given state and moves it along. |
 
@@ -60,8 +60,8 @@ Leviath turns that inside out. The loop belongs to the engine, not to any agent,
 pipeline: a fixed sequence of phases that runs start to finish, over and over. Each phase is one
 function, and it acts on whichever agents happen to be sitting at that phase right now.
 
-Here is the spine of it. The real pipeline has about forty-five functions; these five are the ones
-that move an ordinary turn, and the rest handle summarizing context, spotting a stuck agent,
+Here is the spine of it. The real pipeline has about forty-five functions, and these five are the
+ones that move an ordinary turn. The rest handle summarizing context, spotting a stuck agent,
 iteration caps, checkpoints, fan-out, telemetry, and writing to disk.
 
 ```mermaid
@@ -90,8 +90,8 @@ An agent's position in the pipeline is itself a piece of its data, which is what
 find its agents by looking rather than by being told.
 
 The difference shows up when there are many of them. Give each agent its own task and the runtime
-has 100 things it must schedule, each holding a turn's worth of stack, and any budget you want to
-apply across all of them has to be coordinated between them:
+has 100 things it must schedule, each holding a turn's worth of stack. Any budget you want to
+apply across all of them then has to be coordinated between them:
 
 ```mermaid
 flowchart TB
@@ -151,7 +151,7 @@ From here the page gets specific:
 Leviath gets this from [bevy_ecs](https://bevy.org/), a library built for game engines and
 used here unchanged. Precisely:
 
-- An **entity** is just an id. No data, no methods. Think of it as a row number.
+- An **entity** is an id and nothing else. No data, no methods. Think of it as a row number.
 - A **component** is a plain struct attached to an entity. `AgentState` is a component,
   `ContextWindow` is a component. An entity is nothing more than the components it carries.
 - A **system** is an ordinary function that runs over every entity carrying some particular set of
@@ -159,7 +159,7 @@ used here unchanged. Precisely:
 
 So there is no agent object that knows how to run itself. There is agent-shaped **data**, and the
 pipeline of functions above running across all of it. Nothing sits on an `await`, because nothing
-owns a call stack. A blocked agent is just a row that this pass skipped.
+owns a call stack. A blocked agent is a row that this pass skipped.
 
 That trade is aimed at running many agents at once:
 
@@ -233,7 +233,7 @@ components, and each system asks for the marker it acts on.
 | `AwaitingTitle` | The title call is in flight. Titling runs alongside the first turn | the title-collect system |
 
 Moving an agent forward means removing one marker and adding another. `dispatch_inference` asks for
-entities `With<ReadyToInfer>`, so an agent without that marker is simply not in the results. The
+entities `With<ReadyToInfer>`, so an agent without that marker is not in the results at all. The
 same trick makes control operations nearly free: pausing a run sets `AgentStatus::Paused`, and
 every dispatch system already ignores agents that are not `Active`.
 
@@ -262,7 +262,7 @@ flowchart TD
 3. **`process_response`** reads the reply. Tool calls go down the tool path; plain text goes toward
    a transition.
 4. **`dispatch_tools`** checks each requested call before it runs. A tool the stage never
-   advertised in `available_tools` is refused rather than hidden, [permissions](/docs/tools) decide
+   advertised in `available_tools` is refused rather than hidden. [Permissions](/docs/tools) decide
    whether the call needs you, and [taint tracking](/docs/security#taint-tracking-experimental)
    blocks a call that would carry sensitive data somewhere it should not go. Calls that only edit
    the agent's own context apply here; the rest go to the tool lane.
@@ -271,11 +271,11 @@ flowchart TD
    `ReadyToInfer`.
 6. **`resolve_transition`** picks what happens at the end of a stage. A stage's outgoing edges are
    its [transitions](/docs/stages), including ones that fire on an error or when the agent is
-   detected going in circles. There are six answers: `Terminal` (done), `TerminalError` (failed,
-   with no `error` edge to catch it), `Next` (take this edge), `Choose` (ask the model which edge),
-   `Resume` (the agent looked stuck, but the stage has no edge for that, so carry on), and
-   `DeadEnd` (every edge out is exhausted, which routes to the `error` edge or fails the run rather
-   than reporting a completion that did not happen).
+   detected going in circles. There are six answers. Four are ordinary: `Terminal` (done),
+   `TerminalError` (failed, with no `error` edge to catch it), `Next` (take this edge), and
+   `Choose` (ask the model which edge). `Resume` means the agent looked stuck but the stage has no
+   edge for that, so it carries on. `DeadEnd` means every edge out is exhausted, which routes to the
+   `error` edge or fails the run rather than reporting a completion that did not happen.
 
 Those are six of the roughly forty-five. See [Multi-stage workflows](/docs/stages) for what the
 transition conditions mean and [Structured context](/docs/context) for what the regions do.
@@ -286,13 +286,13 @@ A **tick** is one pass of that whole system list over every agent in the world. 
 one after another in a fixed order, so no two ever overlap, and no system ever awaits. A dispatch
 system starts async work and swaps in an `Awaiting*` marker; a collect system on a later tick
 picks the result up. That one rule is what keeps a pass short no matter how many agents are
-waiting, and it gives you backpressure for free: a full pool just means an agent stays
+waiting. It also gives you backpressure for free: a full pool means an agent stays
 `ReadyToInfer` until a later tick finds it a slot.
 
 At the end of a tick, Leviath counts how many agents carry each of the twelve markers. Those
 counts are the world's **fingerprint**. The loop does not do its work on a clock. It ticks for as
-long as the fingerprint keeps changing, and when a whole tick changes nothing it sleeps (one slow
-30-second timer stays armed as a safety net, re-driving anything a lost wakeup would strand):
+long as the fingerprint keeps changing, and when a whole tick changes nothing it sleeps. One slow
+30-second timer stays armed as a safety net, re-driving anything a lost wakeup would strand:
 
 ```rust
 loop {

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -3,7 +3,7 @@ title: The agent engine
 description: How one process runs many agents at once: each is a row of data in an Entity Component System, so a waiting agent costs almost nothing.
 group: Concepts
 group_order: 2
-order: 3
+order: 4
 ---
 
 # The agent engine

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -148,7 +148,7 @@ From here the page gets specific:
 
 ## Entities, components, and systems
 
-Leviath gets this from [bevy_ecs](https://bevyengine.org/), a library built for game engines and
+Leviath gets this from [bevy_ecs](https://bevy.org/), a library built for game engines and
 used here unchanged. Precisely:
 
 - An **entity** is just an id. No data, no methods. Think of it as a row number.

--- a/docs/content/first-agent.md
+++ b/docs/content/first-agent.md
@@ -1,0 +1,400 @@
+---
+title: Build your first agent
+description: Build a release-notes agent from an empty directory: stages, models, context regions, an error edge, and a structured answer.
+group: Concepts
+group_order: 2
+order: 2
+---
+
+# Build your first agent
+
+[Getting Started](/docs/getting-started) had you run somebody else's agent. This page has you write
+one, a stage at a time, and explains each piece as you add it. At the end you will have an agent
+that turns your project's recent commits into release notes a user can read.
+
+It is a good first agent because the work genuinely has phases. Deciding which commits matter is
+cheap sorting. Writing the notes is the part worth a better model. Handing back a clean answer is a
+third job again, and none of them wants the others' tools.
+
+You need what Getting Started set up: `lev` installed and one provider configured. Run this in a
+git repository with some history, because the agent reads your commit log.
+
+```mermaid
+flowchart LR
+  S["survey<br/>sort the commits<br/>(cheap model)"] --> D["draft<br/>write the notes<br/>(better model)"]
+  D --> P["publish<br/>hand back markdown"]
+  S -.->|error| R["recover"]
+  D -.->|error| R
+```
+
+## Step 1: scaffold
+
+```bash
+lev create release-notes
+cd release-notes
+```
+
+That writes a directory with an `agent.leviath` file in it, plus a `.gitignore` and a
+`.env.example`. The blueprint it generates is a working one-stage agent. You are going to replace
+it, so open it and delete everything.
+
+Every agent needs a name and an entry stage. Start there:
+
+```toml
+[agent]
+name = "release-notes"
+version = "0.1.0"
+description = "Turns the commits since your last release into notes a user can read"
+entry_stage = "survey"
+```
+
+`entry_stage` names the stage a run begins in. Without it, a run starts at whichever stage you
+declared first, which is fine until you reorder the file.
+
+## Step 2: give it something to read
+
+An agent's memory is divided into named **regions**, each with its own budget and its own rule for
+what to drop first. That is [structured context](/docs/context), and it is the reason a large file
+read cannot push your task description out of the window.
+
+Four regions is enough here:
+
+```toml
+[context.regions]
+task    = { kind = "pinned", budget = "3%", seed = "task_input" }
+commits = { kind = "pinned", budget = "25%", seed = { command = "git log --oneline -50" } }
+notes   = { kind = "pinned", budget = "20%" }
+conversation = { kind = "sliding_window", budget = "25%", max_items = 20 }
+```
+
+Three things are happening.
+
+**`pinned` means never dropped.** The task and the commit list are the whole point of the run, so
+nothing may evict them to make room. `conversation` is a `sliding_window` instead, because the
+back-and-forth is worth keeping recent and not worth keeping forever.
+
+**Budgets are percentages of whatever model the stage runs on**, so this layout works the same on a
+1M-token model and a 200K one. They are ceilings rather than allocations, which is why they may sum
+past 100%: regions rarely all fill at once.
+
+**`seed` fills a region before the first inference.** `task_input` is whatever you pass to
+`--task`. The `command` form runs a shell command and keeps its output, so the agent starts already
+holding your commit log instead of spending a turn fetching it.
+
+> [!NOTE]
+> A seed command runs at spawn, before any approval prompt, so it only runs if it is already
+> trusted. `git log` is on Leviath's built-in safe list, which is why this one needs no
+> configuration from you. A seed running something less ordinary needs a
+> [`[safe_commands]`](/docs/interaction#what-runs-without-asking) entry, and `lev validate` prints
+> every seed a blueprint will run.
+
+## Step 3: the first stage
+
+A **stage** is one phase of the work, with its own prompt, model, and tools:
+
+```toml
+[stages.survey]
+mode = "autonomous"
+description = "Sort the commits into what a user would notice and what they would not"
+model = { models = [
+  { provider = "anthropic", model = "claude-sonnet-5" },
+  { provider = "openai", model = "gpt-5.4-mini" },
+] }
+available_tools = ["context_write"]
+max_iterations = 10
+system_prompt = """
+The `commits` region holds this project's recent commits, newest first.
+
+Sort them into changes a user of this project would notice, and changes they
+would not: refactors, test-only work, dependency bumps, CI.
+
+Write the user-visible ones into the `notes` region with context_write, one per
+line, each keeping its short commit hash. Then say you are done.
+"""
+```
+
+`models` is an ordered fallback list, not a choice. The first entry whose provider you have
+configured wins, so this stage runs on Anthropic if you have a key for it and OpenAI if you do not.
+Adding your own provider to the front is how you take an agent somewhere else.
+
+`available_tools` is the entire set this stage may call. Sorting text needs no file access and no
+shell, so it gets neither. A tool left out here is refused if the model asks for it, rather than
+quietly hidden, which is what keeps a stage's blast radius equal to its list.
+
+`max_iterations` bounds the loop. A stage that never decides it is finished stops here rather than
+spending your budget.
+
+## Step 4: a second stage, and the edge between them
+
+Stages are joined by **transitions**, which form a [graph](/docs/stages):
+
+```toml
+[stages.survey.transitions.draft]
+hint = "The commits are sorted and the user-visible ones are in the notes region"
+```
+
+The table name is the destination stage. `hint` is what the model reads when it decides whether to
+take this edge, so write it as the condition it describes rather than as an instruction.
+
+Now the stage it points at:
+
+```toml
+[stages.draft]
+mode = "autonomous"
+description = "Turn the sorted changes into release notes"
+model = { models = [
+  { provider = "anthropic", model = "claude-opus-5" },
+  { provider = "openai", model = "gpt-5.5" },
+] }
+available_tools = ["bash", "read_file"]
+max_iterations = 15
+system_prompt = """
+Write release notes from the `notes` region, grouped under Added, Changed, and
+Fixed. Drop any group with nothing in it.
+
+Write for someone who uses this project and has not read its commit log. If a
+commit message is too terse to explain, run `git show --stat <hash>` to see what
+it touched before you describe it.
+
+Then hand the notes to the publish stage.
+"""
+```
+
+This is the payoff of splitting the work. `draft` runs on a stronger model than `survey`, because
+prose about your project is worth more than sorting a list. It also gets tools `survey` had no use
+for, so it can look at a commit whose message says `fix edge case` and find out which one.
+
+Both facts are per stage. Neither could be expressed if this were one agent with one prompt.
+
+## Step 5: hand back a real answer
+
+A run's result should be something a script can use, not a transcript to read. That is what a
+[final output](/docs/outputs) is:
+
+```toml
+[stages.publish]
+mode = "output"
+description = "Hand back the finished notes"
+max_iterations = 3
+model = { models = [
+  { provider = "anthropic", model = "claude-sonnet-5" },
+  { provider = "openai", model = "gpt-5.4-mini" },
+] }
+
+[stages.publish.output]
+format = "markdown"
+instructions = "The release notes only. Start at the first heading, with no preamble."
+```
+
+`mode = "output"` does three things: it grants the `submit_output` tool, it requires the stage to
+call it, and it takes away everything else. The stage has one job and one way to finish it.
+
+`format` is a label carried to the model and recorded beside the answer. It is not an enum, so a
+shape Leviath has never heard of works the same way; `instructions` is where you explain one.
+
+Point `draft` at it:
+
+```toml
+[stages.draft.transitions.publish]
+hint = "The notes are written"
+```
+
+## Step 6: somewhere to land when something breaks
+
+Every edge so far is a happy path. Give both working stages somewhere to go when they fail:
+
+```toml
+[stages.survey.transitions.recover]
+condition = "error"
+
+[stages.draft.transitions.recover]
+condition = "error"
+
+[stages.recover]
+mode = "autonomous"
+description = "Say what went wrong when a stage fails"
+model = { models = [
+  { provider = "anthropic", model = "claude-sonnet-5" },
+  { provider = "openai", model = "gpt-5.4-mini" },
+] }
+available_tools = []
+max_iterations = 3
+system_prompt = """
+A stage failed. Say briefly what was being attempted and what the error was, so
+the person running this can decide what to do.
+"""
+```
+
+`condition = "error"` fires on a failure rather than on the model's judgement, so it needs no
+`hint`. Without an error edge a failed stage ends the run with whatever the runtime knows, which is
+usually less than the agent knows. See [transitions](/docs/stages) for the other conditions,
+including `stuck` and `max_iterations`.
+
+## Step 7: check it before you run it
+
+```bash
+lev validate .
+```
+
+`lev validate` reads the blueprint the way the runtime will, then says what it found:
+
+```console
+✓ Blueprint 'release-notes' is valid.
+  4 stages, version 0.1.0
+  Graph mode: entry stage 'survey'
+  - survey → draft, recover
+  - draft → recover, publish
+  - publish (linear)
+  - recover (linear)
+  NOTE 1 region(s) run a shell command at spawn, before the first inference and
+       before any tool-approval prompt: commits: git log --oneline -50 (pre-approved)
+```
+
+The graph it prints is the one to read carefully, because a stage with no way out and a stage
+nothing reaches both look fine in a text editor. The note about the seed is the check from step 2
+confirming itself: `(pre-approved)` means `git log` needed no permission from you.
+
+Warnings are worth fixing even though they do not stop a run. A stage with no `max_iterations` and
+a model this build has never heard of both turn up here.
+
+## Step 8: run it
+
+```bash
+lev run . --task "Release notes for the changes since the last tag"
+```
+
+`lev run .` runs the blueprint in the current directory, which is what you want while you are still
+editing it. Install it as a named agent once you are happy:
+
+```bash
+lev add .
+lev run release-notes --task "..."
+```
+
+The run goes to the background, so watch it or come back later:
+
+```bash
+lev dash                    # live view
+lev result <run-id>         # the notes, once it finishes
+```
+
+Expect to be asked once. `draft` may call `git show`, and the shell defaults to asking before it
+runs anything, so answer in `lev dash` or with [`lev respond`](/docs/interaction). Pass `--yolo` if
+you would rather it not stop.
+
+## The whole file
+
+```toml
+[agent]
+name = "release-notes"
+version = "0.1.0"
+description = "Turns the commits since your last release into notes a user can read"
+entry_stage = "survey"
+
+[tool_permissions]
+read_file = "allow"
+bash = "ask"
+
+[context.regions]
+task    = { kind = "pinned", budget = "3%", seed = "task_input" }
+commits = { kind = "pinned", budget = "25%", seed = { command = "git log --oneline -50" } }
+notes   = { kind = "pinned", budget = "20%" }
+conversation = { kind = "sliding_window", budget = "25%", max_items = 20 }
+
+[stages.survey]
+mode = "autonomous"
+description = "Sort the commits into what a user would notice and what they would not"
+model = { models = [
+  { provider = "anthropic", model = "claude-sonnet-5" },
+  { provider = "openai", model = "gpt-5.4-mini" },
+] }
+available_tools = ["context_write"]
+max_iterations = 10
+system_prompt = """
+The `commits` region holds this project's recent commits, newest first.
+
+Sort them into changes a user of this project would notice, and changes they
+would not: refactors, test-only work, dependency bumps, CI.
+
+Write the user-visible ones into the `notes` region with context_write, one per
+line, each keeping its short commit hash. Then say you are done.
+"""
+
+[stages.survey.transitions.draft]
+hint = "The commits are sorted and the user-visible ones are in the notes region"
+
+[stages.survey.transitions.recover]
+condition = "error"
+
+[stages.draft]
+mode = "autonomous"
+description = "Turn the sorted changes into release notes"
+model = { models = [
+  { provider = "anthropic", model = "claude-opus-5" },
+  { provider = "openai", model = "gpt-5.5" },
+] }
+available_tools = ["bash", "read_file"]
+max_iterations = 15
+system_prompt = """
+Write release notes from the `notes` region, grouped under Added, Changed, and
+Fixed. Drop any group with nothing in it.
+
+Write for someone who uses this project and has not read its commit log. If a
+commit message is too terse to explain, run `git show --stat <hash>` to see what
+it touched before you describe it.
+
+Then hand the notes to the publish stage.
+"""
+
+[stages.draft.transitions.publish]
+hint = "The notes are written"
+
+[stages.draft.transitions.recover]
+condition = "error"
+
+[stages.publish]
+mode = "output"
+description = "Hand back the finished notes"
+max_iterations = 3
+model = { models = [
+  { provider = "anthropic", model = "claude-sonnet-5" },
+  { provider = "openai", model = "gpt-5.4-mini" },
+] }
+
+[stages.publish.output]
+format = "markdown"
+instructions = "The release notes only. Start at the first heading, with no preamble."
+
+[stages.recover]
+mode = "autonomous"
+description = "Say what went wrong when a stage fails"
+model = { models = [
+  { provider = "anthropic", model = "claude-sonnet-5" },
+  { provider = "openai", model = "gpt-5.4-mini" },
+] }
+available_tools = []
+max_iterations = 3
+system_prompt = """
+A stage failed. Say briefly what was being attempted and what the error was, so
+the person running this can decide what to do.
+"""
+```
+
+## Make it yours
+
+Small changes worth trying, each of which reaches for one more idea:
+
+- **Point it at a range.** Change the seed to `git log --oneline $(git describe --tags --abbrev=0)..HEAD` so it reads only what is genuinely unreleased.
+- **Make the shape strict.** Add a `schema` to `[stages.publish.output]` and the answer is validated against it before the run is allowed to finish. See [final outputs](/docs/outputs).
+- **Ask before publishing.** Set `mode = "interactive_points"` on `draft` and declare an [interaction point](/docs/interaction), so you approve the notes before they are finalized.
+- **Split the reading.** If your project is large, give `draft` a [fan-out](/docs/sub-agents) stage that reads several commits at once instead of one at a time.
+
+## Where to go next
+
+- [Agent blueprints](/docs/agents) is the field-by-field reference for everything used here.
+- [Multi-stage workflows](/docs/stages) covers the rest of the graph: conditions, gates, revisit
+  limits, and what happens at a dead end.
+- [Structured context](/docs/context) covers the other region kinds, including one that compacts
+  instead of dropping and one that tracks a checklist.
+- [The agent catalog](/docs/agent-catalog) has ten shipped blueprints, each with its graph drawn,
+  which are worth reading now that the syntax means something.

--- a/docs/content/gas-city.md
+++ b/docs/content/gas-city.md
@@ -111,7 +111,7 @@ real work is slower than that, mostly because it is waiting on models:
 | Setting | Default | Why you might raise it |
 |---|---|---|
 | `handshake_timeout` | `30s` | Only covers the handshake, so the default is usually fine. Raise it if the daemon has to cold-start first |
-| `nudge_busy_timeout` | `60s` | How long Gas City waits for the agent to go idle before sending another prompt. A multi-stage run is busy for much longer than a minute |
+| `nudge_busy_timeout` | `60s` | How long Gas City waits for the agent to go idle before prompting again. A multi-stage run needs longer |
 | `output_buffer_lines` | `1000` | How much output is kept for `Peek`. A long run produces more than this |
 
 ## Checking it works

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -198,12 +198,15 @@ cd my-agent
 lev run . --task "Your task here"
 ```
 
-This writes an `agent.leviath` config you can customize: the stages, the model for each phase,
-and the context regions. See [Agents](/docs/agents) to go deeper.
+This writes an `agent.leviath` file you can customize: the stages, the model for each phase, and
+the context regions. [Build your first agent](/docs/first-agent) walks through writing one from
+scratch, a stage at a time, and is the natural next thing to read.
 
 ## Where to go next
 
 - The [Agent catalog](/docs/agent-catalog) tours the ten pre-built agents and what each is for.
+- [Build your first agent](/docs/first-agent) writes one from an empty directory, explaining each
+  piece as it goes.
 - [Overview](/docs/overview) explains what Leviath is doing underneath: stages, context regions,
   and the shared world your agents run in.
 - [Agent blueprints](/docs/agents) covers what goes in an `agent.leviath` file, for building your

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -8,9 +8,9 @@ order: 1
 
 # Getting Started
 
-Leviath runs LLM agents. What it adds over asking a model directly is **structure**: context that
-stays coherent across hundreds of tool calls, a different model for each phase of a task, and
-hundreds of agents running at once in one process.
+Leviath runs LLM agents. What it adds over asking a model directly is **structure**. That means
+context that stays coherent across hundreds of tool calls, a different model for each phase of a
+task, and hundreds of agents running at once in one process.
 
 You'll go from nothing to a running agent in four steps:
 

--- a/docs/content/glossary.md
+++ b/docs/content/glossary.md
@@ -107,7 +107,7 @@ call finishes.
 **Tool lane**: the shared cap on how many agents' tool batches may run at once across the whole
 daemon. See [the tool lane](/docs/engine#the-tool-lane).
 
-**Backpressure**: what happens when a pool is full. New work simply is not started yet. Nothing
+**Backpressure**: what happens when a pool is full. New work is not started yet. Nothing
 fails and nothing queues up at the provider.
 
 **Park**: to stop and wait, without holding anything up. It means two related things. A run parks

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -3,7 +3,7 @@ title: Human-in-the-loop
 description: What to do when a run shows waiting: answer agent questions, tool approvals, and checkpoints with lev respond, the dashboard, or the API.
 group: Concepts
 group_order: 2
-order: 9
+order: 10
 ---
 
 # Human-in-the-loop

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -87,7 +87,10 @@ waits indefinitely. When it passes, the prompt resolves exactly as cancelling it
 | Tool approval | Denied. A timeout is never read as consent. |
 | Taint gate | Denied. |
 | `ask_user_*` | The model is told no answer came, and carries on. |
-| Interaction point | Proceeds with no user text, as a cancelled checkpoint does - unless it declared `unattended = "ask"`, in which case the run **stops with an error** rather than approving a checkpoint nobody made. |
+| Interaction point | Proceeds with no user text, as a cancelled checkpoint does. See below. |
+
+An interaction point that declared `unattended = "ask"` behaves differently on a timeout: the run
+**stops with an error**, rather than approving a checkpoint nobody made.
 
 The deadline is read once when the daemon starts, so changing it needs a daemon restart.
 
@@ -152,11 +155,11 @@ approve `git push`. A line the parser cannot read as a list of commands (a backt
 
 Nothing is written to disk. Every grant dies with the run that made it.
 
-The taint gate in [security](/docs/security) uses the same prompt shape with its own wording: an
-outbound tool that would carry sensitive data above its clearance is blocked and surfaced as a
-tool-approval, where **Allow for this session** raises the tool's clearance for the rest of the
-run and **Deny** blocks it. It offers no per-stage option, because a clearance is not keyed on what a call
-runs.
+The taint gate in [security](/docs/security) uses the same prompt shape with its own wording. An
+outbound tool that would carry sensitive data above its clearance is blocked, then surfaced as a
+tool-approval. There, **Allow for this session** raises the tool's clearance for the rest of the
+run, and **Deny** blocks it. It offers no per-stage option, because a clearance is not keyed on
+what a call runs.
 
 ## Interaction points
 
@@ -212,8 +215,8 @@ loop keeps regenerating from scratch and your edits are lost each time.
 
 `unattended` decides what the point does in a `--yolo` run. The default, `auto_approve`, resolves it
 as approved without opening a prompt: nobody is watching, and a checkpoint that waited would park
-the run. Set it to `ask` for a gate whose whole purpose is a human decision - a plan signed off
-before any code is written - and the prompt opens even under `--yolo`. The shipped
+the run. Set it to `ask` for a gate whose whole purpose is a human decision, such as a plan signed
+off before any code is written. The prompt then opens even under `--yolo`. The shipped
 `software-engineer` agent does exactly that for its plan approval. Give a run like that an
 [`interaction_timeout_secs`](/docs/configuration#limits), so an unanswered gate releases on its own
 terms instead of waiting for ever.

--- a/docs/content/observability.md
+++ b/docs/content/observability.md
@@ -117,3 +117,11 @@ block above and run an agent. The run shows up as a trace named `agent.run` unde
 The daemon owns the exporter. It starts with the daemon and flushes on shutdown, so short-lived CLI
 commands do not each pay the setup cost. See [the daemon](/docs/daemon) for where this sits in its
 lifecycle.
+
+## Where one run's cost went
+
+The metrics above answer "is the fleet healthy". For "what did this one run spend, and on which
+stage", read its stage ledger instead: [`lev stages <run-id>`](/docs/cli#lev-stages-run-id) at a terminal,
+or [`GET /api/agents/{id}/stages`](/docs/api#where-a-runs-cost-went) over HTTP. Both carry the
+per-stage token split, the cache read and write halves, and the largest each context region reached
+while that stage was active, which is the number to look at before trimming a layout.

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -3,7 +3,7 @@ title: Final outputs
 description: Get a structured answer out of a run with output formats, schemas, and lev result, instead of scraping its logs.
 group: Concepts
 group_order: 2
-order: 7
+order: 8
 ---
 
 # Final outputs

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -184,10 +184,10 @@ good default behaviour and directly at odds with `--output-instructions "reply w
 integer"`.
 
 Once the three levels above have combined, the winning spec is stated to the model as the one that
-governs how the answer is presented, and the stage prompt yields to it wherever the two disagree. So
-a caller who passes `--output-format` or `--output-instructions` does not have to know what the
-blueprint's prompt says, and a blueprint author does not have to strip presentation guidance out of
-a prompt to leave room for callers who may never pass anything.
+governs how the answer is presented. The stage prompt yields to it wherever the two disagree. So a
+caller who passes `--output-format` or `--output-instructions` does not have to know what the
+blueprint's prompt says. A blueprint author, in turn, does not have to strip presentation guidance
+out of a prompt to leave room for callers who may never pass anything.
 
 The claim is scoped to presentation: length, structure, what to lead with. It does not tell the
 model to disregard what the stage prompt asked it to *do*.

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -117,7 +117,9 @@ webhooks can deliver a finished run to you. See
 
 ## Where to go next
 
-- [Agent blueprints](/docs/agents) is the natural next page, since everything else configures one.
+- [Build your first agent](/docs/first-agent) is the natural next page: it writes one from
+  scratch, and the ideas below make more sense once you have.
+- [Agent blueprints](/docs/agents) is the field-by-field reference for what you wrote.
 - [Multi-stage workflows](/docs/stages) and [Structured context](/docs/context) are the two ideas
   that do the most work.
 - [Glossary](/docs/glossary) defines every term these docs use in a particular way.

--- a/docs/content/packaging.md
+++ b/docs/content/packaging.md
@@ -94,9 +94,9 @@ project directory.
 
 > [!IMPORTANT]
 > An installed blueprint can only ever **tighten** its sandbox, never loosen it. The permission
-> floor your own config sets always wins, and for a tool you have not configured a blueprint may
-> go no higher than Leviath's own default - except `web_search` and `web_fetch`, which read-only
-> research agents pre-approve. Installing an agent does not let it grant itself more than you
+> floor your own config sets always wins. For a tool you have not configured, a blueprint may go no
+> higher than Leviath's own default. The exceptions are `web_search` and `web_fetch`, which
+> read-only research agents pre-approve. Installing an agent does not let it grant itself more than you
 > allow. See [Security](/docs/security) for how the sandbox and permission floor work.
 
 See the [CLI reference](/docs/cli) for every command and flag.

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -95,12 +95,19 @@ Ubuntu 24.04 and up; anything older fails at exec with a `version not found` mes
 a line of Leviath. The musl archives are statically linked and need nothing from the image at all.
 
 ```bash
+# The rolling tag for the channel you want: latest (stable), beta, or alpha.
+CHANNEL=latest
+
 # glibc: fine on a modern host, fails on an older container image
-curl -fsSLO https://github.com/GEMISIS/leviath/releases/download/alpha/leviath-linux-x64.tar.gz
+curl -fsSLO "https://github.com/GEMISIS/leviath/releases/download/$CHANNEL/leviath-linux-x64.tar.gz"
 
 # musl: runs anywhere
-curl -fsSLO https://github.com/GEMISIS/leviath/releases/download/alpha/leviath-linux-x64-musl.tar.gz
+curl -fsSLO "https://github.com/GEMISIS/leviath/releases/download/$CHANNEL/leviath-linux-x64-musl.tar.gz"
 ```
+
+The musl archives were added after the current stable release, so they are on `alpha` and `beta`
+today and reach `latest` with the next stable promotion. `gh release view <channel>` lists what a
+channel actually carries.
 
 They are the same binary otherwise. The glibc builds stay the default because they use the
 platform's own resolver and NSS configuration, which is what you want on a machine you control.

--- a/docs/content/releases.md
+++ b/docs/content/releases.md
@@ -28,8 +28,8 @@ the commit carrying the bump is the one that gets built.
 
 Alpha picks it up as soon as the merge lands, and re-checks every night in case
 it missed one. Beta and stable stay on their weekly cadence, but each one asks
-the same question before it does anything: is the version at the build I would
-publish different from the version at the build I last published? When the
+the same question first. Is the version at the build I would publish different
+from the version at the build I last published? When the
 answer is no, the run finishes in seconds having touched nothing. A quiet
 Monday means there was nothing new to promote, not that something failed.
 
@@ -43,9 +43,9 @@ cuts an immutable versioned release. Release titles follow the same scheme:
 `Leviath v0.1.2-Alpha`, `Leviath v0.1.2-Beta`, and `Leviath v0.1.2` for the immutable stable
 release, while the rolling `latest` is titled with its channel.
 
-Maintainers can re-cut a channel without a bump - to recover from an
-infrastructure failure, say - by running the workflow by hand with its `force`
-input. That is the only path that can land on a version already released, and
+Maintainers can re-cut a channel without a bump by running the workflow by hand
+with its `force` input, which is how they recover from an infrastructure
+failure. That is the only path that can land on a version already released, and
 the versioned tag gets a date suffix (`v0.1.2+20260802`) when it does, so an
 immutable tag is never moved.
 
@@ -91,8 +91,8 @@ macOS on both and Windows on x64.
 
 Reach for the musl ones when you are dropping `lev` into an image you did not build. The glibc
 binaries link against the release runner's C library and so need `GLIBC_2.38` or newer, which is
-Ubuntu 24.04 and up; anything older fails at exec with a `version not found` message before it runs
-a line of Leviath. The musl archives are statically linked and need nothing from the image at all.
+Ubuntu 24.04 and up. Anything older fails at exec with a `version not found` message, before it
+runs a line of Leviath. The musl archives are statically linked and need nothing from the image.
 
 ```bash
 # The rolling tag for the channel you want: latest (stable), beta, or alpha.

--- a/docs/content/rhai-hooks.md
+++ b/docs/content/rhai-hooks.md
@@ -1,6 +1,6 @@
 ---
 title: Rhai stage hooks
-description: Run your own Rhai at seven points in an agent's lifecycle - seed a stage, gate a call, reshape an answer.
+description: Run your own Rhai at seven points in an agent's lifecycle to seed a stage, gate a call, or reshape an answer.
 group: Reference
 group_order: 3
 order: 12
@@ -76,7 +76,7 @@ The same four answers everywhere, so there is no vocabulary to learn per hook:
 | `#{ action: "retry" }` | do it again |
 
 Hooks are a **return-value contract**. Rhai passes arguments by value, so mutating `ctx` does
-nothing - the script has to return its decision.
+nothing. The script has to return its decision.
 
 Not every hook can honour `retry`, and one that cannot says so rather than treating it as allow.
 Today none of them do: it is reserved for re-inference, which needs an attempt bound first or a hook
@@ -85,13 +85,13 @@ that always retries would wedge the run.
 ## What hooks cannot do
 
 **`on_tool_call` runs before the gate, not after.** Whatever it leaves is what your tool policy, the
-taint gate, and the approval prompt then check. So a hook can *narrow* what runs - veto a call,
-rewrite arguments to something tamer - and cannot widen anything, because nothing it produces skips
+taint gate, and the approval prompt then check. So a hook can *narrow* what runs. It can veto a call
+or rewrite arguments to something tamer. It cannot widen anything, because nothing it produces skips
 those checks. It also has no access to the gate itself: it cannot mark its own calls approved.
 
-**`after_inference` cannot rewrite tool calls.** It is shown their names - enough to notice "it wants
-to run shell" - and can replace the response text only. Editing the calls there would be a way around
-checks you configured; that is `on_tool_call`'s job, where the gate can see it.
+**`after_inference` cannot rewrite tool calls.** It is shown their names, which is enough to notice
+"it wants to run shell". It can replace the response text only. Editing the calls there would be a
+way around checks you configured; that is `on_tool_call`'s job, where the gate can see it.
 
 **A failed hook is not an allowed hook.** A script that throws, or returns something malformed, fails
 the run. Treating a broken gate as permission is how a gate quietly stops gating.

--- a/docs/content/rhai-tools.md
+++ b/docs/content/rhai-tools.md
@@ -111,7 +111,7 @@ schema   = { type = "string", enum = ["json", "yaml"], description = "output for
 ## Inspecting the inventory
 
 `lev tools` lists the global inventory without starting the daemon. Compiled tools are marked,
-files that failed to compile are shown with their reason (they are simply not advertised), and a tool
+files that failed to compile are shown with their reason (they are not advertised at all), and a tool
 whose `@requires` capability the platform cannot satisfy is flagged unavailable:
 
 ```bash

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -28,7 +28,7 @@ can copy and change. [rhai.rs](https://rhai.rs) has the language reference if yo
 |---|---|---|
 | [**Model providers**](/docs/rhai-providers) | `~/.leviath/providers/<name>.rhai` | How to map a request onto some HTTP API, and the response back |
 | [**Context regions**](/docs/rhai-regions) | beside the agent, referenced by `script =` | How one region renders, accepts writes, and sheds content under pressure |
-| [**Stage hooks**](/docs/rhai-hooks) | beside the agent, referenced by `[stages.<name>.hooks]` | What happens at seven points in an agent's lifecycle - entering a stage, either side of an inference, before a tool call, and at the end |
+| [**Stage hooks**](/docs/rhai-hooks) | beside the agent, referenced by `[stages.<name>.hooks]` | What happens at seven points in an agent's lifecycle, from entering a stage through to the end |
 | [**Global tools**](/docs/rhai-tools) | `~/.leviath/tools/*.rhai`, or an agent's own `tools/` | A new tool, its schema, and what it does |
 | [**Output validators**](/docs/rhai-validators) | beside the agent, referenced by the stage's `[output]` block | Whether a submitted final output is accepted, and what the model is told when it is not |
 | [**Policy rules**](/docs/rhai-tools#policy-rules) | `rules/*.rhai` in your OS config dir, see [configuration](/docs/configuration#policytoml) | Whether a given tool call is allowed to fire |
@@ -50,7 +50,7 @@ by point:
 - Region hooks and policy rules get **nothing**. They are pure data transforms over the `ctx` they
   are handed.
 
-Names are matched exactly, and the match is enforced: a script missing the function its surface
+Names are matched exactly, and the match is enforced. A script missing the function its surface
 needs, or defining it with the wrong arity, fails at spawn with a compile error rather than
 silently never firing. `lev validate` and `lev tools` catch it before a run does.
 

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -61,9 +61,10 @@ kind = "none"             # run discovery on the host…
 >
 > Inside the boundary: the `shell` tool, a blueprint's seed commands, and a Rhai script tool's
 > `shell()` calls. Outside it: file tools, which stay on the host and rely on workdir
-> [path confinement](#reading-outside-the-workdir) instead, and `web_fetch`, `web_search`, and a
-> script's HTTP functions, which use the host network, so `network = false` fences the sandboxed
-> commands and not those tools. [MCP servers](/docs/mcp) are host processes shared across agents,
+> [path confinement](#reading-outside-the-workdir) instead. Also outside are `web_fetch`,
+> `web_search`, and a script's HTTP functions, which use the host network, so `network = false`
+> fences the sandboxed commands and not those tools.
+> [MCP servers](/docs/mcp) are host processes shared across agents,
 > so they sit outside too.
 >
 > Covering every side effect, and letting a single run opt into a sandbox, is
@@ -89,7 +90,7 @@ engine on `PATH`, the agent **fails to spawn** with a clear error. That is
 host instead.
 
 > [!IMPORTANT]
-> An *installed* agent can never weaken the sandbox you configured: it may pick a stricter kind,
+> An *installed* agent can never weaken the sandbox you configured. It may pick a stricter kind,
 > never a looser one, and its own `engine` choice is always discarded, because the engine binary
 > runs on the host at spawn, before any prompt. With no `[sandbox]` of your own, a blueprint may
 > still opt in with its own image and mounts, so read a downloaded agent's sandbox block rather
@@ -152,7 +153,7 @@ Four other commands surface the same thing, so this is hard to miss:
 | `lev list` | The same granted-over-declared counts under each agent |
 | `lev add` | The status of what you just installed |
 | `lev run` | Warns in the daemon log when an agent declares reads and your config grants none |
-| `lev ps` | A `READS` column, granted over declared. `0/2` is a run that is up and will have every read outside its workdir refused |
+| `lev ps` | A `READS` column, granted over declared. `0/2` means every read outside the workdir will be refused |
 
 Those checks compare patterns, not paths on disk, so treat them as the first answer rather than the
 last: an individual read is still matched against the real, symlink-resolved path at run time.
@@ -197,7 +198,7 @@ can, which matters, because otherwise an agent could relabel its own data.
 
 Every tool that could send bytes off the machine has a **clearance**, the highest sensitivity it is
 trusted with. Before such a tool runs, Leviath compares the two. If the data is more sensitive than
-the tool's clearance, the call does not simply proceed.
+the tool's clearance, your policy decides what happens next.
 
 ```mermaid
 flowchart TD

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -3,7 +3,7 @@ title: Security & sandboxing
 description: Sandboxed execution, tool permissions, and taint tracking, for running a blueprint you did not write.
 group: Concepts
 group_order: 2
-order: 10
+order: 11
 ---
 
 # Security: sandboxed execution and taint tracking

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -3,7 +3,7 @@ title: Multi-stage workflows
 description: Split an agent into stages so each phase of a task gets its own model, tools, and context.
 group: Concepts
 group_order: 2
-order: 6
+order: 7
 ---
 
 # Multi-stage workflows

--- a/docs/content/stages.md
+++ b/docs/content/stages.md
@@ -81,8 +81,8 @@ quietly does nothing, so a typo fails at `lev validate` instead of at 2am.
 ### The escape that is not also a shortcut
 
 `condition = "dead_end"` fires in one situation: the stage finished, and every normal edge's target
-has spent its `max_revisits`. Without it the run errors out and everything it established - a
-profiled dataset, a plan, two rounds of critique - is discarded.
+has spent its `max_revisits`. Without it the run errors out, and everything it established is
+discarded: a profiled dataset, a plan, two rounds of critique.
 
 ```toml
 [stages.plan.transitions.review]
@@ -93,8 +93,8 @@ hint = "Plan is ready for review"
 condition = "dead_end"
 ```
 
-The reason this is its own condition, rather than "add an ordinary edge to the output stage": an
-ordinary edge is offered to the model at the end of **every** visit, so it becomes a shortcut past
+Why is this its own condition, rather than "add an ordinary edge to the output stage"? An ordinary
+edge is offered to the model at the end of **every** visit, so it becomes a shortcut past
 the rest of the pipeline. Measured on four agents, that shortcut was taken in 10 of 24 runs of one
 and 21 of 36 of another, computing nothing on the way. A `dead_end` edge is invisible to the model's
 choice and reachable only when the alternative is dying.
@@ -105,14 +105,14 @@ somewhere else.
 
 > [!NOTE]
 > `condition = "max_iterations"` does **not** cover this. It fires when a stage burns its iteration
-> budget, which is a different event - on the stranding path it is never consulted. `lev validate`
+> budget, which is a different event. On the stranding path it is never consulted. `lev validate`
 > reflects that: a `max_iterations` edge does not silence `dead-end-possible`.
 
 ### Stage keys that shape routing
 
 | Key | Default | Effect |
 |---|---|---|
-| `max_revisits` | unlimited | How many times this stage may be re-entered, not counting the first visit. An edge pointing at a stage that is out of budget is dropped from the choices |
+| `max_revisits` | unlimited | How many times this stage may be re-entered, not counting the first visit. See below |
 | `transition_prompt` | built-in | Replaces the prompt used to ask the model which edge to take |
 | `allow_complete` | `false` | Offers the model an explicit `DONE` answer that ends the run, rather than forcing it down the one available edge |
 | `requires_children` | `false` | Holds the stage until every sub-agent it spawned has finished |
@@ -120,7 +120,10 @@ somewhere else.
 | `accepts_messages` | `true` | Whether `lev msg` reaches this stage. See [Human-in-the-loop](/docs/interaction) |
 | `allow_blocking_tools` | `false` | Marks an autonomous stage as deliberately offering the tools that wait on a person |
 
-Two of those need a sentence more.
+Three of those need a sentence more.
+
+`max_revisits` is also read when the runtime builds the list of edges to offer. An edge pointing at
+a stage that is out of budget is dropped from the choices.
 
 `allow_as_worker` is off by default so that you can only fan out into a stage that was designed for
 it, rather than into any stage that happens to look suitable.
@@ -154,8 +157,8 @@ transform = "compact"        # direct | clear | compact | summarize | custom
 - `direct` is the default and carries everything as-is.
 - `clear` drops stage-specific regions and keeps pinned ones.
 - `compact`, and its alias `summarize`, sends the stage's content through a summarization pass
-  before the next stage starts. **It summarizes every region that is not pinned**, not just the
-  transcript - including the ones holding your results. A region whose content does not survive a
+  before the next stage starts. **It summarizes every region that is not pinned**, not only the
+  transcript. That includes the ones holding your results. A region whose content does not survive a
   rewrite should say so:
 
   ```toml
@@ -198,10 +201,10 @@ gate = { require_modifications = true, max_attempts = 3 }
 |---|---|---|
 | `require_modifications` | `false` | Require at least one successful file-modifying tool call in the stage being left |
 | `require_regions` | `[]` | Regions that must **all** hold content. ANDed with every other condition here |
-| `require_region_updated` | unset | Require that a named region **changed** during this stage, not merely that it has content. See below |
+| `require_region_updated` | unset | Require that a named region **changed** during this stage, rather than only holding content. See below |
 | `require_no_open_items` | unset | Name a [checklist region](/docs/context) that must have no open items before this edge is taken |
 | `message` | generated | The nudge shown when the gate blocks |
-| `region` | unset | An **alternative** way to satisfy `require_modifications`: the gate also passes if this region is non-empty. Not a requirement - see below |
+| `region` | unset | An **alternative** way to satisfy `require_modifications`: the gate also passes if this region is non-empty. See below |
 | `tools` | `[]` | Extra tool names to count as modifying, beyond `write_file` and `edit_file` |
 
 ### `region` is an alternative, `require_regions` is a requirement
@@ -251,9 +254,9 @@ gate = { require_region_updated = "plan",
 The region's content is hashed when the stage is entered and compared when it tries to leave, so
 "changed" means changed by *this* pass. It shares the same `max_attempts` budget as every other
 gate: a gate that could hold a stage forever would strand the run, so after the budget the edge is
-taken with a warning. A gate naming a region no stage declares is refused by `lev validate`: at
-runtime it passes rather than blocking, since no amount of work could satisfy it, so a typo there
-would read as a gate that is simply never reached.
+taken with a warning. A gate naming a region no stage declares is refused by `lev validate`. At runtime such a gate
+would pass rather than block, since no amount of work could satisfy it. A typo there would read as
+a gate that is never reached.
 | `max_attempts` | `3` | How many times the stage re-runs before the gate gives up and lets the transition through with a warning |
 
 Per-stage tool counters reset when a stage is entered, and they are not restored when a run resumes

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -3,7 +3,7 @@ title: Sub-agents & fan-out
 description: Start child agents and fan work out across them, so many small jobs run at once.
 group: Concepts
 group_order: 2
-order: 8
+order: 9
 ---
 
 # Sub-agents and fan-out

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -37,7 +37,7 @@ Read and modify files relative to the agent's working directory.
 
 | Tool | Purpose | Arguments |
 | --- | --- | --- |
-| `shell` | Run a shell command in the working directory using the system shell. Has a 60-second timeout, and keeps at most 1 MB of each of stdout and stderr. | `command` |
+| `shell` | Run a shell command in the working directory, using the system shell. It has a 60-second timeout. | `command` |
 
 `bash` is an accepted alias for `shell`: a stage's `available_tools` may name either, and both
 resolve to the same tool advertised to the model.
@@ -83,8 +83,9 @@ question.
 Discarded writes cost nothing. `2>/dev/null`, `> /dev/null 2>&1`, `&> /dev/null` and `> NUL` write
 nowhere anyone can read back, so they are neither clamped nor confined.
 
-A target the parser cannot name - `> $OUT`, or bash's `/dev/tcp/host/port` - has no path to check,
-so it is ungrantable instead: it prompts every time and no approval makes it reusable.
+Some targets the parser cannot name at all, such as `> $OUT` or bash's `/dev/tcp/host/port`. Those
+have no path to check, so they are ungrantable: they prompt every time, and no approval makes them
+reusable.
 
 ### How much output comes back
 
@@ -151,7 +152,7 @@ Present work to the user for approval or direct editing.
 ### These tools need someone there
 
 Every tool in the two tables above does the same thing: it opens a prompt and waits. That is fine
-when you are watching the run. When nobody is, the wait has no end - the agent sits in
+when you are watching the run. When nobody is, the wait has no end. The agent sits in
 `WaitingInput`, holding a concurrency slot, until the daemon restarts.
 
 So an unattended run does not get them. A run launched with `--yolo` (and every sub-agent and
@@ -201,8 +202,12 @@ network at all.
 
 | Tool | Purpose | Arguments |
 | --- | --- | --- |
-| `web_search` | Search the web and return a JSON list of `{title, url, snippet}`. Uses Brave Search when `BRAVE_API_KEY` is readable, otherwise a keyless Wikipedia search that works with no configuration. | `query`, `count` (optional, default 5) |
-| `web_fetch` | Fetch a URL and return its readable text. HTML is stripped to prose; large pages are truncated, and a blocked or oversized request returns a diagnostic rather than failing the run. | `url` |
+| `web_search` | Search the web and return a JSON list of `{title, url, snippet}`. See below | `query`, `count` (optional, default 5) |
+| `web_fetch` | Fetch a URL and return its readable text, with HTML stripped to prose. See below | `url` |
+
+`web_search` uses Brave Search when `BRAVE_API_KEY` is readable. Otherwise it falls back to a
+keyless Wikipedia search that needs no configuration. `web_fetch` truncates large pages, and a
+blocked or oversized request comes back as a diagnostic rather than failing the run.
 
 Both ship with `researcher`, `deep-researcher`, `wide-researcher`, `daily-briefer`, and
 `writing-assistant`. To give another agent web access, copy them into that agent's `tools/`
@@ -280,9 +285,9 @@ Two rules constrain that:
 
 - A blueprint may only **tighten** what your config set. A downloaded agent cannot grant itself
   `shell = "allow"` over your `ask`. For a tool you have not configured there is nothing of yours
-  to clamp against, so a blueprint may raise it no higher than the built-in default - except
-  `web_search` and `web_fetch`, which research agents pre-approve and which can neither write nor
-  execute. To trust one agent with more, name the tool in
+  to clamp against, so a blueprint may raise it no higher than the built-in default. The exceptions
+  are `web_search` and `web_fetch`, which research agents pre-approve and which can neither write
+  nor execute. To trust one agent with more, name the tool in
   `[agent_tool_permissions.<agent>]` in your own [config](/docs/configuration#tool-permissions),
   or set `[security] allow_blueprint_permissions` for every agent.
 - A launch flag (`--allow`, `--yolo`) can turn an `ask` into an `allow`, but it can **never** lift

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -76,7 +76,7 @@ layer and names the first one that breaks.
 ## `has no usable provider`, but I do have a key
 
 The message names what it tried: `stage 'parallel_fix' has no usable provider (tried: anthropic)`.
-That stage's `models` list simply never mentions the provider you configured. A blueprint only
+That stage's `models` list never mentions the provider you configured. A blueprint only
 starts on a provider it lists. The [bundled agents](/docs/agent-catalog) list all five providers,
 so with them any key qualifies; a blueprint you downloaded or wrote may list fewer.
 
@@ -226,8 +226,8 @@ console on purpose, and that is not this bug.
 Run `lev ps` and read the line under the table. If there isn't one, the daemon thinks it is
 getting somewhere and the problem is in a particular run rather than the daemon as a whole.
 
-A `lanes:` line means the tool lane is full with batches queued behind it. On its own that is just
-a busy factory. What matters is the second half:
+A `lanes:` line means the tool lane is full with batches queued behind it. On its own that is a
+normal sign of a busy daemon. What matters is the second half:
 
 ```
 lanes: tools 8/8 busy, 3 parked, 12 queued  ·  no progress for 14 cycles (7m)
@@ -270,7 +270,7 @@ is off by default because it fails runs. A run it fails logs at `error` level an
 carries the reason, which begins `[wedged]` in the stage log. Nothing else in Leviath produces that
 line, so it means the engine lost track of a run. Please report it.
 
-It never fires on a run that is merely slow. An agent waiting on the model, on a tool, on its
+A slow run never trips it. An agent waiting on the model, on a tool, on its
 sub-agents, or on a person is holding the marker that says so and is exempt however long it takes.
 
 ## An agent seems stuck in a loop
@@ -306,7 +306,7 @@ passed to `--token`.
 ## An admin action returns `405` or `404`
 
 Config-write and MCP add/remove live behind `--allow-admin`. Without that flag the mutating route is
-not mounted, and you get whichever error fits the path: **405** for `PUT /api/config` and
-`POST /api/mcp/servers`, because those paths still answer `GET`, and **404** for
-`DELETE /api/mcp/servers/{name}`, because nothing is mounted there at all. The read routes keep
+not mounted, and you get whichever error fits the path. `PUT /api/config` and
+`POST /api/mcp/servers` return **405**, because those paths still answer `GET`.
+`DELETE /api/mcp/servers/{name}` returns **404**, because nothing is mounted there at all. The read routes keep
 working either way. Restart with `lev serve … --allow-admin`.

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -218,6 +218,7 @@
         "shell_hint": { "type": "boolean" },
         "model": { "$ref": "#/$defs/modelConfig" },
         "nudge": { "$ref": "#/$defs/nudge" },
+        "hooks": { "$ref": "#/$defs/stageHooks" },
         "sandbox": { "$ref": "#/$defs/sandbox" },
         "security": { "type": "object" },
         "tool_permissions": { "$ref": "#/$defs/toolPermissions" },
@@ -360,6 +361,7 @@
             "clearable",
             "hashmap",
             "hash_map",
+            "checklist",
             "custom"
           ]
         },
@@ -576,6 +578,21 @@
           "type": "string",
           "description": "`{stage}` and `{regions}` interpolate."
         }
+      }
+    },
+
+    "stageHooks": {
+      "type": "object",
+      "description": "Rhai scripts run at points in this stage's lifecycle. Each value is a script path relative to the agent directory.",
+      "additionalProperties": false,
+      "properties": {
+        "on_stage_enter": { "type": "string" },
+        "on_stage_exit": { "type": "string" },
+        "before_inference": { "type": "string" },
+        "after_inference": { "type": "string" },
+        "on_tool_call": { "type": "string" },
+        "on_completion": { "type": "string" },
+        "on_error": { "type": "string" }
       }
     }
   }


### PR DESCRIPTION
Everything from the docs audit, plus the tutorial.

## A published schema that rejected shipped features

`blueprint.schema.json` has `additionalProperties: false` and a closed `kind` enum, and it was missing both **`checklist`** (a region kind) and **`hooks`** (a stage key). Both parse fine and are documented in prose, so every blueprint using either one failed against the schema we publish, link from Configuration, and advertise in `llms.txt`.

It survived because `every_bundled_blueprint_validates_against_the_published_schema` only checks bundled blueprints, and none of them uses either feature. Two tests now close that gap, and **both fail against the old schema**:

- `the_blueprint_schema_accepts_every_region_kind_the_parser_names` reads the valid kinds out of the parser's own error message and holds the schema to them, so a new kind cannot land schema-less.
- `the_blueprint_schema_accepts_stage_hooks` pins the hooks table.

## Things that were broken in the published site

- **`config.example.toml` has always 404'd.** Configuration links it next to the schema, but the publish step copied `docs/schema/*.json`, and the verification loop below it did not name the example either. That is exactly how a linked file went missing for its whole life. Both now include it.
- **A channel could publish with no search index and look fine.** The site falls back to a title-only filter and says nothing, which is how stable has been serving docs with no full-text search. The publish job now asserts the Pagefind index exists, the same way it already asserts the schemas do.
- **`api.md` had an empty section.** The stage-ledger commit inserted `## Where a run's cost went` under `## A run's files`, leaving that heading bodyless while the endpoint table linked to its anchor.
- **Links**: bevy moved to `bevy.org`; an example used `34.132.206.6`, a real routable Google Cloud address, now a reserved documentation address; the container examples pulled `alpha` binaries, now channel-parameterised with an honest note that the musl archives have not reached stable yet.

## Shipped without docs

The `[compaction]` block (which model summarizes a compacting region, and what happens when its provider is not configured), `lev list --filter`, the `output-missing-submit-tool` and `compact-summarizes-deliverable` lint codes, `lev stages` in the `--json` roster, and a cost cross-link from Observability to the stage ledger.

## Build your first agent

The tutorial gap was the biggest one: Getting Started ended at `lev create` plus a link to a field reference, so anyone wanting to write an agent faced ~9,000 words ordered by field rather than by build step.

`/docs/first-agent` builds a **release-notes** agent, which is deliberately not in the catalog: it sorts your commits on a cheap model, writes the notes on a better one, and hands back markdown, with an error edge to land on. It teaches in the order you type, one idea per step, each linking the page that covers it properly.

The blueprint is real. It is **byte-identical to one `lev validate` accepts with no errors and no warnings**, and the console output shown is that run's, including the `(pre-approved)` seed note that demonstrates why `git log` needs no configuration.

## House rules

47 afterthought dash clauses, 42 sentences past the 35-word ceiling, and 46 oversized table cells, including the two tables that were using cells as prose storage. Banned vocabulary as well. Verified rather than trusted: every code block and markdown link is byte-identical to what it replaced, and no backticked identifier in any restructured table went missing.

## Filed, not fixed here

Five issues on `GEMISIS/leviath.dev`, since the renderer is that repo: the [`llms.txt` quickstart regression](https://github.com/GEMISIS/leviath.dev/issues/25), [~1MB of mermaid JS per page](https://github.com/GEMISIS/leviath.dev/issues/26), [missing meta description, canonical, and OG tags](https://github.com/GEMISIS/leviath.dev/issues/27), [`/docs` being a copy of getting-started plus a channel switcher that links to 404s](https://github.com/GEMISIS/leviath.dev/issues/28), and [silent search degradation](https://github.com/GEMISIS/leviath.dev/issues/29).

Worth knowing separately: **none of this reaches readers until stable is promoted.** The default channel still serves the pre-cleanup docs from v0.2.0 (Aug 4), including the Smithy page that was deleted two rounds ago.

`cargo xtask docs` passes; the new tests pass.
