### PR TITLE
chore(release): 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ same list.
 
 ## Unreleased
 
+## 0.3.4 - 2026-08-12
+
 - Changed: the bundled set is seven agents, not ten (#395). `software-engineer`
   merged into `coder`, which keeps the plan checkpoint and the discovery pass
   that grounds it; `writing-assistant` and `daily-briefer` are gone. **If you
@@ -38,6 +40,18 @@ same list.
   bundled agent and point at `lev setup`. The check compares the bytes on disk
   with the bundled ones rather than the `version` field, which routinely does
   not move when a blueprint does.
+- Fixed: the published blueprint schema accepts `checklist` regions and
+  `[stages.<name>.hooks]` (#393). Both parse, both are documented, and both were
+  rejected by the schema Leviath publishes and points people at, so a blueprint
+  using either failed to validate against the file it is told to validate
+  against. The test that should have caught it only checked the bundled
+  blueprints, none of which use either feature; it now reads the valid values
+  out of the parser's own error message, so a new one cannot ship schema-less.
+- Fixed: `config.example.toml` is published alongside the schemas (#393).
+  Configuration links it, the publish step copied only `*.json`, and the check
+  meant to catch a missing artifact listed only what the glob already caught, so
+  the link had 404'd for its whole life. The docs publish also now fails when a
+  channel has no search index rather than quietly serving title-only search.
 - Fixed: `condition = "dead_end"` is in the published blueprint schema (#395).
   The parser accepted it and the `dead-end-possible` lint recommended writing
   it, while the schema Leviath publishes rejected it, so a blueprint following

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
-
 ## 0.3.4 - 2026-08-12
 
 - Changed: the bundled set is seven agents, not ten (#395). `software-engineer`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.3" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.3" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.3" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.3" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.3" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.3" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.3" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.3" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.3" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.3" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.3" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.3" }
+leviath = { path = "crates/leviath", version = "0.3.4" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.4" }
+leviath-net = { path = "crates/leviath-net", version = "0.3.4" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.4" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.4" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.4" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.4" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.4" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.4" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.4" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.4" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.4" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.3", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.4", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/xtask/src/version.rs
+++ b/xtask/src/version.rs
@@ -296,18 +296,25 @@ fn replace_pin(line: &str, new: &str) -> String {
     format!("{before}version = \"{new}\"{tail}")
 }
 
-/// Roll `## Unreleased` under a dated heading and open a fresh empty one.
+/// Rename `## Unreleased` to a dated heading for this version.
 ///
 /// The entries themselves are left untouched: what was accumulating under
 /// `## Unreleased` is exactly what this version ships.
+///
+/// No fresh `## Unreleased` is opened behind it. leviath.dev reads this file to
+/// build its release notes and rejects a section with no entries, so a bump
+/// that left an empty heading failed the docs check on its own release PR - and
+/// the failure landed on whoever cut the release, for a heading they did not
+/// write. The next person to write an entry adds the heading back, which the
+/// error below asks for by name.
 pub fn roll_changelog(changelog: &str, version: &str, date: &str) -> Result<String> {
     anyhow::ensure!(
         changelog.contains("\n## Unreleased\n"),
-        "no `## Unreleased` heading in {CHANGELOG} - add one before bumping"
+        "no `## Unreleased` heading in {CHANGELOG} - add one, with the entries this version ships, before bumping"
     );
     Ok(changelog.replacen(
         "\n## Unreleased\n",
-        &format!("\n## Unreleased\n\n## {version} - {date}\n"),
+        &format!("\n## {version} - {date}\n"),
         1,
     ))
 }
@@ -870,14 +877,18 @@ mod tests {
     // ── Changelog ─────────────────────────────────────────────────────────────
 
     #[test]
-    fn roll_changelog_inserts_a_dated_heading_below_a_fresh_unreleased() {
+    fn roll_changelog_dates_the_unreleased_heading_and_leaves_no_empty_one() {
         let rolled = roll_changelog(
             "# Changelog\n\n## Unreleased\n\n- did a thing\n\n## 0.1.1 - 2026-07-31\n",
             "0.1.2",
             "2026-08-02",
         )
         .unwrap();
-        assert!(rolled.contains("## Unreleased\n\n## 0.1.2 - 2026-08-02\n\n- did a thing"));
+        assert!(rolled.contains("## 0.1.2 - 2026-08-02\n\n- did a thing"));
+        assert!(
+            !rolled.contains("## Unreleased"),
+            "an empty Unreleased fails the site's changelog check: {rolled}"
+        );
         assert!(rolled.contains("## 0.1.1 - 2026-07-31"), "history is kept");
     }
 


### PR DESCRIPTION
Cuts **0.3.4** to alpha. Everything since 0.3.3 that is user-visible, rolled from `## Unreleased`:

- **The bundled set is seven agents, not ten.** `software-engineer` merged into `coder`; `writing-assistant` and `daily-briefer` are gone. The changelog carries the migration note, since anyone who used the three will notice `lev setup` no longer offering them.
- **Five of the seven fan out**, including two whose workers are full `researcher` sub-agent runs.
- **An installed agent that will not load now says whether it is simply out of date**, which is the alpha report this started from.
- **Three published-artifact fixes**: `condition = "dead_end"`, `checklist` regions, and `[stages.<name>.hooks]` are all in the blueprint schema now, and `config.example.toml` is actually published.
- **`GET /api/agents/{id}/stages`**, the per-stage cost ledger.

`cargo xtask version --check` passes, the full workspace suite passes locally (37 targets, zero failures), and the changelog validates against leviath.dev's contract checker.

Needs the `allow-version-bump` label to get past the guard.
