### PR TITLE
UX batch: a wizard that scrolls, clicks and explains itself, plus lev update and a run launcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## Unreleased
+
+- Added: `lev update`, which updates Leviath with the installer that put it
+  there and then offers to bring the bundled blueprints and the config along
+  with it. The install method is read off the filesystem, not guessed from the
+  version string: a Homebrew Cellar path carries the formula name and the
+  formula carries the channel, so a beta install runs `brew upgrade
+  leviath-beta` without being told, and Scoop works the same way. The install
+  script keeps no record of the channel it used, so that arm defaults to
+  `stable` and `--channel` is how you say otherwise. A `cargo install` is
+  described rather than run, because updating it is a full compile.
+
+  The blueprints and the config are checked every time, whatever the binary
+  step did. `brew upgrade` on its own leaves both behind, so anyone who has
+  ever updated that way is running blueprints from whenever they last ran
+  `lev setup`, and a binary that needs no update is not a reason to stop
+  looking.
+
+  Nothing is written to your agents directory without a yes: the list is
+  printed first and one confirmation covers it, with `--install-agents` for
+  scripts. `--yes` alone does not install blueprints, because updating a binary
+  and replacing your agents directory are different requests. A copy you edited
+  is named as edited and asked about on its own, and no flag covers it.
+  `--check` and `--json` report and change nothing; `--dry-run` walks the whole
+  flow and performs none of it.
+
 ## 0.3.4 - 2026-08-12
 
 - Changed: the bundled set is seven agents, not ten (#395). `software-engineer`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,44 @@ same list.
 
 ## Unreleased
 
+- Added: you can start a run from the dashboard. `n` on the main list opens a
+  screen with the installed agents on one side (type to filter) and a task
+  editor on the other, where `@` completes a path from the working directory
+  the way a coding agent does. Until now the dashboard could watch, pause and
+  cancel runs but not begin one, so the answer to "start another" was always
+  another terminal.
+- Fixed: `lev -v setup` no longer fills the wizard with debug text. The tracing
+  layer writes to stderr, the wizard owns the alternate screen on stdout, and
+  both are the same terminal, so a provider check under `-v` drew hyper and
+  rustls lines straight into the frame. Raw mode staircased them and ratatui's
+  cell diffing never painted over them, so the screen stayed broken until exit.
+  Log lines are now buffered while a TUI holds the terminal and flushed to the
+  scrollback when it lets go, including on the panic path. Also fixed next to
+  it: the `.env` filter warned even when it had filtered nothing, printing
+  `Ignoring  from .env` with a hole where a name belonged.
+- Changed: every `lev setup` screen scrolls, so the wizard works at any window
+  size. The tuning screen is thirteen two-line fields, and a twenty-row
+  terminal showed twelve of them with nothing on screen to say the rest
+  existed, the Continue button included. Page keys move the selection and the
+  view follows it; below 24x6 the wizard says the window is too small rather
+  than drawing half a frame.
+- Changed: the tuning screen is now opt-in, from a toggle on Defaults. Every
+  one of those limits already has a working default, so walking a first-time
+  user through concurrency and retry ceilings taught them that setup is long
+  rather than that Leviath is configurable. Skipping it changes nothing about
+  what gets written.
+- Changed: `lev setup` takes the mouse. The credential screen's actions (open
+  the provider's key page, check the credential) are rows you can click or
+  reach with the arrows, rather than `o` and `v` in a footer; clicking a
+  provider selects it, and the wheel scrolls.
+- Changed: the default provider and model are chosen from a searchable list
+  that explains what the choice decides. The list is long and the field showed
+  one line of it. More importantly, the field never said that a stage listing
+  its own models keeps them, or that `default_provider` does nothing at all
+  until `default_model` is also set. The model list's first option read
+  `(provider default)`, which is not a thing: no provider default model is
+  consulted at run time, and a stage naming no model falls back to one built
+  into Leviath. It now reads `(each blueprint decides)`.
 - Added: `lev update`, which updates Leviath with the installer that put it
   there and then offers to bring the bundled blueprints and the config along
   with it. The install method is read off the filesystem, not guessed from the

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ powershell -ExecutionPolicy Bypass -c "irm https://leviath.dev/install.ps1 | iex
 ```
 
 The script picks the right installer for your platform and takes the stable
-channel by default; set `LEVIATH_CHANNEL` to `beta` or `alpha` to switch. Both
+channel by default. For beta or alpha, pass the channel as an argument:
+`curl -fsSL https://leviath.dev/install.sh | sh -s -- --channel beta`. Both
 install prebuilt binaries, so no Rust toolchain is needed.
 
 <details>

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -1,0 +1,298 @@
+//! How a [`Dashboard`] is built, and how it hands its background loops their
+//! ends of the channels.
+//!
+//! Split out of `state.rs`, which is about what a running dashboard does. This
+//! is about the moment before that: which paths and seams get injected (so no
+//! test touches the real home directory, clipboard, or wall clock), and the
+//! one-time handover of the MCP, spawn, and daemon-command channel ends to the
+//! tasks that own them for the rest of the process.
+
+use ratatui::widgets::TableState;
+use ratatui_textarea::TextArea;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+
+use super::state::Dashboard;
+use super::types::*;
+use crate::runstate;
+
+/// Production clock for staleness checks: wall-clock Unix seconds.
+fn system_now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+impl Dashboard {
+    /// Default/test constructor: points the activity log at a shared temp file
+    /// and uses a no-op clipboard, so unit tests never touch the real
+    /// `~/.leviath/dashboard.log`, the system clipboard, or the TTY. Production
+    /// builds the dashboard via [`new_with_log_path`](Self::new_with_log_path)
+    /// (see `init_dashboard`), injecting the real log path and clipboard fn.
+    /// Test-only: production always goes through `new_with_log_path`.
+    #[cfg(test)]
+    pub(super) fn new(cmd_tx: mpsc::UnboundedSender<DaemonCommand>) -> Self {
+        let log_path = std::env::temp_dir()
+            .join("leviath-test-dashboard")
+            .join("dashboard.log");
+        // A test MCP context: temp paths, a no-op browser, and a fixed clock so
+        // no test touches the real home directory, a browser, or the wall clock.
+        let ctx = McpContext {
+            config_path: std::env::temp_dir()
+                .join("leviath-test-dashboard")
+                .join("config.toml"),
+            store_path: std::env::temp_dir()
+                .join("leviath-test-dashboard")
+                .join("mcp-auth.json"),
+            opener: std::sync::Arc::new(|_| false),
+            clock: || 1_000,
+        };
+        // A test new-run context: an empty temp tree, so the agent picker and
+        // the `@` completion never read the real agents dir or working
+        // directory. Tests that need either point these at their own tempdir.
+        let new_run_ctx = NewRunContext {
+            agents_dir: std::env::temp_dir()
+                .join("leviath-test-dashboard")
+                .join("agents"),
+            config_path: std::env::temp_dir()
+                .join("leviath-test-dashboard")
+                .join("config.toml"),
+            workdir: std::env::temp_dir()
+                .join("leviath-test-dashboard")
+                .join("workdir"),
+        };
+        Self::new_with_log_path(cmd_tx, log_path, |_| false, ctx, new_run_ctx)
+    }
+
+    /// Core of [`new`](Self::new) with the activity-log path and clipboard
+    /// function injected, so production can supply the real
+    /// `~/.leviath/dashboard.log` + real OSC52/native clipboard while tests
+    /// point them at a temp dir + a no-op.
+    pub(super) fn new_with_log_path(
+        cmd_tx: mpsc::UnboundedSender<DaemonCommand>,
+        log_path: std::path::PathBuf,
+        yank_fn: fn(&str) -> bool,
+        mcp_ctx: McpContext,
+        new_run_ctx: NewRunContext,
+    ) -> Self {
+        let mut table_state = TableState::default();
+        table_state.select(Some(0));
+
+        // The MCP action lane: the dashboard keeps the command sender + outcome
+        // receiver; the other ends go to the background loop (production) or are
+        // retained for tests to drive.
+        let (mcp_cmd_tx, mcp_cmd_rx) = mpsc::unbounded_channel();
+        let (mcp_outcome_tx, mcp_outcome_rx) = mpsc::unbounded_channel();
+        let (daemon_outcome_tx, daemon_outcome_rx) = mpsc::unbounded_channel();
+        // The spawn lane, split the same way: resolving a blueprint and the
+        // socket round trip both happen off the draw loop.
+        let (spawn_cmd_tx, spawn_cmd_rx) = mpsc::unbounded_channel();
+        let (spawn_outcome_tx, spawn_outcome_rx) = mpsc::unbounded_channel();
+
+        // Seed the in-memory log buffer from the tail of the persistent log so
+        // the panel shows recent history immediately on launch (not a blank panel).
+        let log = Self::load_log_seed(&log_path);
+
+        Self {
+            log_path,
+            yank_fn,
+            selection: None,
+            selection_regions: Vec::new(),
+            agents: Vec::new(),
+            selected: 0,
+            log,
+            input_textarea: TextArea::default(),
+            input_mode: false,
+            detail_view: false,
+            cmd_tx,
+            pending_interactions: HashMap::new(),
+            table_state,
+            should_quit: false,
+            pending_confirm: None,
+            sort_mode: SortMode::StartedAt,
+            main_focus: MainPane::RunList,
+            log_scroll: crate::tui::widgets::scroll::ScrollState::default(),
+            pane_rects: Vec::new(),
+            log_viewport: 0,
+            stage_explorer: None,
+            context_tree: ContextTreeState::default(),
+            history: None,
+            history_loader: runstate::context_history,
+            detail_scroll: 0,
+            choice_selected: 0,
+            selected_stage: 0,
+            stage_content_mode: StageContentMode::Output,
+            context_history_idx: None,
+            initial_sync_done: false,
+            meta_cache: runstate::StatCache::default(),
+            stages_cache: runstate::StatCache::default(),
+            context_cache: runstate::StatCache::default(),
+            tick_count: 0,
+            toasts: Vec::new(),
+            show_help: false,
+            review_scroll: 0,
+            search_mode: false,
+            search_query: String::new(),
+            search_match_idx: 0,
+            list_search_mode: false,
+            list_search_query: String::new(),
+            display_indices: Vec::new(),
+            tree_prefixes: Vec::new(),
+            mcp_screen: false,
+            mcp_add_mode: false,
+            mcp_add_input: String::new(),
+            mcp_rows: Vec::new(),
+            mcp_selected: 0,
+            mcp_ctx,
+            mcp_cmd_tx,
+            mcp_outcome_rx,
+            mcp_bg_ends: Some((mcp_cmd_rx, mcp_outcome_tx)),
+            new_run_screen: false,
+            new_run_agents: Vec::new(),
+            new_run_filter: String::new(),
+            new_run_selected: 0,
+            new_run_task: TextArea::default(),
+            new_run_focus: NewRunPane::Agents,
+            new_run_files: Vec::new(),
+            new_run_file_ref: false,
+            new_run_file_query: String::new(),
+            new_run_file_selected: 0,
+            new_run_ctx,
+            spawn_cmd_tx,
+            spawn_outcome_rx,
+            spawn_bg_ends: Some((spawn_cmd_rx, spawn_outcome_tx)),
+            daemon_outcome_rx,
+            daemon_outcome_tx: Some(daemon_outcome_tx),
+            daemon_run_ids: None,
+            clock: system_now_secs,
+        }
+    }
+
+    /// Take the background loop's channel ends, so `init_dashboard` can spawn
+    /// [`super::mcp::mcp_background_loop`]. Returns `None` if already taken.
+    pub(super) fn take_mcp_bg_ends(
+        &mut self,
+    ) -> Option<(
+        mpsc::UnboundedReceiver<super::types::McpCommand>,
+        mpsc::UnboundedSender<super::types::McpOutcome>,
+    )> {
+        self.mcp_bg_ends.take()
+    }
+
+    /// Take the background loop's ends of the spawn channels, so
+    /// `init_dashboard` can spawn [`super::new_run::spawn_background_loop`].
+    /// Returns `None` if already taken.
+    pub(super) fn take_spawn_bg_ends(
+        &mut self,
+    ) -> Option<(
+        mpsc::UnboundedReceiver<SpawnCommand>,
+        mpsc::UnboundedSender<SpawnOutcome>,
+    )> {
+        self.spawn_bg_ends.take()
+    }
+
+    /// Take the daemon-outcome sender, so `init_dashboard` can hand it to
+    /// [`super::daemon_background_loop`]. Returns `None` if already taken.
+    pub(super) fn take_daemon_outcome_tx(
+        &mut self,
+    ) -> Option<mpsc::UnboundedSender<DaemonOutcome>> {
+        self.daemon_outcome_tx.take()
+    }
+    /// The MCP screen's context, for `init_dashboard` to hand to the loop.
+    pub(super) fn mcp_context(&self) -> McpContext {
+        self.mcp_ctx.clone()
+    }
+
+    /// Read the last 32 KB of dashboard.log and convert each line into a
+    /// `LogEntry` for the initial in-memory buffer.
+    fn load_log_seed(log_path: &std::path::Path) -> Vec<LogEntry> {
+        let tail = runstate::tail_file(log_path, 32_768);
+        Self::parse_log_lines(&tail)
+    }
+
+    /// Core parsing logic of [`load_log_seed`], split out so it can be
+    /// exercised in tests against controlled input independently of the log
+    /// path (which `load_log_seed` now takes as a parameter).
+    fn parse_log_lines(tail: &str) -> Vec<LogEntry> {
+        let mut entries = Vec::new();
+        for line in tail.lines() {
+            // Lines are written as "YYYY-MM-DD HH:MM:SS <message>"
+            // Split off the first two space-separated tokens as the timestamp.
+            let mut parts = line.splitn(3, ' ');
+            let date = parts.next().unwrap_or("");
+            let time = parts.next().unwrap_or("");
+            let message = parts.next().unwrap_or(line).to_string();
+            if message.is_empty() {
+                continue;
+            }
+            // In the panel we show only the time portion for compactness.
+            let timestamp = if time.is_empty() {
+                date.to_string()
+            } else {
+                time.to_string()
+            };
+            entries.push(LogEntry { timestamp, message });
+        }
+        entries
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The production clock answers with a plausible wall-clock time (the tests
+    /// above inject a fixed one, so this is the only place it runs).
+    #[test]
+    fn system_clock_reports_a_wall_clock_time() {
+        // Well after 2020 and before 2100 - i.e. a real epoch second.
+        let now = system_now_secs();
+        assert!(now > 1_577_836_800 && now < 4_102_444_800, "got {now}");
+    }
+
+    // ─── load_log_seed: exercises the parsing code ───────────────────────
+
+    #[test]
+    fn load_log_seed_returns_vec() {
+        // Missing file → empty seed, no panic.
+        let missing = std::env::temp_dir().join("leviath-nonexistent-dashboard-seed.log");
+        let _ = std::fs::remove_file(&missing);
+        assert!(Dashboard::load_log_seed(&missing).is_empty());
+
+        // Existing file → its lines are parsed into the seed buffer.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dashboard.log");
+        std::fs::write(&path, "2026-01-02 03:04:05 seeded message\n").unwrap();
+        let entries = Dashboard::load_log_seed(&path);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].message.contains("seeded message"));
+    }
+
+    // ─── parse_log_lines: the pure parsing core of load_log_seed ──────────
+
+    #[test]
+    fn parse_log_lines_normal_line_uses_time_portion() {
+        let entries = Dashboard::parse_log_lines("2026-01-01 12:00:00 something happened");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].timestamp, "12:00:00");
+        assert_eq!(entries[0].message, "something happened");
+    }
+
+    #[test]
+    fn parse_log_lines_missing_time_token_falls_back_to_date() {
+        // A double space between the first token and the message leaves the
+        // "time" slot empty, exercising the `if time.is_empty() { date }`
+        // fallback branch.
+        let entries = Dashboard::parse_log_lines("2026-01-01  something happened");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].timestamp, "2026-01-01");
+        assert_eq!(entries[0].message, "something happened");
+    }
+
+    #[test]
+    fn parse_log_lines_skips_lines_with_empty_message() {
+        let entries = Dashboard::parse_log_lines("2026-01-01 12:00:00 \n");
+        assert!(entries.is_empty());
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -43,6 +43,13 @@ impl Dashboard {
             return;
         }
 
+        // So is the new-run screen. It has to be: a task is typed here, so
+        // every letter belongs to the editor rather than to a list command.
+        if self.new_run_screen {
+            self.handle_new_run_key(key);
+            return;
+        }
+
         // ── Detail view ─────────────────────────────────────────────────────
         if self.detail_view {
             if self.input_mode {
@@ -766,6 +773,7 @@ impl Dashboard {
                 self.mcp_selected = 0;
                 self.refresh_mcp_rows();
             }
+            KeyCode::Char('n') => self.open_new_run_screen(),
             _ => {}
         }
     }
@@ -3711,5 +3719,43 @@ mod tests {
         dash.mcp_screen = true;
         dash.handle_key(key(KeyCode::Char('z')));
         assert!(dash.mcp_screen, "an unbound key does nothing");
+    }
+
+    // ─── the new-run screen ───────────────────────────────────────────────
+
+    /// A dashboard whose new-run screen reads from an empty temp tree, so `n`
+    /// never scans the real agents directory or working directory.
+    fn new_run_dash(dir: &std::path::Path) -> Dashboard {
+        let mut dash = make_test_dashboard();
+        dash.new_run_ctx = NewRunContext {
+            agents_dir: dir.join("agents"),
+            config_path: dir.join("config.toml"),
+            workdir: dir.join("work"),
+        };
+        dash
+    }
+
+    #[test]
+    fn n_opens_the_new_run_screen() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = new_run_dash(dir.path());
+        dash.handle_key(key(KeyCode::Char('n')));
+        assert!(dash.new_run_screen);
+    }
+
+    #[test]
+    fn the_new_run_screen_owns_the_keys_while_open() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = new_run_dash(dir.path());
+        dash.handle_key(key(KeyCode::Char('n')));
+        // `q` would quit from the main list; here it is filter text, because a
+        // task is typed on this screen.
+        dash.handle_key(key(KeyCode::Char('q')));
+        assert!(!dash.should_quit);
+        assert_eq!(dash.new_run_filter, "q");
+
+        dash.handle_key(key(KeyCode::Esc));
+        dash.handle_key(key(KeyCode::Esc));
+        assert!(!dash.new_run_screen);
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -1,5 +1,6 @@
 //! `lev dash` - Interactive terminal UI for managing concurrent agents.
 
+mod construct;
 mod context_tree;
 mod graph;
 mod graph_layout;
@@ -7,6 +8,7 @@ mod helpers;
 mod history;
 mod input;
 mod mcp;
+mod new_run;
 mod render;
 mod selection;
 mod state;
@@ -174,6 +176,9 @@ async fn run_dashboard_loop<B: ratatui::backend::Backend>(
         // Surface any completed MCP login/test as a toast.
         dashboard.drain_mcp_outcomes();
 
+        // …and any run the new-run screen asked for.
+        dashboard.drain_spawn_outcomes();
+
         // Report what the daemon did with this tick's commands.
         dashboard.drain_daemon_outcomes();
 
@@ -223,6 +228,7 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
         crate::runstate::dashboard_log_path(),
         yank_fn,
         mcp_ctx,
+        new_run::production_new_run_context(),
     );
 
     // Forward the dashboard's control commands to the daemon, and report each
@@ -231,7 +237,11 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
     let daemon_outcome_tx = dashboard
         .take_daemon_outcome_tx()
         .expect("a fresh dashboard has its daemon outcome sender");
-    tokio::spawn(daemon_background_loop(control, cmd_rx, daemon_outcome_tx));
+    tokio::spawn(daemon_background_loop(
+        control.clone(),
+        cmd_rx,
+        daemon_outcome_tx,
+    ));
 
     // Run MCP logins/tests off the UI loop. A freshly-built dashboard always
     // has its background channel ends.
@@ -244,7 +254,18 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
         mcp_outcome_tx,
     ));
 
-    dashboard.add_log("Dashboard started. Use `lev run <agent>` to start an agent.".to_string());
+    // Resolve-and-spawn for the new-run screen, off the UI loop for the same
+    // reason. A freshly-built dashboard always has these ends too.
+    let (spawn_cmd_rx, spawn_outcome_tx) = dashboard
+        .take_spawn_bg_ends()
+        .expect("a fresh dashboard has its spawn background channel ends");
+    tokio::spawn(new_run::spawn_background_loop(
+        control,
+        spawn_cmd_rx,
+        spawn_outcome_tx,
+    ));
+
+    dashboard.add_log("Dashboard started. Press `n` to start an agent.".to_string());
 
     dashboard
 }

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -1,0 +1,1098 @@
+//! New-run screen: the agent catalog, the `@` file completion, and the async
+//! spawn lane.
+//!
+//! `lev dash` could only ever watch runs somebody else had started. This is the
+//! other half: pick an agent, write the task, press Enter. The screen is modal
+//! like the MCP one, and for the same reason - it owns the keys while open, so
+//! typing a task can never also mean "kill the selected run".
+//!
+//! Resolving a blueprint reads and parses files, and the spawn is a socket
+//! round trip, so both go to [`spawn_background_loop`] and come back as toasts.
+//! `send_spawn` is deliberately not reused: it prints its report on stdout,
+//! which would land in the middle of the alternate screen.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use leviath_runtime::control_socket::{ControlClient, ControlResponse};
+use tokio::sync::mpsc;
+
+use super::state::Dashboard;
+use super::types::{
+    NewRunAgent, NewRunContext, NewRunPane, SpawnCommand, SpawnOutcome, ToastLevel,
+};
+use crate::commands::list::{ListFilter, build_list_report};
+use crate::config::Config;
+use crate::daemon::client::{LaunchRequest, never_interactive, resolve_spawn_args};
+
+/// How many workdir files the `@` completion will offer.
+///
+/// A repository can hold hundreds of thousands of files; walking all of them
+/// would stall the screen open, and the menu only ever shows the first handful
+/// of matches anyway. Typing more of the path is what narrows it, not a longer
+/// list.
+const FILE_CANDIDATE_CAP: usize = 2_000;
+
+/// How many completions are shown at once.
+const FILE_REF_VISIBLE: usize = 8;
+
+impl Dashboard {
+    /// Open the new-run screen: rebuild the agent catalog, walk the workdir for
+    /// `@` candidates, and start from an empty task.
+    pub(super) fn open_new_run_screen(&mut self) {
+        self.new_run_screen = true;
+        self.new_run_focus = NewRunPane::Agents;
+        self.new_run_filter.clear();
+        self.new_run_selected = 0;
+        self.new_run_task = ratatui_textarea::TextArea::default();
+        self.close_file_ref();
+        self.refresh_new_run_agents();
+        self.new_run_files = collect_workdir_files(&self.new_run_ctx.workdir, FILE_CANDIDATE_CAP);
+    }
+
+    /// Close the screen, discarding whatever was typed.
+    pub(super) fn close_new_run_screen(&mut self) {
+        self.new_run_screen = false;
+        self.close_file_ref();
+    }
+
+    /// Rebuild the agent list from the same catalog `lev list` reports, so the
+    /// picker offers exactly the agents `lev run` can resolve - plus the
+    /// bundled blueprints, which say so when they are not installed yet.
+    pub(super) fn refresh_new_run_agents(&mut self) {
+        let ctx = &self.new_run_ctx;
+        let config = Config::load_from_path_public(&ctx.config_path).unwrap_or_default();
+        let report = build_list_report(&ctx.agents_dir, &ctx.workdir, &config, ListFilter::All);
+        let mut agents: Vec<NewRunAgent> = report
+            .agents
+            .iter()
+            .map(|a| NewRunAgent {
+                name: a.info.name.clone(),
+                source: a.source.to_string(),
+                description: a.info.description.clone(),
+                path: a.path.clone(),
+            })
+            .collect();
+        // A bundled blueprint already installed under the same name is the same
+        // agent twice; the installed copy is the one that resolves, so it wins.
+        for entry in &report.bundled {
+            if !agents.iter().any(|a| a.name == entry.name) {
+                agents.push(NewRunAgent {
+                    name: entry.name.clone(),
+                    source: "bundled".to_string(),
+                    description: format!("v{} - install with `lev setup`", entry.version),
+                    path: entry.name.clone(),
+                });
+            }
+        }
+        agents.sort_by(|a, b| a.name.cmp(&b.name));
+        self.new_run_agents = agents;
+        self.clamp_new_run_selection();
+    }
+
+    /// Indices into `new_run_agents` that match the filter, in display order.
+    pub(super) fn filtered_new_run_agents(&self) -> Vec<usize> {
+        let query = self.new_run_filter.to_lowercase();
+        self.new_run_agents
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| {
+                query.is_empty()
+                    || a.name.to_lowercase().contains(&query)
+                    || a.description.to_lowercase().contains(&query)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// The agent the picker is pointing at, if the filtered list is not empty.
+    pub(super) fn new_run_selected_agent(&self) -> Option<&NewRunAgent> {
+        let visible = self.filtered_new_run_agents();
+        visible
+            .get(self.new_run_selected)
+            .and_then(|i| self.new_run_agents.get(*i))
+    }
+
+    /// Keep the selection inside the filtered list after a filter edit.
+    fn clamp_new_run_selection(&mut self) {
+        let len = self.filtered_new_run_agents().len();
+        if self.new_run_selected >= len {
+            self.new_run_selected = len.saturating_sub(1);
+        }
+    }
+
+    /// Dispatch the run to the background lane and close the screen, so the new
+    /// row shows up in the list the user is returned to.
+    pub(super) fn submit_new_run(&mut self) {
+        let Some(agent) = self.new_run_selected_agent().cloned() else {
+            self.toast("Pick an agent first", ToastLevel::Error);
+            return;
+        };
+        let task = self.new_run_task.lines().join("\n").trim().to_string();
+        // An agent driven entirely by `--<region>` flags takes no task, and
+        // there is no way to give it one here; that is a `lev run` command line,
+        // and the daemon says so if this screen is pointed at such an agent.
+        if task.is_empty() {
+            self.toast("Write a task first", ToastLevel::Error);
+            return;
+        }
+        let _ = self.spawn_cmd_tx.send(SpawnCommand {
+            agent_path: agent.path.clone(),
+            task,
+            workdir: self.new_run_ctx.workdir.display().to_string(),
+        });
+        self.toast(format!("Starting '{}'…", agent.name), ToastLevel::Info);
+        self.add_log(format!("run requested: {}", agent.name));
+        self.close_new_run_screen();
+    }
+
+    /// Drain finished spawns into toasts, mirroring [`Self::drain_mcp_outcomes`].
+    pub(super) fn drain_spawn_outcomes(&mut self) {
+        while let Ok(outcome) = self.spawn_outcome_rx.try_recv() {
+            let level = match outcome.ok {
+                true => ToastLevel::Info,
+                false => ToastLevel::Error,
+            };
+            self.add_log(outcome.message.clone());
+            self.toast(outcome.message, level);
+        }
+    }
+
+    // ── `@` file references ──────────────────────────────────────────────────
+
+    /// The workdir paths matching what has been typed after the `@`, capped to
+    /// what the popup shows.
+    pub(super) fn file_ref_matches(&self) -> Vec<&str> {
+        if !self.new_run_file_ref {
+            return Vec::new();
+        }
+        let query = self.new_run_file_query.to_lowercase();
+        self.new_run_files
+            .iter()
+            .filter(|p| p.to_lowercase().contains(&query))
+            .take(FILE_REF_VISIBLE)
+            .map(String::as_str)
+            .collect()
+    }
+
+    /// Replace the typed query with the highlighted path and close the popup.
+    /// With nothing matching there is nothing to insert, so the text stands as
+    /// typed.
+    fn accept_file_ref(&mut self) {
+        let chosen = self
+            .file_ref_matches()
+            .get(self.new_run_file_selected)
+            .map(|p| p.to_string());
+        if let Some(path) = chosen {
+            for _ in 0..self.new_run_file_query.chars().count() {
+                self.new_run_task.delete_char();
+            }
+            self.new_run_task.insert_str(&path);
+        }
+        self.close_file_ref();
+    }
+
+    /// Dismiss the completion, leaving the task text exactly as typed.
+    fn close_file_ref(&mut self) {
+        self.new_run_file_ref = false;
+        self.new_run_file_query.clear();
+        self.new_run_file_selected = 0;
+    }
+
+    // ── Keys ─────────────────────────────────────────────────────────────────
+
+    /// Keys while the new-run screen is open. The `@` popup takes them first -
+    /// it is a menu over the text being typed, not a mode beside it - then the
+    /// focused pane.
+    pub(super) fn handle_new_run_key(&mut self, key: crossterm::event::KeyEvent) {
+        if self.new_run_file_ref {
+            self.handle_file_ref_key(key);
+            return;
+        }
+        match self.new_run_focus {
+            NewRunPane::Agents => self.handle_new_run_agents_key(key.code),
+            NewRunPane::Task => self.handle_new_run_task_key(key),
+        }
+    }
+
+    /// Agent picker keys. Every printable character filters, so there is no
+    /// separate search mode to enter - and no letter is free to mean something
+    /// else here.
+    fn handle_new_run_agents_key(&mut self, key_code: crossterm::event::KeyCode) {
+        use crossterm::event::KeyCode;
+        match key_code {
+            // Esc clears the filter first, then closes - the same two-step the
+            // main list's filter uses.
+            KeyCode::Esc => match self.new_run_filter.is_empty() {
+                true => self.close_new_run_screen(),
+                false => {
+                    self.new_run_filter.clear();
+                    self.new_run_selected = 0;
+                }
+            },
+            KeyCode::Tab | KeyCode::BackTab | KeyCode::Enter => {
+                self.new_run_focus = NewRunPane::Task;
+            }
+            KeyCode::Up => {
+                self.new_run_selected = self.new_run_selected.saturating_sub(1);
+            }
+            KeyCode::Down => {
+                if self.new_run_selected + 1 < self.filtered_new_run_agents().len() {
+                    self.new_run_selected += 1;
+                }
+            }
+            KeyCode::Backspace => {
+                self.new_run_filter.pop();
+                self.new_run_selected = 0;
+            }
+            KeyCode::Char(c) => {
+                self.new_run_filter.push(c);
+                self.new_run_selected = 0;
+            }
+            _ => {}
+        }
+    }
+
+    /// Task editor keys. Enter starts the run and Alt+Enter breaks the line,
+    /// matching the response pane so the two editors do not disagree.
+    fn handle_new_run_task_key(&mut self, key: crossterm::event::KeyEvent) {
+        use crossterm::event::KeyCode;
+        match key.code {
+            KeyCode::Esc => self.new_run_focus = NewRunPane::Agents,
+            KeyCode::Tab | KeyCode::BackTab => self.new_run_focus = NewRunPane::Agents,
+            KeyCode::Enter if key.modifiers.is_empty() => self.submit_new_run(),
+            KeyCode::Char('@') => {
+                self.new_run_task.insert_char('@');
+                self.new_run_file_ref = true;
+            }
+            _ => {
+                self.new_run_task.input(ratatui_textarea::Input::from(key));
+            }
+        }
+    }
+
+    /// Keys while an `@` completion is open.
+    fn handle_file_ref_key(&mut self, key: crossterm::event::KeyEvent) {
+        use crossterm::event::KeyCode;
+        let matches = self.file_ref_matches().len();
+        match key.code {
+            KeyCode::Esc => self.close_file_ref(),
+            KeyCode::Enter | KeyCode::Tab => self.accept_file_ref(),
+            KeyCode::Up => {
+                self.new_run_file_selected = self.new_run_file_selected.saturating_sub(1);
+            }
+            KeyCode::Down => {
+                if self.new_run_file_selected + 1 < matches {
+                    self.new_run_file_selected += 1;
+                }
+            }
+            KeyCode::Backspace => {
+                self.new_run_task.delete_char();
+                // Backspacing over the `@` itself ends the reference; there is
+                // nothing left to complete.
+                match self.new_run_file_query.pop() {
+                    // The match set changed, so the highlight goes back to the top.
+                    Some(_) => self.new_run_file_selected = 0,
+                    None => self.close_file_ref(),
+                }
+            }
+            KeyCode::Char(c) => {
+                self.new_run_task.insert_char(c);
+                self.new_run_file_query.push(c);
+                self.new_run_file_selected = 0;
+            }
+            _ => {}
+        }
+    }
+}
+
+/// Workdir-relative paths of the files under `root`, sorted, at most `cap`.
+///
+/// There is no `.gitignore` reader in the dependency tree and adding one to
+/// populate a completion menu is not worth it, so the walk skips what an
+/// ignore file would almost always cover anyway: dot-entries (`.git`,
+/// `.venv`, editor state) and `target`. An unreadable directory is skipped
+/// rather than reported - this list is a convenience, and half of it beats an
+/// error message.
+fn collect_workdir_files(root: &Path, cap: usize) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut stack = vec![(root.to_path_buf(), String::new())];
+    while let Some((dir, prefix)) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            if out.len() >= cap {
+                out.sort();
+                return out;
+            }
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.starts_with('.') || name == "target" {
+                continue;
+            }
+            let relative = match prefix.is_empty() {
+                true => name,
+                false => format!("{prefix}/{name}"),
+            };
+            match entry.path().is_dir() {
+                true => stack.push((entry.path(), relative)),
+                false => out.push(relative),
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Resolve and spawn each requested run off the UI loop, reporting every
+/// result back so a refused spawn is surfaced rather than swallowed.
+pub(super) async fn spawn_background_loop(
+    control: ControlClient,
+    mut cmd_rx: mpsc::UnboundedReceiver<SpawnCommand>,
+    outcome_tx: mpsc::UnboundedSender<SpawnOutcome>,
+) {
+    while let Some(cmd) = cmd_rx.recv().await {
+        if outcome_tx.send(run_spawn(&control, cmd).await).is_err() {
+            return; // dashboard dropped the receiver
+        }
+    }
+}
+
+/// One spawn: resolve the blueprint locally, then hand it to the daemon.
+async fn run_spawn(control: &ControlClient, cmd: SpawnCommand) -> SpawnOutcome {
+    let args = match resolve_spawn_args(LaunchRequest {
+        path: &cmd.agent_path,
+        // Always `Some`, never `None`: `None` opens `$EDITOR`, which would
+        // start a second full-screen program inside this one.
+        task: Some(&cmd.task),
+        stdin_is_terminal: &never_interactive,
+        model: None,
+        workdir: &cmd.workdir,
+        yolo: false,
+        allow: Vec::new(),
+        max_depth: None,
+        // Region seeds are a `lev run` command line; this screen writes a task.
+        regions: HashMap::new(),
+        no_seed_commands: false,
+        output_request: None,
+    }) {
+        Ok(args) => args,
+        Err(e) => {
+            return SpawnOutcome {
+                message: format!("Could not start '{}': {e}", cmd.agent_path),
+                ok: false,
+            };
+        }
+    };
+    match control.spawn(args).await {
+        Ok(ControlResponse::Spawned { run_id }) => SpawnOutcome {
+            message: format!("Started {run_id}"),
+            ok: true,
+        },
+        Ok(ControlResponse::Error { message }) => SpawnOutcome {
+            message: format!("The daemon refused the run: {message}"),
+            ok: false,
+        },
+        Ok(other) => SpawnOutcome {
+            message: format!("Unexpected daemon response to spawn: {other:?}"),
+            ok: false,
+        },
+        Err(e) => SpawnOutcome {
+            message: format!("Could not reach the daemon: {e}"),
+            ok: false,
+        },
+    }
+}
+
+/// The production new-run context: the real agents directory, config, and
+/// working directory `lev dash` was started in.
+pub(super) fn production_new_run_context() -> NewRunContext {
+    NewRunContext {
+        agents_dir: leviath_core::paths::agents_dir().unwrap_or_default(),
+        config_path: Config::config_path(),
+        workdir: crate::commands::resolve_cwd().unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+impl Dashboard {
+    /// The retained spawn-command receiver, for asserting dispatches.
+    pub(super) fn spawn_cmd_rx_for_test(&mut self) -> &mut mpsc::UnboundedReceiver<SpawnCommand> {
+        &mut self
+            .spawn_bg_ends
+            .as_mut()
+            .expect("background ends retained in tests")
+            .0
+    }
+
+    /// Inject an outcome as if the background loop had produced it.
+    pub(super) fn inject_spawn_outcome_for_test(&self, outcome: SpawnOutcome) {
+        self.spawn_bg_ends
+            .as_ref()
+            .expect("background ends retained in tests")
+            .1
+            .send(outcome)
+            .expect("outcome receiver is alive");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    /// A manifest the real parser accepts, for the agent picker's catalog.
+    fn write_agent(dir: &Path, name: &str, description: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(
+            dir.join("agent.leviath"),
+            format!(
+                "[agent]\nname = \"{name}\"\nversion = \"0.1.0\"\n\
+                 description = \"{description}\"\n\n\
+                 [stages.main]\nmode = \"autonomous\"\n\n\
+                 [stages.main.model]\n\
+                 provider = \"anthropic\"\nmodel = \"claude-sonnet-5\"\n\n\
+                 [context.regions]\n\
+                 task = {{ kind = \"pinned\", max_tokens = 1000, seed = \"task\" }}\n\
+                 conversation = {{ kind = \"sliding_window\", max_items = 20, \
+                 max_tokens = 10000 }}\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    /// A dashboard whose new-run screen reads from `dir` only.
+    fn dash_at(dir: &Path) -> Dashboard {
+        let mut dash = make_test_dashboard();
+        dash.new_run_ctx = NewRunContext {
+            agents_dir: dir.join("agents"),
+            config_path: dir.join("config.toml"),
+            workdir: dir.join("work"),
+        };
+        std::fs::create_dir_all(dir.join("work")).unwrap();
+        dash
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    // ─── catalog ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn opening_the_screen_loads_agents_and_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/writer"), "writer", "writes things");
+        let mut dash = dash_at(dir.path());
+        std::fs::write(dir.path().join("work/notes.md"), b"x").unwrap();
+
+        dash.open_new_run_screen();
+        assert!(dash.new_run_screen);
+        assert_eq!(dash.new_run_focus, NewRunPane::Agents);
+        let names: Vec<&str> = dash
+            .new_run_agents
+            .iter()
+            .map(|a| a.name.as_str())
+            .collect();
+        assert!(
+            names.contains(&"writer"),
+            "installed agent listed: {names:?}"
+        );
+        assert_eq!(dash.new_run_files, vec!["notes.md".to_string()]);
+    }
+
+    #[test]
+    fn the_catalog_includes_bundled_blueprints_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        dash.refresh_new_run_agents();
+        let bundled: Vec<&NewRunAgent> = dash
+            .new_run_agents
+            .iter()
+            .filter(|a| a.source == "bundled")
+            .collect();
+        assert!(!bundled.is_empty(), "the binary ships blueprints");
+
+        // Installing one of them under the same name replaces the bundled row
+        // rather than adding a second one.
+        let name = bundled[0].name.clone();
+        write_agent(&dir.path().join("agents").join(&name), &name, "installed");
+        dash.refresh_new_run_agents();
+        let same: Vec<&NewRunAgent> = dash
+            .new_run_agents
+            .iter()
+            .filter(|a| a.name == name)
+            .collect();
+        assert_eq!(same.len(), 1, "one row per name: {same:?}");
+        assert_eq!(same[0].source, "installed");
+    }
+
+    #[test]
+    fn a_local_agent_in_the_workdir_is_offered() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("work"), "here", "the cwd agent");
+        let mut dash = dash_at(dir.path());
+        dash.refresh_new_run_agents();
+        let local = dash
+            .new_run_agents
+            .iter()
+            .find(|a| a.name == "here")
+            .expect("the cwd agent is listed");
+        assert_eq!(local.source, "local");
+    }
+
+    #[test]
+    fn filtering_narrows_the_list_and_clamps_the_selection() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
+        write_agent(&dir.path().join("agents/beta"), "beta", "second");
+        let mut dash = dash_at(dir.path());
+        dash.refresh_new_run_agents();
+
+        let all = dash.filtered_new_run_agents().len();
+        dash.new_run_selected = all - 1;
+        dash.new_run_filter = "alpha".to_string();
+        dash.clamp_new_run_selection();
+        assert_eq!(dash.filtered_new_run_agents().len(), 1);
+        assert_eq!(dash.new_run_selected, 0);
+        assert_eq!(dash.new_run_selected_agent().unwrap().name, "alpha");
+
+        // The description matches too, not just the name.
+        dash.new_run_filter = "second".to_string();
+        assert_eq!(dash.new_run_selected_agent().unwrap().name, "beta");
+    }
+
+    #[test]
+    fn a_filter_matching_nothing_selects_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        dash.refresh_new_run_agents();
+        dash.new_run_filter = "no-such-agent-anywhere".to_string();
+        dash.clamp_new_run_selection();
+        assert!(dash.filtered_new_run_agents().is_empty());
+        assert!(dash.new_run_selected_agent().is_none());
+    }
+
+    #[test]
+    fn an_unreadable_config_still_lists_the_bundled_catalog() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        // A directory where the config file should be: load fails, defaults win.
+        std::fs::create_dir(dir.path().join("config.toml")).unwrap();
+        dash.refresh_new_run_agents();
+        assert!(dash.new_run_agents.iter().any(|a| a.source == "bundled"));
+    }
+
+    #[test]
+    fn a_configured_agent_path_is_scanned() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("extra/scout"), "scout", "from the config");
+        let mut dash = dash_at(dir.path());
+        let mut config = Config::default();
+        config.agent_paths.push(dir.path().join("extra"));
+        config
+            .save_to_path_public(&dash.new_run_ctx.config_path)
+            .unwrap();
+        dash.refresh_new_run_agents();
+        let scout = dash
+            .new_run_agents
+            .iter()
+            .find(|a| a.name == "scout")
+            .expect("the configured agent is listed");
+        assert_eq!(scout.source, "configured");
+    }
+
+    // ─── file walking ─────────────────────────────────────────────────────
+
+    #[test]
+    fn the_walk_recurses_and_skips_dots_and_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("src/deep")).unwrap();
+        std::fs::create_dir_all(root.join(".git")).unwrap();
+        std::fs::create_dir_all(root.join("target")).unwrap();
+        std::fs::write(root.join("README.md"), b"x").unwrap();
+        std::fs::write(root.join("src/main.rs"), b"x").unwrap();
+        std::fs::write(root.join("src/deep/mod.rs"), b"x").unwrap();
+        std::fs::write(root.join(".env"), b"x").unwrap();
+        std::fs::write(root.join(".git/HEAD"), b"x").unwrap();
+        std::fs::write(root.join("target/binary"), b"x").unwrap();
+
+        let files = collect_workdir_files(root, 100);
+        assert_eq!(
+            files,
+            vec![
+                "README.md".to_string(),
+                "src/deep/mod.rs".to_string(),
+                "src/main.rs".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn the_walk_stops_at_the_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..10 {
+            std::fs::write(dir.path().join(format!("f{i}")), b"x").unwrap();
+        }
+        assert_eq!(collect_workdir_files(dir.path(), 4).len(), 4);
+    }
+
+    #[test]
+    fn an_unreadable_root_yields_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(collect_workdir_files(&dir.path().join("nope"), 10).is_empty());
+    }
+
+    // ─── keys: agent picker ───────────────────────────────────────────────
+
+    #[test]
+    fn typing_filters_and_backspace_undoes_it() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+
+        dash.handle_new_run_key(key(KeyCode::Char('a')));
+        dash.handle_new_run_key(key(KeyCode::Char('l')));
+        assert_eq!(dash.new_run_filter, "al");
+        dash.handle_new_run_key(key(KeyCode::Backspace));
+        assert_eq!(dash.new_run_filter, "a");
+    }
+
+    #[test]
+    fn escape_clears_the_filter_then_closes() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_filter = "x".to_string();
+
+        dash.handle_new_run_key(key(KeyCode::Esc));
+        assert!(dash.new_run_filter.is_empty());
+        assert!(dash.new_run_screen, "the first Esc only clears the filter");
+
+        dash.handle_new_run_key(key(KeyCode::Esc));
+        assert!(!dash.new_run_screen);
+    }
+
+    #[test]
+    fn arrows_move_within_the_filtered_list_only() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
+        write_agent(&dir.path().join("agents/beta"), "beta", "second");
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        let count = dash.filtered_new_run_agents().len();
+
+        dash.handle_new_run_key(key(KeyCode::Down));
+        assert_eq!(dash.new_run_selected, 1);
+        dash.handle_new_run_key(key(KeyCode::Up));
+        assert_eq!(dash.new_run_selected, 0);
+        dash.handle_new_run_key(key(KeyCode::Up));
+        assert_eq!(dash.new_run_selected, 0, "up at the top stays put");
+
+        for _ in 0..count + 3 {
+            dash.handle_new_run_key(key(KeyCode::Down));
+        }
+        assert_eq!(dash.new_run_selected, count - 1, "down stops at the end");
+    }
+
+    #[test]
+    fn tab_enter_and_backtab_all_reach_the_task_editor() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        for code in [KeyCode::Tab, KeyCode::Enter, KeyCode::BackTab] {
+            dash.open_new_run_screen();
+            dash.handle_new_run_key(key(code));
+            assert_eq!(dash.new_run_focus, NewRunPane::Task, "{code:?}");
+        }
+    }
+
+    #[test]
+    fn an_unbound_picker_key_does_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.handle_new_run_key(key(KeyCode::F(5)));
+        assert!(dash.new_run_screen);
+        assert!(dash.new_run_filter.is_empty());
+    }
+
+    // ─── keys: task editor ────────────────────────────────────────────────
+
+    #[test]
+    fn the_task_editor_takes_text_and_alt_enter_breaks_the_line() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_focus = NewRunPane::Task;
+
+        dash.handle_new_run_key(key(KeyCode::Char('h')));
+        dash.handle_new_run_key(key(KeyCode::Char('i')));
+        dash.handle_new_run_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
+        dash.handle_new_run_key(key(KeyCode::Char('!')));
+        assert_eq!(
+            dash.new_run_task.lines(),
+            vec!["hi".to_string(), "!".to_string()]
+        );
+    }
+
+    #[test]
+    fn escape_and_tab_hand_focus_back_to_the_picker() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        for code in [KeyCode::Esc, KeyCode::Tab, KeyCode::BackTab] {
+            dash.open_new_run_screen();
+            dash.new_run_focus = NewRunPane::Task;
+            dash.handle_new_run_key(key(code));
+            assert_eq!(dash.new_run_focus, NewRunPane::Agents, "{code:?}");
+        }
+    }
+
+    // ─── keys: `@` completion ─────────────────────────────────────────────
+
+    /// A dashboard sitting in the task editor with three workdir files.
+    fn dash_ready_to_type(dir: &Path) -> Dashboard {
+        std::fs::create_dir_all(dir.join("work/src")).unwrap();
+        std::fs::write(dir.join("work/README.md"), b"x").unwrap();
+        std::fs::write(dir.join("work/src/main.rs"), b"x").unwrap();
+        std::fs::write(dir.join("work/src/lib.rs"), b"x").unwrap();
+        let mut dash = dash_at(dir);
+        dash.open_new_run_screen();
+        dash.new_run_focus = NewRunPane::Task;
+        dash
+    }
+
+    #[test]
+    fn at_opens_the_popup_and_typing_filters_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_ready_to_type(dir.path());
+
+        dash.handle_new_run_key(key(KeyCode::Char('@')));
+        assert!(dash.new_run_file_ref);
+        assert_eq!(dash.file_ref_matches().len(), 3, "everything, unfiltered");
+
+        dash.handle_new_run_key(key(KeyCode::Char('l')));
+        dash.handle_new_run_key(key(KeyCode::Char('i')));
+        assert_eq!(dash.new_run_file_query, "li");
+        assert_eq!(dash.file_ref_matches(), vec!["src/lib.rs"]);
+        // The typed characters are in the task text too, so an unaccepted
+        // reference still reads as what the user wrote.
+        assert_eq!(dash.new_run_task.lines(), vec!["@li".to_string()]);
+    }
+
+    #[test]
+    fn accepting_a_completion_replaces_the_query_with_the_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_ready_to_type(dir.path());
+        dash.handle_new_run_key(key(KeyCode::Char('r')));
+        dash.handle_new_run_key(key(KeyCode::Char('e')));
+        dash.handle_new_run_key(key(KeyCode::Char('a')));
+        dash.handle_new_run_key(key(KeyCode::Char('d')));
+        dash.handle_new_run_key(key(KeyCode::Char(' ')));
+        dash.handle_new_run_key(key(KeyCode::Char('@')));
+        dash.handle_new_run_key(key(KeyCode::Char('m')));
+        dash.handle_new_run_key(key(KeyCode::Char('a')));
+        dash.handle_new_run_key(key(KeyCode::Enter));
+
+        assert!(!dash.new_run_file_ref, "the popup closes");
+        assert_eq!(dash.new_run_task.lines(), vec!["read @src/main.rs"]);
+    }
+
+    #[test]
+    fn tab_accepts_the_highlighted_completion() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_ready_to_type(dir.path());
+        dash.handle_new_run_key(key(KeyCode::Char('@')));
+        dash.handle_new_run_key(key(KeyCode::Char('s')));
+        dash.handle_new_run_key(key(KeyCode::Down));
+        assert_eq!(dash.new_run_file_selected, 1);
+        dash.handle_new_run_key(key(KeyCode::Tab));
+        assert_eq!(dash.new_run_task.lines(), vec!["@src/main.rs"]);
+    }
+
+    #[test]
+    fn the_popup_selection_stops_at_both_ends() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_ready_to_type(dir.path());
+        dash.handle_new_run_key(key(KeyCode::Char('@')));
+
+        dash.handle_new_run_key(key(KeyCode::Up));
+        assert_eq!(dash.new_run_file_selected, 0);
+        for _ in 0..10 {
+            dash.handle_new_run_key(key(KeyCode::Down));
+        }
+        assert_eq!(dash.new_run_file_selected, 2);
+    }
+
+    #[test]
+    fn accepting_with_nothing_matching_leaves_the_text_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_ready_to_type(dir.path());
+        dash.handle_new_run_key(key(KeyCode::Char('@')));
+        dash.handle_new_run_key(key(KeyCode::Char('z')));
+        assert!(dash.file_ref_matches().is_empty());
+        dash.handle_new_run_key(key(KeyCode::Enter));
+        assert!(!dash.new_run_file_ref);
+        assert_eq!(dash.new_run_task.lines(), vec!["@z"]);
+    }
+
+    #[test]
+    fn escape_closes_the_popup_without_leaving_the_editor() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_ready_to_type(dir.path());
+        dash.handle_new_run_key(key(KeyCode::Char('@')));
+        dash.handle_new_run_key(key(KeyCode::Esc));
+        assert!(!dash.new_run_file_ref);
+        assert_eq!(dash.new_run_focus, NewRunPane::Task);
+        assert!(dash.new_run_screen);
+    }
+
+    #[test]
+    fn backspacing_over_the_at_ends_the_reference() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_ready_to_type(dir.path());
+        dash.handle_new_run_key(key(KeyCode::Char('@')));
+        dash.handle_new_run_key(key(KeyCode::Char('s')));
+        dash.handle_new_run_key(key(KeyCode::Down));
+
+        dash.handle_new_run_key(key(KeyCode::Backspace));
+        assert_eq!(dash.new_run_file_query, "");
+        assert_eq!(
+            dash.new_run_file_selected, 0,
+            "the match set changed, so the highlight resets"
+        );
+
+        dash.handle_new_run_key(key(KeyCode::Backspace));
+        assert!(!dash.new_run_file_ref);
+        assert_eq!(dash.new_run_task.lines(), vec![""]);
+    }
+
+    #[test]
+    fn an_unbound_popup_key_does_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_ready_to_type(dir.path());
+        dash.handle_new_run_key(key(KeyCode::Char('@')));
+        dash.handle_new_run_key(key(KeyCode::F(5)));
+        assert!(dash.new_run_file_ref);
+    }
+
+    #[test]
+    fn matches_are_empty_with_no_popup_open() {
+        let dash = make_test_dashboard();
+        assert!(dash.file_ref_matches().is_empty());
+    }
+
+    // ─── submitting ───────────────────────────────────────────────────────
+
+    #[test]
+    fn submitting_dispatches_the_run_and_closes_the_screen() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_filter = "alpha".to_string();
+        dash.new_run_focus = NewRunPane::Task;
+        dash.new_run_task.insert_str("  ship it  ");
+
+        dash.handle_new_run_key(key(KeyCode::Enter));
+
+        assert!(!dash.new_run_screen, "the screen closes on dispatch");
+        let cmd = dash
+            .spawn_cmd_rx_for_test()
+            .try_recv()
+            .expect("a spawn was dispatched");
+        assert_eq!(cmd.task, "ship it", "the task is trimmed");
+        assert!(cmd.agent_path.ends_with("alpha"), "got: {}", cmd.agent_path);
+        assert_eq!(cmd.workdir, dir.path().join("work").display().to_string());
+    }
+
+    #[test]
+    fn submitting_without_a_task_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_focus = NewRunPane::Task;
+        dash.new_run_task.insert_str("   ");
+
+        dash.handle_new_run_key(key(KeyCode::Enter));
+        assert!(dash.new_run_screen, "the screen stays open to fix it");
+        assert!(dash.spawn_cmd_rx_for_test().try_recv().is_err());
+        let toasts = dash.toast_messages_for_test();
+        assert!(toasts.iter().any(|m| m.contains("task")), "got: {toasts:?}");
+    }
+
+    #[test]
+    fn submitting_without_an_agent_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_filter = "no-such-agent-anywhere".to_string();
+        dash.new_run_task.insert_str("do a thing");
+
+        dash.submit_new_run();
+        assert!(dash.spawn_cmd_rx_for_test().try_recv().is_err());
+        let toasts = dash.toast_messages_for_test();
+        assert!(
+            toasts.iter().any(|m| m.contains("agent")),
+            "got: {toasts:?}"
+        );
+    }
+
+    #[test]
+    fn spawn_outcomes_drain_into_toasts() {
+        let mut dash = make_test_dashboard();
+        dash.inject_spawn_outcome_for_test(SpawnOutcome {
+            message: "Started run-1".to_string(),
+            ok: true,
+        });
+        dash.inject_spawn_outcome_for_test(SpawnOutcome {
+            message: "boom".to_string(),
+            ok: false,
+        });
+        dash.drain_spawn_outcomes();
+        assert_eq!(
+            dash.toast_messages_for_test(),
+            vec!["Started run-1".to_string(), "boom".to_string()]
+        );
+    }
+
+    #[test]
+    fn draining_with_nothing_pending_is_a_noop() {
+        let mut dash = make_test_dashboard();
+        dash.drain_spawn_outcomes();
+        assert!(dash.toast_messages_for_test().is_empty());
+    }
+
+    // ─── the spawn lane ───────────────────────────────────────────────────
+
+    /// A daemon that replies `reply` (verbatim, newline added) to one request.
+    /// `None` closes the connection without replying.
+    fn replying_daemon(
+        dir: &Path,
+        reply: Option<&'static str>,
+    ) -> (ControlClient, tokio::task::JoinHandle<()>) {
+        use leviath_runtime::control_socket::{bind_control_listener, control_id};
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        let id = control_id(dir);
+        let mut listener = bind_control_listener(&id).unwrap();
+        let handle = tokio::spawn(async move {
+            let stream = listener
+                .accept()
+                .await
+                .expect("accept succeeds")
+                .expect("our own connection is admitted");
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _ = lines.next_line().await;
+            if let Some(reply) = reply {
+                let _ = write_half.write_all(format!("{reply}\n").as_bytes()).await;
+            }
+        });
+        (ControlClient::new(id), handle)
+    }
+
+    /// Drive one spawn of a real manifest through the loop against a daemon
+    /// giving `reply`, and return what the dashboard would toast.
+    async fn spawn_outcome(reply: Option<&'static str>) -> SpawnOutcome {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("alpha"), "alpha", "first");
+        let (control, server) = replying_daemon(dir.path(), reply);
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (out_tx, mut out_rx) = mpsc::unbounded_channel();
+        tokio::spawn(spawn_background_loop(control, cmd_rx, out_tx));
+        cmd_tx
+            .send(SpawnCommand {
+                agent_path: dir.path().join("alpha").display().to_string(),
+                task: "ship it".to_string(),
+                workdir: dir.path().display().to_string(),
+            })
+            .unwrap();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(5), out_rx.recv())
+            .await
+            .expect("an outcome was reported")
+            .expect("the loop is alive");
+        let _ = server.await;
+        outcome
+    }
+
+    #[tokio::test]
+    async fn every_daemon_answer_is_reported() {
+        let started = spawn_outcome(Some(r#"{"result":"spawned","run_id":"alpha-1"}"#)).await;
+        assert!(started.ok);
+        assert!(started.message.contains("alpha-1"), "{}", started.message);
+
+        let refused =
+            spawn_outcome(Some(r#"{"result":"error","message":"no such blueprint"}"#)).await;
+        assert!(!refused.ok);
+        assert!(
+            refused.message.contains("no such blueprint"),
+            "{}",
+            refused.message
+        );
+
+        let odd = spawn_outcome(Some(r#"{"result":"ok","ok":true}"#)).await;
+        assert!(!odd.ok);
+        assert!(odd.message.contains("Unexpected"), "{}", odd.message);
+
+        // Connection closed with no reply: a transport error, surfaced as one.
+        let broken = spawn_outcome(None).await;
+        assert!(!broken.ok);
+        assert!(
+            broken.message.contains("Could not reach the daemon"),
+            "{}",
+            broken.message
+        );
+    }
+
+    #[tokio::test]
+    async fn an_unresolvable_agent_never_reaches_the_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let control = ControlClient::new(leviath_runtime::control_socket::control_id(dir.path()));
+        let outcome = run_spawn(
+            &control,
+            SpawnCommand {
+                agent_path: dir.path().join("nope").display().to_string(),
+                task: "ship it".to_string(),
+                workdir: dir.path().display().to_string(),
+            },
+        )
+        .await;
+        assert!(!outcome.ok);
+        assert!(
+            outcome.message.contains("Could not start"),
+            "{}",
+            outcome.message
+        );
+    }
+
+    #[tokio::test]
+    async fn the_loop_stops_when_the_dashboard_drops_its_receiver() {
+        let dir = tempfile::tempdir().unwrap();
+        let control = ControlClient::new(leviath_runtime::control_socket::control_id(dir.path()));
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (out_tx, out_rx) = mpsc::unbounded_channel();
+        drop(out_rx);
+        let handle = tokio::spawn(spawn_background_loop(control, cmd_rx, out_tx));
+        cmd_tx
+            .send(SpawnCommand {
+                agent_path: dir.path().join("nope").display().to_string(),
+                task: "t".to_string(),
+                workdir: dir.path().display().to_string(),
+            })
+            .unwrap();
+        tokio::time::timeout(std::time::Duration::from_secs(5), handle)
+            .await
+            .expect("the loop returns once nothing is listening")
+            .unwrap();
+    }
+
+    #[test]
+    fn the_production_context_points_at_the_real_paths() {
+        let ctx = production_new_run_context();
+        assert!(ctx.config_path.ends_with("config.toml"));
+        assert!(ctx.agents_dir.ends_with("agents"));
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -7,6 +7,7 @@ mod graph_view;
 mod header;
 mod input;
 mod mcp;
+mod new_run;
 mod overlays;
 mod stages;
 mod table;
@@ -40,6 +41,12 @@ impl Dashboard {
             if let Some((_, dialog)) = &self.pending_confirm {
                 dialog.draw(frame, frame.area());
             }
+            return;
+        }
+        if self.new_run_screen {
+            self.draw_new_run_screen(frame, frame.area());
+            self.apply_selection_overlay(frame);
+            self.draw_toasts(frame);
             return;
         }
         if self.detail_view {

--- a/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
@@ -1,0 +1,373 @@
+//! New-run screen rendering: the agent picker, the task editor, and the `@`
+//! file-reference popup drawn over it.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{
+    Block, BorderType, Borders, Cell, Clear, Paragraph, Row, Table, TableState,
+};
+
+use crate::commands::dashboard::state::Dashboard;
+use crate::commands::dashboard::theme::*;
+use crate::commands::dashboard::types::NewRunPane;
+
+impl Dashboard {
+    pub(in crate::commands::dashboard) fn draw_new_run_screen(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+    ) {
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(area);
+        let panes = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+            .split(rows[0]);
+
+        self.draw_new_run_agents(frame, panes[0]);
+        self.draw_new_run_task(frame, panes[1]);
+        // The completion floats over the task pane, so it is drawn after it.
+        self.draw_file_ref_popup(frame, panes[1]);
+        self.draw_new_run_help_bar(frame, rows[1]);
+    }
+
+    fn draw_new_run_agents(&self, frame: &mut Frame, area: Rect) {
+        let visible = self.filtered_new_run_agents();
+        let header = Row::new(["Agent", "Source", "Description"].into_iter().map(|h| {
+            Cell::from(Span::styled(
+                h,
+                Style::default().add_modifier(Modifier::BOLD),
+            ))
+        }));
+        let rows: Vec<Row> = visible
+            .iter()
+            .filter_map(|i| self.new_run_agents.get(*i))
+            .map(|a| {
+                Row::new(vec![
+                    Cell::from(a.name.clone()),
+                    Cell::from(Span::styled(
+                        a.source.clone(),
+                        Style::default().fg(source_colour(&a.source)),
+                    )),
+                    Cell::from(Span::styled(
+                        a.description.clone(),
+                        Style::default().fg(C_DIM),
+                    )),
+                ])
+            })
+            .collect();
+
+        // The filter reads as part of the title, the way the main list's does,
+        // so there is no separate line to notice.
+        let title = match self.new_run_filter.is_empty() {
+            true => format!(" Agents ({}) ", visible.len()),
+            false => format!(
+                " Agents  /{}▌  {}/{} ",
+                self.new_run_filter,
+                visible.len(),
+                self.new_run_agents.len()
+            ),
+        };
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Percentage(34),
+                Constraint::Percentage(20),
+                Constraint::Percentage(46),
+            ],
+        )
+        .header(header)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(focus_style(self.new_run_focus == NewRunPane::Agents))
+                .title(title),
+        )
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("› ");
+
+        let mut state = TableState::default();
+        if !visible.is_empty() {
+            state.select(Some(self.new_run_selected.min(visible.len() - 1)));
+        }
+        frame.render_stateful_widget(table, area, &mut state);
+
+        if visible.is_empty() {
+            let hint = match self.new_run_filter.is_empty() {
+                true => "No agents found. `lev setup` installs the bundled ones.".to_string(),
+                false => format!("No agents match \"{}\".", self.new_run_filter),
+            };
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(hint, Style::default().fg(C_DIM)))),
+                Rect {
+                    x: area.x + 2,
+                    y: area.y + 2,
+                    width: area.width.saturating_sub(4),
+                    height: 1,
+                },
+            );
+        }
+    }
+
+    fn draw_new_run_task(&mut self, frame: &mut Frame, area: Rect) {
+        let focused = self.new_run_focus == NewRunPane::Task;
+        let agent = self
+            .new_run_selected_agent()
+            .map(|a| a.name.clone())
+            .unwrap_or_else(|| "no agent selected".to_string());
+        self.new_run_task.set_block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(focus_style(focused))
+                .title(Span::styled(
+                    format!(" Task for {agent} "),
+                    Style::default()
+                        .fg(focus_colour(focused))
+                        .add_modifier(Modifier::BOLD),
+                )),
+        );
+        self.new_run_task.set_style(Style::default().fg(C_WHITE));
+        self.new_run_task
+            .set_cursor_style(Style::default().fg(Color::Black).bg(C_ACCENT));
+        frame.render_widget(&self.new_run_task, area);
+    }
+
+    /// The `@` completion, drawn as a floating menu inside the task pane.
+    fn draw_file_ref_popup(&self, frame: &mut Frame, area: Rect) {
+        if !self.new_run_file_ref {
+            return;
+        }
+        let matches = self.file_ref_matches();
+        let selected = self.new_run_file_selected;
+        let lines: Vec<Line> = match matches.is_empty() {
+            true => vec![Line::from(Span::styled(
+                " no matching file ",
+                Style::default().fg(C_DIM),
+            ))],
+            false => matches
+                .iter()
+                .enumerate()
+                .map(|(i, path)| {
+                    let style = match i == selected {
+                        true => Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+                        false => Style::default().fg(C_MUTED),
+                    };
+                    Line::from(Span::styled(format!(" {path} "), style))
+                })
+                .collect(),
+        };
+
+        // Anchored to the bottom of the pane so it never covers the title, and
+        // clamped to the pane so a long list cannot overflow the frame.
+        let height = (lines.len() as u16 + 2).min(area.height);
+        let popup = Rect {
+            x: area.x + 1,
+            y: area.y + area.height.saturating_sub(height),
+            width: area.width.saturating_sub(2),
+            height,
+        };
+        frame.render_widget(Clear, popup);
+        frame.render_widget(
+            Paragraph::new(lines).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .border_style(Style::default().fg(C_ACCENT))
+                    .title(" files "),
+            ),
+            popup,
+        );
+    }
+
+    fn draw_new_run_help_bar(&self, frame: &mut Frame, area: Rect) {
+        let hint = match (self.new_run_file_ref, self.new_run_focus) {
+            (true, _) => " ↑↓ choose · Enter/Tab insert · Esc dismiss ",
+            (false, NewRunPane::Agents) => {
+                " ↑↓ select · type to filter · Tab/Enter write task · Esc back "
+            }
+            (false, NewRunPane::Task) => {
+                " Enter start · Alt+↵ newline · @ file · Tab agents · Esc back "
+            }
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(hint, Style::default().fg(C_DIM)))),
+            area,
+        );
+    }
+}
+
+/// Border colour for a pane, by whether it holds the keys.
+fn focus_style(focused: bool) -> Style {
+    Style::default().fg(focus_colour(focused))
+}
+
+fn focus_colour(focused: bool) -> Color {
+    match focused {
+        true => C_BORDER_FOCUS,
+        false => C_BORDER,
+    }
+}
+
+/// Colour an agent's source, so a bundled-but-not-installed row reads as the
+/// one that needs a step before it will run.
+fn source_colour(source: &str) -> Color {
+    match source {
+        "bundled" => C_WARN,
+        _ => C_ACCENT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::types::NewRunAgent;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn rendered(dash: &mut Dashboard) -> String {
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect()
+    }
+
+    fn agent(name: &str, source: &str) -> NewRunAgent {
+        NewRunAgent {
+            name: name.to_string(),
+            source: source.to_string(),
+            description: format!("does {name} things"),
+            path: format!("/agents/{name}"),
+        }
+    }
+
+    /// A dashboard on the new-run screen with two agents and three files, and
+    /// no toasts to overlay the assertions.
+    fn screen() -> Dashboard {
+        let mut dash = make_test_dashboard();
+        dash.new_run_screen = true;
+        dash.new_run_agents = vec![agent("alpha", "installed"), agent("beta", "bundled")];
+        dash.new_run_files = vec![
+            "README.md".to_string(),
+            "src/lib.rs".to_string(),
+            "src/main.rs".to_string(),
+        ];
+        dash
+    }
+
+    #[test]
+    fn the_screen_lists_agents_with_their_source() {
+        let mut dash = screen();
+        let out = rendered(&mut dash);
+        assert!(out.contains("Agents (2)"), "{out}");
+        assert!(out.contains("alpha"), "{out}");
+        assert!(out.contains("installed"), "{out}");
+        assert!(out.contains("bundled"), "{out}");
+        assert!(out.contains("Task for alpha"), "{out}");
+        assert!(out.contains("type to filter"), "help bar: {out}");
+    }
+
+    #[test]
+    fn the_filter_shows_in_the_title_with_its_counts() {
+        let mut dash = screen();
+        dash.new_run_filter = "alph".to_string();
+        let out = rendered(&mut dash);
+        assert!(out.contains("/alph"), "{out}");
+        assert!(out.contains("1/2"), "{out}");
+    }
+
+    #[test]
+    fn an_empty_catalog_says_how_to_get_agents() {
+        let mut dash = make_test_dashboard();
+        dash.new_run_screen = true;
+        let out = rendered(&mut dash);
+        assert!(out.contains("No agents found"), "{out}");
+        assert!(out.contains("lev setup"), "{out}");
+        assert!(out.contains("no agent selected"), "task title: {out}");
+    }
+
+    #[test]
+    fn a_filter_matching_nothing_says_so() {
+        let mut dash = screen();
+        dash.new_run_filter = "zzz".to_string();
+        let out = rendered(&mut dash);
+        assert!(out.contains("No agents match"), "{out}");
+    }
+
+    #[test]
+    fn the_focused_pane_is_the_one_with_the_lit_border() {
+        assert_eq!(focus_style(true).fg, Some(C_BORDER_FOCUS));
+        assert_eq!(focus_style(false).fg, Some(C_BORDER));
+        assert_eq!(source_colour("bundled"), C_WARN);
+        assert_eq!(source_colour("installed"), C_ACCENT);
+    }
+
+    #[test]
+    fn focusing_the_task_pane_changes_the_help_bar() {
+        let mut dash = screen();
+        dash.new_run_focus = NewRunPane::Task;
+        let out = rendered(&mut dash);
+        assert!(out.contains("Enter start"), "{out}");
+        assert!(out.contains("@ file"), "{out}");
+    }
+
+    #[test]
+    fn the_completion_popup_lists_matching_files() {
+        let mut dash = screen();
+        dash.new_run_focus = NewRunPane::Task;
+        dash.new_run_file_ref = true;
+        dash.new_run_file_query = "src".to_string();
+        dash.new_run_file_selected = 1;
+        let out = rendered(&mut dash);
+        assert!(out.contains("src/lib.rs"), "{out}");
+        assert!(out.contains("src/main.rs"), "{out}");
+        assert!(!out.contains("README.md"), "filtered out: {out}");
+        assert!(out.contains("Enter/Tab insert"), "help bar: {out}");
+    }
+
+    #[test]
+    fn the_completion_popup_says_when_nothing_matches() {
+        let mut dash = screen();
+        dash.new_run_focus = NewRunPane::Task;
+        dash.new_run_file_ref = true;
+        dash.new_run_file_query = "nothing-like-this".to_string();
+        let out = rendered(&mut dash);
+        assert!(out.contains("no matching file"), "{out}");
+    }
+
+    #[test]
+    fn the_popup_is_clamped_to_a_short_pane() {
+        let mut dash = screen();
+        dash.new_run_focus = NewRunPane::Task;
+        dash.new_run_file_ref = true;
+        let backend = TestBackend::new(80, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        // Drawing inside the frame is the assertion: an unclamped popup panics
+        // ratatui's buffer bounds check.
+        let out: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(out.contains("files"), "{out}");
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -106,7 +106,7 @@ impl Dashboard {
             .collect();
 
         let empty_state_msg: Option<String> = if self.agents.is_empty() {
-            Some("  No agents running. Use `lev run <agent>` to start one.".to_string())
+            Some("  No agents running. Press `n` to start one.".to_string())
         } else if self.display_indices.is_empty() {
             Some(format!("  No agents match \"{}\".", self.list_search_query))
         } else {
@@ -489,6 +489,11 @@ impl Dashboard {
                 Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
             ),
             Span::raw(" detail  "),
+            Span::styled(
+                "[n]",
+                Style::default().fg(C_SUCCESS).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" new run  "),
             Span::styled(
                 "[Tab]",
                 Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -12,14 +12,6 @@ use super::types::*;
 use crate::runstate::{self, RunStatus};
 use leviath_core::interaction;
 
-/// Production clock for staleness checks: wall-clock Unix seconds.
-fn system_now_secs() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
-}
-
 /// The interactive dashboard state.
 pub(crate) struct Dashboard {
     pub(super) agents: Vec<DashboardAgent>,
@@ -144,6 +136,45 @@ pub(crate) struct Dashboard {
     pub(super) mcp_cmd_tx: mpsc::UnboundedSender<McpCommand>,
     /// Receives completed MCP action outcomes, drained into toasts each tick.
     pub(super) mcp_outcome_rx: mpsc::UnboundedReceiver<McpOutcome>,
+
+    // ── New-run screen ─────────────────────────────────────────────────────
+    /// True when the full-screen "start a run" view is open (`n`).
+    pub(super) new_run_screen: bool,
+    /// The agents the picker offers, rebuilt when the screen opens.
+    pub(super) new_run_agents: Vec<NewRunAgent>,
+    /// Type-to-filter query over the agent picker.
+    pub(super) new_run_filter: String,
+    /// Selected row of the *filtered* agent list.
+    pub(super) new_run_selected: usize,
+    /// The task editor. The same `TextArea` the response pane uses, so word
+    /// motions, selection, and undo behave identically in both.
+    pub(super) new_run_task: TextArea<'static>,
+    /// Which of the two panes has the keys.
+    pub(super) new_run_focus: NewRunPane,
+    /// Workdir-relative file paths the `@` completion offers, walked once when
+    /// the screen opens rather than per keystroke.
+    pub(super) new_run_files: Vec<String>,
+    /// True while an `@` file reference is being typed, so the completion
+    /// popup has the keys.
+    pub(super) new_run_file_ref: bool,
+    /// The text typed after the `@`, held apart from the task buffer so
+    /// accepting a completion knows how many characters to replace.
+    pub(super) new_run_file_query: String,
+    /// Highlighted row of the completion popup.
+    pub(super) new_run_file_selected: usize,
+    /// Paths the screen reads its agents and file candidates from.
+    pub(super) new_run_ctx: NewRunContext,
+    /// Sends resolve-and-spawn work to the background lane.
+    pub(super) spawn_cmd_tx: mpsc::UnboundedSender<SpawnCommand>,
+    /// Receives spawn results, drained into toasts each tick.
+    pub(super) spawn_outcome_rx: mpsc::UnboundedReceiver<SpawnOutcome>,
+    /// The background loop's ends of the spawn channels, taken by
+    /// `init_dashboard`; tests keep them to assert dispatches and inject
+    /// outcomes.
+    pub(super) spawn_bg_ends: Option<(
+        mpsc::UnboundedReceiver<SpawnCommand>,
+        mpsc::UnboundedSender<SpawnOutcome>,
+    )>,
     /// Receives the daemon's answer to each [`DaemonCommand`], drained each tick
     /// so a refused cancel is surfaced instead of silently reverting.
     pub(super) daemon_outcome_rx: mpsc::UnboundedReceiver<DaemonOutcome>,
@@ -166,136 +197,6 @@ pub(crate) struct Dashboard {
 }
 
 impl Dashboard {
-    /// Default/test constructor: points the activity log at a shared temp file
-    /// and uses a no-op clipboard, so unit tests never touch the real
-    /// `~/.leviath/dashboard.log`, the system clipboard, or the TTY. Production
-    /// builds the dashboard via [`new_with_log_path`](Self::new_with_log_path)
-    /// (see `init_dashboard`), injecting the real log path and clipboard fn.
-    /// Test-only: production always goes through `new_with_log_path`.
-    #[cfg(test)]
-    pub(super) fn new(cmd_tx: mpsc::UnboundedSender<DaemonCommand>) -> Self {
-        let log_path = std::env::temp_dir()
-            .join("leviath-test-dashboard")
-            .join("dashboard.log");
-        // A test MCP context: temp paths, a no-op browser, and a fixed clock so
-        // no test touches the real home directory, a browser, or the wall clock.
-        let ctx = McpContext {
-            config_path: std::env::temp_dir()
-                .join("leviath-test-dashboard")
-                .join("config.toml"),
-            store_path: std::env::temp_dir()
-                .join("leviath-test-dashboard")
-                .join("mcp-auth.json"),
-            opener: std::sync::Arc::new(|_| false),
-            clock: || 1_000,
-        };
-        Self::new_with_log_path(cmd_tx, log_path, |_| false, ctx)
-    }
-
-    /// Core of [`new`](Self::new) with the activity-log path and clipboard
-    /// function injected, so production can supply the real
-    /// `~/.leviath/dashboard.log` + real OSC52/native clipboard while tests
-    /// point them at a temp dir + a no-op.
-    pub(super) fn new_with_log_path(
-        cmd_tx: mpsc::UnboundedSender<DaemonCommand>,
-        log_path: std::path::PathBuf,
-        yank_fn: fn(&str) -> bool,
-        mcp_ctx: McpContext,
-    ) -> Self {
-        let mut table_state = TableState::default();
-        table_state.select(Some(0));
-
-        // The MCP action lane: the dashboard keeps the command sender + outcome
-        // receiver; the other ends go to the background loop (production) or are
-        // retained for tests to drive.
-        let (mcp_cmd_tx, mcp_cmd_rx) = mpsc::unbounded_channel();
-        let (mcp_outcome_tx, mcp_outcome_rx) = mpsc::unbounded_channel();
-        let (daemon_outcome_tx, daemon_outcome_rx) = mpsc::unbounded_channel();
-
-        // Seed the in-memory log buffer from the tail of the persistent log so
-        // the panel shows recent history immediately on launch (not a blank panel).
-        let log = Self::load_log_seed(&log_path);
-
-        Self {
-            log_path,
-            yank_fn,
-            selection: None,
-            selection_regions: Vec::new(),
-            agents: Vec::new(),
-            selected: 0,
-            log,
-            input_textarea: TextArea::default(),
-            input_mode: false,
-            detail_view: false,
-            cmd_tx,
-            pending_interactions: HashMap::new(),
-            table_state,
-            should_quit: false,
-            pending_confirm: None,
-            sort_mode: SortMode::StartedAt,
-            main_focus: MainPane::RunList,
-            log_scroll: crate::tui::widgets::scroll::ScrollState::default(),
-            pane_rects: Vec::new(),
-            log_viewport: 0,
-            stage_explorer: None,
-            context_tree: ContextTreeState::default(),
-            history: None,
-            history_loader: runstate::context_history,
-            detail_scroll: 0,
-            choice_selected: 0,
-            selected_stage: 0,
-            stage_content_mode: StageContentMode::Output,
-            context_history_idx: None,
-            initial_sync_done: false,
-            meta_cache: runstate::StatCache::default(),
-            stages_cache: runstate::StatCache::default(),
-            context_cache: runstate::StatCache::default(),
-            tick_count: 0,
-            toasts: Vec::new(),
-            show_help: false,
-            review_scroll: 0,
-            search_mode: false,
-            search_query: String::new(),
-            search_match_idx: 0,
-            list_search_mode: false,
-            list_search_query: String::new(),
-            display_indices: Vec::new(),
-            tree_prefixes: Vec::new(),
-            mcp_screen: false,
-            mcp_add_mode: false,
-            mcp_add_input: String::new(),
-            mcp_rows: Vec::new(),
-            mcp_selected: 0,
-            mcp_ctx,
-            mcp_cmd_tx,
-            mcp_outcome_rx,
-            mcp_bg_ends: Some((mcp_cmd_rx, mcp_outcome_tx)),
-            daemon_outcome_rx,
-            daemon_outcome_tx: Some(daemon_outcome_tx),
-            daemon_run_ids: None,
-            clock: system_now_secs,
-        }
-    }
-
-    /// Take the background loop's channel ends, so `init_dashboard` can spawn
-    /// [`super::mcp::mcp_background_loop`]. Returns `None` if already taken.
-    pub(super) fn take_mcp_bg_ends(
-        &mut self,
-    ) -> Option<(
-        mpsc::UnboundedReceiver<super::types::McpCommand>,
-        mpsc::UnboundedSender<super::types::McpOutcome>,
-    )> {
-        self.mcp_bg_ends.take()
-    }
-
-    /// Take the daemon-outcome sender, so `init_dashboard` can hand it to
-    /// [`super::daemon_background_loop`]. Returns `None` if already taken.
-    pub(super) fn take_daemon_outcome_tx(
-        &mut self,
-    ) -> Option<mpsc::UnboundedSender<DaemonOutcome>> {
-        self.daemon_outcome_tx.take()
-    }
-
     /// Drain the daemon's answers to this tick's commands. A refused command
     /// becomes a toast and a log line, so the row reverting on the next disk
     /// sync has a visible explanation rather than none.
@@ -312,44 +213,6 @@ impl Dashboard {
             );
             self.add_log(format!("{}: {}", outcome.run_id, outcome.message));
         }
-    }
-
-    /// The MCP screen's context, for `init_dashboard` to hand to the loop.
-    pub(super) fn mcp_context(&self) -> McpContext {
-        self.mcp_ctx.clone()
-    }
-
-    /// Read the last 32 KB of dashboard.log and convert each line into a
-    /// `LogEntry` for the initial in-memory buffer.
-    fn load_log_seed(log_path: &std::path::Path) -> Vec<LogEntry> {
-        let tail = runstate::tail_file(log_path, 32_768);
-        Self::parse_log_lines(&tail)
-    }
-
-    /// Core parsing logic of [`load_log_seed`], split out so it can be
-    /// exercised in tests against controlled input independently of the log
-    /// path (which `load_log_seed` now takes as a parameter).
-    fn parse_log_lines(tail: &str) -> Vec<LogEntry> {
-        let mut entries = Vec::new();
-        for line in tail.lines() {
-            // Lines are written as "YYYY-MM-DD HH:MM:SS <message>"
-            // Split off the first two space-separated tokens as the timestamp.
-            let mut parts = line.splitn(3, ' ');
-            let date = parts.next().unwrap_or("");
-            let time = parts.next().unwrap_or("");
-            let message = parts.next().unwrap_or(line).to_string();
-            if message.is_empty() {
-                continue;
-            }
-            // In the panel we show only the time portion for compactness.
-            let timestamp = if time.is_empty() {
-                date.to_string()
-            } else {
-                time.to_string()
-            };
-            entries.push(LogEntry { timestamp, message });
-        }
-        entries
     }
 
     /// Recompute display_indices: ordered by [`SortMode`], filtered by
@@ -2185,51 +2048,6 @@ mod tests {
         });
     }
 
-    // ─── load_log_seed: exercises the parsing code ───────────────────────
-
-    #[test]
-    fn load_log_seed_returns_vec() {
-        // Missing file → empty seed, no panic.
-        let missing = std::env::temp_dir().join("leviath-nonexistent-dashboard-seed.log");
-        let _ = std::fs::remove_file(&missing);
-        assert!(Dashboard::load_log_seed(&missing).is_empty());
-
-        // Existing file → its lines are parsed into the seed buffer.
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("dashboard.log");
-        std::fs::write(&path, "2026-01-02 03:04:05 seeded message\n").unwrap();
-        let entries = Dashboard::load_log_seed(&path);
-        assert_eq!(entries.len(), 1);
-        assert!(entries[0].message.contains("seeded message"));
-    }
-
-    // ─── parse_log_lines: the pure parsing core of load_log_seed ──────────
-
-    #[test]
-    fn parse_log_lines_normal_line_uses_time_portion() {
-        let entries = Dashboard::parse_log_lines("2026-01-01 12:00:00 something happened");
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].timestamp, "12:00:00");
-        assert_eq!(entries[0].message, "something happened");
-    }
-
-    #[test]
-    fn parse_log_lines_missing_time_token_falls_back_to_date() {
-        // A double space between the first token and the message leaves the
-        // "time" slot empty, exercising the `if time.is_empty() { date }`
-        // fallback branch.
-        let entries = Dashboard::parse_log_lines("2026-01-01  something happened");
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].timestamp, "2026-01-01");
-        assert_eq!(entries[0].message, "something happened");
-    }
-
-    #[test]
-    fn parse_log_lines_skips_lines_with_empty_message() {
-        let entries = Dashboard::parse_log_lines("2026-01-01 12:00:00 \n");
-        assert!(entries.is_empty());
-    }
-
     // ─── push_toast: level variants ──────────────────────────────────────
 
     #[test]
@@ -2606,15 +2424,6 @@ mod tests {
         )))
         .await;
         assert_eq!(dash.daemon_run_ids, None);
-    }
-
-    /// The production clock answers with a plausible wall-clock time (the tests
-    /// above inject a fixed one, so this is the only place it runs).
-    #[test]
-    fn system_clock_reports_a_wall_clock_time() {
-        // Well after 2020 and before 2100 - i.e. a real epoch second.
-        let now = system_now_secs();
-        assert!(now > 1_577_836_800 && now < 4_102_444_800, "got {now}");
     }
 
     /// A stale run sorts above the finished ones: it is unfinished business the

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -357,6 +357,63 @@ pub(super) struct McpContext {
     pub(super) clock: fn() -> u64,
 }
 
+/// Which pane of the new-run screen holds keyboard focus (Tab toggles).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum NewRunPane {
+    Agents,
+    Task,
+}
+
+/// One runnable agent offered by the new-run screen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct NewRunAgent {
+    pub(super) name: String,
+    /// Where it came from: `installed`, `configured`, `local`, or `bundled`.
+    pub(super) source: String,
+    pub(super) description: String,
+    /// What gets handed to `lev run`'s resolver: the manifest's directory for a
+    /// discovered agent, the bare name for a bundled one (which resolves only
+    /// once `lev setup` has installed it - and says so if it has not).
+    pub(super) path: String,
+}
+
+/// Where the new-run screen reads its agent catalog and its `@` file
+/// candidates from, so the whole screen is testable against a temp tree
+/// instead of the user's real home directory and working directory.
+#[derive(Clone)]
+pub(super) struct NewRunContext {
+    /// `~/.leviath/agents`, scanned for installed agents.
+    pub(super) agents_dir: std::path::PathBuf,
+    /// The config whose `agent_paths` add more places to look.
+    pub(super) config_path: std::path::PathBuf,
+    /// The directory the run's tools are confined to, and the root the `@`
+    /// completion offers files from.
+    pub(super) workdir: std::path::PathBuf,
+}
+
+/// A run the new-run screen asked for, dispatched to the async spawn lane.
+///
+/// Resolving a blueprint reads and parses files and the spawn itself is a
+/// socket round trip, so neither happens on the draw loop.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct SpawnCommand {
+    /// The agent path or name to resolve.
+    pub(super) agent_path: String,
+    /// The task text as typed.
+    pub(super) task: String,
+    /// The working directory the run gets.
+    pub(super) workdir: String,
+}
+
+/// The result of a [`SpawnCommand`], drained each tick and shown as a toast.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) struct SpawnOutcome {
+    /// Human-readable result to toast.
+    pub(super) message: String,
+    /// Whether the run actually started (drives the toast colour).
+    pub(super) ok: bool,
+}
+
 /// Toast notification shown as an overlay.
 #[derive(Debug, Clone)]
 pub(super) struct Toast {

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -51,10 +51,10 @@ pub struct ListArgs {
 
 /// Info parsed from an agent manifest for display.
 #[derive(serde::Serialize)]
-struct AgentInfo {
-    name: String,
+pub(crate) struct AgentInfo {
+    pub(crate) name: String,
     version: String,
-    description: String,
+    pub(crate) description: String,
     /// The agent's `[read_paths]` grant status under the active config, when it
     /// declares any. Shown because a declaration nothing grants is inert, and
     /// the listing is where someone looks before running an agent they just
@@ -65,28 +65,28 @@ struct AgentInfo {
 /// One agent in `lev list --json`, with the source the prose report puts in a
 /// heading and the path `lev run` would resolve.
 #[derive(serde::Serialize)]
-struct ListedAgent {
+pub(crate) struct ListedAgent {
     #[serde(flatten)]
-    info: AgentInfo,
+    pub(crate) info: AgentInfo,
     /// `installed`, `configured`, or `local`.
-    source: &'static str,
-    path: String,
+    pub(crate) source: &'static str,
+    pub(crate) path: String,
 }
 
 /// What `lev list --json` prints.
 #[derive(serde::Serialize)]
-struct ListReport {
+pub(crate) struct ListReport {
     /// Every agent that can be run by name or path right now.
-    agents: Vec<ListedAgent>,
+    pub(crate) agents: Vec<ListedAgent>,
     /// The catalog embedded in this binary, which `lev setup` installs from.
     /// Not runnable until installed, which is why it is a separate key.
-    bundled: Vec<BundledEntry>,
+    pub(crate) bundled: Vec<BundledEntry>,
 }
 
 #[derive(serde::Serialize)]
-struct BundledEntry {
-    name: String,
-    version: String,
+pub(crate) struct BundledEntry {
+    pub(crate) name: String,
+    pub(crate) version: String,
 }
 
 fn read_agent_info(manifest_path: &Path, config: &Config, cwd: &Path) -> Option<AgentInfo> {
@@ -205,8 +205,9 @@ fn json_agent_listing(
 }
 
 /// The report [`json_agent_listing`] prints. Split out so its contents are
-/// assertable without capturing stdout.
-fn build_list_report(
+/// assertable without capturing stdout, and shared with the dashboard's
+/// new-run picker so the two offer exactly the same agents.
+pub(crate) fn build_list_report(
     agents_dir: &Path,
     cwd: &Path,
     config: &Config,

--- a/crates/leviath-cli/src/commands/mod.rs
+++ b/crates/leviath-cli/src/commands/mod.rs
@@ -57,4 +57,5 @@ pub mod setup;
 pub mod stages;
 pub mod test;
 pub mod tools;
+pub mod update;
 pub mod validate;

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -17,7 +17,9 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
 use ratatui::layout::Rect;
 
 use super::catalog::Credential;
-use super::state::{ConfirmPurpose, DetailAction, Edit, EditTarget, FieldValue, Step, Wizard};
+use super::state::{
+    ConfirmPurpose, DetailAction, Edit, EditTarget, FieldValue, Picker, Step, Wizard,
+};
 use crate::tui::keymap;
 use crate::tui::widgets::confirm::ConfirmOutcome;
 use crate::tui::widgets::help::dismisses_help;
@@ -61,8 +63,8 @@ impl Wizard {
         if self.confirm.is_some() {
             return self.handle_confirm_key(key);
         }
-        if self.picker.is_some() {
-            self.handle_picker_key(key);
+        if let Some(picker) = self.picker.take() {
+            self.handle_picker_key(key, picker);
             return Action::Continue;
         }
         if let Some(edit) = self.edit.take() {
@@ -90,8 +92,8 @@ impl Wizard {
         if self.confirm.is_some() || self.edit.is_some() || self.show_help {
             return Action::Continue;
         }
-        if self.picker.is_some() {
-            self.handle_picker_mouse(mouse, area);
+        if let Some(picker) = self.picker.take() {
+            self.handle_picker_mouse(mouse, area, picker);
             return Action::Continue;
         }
         match mouse.kind {
@@ -143,18 +145,14 @@ impl Wizard {
     /// A click outside the list is ignored rather than closing the chooser.
     /// Closing on a stray click would discard a search somebody was halfway
     /// through typing, and Esc is right there.
-    fn handle_picker_mouse(&mut self, mouse: MouseEvent, area: Rect) {
-        let Some(mut picker) = self.picker.take() else {
-            return;
-        };
+    fn handle_picker_mouse(&mut self, mouse: MouseEvent, area: Rect, mut picker: Picker) {
         match mouse.kind {
             MouseEventKind::ScrollDown => picker.move_cursor(1),
             MouseEventKind::ScrollUp => picker.move_cursor(-1),
             MouseEventKind::Down(MouseButton::Left) => {
                 if let Some(row) = super::render::picker_row_at(area, &picker, mouse.row) {
                     picker.cursor = row;
-                    self.picker = Some(picker);
-                    self.commit_picker();
+                    self.commit_picker(picker);
                     return;
                 }
             }
@@ -168,10 +166,7 @@ impl Wizard {
     /// Everything that is not navigation goes to the search box, so letters
     /// type rather than acting: `q` in a chooser means the user is looking for
     /// Qwen, and quitting setup instead would be indefensible.
-    fn handle_picker_key(&mut self, key: KeyEvent) {
-        let Some(mut picker) = self.picker.take() else {
-            return;
-        };
+    fn handle_picker_key(&mut self, key: KeyEvent, mut picker: Picker) {
         match key.code {
             KeyCode::Up => picker.move_cursor(-1),
             KeyCode::Down => picker.move_cursor(1),
@@ -182,8 +177,7 @@ impl Wizard {
             _ => {
                 match picker.query.handle_key(&key) {
                     EditOutcome::Commit => {
-                        self.picker = Some(picker);
-                        self.commit_picker();
+                        self.commit_picker(picker);
                         return;
                     }
                     // Esc closes without choosing, leaving the field as it was.
@@ -312,28 +306,26 @@ impl Wizard {
     fn activate_field(&mut self) {
         // The choice is cloned out before acting, because opening the chooser
         // needs `&mut self` while the field it came from is still borrowed.
-        let choice = match self.fields().get(self.cursor).map(|f| &f.value) {
-            Some(FieldValue::Bool(_)) => {
+        let Some(field) = self.fields().get(self.cursor) else {
+            // Reachable only with a hand-forced cursor past the fields.
+            return;
+        };
+        let label = field.label;
+        let choice = match &field.value {
+            FieldValue::Bool(_) => {
                 self.toggle();
                 return;
             }
-            Some(FieldValue::Number(_)) => {
+            FieldValue::Number(_) => {
                 self.open_field_editor();
                 return;
             }
-            Some(FieldValue::Choice { options, index }) => (options.clone(), *index),
-            // Reachable only with a hand-forced cursor past the fields.
-            None => return,
+            FieldValue::Choice { options, index } => (options.clone(), *index),
         };
-        // The two Defaults choices are a provider list and a model list, which
-        // is what the chooser exists for. The tuning screen's choices are
-        // two-or-three-value switches, where a full-screen list would be
-        // ceremony around something the arrows already do well.
-        if self.step == Step::Defaults {
-            self.open_picker(choice.0, choice.1);
-        } else {
-            self.adjust(1);
-        }
+        // Unconditionally, because the only list-valued fields in the wizard
+        // are the Defaults screen's provider and model. The tuning screen is
+        // numbers and switches, which the arrows already handle well.
+        self.open_picker(label, choice.0, choice.1);
     }
 
     /// Open the credential editor for the provider on screen. Returns false

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -130,6 +130,10 @@ impl Wizard {
             KeyCode::Char('s') if ctrl => return self.try_save(),
             KeyCode::Char('o') => self.open_signup_page(),
             KeyCode::Char('v') => self.verify_current(),
+            KeyCode::PageUp => self.scroll_by(-Wizard::PAGE),
+            KeyCode::PageDown => self.scroll_by(Wizard::PAGE),
+            KeyCode::Home => self.scroll_home(),
+            KeyCode::End => self.scroll_end(),
             _ => match keymap::resolve(&key) {
                 Some(keymap::Action::Up) => self.move_cursor(-1),
                 Some(keymap::Action::Down) => self.move_cursor(1),
@@ -293,6 +297,13 @@ impl Wizard {
                 }
                 if changed {
                     self.dirty = true;
+                    // One of those booleans decides whether the tuning screen
+                    // is on the path at all. The field was built from the flag,
+                    // so flipping one flips the other, and the Continue
+                    // button's label changes with it.
+                    if self.step == Step::Defaults && cursor == Wizard::ADVANCED_FIELD {
+                        self.show_advanced = !self.show_advanced;
+                    }
                 }
             }
             Step::Welcome | Step::ProviderDetail | Step::Review => {}

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -13,10 +13,11 @@
 //! toggles a provider, opens an editor, cycles a choice - and only advances
 //! the screen when the cursor is visibly on the step's Continue button.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::layout::Rect;
 
 use super::catalog::Credential;
-use super::state::{ConfirmPurpose, Edit, EditTarget, FieldValue, Step, Wizard};
+use super::state::{ConfirmPurpose, DetailAction, Edit, EditTarget, FieldValue, Step, Wizard};
 use crate::tui::keymap;
 use crate::tui::widgets::confirm::ConfirmOutcome;
 use crate::tui::widgets::help::dismisses_help;
@@ -71,6 +72,32 @@ impl Wizard {
             return Action::Continue;
         }
         self.handle_nav_key(key)
+    }
+
+    /// Handle one mouse event against the window it was clicked in.
+    ///
+    /// A click acts on what it lands on rather than only selecting it, which
+    /// is the point: the wizard leaned on `o` and `v` and a footer nobody
+    /// read, and a row you can press is the version of that a first-time user
+    /// finds on their own. Clicks are ignored while a dialog, an edit or the
+    /// help overlay is up, because a click cannot mean anything there and
+    /// dismissing them by accident would lose typed input.
+    pub fn handle_mouse(&mut self, mouse: MouseEvent, area: Rect) -> Action {
+        if self.confirm.is_some() || self.edit.is_some() || self.show_help {
+            return Action::Continue;
+        }
+        match mouse.kind {
+            MouseEventKind::ScrollDown => self.scroll_by(1),
+            MouseEventKind::ScrollUp => self.scroll_by(-1),
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(row) = super::render::row_at(area, self, mouse.column, mouse.row) {
+                    self.cursor = row;
+                    return self.activate();
+                }
+            }
+            _ => {}
+        }
+        Action::Continue
     }
 
     /// Keys while a confirmation dialog is open. Its Yes routes by purpose;
@@ -190,13 +217,18 @@ impl Wizard {
         }
         match self.step {
             Step::Providers | Step::Agents | Step::Mcp => self.toggle(),
-            Step::ProviderDetail => {
-                // The credential row opens its editor; the Claude Code row has
-                // nothing to type, so Enter cycles its effort instead.
-                if !self.open_credential_editor() {
-                    self.adjust(1);
+            Step::ProviderDetail => match self.detail_actions().get(self.cursor.wrapping_sub(1)) {
+                // Row 0 is the credential: it opens its editor, and the Claude
+                // Code row has nothing to type, so Enter cycles its effort.
+                // `wrapping_sub` turns that row into an index no action has.
+                None => {
+                    if !self.open_credential_editor() {
+                        self.adjust(1);
+                    }
                 }
-            }
+                Some(DetailAction::OpenSignup) => self.open_signup_page(),
+                Some(DetailAction::Verify) => self.verify_current(),
+            },
             Step::Defaults | Step::Limits => self.activate_field(),
             // Rowless steps put the cursor on their button, so these arms are
             // reachable only with a hand-forced cursor; acting on nothing is

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -61,6 +61,10 @@ impl Wizard {
         if self.confirm.is_some() {
             return self.handle_confirm_key(key);
         }
+        if self.picker.is_some() {
+            self.handle_picker_key(key);
+            return Action::Continue;
+        }
         if let Some(edit) = self.edit.take() {
             self.handle_edit_key(key, edit);
             return Action::Continue;
@@ -84,6 +88,10 @@ impl Wizard {
     /// dismissing them by accident would lose typed input.
     pub fn handle_mouse(&mut self, mouse: MouseEvent, area: Rect) -> Action {
         if self.confirm.is_some() || self.edit.is_some() || self.show_help {
+            return Action::Continue;
+        }
+        if self.picker.is_some() {
+            self.handle_picker_mouse(mouse, area);
             return Action::Continue;
         }
         match mouse.kind {
@@ -127,6 +135,67 @@ impl Wizard {
                 }
             },
         }
+    }
+
+    /// The mouse while the chooser is open: the wheel moves within the list, a
+    /// click on a row takes it.
+    ///
+    /// A click outside the list is ignored rather than closing the chooser.
+    /// Closing on a stray click would discard a search somebody was halfway
+    /// through typing, and Esc is right there.
+    fn handle_picker_mouse(&mut self, mouse: MouseEvent, area: Rect) {
+        let Some(mut picker) = self.picker.take() else {
+            return;
+        };
+        match mouse.kind {
+            MouseEventKind::ScrollDown => picker.move_cursor(1),
+            MouseEventKind::ScrollUp => picker.move_cursor(-1),
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(row) = super::render::picker_row_at(area, &picker, mouse.row) {
+                    picker.cursor = row;
+                    self.picker = Some(picker);
+                    self.commit_picker();
+                    return;
+                }
+            }
+            _ => {}
+        }
+        self.picker = Some(picker);
+    }
+
+    /// Keys while the chooser is open.
+    ///
+    /// Everything that is not navigation goes to the search box, so letters
+    /// type rather than acting: `q` in a chooser means the user is looking for
+    /// Qwen, and quitting setup instead would be indefensible.
+    fn handle_picker_key(&mut self, key: KeyEvent) {
+        let Some(mut picker) = self.picker.take() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Up => picker.move_cursor(-1),
+            KeyCode::Down => picker.move_cursor(1),
+            KeyCode::PageUp => picker.move_cursor(-Wizard::PAGE),
+            KeyCode::PageDown => picker.move_cursor(Wizard::PAGE),
+            KeyCode::Home => picker.cursor = 0,
+            KeyCode::End => picker.move_cursor(isize::MAX),
+            _ => {
+                match picker.query.handle_key(&key) {
+                    EditOutcome::Commit => {
+                        self.picker = Some(picker);
+                        self.commit_picker();
+                        return;
+                    }
+                    // Esc closes without choosing, leaving the field as it was.
+                    EditOutcome::Cancel => return,
+                    EditOutcome::Pending => {}
+                }
+                // The filter just changed under the cursor, so a selection
+                // that has been filtered away must not linger off the end.
+                picker.move_cursor(0);
+            }
+        }
+        self.picker = Some(picker);
     }
 
     /// Keys while a text field is open.
@@ -241,14 +310,29 @@ impl Wizard {
     /// Enter on a Defaults/Limits row always acts on that row's kind: toggle
     /// a bool, cycle a choice, open the editor for a number.
     fn activate_field(&mut self) {
-        match self.fields().get(self.cursor).map(|f| &f.value) {
-            Some(FieldValue::Bool(_)) => self.toggle(),
-            Some(FieldValue::Choice { .. }) => self.adjust(1),
+        // The choice is cloned out before acting, because opening the chooser
+        // needs `&mut self` while the field it came from is still borrowed.
+        let choice = match self.fields().get(self.cursor).map(|f| &f.value) {
+            Some(FieldValue::Bool(_)) => {
+                self.toggle();
+                return;
+            }
             Some(FieldValue::Number(_)) => {
                 self.open_field_editor();
+                return;
             }
+            Some(FieldValue::Choice { options, index }) => (options.clone(), *index),
             // Reachable only with a hand-forced cursor past the fields.
-            None => {}
+            None => return,
+        };
+        // The two Defaults choices are a provider list and a model list, which
+        // is what the chooser exists for. The tuning screen's choices are
+        // two-or-three-value switches, where a full-screen list would be
+        // ceremony around something the arrows already do well.
+        if self.step == Step::Defaults {
+            self.open_picker(choice.0, choice.1);
+        } else {
+            self.adjust(1);
         }
     }
 

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1415,7 +1415,10 @@ fn clicking_a_row_in_the_chooser_takes_it_and_the_wheel_moves_within_it() {
 
     w.handle_mouse(wheel(true), AREA);
     let moved = w.picker.as_ref().expect("open").cursor;
-    assert_eq!(moved, 1, "the wheel moves inside the chooser, not behind it");
+    assert_eq!(
+        moved, 1,
+        "the wheel moves inside the chooser, not behind it"
+    );
 
     // A click outside the list keeps the chooser open rather than discarding a
     // half-typed search.
@@ -1436,4 +1439,121 @@ fn clicking_a_row_in_the_chooser_takes_it_and_the_wheel_moves_within_it() {
     assert!(w.picker.is_none(), "a click on a row chooses it");
     // Row 0 is the "no default" option and the models sort after it.
     assert_eq!(w.defaults[1].value.display(), "claude-opus-4");
+}
+
+/// Page keys and Home/End are bound, not only reachable through the methods
+/// the render tests call directly.
+#[test]
+fn the_page_and_edge_keys_move_the_selection() {
+    let (_dir, mut w) = wizard();
+    w.show_advanced = true;
+    w.enter(Step::Limits);
+
+    w.handle_key(press(KeyCode::PageDown));
+    assert_eq!(w.cursor, Wizard::PAGE as usize);
+    w.handle_key(press(KeyCode::PageUp));
+    assert_eq!(w.cursor, 0);
+    w.handle_key(press(KeyCode::End));
+    assert_eq!(w.cursor, w.nav_rows() - 1);
+    w.handle_key(press(KeyCode::Home));
+    assert_eq!(w.cursor, 0);
+}
+
+/// Everything the terminal reports that is not a wheel or a left click is
+/// ignored, on the screen and inside the chooser alike. Mouse movement in
+/// particular arrives constantly once capture is on.
+#[test]
+fn mouse_events_that_are_not_a_click_or_a_wheel_are_ignored() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+    let moved = MouseEvent {
+        kind: MouseEventKind::Moved,
+        column: 4,
+        row: 4,
+        modifiers: KeyModifiers::empty(),
+    };
+
+    w.handle_mouse(moved, AREA);
+    assert_eq!(w.cursor, 0);
+    assert!(!w.providers[0].selected, "hovering is not clicking");
+
+    w.enter(Step::Defaults);
+    w.open_picker("Default provider", w.defaults[0].value.options().to_vec(), 0);
+    w.handle_mouse(moved, AREA);
+    assert!(w.picker.is_some(), "and it does not close the chooser");
+    w.handle_mouse(wheel(false), AREA);
+    assert_eq!(
+        w.picker.as_ref().expect("open").cursor,
+        0,
+        "the wheel up stops at the top"
+    );
+}
+
+/// A value the catalog has never heard of still reads as a choice: it is in
+/// the config, so it is legitimate, and the row says where it came from.
+#[test]
+fn a_configured_provider_outside_the_catalog_still_describes_itself() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut config = crate::config::Config::default();
+    config.default_provider = "in-house".to_string();
+    config.default_model = Some("ghost-model".to_string());
+    let mut w = Wizard::new(
+        config,
+        &|_| None,
+        Vec::new(),
+        Vec::new(),
+        dir.path(),
+        std::sync::Arc::new(|_| true),
+    );
+    w.enter(Step::Defaults);
+
+    w.open_picker("Default provider", w.defaults[0].value.options().to_vec(), 0);
+    let picker = w.picker.take().expect("open");
+    assert_eq!(picker.options[0].value, "in-house");
+    assert_eq!(picker.options[0].detail, "from your config");
+
+    w.cursor = 1;
+    w.open_picker("Default model", w.defaults[1].value.options().to_vec(), 0);
+    let picker = w.picker.as_ref().expect("open");
+    let ghost = picker
+        .options
+        .iter()
+        .find(|o| o.value == "ghost-model")
+        .expect("the configured model is offered even unreported");
+    assert_eq!(ghost.detail, "not reported by a provider you selected");
+}
+
+/// Choosing a provider re-picks the concurrency default, the same way an arrow
+/// press does, so a local-first setup does not keep a hosted-API number.
+#[test]
+fn choosing_a_provider_in_the_chooser_repicks_the_concurrency_default() {
+    let (_dir, mut w) = wizard();
+    let ollama = w
+        .providers
+        .iter()
+        .position(|r| r.provider.id == "ollama")
+        .expect("ollama is offered");
+    w.providers[0].selected = true;
+    w.providers[ollama].selected = true;
+    w.enter(Step::Defaults);
+    w.cursor = 0;
+    w.handle_key(press(KeyCode::Enter));
+
+    // Move onto ollama and take it.
+    while w
+        .picker
+        .as_ref()
+        .and_then(|p| p.selected())
+        .map(|i| w.picker.as_ref().expect("open").options[i].value.clone())
+        != Some("ollama".to_string())
+    {
+        w.handle_key(press(KeyCode::Down));
+    }
+    w.handle_key(press(KeyCode::Enter));
+
+    assert_eq!(w.defaults[0].value.display(), "ollama");
+    assert_eq!(
+        w.limits[0].value.display(),
+        crate::commands::setup::catalog::OLLAMA_MAX_CONCURRENT_INFERENCES.to_string()
+    );
 }

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -692,14 +692,24 @@ fn tab_and_shift_tab_walk_the_steps() {
     assert_eq!(w.step, Step::Welcome);
 }
 
+/// Back from Agents skips the tuning screen, because it is off by default.
+/// Turning it on puts it back in the path, in both directions.
 #[test]
-fn escape_goes_back_a_step() {
+fn escape_goes_back_a_step_and_the_advanced_toggle_decides_which() {
     let (_dir, mut w) = wizard();
     w.enter(Step::Agents);
 
     w.handle_key(press(KeyCode::Esc));
+    assert_eq!(w.step, Step::Defaults);
 
+    w.cursor = Wizard::ADVANCED_FIELD;
+    w.handle_key(press(KeyCode::Char(' ')));
+    assert!(w.show_advanced, "space on the toggle turns tuning on");
+
+    w.handle_key(press(KeyCode::Tab));
     assert_eq!(w.step, Step::Limits);
+    w.handle_key(press(KeyCode::Esc));
+    assert_eq!(w.step, Step::Defaults);
 }
 
 #[test]

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1318,6 +1318,12 @@ fn the_search_matches_terms_in_any_order_and_across_the_detail() {
     // The provider name is part of the row, so it is part of the search.
     type_str(&mut w, "anthropic");
     assert_eq!(w.picker.as_ref().expect("open").matches().len(), 3);
+
+    // The "no default" row is the absence of a model, so it does not claim a
+    // provider failed to report it.
+    let none = &w.picker.as_ref().expect("open").options[0];
+    assert_eq!(none.value, Wizard::NO_DEFAULT_MODEL);
+    assert!(none.detail.starts_with("no default"), "{}", none.detail);
 }
 
 #[test]

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1478,7 +1478,11 @@ fn mouse_events_that_are_not_a_click_or_a_wheel_are_ignored() {
     assert!(!w.providers[0].selected, "hovering is not clicking");
 
     w.enter(Step::Defaults);
-    w.open_picker("Default provider", w.defaults[0].value.options().to_vec(), 0);
+    w.open_picker(
+        "Default provider",
+        w.defaults[0].value.options().to_vec(),
+        0,
+    );
     w.handle_mouse(moved, AREA);
     assert!(w.picker.is_some(), "and it does not close the chooser");
     w.handle_mouse(wheel(false), AREA);
@@ -1494,9 +1498,11 @@ fn mouse_events_that_are_not_a_click_or_a_wheel_are_ignored() {
 #[test]
 fn a_configured_provider_outside_the_catalog_still_describes_itself() {
     let dir = tempfile::tempdir().unwrap();
-    let mut config = crate::config::Config::default();
-    config.default_provider = "in-house".to_string();
-    config.default_model = Some("ghost-model".to_string());
+    let config = crate::config::Config {
+        default_provider: "in-house".to_string(),
+        default_model: Some("ghost-model".to_string()),
+        ..Default::default()
+    };
     let mut w = Wizard::new(
         config,
         &|_| None,
@@ -1507,7 +1513,11 @@ fn a_configured_provider_outside_the_catalog_still_describes_itself() {
     );
     w.enter(Step::Defaults);
 
-    w.open_picker("Default provider", w.defaults[0].value.options().to_vec(), 0);
+    w.open_picker(
+        "Default provider",
+        w.defaults[0].value.options().to_vec(),
+        0,
+    );
     let picker = w.picker.take().expect("open");
     assert_eq!(picker.options[0].value, "in-house");
     assert_eq!(picker.options[0].detail, "from your config");

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -271,7 +271,7 @@ fn enter_on_a_toggle_flips_it_and_stays() {
 }
 
 #[test]
-fn enter_on_a_choice_cycles_it_and_stays() {
+fn the_arrows_still_cycle_a_choice_in_place() {
     let (_dir, mut w) = wizard();
     w.providers[0].selected = true;
     let ollama = w
@@ -283,9 +283,10 @@ fn enter_on_a_choice_cycles_it_and_stays() {
     w.enter(Step::Defaults);
     w.cursor = 0; // the provider choice
 
-    w.handle_key(press(KeyCode::Enter));
+    w.handle_key(press(KeyCode::Right));
 
     assert_eq!(w.step, Step::Defaults);
+    assert!(w.picker.is_none(), "an arrow is not a chooser");
     assert_eq!(w.defaults[0].value.display(), "ollama");
 }
 
@@ -1229,4 +1230,204 @@ fn clicks_are_ignored_while_a_dialog_or_an_edit_is_open() {
     w.handle_mouse(click(4, 4), AREA);
     assert!(w.confirm.is_some());
     assert!(!w.providers[0].selected);
+}
+
+// ─── the chooser ────────────────────────────────────────────────────────
+
+/// A wizard on the Defaults screen with a model list worth searching.
+fn wizard_with_models() -> (tempfile::TempDir, Wizard) {
+    let (dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.providers[0].outcome = crate::commands::setup::verify::Outcome::Reachable {
+        models: vec![
+            "claude-opus-4".to_string(),
+            "claude-sonnet-4-6".to_string(),
+            "claude-haiku-4-5".to_string(),
+        ],
+    };
+    w.enter(Step::Defaults);
+    w.cursor = 1; // the model choice
+    (dir, w)
+}
+
+fn type_str(w: &mut Wizard, text: &str) {
+    for c in text.chars() {
+        w.handle_key(press(KeyCode::Char(c)));
+    }
+}
+
+#[test]
+fn enter_on_a_default_opens_a_chooser_that_says_what_it_decides() {
+    let (_dir, mut w) = wizard_with_models();
+
+    w.handle_key(press(KeyCode::Enter));
+
+    let picker = w.picker.as_ref().expect("the chooser is open");
+    assert_eq!(picker.title, "Default model");
+    assert!(
+        !picker.explain.is_empty(),
+        "the chooser exists to explain the value, not only to list it"
+    );
+    assert!(
+        picker.options.iter().any(|o| o.value == "claude-opus-4"),
+        "every discovered model is offered"
+    );
+    // Where a model came from is on the row, so a name nobody recognises is
+    // still attributable.
+    let opus = picker
+        .options
+        .iter()
+        .find(|o| o.value == "claude-opus-4")
+        .expect("listed");
+    assert!(opus.detail.contains("Anthropic"), "{}", opus.detail);
+}
+
+#[test]
+fn typing_filters_the_chooser_and_enter_takes_the_match() {
+    let (_dir, mut w) = wizard_with_models();
+    w.handle_key(press(KeyCode::Enter));
+
+    type_str(&mut w, "haiku");
+    let picker = w.picker.as_ref().expect("still open");
+    assert_eq!(picker.matches().len(), 1, "one model matches 'haiku'");
+
+    w.handle_key(press(KeyCode::Enter));
+
+    assert!(w.picker.is_none(), "choosing closes it");
+    assert_eq!(w.defaults[1].value.display(), "claude-haiku-4-5");
+    assert!(w.dirty, "a chosen default is an unsaved change");
+}
+
+/// Every term has to land somewhere on the row, in any order, so a search
+/// reads the way somebody would say the model out loud.
+#[test]
+fn the_search_matches_terms_in_any_order_and_across_the_detail() {
+    let (_dir, mut w) = wizard_with_models();
+    w.handle_key(press(KeyCode::Enter));
+
+    type_str(&mut w, "4-6 claude");
+    assert_eq!(
+        w.picker.as_ref().expect("open").matches().len(),
+        1,
+        "terms are matched independently of their order"
+    );
+
+    for _ in 0.."4-6 claude".len() {
+        w.handle_key(press(KeyCode::Backspace));
+    }
+    // The provider name is part of the row, so it is part of the search.
+    type_str(&mut w, "anthropic");
+    assert_eq!(w.picker.as_ref().expect("open").matches().len(), 3);
+}
+
+#[test]
+fn escape_closes_the_chooser_and_keeps_the_value() {
+    let (_dir, mut w) = wizard_with_models();
+    let before = w.defaults[1].value.display();
+    w.handle_key(press(KeyCode::Enter));
+
+    w.handle_key(press(KeyCode::Down));
+    w.handle_key(press(KeyCode::Esc));
+
+    assert!(w.picker.is_none());
+    assert_eq!(w.defaults[1].value.display(), before);
+    assert!(!w.dirty, "looking is not changing");
+}
+
+/// A filter that matches nothing must not leave the cursor pointing past the
+/// end of the list, and Enter on it must not choose whatever was there before.
+#[test]
+fn a_filter_that_matches_nothing_chooses_nothing() {
+    let (_dir, mut w) = wizard_with_models();
+    let before = w.defaults[1].value.display();
+    w.handle_key(press(KeyCode::Enter));
+
+    type_str(&mut w, "zzzz");
+    assert!(w.picker.as_ref().expect("open").selected().is_none());
+
+    w.handle_key(press(KeyCode::Enter));
+    assert!(w.picker.is_none(), "Enter still closes it");
+    assert_eq!(w.defaults[1].value.display(), before);
+}
+
+/// The chooser is modal, so a letter is a letter. `q` here means the user is
+/// looking for Qwen.
+#[test]
+fn letters_search_rather_than_acting_while_the_chooser_is_open() {
+    let (_dir, mut w) = wizard_with_models();
+    w.handle_key(press(KeyCode::Enter));
+
+    w.handle_key(press(KeyCode::Char('q')));
+
+    assert!(!w.should_quit, "q must not quit out of a search box");
+    assert_eq!(w.picker.as_ref().expect("open").query.value(), "q");
+}
+
+#[test]
+fn the_provider_chooser_lists_providers_with_their_names() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.enter(Step::Defaults);
+    w.cursor = 0;
+
+    w.handle_key(press(KeyCode::Enter));
+
+    let picker = w.picker.as_ref().expect("open");
+    assert_eq!(picker.title, "Default provider");
+    assert!(picker.options.iter().any(|o| o.value == "anthropic"));
+    assert!(
+        picker.options.iter().all(|o| !o.detail.is_empty()),
+        "an id alone does not say which service it is"
+    );
+}
+
+/// Moving stops at the ends. Wrapping from the top of eighty models to the
+/// bottom looks like the list jumped rather than moved.
+#[test]
+fn the_chooser_cursor_clamps_at_both_ends() {
+    let (_dir, mut w) = wizard_with_models();
+    w.handle_key(press(KeyCode::Enter));
+    let total = w.picker.as_ref().expect("open").matches().len();
+
+    w.handle_key(press(KeyCode::Home));
+    assert_eq!(w.picker.as_ref().expect("open").cursor, 0);
+    w.handle_key(press(KeyCode::Up));
+    assert_eq!(w.picker.as_ref().expect("open").cursor, 0);
+
+    w.handle_key(press(KeyCode::End));
+    assert_eq!(w.picker.as_ref().expect("open").cursor, total - 1);
+    w.handle_key(press(KeyCode::PageDown));
+    assert_eq!(w.picker.as_ref().expect("open").cursor, total - 1);
+    w.handle_key(press(KeyCode::PageUp));
+    assert_eq!(w.picker.as_ref().expect("open").cursor, 0);
+}
+
+#[test]
+fn clicking_a_row_in_the_chooser_takes_it_and_the_wheel_moves_within_it() {
+    let (_dir, mut w) = wizard_with_models();
+    w.handle_key(press(KeyCode::Enter));
+
+    w.handle_mouse(wheel(true), AREA);
+    let moved = w.picker.as_ref().expect("open").cursor;
+    assert_eq!(moved, 1, "the wheel moves inside the chooser, not behind it");
+
+    // A click outside the list keeps the chooser open rather than discarding a
+    // half-typed search.
+    w.handle_mouse(click(4, 0), AREA);
+    assert!(w.picker.is_some());
+
+    let row = (0..AREA.height)
+        .find(|y| {
+            crate::commands::setup::render::picker_row_at(
+                AREA,
+                w.picker.as_ref().expect("open"),
+                *y,
+            ) == Some(2)
+        })
+        .expect("the third match is on screen");
+    w.handle_mouse(click(6, row), AREA);
+
+    assert!(w.picker.is_none(), "a click on a row chooses it");
+    // Row 0 is the "no default" option and the models sort after it.
+    assert_eq!(w.defaults[1].value.display(), "claude-opus-4");
 }

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1,5 +1,5 @@
 use super::*;
-use crate::commands::setup::state::{ConfirmPurpose, Edit, EditTarget, FieldValue};
+use crate::commands::setup::state::{ConfirmPurpose, DetailAction, Edit, EditTarget, FieldValue};
 
 fn press(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::empty())
@@ -1081,4 +1081,152 @@ fn without_claude_code_review_saves_immediately() {
 
     let action = w.handle_key(press(KeyCode::Enter));
     assert_eq!(action, Action::Save, "no claude-code means no gate");
+}
+
+// ─── the mouse ──────────────────────────────────────────────────────────
+
+/// The window the click tests aim at.
+const AREA: Rect = Rect::new(0, 0, 90, 40);
+
+fn click(column: u16, row: u16) -> MouseEvent {
+    MouseEvent {
+        kind: MouseEventKind::Down(MouseButton::Left),
+        column,
+        row,
+        modifiers: KeyModifiers::empty(),
+    }
+}
+
+fn wheel(down: bool) -> MouseEvent {
+    MouseEvent {
+        kind: if down {
+            MouseEventKind::ScrollDown
+        } else {
+            MouseEventKind::ScrollUp
+        },
+        column: 4,
+        row: 6,
+        modifiers: KeyModifiers::empty(),
+    }
+}
+
+/// Where a given row is drawn, so the assertions below say which row they
+/// clicked rather than encoding a line layout that will move.
+fn point_of_row(w: &Wizard, row: usize) -> (u16, u16) {
+    for y in 0..AREA.height {
+        if crate::commands::setup::render::row_at(AREA, w, 4, y) == Some(row) {
+            return (4, y);
+        }
+    }
+    panic!("row {row} is not on screen");
+}
+
+#[test]
+fn clicking_a_provider_selects_and_toggles_it() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+    let (x, y) = point_of_row(&w, 1);
+
+    w.handle_mouse(click(x, y), AREA);
+
+    assert_eq!(w.cursor, 1, "the click moves the selection to what it hit");
+    assert!(w.providers[1].selected, "and acts on it, as Enter would");
+}
+
+#[test]
+fn clicking_the_button_advances_the_step() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Agents);
+    let button = w.nav_rows() - 1;
+    let (x, y) = point_of_row(&w, button);
+
+    w.handle_mouse(click(x, y), AREA);
+
+    assert_ne!(w.step, Step::Agents, "the button is a button when clicked");
+}
+
+/// The two actions that used to be shortcut keys and nothing else.
+#[test]
+fn the_credential_screen_offers_its_actions_as_clickable_rows() {
+    let (_dir, mut w) = wizard();
+    w.providers[0].selected = true;
+    w.enter(Step::ProviderDetail);
+    assert_eq!(
+        w.detail_actions(),
+        vec![DetailAction::OpenSignup, DetailAction::Verify],
+        "a provider with a key page offers both"
+    );
+
+    let (x, y) = point_of_row(&w, 1);
+    w.handle_mouse(click(x, y), AREA);
+    assert!(
+        w.message
+            .as_deref()
+            .is_some_and(|m| m.starts_with("Opened")),
+        "clicking the signup row opens the page: {:?}",
+        w.message
+    );
+
+    let (x, y) = point_of_row(&w, 2);
+    w.handle_mouse(click(x, y), AREA);
+    assert_eq!(w.message.as_deref(), Some("Checking…"));
+}
+
+/// A provider with nowhere to sign up offers only the check, and the rows stay
+/// contiguous rather than leaving a gap where a button would have been.
+#[test]
+fn a_provider_without_a_key_page_offers_only_the_check() {
+    let (_dir, mut w) = wizard();
+    let index = w
+        .providers
+        .iter()
+        .position(|r| r.provider.signup_url.is_none())
+        .expect("the catalog has one");
+    w.providers[index].selected = true;
+    w.enter(Step::ProviderDetail);
+
+    assert_eq!(w.detail_actions(), vec![DetailAction::Verify]);
+    assert_eq!(w.row_count(), 2, "the credential row plus the one action");
+}
+
+#[test]
+fn a_click_outside_the_body_does_nothing() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+    let before = w.providers[0].selected;
+
+    // The footer, which is not a row and must not be treated as the nearest one.
+    w.handle_mouse(click(4, AREA.height - 1), AREA);
+
+    assert_eq!(w.cursor, 0);
+    assert_eq!(w.providers[0].selected, before);
+}
+
+#[test]
+fn the_wheel_moves_the_selection_so_the_view_follows_it() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+
+    w.handle_mouse(wheel(true), AREA);
+    assert_eq!(w.cursor, 1);
+    w.handle_mouse(wheel(false), AREA);
+    assert_eq!(w.cursor, 0);
+}
+
+/// A click cannot mean anything while a dialog or an edit is up, and taking it
+/// as a dismissal would throw away a half-typed credential.
+#[test]
+fn clicks_are_ignored_while_a_dialog_or_an_edit_is_open() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+    w.edit = Some(credential_edit("half-typed", true));
+    w.handle_mouse(click(4, 4), AREA);
+    assert!(w.edit.is_some(), "the edit survives a stray click");
+    assert!(!w.providers[0].selected);
+
+    w.edit = None;
+    w.open_quit_confirm();
+    w.handle_mouse(click(4, 4), AREA);
+    assert!(w.confirm.is_some());
+    assert!(!w.providers[0].selected);
 }

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -305,11 +305,26 @@ pub async fn run_wizard_loop<B: ratatui::backend::Backend>(
             // Send/Sync guarantee, so convert by message rather than by `?`.
             .map_err(|e| anyhow::anyhow!("terminal draw failed: {e}"))?;
 
-        if let Some(Event::Key(key)) = events.poll_event(tick_rate)?
-            && key.kind == KeyEventKind::Press
-            && wizard.handle_key(key) == input::Action::Save
-        {
-            wizard.finished = true;
+        match events.poll_event(tick_rate)? {
+            Some(Event::Key(key))
+                if key.kind == KeyEventKind::Press
+                    && wizard.handle_key(key) == input::Action::Save =>
+            {
+                wizard.finished = true;
+            }
+            // The window the mouse was clicked in is the one just drawn, and
+            // asking the terminal for its size is what lets the hit test
+            // rebuild that layout without the renderer storing it.
+            Some(Event::Mouse(mouse)) => {
+                let area = terminal
+                    .size()
+                    .map(|size| ratatui::layout::Rect::new(0, 0, size.width, size.height))
+                    .unwrap_or_default();
+                if wizard.handle_mouse(mouse, area) == input::Action::Save {
+                    wizard.finished = true;
+                }
+            }
+            _ => {}
         }
 
         if wizard.finished {

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -299,8 +299,15 @@ pub async fn run_wizard_loop<B: ratatui::backend::Backend>(
     loop {
         wizard.ticks += 1;
         wizard.drain_verifications();
+        // The area is taken from the frame that was actually drawn, so a click
+        // resolves against the layout the user was looking at rather than
+        // against a size asked for separately afterwards.
+        let mut area = ratatui::layout::Rect::default();
         terminal
-            .draw(|frame| render::draw(frame, wizard))
+            .draw(|frame| {
+                area = frame.area();
+                render::draw(frame, wizard);
+            })
             // ratatui 0.30 made the backend error an associated type with no
             // Send/Sync guarantee, so convert by message rather than by `?`.
             .map_err(|e| anyhow::anyhow!("terminal draw failed: {e}"))?;
@@ -312,14 +319,7 @@ pub async fn run_wizard_loop<B: ratatui::backend::Backend>(
             {
                 wizard.finished = true;
             }
-            // The window the mouse was clicked in is the one just drawn, and
-            // asking the terminal for its size is what lets the hit test
-            // rebuild that layout without the renderer storing it.
             Some(Event::Mouse(mouse)) => {
-                let area = terminal
-                    .size()
-                    .map(|size| ratatui::layout::Rect::new(0, 0, size.width, size.height))
-                    .unwrap_or_default();
                 if wizard.handle_mouse(mouse, area) == input::Action::Save {
                     wizard.finished = true;
                 }
@@ -823,6 +823,88 @@ mod tests {
         .unwrap();
 
         assert!(plan.is_none(), "only the real press quit");
+    }
+
+    /// A click reaches the wizard through the loop, against the size the
+    /// terminal reports, and can finish the run the same way a key can.
+    #[tokio::test]
+    async fn a_click_is_routed_with_the_window_it_was_made_in() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = build_wizard(&env_in(dir.path()));
+        wizard.enter(state::Step::Providers);
+        let mut terminal = test_terminal();
+        let size = terminal.size().expect("the test backend has a size");
+        let area = ratatui::layout::Rect::new(0, 0, size.width, size.height);
+        // The row the click has to land on is asked for, not assumed, so the
+        // test does not encode a layout.
+        let row = (0..area.height)
+            .find(|y| render::row_at(area, &wizard, 4, *y) == Some(1))
+            .expect("the second provider is on screen");
+
+        let mut events = TestEventSource::new(vec![
+            crossterm::event::Event::Mouse(crossterm::event::MouseEvent {
+                kind: crossterm::event::MouseEventKind::Down(
+                    crossterm::event::MouseButton::Left,
+                ),
+                column: 4,
+                row,
+                modifiers: KeyModifiers::empty(),
+            }),
+            key_with(KeyCode::Char('s'), KeyModifiers::CONTROL),
+        ]);
+
+        let plan = run_wizard_loop(
+            &mut wizard,
+            &mut terminal,
+            &mut events,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap()
+        .expect("ctrl-s finished it");
+
+        assert!(
+            wizard.providers[1].selected,
+            "the click selected what it landed on"
+        );
+        assert!(!plan.agents.is_empty());
+    }
+
+    /// The last button finishes the run, whether it is pressed or clicked.
+    #[tokio::test]
+    async fn clicking_apply_and_finish_ends_the_wizard() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = build_wizard(&env_in(dir.path()));
+        wizard.enter(state::Step::Review);
+        let mut terminal = test_terminal();
+        let size = terminal.size().expect("the test backend has a size");
+        let area = ratatui::layout::Rect::new(0, 0, size.width, size.height);
+        let button = wizard.nav_rows() - 1;
+        let row = (0..area.height)
+            .find(|y| render::row_at(area, &wizard, 4, *y) == Some(button))
+            .expect("the button is on screen");
+
+        let mut events = TestEventSource::new(vec![crossterm::event::Event::Mouse(
+            crossterm::event::MouseEvent {
+                kind: crossterm::event::MouseEventKind::Down(
+                    crossterm::event::MouseButton::Left,
+                ),
+                column: 4,
+                row,
+                modifiers: KeyModifiers::empty(),
+            },
+        )]);
+
+        let plan = run_wizard_loop(
+            &mut wizard,
+            &mut terminal,
+            &mut events,
+            Duration::from_millis(1),
+        )
+        .await
+        .unwrap();
+
+        assert!(plan.is_some(), "the click applied the plan");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -319,10 +319,10 @@ pub async fn run_wizard_loop<B: ratatui::backend::Backend>(
             {
                 wizard.finished = true;
             }
-            Some(Event::Mouse(mouse)) => {
-                if wizard.handle_mouse(mouse, area) == input::Action::Save {
-                    wizard.finished = true;
-                }
+            Some(Event::Mouse(mouse))
+                if wizard.handle_mouse(mouse, area) == input::Action::Save =>
+            {
+                wizard.finished = true;
             }
             _ => {}
         }
@@ -843,9 +843,7 @@ mod tests {
 
         let mut events = TestEventSource::new(vec![
             crossterm::event::Event::Mouse(crossterm::event::MouseEvent {
-                kind: crossterm::event::MouseEventKind::Down(
-                    crossterm::event::MouseButton::Left,
-                ),
+                kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
                 column: 4,
                 row,
                 modifiers: KeyModifiers::empty(),
@@ -886,9 +884,7 @@ mod tests {
 
         let mut events = TestEventSource::new(vec![crossterm::event::Event::Mouse(
             crossterm::event::MouseEvent {
-                kind: crossterm::event::MouseEventKind::Down(
-                    crossterm::event::MouseButton::Left,
-                ),
+                kind: crossterm::event::MouseEventKind::Down(crossterm::event::MouseButton::Left),
                 column: 4,
                 row,
                 modifiers: KeyModifiers::empty(),

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -6,12 +6,12 @@
 //! widgets - no state changes here, so a render can never be the reason
 //! something moved.
 //!
-//! Every step builds a [`Screen`]: flat lines, plus the line each selectable
+//! Every step builds a `Screen`: flat lines, plus the line each selectable
 //! row starts on. That shape is what makes the wizard survive a small window.
 //! The screens used to be `List`s of pre-sized items and assumed the terminal
 //! was tall enough, so the tuning screen's thirteen fields simply stopped at
 //! whatever row ran out of pane, with nothing on screen to say more existed.
-//! Wrapping happens here too, in [`wrap_line`], for the same reason: the
+//! Wrapping happens here too, in `wrap_line`, for the same reason: the
 //! number of rows a screen occupies is only knowable once its text is wrapped,
 //! and without that number there is nothing to scroll against.
 
@@ -86,7 +86,7 @@ fn picker_layout(inner: Rect, picker: &Picker) -> std::rc::Rc<[Rect]> {
 }
 
 /// Which option a click in the chooser landed on, as an index into the
-/// filtered list. Shares [`picker_layout`] with the drawing, so a click cannot
+/// filtered list. Shares `picker_layout` with the drawing, so a click cannot
 /// resolve against rows that were not on screen.
 pub fn picker_row_at(area: Rect, picker: &Picker, row: u16) -> Option<usize> {
     let popup = centered(80, 88, area);
@@ -1181,10 +1181,7 @@ mod tests {
         // is a whole run arriving with a row already broken under it.
         assert_eq!(wrapped_text(&Line::from("aaaa  bbbb"), 4), ["aaaa", "bbbb"]);
         assert_eq!(
-            wrapped_text(
-                &Line::from(vec![Span::raw("aaaa "), Span::raw(" bbbb")]),
-                4
-            ),
+            wrapped_text(&Line::from(vec![Span::raw("aaaa "), Span::raw(" bbbb")]), 4),
             ["aaaa", "bbbb"]
         );
         // Text ending exactly at a break leaves nothing to close.
@@ -1384,7 +1381,11 @@ mod tests {
     fn the_chooser_survives_a_short_window() {
         let (_dir, mut w) = wizard();
         w.enter(Step::Defaults);
-        w.open_picker("Default provider", w.defaults[0].value.options().to_vec(), 0);
+        w.open_picker(
+            "Default provider",
+            w.defaults[0].value.options().to_vec(),
+            0,
+        );
 
         let screen = rendered_at(&w, 70, 14);
         assert!(screen.contains("anthropic"), "{screen}");
@@ -1396,7 +1397,11 @@ mod tests {
     fn a_window_too_short_for_the_chooser_declines_to_draw_it() {
         let (_dir, mut w) = wizard();
         w.enter(Step::Defaults);
-        w.open_picker("Default provider", w.defaults[0].value.options().to_vec(), 0);
+        w.open_picker(
+            "Default provider",
+            w.defaults[0].value.options().to_vec(),
+            0,
+        );
         let picker = w.picker.as_ref().expect("open");
 
         // `draw` refuses to draw anything under its own floor, so this size

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -20,14 +20,15 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
+    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap},
 };
 
 use super::catalog::{self, Credential};
-use super::state::{FieldValue, Step, Wizard};
+use super::state::{FieldValue, Picker, Step, Wizard};
 use crate::tui::theme::*;
 use crate::tui::widgets::footer::{Hint, draw_hint_bar, hint};
 use crate::tui::widgets::help::{HelpSection, draw_help};
+use crate::tui::widgets::popup::{centered, popup_frame};
 
 /// The smallest window the wizard will try to draw in. Below this there is no
 /// honest layout left, and half a bordered pane reads as a broken program
@@ -64,9 +65,116 @@ pub fn draw(frame: &mut Frame, wizard: &Wizard) {
 
     if let Some(pending) = &wizard.confirm {
         pending.dialog.draw(frame, frame.area());
+    } else if let Some(picker) = &wizard.picker {
+        draw_picker(frame, frame.area(), picker);
     } else if wizard.show_help {
         draw_help(frame, frame.area(), &help_sections());
     }
+}
+
+/// The chooser's split: prose, search box, then the list with the rest.
+fn picker_layout(inner: Rect, picker: &Picker) -> std::rc::Rc<[Rect]> {
+    let explain = (picker.explain.len() as u16 + 2).min(inner.height.saturating_sub(4));
+    Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(explain),
+            Constraint::Length(2),
+            Constraint::Min(1),
+        ])
+        .split(inner)
+}
+
+/// Which option a click in the chooser landed on, as an index into the
+/// filtered list. Shares [`picker_layout`] with the drawing, so a click cannot
+/// resolve against rows that were not on screen.
+pub fn picker_row_at(area: Rect, picker: &Picker, row: u16) -> Option<usize> {
+    let popup = centered(80, 88, area);
+    // What `popup_frame` leaves after its border.
+    let inner = Block::default().borders(Borders::ALL).inner(popup);
+    if inner.height < 4 {
+        return None;
+    }
+    let list = picker_layout(inner, picker)[2];
+    if row < list.y || row >= list.y + list.height {
+        return None;
+    }
+    let height = list.height as usize;
+    let offset = picker.cursor.saturating_sub(height.saturating_sub(1));
+    let position = offset + (row - list.y) as usize;
+    (position < picker.matches().len()).then_some(position)
+}
+
+/// Draw the chooser over everything else.
+///
+/// It takes most of the window rather than a small popup: the whole complaint
+/// it answers is that a long list read through one line is unreadable, and the
+/// prose above it is the other half of the answer.
+fn draw_picker(frame: &mut Frame, area: Rect, picker: &Picker) {
+    let popup = centered(80, 88, area);
+    let inner = popup_frame(frame, popup, picker.title, C_BORDER_FOCUS);
+    if inner.height < 4 {
+        return;
+    }
+    let chunks = picker_layout(inner, picker);
+
+    let mut lines: Vec<Line<'static>> = picker
+        .explain
+        .iter()
+        .map(|text| Line::from(Span::styled(*text, Style::default().fg(C_MUTED))))
+        .collect();
+    lines.push(Line::from(""));
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), chunks[0]);
+
+    let mut search = vec![Span::styled("Search  ", Style::default().fg(C_DIM))];
+    search.extend(picker.query.display_spans(true).spans);
+    frame.render_widget(
+        Paragraph::new(vec![Line::from(search), Line::from("")]),
+        chunks[1],
+    );
+
+    let matches = picker.matches();
+    if matches.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "Nothing matches that.",
+                Style::default().fg(C_WARN),
+            ))),
+            chunks[2],
+        );
+        return;
+    }
+
+    let height = chunks[2].height as usize;
+    // Keep the cursor in view without a stored offset: the list is rebuilt
+    // every frame anyway, so the window into it is arithmetic, not state.
+    let offset = picker.cursor.saturating_sub(height.saturating_sub(1));
+    let rows: Vec<Line<'static>> = matches
+        .iter()
+        .enumerate()
+        .skip(offset)
+        .take(height)
+        .map(|(position, option)| {
+            let option = &picker.options[*option];
+            let selected = position == picker.cursor;
+            Line::from(vec![
+                Span::styled(
+                    if selected { "› " } else { "  " },
+                    Style::default().fg(C_ACCENT),
+                ),
+                Span::styled(
+                    format!("{:<38}", option.value),
+                    if selected {
+                        Style::default().fg(C_ACTIVE).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(C_WHITE)
+                    },
+                ),
+                Span::styled(option.detail.clone(), Style::default().fg(C_DIM)),
+            ])
+        })
+        .collect();
+    frame.render_widget(Paragraph::new(rows), chunks[2]);
 }
 
 /// The help overlay's content, matching the bindings in `input.rs`.
@@ -81,6 +189,7 @@ fn help_sections() -> [HelpSection; 3] {
                 ("← → / h l", "change a choice"),
                 ("space", "select / toggle"),
                 ("enter", "act on the focused row; Continue moves on"),
+                ("enter", "on a default, opens a searchable list"),
                 ("tab", "next screen"),
                 ("shift-tab / esc", "previous screen"),
             ],
@@ -936,6 +1045,14 @@ fn footer_hints(wizard: &Wizard) -> Vec<Hint> {
             hint("esc", "cancel"),
         ];
     }
+    if wizard.picker.is_some() {
+        return vec![
+            hint("type", "search"),
+            hint("↑↓", "move"),
+            hint("enter/click", "choose"),
+            hint("esc", "keep what it was"),
+        ];
+    }
     if wizard.edit.is_some() {
         return vec![
             hint("enter", "save"),
@@ -1206,6 +1323,47 @@ mod tests {
             !small.contains("\u{203a} Providers"),
             "the breadcrumb is what gives way first:\n{small}"
         );
+    }
+
+    /// The chooser draws its prose, its search box and its rows, and a filter
+    /// that matches nothing says so rather than showing an empty pane.
+    #[test]
+    fn the_chooser_draws_the_explanation_the_field_had_no_room_for() {
+        let (_dir, mut w) = wizard();
+        w.providers[0].selected = true;
+        w.providers[0].outcome = crate::commands::setup::verify::Outcome::Reachable {
+            models: vec!["claude-opus-4".to_string()],
+        };
+        w.enter(Step::Defaults);
+        w.cursor = 1;
+        w.open_picker(w.defaults[1].value.options().to_vec(), 0);
+
+        let screen = rendered(&w);
+        assert!(screen.contains("Default model"), "{screen}");
+        assert!(
+            screen.contains("never sent to a different provider"),
+            "the precedence prose is the point of the screen:\n{screen}"
+        );
+        assert!(screen.contains("claude-opus-4"), "{screen}");
+        assert!(screen.contains("Search"), "{screen}");
+
+        // Nothing matching is a state worth naming.
+        if let Some(picker) = w.picker.as_mut() {
+            picker.query = crate::tui::widgets::line_edit::LineEdit::new("zzz", false);
+        }
+        assert!(rendered(&w).contains("Nothing matches that."));
+    }
+
+    /// The chooser fills most of the window, so a short one still gets a list
+    /// rather than only a heading.
+    #[test]
+    fn the_chooser_survives_a_short_window() {
+        let (_dir, mut w) = wizard();
+        w.enter(Step::Defaults);
+        w.open_picker(w.defaults[0].value.options().to_vec(), 0);
+
+        let screen = rendered_at(&w, 70, 14);
+        assert!(screen.contains("anthropic"), "{screen}");
     }
 
     fn wizard() -> (tempfile::TempDir, Wizard) {

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -55,20 +55,8 @@ pub fn draw(frame: &mut Frame, wizard: &Wizard) {
         return;
     }
 
-    // The breadcrumb is the first thing to go on a short window. It says where
-    // you are, which the body's own title also says, so spending three of
-    // twelve rows on it costs more than it tells you.
-    let header = if area.height >= 14 { 3 } else { 0 };
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(header),
-            Constraint::Min(3),
-            Constraint::Length(3),
-        ])
-        .split(area);
-
-    if header > 0 {
+    let chunks = body_layout(area);
+    if chunks[0].height > 0 {
         draw_header(frame, chunks[0], wizard);
     }
     draw_body(frame, chunks[1], wizard);
@@ -120,21 +108,7 @@ fn help_sections() -> [HelpSection; 3] {
 
 /// The step's Continue/action button, rendered as the last cursor row.
 fn continue_line(wizard: &Wizard) -> Line<'static> {
-    let focused = wizard.on_continue();
-    let style = if focused {
-        Style::default()
-            .fg(C_ACCENT)
-            .add_modifier(Modifier::BOLD | Modifier::REVERSED)
-    } else {
-        Style::default().fg(C_MUTED)
-    };
-    Line::from(vec![
-        Span::styled(
-            if focused { "› " } else { "  " },
-            Style::default().fg(C_ACCENT),
-        ),
-        Span::styled(format!("[ {} ]", wizard.continue_label()), style),
-    ])
+    button_line(&wizard.continue_label(), wizard.on_continue())
 }
 
 /// The step breadcrumb.
@@ -227,7 +201,71 @@ fn draw_body(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    let screen = match wizard.step {
+    draw_screen(
+        frame,
+        inner,
+        area,
+        &build_screen(wizard).wrapped(inner.width as usize),
+        wizard,
+    );
+}
+
+/// Which selectable row, if any, sits under a point in the window.
+///
+/// This rebuilds the layout the last frame used rather than remembering it.
+/// A stored layout would make drawing a state change, and the wizard's one
+/// rule is that a render never moves anything; rebuilding costs a screenful of
+/// lines on a click, which is not a cost worth trading that rule for.
+pub fn row_at(area: Rect, wizard: &Wizard, column: u16, row: u16) -> Option<usize> {
+    if area.width < MIN_WIDTH || area.height < MIN_HEIGHT {
+        return None;
+    }
+    let chunks = body_layout(area);
+    let block = Block::default().borders(Borders::ALL);
+    let inner = block.inner(chunks[1]);
+    if column < inner.x
+        || column >= inner.x + inner.width
+        || row < inner.y
+        || row >= inner.y + inner.height
+    {
+        return None;
+    }
+
+    let screen = build_screen(wizard).wrapped(inner.width as usize);
+    let offset = first_visible(&screen, wizard, inner.height as usize);
+    let line = offset + (row - inner.y) as usize;
+    // The row that owns this line is the last one starting at or before it,
+    // and only if the line is still inside the screen's content.
+    if line >= screen.lines.len() {
+        return None;
+    }
+    screen
+        .rows
+        .iter()
+        .rposition(|start| *start <= line)
+        .filter(|_| screen.rows.first().is_some_and(|first| *first <= line))
+}
+
+/// The header/body/footer split, shared by drawing and hit-testing so a click
+/// can never land on a layout the frame did not use.
+fn body_layout(area: Rect) -> std::rc::Rc<[Rect]> {
+    // The breadcrumb is the first thing to go on a short window. It says where
+    // you are, which the body's own title also says, so spending three of
+    // twelve rows on it costs more than it tells you.
+    let header = if area.height >= 14 { 3 } else { 0 };
+    Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(header),
+            Constraint::Min(3),
+            Constraint::Length(3),
+        ])
+        .split(area)
+}
+
+/// The current step's content, before wrapping.
+fn build_screen(wizard: &Wizard) -> Screen {
+    match wizard.step {
         Step::Welcome => build_welcome(wizard),
         Step::Providers => build_providers(wizard),
         Step::ProviderDetail => build_provider_detail(wizard),
@@ -235,8 +273,7 @@ fn draw_body(frame: &mut Frame, area: Rect, wizard: &Wizard) {
         Step::Agents => build_agents(wizard),
         Step::Mcp => build_mcp(wizard),
         Step::Review => build_review(wizard),
-    };
-    draw_screen(frame, inner, area, &screen.wrapped(inner.width as usize), wizard);
+    }
 }
 
 /// Total width of a styled line, counted the way [`wrap_line`] counts.
@@ -280,7 +317,11 @@ fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
         .spans
         .first()
         .map_or(0, |s| s.content.chars().take_while(|c| *c == ' ').count());
-    let indent_len = if indent_len * 2 >= width { 0 } else { indent_len };
+    let indent_len = if indent_len * 2 >= width {
+        0
+    } else {
+        indent_len
+    };
 
     let mut out: Vec<Line<'static>> = Vec::new();
     let mut current: Vec<Span<'static>> = Vec::new();
@@ -341,7 +382,11 @@ fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
     }
     // The break stands in for the space it happened at, so no row ends in one.
     for line in &mut out {
-        while line.spans.len() > 1 && line.spans.last().is_some_and(|s| s.content.trim().is_empty())
+        while line.spans.len() > 1
+            && line
+                .spans
+                .last()
+                .is_some_and(|s| s.content.trim().is_empty())
         {
             line.spans.pop();
         }
@@ -561,7 +606,7 @@ fn build_provider_detail(wizard: &Wizard) -> Screen {
                 )));
             }
             lines.push(Line::from(Span::styled(
-                "Enter to edit.  Ctrl-R shows it.  o opens the signup page.  v re-checks.",
+                "Enter or click to edit.  Ctrl-R shows what you typed.",
                 Style::default().fg(C_DIM),
             )));
         }
@@ -596,12 +641,38 @@ fn build_provider_detail(wizard: &Wizard) -> Screen {
 
     lines.push(Line::from(""));
     lines.push(status_line(wizard, index));
+    lines.push(Line::from(""));
 
-    Screen {
+    let mut screen = Screen {
         lines,
         rows: vec![credential_row],
+    };
+    for (offset, action) in wizard.detail_actions().iter().enumerate() {
+        // Row 0 is the credential itself, so the actions start after it.
+        let focused = wizard.cursor == offset + 1;
+        screen.row();
+        screen.push(button_line(&action.label(row.provider.display), focused));
     }
-    .finish(wizard)
+    screen.finish(wizard)
+}
+
+/// A clickable action, drawn the same way the Continue button is so that what
+/// can be pressed looks like one thing.
+fn button_line(label: &str, focused: bool) -> Line<'static> {
+    let style = if focused {
+        Style::default()
+            .fg(C_ACCENT)
+            .add_modifier(Modifier::BOLD | Modifier::REVERSED)
+    } else {
+        Style::default().fg(C_MUTED)
+    };
+    Line::from(vec![
+        Span::styled(
+            if focused { "› " } else { "  " },
+            Style::default().fg(C_ACCENT),
+        ),
+        Span::styled(format!("[ {label} ]"), style),
+    ])
 }
 
 /// What to print in place of a credential when it is not being edited.
@@ -1019,7 +1090,11 @@ mod tests {
         assert_eq!(
             wrapped
                 .iter()
-                .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect::<String>())
+                .map(|l| l
+                    .spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>())
                 .collect::<Vec<_>>(),
             ["name", "value"]
         );

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -5,13 +5,22 @@
 //! optional help overlay on top. Every function takes `&Wizard` and produces
 //! widgets - no state changes here, so a render can never be the reason
 //! something moved.
+//!
+//! Every step builds a [`Screen`]: flat lines, plus the line each selectable
+//! row starts on. That shape is what makes the wizard survive a small window.
+//! The screens used to be `List`s of pre-sized items and assumed the terminal
+//! was tall enough, so the tuning screen's thirteen fields simply stopped at
+//! whatever row ran out of pane, with nothing on screen to say more existed.
+//! Wrapping happens here too, in [`wrap_line`], for the same reason: the
+//! number of rows a screen occupies is only knowable once its text is wrapped,
+//! and without that number there is nothing to scroll against.
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
 };
 
 use super::catalog::{self, Credential};
@@ -20,18 +29,48 @@ use crate::tui::theme::*;
 use crate::tui::widgets::footer::{Hint, draw_hint_bar, hint};
 use crate::tui::widgets::help::{HelpSection, draw_help};
 
+/// The smallest window the wizard will try to draw in. Below this there is no
+/// honest layout left, and half a bordered pane reads as a broken program
+/// rather than a small one.
+const MIN_WIDTH: u16 = 24;
+const MIN_HEIGHT: u16 = 6;
+
 /// Draw one frame.
 pub fn draw(frame: &mut Frame, wizard: &Wizard) {
+    let area = frame.area();
+    if area.width < MIN_WIDTH || area.height < MIN_HEIGHT {
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "Window too small",
+                    Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
+                )),
+                Line::from(Span::styled(
+                    format!("Need {MIN_WIDTH}x{MIN_HEIGHT}"),
+                    Style::default().fg(C_MUTED),
+                )),
+            ]),
+            area,
+        );
+        return;
+    }
+
+    // The breadcrumb is the first thing to go on a short window. It says where
+    // you are, which the body's own title also says, so spending three of
+    // twelve rows on it costs more than it tells you.
+    let header = if area.height >= 14 { 3 } else { 0 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
-            Constraint::Length(3),
-            Constraint::Min(5),
+            Constraint::Length(header),
+            Constraint::Min(3),
             Constraint::Length(3),
         ])
-        .split(frame.area());
+        .split(area);
 
-    draw_header(frame, chunks[0], wizard);
+    if header > 0 {
+        draw_header(frame, chunks[0], wizard);
+    }
     draw_body(frame, chunks[1], wizard);
     draw_footer(frame, chunks[2], wizard);
 
@@ -49,6 +88,8 @@ fn help_sections() -> [HelpSection; 3] {
             title: "Navigate",
             entries: vec![
                 ("↑ ↓ / k j", "move"),
+                ("pgup / pgdn", "scroll a page"),
+                ("home / end", "first row / the button"),
                 ("← → / h l", "change a choice"),
                 ("space", "select / toggle"),
                 ("enter", "act on the focused row; Continue moves on"),
@@ -127,6 +168,56 @@ fn draw_header(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     );
 }
 
+/// One step's content: flat lines, plus where each selectable row begins.
+///
+/// The row index is what lets scrolling follow the selection. A `List` tracks
+/// that itself, but its items cannot wrap, and a wizard row is a label and a
+/// help line that both have to fold on a narrow window.
+#[derive(Default)]
+struct Screen {
+    lines: Vec<Line<'static>>,
+    /// First line of each selectable row, in cursor order. The last entry is
+    /// always the Continue button, matching [`Wizard::nav_rows`].
+    rows: Vec<usize>,
+}
+
+impl Screen {
+    /// Mark the next line as the start of the next selectable row.
+    fn row(&mut self) {
+        self.rows.push(self.lines.len());
+    }
+
+    fn push(&mut self, line: Line<'static>) {
+        self.lines.push(line);
+    }
+
+    fn blank(&mut self) {
+        self.lines.push(Line::from(""));
+    }
+
+    /// Close the screen with its Continue button, which every step has.
+    fn finish(mut self, wizard: &Wizard) -> Self {
+        self.blank();
+        self.row();
+        self.push(continue_line(wizard));
+        self
+    }
+
+    /// Re-flow to `width`, keeping the row markers pointing at the same rows.
+    fn wrapped(self, width: usize) -> Self {
+        let mut out = Screen::default();
+        let mut rows = self.rows.iter().peekable();
+        for (index, line) in self.lines.iter().enumerate() {
+            while rows.peek().is_some_and(|start| **start == index) {
+                rows.next();
+                out.row();
+            }
+            out.lines.extend(wrap_line(line, width));
+        }
+        out
+    }
+}
+
 /// The step's own content.
 fn draw_body(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     let block = Block::default()
@@ -136,18 +227,189 @@ fn draw_body(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    match wizard.step {
-        Step::Welcome => draw_welcome(frame, inner, wizard),
-        Step::Providers => draw_providers(frame, inner, wizard),
-        Step::ProviderDetail => draw_provider_detail(frame, inner, wizard),
-        Step::Defaults | Step::Limits => draw_fields(frame, inner, wizard),
-        Step::Agents => draw_agents(frame, inner, wizard),
-        Step::Mcp => draw_mcp(frame, inner, wizard),
-        Step::Review => draw_review(frame, inner, wizard),
+    let screen = match wizard.step {
+        Step::Welcome => build_welcome(wizard),
+        Step::Providers => build_providers(wizard),
+        Step::ProviderDetail => build_provider_detail(wizard),
+        Step::Defaults | Step::Limits => build_fields(wizard),
+        Step::Agents => build_agents(wizard),
+        Step::Mcp => build_mcp(wizard),
+        Step::Review => build_review(wizard),
+    };
+    draw_screen(frame, inner, area, &screen.wrapped(inner.width as usize), wizard);
+}
+
+/// Total width of a styled line, counted the way [`wrap_line`] counts.
+fn line_width(line: &Line<'_>) -> usize {
+    line.spans.iter().map(|s| s.content.chars().count()).sum()
+}
+
+/// Split into alternating runs of whitespace and non-whitespace, so wrapping
+/// can keep column padding that fits and drop it at a break.
+fn runs(text: &str) -> Vec<&str> {
+    let mut out = Vec::new();
+    let mut rest = text;
+    while !rest.is_empty() {
+        let blank = rest.starts_with(char::is_whitespace);
+        let end = rest
+            .char_indices()
+            .find(|(_, c)| c.is_whitespace() != blank)
+            .map_or(rest.len(), |(i, _)| i);
+        let (head, tail) = rest.split_at(end);
+        out.push(head);
+        rest = tail;
+    }
+    out
+}
+
+/// Word-wrap a styled line to `width`, keeping every span's style and
+/// indenting continuations to the line's own leading spaces.
+///
+/// `Paragraph`'s `Wrap` would fold the text, but only inside the widget: the
+/// caller never learns how many rows came out, and the wizard needs that
+/// number to scroll. Wrapping up front means the row count and the scroll
+/// offset are the same units.
+fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
+    let width = width.max(1);
+    if line_width(line) <= width {
+        return vec![line.clone()];
+    }
+    // A hanging indent keeps a wrapped help line reading as one item, but only
+    // when it leaves most of the width for text.
+    let indent_len = line
+        .spans
+        .first()
+        .map_or(0, |s| s.content.chars().take_while(|c| *c == ' ').count());
+    let indent_len = if indent_len * 2 >= width { 0 } else { indent_len };
+
+    let mut out: Vec<Line<'static>> = Vec::new();
+    let mut current: Vec<Span<'static>> = Vec::new();
+    let mut used = 0usize;
+    let mut has_word = false;
+
+    for span in &line.spans {
+        for run in runs(&span.content) {
+            let blank = run.starts_with(char::is_whitespace);
+            // Whitespace that a break already stood in for.
+            if blank && !has_word && !out.is_empty() {
+                continue;
+            }
+            let mut piece = run;
+            loop {
+                let len = piece.chars().count();
+                if used + len <= width {
+                    current.push(Span::styled(piece.to_string(), span.style));
+                    used += len;
+                    has_word |= !blank;
+                    break;
+                }
+                if has_word {
+                    out.push(Line::from(std::mem::take(&mut current)));
+                    used = indent_len;
+                    has_word = false;
+                    if indent_len > 0 {
+                        current.push(Span::raw(" ".repeat(indent_len)));
+                    }
+                    // The break stands in for the space that did not fit.
+                    if blank {
+                        break;
+                    }
+                    continue;
+                }
+                // A single word wider than the pane, on a line with nothing
+                // else on it: hard-break it at a char boundary. `used` is the
+                // indent here, which is strictly under `width`, so there is
+                // always at least one character of room.
+                let cut = piece
+                    .char_indices()
+                    .nth(width - used)
+                    .map(|(i, _)| i)
+                    .expect("infallible: the run is longer than the room left");
+                let (head, tail) = piece.split_at(cut);
+                current.push(Span::styled(head.to_string(), span.style));
+                out.push(Line::from(std::mem::take(&mut current)));
+                used = indent_len;
+                if indent_len > 0 {
+                    current.push(Span::raw(" ".repeat(indent_len)));
+                }
+                piece = tail;
+            }
+        }
+    }
+    if !current.is_empty() {
+        out.push(Line::from(current));
+    }
+    // The break stands in for the space it happened at, so no row ends in one.
+    for line in &mut out {
+        while line.spans.len() > 1 && line.spans.last().is_some_and(|s| s.content.trim().is_empty())
+        {
+            line.spans.pop();
+        }
+        if let Some(last) = line.spans.last_mut() {
+            last.content = last.content.trim_end().to_string().into();
+        }
+    }
+    out
+}
+
+/// The first line to show, given where the user last scrolled and where the
+/// cursor is.
+///
+/// The cursor wins. `wizard.scroll` is what the wheel and the page keys move,
+/// but a selection the user cannot see is worse than a lost scroll position,
+/// so an off-screen cursor pulls the viewport back to it.
+fn first_visible(screen: &Screen, wizard: &Wizard, height: usize) -> usize {
+    let total = screen.lines.len();
+    let max = total.saturating_sub(height);
+    let mut offset = wizard.scroll.min(max);
+    let Some(&start) = screen.rows.get(wizard.cursor) else {
+        return offset;
+    };
+    // The row runs to the start of the next one, so a two-line field scrolls
+    // into view whole rather than showing its label with the help cut off.
+    let end = screen
+        .rows
+        .get(wizard.cursor + 1)
+        .copied()
+        .unwrap_or(total)
+        .max(start + 1);
+    if start < offset {
+        offset = start;
+    } else if end > offset + height {
+        offset = end.saturating_sub(height).min(start);
+    }
+    offset
+}
+
+/// Render a built screen into `inner`, with a scrollbar on `outer`'s border
+/// when there is more than fits.
+fn draw_screen(frame: &mut Frame, inner: Rect, outer: Rect, screen: &Screen, wizard: &Wizard) {
+    // At least one row: the floor in `draw` leaves the body three rows and its
+    // border takes two.
+    let height = inner.height as usize;
+    let offset = first_visible(screen, wizard, height);
+    frame.render_widget(
+        Paragraph::new(screen.lines.clone()).scroll((offset.min(u16::MAX as usize) as u16, 0)),
+        inner,
+    );
+
+    let total = screen.lines.len();
+    if total > height {
+        let mut state = ScrollbarState::new(total - height).position(offset);
+        frame.render_stateful_widget(
+            Scrollbar::new(ScrollbarOrientation::VerticalRight)
+                .begin_symbol(Some("↑"))
+                .end_symbol(Some("↓")),
+            outer.inner(Margin {
+                vertical: 1,
+                horizontal: 0,
+            }),
+            &mut state,
+        );
     }
 }
 
-fn draw_welcome(frame: &mut Frame, area: Rect, wizard: &Wizard) {
+fn build_welcome(wizard: &Wizard) -> Screen {
     let configured: Vec<&str> = wizard
         .providers
         .iter()
@@ -197,110 +459,51 @@ fn draw_welcome(frame: &mut Frame, area: Rect, wizard: &Wizard) {
         "Nothing is written until the last screen.",
         Style::default().fg(C_DIM),
     )));
-    lines.push(Line::from(""));
-    lines.push(continue_line(wizard));
 
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+    Screen {
+        lines,
+        rows: Vec::new(),
+    }
+    .finish(wizard)
 }
 
-/// Greedy word-wrap for plain text rendered inside `List` items, which
-/// (unlike `Paragraph`) cannot wrap. Words longer than `width` break at a
-/// character boundary rather than overflowing.
-fn wrap_plain(text: &str, width: usize) -> Vec<String> {
-    let width = width.max(1);
-    let mut lines = Vec::new();
-    let mut current = String::new();
-    for word in text.split_whitespace() {
-        let mut word = word;
-        loop {
-            let need = if current.is_empty() {
-                word.chars().count()
-            } else {
-                current.chars().count() + 1 + word.chars().count()
-            };
-            if need <= width {
-                if !current.is_empty() {
-                    current.push(' ');
-                }
-                current.push_str(word);
-                break;
-            }
-            if current.is_empty() {
-                // A single word wider than the pane: hard-break it after
-                // `width` characters (a char boundary by construction).
-                // This branch is only reachable when the word has more than
-                // `width` chars (a shorter word takes the fits-branch above),
-                // so the boundary at char `width` always exists.
-                let cut = word
-                    .char_indices()
-                    .nth(width)
-                    .map(|(i, _)| i)
-                    .expect("infallible: the word is longer than width chars");
-                let (head, tail) = word.split_at(cut);
-                lines.push(head.to_string());
-                // The cut is strictly inside the word, so the tail is never
-                // empty; the loop re-tests it against the width.
-                word = tail;
-            } else {
-                lines.push(std::mem::take(&mut current));
-            }
+fn build_providers(wizard: &Wizard) -> Screen {
+    let mut screen = Screen::default();
+    for (index, row) in wizard.providers.iter().enumerate() {
+        let mark = if row.selected {
+            GLYPH_COMPLETE
+        } else {
+            GLYPH_PENDING
+        };
+        let mut spans = vec![
+            Span::styled(
+                format!("{mark} "),
+                Style::default().fg(if row.selected { C_SUCCESS } else { C_DIM }),
+            ),
+            Span::styled(row.provider.display, name_style(index == wizard.cursor)),
+        ];
+        if let Some(var) = row.from_env {
+            spans.push(Span::styled(
+                format!("  (${var})"),
+                Style::default().fg(C_WARN),
+            ));
+        } else if !row.value.is_empty() {
+            spans.push(Span::styled("  (set)", Style::default().fg(C_MUTED)));
         }
+        screen.row();
+        screen.push(Line::from(spans));
+        screen.push(Line::from(Span::styled(
+            format!("    {}", row.provider.blurb),
+            Style::default().fg(C_DIM),
+        )));
     }
-    if !current.is_empty() {
-        lines.push(current);
-    }
-    lines
+    screen.finish(wizard)
 }
 
-fn draw_providers(frame: &mut Frame, area: Rect, wizard: &Wizard) {
-    let mut items: Vec<ListItem> = wizard
-        .providers
-        .iter()
-        .enumerate()
-        .map(|(index, row)| {
-            let mark = if row.selected {
-                GLYPH_COMPLETE
-            } else {
-                GLYPH_PENDING
-            };
-            let mut spans = vec![
-                Span::styled(
-                    format!("{mark} "),
-                    Style::default().fg(if row.selected { C_SUCCESS } else { C_DIM }),
-                ),
-                Span::styled(row.provider.display, name_style(index == wizard.cursor)),
-            ];
-            if let Some(var) = row.from_env {
-                spans.push(Span::styled(
-                    format!("  (${var})"),
-                    Style::default().fg(C_WARN),
-                ));
-            } else if !row.value.is_empty() {
-                spans.push(Span::styled("  (set)", Style::default().fg(C_MUTED)));
-            }
-            let mut item_lines = vec![Line::from(spans)];
-            // Word-wrap the blurb to the pane: `List` does not wrap, so a
-            // long description on a narrow window would otherwise clip
-            // mid-sentence with nothing to say more text exists.
-            for chunk in wrap_plain(row.provider.blurb, area.width.saturating_sub(6) as usize) {
-                item_lines.push(Line::from(Span::styled(
-                    format!("    {chunk}"),
-                    Style::default().fg(C_DIM),
-                )));
-            }
-            ListItem::new(item_lines)
-        })
-        .collect();
-    items.push(ListItem::new(vec![Line::from(""), continue_line(wizard)]));
-
-    frame.render_widget(List::new(items), area);
-}
-
-fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
+fn build_provider_detail(wizard: &Wizard) -> Screen {
     let Some(index) = wizard.detail_row() else {
         // Forced onto an empty credential screen (tests do): only the button.
-        frame.render_widget(Paragraph::new(vec![continue_line(wizard)]), area);
-        return;
+        return Screen::default().finish(wizard);
     };
     // `detail_row` yields an index into `providers`, so this is a read rather
     // than a lookup that could miss.
@@ -329,6 +532,7 @@ fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
     // The credential (or effort) row is the screen's one cursor row; the
     // marker shows whether it or the Continue button holds focus.
     let row_marker = if wizard.on_continue() { "  " } else { "› " };
+    let credential_row = lines.len();
     match row.provider.credential {
         Credential::ApiKey | Credential::BaseUrl => {
             let label = if row.provider.credential == Credential::ApiKey {
@@ -392,10 +596,12 @@ fn draw_provider_detail(frame: &mut Frame, area: Rect, wizard: &Wizard) {
 
     lines.push(Line::from(""));
     lines.push(status_line(wizard, index));
-    lines.push(Line::from(""));
-    lines.push(continue_line(wizard));
 
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+    Screen {
+        lines,
+        rows: vec![credential_row],
+    }
+    .finish(wizard)
 }
 
 /// What to print in place of a credential when it is not being edited.
@@ -439,161 +645,142 @@ fn status_line(wizard: &Wizard, index: usize) -> Line<'static> {
     }
 }
 
-fn draw_fields(frame: &mut Frame, area: Rect, wizard: &Wizard) {
-    let mut items: Vec<ListItem> = wizard
-        .fields()
-        .iter()
-        .enumerate()
-        .map(|(index, field)| {
-            let selected = index == wizard.cursor;
-            let hint = match &field.value {
-                FieldValue::Bool(_) => "enter/space",
-                FieldValue::Choice { .. } => "enter/← →",
-                _ => "enter",
-            };
-            let mut spans = vec![
-                Span::styled(
-                    if selected { "› " } else { "  " },
-                    Style::default().fg(C_ACCENT),
-                ),
-                Span::styled(format!("{:<28}", field.label), name_style(selected)),
-            ];
-            match &wizard.edit {
-                Some(edit) if edit.target == super::state::EditTarget::Field(index) => {
-                    spans.extend(edit.line.display_spans(wizard.reveal).spans);
-                }
-                _ => spans.push(Span::styled(
-                    field.value.display(),
-                    Style::default().fg(C_ACCENT),
-                )),
+fn build_fields(wizard: &Wizard) -> Screen {
+    let mut screen = Screen::default();
+    for (index, field) in wizard.fields().iter().enumerate() {
+        let selected = index == wizard.cursor;
+        let hint = match &field.value {
+            FieldValue::Bool(_) => "enter/space",
+            FieldValue::Choice { .. } => "enter/← →",
+            _ => "enter",
+        };
+        let mut spans = vec![
+            Span::styled(
+                if selected { "› " } else { "  " },
+                Style::default().fg(C_ACCENT),
+            ),
+            Span::styled(format!("{:<28}", field.label), name_style(selected)),
+        ];
+        match &wizard.edit {
+            Some(edit) if edit.target == super::state::EditTarget::Field(index) => {
+                spans.extend(edit.line.display_spans(wizard.reveal).spans);
             }
-            spans.push(Span::styled(
-                format!("   [{hint}]"),
+            _ => spans.push(Span::styled(
+                field.value.display(),
+                Style::default().fg(C_ACCENT),
+            )),
+        }
+        spans.push(Span::styled(
+            format!("   [{hint}]"),
+            Style::default().fg(C_DIM),
+        ));
+        screen.row();
+        screen.push(Line::from(spans));
+        screen.push(Line::from(Span::styled(
+            format!("    {}", field.help),
+            Style::default().fg(C_DIM),
+        )));
+    }
+    screen.finish(wizard)
+}
+
+fn build_agents(wizard: &Wizard) -> Screen {
+    let mut screen = Screen::default();
+    for (index, row) in wizard.agents.iter().enumerate() {
+        let mark = if row.selected {
+            GLYPH_COMPLETE
+        } else {
+            GLYPH_PENDING
+        };
+        let action = row.action.label(row.agent.version);
+        // Dim for "nothing to do", and for a locally edited install too:
+        // it is offered, not urged, because reinstalling destroys the edit.
+        let action_style = if row.action.preselect() {
+            Style::default().fg(C_ACCENT)
+        } else {
+            Style::default().fg(C_DIM)
+        };
+        screen.row();
+        screen.push(Line::from(vec![
+            Span::styled(
+                format!("{mark} "),
+                Style::default().fg(if row.selected { C_SUCCESS } else { C_DIM }),
+            ),
+            Span::styled(
+                format!("{:<22}", row.agent.name),
+                name_style(index == wizard.cursor),
+            ),
+            Span::styled(action, action_style),
+        ]));
+    }
+    screen.finish(wizard)
+}
+
+fn build_mcp(wizard: &Wizard) -> Screen {
+    let mut screen = Screen::default();
+    for (index, row) in wizard.mcp.iter().enumerate() {
+        let mark = if row.selected {
+            GLYPH_COMPLETE
+        } else {
+            GLYPH_PENDING
+        };
+        let mut detail = vec![Span::styled(
+            format!("    from {}", row.source),
+            Style::default().fg(C_DIM),
+        )];
+        if !row.candidate.scope.is_empty() {
+            detail.push(Span::styled(
+                format!(" · {}", row.candidate.scope),
                 Style::default().fg(C_DIM),
             ));
-            ListItem::new(vec![
-                Line::from(spans),
-                Line::from(Span::styled(
-                    format!("    {}", field.help),
-                    Style::default().fg(C_DIM),
-                )),
-            ])
-        })
-        .collect();
-    items.push(ListItem::new(vec![Line::from(""), continue_line(wizard)]));
-
-    frame.render_widget(List::new(items), area);
-}
-
-fn draw_agents(frame: &mut Frame, area: Rect, wizard: &Wizard) {
-    let mut items: Vec<ListItem> = wizard
-        .agents
-        .iter()
-        .enumerate()
-        .map(|(index, row)| {
-            let mark = if row.selected {
-                GLYPH_COMPLETE
-            } else {
-                GLYPH_PENDING
-            };
-            let action = row.action.label(row.agent.version);
-            // Dim for "nothing to do", and for a locally edited install too:
-            // it is offered, not urged, because reinstalling destroys the edit.
-            let action_style = if row.action.preselect() {
-                Style::default().fg(C_ACCENT)
-            } else {
-                Style::default().fg(C_DIM)
-            };
-            ListItem::new(Line::from(vec![
-                Span::styled(
-                    format!("{mark} "),
-                    Style::default().fg(if row.selected { C_SUCCESS } else { C_DIM }),
+        }
+        if row.collides {
+            detail.push(Span::styled(
+                format!(" · already configured; would be added as {}", row.name),
+                Style::default().fg(C_WARN),
+            ));
+        }
+        if !row.candidate.inline_secrets.is_empty() {
+            detail.push(Span::styled(
+                format!(
+                    " · carries a literal secret in {}",
+                    row.candidate.inline_secrets.join(", ")
                 ),
-                Span::styled(
-                    format!("{:<22}", row.agent.name),
-                    name_style(index == wizard.cursor),
-                ),
-                Span::styled(action, action_style),
-            ]))
-        })
-        .collect();
-    items.push(ListItem::new(vec![Line::from(""), continue_line(wizard)]));
-
-    frame.render_widget(List::new(items), area);
-}
-
-fn draw_mcp(frame: &mut Frame, area: Rect, wizard: &Wizard) {
-    let mut items: Vec<ListItem> = wizard
-        .mcp
-        .iter()
-        .enumerate()
-        .map(|(index, row)| {
-            let mark = if row.selected {
-                GLYPH_COMPLETE
-            } else {
-                GLYPH_PENDING
-            };
-            let mut detail = vec![Span::styled(
-                format!("    from {}", row.source),
-                Style::default().fg(C_DIM),
-            )];
-            if !row.candidate.scope.is_empty() {
-                detail.push(Span::styled(
-                    format!(" · {}", row.candidate.scope),
-                    Style::default().fg(C_DIM),
-                ));
-            }
-            if row.collides {
-                detail.push(Span::styled(
-                    format!(" · already configured; would be added as {}", row.name),
-                    Style::default().fg(C_WARN),
-                ));
-            }
-            if !row.candidate.inline_secrets.is_empty() {
-                detail.push(Span::styled(
-                    format!(
-                        " · carries a literal secret in {}",
-                        row.candidate.inline_secrets.join(", ")
-                    ),
-                    Style::default().fg(C_WARN),
-                ));
-            }
-            let endpoint = row
-                .candidate
-                .config
-                .url
-                .clone()
-                .or_else(|| row.candidate.config.command.clone())
-                .unwrap_or_default();
-            ListItem::new(vec![
-                Line::from(vec![
-                    Span::styled(
-                        format!("{mark} "),
-                        Style::default().fg(if row.selected { C_SUCCESS } else { C_DIM }),
-                    ),
-                    Span::styled(
-                        format!("{:<22}", row.candidate.config.name),
-                        name_style(index == wizard.cursor),
-                    ),
-                    Span::styled(endpoint, Style::default().fg(C_MUTED)),
-                ]),
-                Line::from(detail),
-            ])
-        })
-        .collect();
+                Style::default().fg(C_WARN),
+            ));
+        }
+        let endpoint = row
+            .candidate
+            .config
+            .url
+            .clone()
+            .or_else(|| row.candidate.config.command.clone())
+            .unwrap_or_default();
+        screen.row();
+        screen.push(Line::from(vec![
+            Span::styled(
+                format!("{mark} "),
+                Style::default().fg(if row.selected { C_SUCCESS } else { C_DIM }),
+            ),
+            Span::styled(
+                format!("{:<22}", row.candidate.config.name),
+                name_style(index == wizard.cursor),
+            ),
+            Span::styled(endpoint, Style::default().fg(C_MUTED)),
+        ]));
+        screen.push(Line::from(detail));
+    }
 
     for error in &wizard.mcp_scan_errors {
-        items.push(ListItem::new(Line::from(Span::styled(
+        screen.push(Line::from(Span::styled(
             format!("{GLYPH_ERROR} {error}"),
             Style::default().fg(C_WARN),
-        ))));
+        )));
     }
-    items.push(ListItem::new(vec![Line::from(""), continue_line(wizard)]));
-
-    frame.render_widget(List::new(items), area);
+    screen.finish(wizard)
 }
 
-fn draw_review(frame: &mut Frame, area: Rect, wizard: &Wizard) {
+fn build_review(wizard: &Wizard) -> Screen {
     let mut lines = vec![Line::from(Span::styled(
         "About to write:",
         Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
@@ -662,10 +849,11 @@ fn draw_review(frame: &mut Frame, area: Rect, wizard: &Wizard) {
         }
     }
 
-    lines.push(Line::from(""));
-    lines.push(continue_line(wizard));
-
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), area);
+    Screen {
+        lines,
+        rows: Vec::new(),
+    }
+    .finish(wizard)
 }
 
 /// The footer's key hints for the wizard's current mode.
@@ -773,22 +961,176 @@ mod tests {
         );
     }
 
+    /// The text of one wrapped line, span styles collapsed away.
+    fn wrapped_text(line: &Line<'static>, width: usize) -> Vec<String> {
+        wrap_line(line, width)
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect()
+    }
+
     #[test]
-    fn wrap_plain_wraps_at_word_boundaries_and_hard_breaks_long_words() {
-        assert_eq!(
-            wrap_plain("alpha beta gamma", 11),
-            vec!["alpha beta", "gamma"]
-        );
+    fn wrap_line_breaks_at_words_and_hard_breaks_one_that_never_fits() {
+        let plain = Line::from("alpha beta gamma");
+        assert_eq!(wrapped_text(&plain, 11), ["alpha beta", "gamma"]);
+        // Nothing to do when it already fits, and the line comes back whole.
+        assert_eq!(wrapped_text(&plain, 40), ["alpha beta gamma"]);
         // One word wider than the pane hard-breaks by characters.
-        assert_eq!(wrap_plain("abcdefghij", 4), vec!["abcd", "efgh", "ij"]);
+        assert_eq!(
+            wrapped_text(&Line::from("abcdefghij"), 4),
+            ["abcd", "efgh", "ij"]
+        );
         // Multibyte characters break on char boundaries, never mid-character.
         assert_eq!(
-            wrap_plain("\u{65e5}\u{672c}\u{8a9e}\u{3067}\u{3059}", 2),
-            vec!["\u{65e5}\u{672c}", "\u{8a9e}\u{3067}", "\u{3059}"]
+            wrapped_text(&Line::from("\u{65e5}\u{672c}\u{8a9e}\u{3067}\u{3059}"), 2),
+            ["\u{65e5}\u{672c}", "\u{8a9e}\u{3067}", "\u{3059}"]
         );
-        assert!(wrap_plain("", 10).is_empty());
-        // A degenerate zero width still terminates and yields one char per line.
-        assert_eq!(wrap_plain("ab", 0), vec!["a", "b"]);
+        // A degenerate zero width still terminates.
+        assert_eq!(wrapped_text(&Line::from("ab"), 0), ["a", "b"]);
+    }
+
+    /// An indented help line keeps its indent on every row it folds onto, so a
+    /// wrapped help string still reads as belonging to the field above it.
+    #[test]
+    fn wrap_line_hangs_continuations_under_the_indent() {
+        let indented = Line::from("    alpha beta gamma delta");
+        assert_eq!(
+            wrapped_text(&indented, 14),
+            ["    alpha beta", "    gamma", "    delta"]
+        );
+        // Unless the indent would leave no useful width, in which case the text
+        // is worth more than the alignment and continuations start at column 0.
+        assert_eq!(
+            wrapped_text(&indented, 8),
+            ["    alph", "a beta", "gamma", "delta"]
+        );
+    }
+
+    /// Styles survive the fold, and column padding that no longer fits is
+    /// dropped at the break rather than pushed onto the next row.
+    #[test]
+    fn wrap_line_keeps_styles_and_drops_padding_at_a_break() {
+        let line = Line::from(vec![
+            Span::styled("name", Style::default().fg(C_WHITE)),
+            Span::styled("        ", Style::default()),
+            Span::styled("value", Style::default().fg(C_ACCENT)),
+        ]);
+        let wrapped = wrap_line(&line, 8);
+        assert_eq!(
+            wrapped
+                .iter()
+                .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect::<String>())
+                .collect::<Vec<_>>(),
+            ["name", "value"]
+        );
+        assert_eq!(wrapped[1].spans[0].style.fg, Some(C_ACCENT));
+    }
+
+    /// Draw into a window of a given size and return what it says.
+    fn rendered_at(wizard: &Wizard, width: u16, height: u16) -> String {
+        let mut terminal = Terminal::new(TestBackendHarness::new(width, height)).unwrap();
+        terminal.draw(|frame| draw(frame, wizard)).unwrap();
+        terminal.backend().text()
+    }
+
+    /// The tuning screen has thirteen two-line fields, which is more than most
+    /// windows are tall. It used to render as a `List` that simply stopped at
+    /// the bottom of the pane, so the last fields and the Continue button were
+    /// unreachable with no sign they existed.
+    #[test]
+    fn a_short_window_can_still_reach_the_last_field_and_the_button() {
+        let (_dir, mut w) = wizard();
+        w.show_advanced = true;
+        w.enter(Step::Limits);
+
+        let top = rendered_at(&w, 90, 20);
+        assert!(top.contains("Max concurrent inferences"), "{top}");
+        assert!(
+            !top.contains("Max bytes one run may write"),
+            "the far end of the form is not on the first screenful:\n{top}"
+        );
+        // The scrollbar is what says there is more, since nothing else can.
+        assert!(top.contains('\u{2193}'), "no scrollbar drawn:\n{top}");
+
+        w.scroll_end();
+        let bottom = rendered_at(&w, 90, 20);
+        assert!(bottom.contains("Max bytes one run may write"), "{bottom}");
+        assert!(
+            bottom.contains("Continue:"),
+            "the button has to be reachable:\n{bottom}"
+        );
+    }
+
+    /// Paging moves the selection as well as the view, so the two can never
+    /// end up looking at different parts of the form.
+    #[test]
+    fn paging_moves_the_selection_and_the_view_together() {
+        let (_dir, mut w) = wizard();
+        w.show_advanced = true;
+        w.enter(Step::Limits);
+
+        w.scroll_by(Wizard::PAGE);
+        assert_eq!(w.cursor, Wizard::PAGE as usize);
+        let screen = rendered_at(&w, 90, 20);
+        assert!(
+            screen.contains("Finished run retention"),
+            "the newly selected row has to be on screen:\n{screen}"
+        );
+
+        // Moving the selection back up pulls the view with it, even though the
+        // scroll offset was left pointing at the far end of the form.
+        w.scroll_end();
+        w.move_cursor(-100);
+        let back = rendered_at(&w, 90, 20);
+        assert!(back.contains("Max concurrent inferences"), "{back}");
+
+        w.scroll_home();
+        assert_eq!(w.cursor, 0);
+        assert!(rendered_at(&w, 90, 20).contains("Max concurrent inferences"));
+    }
+
+    /// A cursor past the end of the rows draws the top of the screen rather
+    /// than panicking. Nothing in the wizard puts it there, but tests do, and
+    /// a render is never the right place to discover an inconsistency.
+    #[test]
+    fn a_cursor_past_the_last_row_still_draws() {
+        let (_dir, mut w) = wizard();
+        w.enter(Step::Providers);
+        w.cursor = 999;
+        let screen = rendered_at(&w, 90, 20);
+        assert!(screen.contains("Providers"), "{screen}");
+    }
+
+    /// Review has nothing to select, so there the offset moves on its own
+    /// rather than being pinned to a cursor that cannot move.
+    #[test]
+    fn a_screen_with_no_rows_scrolls_by_offset() {
+        let (_dir, mut w) = wizard();
+        w.enter(Step::Review);
+        assert_eq!(w.row_count(), 0);
+
+        w.scroll_by(Wizard::PAGE);
+        assert_eq!(w.scroll, Wizard::PAGE as usize);
+        w.scroll_by(-Wizard::PAGE * 4);
+        assert_eq!(w.scroll, 0, "scrolling up past the top stops at the top");
+    }
+
+    /// Below a floor there is no layout left worth drawing, and half a
+    /// bordered pane reads as a crash rather than a small window.
+    #[test]
+    fn a_window_under_the_floor_says_so_instead_of_drawing_wreckage() {
+        let (_dir, w) = wizard();
+        let tiny = rendered_at(&w, 20, 5);
+        assert!(tiny.contains("Window too small"), "{tiny}");
+
+        // Just above the floor it draws, and drops the breadcrumb to spend the
+        // rows on content instead.
+        let small = rendered_at(&w, 60, 12);
+        assert!(small.contains("Get started"), "{small}");
+        assert!(
+            !small.contains("\u{203a} Providers"),
+            "the breadcrumb is what gives way first:\n{small}"
+        );
     }
 
     fn wizard() -> (tempfile::TempDir, Wizard) {

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -113,9 +113,6 @@ pub fn picker_row_at(area: Rect, picker: &Picker, row: u16) -> Option<usize> {
 fn draw_picker(frame: &mut Frame, area: Rect, picker: &Picker) {
     let popup = centered(80, 88, area);
     let inner = popup_frame(frame, popup, picker.title, C_BORDER_FOCUS);
-    if inner.height < 4 {
-        return;
-    }
     let chunks = picker_layout(inner, picker);
 
     let mut lines: Vec<Line<'static>> = picker
@@ -432,6 +429,20 @@ fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
         indent_len
     };
 
+    /// Close a row, dropping the whitespace it would otherwise end in: the
+    /// break stands in for the space it happened at.
+    ///
+    /// Indexing rather than `last_mut`, because a row is only ever closed with
+    /// something on it - `has_word` is what decides to close one.
+    fn close_row(spans: &mut Vec<Span<'static>>) -> Line<'static> {
+        while spans.len() > 1 && spans[spans.len() - 1].content.trim().is_empty() {
+            spans.pop();
+        }
+        let last = spans.len() - 1;
+        spans[last].content = spans[last].content.trim_end().to_string().into();
+        Line::from(std::mem::take(spans))
+    }
+
     let mut out: Vec<Line<'static>> = Vec::new();
     let mut current: Vec<Span<'static>> = Vec::new();
     let mut used = 0usize;
@@ -454,7 +465,7 @@ fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
                     break;
                 }
                 if has_word {
-                    out.push(Line::from(std::mem::take(&mut current)));
+                    out.push(close_row(&mut current));
                     used = indent_len;
                     has_word = false;
                     if indent_len > 0 {
@@ -477,7 +488,7 @@ fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
                     .expect("infallible: the run is longer than the room left");
                 let (head, tail) = piece.split_at(cut);
                 current.push(Span::styled(head.to_string(), span.style));
-                out.push(Line::from(std::mem::take(&mut current)));
+                out.push(close_row(&mut current));
                 used = indent_len;
                 if indent_len > 0 {
                     current.push(Span::raw(" ".repeat(indent_len)));
@@ -486,22 +497,9 @@ fn wrap_line(line: &Line<'static>, width: usize) -> Vec<Line<'static>> {
             }
         }
     }
+    // Empty when the text ended exactly at a break.
     if !current.is_empty() {
-        out.push(Line::from(current));
-    }
-    // The break stands in for the space it happened at, so no row ends in one.
-    for line in &mut out {
-        while line.spans.len() > 1
-            && line
-                .spans
-                .last()
-                .is_some_and(|s| s.content.trim().is_empty())
-        {
-            line.spans.pop();
-        }
-        if let Some(last) = line.spans.last_mut() {
-            last.content = last.content.trim_end().to_string().into();
-        }
+        out.push(close_row(&mut current));
     }
     out
 }
@@ -1175,6 +1173,33 @@ mod tests {
         );
         // A degenerate zero width still terminates.
         assert_eq!(wrapped_text(&Line::from("ab"), 0), ["a", "b"]);
+        // Padding that fits is kept, and dropped from the end of a row it
+        // would otherwise trail off.
+        assert_eq!(wrapped_text(&Line::from("ab  cdef"), 4), ["ab", "cdef"]);
+        // Whitespace that lands at the start of a continuation is dropped
+        // too: the break already stood in for it. Across a span boundary that
+        // is a whole run arriving with a row already broken under it.
+        assert_eq!(wrapped_text(&Line::from("aaaa  bbbb"), 4), ["aaaa", "bbbb"]);
+        assert_eq!(
+            wrapped_text(
+                &Line::from(vec![Span::raw("aaaa "), Span::raw(" bbbb")]),
+                4
+            ),
+            ["aaaa", "bbbb"]
+        );
+        // Text ending exactly at a break leaves nothing to close.
+        assert_eq!(wrapped_text(&Line::from("aaaa "), 4), ["aaaa"]);
+        assert_eq!(wrapped_text(&Line::from("aaaa bb"), 4), ["aaaa", "bb"]);
+    }
+
+    /// An indented line whose word cannot fit even after the indent breaks the
+    /// word and keeps indenting what follows.
+    #[test]
+    fn wrap_line_hard_breaks_under_an_indent_it_can_afford() {
+        assert_eq!(
+            wrapped_text(&Line::from("  abcdefghijklmno"), 10),
+            ["  abcdefgh", "  ijklmno"]
+        );
     }
 
     /// An indented help line keeps its indent on every row it folds onto, so a
@@ -1336,7 +1361,7 @@ mod tests {
         };
         w.enter(Step::Defaults);
         w.cursor = 1;
-        w.open_picker(w.defaults[1].value.options().to_vec(), 0);
+        w.open_picker("Default model", w.defaults[1].value.options().to_vec(), 0);
 
         let screen = rendered(&w);
         assert!(screen.contains("Default model"), "{screen}");
@@ -1348,9 +1373,8 @@ mod tests {
         assert!(screen.contains("Search"), "{screen}");
 
         // Nothing matching is a state worth naming.
-        if let Some(picker) = w.picker.as_mut() {
-            picker.query = crate::tui::widgets::line_edit::LineEdit::new("zzz", false);
-        }
+        w.picker.as_mut().expect("open").query =
+            crate::tui::widgets::line_edit::LineEdit::new("zzz", false);
         assert!(rendered(&w).contains("Nothing matches that."));
     }
 
@@ -1360,10 +1384,41 @@ mod tests {
     fn the_chooser_survives_a_short_window() {
         let (_dir, mut w) = wizard();
         w.enter(Step::Defaults);
-        w.open_picker(w.defaults[0].value.options().to_vec(), 0);
+        w.open_picker("Default provider", w.defaults[0].value.options().to_vec(), 0);
 
         let screen = rendered_at(&w, 70, 14);
         assert!(screen.contains("anthropic"), "{screen}");
+    }
+
+    /// A window too short to hold the chooser's frame has nothing in it to
+    /// click, and neither does the space outside its list.
+    #[test]
+    fn a_window_too_short_for_the_chooser_declines_to_draw_it() {
+        let (_dir, mut w) = wizard();
+        w.enter(Step::Defaults);
+        w.open_picker("Default provider", w.defaults[0].value.options().to_vec(), 0);
+        let picker = w.picker.as_ref().expect("open");
+
+        // `draw` refuses to draw anything under its own floor, so this size
+        // only reaches the hit test - which a real 5-row terminal can.
+        assert_eq!(picker_row_at(Rect::new(0, 0, 60, 5), picker, 3), None);
+        // A click outside the list is not a row either.
+        assert_eq!(picker_row_at(Rect::new(0, 0, 90, 40), picker, 1), None);
+    }
+
+    /// Hit-testing agrees with drawing about what is on screen: nothing below
+    /// the last line is a row, and a window under the floor has no rows at all.
+    #[test]
+    fn a_click_below_the_content_is_not_the_nearest_row() {
+        let (_dir, mut w) = wizard();
+        w.enter(Step::Welcome);
+        let area = Rect::new(0, 0, 90, 40);
+
+        // Welcome is a handful of lines in a forty-row window, so most of the
+        // pane is empty space under them.
+        assert_eq!(row_at(area, &w, 4, 34), None);
+        // And below the floor there is no layout to resolve against.
+        assert_eq!(row_at(Rect::new(0, 0, 10, 4), &w, 2, 2), None);
     }
 
     fn wizard() -> (tempfile::TempDir, Wizard) {

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -86,6 +86,18 @@ pub struct Wizard {
     pub reply_rx: mpsc::UnboundedReceiver<VerifyReply>,
     /// Tick counter, for the spinner.
     pub ticks: u64,
+    /// First visible row of the current step, so a screen taller than the
+    /// terminal can still be reached. Head-anchored, unlike the log panel's
+    /// tail-anchored [`crate::tui::widgets::scroll::ScrollState`]: a wizard
+    /// screen is read from the top, and the cursor decides what must be shown.
+    pub scroll: usize,
+    /// Whether the tuning screen is on the path.
+    ///
+    /// Off by default. Every one of those limits has a working default, so
+    /// walking a first-time user through them taught them that setup is long
+    /// rather than that Leviath is configurable. Turned on from the Defaults
+    /// screen, it slots [`Step::Limits`] back into the flow.
+    pub show_advanced: bool,
 }
 
 /// The environment variables the wizard reports as already-supplying a
@@ -197,6 +209,8 @@ impl Wizard {
             reply_tx,
             reply_rx,
             ticks: 0,
+            scroll: 0,
+            show_advanced: false,
         };
         wizard.rebuild_defaults();
         wizard
@@ -335,6 +349,40 @@ impl Wizard {
         self.cursor = next.clamp(0, count as isize - 1) as usize;
     }
 
+    /// How many rows a page key moves. Smaller than most windows on purpose:
+    /// a page that overshoots the pane is indistinguishable from a jump.
+    pub const PAGE: isize = 8;
+
+    /// Scroll by whole rows.
+    ///
+    /// Where there is something to select, this moves the selection and lets
+    /// the renderer follow it, so the view and the cursor can never disagree
+    /// about what the user is looking at. Welcome and Review have no rows, so
+    /// there the offset moves on its own.
+    pub fn scroll_by(&mut self, rows: isize) {
+        if self.row_count() > 0 {
+            self.move_cursor(rows);
+            return;
+        }
+        self.scroll = self.scroll.saturating_add_signed(rows);
+    }
+
+    /// Jump to the top of the current step.
+    pub fn scroll_home(&mut self) {
+        self.cursor = 0;
+        self.scroll = 0;
+    }
+
+    /// Jump to the end of the current step, which is always its button.
+    ///
+    /// The offset is set past any possible content and clamped when drawn,
+    /// because the number of lines a step occupies depends on the window it is
+    /// drawn into and is not known here.
+    pub fn scroll_end(&mut self) {
+        self.cursor = self.nav_rows().saturating_sub(1);
+        self.scroll = usize::MAX;
+    }
+
     /// Advance to the next step, skipping ones with nothing to show. Skipping
     /// the credential screen is announced rather than silent: it looks exactly
     /// like a bug when a screen the breadcrumb promises never appears.
@@ -377,6 +425,11 @@ impl Wizard {
         match step {
             Step::Mcp => self.mcp.is_empty() && self.mcp_scan_errors.is_empty(),
             Step::ProviderDetail => self.detail_row().is_none(),
+            // Not empty so much as not asked for. Routing it through the same
+            // predicate keeps `next_step`, `prev_step` and the Continue
+            // button's own label agreeing about what comes next, which they
+            // would not if the skip were special-cased at one call site.
+            Step::Limits => !self.show_advanced,
             _ => false,
         }
     }
@@ -385,6 +438,7 @@ impl Wizard {
     pub fn enter(&mut self, step: Step) {
         self.step = step;
         self.cursor = 0;
+        self.scroll = 0;
         self.edit = None;
         if step == Step::Defaults {
             // The model picker is populated by verification, which may have
@@ -565,6 +619,12 @@ impl Wizard {
                 help: "How long to wait on one inference. Unset uses the provider default.",
                 value: FieldValue::Number(timeout),
             },
+            Field {
+                label: "Show advanced tuning",
+                help: "Adds a screen of concurrency, retry and context limits. Every one of \
+                       them already has a default that works.",
+                value: FieldValue::Bool(self.show_advanced),
+            },
         ];
         // Re-pick the concurrency default now that the provider choice is
         // settled. Doing this only on an arrow press missed the commonest
@@ -573,6 +633,9 @@ impl Wizard {
         // stayed at the hosted-API default of 8.
         self.apply_provider_concurrency_default();
     }
+
+    /// Where the advanced-tuning toggle sits on the Defaults screen.
+    pub const ADVANCED_FIELD: usize = 3;
 
     /// The default provider as it currently stands in the form, or the base
     /// config's value before the form exists.

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -98,6 +98,8 @@ pub struct Wizard {
     /// rather than that Leviath is configurable. Turned on from the Defaults
     /// screen, it slots [`Step::Limits`] back into the flow.
     pub show_advanced: bool,
+    /// The open chooser for a Defaults value, if one is open.
+    pub picker: Option<Picker>,
 }
 
 /// The environment variables the wizard reports as already-supplying a
@@ -211,6 +213,7 @@ impl Wizard {
             ticks: 0,
             scroll: 0,
             show_advanced: false,
+            picker: None,
         };
         wizard.rebuild_defaults();
         wizard
@@ -570,6 +573,45 @@ impl Wizard {
         }
     }
 
+    /// What choosing one of these values actually decides.
+    ///
+    /// Written against `leviath_runtime::pipeline::resolve`, which is the code
+    /// that reads them. The line about a blueprint winning is the one worth
+    /// having: a user who sets a default and then watches an agent run on
+    /// something else has been told, by every other tool, that a default is a
+    /// default.
+    fn precedence_explanation(provider: bool) -> Vec<&'static str> {
+        if provider {
+            vec![
+                "Where your runs go by default. A stage that lists this provider among",
+                "its models is served by it first, ahead of the blueprint's own order.",
+                "",
+                "This field does nothing on its own. Until you also set a default model",
+                "below, the only thing it can do is reorder a list that already names",
+                "this provider, so on a machine keyed for one provider that no blueprint",
+                "mentions, every stage still goes somewhere else.",
+                "",
+                "It never overrides a blueprint that pins its provider: a stage with",
+                "allow_user_default = false ignores this, and so does a provider you",
+                "have not given a credential.",
+            ]
+        } else {
+            vec![
+                "The model your default provider is asked for. The two travel together:",
+                "this name is never sent to a different provider, so an OpenAI model is",
+                "never asked of Anthropic.",
+                "",
+                "Setting it is what makes the default provider above take effect. The",
+                "pair is offered to every stage that allows a user default, and moves to",
+                "the front of the models that stage lists.",
+                "",
+                "Leaving it unset does not mean your provider picks a model. It means",
+                "each blueprint uses the models it names, and a stage that names none",
+                "falls back to a model built into Leviath, whoever you configured.",
+            ]
+        }
+    }
+
     /// Every model id any provider reported, deduplicated, for the picker.
     pub fn discovered_models(&self) -> Vec<String> {
         let mut models: Vec<String> = self
@@ -603,11 +645,11 @@ impl Wizard {
         };
         let index = providers.iter().position(|p| *p == chosen).unwrap_or(0);
 
-        let mut models = vec!["(provider default)".to_string()];
+        let mut models = vec![Self::NO_DEFAULT_MODEL.to_string()];
         models.extend(self.discovered_models());
         let current_model = self
             .current_default_model()
-            .unwrap_or_else(|| "(provider default)".to_string());
+            .unwrap_or_else(|| Self::NO_DEFAULT_MODEL.to_string());
         if !models.contains(&current_model) {
             models.push(current_model.clone());
         }
@@ -620,7 +662,8 @@ impl Wizard {
         self.defaults = vec![
             Field {
                 label: "Default provider",
-                help: "Used by any blueprint that allows a user default.",
+                help: "Preferred by any stage that allows a user default. Takes effect once a \
+                       default model is set below.",
                 value: FieldValue::Choice {
                     options: providers,
                     index,
@@ -628,7 +671,8 @@ impl Wizard {
             },
             Field {
                 label: "Default model",
-                help: "Filled in from the models your providers reported.",
+                help: "Offered to every stage that allows a user default, paired with the \
+                       provider above. Listed from what your providers reported.",
                 value: FieldValue::Choice {
                     options: models,
                     index: model_index,
@@ -656,6 +700,97 @@ impl Wizard {
 
     /// Where the advanced-tuning toggle sits on the Defaults screen.
     pub const ADVANCED_FIELD: usize = 3;
+
+    /// The model field's "no default" option.
+    ///
+    /// It read "(provider default)", which is a thing that does not exist: no
+    /// provider default model is consulted anywhere at run time. A stage that
+    /// names no model of its own falls back to a model built into Leviath, not
+    /// to anything your provider chose, so the old label promised a mechanism
+    /// and delivered the opposite of what it said.
+    pub const NO_DEFAULT_MODEL: &'static str = "(each blueprint decides)";
+
+    /// Open the chooser for the Defaults field the cursor is on.
+    ///
+    /// The options come from the caller because it has already matched on the
+    /// field's kind: re-reading them here would add a shape this cannot be in.
+    pub(super) fn open_picker(&mut self, options: Vec<String>, index: usize) {
+        let field = self.cursor;
+        let title = match field {
+            0 => "Default provider",
+            _ => "Default model",
+        };
+        let options = options
+            .into_iter()
+            .map(|value| {
+                let detail = if field == 0 {
+                    self.provider_detail(&value)
+                } else {
+                    self.model_detail(&value)
+                };
+                PickerOption { value, detail }
+            })
+            .collect();
+        self.picker = Some(Picker {
+            field,
+            title,
+            explain: Self::precedence_explanation(field == 0),
+            query: crate::tui::widgets::line_edit::LineEdit::new(String::new(), false),
+            options,
+            // Opening on the current value rather than at the top: the list is
+            // long, and "where am I now" is the first thing you look for.
+            cursor: index,
+        });
+    }
+
+    /// What a provider id is, for the chooser's second column.
+    fn provider_detail(&self, id: &str) -> String {
+        match self.providers.iter().find(|r| r.provider.id == id) {
+            Some(row) => row.provider.display.to_string(),
+            // A provider that is configured but not in the catalog: it came
+            // from the config file, so it is still a legitimate choice.
+            None => "from your config".to_string(),
+        }
+    }
+
+    /// Which providers reported a model, so the row says where it came from.
+    fn model_detail(&self, model: &str) -> String {
+        let reported: Vec<&str> = self
+            .providers
+            .iter()
+            .filter(|r| r.selected && r.outcome.models().iter().any(|m| m == model))
+            .map(|r| r.provider.display)
+            .collect();
+        if reported.is_empty() {
+            return "not reported by a provider you selected".to_string();
+        }
+        format!("reported by {}", reported.join(", "))
+    }
+
+    /// Take the chooser's answer, writing it back into the field it came from.
+    pub(super) fn commit_picker(&mut self) {
+        let Some(picker) = self.picker.take() else {
+            return;
+        };
+        let Some(chosen) = picker.selected() else {
+            // An empty filter has nothing to choose; closing without a change
+            // is the only honest outcome.
+            return;
+        };
+        let value = picker.options[chosen].value.clone();
+        if let Some(field) = self.defaults.get_mut(picker.field)
+            && let FieldValue::Choice { options, index } = &mut field.value
+            && let Some(position) = options.iter().position(|option| *option == value)
+        {
+            *index = position;
+            self.dirty = true;
+        }
+        // The concurrency default follows the provider, so an Ollama-first
+        // setup does not inherit a number meant for hosted APIs.
+        if picker.field == 0 {
+            self.apply_provider_concurrency_default();
+        }
+    }
 
     /// The default provider as it currently stands in the form, or the base
     /// config's value before the form exists.
@@ -851,7 +986,7 @@ impl Wizard {
         config.default_provider = self.current_default_provider();
         config.default_model = self
             .current_default_model()
-            .filter(|m| m != "(provider default)");
+            .filter(|m| m != Self::NO_DEFAULT_MODEL);
         config.request_timeout_secs = self.current_request_timeout();
 
         apply_limits_fields(&mut config, &self.limits);
@@ -1545,7 +1680,7 @@ pub(super) mod tests {
         wizard.enter(Step::Defaults);
         assert_eq!(
             wizard.defaults[1].value.options(),
-            ["(provider default)".to_string()],
+            [Wizard::NO_DEFAULT_MODEL.to_string()],
             "nothing has been reported yet"
         );
 
@@ -1664,7 +1799,7 @@ pub(super) mod tests {
         wizard.enter(Step::Defaults);
 
         let options = wizard.defaults[1].value.options();
-        assert!(options.contains(&"(provider default)".to_string()));
+        assert!(options.contains(&Wizard::NO_DEFAULT_MODEL.to_string()));
         assert!(options.contains(&"claude-opus-5".to_string()));
         assert_eq!(
             wizard.defaults[1].value.display(),
@@ -2172,7 +2307,7 @@ pub(super) mod tests {
         wizard.providers[0].selected = true;
         wizard.enter(Step::Defaults);
 
-        // Index 0 of the model picker is always "(provider default)".
+        // Index 0 of the model field is always the "no default" option.
         assert!(wizard.build_config().default_model.is_none());
     }
 

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -276,12 +276,32 @@ impl Wizard {
         }
     }
 
+    /// The credential screen's action rows, after the credential itself.
+    ///
+    /// They exist as rows rather than as shortcut keys alone because that is
+    /// how they become discoverable: a row can be seen, moved onto, and
+    /// clicked, and `o` and `v` still work for anyone who knows them.
+    pub fn detail_actions(&self) -> Vec<DetailAction> {
+        let Some(index) = self.detail_row() else {
+            return Vec::new();
+        };
+        let mut actions = Vec::new();
+        if self.providers[index].provider.signup_url.is_some() {
+            actions.push(DetailAction::OpenSignup);
+        }
+        actions.push(DetailAction::Verify);
+        actions
+    }
+
     /// How many selectable rows the current step has.
     pub fn row_count(&self) -> usize {
         match self.step {
             Step::Welcome | Step::Review => 0,
             Step::Providers => self.providers.len(),
-            Step::ProviderDetail => usize::from(self.detail_row().is_some()),
+            Step::ProviderDetail => match self.detail_row() {
+                Some(_) => 1 + self.detail_actions().len(),
+                None => 0,
+            },
             Step::Defaults => self.defaults.len(),
             Step::Limits => self.limits.len(),
             Step::Agents => self.agents.len(),

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -698,6 +698,9 @@ impl Wizard {
         self.apply_provider_concurrency_default();
     }
 
+    /// Where the provider choice sits on the Defaults screen.
+    pub const PROVIDER_FIELD: usize = 0;
+
     /// Where the advanced-tuning toggle sits on the Defaults screen.
     pub const ADVANCED_FIELD: usize = 3;
 
@@ -714,16 +717,17 @@ impl Wizard {
     ///
     /// The options come from the caller because it has already matched on the
     /// field's kind: re-reading them here would add a shape this cannot be in.
-    pub(super) fn open_picker(&mut self, options: Vec<String>, index: usize) {
+    pub(super) fn open_picker(
+        &mut self,
+        title: &'static str,
+        options: Vec<String>,
+        index: usize,
+    ) {
         let field = self.cursor;
-        let title = match field {
-            0 => "Default provider",
-            _ => "Default model",
-        };
         let options = options
             .into_iter()
             .map(|value| {
-                let detail = if field == 0 {
+                let detail = if field == Self::PROVIDER_FIELD {
                     self.provider_detail(&value)
                 } else {
                     self.model_detail(&value)
@@ -734,7 +738,7 @@ impl Wizard {
         self.picker = Some(Picker {
             field,
             title,
-            explain: Self::precedence_explanation(field == 0),
+            explain: Self::precedence_explanation(field == Self::PROVIDER_FIELD),
             query: crate::tui::widgets::line_edit::LineEdit::new(String::new(), false),
             options,
             // Opening on the current value rather than at the top: the list is
@@ -773,26 +777,21 @@ impl Wizard {
     }
 
     /// Take the chooser's answer, writing it back into the field it came from.
-    pub(super) fn commit_picker(&mut self) {
-        let Some(picker) = self.picker.take() else {
-            return;
-        };
+    pub(super) fn commit_picker(&mut self, picker: Picker) {
         let Some(chosen) = picker.selected() else {
             // An empty filter has nothing to choose; closing without a change
             // is the only honest outcome.
             return;
         };
-        let value = picker.options[chosen].value.clone();
-        if let Some(field) = self.defaults.get_mut(picker.field)
-            && let FieldValue::Choice { options, index } = &mut field.value
-            && let Some(position) = options.iter().position(|option| *option == value)
-        {
-            *index = position;
-            self.dirty = true;
-        }
+        // The chooser's options were built from this field's, one for one and
+        // in order, so the match index *is* the field's index. Indexing rather
+        // than looking up: the field is where it was when the chooser opened,
+        // and nothing rebuilds the form while one is on screen.
+        self.defaults[picker.field].value.set_index(chosen);
+        self.dirty = true;
         // The concurrency default follows the provider, so an Ollama-first
         // setup does not inherit a number meant for hosted APIs.
-        if picker.field == 0 {
+        if picker.field == Self::PROVIDER_FIELD {
             self.apply_provider_concurrency_default();
         }
     }
@@ -1849,6 +1848,23 @@ pub(super) mod tests {
             .display(),
             "(none)"
         );
+    }
+
+    /// Moving a choice is total: the chooser hands back an index and the
+    /// field it came from takes it, while a kind with no list ignores it
+    /// rather than making every caller check first.
+    #[test]
+    fn setting_an_index_moves_a_choice_and_leaves_other_kinds_alone() {
+        let mut choice = FieldValue::Choice {
+            options: vec!["a".into(), "b".into()],
+            index: 0,
+        };
+        choice.set_index(1);
+        assert_eq!(choice.display(), "b");
+
+        let mut number = FieldValue::Number(Some(7));
+        number.set_index(1);
+        assert_eq!(number.display(), "7");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -755,6 +755,11 @@ impl Wizard {
 
     /// Which providers reported a model, so the row says where it came from.
     fn model_detail(&self, model: &str) -> String {
+        // The first row is the absence of a model, not a model, so the
+        // question "who reported it" does not apply to it.
+        if model == Self::NO_DEFAULT_MODEL {
+            return "no default; every blueprint uses the models it names".to_string();
+        }
         let reported: Vec<&str> = self
             .providers
             .iter()

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -88,7 +88,7 @@ pub struct Wizard {
     pub ticks: u64,
     /// First visible row of the current step, so a screen taller than the
     /// terminal can still be reached. Head-anchored, unlike the log panel's
-    /// tail-anchored [`crate::tui::widgets::scroll::ScrollState`]: a wizard
+    /// tail-anchored `ScrollState` the log panel uses: a wizard
     /// screen is read from the top, and the cursor decides what must be shown.
     pub scroll: usize,
     /// Whether the tuning screen is on the path.
@@ -96,7 +96,7 @@ pub struct Wizard {
     /// Off by default. Every one of those limits has a working default, so
     /// walking a first-time user through them taught them that setup is long
     /// rather than that Leviath is configurable. Turned on from the Defaults
-    /// screen, it slots [`Step::Limits`] back into the flow.
+    /// screen, it slots the `Limits` step back into the flow.
     pub show_advanced: bool,
     /// The open chooser for a Defaults value, if one is open.
     pub picker: Option<Picker>,
@@ -717,12 +717,7 @@ impl Wizard {
     ///
     /// The options come from the caller because it has already matched on the
     /// field's kind: re-reading them here would add a shape this cannot be in.
-    pub(super) fn open_picker(
-        &mut self,
-        title: &'static str,
-        options: Vec<String>,
-        index: usize,
-    ) {
+    pub(super) fn open_picker(&mut self, title: &'static str, options: Vec<String>, index: usize) {
         let field = self.cursor;
         let options = options
             .into_iter()

--- a/crates/leviath-cli/src/commands/setup/state/types.rs
+++ b/crates/leviath-cli/src/commands/setup/state/types.rs
@@ -137,8 +137,9 @@ pub struct Picker {
     pub title: &'static str,
     /// What the value actually decides, and what it does not.
     pub explain: Vec<&'static str>,
-    /// The search box.
-    pub query: crate::tui::widgets::line_edit::LineEdit,
+    /// The search box. Crate-visible like the widget it holds, which is not
+    /// part of any public surface.
+    pub(crate) query: crate::tui::widgets::line_edit::LineEdit,
     /// Every option, in the field's own order.
     pub options: Vec<PickerOption>,
     /// Cursor into the *filtered* list, not into `options`.
@@ -254,6 +255,17 @@ impl FieldValue {
                 Some(chosen) => chosen.clone(),
                 None => "(none)".to_string(),
             },
+        }
+    }
+
+    /// Move a choice to `index`.
+    ///
+    /// A no-op for the other kinds, which have no list to move within. Total
+    /// rather than fallible because the caller that has a chosen index already
+    /// knows which field it came from.
+    pub fn set_index(&mut self, next: usize) {
+        if let Self::Choice { index, .. } = self {
+            *index = next;
         }
     }
 

--- a/crates/leviath-cli/src/commands/setup/state/types.rs
+++ b/crates/leviath-cli/src/commands/setup/state/types.rs
@@ -123,6 +123,30 @@ pub struct McpRow {
     pub name: String,
 }
 
+/// A thing the credential screen can do, offered as its own row.
+///
+/// These were shortcut keys and nothing else, which meant they existed only
+/// for people who had read the footer. As rows they can be seen, moved onto
+/// with the arrows, and clicked; `o` and `v` still work.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetailAction {
+    /// Open the provider's signup or key page in a browser.
+    OpenSignup,
+    /// Check the credential against the provider.
+    Verify,
+}
+
+impl DetailAction {
+    /// The button's text, which names the provider so the row says what it
+    /// will do rather than what it is called.
+    pub fn label(self, provider: &str) -> String {
+        match self {
+            Self::OpenSignup => format!("Open the {provider} key page"),
+            Self::Verify => "Check this credential".to_string(),
+        }
+    }
+}
+
 /// A single editable setting on the Defaults / Limits screens.
 #[derive(Debug, Clone)]
 pub struct Field {

--- a/crates/leviath-cli/src/commands/setup/state/types.rs
+++ b/crates/leviath-cli/src/commands/setup/state/types.rs
@@ -123,6 +123,73 @@ pub struct McpRow {
     pub name: String,
 }
 
+/// A full-screen chooser for one of the Defaults screen's list values.
+///
+/// The arrows cycle those fields in place, which is fine for three providers
+/// and hopeless for eighty models: you read the list one value at a time
+/// through a single line, and the only way back is round again. The picker
+/// shows the list, filters it as you type, and says what the value decides -
+/// which the field could not, in the one line it had.
+pub struct Picker {
+    /// Which Defaults field this is choosing for.
+    pub field: usize,
+    /// Its heading, taken from the field it opened from.
+    pub title: &'static str,
+    /// What the value actually decides, and what it does not.
+    pub explain: Vec<&'static str>,
+    /// The search box.
+    pub query: crate::tui::widgets::line_edit::LineEdit,
+    /// Every option, in the field's own order.
+    pub options: Vec<PickerOption>,
+    /// Cursor into the *filtered* list, not into `options`.
+    pub cursor: usize,
+}
+
+/// One row of a [`Picker`].
+pub struct PickerOption {
+    /// The value that would be written.
+    pub value: String,
+    /// Where it came from, or what it is, in a few words.
+    pub detail: String,
+}
+
+impl Picker {
+    /// The options matching the query, as indices into `options`.
+    ///
+    /// Every whitespace-separated term has to appear somewhere in the row, so
+    /// "claude sonnet" finds the model whichever order the id puts them in,
+    /// and a term can match the provider that reported it as easily as the
+    /// name itself.
+    pub fn matches(&self) -> Vec<usize> {
+        let query = self.query.value().to_lowercase();
+        let terms: Vec<&str> = query.split_whitespace().collect();
+        self.options
+            .iter()
+            .enumerate()
+            .filter(|(_, option)| {
+                let haystack = format!("{} {}", option.value, option.detail).to_lowercase();
+                terms.iter().all(|term| haystack.contains(term))
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    /// Which option the cursor is on, if the filter left anything.
+    pub fn selected(&self) -> Option<usize> {
+        self.matches().get(self.cursor).copied()
+    }
+
+    /// Move within the filtered list, clamped to it.
+    ///
+    /// Clamping rather than wrapping: at eighty models, wrapping from the top
+    /// to the bottom looks like the list jumped rather than moved.
+    pub fn move_cursor(&mut self, delta: isize) {
+        let count = self.matches().len();
+        let next = self.cursor as isize + delta;
+        self.cursor = next.clamp(0, count.saturating_sub(1) as isize) as usize;
+    }
+}
+
 /// A thing the credential screen can do, offered as its own row.
 ///
 /// These were shortcut keys and nothing else, which meant they existed only

--- a/crates/leviath-cli/src/commands/update.rs
+++ b/crates/leviath-cli/src/commands/update.rs
@@ -1,0 +1,841 @@
+//! `lev update` - bring this copy of Leviath up to date, then everything that
+//! shipped with it.
+//!
+//! Three steps, in the order that matters: the binary, the bundled blueprints,
+//! and the config file. The binary first because the other two are decided by
+//! what the *new* binary ships, and a user who updates the agents against the
+//! old one has done half a job.
+//!
+//! All three run every time. The binary step is never a reason to skip the
+//! other two, and this is the whole point: `brew upgrade` and `scoop update`
+//! hand over a new binary and say nothing about the blueprints in the user's
+//! agents directory or the config beside them, so anyone who has ever updated
+//! that way is carrying blueprints from whenever they last ran `lev setup`. A
+//! binary that needs no update is not evidence that anything else is current,
+//! which is why "already up to date" is a sentence this command never says on
+//! its own.
+//!
+//! # Why the install method is detected rather than guessed
+//!
+//! Every channel installs the same `CARGO_PKG_VERSION`: the `-alpha` and
+//! `-beta` suffixes live in the tap manifests the release workflow bumps, not
+//! in `Cargo.toml`. So the version string says nothing about which channel this
+//! binary came from, and nothing about which installer put it there. What does
+//! say something is *where the file is*: a Homebrew Cellar path carries the
+//! formula name, and the formula name carries the channel; a Scoop `apps` path
+//! carries the package the same way; `~/.cargo/bin` means somebody compiled it.
+//!
+//! The hosted install script is the one method that records nothing. It writes
+//! a plain binary into an ordinary directory and keeps no receipt, so a copy
+//! that came from it is indistinguishable from any other loose binary. That is
+//! what [`UpdateArgs::channel`] is for, and why the script arm defaults to
+//! `stable` and says so rather than inferring a channel it cannot know.
+//!
+//! # Seams
+//!
+//! Running the upgrade and asking the user a question are both injected (see
+//! [`UpdateEnv`]), so the tests assert the command that *would* run without a
+//! single process being spawned - the same shape `lev mcp` uses for the browser
+//! and the daemon uses for seed commands.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use clap::Args;
+
+use crate::bundled::{AgentAction, BundledAgent, install_bundled, plan_agent_actions};
+use crate::config::Config;
+
+/// Where the hosted installer lives. One constant, because the invocation below
+/// is easy to get subtly wrong and there must be exactly one copy of it.
+const INSTALL_URL: &str = "https://leviath.dev/install.sh";
+
+/// `lev update --help`.
+pub const UPDATE_LONG_ABOUT: &str = "\
+Update Leviath, then offer to bring everything else up to date with it.
+
+The binary is updated with the installer that put it there, which is worked out
+from where the file is rather than guessed from the version string (every
+channel ships the same version number, so the string cannot tell you):
+
+  Homebrew   a Cellar path names the formula, and the formula names the
+             channel: `brew upgrade leviath-beta`
+  Scoop      the same, from the package under scoop/apps
+  cargo      says to run `cargo install leviath-cli` and stops. Updating it
+             means a long compile, which is not something to start unasked
+  script     re-runs the hosted installer for a channel. The install script
+             keeps no record of the channel it used, so this defaults to
+             stable - pass --channel to say otherwise
+
+The blueprints and the config are checked every time, whatever the binary step
+did. `brew upgrade` on its own leaves both behind, and a binary that was
+already current is not a reason to stop looking: an install can be months
+behind on its blueprints with a `lev` that needs no update at all.
+
+Nothing is written to your agents directory without a yes. The whole list is
+printed first, then one confirmation covers it; --install-agents is how a
+script says yes. --yes alone is not enough, because updating a binary and
+replacing the blueprints in your agents directory are different requests. A
+copy you edited is named as edited and asked about on its own, and no flag
+covers it: installing removes the directory and takes your edits with it.
+
+Config migrations are described line by line before anything is written, and
+then asked about.
+
+--check and --json report the plan and change nothing. --dry-run walks the
+whole flow, prompts and all, and prints what each step would do instead of
+doing it.";
+
+// ─── Channels ─────────────────────────────────────────────────────────────────
+
+/// A release channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+#[value(rename_all = "lowercase")]
+pub enum Channel {
+    /// The weekly stable release. What crates.io and `brew install leviath` track.
+    Stable,
+    /// The promoted build a week ahead of stable.
+    Beta,
+    /// The nightly build.
+    Alpha,
+}
+
+impl Channel {
+    /// The name the install script and the docs use.
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Stable => "stable",
+            Self::Beta => "beta",
+            Self::Alpha => "alpha",
+        }
+    }
+
+    /// The Homebrew formula and Scoop package for this channel. They share a
+    /// naming scheme on purpose, so one function answers for both.
+    pub fn package(self) -> &'static str {
+        match self {
+            Self::Stable => "leviath",
+            Self::Beta => "leviath-beta",
+            Self::Alpha => "leviath-alpha",
+        }
+    }
+
+    /// The channel a package name carries, or `None` for a name this build does
+    /// not ship (someone's own formula, or one from a future channel).
+    pub fn from_package(name: &str) -> Option<Self> {
+        [Self::Stable, Self::Beta, Self::Alpha]
+            .into_iter()
+            .find(|c| c.package() == name)
+    }
+}
+
+// ─── Install-method detection ─────────────────────────────────────────────────
+
+/// How this copy of `lev` got onto the machine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InstallMethod {
+    /// Homebrew, under the named formula.
+    Homebrew {
+        /// The formula, which is also what carries the channel.
+        formula: String,
+    },
+    /// Scoop, under the named package.
+    Scoop {
+        /// The package, which carries the channel the same way a formula does.
+        package: String,
+    },
+    /// `cargo install`, so the binary was compiled locally.
+    Cargo,
+    /// The hosted install script, or something else that dropped a plain binary
+    /// where the install script puts one.
+    Script {
+        /// The channel to re-install. Never detected: see the module docs.
+        channel: Channel,
+    },
+    /// Somewhere no supported installer writes.
+    Unknown {
+        /// Where the binary actually is, so the report can say it.
+        path: PathBuf,
+    },
+}
+
+impl InstallMethod {
+    /// The short name used in `--json`.
+    pub fn id(&self) -> &'static str {
+        match self {
+            Self::Homebrew { .. } => "homebrew",
+            Self::Scoop { .. } => "scoop",
+            Self::Cargo => "cargo",
+            Self::Script { .. } => "script",
+            Self::Unknown { .. } => "unknown",
+        }
+    }
+
+    /// The channel this install tracks, where that is knowable.
+    ///
+    /// `cargo install leviath-cli` resolves crates.io, and each stable deploy
+    /// publishes there from the same commit the binaries were built at, so a
+    /// cargo install is a stable install by construction.
+    pub fn channel(&self) -> Option<Channel> {
+        match self {
+            Self::Homebrew { formula } => Channel::from_package(formula),
+            Self::Scoop { package } => Channel::from_package(package),
+            Self::Cargo => Some(Channel::Stable),
+            Self::Script { channel } => Some(*channel),
+            Self::Unknown { .. } => None,
+        }
+    }
+
+    /// The one-line description the report opens with.
+    pub fn describe(&self) -> String {
+        let channel = match self.channel() {
+            Some(c) => format!(", {} channel", c.id()),
+            // A formula this build does not ship, or a path nothing claims.
+            None => String::new(),
+        };
+        match self {
+            Self::Homebrew { formula } => format!("Homebrew (formula {formula}{channel})"),
+            Self::Scoop { package } => format!("Scoop (package {package}{channel})"),
+            Self::Cargo => format!("cargo install (crates.io{channel})"),
+            Self::Script { .. } => format!("the install script ({INSTALL_URL}{channel})"),
+            Self::Unknown { path } => {
+                format!("something else - the binary is at {}", path.display())
+            }
+        }
+    }
+}
+
+/// The component of `path` immediately after the first one equal to `marker`.
+///
+/// This is how both package managers record what they installed: Homebrew lays
+/// a binary out as `<prefix>/Cellar/<formula>/<version>/bin/lev`, and Scoop as
+/// `<root>/apps/<package>/current/lev.exe`. The name in that slot is the real
+/// answer to "which channel is this", and it is on disk rather than inferred.
+fn component_after(path: &Path, marker: &str) -> Option<String> {
+    let mut components = path
+        .components()
+        .map(|c| c.as_os_str().to_string_lossy().into_owned());
+    components.by_ref().find(|c| c == marker)?;
+    components.next()
+}
+
+/// Whether `path` has a component equal to `marker`, ignoring case.
+///
+/// Scoop's root is a user-chosen directory that is conventionally but not
+/// reliably lowercase, and Windows paths are case-insensitive anyway.
+fn has_component(path: &Path, marker: &str) -> bool {
+    path.components()
+        .any(|c| c.as_os_str().to_string_lossy().eq_ignore_ascii_case(marker))
+}
+
+/// Homebrew prefixes that mean Homebrew and nothing else, for the case where
+/// the binary is the `bin/lev` symlink rather than the Cellar path behind it.
+///
+/// `/usr/local` is deliberately absent even though it is Homebrew's own prefix
+/// on Intel macOS: it is also where the install script and a hand-unpacked
+/// tarball put a binary, so treating everything under it as Homebrew would send
+/// a script install to `brew upgrade`. Under that prefix the Cellar component is
+/// the only evidence that counts.
+const UNAMBIGUOUS_BREW_PREFIXES: &[&str] = &["/opt/homebrew", "/home/linuxbrew/.linuxbrew"];
+
+/// Absolute directories the installers write to. The Linux installer hard-codes
+/// `/usr/local/bin`; `/usr/bin` is where the manual tarball instructions end up
+/// for anyone who moved it there instead.
+const SCRIPT_DESTINATIONS: &[&str] = &["/usr/local/bin", "/usr/bin"];
+
+/// Every directory a plain-binary install lands in, including the two that are
+/// home-relative: `~/.local/bin`, and the `%LOCALAPPDATA%\Leviath\bin` that
+/// `install.ps1` writes on Windows.
+///
+/// A loose binary in one of these is a script install. A loose binary anywhere
+/// else is not something to guess about, because re-running an installer aims
+/// at a fixed destination and would leave the copy actually on `PATH` untouched.
+fn script_destinations(home: Option<&Path>) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = SCRIPT_DESTINATIONS.iter().map(PathBuf::from).collect();
+    if let Some(home) = home {
+        dirs.push(home.join(".local").join("bin"));
+        dirs.push(
+            home.join("AppData")
+                .join("Local")
+                .join("Leviath")
+                .join("bin"),
+        );
+    }
+    dirs
+}
+
+/// Work out how `exe` was installed.
+///
+/// Pure over its inputs - the resolved executable path, the home directory, the
+/// answer `brew --prefix` gave (if it was asked and answered), and the channel
+/// the user named - so every arm is testable without a Homebrew, a Scoop or a
+/// second machine.
+pub fn detect(
+    exe: &Path,
+    home: Option<&Path>,
+    brew_prefix: Option<&Path>,
+    requested: Option<Channel>,
+) -> InstallMethod {
+    // The channel to fall back on where the path does not name one.
+    let channel = requested.unwrap_or(Channel::Stable);
+
+    // Homebrew, from the strongest evidence down. A Cellar path names the
+    // formula outright; a prefix only says "Homebrew put this here".
+    if let Some(formula) = component_after(exe, "Cellar") {
+        return InstallMethod::Homebrew { formula };
+    }
+    let under_brew = UNAMBIGUOUS_BREW_PREFIXES.iter().any(|p| exe.starts_with(p))
+        || brew_prefix.is_some_and(|p| exe.starts_with(p) && !is_ambiguous_prefix(p));
+    if under_brew {
+        return InstallMethod::Homebrew {
+            formula: channel.package().to_string(),
+        };
+    }
+
+    // Scoop, the same two ways round.
+    if has_component(exe, "scoop") {
+        let package = component_after(exe, "apps").unwrap_or_else(|| channel.package().to_string());
+        return InstallMethod::Scoop { package };
+    }
+
+    // A cargo install, which is the one method that cannot be updated in place.
+    let cargo_bin = home.map(|h| h.join(".cargo").join("bin"));
+    if cargo_bin.is_some_and(|dir| exe.starts_with(dir)) {
+        return InstallMethod::Cargo;
+    }
+
+    let parent = exe.parent();
+    let script_dir = script_destinations(home)
+        .iter()
+        .any(|d| parent == Some(d.as_path()));
+    match script_dir {
+        true => InstallMethod::Script { channel },
+        false => InstallMethod::Unknown {
+            path: exe.to_path_buf(),
+        },
+    }
+}
+
+/// Whether a prefix is too general to be evidence of anything on its own. See
+/// [`UNAMBIGUOUS_BREW_PREFIXES`] for why `/usr/local` is the case that matters.
+fn is_ambiguous_prefix(prefix: &Path) -> bool {
+    matches!(
+        prefix.to_string_lossy().trim_end_matches('/'),
+        "/usr/local" | "/usr" | "" | "/"
+    )
+}
+
+// ─── Config migrations ────────────────────────────────────────────────────────
+
+/// One config change `lev update` knows how to make on the user's behalf.
+///
+/// The mechanism exists so that a future incompatibility - a key that moved, a
+/// value whose meaning changed - is either fixed automatically or at least
+/// explained at the moment the user updates into it, rather than surfacing as a
+/// broken run days later. [`MIGRATIONS`] is empty today because no shipped
+/// version has changed a key's name or meaning; the tests drive the machinery
+/// with a sample so the wiring is proven rather than assumed.
+pub struct Migration {
+    /// A short stable name, shown in the report and in `--json`.
+    pub name: &'static str,
+    /// What it changes and why, in one line.
+    pub description: &'static str,
+    /// Whether this config needs it.
+    ///
+    /// Gets the parsed [`Config`] *and* the raw document, because the two see
+    /// different things: a key serde no longer reads vanishes from the parsed
+    /// value entirely, and a key that is still read but now means something
+    /// else is only visible there.
+    pub applies: fn(&Config, &toml::Table) -> bool,
+    /// Make the change, returning one line per thing it did.
+    pub apply: fn(&mut Config) -> Vec<String>,
+}
+
+/// The migrations this build knows about, oldest first.
+///
+/// Empty, and honestly so: nothing in a released `config.toml` has to change to
+/// work with this version. Adding one is adding an entry here.
+pub const MIGRATIONS: &[Migration] = &[];
+
+// ─── The plan ─────────────────────────────────────────────────────────────────
+
+/// What to do about the binary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BinaryStep {
+    /// Run this, argv-style.
+    Run(Vec<String>),
+    /// There is nothing to run here. Tell the user this instead.
+    Advise(String),
+}
+
+/// Everything `lev update` intends to do, as plain data.
+///
+/// Built before anything happens and rendered before anything happens, so the
+/// report, the JSON and the actions can never disagree about what was planned.
+pub struct UpdatePlan {
+    /// How this copy was installed.
+    pub method: InstallMethod,
+    /// The binary step.
+    pub binary: BinaryStep,
+    /// Every bundled blueprint and what would happen to it.
+    pub agents: Vec<(&'static BundledAgent, AgentAction)>,
+    /// The migrations that apply to the config as it stands.
+    pub migrations: Vec<&'static Migration>,
+    /// What reading the config found.
+    pub config: ConfigState,
+}
+
+/// What the plan found when it read the config file.
+///
+/// One value rather than a `Config` and an error beside it, because those two
+/// only ever come in two of the four combinations and the other two would be
+/// arms nothing could reach.
+///
+/// The config is carried rather than re-read at write time so there is exactly
+/// one read: re-opening the file would add an error arm only a race could take,
+/// and applying a migration to a document nobody has looked at since the report
+/// was printed is exactly the surprise this command exists to avoid.
+pub enum ConfigState {
+    /// The config as it stands, for the migrations to be applied to. Boxed
+    /// because a `Config` is far larger than the message beside it.
+    Loaded(Box<Config>),
+    /// It could not be read, and this is why.
+    Unreadable(String),
+}
+
+/// The upgrade step for an install method: a command, or the reason there
+/// isn't one.
+pub fn binary_step(method: &InstallMethod) -> BinaryStep {
+    match method {
+        InstallMethod::Homebrew { formula } => BinaryStep::Run(vec![
+            "brew".to_string(),
+            "upgrade".to_string(),
+            formula.clone(),
+        ]),
+        InstallMethod::Scoop { package } => BinaryStep::Run(vec![
+            "scoop".to_string(),
+            "update".to_string(),
+            package.clone(),
+        ]),
+        // Deliberately not run. `cargo install` rebuilds the whole workspace
+        // from source, which is minutes of CPU nobody asked for by typing
+        // `lev update`.
+        InstallMethod::Cargo => BinaryStep::Advise(
+            "this copy was built by `cargo install`. Update it with \
+             `cargo install leviath-cli` - that is a full compile, so it is not \
+             something to start for you."
+                .to_string(),
+        ),
+        // One shell, one pipeline. `LEVIATH_CHANNEL=beta curl ... | sh` is the
+        // form to never generate: the assignment belongs to `curl`, the piped
+        // shell never sees it, and the installer silently takes stable.
+        InstallMethod::Script { channel } => BinaryStep::Run(vec![
+            "sh".to_string(),
+            "-c".to_string(),
+            format!(
+                "curl -fsSL {INSTALL_URL} | sh -s -- --channel {}",
+                channel.id()
+            ),
+        ]),
+        InstallMethod::Unknown { path } => BinaryStep::Advise(format!(
+            "`lev` is at {}, which is not where any installer Leviath ships puts it. \
+             Update it the way you installed it, or re-install with \
+             `curl -fsSL {INSTALL_URL} | sh`.",
+            path.display()
+        )),
+    }
+}
+
+/// The config as `lev update` needs to see it: parsed, and the document behind
+/// it.
+struct LoadedConfig {
+    config: Config,
+    raw: toml::Table,
+}
+
+/// Read the config file both ways.
+fn load_config(path: &Path) -> anyhow::Result<LoadedConfig> {
+    let config = Config::load_from_path_public(path)?;
+    let raw = match std::fs::read_to_string(path) {
+        // `expect`: `load_from_path_public` above parsed this same text as
+        // TOML, so a document that reaches here is a document that parses.
+        Ok(text) => toml::from_str::<toml::Table>(&text).expect("the config parsed a moment ago"),
+        // No file at all, which loads as the defaults and an empty document.
+        Err(_) => toml::Table::new(),
+    };
+    Ok(LoadedConfig { config, raw })
+}
+
+/// Work out everything the command would do, without doing any of it.
+pub fn plan(args: &UpdateArgs, env: &UpdateEnv) -> UpdatePlan {
+    let method = detect(
+        &env.exe,
+        env.home.as_deref(),
+        env.brew_prefix.as_deref(),
+        args.channel,
+    );
+    let binary = binary_step(&method);
+    let agents = plan_agent_actions(&env.agents_dir);
+
+    // A config that will not parse is reported, not fatal: the binary step is
+    // the part of this command that matters most and it does not need one.
+    let (migrations, config) = match load_config(&env.config_path) {
+        Ok(loaded) => (
+            env.migrations
+                .iter()
+                .filter(|m| (m.applies)(&loaded.config, &loaded.raw))
+                .collect(),
+            ConfigState::Loaded(Box::new(loaded.config)),
+        ),
+        Err(e) => (Vec::new(), ConfigState::Unreadable(e.to_string())),
+    };
+
+    UpdatePlan {
+        method,
+        binary,
+        agents,
+        migrations,
+        config,
+    }
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+/// The blueprints this plan would change.
+fn changing(plan: &UpdatePlan) -> Vec<&(&'static BundledAgent, AgentAction)> {
+    plan.agents.iter().filter(|(_, a)| a.is_change()).collect()
+}
+
+/// Render the plan the way `lev update` prints it.
+///
+/// Pure, so the tests assert the text exactly - everything that varies between
+/// machines is already in the [`UpdatePlan`].
+pub fn format_plan(plan: &UpdatePlan, version: &str) -> String {
+    let mut out = format!(
+        "\nlev {version}, installed with {}\n\n",
+        plan.method.describe()
+    );
+
+    match &plan.binary {
+        BinaryStep::Run(argv) => out.push_str(&format!("  binary   {}\n", argv.join(" "))),
+        BinaryStep::Advise(text) => out.push_str(&format!("  binary   {text}\n")),
+    }
+
+    let changes = changing(plan);
+    match changes.is_empty() {
+        true => out.push_str(&format!(
+            "  agents   all {} bundled blueprints are up to date\n",
+            plan.agents.len()
+        )),
+        false => {
+            out.push_str(&format!(
+                "  agents   {} of {} would change\n",
+                changes.len(),
+                plan.agents.len()
+            ));
+            for (agent, action) in &changes {
+                out.push_str(&format!(
+                    "             {} - {}\n",
+                    agent.name,
+                    action.label(agent.version)
+                ));
+            }
+        }
+    }
+
+    match (&plan.config, plan.migrations.is_empty()) {
+        (ConfigState::Unreadable(e), _) => {
+            out.push_str(&format!("  config   could not be read: {e}\n"))
+        }
+        (ConfigState::Loaded(_), true) => out.push_str("  config   nothing to migrate\n"),
+        (ConfigState::Loaded(_), false) => {
+            out.push_str(&format!(
+                "  config   {} migration(s)\n",
+                plan.migrations.len()
+            ));
+            for migration in &plan.migrations {
+                out.push_str(&format!(
+                    "             {} - {}\n",
+                    migration.name, migration.description
+                ));
+            }
+        }
+    }
+    out
+}
+
+/// The plan as JSON. Built by hand, like `lev tools` and `lev doctor`, so the
+/// shape is explicit and does not move when a type gains a field.
+pub fn plan_json(plan: &UpdatePlan, version: &str) -> serde_json::Value {
+    let binary = match &plan.binary {
+        BinaryStep::Run(argv) => serde_json::json!({ "action": "run", "command": argv }),
+        BinaryStep::Advise(text) => serde_json::json!({ "action": "advise", "message": text }),
+    };
+    let agents: Vec<serde_json::Value> = plan
+        .agents
+        .iter()
+        .map(|(agent, action)| {
+            serde_json::json!({
+                "name": agent.name,
+                "version": agent.version,
+                "change": action.label(agent.version),
+                "changes": action.is_change(),
+                "preselected": action.preselect(),
+            })
+        })
+        .collect();
+    let migrations: Vec<serde_json::Value> = plan
+        .migrations
+        .iter()
+        .map(|m| serde_json::json!({ "name": m.name, "description": m.description }))
+        .collect();
+    serde_json::json!({
+        "version": version,
+        "install_method": plan.method.id(),
+        "channel": plan.method.channel().map(Channel::id),
+        "binary": binary,
+        "agents": agents,
+        "migrations": migrations,
+        "config_error": match &plan.config {
+            ConfigState::Unreadable(e) => serde_json::Value::String(e.clone()),
+            ConfigState::Loaded(_) => serde_json::Value::Null,
+        },
+    })
+}
+
+// ─── Arguments and seams ──────────────────────────────────────────────────────
+
+/// Arguments for `lev update`.
+#[derive(Args, Debug, Clone, Default)]
+pub struct UpdateArgs {
+    /// Report what would happen and change nothing.
+    #[arg(long)]
+    pub check: bool,
+
+    /// Answer yes to the binary upgrade and the config write without asking.
+    /// It deliberately does not install blueprints: see `--install-agents`.
+    #[arg(long)]
+    pub yes: bool,
+
+    /// Install the bundled blueprints without asking. A copy you edited
+    /// locally is still asked about on its own, since installing destroys it.
+    #[arg(long)]
+    pub install_agents: bool,
+
+    /// The channel to install, for the install-script method, which records
+    /// none. Ignored by Homebrew and Scoop, whose package name already says.
+    #[arg(long, value_name = "CHANNEL")]
+    pub channel: Option<Channel>,
+
+    /// Walk the whole flow, but print each action instead of performing it.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Print the plan as JSON and change nothing.
+    #[arg(long)]
+    pub json: bool,
+}
+
+/// Runs the upgrade command: argv in, success or the reason it failed out.
+///
+/// Injected rather than called directly so the tests assert *which* command
+/// would run without spawning anything. Mirrors the `BrowserOpener` and
+/// `SeedCommandRunner` seams.
+pub type CommandRunner = Arc<dyn Fn(&[String]) -> anyhow::Result<()> + Send + Sync>;
+
+/// Asks the user a yes/no question. Injected for the same reason: a unit test
+/// has no terminal, and which questions a flag answers on the user's behalf -
+/// and, for a blueprint they edited, which ones no flag answers - is something
+/// the tests have to be able to prove rather than describe.
+pub type Confirm = Arc<dyn Fn(&str) -> bool + Send + Sync>;
+
+/// The real I/O `lev update` depends on, injected so the command logic is
+/// testable without a package manager, a terminal, or the real home directory.
+pub struct UpdateEnv {
+    /// The running binary, symlinks already resolved. Resolving matters: a
+    /// Homebrew `bin/lev` is a symlink into the Cellar, and the Cellar path is
+    /// the one that names the formula.
+    pub exe: PathBuf,
+    /// The user's home directory, when one resolves.
+    pub home: Option<PathBuf>,
+    /// What `brew --prefix` answered, when it was asked and answered.
+    pub brew_prefix: Option<PathBuf>,
+    /// Where the bundled blueprints are installed.
+    pub agents_dir: PathBuf,
+    /// The config file to read and, with permission, rewrite.
+    pub config_path: PathBuf,
+    /// How to run the upgrade command.
+    pub runner: CommandRunner,
+    /// How to ask a yes/no question.
+    pub confirm: Confirm,
+    /// The migrations to consider, in order. Production passes [`MIGRATIONS`].
+    pub migrations: &'static [Migration],
+}
+
+// ─── Execution ────────────────────────────────────────────────────────────────
+
+/// Ask, unless `--yes` has already answered.
+fn agreed(args: &UpdateArgs, env: &UpdateEnv, question: &str) -> bool {
+    args.yes || (env.confirm)(question)
+}
+
+/// Step one: the binary.
+fn update_binary(args: &UpdateArgs, env: &UpdateEnv, plan: &UpdatePlan) -> anyhow::Result<()> {
+    let argv = match &plan.binary {
+        BinaryStep::Advise(text) => {
+            println!("  {text}");
+            return Ok(());
+        }
+        BinaryStep::Run(argv) => argv,
+    };
+    let shown = argv.join(" ");
+    if !agreed(args, env, &format!("Run `{shown}`?")) {
+        println!("  left the binary alone");
+        return Ok(());
+    }
+    if args.dry_run {
+        println!("  would run: {shown}");
+        return Ok(());
+    }
+    (env.runner)(argv)
+}
+
+/// Step two: the bundled blueprints.
+///
+/// Nothing here is a default. The whole list is printed first, and the agents
+/// directory is not written to until someone has said yes to it: `--yes` is
+/// deliberately not enough, because "update my binary without stopping to ask"
+/// and "replace the blueprints in my agents directory" are different requests
+/// and `lev setup` already treats them that way. `--install-agents` is how a
+/// script says the second one.
+///
+/// A copy the user edited is named as edited and asked about on its own, and no
+/// flag covers it: [`install_bundled`] removes the destination directory first,
+/// so a bulk yes would take their edits and any file they added with it.
+///
+/// A failed install is a warning, not an abort, for the same reason `lev setup`
+/// treats it that way: an updated binary plus most of the blueprints is a far
+/// better place to leave someone than a command that gave up in the middle.
+fn update_agents(args: &UpdateArgs, env: &UpdateEnv, plan: &UpdatePlan) {
+    let changes = changing(plan);
+    if changes.is_empty() {
+        println!("  every bundled blueprint is already up to date");
+        return;
+    }
+
+    // Seen before agreed to, always.
+    for (agent, action) in &changes {
+        println!("    {} - {}", agent.name, action.label(agent.version));
+    }
+    let clean = changes.iter().filter(|(_, a)| a.preselect()).count();
+    let edited = changes.len() - clean;
+    if edited > 0 {
+        println!(
+            "  {edited} of these you have edited locally. Installing removes the directory \
+             first, so your edits and any file you added go with it - each is asked about \
+             on its own."
+        );
+    }
+
+    // One question for the whole clean set, rather than one per blueprint: the
+    // list above is already the detail, and seven prompts in a row is how a
+    // person stops reading them.
+    let install_clean = match clean {
+        0 => false,
+        n => args.install_agents || (env.confirm)(&format!("Install these {n} blueprint(s)?")),
+    };
+
+    for (agent, action) in changes {
+        let ok = match action.preselect() {
+            true => install_clean,
+            false => (env.confirm)(&format!(
+                "{} - {}. Overwrite your edited copy?",
+                agent.name,
+                action.label(agent.version)
+            )),
+        };
+        if !ok {
+            println!("  skipped {}", agent.name);
+            continue;
+        }
+        if args.dry_run {
+            println!("  would install {} {}", agent.name, agent.version);
+            continue;
+        }
+        match install_bundled(agent, &env.agents_dir) {
+            Ok(()) => println!("  installed {} {}", agent.name, agent.version),
+            Err(e) => println!("  could not install {}: {e}", agent.name),
+        }
+    }
+}
+
+/// Step three: the config.
+///
+/// Nothing is written before the user has seen, line by line, what changed.
+fn migrate_config(args: &UpdateArgs, env: &UpdateEnv, plan: &UpdatePlan) -> anyhow::Result<()> {
+    let config = match &plan.config {
+        ConfigState::Unreadable(e) => {
+            println!("  the config could not be read, so it was left alone: {e}");
+            return Ok(());
+        }
+        ConfigState::Loaded(config) => config,
+    };
+    if plan.migrations.is_empty() {
+        println!("  the config needs no changes");
+        return Ok(());
+    }
+
+    let mut config = config.as_ref().clone();
+    let mut changed = Vec::new();
+    for migration in &plan.migrations {
+        for line in (migration.apply)(&mut config) {
+            changed.push(format!("{}: {line}", migration.name));
+        }
+    }
+    for line in &changed {
+        println!("    - {line}");
+    }
+
+    let path = env.config_path.display();
+    if !agreed(args, env, &format!("Write these changes to {path}?")) {
+        println!("  config left as it is");
+        return Ok(());
+    }
+    if args.dry_run {
+        println!("  would write {path}");
+        return Ok(());
+    }
+    config.save_to_path_public(&env.config_path)?;
+    println!("  wrote {path}");
+    Ok(())
+}
+
+/// Run `lev update` against an injected environment.
+pub fn execute_with(args: &UpdateArgs, env: &UpdateEnv, version: &str) -> anyhow::Result<()> {
+    let plan = plan(args, env);
+
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&plan_json(&plan, version))
+                .expect("a plan is plain data and always serializes")
+        );
+        return Ok(());
+    }
+
+    print!("{}", format_plan(&plan, version));
+    if args.check {
+        return Ok(());
+    }
+
+    println!("\nbinary");
+    update_binary(args, env, &plan)?;
+    println!("\nblueprints");
+    update_agents(args, env, &plan);
+    println!("\nconfig");
+    migrate_config(args, env, &plan)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-cli/src/commands/update/tests.rs
+++ b/crates/leviath-cli/src/commands/update/tests.rs
@@ -1129,7 +1129,7 @@ fn a_config_that_cannot_be_written_is_an_error() {
             binary: binary_step(&InstallMethod::Cargo),
             agents: Vec::new(),
             migrations: SAMPLE.iter().take(1).collect(),
-            config: ConfigState::Loaded(Box::new(Config::default())),
+            config: ConfigState::Loaded(Box::default()),
         };
         let err = migrate_config(&args, &env, &plan).expect_err("the write failed");
         assert!(!err.to_string().is_empty());

--- a/crates/leviath-cli/src/commands/update/tests.rs
+++ b/crates/leviath-cli/src/commands/update/tests.rs
@@ -1,0 +1,1196 @@
+//! Tests for `lev update`.
+//!
+//! Nothing here spawns a process. The runner and the confirm prompt are both
+//! injected, so every assertion is about the command that *would* run - which
+//! is the whole point of the seam.
+
+use std::sync::{Arc, Mutex};
+
+use super::*;
+use crate::bundled::BUNDLED_AGENTS;
+use crate::test_support::with_tracing;
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+/// Records every argv the command hands it, and answers with a scripted result.
+#[derive(Default)]
+struct Recorder {
+    ran: Mutex<Vec<Vec<String>>>,
+    asked: Mutex<Vec<String>>,
+}
+
+impl Recorder {
+    fn ran(&self) -> Vec<Vec<String>> {
+        self.ran.lock().expect("not poisoned").clone()
+    }
+
+    fn asked(&self) -> Vec<String> {
+        self.asked.lock().expect("not poisoned").clone()
+    }
+}
+
+/// A scratch environment: a tempdir for the agents and the config, a recorder
+/// for the two seams, and whatever answer the prompt should give.
+struct Fixture {
+    dir: tempfile::TempDir,
+    recorder: Arc<Recorder>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self {
+            dir: tempfile::tempdir().expect("a temp dir"),
+            recorder: Arc::new(Recorder::default()),
+        }
+    }
+
+    /// An env whose binary lives at `exe`, whose prompt answers `answer`, and
+    /// whose runner returns `runner_ok`.
+    fn env(&self, exe: &str, answer: bool, runner_ok: bool) -> UpdateEnv {
+        self.env_with(exe, answer, runner_ok, &[])
+    }
+
+    fn env_with(
+        &self,
+        exe: &str,
+        answer: bool,
+        runner_ok: bool,
+        migrations: &'static [Migration],
+    ) -> UpdateEnv {
+        let ran = Arc::clone(&self.recorder);
+        let asked = Arc::clone(&self.recorder);
+        UpdateEnv {
+            exe: PathBuf::from(exe),
+            home: Some(PathBuf::from("/home/u")),
+            brew_prefix: None,
+            agents_dir: self.dir.path().join("agents"),
+            config_path: self.dir.path().join("config.toml"),
+            runner: Arc::new(move |argv: &[String]| {
+                ran.ran.lock().expect("not poisoned").push(argv.to_vec());
+                match runner_ok {
+                    true => Ok(()),
+                    false => anyhow::bail!("the upgrade command failed"),
+                }
+            }),
+            confirm: Arc::new(move |question: &str| {
+                asked
+                    .asked
+                    .lock()
+                    .expect("not poisoned")
+                    .push(question.to_string());
+                answer
+            }),
+            migrations,
+        }
+    }
+}
+
+/// A plan built against a fixture, for the rendering tests.
+fn plan_for(fixture: &Fixture, exe: &str, args: &UpdateArgs) -> UpdatePlan {
+    plan(args, &fixture.env(exe, true, true))
+}
+
+// ─── Channels ─────────────────────────────────────────────────────────────────
+
+/// The three channels, their ids, and the package names that carry them. This
+/// is the mapping `lev update` bets everything on: the formula name is the only
+/// record of the channel that exists anywhere on disk.
+#[test]
+fn every_channel_has_an_id_and_a_package_that_round_trip() {
+    for (channel, id, package) in [
+        (Channel::Stable, "stable", "leviath"),
+        (Channel::Beta, "beta", "leviath-beta"),
+        (Channel::Alpha, "alpha", "leviath-alpha"),
+    ] {
+        assert_eq!(channel.id(), id);
+        assert_eq!(channel.package(), package);
+        assert_eq!(Channel::from_package(package), Some(channel));
+    }
+    // A formula this build does not ship reads as "no channel", not as stable.
+    assert_eq!(Channel::from_package("leviath-nightly"), None);
+}
+
+// ─── Detection ────────────────────────────────────────────────────────────────
+
+/// The strongest evidence there is: a Cellar path names the formula outright,
+/// and the formula names the channel. No flag is consulted.
+#[test]
+fn a_cellar_path_names_the_formula_and_therefore_the_channel() {
+    for (path, formula, channel) in [
+        (
+            "/opt/homebrew/Cellar/leviath/0.3.4/bin/lev",
+            "leviath",
+            Channel::Stable,
+        ),
+        (
+            "/usr/local/Cellar/leviath-beta/0.3.4/bin/lev",
+            "leviath-beta",
+            Channel::Beta,
+        ),
+        (
+            "/home/linuxbrew/.linuxbrew/Cellar/leviath-alpha/0.3.4/bin/lev",
+            "leviath-alpha",
+            Channel::Alpha,
+        ),
+    ] {
+        // `--channel stable` is passed every time on purpose: the path wins.
+        let method = detect(
+            Path::new(path),
+            Some(Path::new("/home/u")),
+            None,
+            Some(Channel::Stable),
+        );
+        assert_eq!(
+            method,
+            InstallMethod::Homebrew {
+                formula: formula.to_string()
+            },
+            "{path}"
+        );
+        assert_eq!(method.channel(), Some(channel));
+    }
+}
+
+/// An unresolved `bin/lev` symlink under a prefix that means Homebrew and
+/// nothing else. There is no formula in the path, so the requested channel is
+/// what picks it.
+#[test]
+fn an_unambiguous_brew_prefix_is_homebrew_at_the_requested_channel() {
+    let method = detect(
+        Path::new("/opt/homebrew/bin/lev"),
+        None,
+        None,
+        Some(Channel::Beta),
+    );
+    assert_eq!(
+        method,
+        InstallMethod::Homebrew {
+            formula: "leviath-beta".to_string()
+        }
+    );
+    // Linuxbrew's prefix counts the same way, and with no flag it is stable.
+    assert_eq!(
+        detect(
+            Path::new("/home/linuxbrew/.linuxbrew/bin/lev"),
+            None,
+            None,
+            None
+        ),
+        InstallMethod::Homebrew {
+            formula: "leviath".to_string()
+        }
+    );
+}
+
+/// A custom `brew --prefix` is evidence; `/usr/local` is not.
+///
+/// This is the case that would do real damage if it were wrong: `/usr/local` is
+/// both Homebrew's prefix on Intel macOS *and* the directory the Linux
+/// installer hard-codes, so treating the prefix as proof would send every
+/// script install to `brew upgrade`.
+#[test]
+fn a_general_purpose_brew_prefix_is_not_evidence_on_its_own() {
+    let custom = detect(
+        Path::new("/home/u/homebrew/bin/lev"),
+        Some(Path::new("/home/u")),
+        Some(Path::new("/home/u/homebrew")),
+        None,
+    );
+    assert_eq!(
+        custom,
+        InstallMethod::Homebrew {
+            formula: "leviath".to_string()
+        }
+    );
+
+    // The same shape under /usr/local reads as the install script instead.
+    assert_eq!(
+        detect(
+            Path::new("/usr/local/bin/lev"),
+            Some(Path::new("/home/u")),
+            Some(Path::new("/usr/local")),
+            None,
+        ),
+        InstallMethod::Script {
+            channel: Channel::Stable
+        }
+    );
+    // Every prefix the guard treats as too general, including the trailing
+    // slash and the degenerate forms a mis-parsed `brew --prefix` could give.
+    for prefix in ["/usr/local", "/usr/local/", "/usr", "/", ""] {
+        assert!(is_ambiguous_prefix(Path::new(prefix)), "{prefix}");
+    }
+    assert!(!is_ambiguous_prefix(Path::new("/opt/homebrew")));
+}
+
+/// Scoop records the package under `apps/`, the same way Homebrew records the
+/// formula under `Cellar/`. A shim has no package in it, so the flag decides.
+#[test]
+fn scoop_reads_the_package_from_apps_and_falls_back_for_a_shim() {
+    assert_eq!(
+        detect(
+            Path::new("C:/Users/u/scoop/apps/leviath-alpha/current/lev.exe"),
+            None,
+            None,
+            None,
+        ),
+        InstallMethod::Scoop {
+            package: "leviath-alpha".to_string()
+        }
+    );
+    // A shim, with the channel named on the command line. The directory is
+    // capitalised to prove the match ignores case, which Windows paths do.
+    assert_eq!(
+        detect(
+            Path::new("C:/Users/u/Scoop/shims/lev.exe"),
+            None,
+            None,
+            Some(Channel::Beta),
+        ),
+        InstallMethod::Scoop {
+            package: "leviath-beta".to_string()
+        }
+    );
+}
+
+/// A cargo install is the one that cannot be updated in place.
+#[test]
+fn a_binary_under_cargo_bin_is_a_cargo_install() {
+    assert_eq!(
+        detect(
+            Path::new("/home/u/.cargo/bin/lev"),
+            Some(Path::new("/home/u")),
+            None,
+            None,
+        ),
+        InstallMethod::Cargo
+    );
+    // crates.io tracks the stable channel, so a cargo install has one even
+    // though nothing on disk says so.
+    assert_eq!(InstallMethod::Cargo.channel(), Some(Channel::Stable));
+    // With no home to resolve, `.cargo/bin` cannot be recognised and the path
+    // falls through to the unknown arm rather than being guessed at.
+    assert_eq!(
+        detect(Path::new("/home/u/.cargo/bin/lev"), None, None, None),
+        InstallMethod::Unknown {
+            path: PathBuf::from("/home/u/.cargo/bin/lev")
+        }
+    );
+}
+
+/// Every directory an installer actually writes to, and the default channel for
+/// the one method that records none.
+#[test]
+fn a_plain_binary_in_an_installer_destination_is_a_script_install() {
+    for dir in [
+        "/usr/local/bin",
+        "/usr/bin",
+        "/home/u/.local/bin",
+        "/home/u/AppData/Local/Leviath/bin",
+    ] {
+        assert_eq!(
+            detect(
+                &Path::new(dir).join("lev"),
+                Some(Path::new("/home/u")),
+                None,
+                None,
+            ),
+            InstallMethod::Script {
+                channel: Channel::Stable
+            },
+            "{dir}"
+        );
+    }
+    // The install script keeps no receipt, so `--channel` is the only way to
+    // say which one to re-install.
+    assert_eq!(
+        detect(
+            Path::new("/usr/local/bin/lev"),
+            None,
+            None,
+            Some(Channel::Alpha),
+        ),
+        InstallMethod::Script {
+            channel: Channel::Alpha
+        }
+    );
+}
+
+/// Anything else is named rather than guessed at.
+#[test]
+fn a_binary_somewhere_else_is_unknown() {
+    let method = detect(
+        Path::new("/home/u/dev/leviath/target/release/lev"),
+        Some(Path::new("/home/u")),
+        None,
+        None,
+    );
+    assert_eq!(
+        method,
+        InstallMethod::Unknown {
+            path: PathBuf::from("/home/u/dev/leviath/target/release/lev")
+        }
+    );
+    assert_eq!(method.channel(), None, "nothing on disk says which channel");
+    // A path with no parent at all still lands here rather than panicking.
+    assert!(matches!(
+        detect(Path::new("/"), None, None, None),
+        InstallMethod::Unknown { .. }
+    ));
+}
+
+#[test]
+fn component_after_finds_the_slot_or_says_there_is_none() {
+    let path = Path::new("/opt/homebrew/Cellar/leviath/0.3.4/bin/lev");
+    assert_eq!(component_after(path, "Cellar").as_deref(), Some("leviath"));
+    // A marker that is not there at all.
+    assert_eq!(component_after(path, "apps"), None);
+    // A marker in the last slot, so there is nothing after it.
+    assert_eq!(component_after(Path::new("/a/Cellar"), "Cellar"), None);
+    assert!(has_component(path, "cellar"), "the check ignores case");
+    assert!(!has_component(path, "scoop"));
+}
+
+#[test]
+fn script_destinations_grow_by_two_when_a_home_resolves() {
+    assert_eq!(script_destinations(None).len(), SCRIPT_DESTINATIONS.len());
+    assert_eq!(
+        script_destinations(Some(Path::new("/home/u"))).len(),
+        SCRIPT_DESTINATIONS.len() + 2
+    );
+}
+
+// ─── The command per method ───────────────────────────────────────────────────
+
+/// The exact command each method runs, and the two that run nothing.
+#[test]
+fn each_install_method_maps_to_one_command() {
+    assert_eq!(
+        binary_step(&InstallMethod::Homebrew {
+            formula: "leviath-beta".to_string()
+        }),
+        BinaryStep::Run(vec![
+            "brew".to_string(),
+            "upgrade".to_string(),
+            "leviath-beta".to_string()
+        ])
+    );
+    assert_eq!(
+        binary_step(&InstallMethod::Scoop {
+            package: "leviath-alpha".to_string()
+        }),
+        BinaryStep::Run(vec![
+            "scoop".to_string(),
+            "update".to_string(),
+            "leviath-alpha".to_string()
+        ])
+    );
+    // A cargo install is a compile. It is described, never started.
+    let BinaryStep::Advise(cargo) = binary_step(&InstallMethod::Cargo) else {
+        panic!("cargo has nothing to run");
+    };
+    assert!(cargo.contains("cargo install leviath-cli"), "{cargo}");
+
+    let BinaryStep::Advise(unknown) = binary_step(&InstallMethod::Unknown {
+        path: PathBuf::from("/somewhere/odd/lev"),
+    }) else {
+        panic!("an unknown install has nothing to run");
+    };
+    assert!(unknown.contains("/somewhere/odd/lev"), "{unknown}");
+}
+
+/// The installer invocation, which is the one command here that is easy to get
+/// silently wrong.
+///
+/// `LEVIATH_CHANNEL=beta curl ... | sh` looks right and is not: the two sides
+/// of a pipe are separate processes, so the assignment belongs to `curl` and
+/// the shell that actually runs the installer never sees it. The installer then
+/// takes its own default without complaint. `sh -s -- --channel <c>` passes the
+/// channel as an argument to the right process.
+#[test]
+fn the_install_script_is_invoked_with_the_channel_as_an_argument() {
+    for channel in [Channel::Stable, Channel::Beta, Channel::Alpha] {
+        let BinaryStep::Run(argv) = binary_step(&InstallMethod::Script { channel }) else {
+            panic!("the script method runs a command");
+        };
+        assert_eq!(argv[0], "sh");
+        assert_eq!(argv[1], "-c");
+        assert_eq!(
+            argv[2],
+            format!(
+                "curl -fsSL https://leviath.dev/install.sh | sh -s -- --channel {}",
+                channel.id()
+            )
+        );
+        assert!(
+            !argv[2].contains("LEVIATH_CHANNEL"),
+            "the env-assignment form must never be generated: {}",
+            argv[2]
+        );
+    }
+}
+
+#[test]
+fn every_method_has_an_id_and_a_description() {
+    let methods = [
+        InstallMethod::Homebrew {
+            formula: "leviath".to_string(),
+        },
+        InstallMethod::Scoop {
+            package: "leviath-beta".to_string(),
+        },
+        InstallMethod::Cargo,
+        InstallMethod::Script {
+            channel: Channel::Alpha,
+        },
+        InstallMethod::Unknown {
+            path: PathBuf::from("/odd/lev"),
+        },
+    ];
+    let ids: Vec<&str> = methods.iter().map(InstallMethod::id).collect();
+    assert_eq!(ids, ["homebrew", "scoop", "cargo", "script", "unknown"]);
+    for method in &methods {
+        assert!(!method.describe().is_empty());
+    }
+    // A formula name this build does not ship describes itself without
+    // claiming a channel it cannot know.
+    let odd = InstallMethod::Homebrew {
+        formula: "leviath-nightly".to_string(),
+    }
+    .describe();
+    assert!(odd.contains("leviath-nightly"), "{odd}");
+    assert!(!odd.contains("channel"), "{odd}");
+    // And a Scoop package this build does not ship, so both `from_package`
+    // callers are exercised on a miss.
+    assert_eq!(
+        InstallMethod::Scoop {
+            package: "leviath-nightly".to_string()
+        }
+        .channel(),
+        None
+    );
+}
+
+// ─── Planning ─────────────────────────────────────────────────────────────────
+
+/// A fresh machine: nothing installed, so every blueprint is offered.
+#[test]
+fn a_plan_offers_every_blueprint_when_none_is_installed() {
+    let fixture = Fixture::new();
+    let plan = plan_for(&fixture, "/opt/homebrew/bin/lev", &UpdateArgs::default());
+
+    assert_eq!(plan.agents.len(), BUNDLED_AGENTS.len());
+    assert!(plan.agents.iter().all(|(_, a)| a.is_change()));
+    assert!(plan.migrations.is_empty(), "none ship today");
+    assert!(
+        matches!(plan.config, ConfigState::Loaded(_)),
+        "a missing config loads as defaults"
+    );
+}
+
+/// A config that will not parse is reported, not fatal: the binary step is
+/// what this command is mostly for and it needs no config at all.
+#[test]
+fn a_config_that_will_not_parse_is_reported_and_the_rest_still_plans() {
+    let fixture = Fixture::new();
+    std::fs::write(
+        fixture.dir.path().join("config.toml"),
+        "this is not = = toml",
+    )
+    .expect("write the broken config");
+
+    let plan = plan_for(&fixture, "/opt/homebrew/bin/lev", &UpdateArgs::default());
+
+    assert!(matches!(plan.config, ConfigState::Unreadable(_)));
+    assert!(plan.migrations.is_empty());
+    assert!(matches!(plan.binary, BinaryStep::Run(_)), "still planned");
+}
+
+/// The sample migration the shipped list is empty of. This is what proves the
+/// mechanism runs rather than being wiring nobody has ever exercised.
+static SAMPLE: &[Migration] = &[
+    Migration {
+        name: "sample-default-provider",
+        description: "point a config with no default_provider at ollama",
+        applies: |config, raw| config.default_provider != "ollama" && !raw.is_empty(),
+        apply: |config| {
+            let was = std::mem::replace(&mut config.default_provider, "ollama".to_string());
+            vec![format!("default_provider: {was} -> ollama")]
+        },
+    },
+    Migration {
+        name: "sample-never-applies",
+        description: "a migration whose predicate is false for this config",
+        applies: |_, _| false,
+        apply: |_| vec!["unreachable".to_string()],
+    },
+];
+
+/// A migration that applies to any config at all, for the tests that need the
+/// write to be reached rather than the predicate to be interesting.
+static ALWAYS: &[Migration] = &[Migration {
+    name: "sample-always-applies",
+    description: "a migration every config needs",
+    applies: |_, _| true,
+    apply: |config| {
+        config.default_provider = "ollama".to_string();
+        vec!["default_provider -> ollama".to_string()]
+    },
+}];
+
+/// The predicate decides, and it sees both the parsed config and the raw
+/// document - which is the whole reason it takes two arguments.
+#[test]
+fn a_migration_is_selected_by_its_predicate_over_the_config_and_the_raw_toml() {
+    let fixture = Fixture::new();
+    std::fs::write(
+        fixture.dir.path().join("config.toml"),
+        "default_provider = \"anthropic\"\n",
+    )
+    .expect("write the config");
+    let env = fixture.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
+
+    let selected = plan(&UpdateArgs::default(), &env);
+
+    let names: Vec<&str> = selected.migrations.iter().map(|m| m.name).collect();
+    assert_eq!(
+        names,
+        ["sample-default-provider"],
+        "only the one whose predicate holds"
+    );
+
+    // With no file at all the raw document is empty, so the same predicate
+    // says no - the arm that only the raw half of the pair can reach.
+    let empty = Fixture::new();
+    let env = empty.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
+    assert!(plan(&UpdateArgs::default(), &env).migrations.is_empty());
+}
+
+#[test]
+fn the_shipped_migration_list_is_empty_and_that_is_deliberate() {
+    // No released config.toml has to change to work with this build. The list
+    // is the place a future one goes; the tests above prove it would run.
+    assert!(MIGRATIONS.is_empty());
+}
+
+// ─── Rendering ────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_report_names_the_method_the_command_and_the_blueprints() {
+    let fixture = Fixture::new();
+    let plan = plan_for(
+        &fixture,
+        "/usr/local/Cellar/leviath-beta/0.3.4/bin/lev",
+        &UpdateArgs::default(),
+    );
+
+    let report = format_plan(&plan, "0.3.4");
+
+    assert!(
+        report.contains("lev 0.3.4, installed with Homebrew"),
+        "{report}"
+    );
+    assert!(report.contains("beta channel"), "{report}");
+    assert!(report.contains("brew upgrade leviath-beta"), "{report}");
+    assert!(
+        report.contains(&format!(
+            "{} of {} would change",
+            BUNDLED_AGENTS.len(),
+            BUNDLED_AGENTS.len()
+        )),
+        "{report}"
+    );
+    assert!(report.contains("nothing to migrate"), "{report}");
+}
+
+/// The other side of each branch: nothing to install, nothing to run, and a
+/// config that could not be read.
+#[test]
+fn the_report_says_so_when_there_is_nothing_to_do() {
+    let fixture = Fixture::new();
+    let agents_dir = fixture.dir.path().join("agents");
+    for agent in BUNDLED_AGENTS {
+        install_bundled(agent, &agents_dir).expect("install the bundled set");
+    }
+    std::fs::write(fixture.dir.path().join("config.toml"), "nope = = nope")
+        .expect("write the broken config");
+
+    let plan = plan_for(&fixture, "/home/u/.cargo/bin/lev", &UpdateArgs::default());
+    let report = format_plan(&plan, "0.3.4");
+
+    assert!(report.contains("cargo install leviath-cli"), "{report}");
+    assert!(
+        report.contains(&format!(
+            "all {} bundled blueprints are up to date",
+            BUNDLED_AGENTS.len()
+        )),
+        "{report}"
+    );
+    assert!(report.contains("could not be read"), "{report}");
+}
+
+/// A pending migration is listed by name and description before anything is
+/// touched, which is the promise the command makes about the config.
+#[test]
+fn the_report_lists_every_pending_migration() {
+    let fixture = Fixture::new();
+    std::fs::write(
+        fixture.dir.path().join("config.toml"),
+        "default_provider = \"anthropic\"\n",
+    )
+    .expect("write the config");
+    let env = fixture.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
+
+    let report = format_plan(&plan(&UpdateArgs::default(), &env), "0.3.4");
+
+    assert!(report.contains("1 migration(s)"), "{report}");
+    assert!(report.contains("sample-default-provider"), "{report}");
+    assert!(
+        report.contains("point a config with no default_provider"),
+        "{report}"
+    );
+}
+
+#[test]
+fn the_json_shape_carries_the_method_channel_command_and_rows() {
+    let fixture = Fixture::new();
+    std::fs::write(
+        fixture.dir.path().join("config.toml"),
+        "default_provider = \"anthropic\"\n",
+    )
+    .expect("write the config");
+    let env = fixture.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
+
+    let json = plan_json(&plan(&UpdateArgs::default(), &env), "0.3.4");
+
+    assert_eq!(json["version"], "0.3.4");
+    assert_eq!(json["install_method"], "homebrew");
+    assert_eq!(json["channel"], "stable");
+    assert_eq!(json["binary"]["action"], "run");
+    assert_eq!(json["binary"]["command"][0], "brew");
+    assert_eq!(json["agents"][0]["changes"], true);
+    assert_eq!(json["migrations"][0]["name"], "sample-default-provider");
+    assert_eq!(json["config_error"], serde_json::Value::Null);
+
+    // The advise arm, and a channel nothing can name.
+    let plan = plan_for(
+        &fixture,
+        "/home/u/dev/target/release/lev",
+        &UpdateArgs::default(),
+    );
+    let json = plan_json(&plan, "0.3.4");
+    assert_eq!(json["install_method"], "unknown");
+    assert_eq!(json["channel"], serde_json::Value::Null);
+    assert_eq!(json["binary"]["action"], "advise");
+    assert!(json["binary"]["message"].is_string());
+
+    // And a config that will not parse, which is the one thing `--json` has to
+    // say that the happy path never produces.
+    let broken = Fixture::new();
+    std::fs::write(broken.dir.path().join("config.toml"), "nope = = nope")
+        .expect("write the broken config");
+    let json = plan_json(
+        &plan_for(&broken, "/opt/homebrew/bin/lev", &UpdateArgs::default()),
+        "0.3.4",
+    );
+    assert!(
+        json["config_error"].as_str().is_some_and(|e| !e.is_empty()),
+        "{json}"
+    );
+}
+
+// ─── Execution ────────────────────────────────────────────────────────────────
+
+/// `--check` prints the plan and stops. Nothing is run, nothing is asked, and
+/// nothing is written.
+#[test]
+fn check_reports_and_changes_nothing() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let args = UpdateArgs {
+            check: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env("/opt/homebrew/bin/lev", true, true);
+
+        execute_with(&args, &env, "0.3.4").expect("check never fails");
+
+        assert!(fixture.recorder.ran().is_empty());
+        assert!(fixture.recorder.asked().is_empty());
+        assert!(!fixture.dir.path().join("agents").exists());
+    });
+}
+
+/// `--json` is the machine-readable twin of `--check`: same guarantee, and the
+/// output parses.
+#[test]
+fn json_reports_and_changes_nothing() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let args = UpdateArgs {
+            json: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env("/opt/homebrew/bin/lev", true, true);
+
+        execute_with(&args, &env, "0.3.4").expect("json never fails");
+
+        assert!(fixture.recorder.ran().is_empty());
+        assert!(fixture.recorder.asked().is_empty());
+    });
+}
+
+/// The happy path, unattended: `--yes --install-agents` answers for the user,
+/// the command runs, and every clean blueprint is installed.
+#[test]
+fn yes_and_install_agents_run_the_command_and_install_the_blueprints() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let args = UpdateArgs {
+            yes: true,
+            install_agents: true,
+            ..UpdateArgs::default()
+        };
+        // The prompt answers `false`, which must not matter: the flags are
+        // what decide, and asking at all would be the bug.
+        let env = fixture.env(
+            "/opt/homebrew/Cellar/leviath-beta/0.3.4/bin/lev",
+            false,
+            true,
+        );
+
+        execute_with(&args, &env, "0.3.4").expect("the whole flow succeeds");
+
+        assert_eq!(
+            fixture.recorder.ran(),
+            vec![vec![
+                "brew".to_string(),
+                "upgrade".to_string(),
+                "leviath-beta".to_string()
+            ]]
+        );
+        assert!(
+            fixture.recorder.asked().is_empty(),
+            "the two flags between them answer everything a clean install asks"
+        );
+        for agent in BUNDLED_AGENTS {
+            assert!(
+                env.agents_dir
+                    .join(agent.name)
+                    .join("agent.leviath")
+                    .exists(),
+                "{} was not installed",
+                agent.name
+            );
+        }
+    });
+}
+
+/// A blueprint the user edited is asked about on its own, and no flag covers
+/// it.
+///
+/// `install_bundled` removes the destination directory first, so agreeing in
+/// bulk would silently destroy work - the user's edits and any file they added
+/// alongside. Both flags are on here, and neither answers this question.
+#[test]
+fn an_edited_blueprint_is_asked_about_separately_whatever_the_flags_say() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let agents_dir = fixture.dir.path().join("agents");
+        for agent in BUNDLED_AGENTS {
+            install_bundled(agent, &agents_dir).expect("install the bundled set");
+        }
+        let edited = &BUNDLED_AGENTS[0];
+        let manifest = agents_dir.join(edited.name).join("agent.leviath");
+        let original = std::fs::read_to_string(&manifest).expect("read it back");
+        std::fs::write(&manifest, format!("{original}\n# a local edit\n")).expect("edit it");
+
+        let args = UpdateArgs {
+            yes: true,
+            install_agents: true,
+            ..UpdateArgs::default()
+        };
+        // The prompt says no, so the edit survives.
+        let env = fixture.env("/opt/homebrew/bin/lev", false, true);
+        execute_with(&args, &env, "0.3.4").expect("the flow succeeds");
+
+        let asked = fixture.recorder.asked();
+        assert_eq!(asked.len(), 1, "exactly the edited blueprint: {asked:?}");
+        assert!(asked[0].contains(edited.name), "{asked:?}");
+        assert!(
+            std::fs::read_to_string(&manifest)
+                .expect("still there")
+                .contains("# a local edit"),
+            "an edited blueprint was overwritten on a blanket yes"
+        );
+    });
+}
+
+/// The same blueprint, with the user saying yes to the separate question.
+#[test]
+fn an_edited_blueprint_is_reinstalled_when_the_user_says_so() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let agents_dir = fixture.dir.path().join("agents");
+        let edited = &BUNDLED_AGENTS[0];
+        install_bundled(edited, &agents_dir).expect("install one");
+        let manifest = agents_dir.join(edited.name).join("agent.leviath");
+        let original = std::fs::read_to_string(&manifest).expect("read it back");
+        std::fs::write(&manifest, format!("{original}\n# a local edit\n")).expect("edit it");
+
+        let env = fixture.env("/opt/homebrew/bin/lev", true, true);
+        execute_with(&UpdateArgs::default(), &env, "0.3.4").expect("the flow succeeds");
+
+        assert!(
+            !std::fs::read_to_string(&manifest)
+                .expect("still there")
+                .contains("# a local edit"),
+            "an explicit yes reinstalls it"
+        );
+    });
+}
+
+/// Saying no leaves everything exactly as it was.
+#[test]
+fn declining_leaves_the_binary_and_the_blueprints_alone() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let env = fixture.env("/opt/homebrew/bin/lev", false, true);
+
+        execute_with(&UpdateArgs::default(), &env, "0.3.4").expect("declining is not a failure");
+
+        assert!(fixture.recorder.ran().is_empty());
+        assert!(!env.agents_dir.exists(), "nothing was installed");
+        // Two questions: the binary, and the whole clean blueprint set at once.
+        // One prompt per blueprint is how a person stops reading them.
+        assert_eq!(fixture.recorder.asked().len(), 2);
+    });
+}
+
+/// The blueprints and the config are checked whatever the binary step did.
+///
+/// This is the case the command exists for. Someone who ran `brew upgrade`
+/// themselves has a current binary and blueprints from whenever they last ran
+/// `lev setup`, so a binary step that reported "nothing to do" and stopped
+/// would leave them exactly where they started.
+#[test]
+fn a_binary_with_nothing_to_do_still_reaches_the_blueprints_and_the_config() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        std::fs::write(
+            fixture.dir.path().join("config.toml"),
+            "default_provider = \"anthropic\"\n",
+        )
+        .expect("write the config");
+        let args = UpdateArgs {
+            yes: true,
+            install_agents: true,
+            ..UpdateArgs::default()
+        };
+        // `cargo` is the method whose binary step runs nothing at all, which is
+        // the strongest form of "the binary had nothing to do".
+        let env = fixture.env_with("/home/u/.cargo/bin/lev", true, true, SAMPLE);
+
+        execute_with(&args, &env, "0.3.4").expect("the flow succeeds");
+
+        assert!(fixture.recorder.ran().is_empty(), "no binary step ran");
+        for agent in BUNDLED_AGENTS {
+            assert!(
+                env.agents_dir
+                    .join(agent.name)
+                    .join("agent.leviath")
+                    .exists(),
+                "{} was not offered",
+                agent.name
+            );
+        }
+        let after = Config::load_from_path_public(&env.config_path).expect("still parses");
+        assert_eq!(
+            after.default_provider, "ollama",
+            "the config migration ran too"
+        );
+    });
+}
+
+/// `--dry-run` walks the whole flow, prompts and all, and performs none of it.
+#[test]
+fn dry_run_prompts_but_performs_nothing() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let args = UpdateArgs {
+            dry_run: true,
+            yes: true,
+            install_agents: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env("/opt/homebrew/bin/lev", true, true);
+
+        execute_with(&args, &env, "0.3.4").expect("a dry run succeeds");
+
+        assert!(fixture.recorder.ran().is_empty(), "nothing was spawned");
+        assert!(!env.agents_dir.exists(), "nothing was written");
+    });
+}
+
+/// An upgrade command that fails is the command's failure, so the shell sees a
+/// non-zero exit and a scripted update does not report success.
+#[test]
+fn a_failing_upgrade_command_fails_the_command() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env("/opt/homebrew/bin/lev", true, false);
+
+        let err = execute_with(&args, &env, "0.3.4").expect_err("the runner failed");
+
+        assert!(err.to_string().contains("the upgrade command failed"));
+    });
+}
+
+/// A method with nothing to run prints its advice and carries on to the rest.
+#[test]
+fn a_cargo_install_is_advised_and_the_blueprints_still_run() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env("/home/u/.cargo/bin/lev", true, true);
+
+        execute_with(&args, &env, "0.3.4").expect("advice is not a failure");
+
+        assert!(fixture.recorder.ran().is_empty(), "no compile was started");
+        assert!(env.agents_dir.exists(), "the blueprints still installed");
+    });
+}
+
+/// Nothing to install, so it says so rather than printing an empty list.
+#[test]
+fn an_up_to_date_install_says_there_is_nothing_to_do() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let agents_dir = fixture.dir.path().join("agents");
+        for agent in BUNDLED_AGENTS {
+            install_bundled(agent, &agents_dir).expect("install the bundled set");
+        }
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env("/opt/homebrew/bin/lev", true, true);
+
+        execute_with(&args, &env, "0.3.4").expect("nothing to do is not a failure");
+
+        assert_eq!(
+            fixture.recorder.asked().len(),
+            0,
+            "--yes covered the binary, and there was nothing else to ask about"
+        );
+    });
+}
+
+/// An install that fails is a warning, not an abort: an updated binary plus
+/// most of the blueprints beats a command that gave up halfway.
+#[test]
+fn a_blueprint_that_cannot_be_installed_warns_rather_than_aborting() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        // The agents directory is a file, so every install fails.
+        std::fs::write(fixture.dir.path().join("agents"), "not a directory")
+            .expect("block the directory");
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env("/opt/homebrew/bin/lev", true, true);
+
+        execute_with(&args, &env, "0.3.4").expect("a failed install is a warning");
+
+        assert_eq!(fixture.recorder.ran().len(), 1, "the binary still updated");
+    });
+}
+
+// ─── Config migration ─────────────────────────────────────────────────────────
+
+/// The full config path: the change is described, agreed to, and written.
+#[test]
+fn an_agreed_migration_is_described_and_then_written() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let config_path = fixture.dir.path().join("config.toml");
+        std::fs::write(&config_path, "default_provider = \"anthropic\"\n").expect("write it");
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
+
+        execute_with(&args, &env, "0.3.4").expect("the migration applies");
+
+        let after = Config::load_from_path_public(&config_path).expect("still parses");
+        assert_eq!(after.default_provider, "ollama");
+    });
+}
+
+/// Declining leaves the file byte for byte as it was.
+#[test]
+fn a_declined_migration_writes_nothing() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let config_path = fixture.dir.path().join("config.toml");
+        let before = "default_provider = \"anthropic\"\n";
+        std::fs::write(&config_path, before).expect("write it");
+        let env = fixture.env_with("/opt/homebrew/bin/lev", false, true, SAMPLE);
+
+        execute_with(&UpdateArgs::default(), &env, "0.3.4").expect("declining is fine");
+
+        assert_eq!(
+            std::fs::read_to_string(&config_path).expect("still there"),
+            before
+        );
+    });
+}
+
+/// `--dry-run` reaches the config step, agrees, and still writes nothing.
+#[test]
+fn a_dry_run_migration_writes_nothing() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let config_path = fixture.dir.path().join("config.toml");
+        let before = "default_provider = \"anthropic\"\n";
+        std::fs::write(&config_path, before).expect("write it");
+        let args = UpdateArgs {
+            dry_run: true,
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
+
+        execute_with(&args, &env, "0.3.4").expect("a dry run succeeds");
+
+        assert_eq!(
+            std::fs::read_to_string(&config_path).expect("still there"),
+            before
+        );
+    });
+}
+
+/// A config that will not parse is left alone and said so, rather than being
+/// rewritten from the defaults - which would silently drop every key in it.
+#[test]
+fn a_config_that_will_not_parse_is_left_alone() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let config_path = fixture.dir.path().join("config.toml");
+        let before = "this is not = = toml";
+        std::fs::write(&config_path, before).expect("write it");
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        let env = fixture.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
+
+        execute_with(&args, &env, "0.3.4").expect("a broken config is not fatal");
+
+        assert_eq!(
+            std::fs::read_to_string(&config_path).expect("still there"),
+            before
+        );
+    });
+}
+
+/// A config that cannot be written surfaces, rather than reporting a change
+/// that did not happen.
+#[test]
+fn a_config_that_cannot_be_written_is_an_error() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let config_path = fixture.dir.path().join("config.toml");
+        std::fs::write(&config_path, "default_provider = \"anthropic\"\n").expect("write it");
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        let mut env = fixture.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
+        // A directory in place of the file: it reads (through the parent that
+        // still holds the real config) but cannot be written over.
+        let blocked = fixture.dir.path().join("blocked");
+        std::fs::write(&blocked, "not a directory").expect("block it");
+        env.config_path = blocked.join("config.toml");
+
+        // Nothing to migrate at that path, so force the write path by pointing
+        // the read at the real file and the write at the blocked one.
+        let plan = UpdatePlan {
+            method: InstallMethod::Cargo,
+            binary: binary_step(&InstallMethod::Cargo),
+            agents: Vec::new(),
+            migrations: SAMPLE.iter().take(1).collect(),
+            config: ConfigState::Loaded(Box::new(Config::default())),
+        };
+        let err = migrate_config(&args, &env, &plan).expect_err("the write failed");
+        assert!(!err.to_string().is_empty());
+    });
+}
+
+/// And that failure is the command's failure, so a scripted update exits
+/// non-zero rather than reporting a config change that never landed.
+#[test]
+fn a_config_write_failure_fails_the_whole_command() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        // A file where the config's parent directory should be: the read finds
+        // nothing and loads the defaults, and the write cannot create the
+        // directory it would need.
+        let blocked = fixture.dir.path().join("blocked");
+        std::fs::write(&blocked, "not a directory").expect("block it");
+        let mut env = fixture.env_with("/home/u/.cargo/bin/lev", true, true, ALWAYS);
+        env.config_path = blocked.join("config.toml");
+
+        let err = execute_with(&args, &env, "0.3.4").expect_err("the write failed");
+
+        assert!(!err.to_string().is_empty());
+    });
+}
+
+#[test]
+fn load_config_reads_the_document_behind_the_parsed_value() {
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let path = dir.path().join("config.toml");
+
+    // No file: the defaults, and an empty document behind them.
+    let loaded = load_config(&path).expect("a missing config loads as defaults");
+    assert!(loaded.raw.is_empty());
+    assert_eq!(loaded.config.default_provider, "anthropic");
+
+    std::fs::write(&path, "default_provider = \"ollama\"\n").expect("write it");
+    let loaded = load_config(&path).expect("it parses");
+    assert_eq!(loaded.config.default_provider, "ollama");
+    assert!(loaded.raw.contains_key("default_provider"));
+
+    std::fs::write(&path, "nope = = nope").expect("write it");
+    assert!(load_config(&path).is_err());
+}
+
+/// The two-arm helper behind every prompt in the command.
+#[test]
+fn agreed_asks_unless_yes_already_answered() {
+    let fixture = Fixture::new();
+    let env = fixture.env("/opt/homebrew/bin/lev", false, true);
+    let yes = UpdateArgs {
+        yes: true,
+        ..UpdateArgs::default()
+    };
+
+    assert!(agreed(&yes, &env, "anything?"), "--yes answers");
+    assert!(fixture.recorder.asked().is_empty(), "and does not ask");
+    assert!(!agreed(&UpdateArgs::default(), &env, "anything?"));
+    assert_eq!(fixture.recorder.asked(), vec!["anything?".to_string()]);
+}

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -872,6 +872,12 @@ fn load_dotenv_filtered(path: &str) {
         .collect();
     let _ = dotenvy::from_read(doc.as_bytes());
 
+    // The common case is that a `.env` sets nothing sensitive, and warning then
+    // printed "Ignoring  from .env" with an empty list where a name belonged.
+    if skipped.is_empty() {
+        return;
+    }
+
     // Joined before the macro rather than inside it: `tracing` does not
     // evaluate field expressions when no subscriber is interested, so an
     // argument built in place reads as an unexecuted region even on the run
@@ -1225,6 +1231,41 @@ mod dotenv_tests {
     fn a_missing_dot_env_is_not_an_error() {
         let dir = make_fake_config_dir("dotenv-missing");
         load_dotenv_filtered(&dir.join("absent.env").to_string_lossy());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A `.env` that sets nothing sensitive is the ordinary case, and it used
+    /// to warn anyway: the message named the skipped variables, so with none
+    /// skipped users read "Ignoring  from .env" with a hole where a name
+    /// belonged. Under `-v` that landed in the middle of the setup wizard.
+    #[test]
+    fn an_ordinary_dot_env_warns_about_nothing() {
+        let dir = make_fake_config_dir("dotenv-nothing-skipped");
+        std::fs::write(dir.join(".env"), "LEV_DOTENV_ORDINARY=fine\n").unwrap();
+
+        {
+            let _cwd = isolate_cwd_for_test();
+            std::env::set_current_dir(&dir).unwrap();
+            temp_env::with_vars(
+                [
+                    (
+                        "LEVIATH_CONFIG_PATH",
+                        Some(dir.join("config.toml").into_os_string()),
+                    ),
+                    ("LEVIATH_SKIP_DOTENV", None),
+                    ("LEV_DOTENV_ORDINARY", None),
+                ],
+                || {
+                    Config::load().expect("a missing config file is not an error");
+                    // The allowed variable still lands, so the early return
+                    // skips the warning and nothing else.
+                    assert_eq!(
+                        std::env::var("LEV_DOTENV_ORDINARY").ok().as_deref(),
+                        Some("fine")
+                    );
+                },
+            );
+        }
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -115,6 +115,10 @@ pub enum Commands {
 
     /// Inspect and move the secrets Leviath holds
     Auth(commands::auth::AuthArgs),
+
+    /// Update Leviath, then everything that shipped with it
+    #[command(long_about = commands::update::UPDATE_LONG_ABOUT)]
+    Update(commands::update::UpdateArgs),
 }
 
 /// The subset of commands whose real execution performs I/O that a unit test
@@ -212,6 +216,13 @@ pub trait RiskyExecutors {
         &self,
         args: commands::auth::AuthArgs,
     ) -> impl std::future::Future<Output = anyhow::Result<()>>;
+
+    /// `lev update` - resolves the real executable, shells out to a package
+    /// manager, blocks on stdin for each confirmation, and rewrites the config.
+    fn update(
+        &self,
+        args: commands::update::UpdateArgs,
+    ) -> impl std::future::Future<Output = anyhow::Result<()>>;
 }
 
 /// Inject argv-prescanned dynamic `--<region>` seed flags into a parsed
@@ -260,6 +271,7 @@ pub async fn dispatch(command: Commands, ex: &impl RiskyExecutors) -> anyhow::Re
         Commands::Result(args) => commands::result::execute(args).await,
         Commands::Mcp(args) => ex.mcp(args).await,
         Commands::Auth(args) => ex.auth(args).await,
+        Commands::Update(args) => ex.update(args).await,
     }
 }
 
@@ -320,6 +332,10 @@ mod tests {
         }
 
         async fn mcp(&self, _args: commands::mcp::McpArgs) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn update(&self, _args: commands::update::UpdateArgs) -> anyhow::Result<()> {
             Ok(())
         }
     }
@@ -460,6 +476,16 @@ mod tests {
     async fn dispatch_auth_variant_is_routed_through_the_executor() {
         let args = commands::auth::AuthArgs::status_for_test();
         let result = dispatch(Commands::Auth(args), &MockRisky).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn dispatch_update_variant_is_routed_through_the_executor() {
+        // Routed, not called directly: the real `lev update` shells out to a
+        // package manager and blocks on stdin, so a unit test must never reach
+        // it. Its own tests drive the command core against injected seams.
+        let args = commands::update::UpdateArgs::default();
+        let result = dispatch(Commands::Update(args), &MockRisky).await;
         assert!(result.is_ok());
     }
 

--- a/crates/leviath-cli/src/logging.rs
+++ b/crates/leviath-cli/src/logging.rs
@@ -202,7 +202,9 @@ mod tests {
         // Released is the resting state, so a write goes straight out.
         release_from_tui();
         assert!(!TUI_HOLDS_TERMINAL.load(Ordering::Relaxed));
-        TerminalAwareWriter.write_all(b"").expect("stderr accepts a write");
+        TerminalAwareWriter
+            .write_all(b"")
+            .expect("stderr accepts a write");
         TerminalAwareWriter.flush().expect("stderr accepts a flush");
 
         hold_for_tui();
@@ -211,7 +213,9 @@ mod tests {
             .expect("a held write is buffered, never refused");
         // A flush while held must not reach the terminal either, or the point
         // of buffering is lost on the very next `tracing` call.
-        TerminalAwareWriter.flush().expect("a held flush is a no-op");
+        TerminalAwareWriter
+            .flush()
+            .expect("a held flush is a no-op");
         assert_eq!(
             PARKED.lock().expect("uncontended").as_slice(),
             b"parked line\n"

--- a/crates/leviath-cli/src/logging.rs
+++ b/crates/leviath-cli/src/logging.rs
@@ -10,8 +10,24 @@
 //! exporter. Everything stays on **stderr** - `lev agent-client` uses stdout
 //! as its JSON-RPC channel, and a stray log line there would corrupt the
 //! stream a host is parsing.
+//!
+//! stderr is not safe either while a full-screen TUI is up, which is what
+//! [`hold_for_tui`] exists for. `lev setup` and `lev dash` own the alternate
+//! screen on stdout, but stderr is the same terminal, so a log line lands
+//! inside the frame. Raw mode makes it worse than untidy: `OPOST` is off, so
+//! the newline is a bare line feed with no carriage return and each line
+//! starts where the last one ended, staircasing across the screen. And
+//! ratatui only redraws cells it believes changed, so nothing ever paints
+//! over the mess. A verification call at `debug` was enough to fill the
+//! wizard with what looked like garbage.
+//!
+//! So while a TUI holds the terminal, log lines are buffered instead of
+//! written, and flushed to stderr when it lets go. Nothing is lost, and
+//! nothing lands on the screen while somebody is looking at it.
 
-use std::sync::OnceLock;
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
 
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -22,6 +38,63 @@ type OtelSlot = Option<leviath_telemetry::LogLayer>;
 
 /// The handle [`install_otel_layer`] reloads through, parked by [`init`].
 static OTEL_HANDLE: OnceLock<reload::Handle<OtelSlot, Registry>> = OnceLock::new();
+
+/// Whether a TUI currently owns the terminal.
+static TUI_HOLDS_TERMINAL: AtomicBool = AtomicBool::new(false);
+
+/// Lines written while the terminal was held, waiting to be flushed.
+static PARKED: Mutex<Vec<u8>> = Mutex::new(Vec::new());
+
+/// Where a log line goes: straight to stderr, or into [`PARKED`] until the
+/// terminal is free.
+///
+/// One writer rather than a runtime swap of the subscriber, because the
+/// subscriber is installed once, process-wide, before any subcommand knows
+/// whether it will draw.
+struct TerminalAwareWriter;
+
+impl Write for TerminalAwareWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        if TUI_HOLDS_TERMINAL.load(Ordering::Relaxed) {
+            // A poisoned lock means another thread panicked mid-write. Dropping
+            // the line beats propagating a panic out of a logging call, which
+            // would turn a stray debug line into a crash.
+            if let Ok(mut parked) = PARKED.lock() {
+                parked.extend_from_slice(buf);
+            }
+            return Ok(buf.len());
+        }
+        std::io::stderr().write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        if TUI_HOLDS_TERMINAL.load(Ordering::Relaxed) {
+            return Ok(());
+        }
+        std::io::stderr().flush()
+    }
+}
+
+/// Park log output for as long as a TUI owns the terminal.
+///
+/// Call from the terminal setup that enters the alternate screen, and pair it
+/// with [`release_from_tui`] on every exit path including the panic hook.
+pub fn hold_for_tui() {
+    TUI_HOLDS_TERMINAL.store(true, Ordering::Relaxed);
+}
+
+/// Hand the terminal back and flush whatever was logged meanwhile.
+///
+/// Safe to call when nothing was held: there is simply nothing parked.
+pub fn release_from_tui() {
+    TUI_HOLDS_TERMINAL.store(false, Ordering::Relaxed);
+    let parked = match PARKED.lock() {
+        Ok(mut parked) if !parked.is_empty() => std::mem::take(&mut *parked),
+        _ => return,
+    };
+    let _ = std::io::stderr().write_all(&parked);
+    let _ = std::io::stderr().flush();
+}
 
 /// Install the process-wide subscriber: fmt → stderr at `info` (`debug` when
 /// verbose), plus the empty reloadable OTLP slot.
@@ -36,7 +109,7 @@ pub fn init(verbose: bool) {
     let (otel_layer, handle) = reload::Layer::new(None as OtelSlot);
     let subscriber = tracing_subscriber::registry().with(otel_layer).with(
         tracing_subscriber::fmt::layer()
-            .with_writer(std::io::stderr)
+            .with_writer(|| TerminalAwareWriter)
             .with_filter(EnvFilter::new(level)),
     );
     let _ = subscriber.try_init();
@@ -118,5 +191,40 @@ mod tests {
         init(true);
         let (layer, _exporter) = bridge_with_exporter();
         assert!(install_otel_layer(layer));
+    }
+
+    /// The hold is what keeps a log line out of a wizard someone is reading,
+    /// and the release is what keeps it from being lost instead. Both halves
+    /// live in one test because the flag is process-wide: a second test
+    /// toggling it in parallel would park the first one's writes.
+    #[test]
+    fn holding_the_terminal_parks_output_until_it_is_released() {
+        // Released is the resting state, so a write goes straight out.
+        release_from_tui();
+        assert!(!TUI_HOLDS_TERMINAL.load(Ordering::Relaxed));
+        TerminalAwareWriter.write_all(b"").expect("stderr accepts a write");
+        TerminalAwareWriter.flush().expect("stderr accepts a flush");
+
+        hold_for_tui();
+        TerminalAwareWriter
+            .write_all(b"parked line\n")
+            .expect("a held write is buffered, never refused");
+        // A flush while held must not reach the terminal either, or the point
+        // of buffering is lost on the very next `tracing` call.
+        TerminalAwareWriter.flush().expect("a held flush is a no-op");
+        assert_eq!(
+            PARKED.lock().expect("uncontended").as_slice(),
+            b"parked line\n"
+        );
+
+        release_from_tui();
+        assert!(
+            PARKED.lock().expect("uncontended").is_empty(),
+            "release hands the buffer to stderr and empties it"
+        );
+        // Releasing twice is what the panic hook plus `Drop` actually does, and
+        // with nothing parked it must stay quiet rather than write an empty
+        // line.
+        release_from_tui();
     }
 }

--- a/crates/leviath-cli/src/logging.rs
+++ b/crates/leviath-cli/src/logging.rs
@@ -27,7 +27,7 @@
 
 use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock, PoisonError};
 
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -56,12 +56,14 @@ struct TerminalAwareWriter;
 impl Write for TerminalAwareWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         if TUI_HOLDS_TERMINAL.load(Ordering::Relaxed) {
-            // A poisoned lock means another thread panicked mid-write. Dropping
-            // the line beats propagating a panic out of a logging call, which
-            // would turn a stray debug line into a crash.
-            if let Ok(mut parked) = PARKED.lock() {
-                parked.extend_from_slice(buf);
-            }
+            // A poisoned lock means a thread panicked while parking a line. The
+            // buffer is still a valid buffer, so it is taken back rather than
+            // handled: a logging call is the worst place to raise a second
+            // panic, and there is nothing here that a poisoned flag protects.
+            PARKED
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .extend_from_slice(buf);
             return Ok(buf.len());
         }
         std::io::stderr().write(buf)
@@ -73,6 +75,16 @@ impl Write for TerminalAwareWriter {
         }
         std::io::stderr().flush()
     }
+}
+
+/// The fmt layer's writer factory.
+///
+/// A named function rather than a closure at the call site, so the one region
+/// this indirection costs is something a test can execute. A closure inside
+/// [`init`] only ever runs when this process owns the global subscriber, which
+/// under a parallel test runner is whichever test won the slot.
+fn writer() -> TerminalAwareWriter {
+    TerminalAwareWriter
 }
 
 /// Park log output for as long as a TUI owns the terminal.
@@ -88,10 +100,10 @@ pub fn hold_for_tui() {
 /// Safe to call when nothing was held: there is simply nothing parked.
 pub fn release_from_tui() {
     TUI_HOLDS_TERMINAL.store(false, Ordering::Relaxed);
-    let parked = match PARKED.lock() {
-        Ok(mut parked) if !parked.is_empty() => std::mem::take(&mut *parked),
-        _ => return,
-    };
+    let parked = std::mem::take(&mut *PARKED.lock().unwrap_or_else(PoisonError::into_inner));
+    if parked.is_empty() {
+        return;
+    }
     let _ = std::io::stderr().write_all(&parked);
     let _ = std::io::stderr().flush();
 }
@@ -109,7 +121,7 @@ pub fn init(verbose: bool) {
     let (otel_layer, handle) = reload::Layer::new(None as OtelSlot);
     let subscriber = tracing_subscriber::registry().with(otel_layer).with(
         tracing_subscriber::fmt::layer()
-            .with_writer(|| TerminalAwareWriter)
+            .with_writer(writer)
             .with_filter(EnvFilter::new(level)),
     );
     let _ = subscriber.try_init();
@@ -202,20 +214,16 @@ mod tests {
         // Released is the resting state, so a write goes straight out.
         release_from_tui();
         assert!(!TUI_HOLDS_TERMINAL.load(Ordering::Relaxed));
-        TerminalAwareWriter
-            .write_all(b"")
-            .expect("stderr accepts a write");
-        TerminalAwareWriter.flush().expect("stderr accepts a flush");
+        writer().write_all(b"").expect("stderr accepts a write");
+        writer().flush().expect("stderr accepts a flush");
 
         hold_for_tui();
-        TerminalAwareWriter
+        writer()
             .write_all(b"parked line\n")
             .expect("a held write is buffered, never refused");
         // A flush while held must not reach the terminal either, or the point
         // of buffering is lost on the very next `tracing` call.
-        TerminalAwareWriter
-            .flush()
-            .expect("a held flush is a no-op");
+        writer().flush().expect("a held flush is a no-op");
         assert_eq!(
             PARKED.lock().expect("uncontended").as_slice(),
             b"parked line\n"

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -217,6 +217,89 @@ impl RiskyExecutors for RealExecutors {
         };
         commands::mcp::execute_with(args, &env).await
     }
+
+    async fn update(&self, args: commands::update::UpdateArgs) -> anyhow::Result<()> {
+        real_update(args)
+    }
+}
+
+/// Real `lev update`: the four things the command needs from the machine, wired
+/// into the tested core.
+///
+/// Resolving the executable is the load-bearing one. A Homebrew `bin/lev` is a
+/// symlink into the Cellar, and the Cellar path is the only place the formula
+/// name - and so the channel - is written down, so the link has to be followed
+/// before detection can read anything off it.
+fn real_update(args: commands::update::UpdateArgs) -> anyhow::Result<()> {
+    let home = dirs::home_dir();
+    let exe = std::env::current_exe()?;
+    // A path that cannot be canonicalized is used as it came: worse detection,
+    // never a failed command.
+    let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
+
+    let env = commands::update::UpdateEnv {
+        exe,
+        agents_dir: commands::setup::real_agents_dir(home.as_deref()),
+        home,
+        brew_prefix: brew_prefix(),
+        config_path: leviath_cli::config::Config::config_path(),
+        runner: std::sync::Arc::new(run_upgrade),
+        confirm: std::sync::Arc::new(ask_yes_no),
+        migrations: commands::update::MIGRATIONS,
+    };
+    commands::update::execute_with(&args, &env, env!("CARGO_PKG_VERSION"))
+}
+
+/// What `brew --prefix` says, when there is a `brew` to ask. Any failure is a
+/// `None`: it only ever adds evidence, and a machine without Homebrew is the
+/// ordinary case rather than an error.
+fn brew_prefix() -> Option<std::path::PathBuf> {
+    let output = leviath_sys::child_command("brew")
+        .arg("--prefix")
+        .output()
+        .ok()?;
+    let prefix = String::from_utf8(output.stdout).ok()?;
+    let prefix = prefix.trim();
+    match prefix.is_empty() {
+        true => None,
+        false => Some(std::path::PathBuf::from(prefix)),
+    }
+}
+
+/// Run the upgrade command, letting it draw on the terminal it inherits - a
+/// package manager's progress output is most of what makes the wait bearable.
+fn run_upgrade(argv: &[String]) -> anyhow::Result<()> {
+    let (program, rest) = argv
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("no upgrade command to run"))?;
+    let status = leviath_sys::child_command(program)
+        .args(rest)
+        .status()
+        .map_err(|e| anyhow::anyhow!("could not run `{program}`: {e}"))?;
+    match status.success() {
+        true => Ok(()),
+        false => anyhow::bail!("`{}` exited with {status}", argv.join(" ")),
+    }
+}
+
+/// Ask a yes/no question on the real terminal.
+///
+/// Without a terminal the answer is no, never a hang: `lev update` in CI is
+/// `--yes` plus whatever that flag deliberately does not cover, and a prompt
+/// waiting forever on a closed stdin would be the worst of both.
+fn ask_yes_no(question: &str) -> bool {
+    use std::io::{IsTerminal, Write};
+    if !io::stdin().is_terminal() {
+        println!("  {question} [no terminal to ask on, so: no]");
+        return false;
+    }
+    print!("  {question} [y/N] ");
+    let _ = io::stdout().flush();
+    let mut answer = String::new();
+    match io::stdin().read_line(&mut answer) {
+        Ok(_) => matches!(answer.trim().to_ascii_lowercase().as_str(), "y" | "yes"),
+        Err(_) => false,
+    }
 }
 
 /// Real `lev run`: ensure the daemon is running (auto-start it detached if not),

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -712,7 +712,7 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
     }
     let mut setup = CrosstermSetup {
         viewport: Viewport::Fullscreen,
-        mouse_capture: false,
+        mouse_capture: true,
         enabled: false,
     };
     let mut events = CrosstermEventSource::open();
@@ -724,9 +724,9 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
 /// binary because it can only be exercised against a real terminal.
 ///
 /// `mouse_capture` is per-surface: the dashboard wants wheel events and its
-/// own click-drag selection, while the setup wizard handles no mouse events
-/// at all - capturing there would only steal the terminal's native
-/// drag-to-select (copying an error or a signup URL) for nothing.
+/// own click-drag selection, and the setup wizard wants clicks on its rows and
+/// buttons. It stays off for the workdir prompt, which is one question with
+/// two answers and nothing to aim at.
 struct CrosstermSetup {
     viewport: Viewport,
     mouse_capture: bool,
@@ -759,6 +759,12 @@ fn install_terminal_restore_panic_hook() {
         std::panic::set_hook(Box::new(move |info| {
             if TERMINAL_HELD.load(std::sync::atomic::Ordering::SeqCst) {
                 restore_terminal();
+                // The screen is back, so parked lines can be shown, and the
+                // panic message that follows is not competing with the frame.
+                // Clearing the flag also stops a loop still running on another
+                // thread from re-parking output nobody will ever flush.
+                TERMINAL_HELD.store(false, std::sync::atomic::Ordering::SeqCst);
+                leviath_cli::logging::release_from_tui();
             }
             previous(info);
         }));
@@ -786,6 +792,10 @@ impl TerminalSetup for CrosstermSetup {
         }
         self.enabled = true;
         TERMINAL_HELD.store(true, std::sync::atomic::Ordering::SeqCst);
+        // stderr is this same terminal, so a log line from here on would land
+        // inside the frame - and in raw mode, without a carriage return,
+        // staircase across it. Park them until the screen is ours again.
+        leviath_cli::logging::hold_for_tui();
         Ok(())
     }
 
@@ -806,6 +816,9 @@ impl TerminalSetup for CrosstermSetup {
         }
         self.enabled = false;
         TERMINAL_HELD.store(false, std::sync::atomic::Ordering::SeqCst);
+        // Flushes whatever was logged while the screen was held, so `-v`
+        // diagnostics are waiting in the scrollback rather than lost.
+        leviath_cli::logging::release_from_tui();
         // Mouse release runs before leaving the alternate screen, and
         // unconditionally (even when capture was never enabled - it's a
         // no-op then): a terminal left in mouse-reporting mode emits escape

--- a/crates/leviath-cli/tests/logging_tui_parking.rs
+++ b/crates/leviath-cli/tests/logging_tui_parking.rs
@@ -1,0 +1,35 @@
+//! The log-parking seam, driven through the real subscriber.
+//!
+//! The unit tests in `logging.rs` exercise the writer directly, which proves
+//! the behaviour but not the wiring: a `tracing` call has to reach the writer
+//! through the layer `init` installs, and that only happens in a process that
+//! won the global subscriber slot. A test binary of its own is the smallest
+//! place where that is guaranteed.
+//!
+//! The stakes are a user-visible bug: `lev -v setup` used to draw hyper and
+//! rustls debug lines across the wizard, staircased by raw mode and never
+//! painted over, because stderr is the same terminal the alternate screen is
+//! on.
+
+use leviath_cli::logging;
+
+/// Nothing logged while the terminal is held reaches stderr, and nothing is
+/// lost either: it arrives when the terminal is handed back.
+#[test]
+fn a_held_terminal_parks_log_lines_until_it_is_released() {
+    logging::init(true);
+
+    // Held: this line is buffered rather than written.
+    logging::hold_for_tui();
+    tracing::info!("a line emitted while a TUI owned the terminal");
+    tracing::debug!("and a second one, at the level `-v` turns on");
+
+    // Released: whatever was parked goes out, and the flag is clear again, so
+    // ordinary logging resumes.
+    logging::release_from_tui();
+    tracing::info!("a line emitted with the terminal free");
+
+    // Releasing again with nothing parked is what the panic hook plus `Drop`
+    // actually do, and it must stay quiet rather than write an empty line.
+    logging::release_from_tui();
+}

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -668,6 +668,71 @@ Transport is inferred from whether you pass `--url` or `--command`.
 `lev auth migrate` moves keys into the OS store by default; `--to-file` moves them back out. Set
 `[security] credential_store` in the [config](/docs/configuration#security) first.
 
+### `lev update`
+
+Update Leviath, then offer to bring everything else up to date with it: the binary, the bundled
+blueprints, and the config file, in that order.
+
+The binary is updated with the installer that put it there, and which one that was is read off the
+filesystem rather than guessed from the version string. The version cannot answer: every
+[channel](/docs/releases) ships the same number, because the `-alpha` and `-beta` suffixes live in
+the tap manifests and not in the binary. Where the file sits does answer.
+
+| Found at | What it runs |
+|---|---|
+| A Homebrew Cellar path, or a Homebrew-only prefix | `brew upgrade <formula>` |
+| `scoop/apps/<package>` or a scoop shim | `scoop update <package>` |
+| `~/.cargo/bin` | Nothing. It says to run `cargo install leviath-cli` |
+| `/usr/local/bin`, `/usr/bin`, `~/.local/bin`, `%LOCALAPPDATA%\Leviath\bin` | `curl -fsSL https://leviath.dev/install.sh \| sh -s -- --channel <CHANNEL>` |
+| Anywhere else | Nothing. It names the path and leaves the choice to you |
+
+A Cellar or `apps` path carries the package name, and the package name carries the channel, so a
+beta install updates to beta without being told. The install script records nothing at all, so its
+channel is genuinely unknowable: that arm defaults to `stable` and `--channel` is how you say
+otherwise.
+
+A `cargo install` is described rather than run, because updating it is a full compile and that is
+not something to start because somebody typed `lev update`.
+
+| Flag | Purpose |
+|---|---|
+| `--check` | Print the plan and change nothing |
+| `--json` | Print the plan as JSON and change nothing |
+| `--channel <stable\|beta\|alpha>` | The channel to re-install. Only the install-script method reads it |
+| `--dry-run` | Walk the whole flow, prompts and all, printing each action instead of doing it |
+| `--yes` | Answer yes to the binary upgrade and the config write. It does **not** install blueprints |
+| `--install-agents` | Install the bundled blueprints without asking |
+
+```bash
+$ lev update --check
+
+lev 0.3.4, installed with Homebrew (formula leviath-beta, beta channel)
+
+  binary   brew upgrade leviath-beta
+  agents   1 of 7 would change
+             coder - update 0.0.1 → 0.0.2
+  config   nothing to migrate
+```
+
+All three steps run every time, whatever the binary step did. That is the point of the command:
+`brew upgrade` and `scoop update` hand you a new binary and say nothing about the blueprints in
+`~/.leviath/agents` or the config beside them, so anyone who has ever updated that way is running
+blueprints from whenever they last ran `lev setup`. A binary that needs no update is not evidence
+that anything else is current.
+
+The blueprint step is the same offer `lev setup` makes, and nothing is written to your agents
+directory without a yes. The whole list is printed first, then one confirmation covers it;
+`--install-agents` is how a script says yes. `--yes` alone is deliberately not enough, because
+updating a binary and replacing the blueprints in your agents directory are different requests.
+
+A copy at the bundled version whose files differ from the bundled ones reads as edited locally. It
+is named as edited, asked about on its own, and no flag covers it: installing removes the
+destination directory first and would take your edits, and any file you added, with it.
+
+The config step applies any migration this build knows how to make, printing every change before it
+asks to write anything. Today there are none: no released `config.toml` has to change to work with
+this version, so the step exists to explain a future one rather than to do work now.
+
 ### `lev tools`
 
 | Flag | Purpose |

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -262,7 +262,8 @@ flowchart TD
 3. **`process_response`** reads the reply. Tool calls go down the tool path; plain text goes toward
    a transition.
 4. **`dispatch_tools`** checks each requested call before it runs. A tool the stage never
-   advertised in `available_tools` is refused rather than hidden. [Permissions](/docs/tools) decide
+   advertised in `available_tools` was never sent to the model, and is refused here too if it
+   guesses the name. [Permissions](/docs/tools) decide
    whether the call needs you, and [taint tracking](/docs/security#taint-tracking-experimental)
    blocks a call that would carry sensitive data somewhere it should not go. Calls that only edit
    the agent's own context apply here; the rest go to the tool lane.

--- a/docs/content/first-agent.md
+++ b/docs/content/first-agent.md
@@ -118,8 +118,11 @@ configured wins, so this stage runs on Anthropic if you have a key for it and Op
 Adding your own provider to the front is how you take an agent somewhere else.
 
 `available_tools` is the entire set this stage may call. Sorting text needs no file access and no
-shell, so it gets neither. A tool left out here is refused if the model asks for it, rather than
-quietly hidden, which is what keeps a stage's blast radius equal to its list.
+shell, so it gets neither. A tool left out here is not sent to the model at all: it never sees the
+name or the schema, so it cannot be tempted by one. If it guesses a name anyway, the call is
+refused before anything runs, and the refusal goes back as that call's result so the model can
+correct itself. Both halves matter, and together they keep a stage's blast radius equal to its
+list.
 
 `max_iterations` bounds the loop. A stage that never decides it is finished stops here rather than
 spending your budget.

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -238,7 +238,8 @@ A tool existing in the catalog does not mean an agent can call it. Two independe
 stage control access:
 
 - **`available_tools`**: the allowlist of tool names advertised to the model in that stage. A tool
-  not listed here is invisible to the LLM. Names may use aliases (e.g. `bash` for `shell`).
+  not listed here is invisible to the LLM, and a call to one it guessed is refused before it runs,
+  with the refusal returned as that call's result. Names may use aliases (e.g. `bash` for `shell`).
 - **`tool_permissions`**: a per-tool map whose values are `allow`, `ask`, or `deny`. `allow` runs
   the call outright, `ask` requires user approval first, and `deny` blocks it. Stage-level entries
   are narrower than agent-level `[tool_permissions]` and wider than launch-time flags. Any other


### PR DESCRIPTION
Eight pieces of UX feedback, plus the two things the work turned up on the way.

## The bug someone actually hit

`lev -v setup` filled the wizard with debug text. The tracing layer writes to
stderr, the wizard owns the alternate screen on stdout, and both are the same
terminal, so a provider check under `-v` drew hyper and rustls straight into
the frame. Raw mode has `OPOST` off, so each line started where the last ended
and staircased across the screen, and ratatui only redraws cells it thinks
changed, so nothing ever painted over it.

Log lines are now parked while a TUI holds the terminal and flushed when it
lets go, including from the panic hook, which restores the terminal first so
the parked lines land ahead of the panic message. Verified against a real pty:
under `-v`, a live credential check produces `reqwest`, `hyper` and `h2` DEBUG
lines, none of which reach the frame, and all of which are waiting in the
scrollback afterwards.

## The wizard

- **It scrolls now.** Every screen was a `List` of pre-sized items with no
  offset, so the tuning screen's thirteen two-line fields simply stopped at
  whatever row ran out of pane, Continue button included. Each step now builds
  flat lines plus the line each selectable row starts on, which is what a
  `List` gave us for free and what we cannot use it for, because a wizard row
  is a label and a help line that both have to fold on a narrow window.
  Wrapping moved into the renderer for the same reason: the row count is only
  knowable once the text is wrapped.
- **A floor, and a graceful one.** Below 24x6 it says the window is too small.
  Between there and fourteen rows the breadcrumb gives way first: it says where
  you are, which the pane title also says.
- **The tuning screen is opt-in**, from a toggle on Defaults. Skipping it
  changes nothing about what gets written, including the Ollama concurrency
  default.
- **The mouse works.** Opening a provider's key page and checking a credential
  were `o` and `v` in a footer; they are rows now, clickable or reachable with
  the arrows. Clicks resolve through a hit test that rebuilds the layout the
  frame used rather than storing it, so drawing stays free of state changes.
- **Defaults are chosen from a searchable list** that explains the choice.

## What the picker work turned up

Tracing `pipeline::resolve` to write that explanation found that
`default_provider` alone does nothing: with no `default_model` there is no
candidate on that provider to promote, so a stage listing other providers goes
to them regardless. That is what `lev doctor` warns about after the fact,
having let setup produce the state. Both fields now say so up front.

And the model list's first option read `(provider default)`, which is not a
thing. No provider default model is consulted at run time; a stage naming no
model of its own falls back to a model built into Leviath. The label promised a
mechanism and delivered its opposite. It now reads `(each blueprint decides)`.

## `lev update`

Updates Leviath with the installer that put it there, read off the filesystem
rather than guessed from the version string, which cannot answer: every channel
ships the same `CARGO_PKG_VERSION`. A Homebrew Cellar path carries the formula
name and the formula carries the channel, so a beta install runs `brew upgrade
leviath-beta` unprompted; Scoop works the same way. The install script keeps no
receipt, so that arm defaults to stable and `--channel` says otherwise.

The blueprints and the config are checked every time, whatever the binary step
did, because `brew upgrade` on its own leaves both behind. Nothing reaches the
agents directory without a yes, and an edited copy is named as edited and asked
about separately, with no flag covering it.

## Starting a run from the dashboard

`n` opens a screen with the installed agents on one side (type to filter) and a
task editor on the other, where `@` completes a path from the working
directory. The dashboard could watch, pause and cancel runs but not begin one.

## Also

The README told people to set `LEVIATH_CHANNEL` without saying where it has to
go. Before the pipe it is given to `curl`, the installer never sees it, and
stable installs silently, which is the exact failure `install.sh` grew
`--channel` to end.

The tutorial said a tool left out of `available_tools` is "refused if the model
asks for it, rather than quietly hidden". It is both, and the order matters:
the filter decides what goes into the request, so the model never sees the name
or the schema on any provider, and the refusal is the first check in the
dispatch loop, ahead of permissions and schema validation. `engine.md` carried
the same either/or and `tools.md` stated only the hiding.

## Verification

`cargo test --workspace` green, `clippy --workspace --all-targets --all-features
-D warnings` clean, `fmt` clean, `xtask docs` and `xtask structure` clean, and
`xtask coverage --package leviath-cli` back at 100%.

Closing the coverage gaps was worth its own commit. Most were branches nothing
can take, and the fix was to delete the branch rather than write a test that
cannot fail. One was real: `hold_for_tui` and the writer are called only from
the terminal setup in `main.rs`, so the *library* copy of them ran in no test.
The unit tests exercise the test build's copy, which is a different symbol, and
the integration tests spawn the real binary headless, where no TUI ever opens.
`tests/logging_tui_parking.rs` drives the seam through the subscriber `init`
installs.

`main.rs` changes, so this needs the `allow-main-rs-change` label.
