### PR TITLE
Fan-out agents skipped their own fan-out: gate the escape edge behind dead_end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ same list.
 
 ## Unreleased
 
+- Fixed: the fan-out agents no longer skip their own fan-out. A
+  `wide-researcher` run finished "complete" having run only its first stage:
+  the escape edge every stage carries for the out-of-revisits case was a plain
+  transition, so it sat on the menu every turn and the model took it on the
+  first one. Ten such edges across six agents are now `condition = "dead_end"`,
+  which the engine consults only when nothing else can be followed. **If you
+  have these blueprints installed, `lev setup` (or `lev update`) reinstalls
+  them; an edited copy is left alone and keeps the old behaviour.**
+- Fixed: a title from a reasoning model is the title rather than the reasoning.
+  Those models answer after thinking out loud, so the first line is prose about
+  the task, and that is what got stored and displayed.
+
 - Fixed: runs get their generated titles. Every run showed its raw task text
   instead, which is what the dashboard falls back to when there is no title.
   The titling call put its instruction in a message with `role: "system"`,

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -54,6 +54,7 @@ transform = "direct"
 # to the deliverable instead of dead-ending.
 [stages.scope.transitions.build]
 hint = "No further splitting is useful - build from what is already gathered"
+condition = "dead_end"
 transform = "compact"
 
 [stages.scope.transitions.error_recovery]
@@ -231,6 +232,7 @@ back so the dataset can be finished from what is reachable.
 # to the deliverable instead of dead-ending.
 [stages.error_recovery.transitions.present]
 hint = "Recovery is not converging - present the analysis built so far"
+condition = "dead_end"
 transform = "compact"
 
 [stages.error_recovery.transitions.split]

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -60,6 +60,7 @@ transform = "direct"
 # to the deliverable instead of dead-ending.
 [stages.gather.transitions.synthesize]
 hint = "Analysis is out of revisits - synthesize from the material in hand"
+condition = "dead_end"
 transform = "compact"
 
 [stages.gather.transitions.error_recovery]
@@ -206,6 +207,7 @@ transform = "compact"
 # to the deliverable instead of dead-ending.
 [stages.follow_citations.transitions.synthesize]
 hint = "Analysis is out of revisits - synthesize from the material in hand"
+condition = "dead_end"
 transform = "compact"
 
 [stages.follow_citations.transitions.error_recovery]

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -48,6 +48,7 @@ transform = "direct"
 # to the deliverable instead of dead-ending.
 [stages.ingest.transitions.report]
 hint = "Analysis is out of revisits - report what ingestion established"
+condition = "dead_end"
 transform = "compact"
 
 [stages.ingest.transitions.error_recovery]
@@ -248,6 +249,7 @@ transform = "compact"
 # to the deliverable instead of dead-ending.
 [stages.script.transitions.report]
 hint = "Analysis is out of revisits - report the findings so far"
+condition = "dead_end"
 transform = "compact"
 
 [stages.script.transitions.error_recovery]

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -53,6 +53,7 @@ transform = "direct"
 # to the deliverable instead of dead-ending.
 [stages.gather.transitions.summarize]
 hint = "Analysis is out of revisits - summarize from the material in hand"
+condition = "dead_end"
 transform = "compact"
 
 [stages.gather.transitions.error_recovery]

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -92,6 +92,7 @@ transform = "direct"
 # to the deliverable instead of dead-ending.
 [stages.scan.transitions.report]
 hint = "The review stages are out of revisits - report the scan findings"
+condition = "dead_end"
 transform = "compact"
 
 [stages.scan.transitions.error_handler]

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -57,6 +57,7 @@ transform = "direct"
 # to the deliverable instead of dead-ending.
 [stages.survey.transitions.summarize]
 hint = "Comparison is out of revisits - write the overview from the survey"
+condition = "dead_end"
 transform = "compact"
 
 [stages.survey.transitions.error_recovery]
@@ -194,6 +195,7 @@ transform = "compact"
 # to the deliverable instead of dead-ending.
 [stages.deep_dive.transitions.summarize]
 hint = "Comparison is out of revisits - write the overview with this depth"
+condition = "dead_end"
 transform = "compact"
 
 [stages.deep_dive.transitions.error_recovery]

--- a/crates/leviath-cli/tests/manifest_integration.rs
+++ b/crates/leviath-cli/tests/manifest_integration.rs
@@ -509,3 +509,77 @@ fn the_bundled_agents_exist_and_are_discoverable() {
         "the binary ships no agents; build.rs found no agents/ directory"
     );
 }
+
+/// A stage that can start a fan-out must not also offer the model a way
+/// straight to the deliverable.
+///
+/// This is what a real `wide-researcher` run did: `survey` listed
+/// `investigate` (the fan-out), `compare`, and `summarize`, and the model
+/// picked `summarize` on its first transition. The run finished "complete"
+/// having skipped the fan-out and the two stages after it, with no sub-agents
+/// and nothing to say anything had been skipped.
+///
+/// The escape to the deliverable is meant for one case - every looping target
+/// out of revisits - and `condition = "dead_end"` is how you say that. The
+/// engine consults such an edge only when nothing else can be followed, so it
+/// is not on the menu. A plain edge to the same stage is offered every single
+/// turn, which is the shape the lint's own fix text warns against.
+#[test]
+fn a_stage_that_can_fan_out_offers_no_shortcut_past_it() {
+    use leviath_core::blueprint::{StageMode, TransitionCondition};
+
+    let manifests = discover_agent_manifests();
+    let mut checked = 0;
+
+    for (name, path) in &manifests {
+        let content = std::fs::read_to_string(path).unwrap();
+        let blueprint = leviath_core::manifest::parse_manifest(&content).unwrap();
+
+        let is_fan_out = |target: &str| {
+            blueprint
+                .stages
+                .iter()
+                .any(|s| s.name == target && matches!(s.mode, StageMode::FanOut { .. }))
+        };
+        let is_output = |target: &str| {
+            blueprint
+                .stages
+                .iter()
+                .any(|s| s.name == target && matches!(s.mode, StageMode::Output))
+        };
+
+        for stage in &blueprint.stages {
+            let Some(edges) = &stage.transitions else {
+                continue;
+            };
+            if !edges.values().any(|e| is_fan_out(&e.target)) {
+                continue;
+            }
+            checked += 1;
+            let shortcuts: Vec<&str> = edges
+                .values()
+                .filter(|e| {
+                    is_output(&e.target)
+                        && matches!(
+                            e.condition,
+                            TransitionCondition::Always | TransitionCondition::LlmChoice
+                        )
+                })
+                .map(|e| e.target.as_str())
+                .collect();
+            assert!(
+                shortcuts.is_empty(),
+                "{name}: stage '{}' can fan out, but also offers the model a \
+                 plain edge straight to {shortcuts:?}. Gate it with \
+                 condition = \"dead_end\" so it is taken only when nothing \
+                 else can be.",
+                stage.name
+            );
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "no bundled agent has a stage that can fan out, so this proves nothing"
+    );
+}

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -113,15 +113,49 @@ fn title_request(task: &str, model: &str) -> InferenceRequest {
 /// non-empty line, unquoted, capped at [`TITLE_MAX_LEN`]. Empty means "no
 /// title" and the metadata stays untouched.
 fn sanitize_title(raw: &str) -> String {
-    let first = raw
+    // Reasoning models answer the instruction *after* thinking about it out
+    // loud, so the first line is prose about the task rather than a title. A
+    // real one read "We need to generate a short title for the task. The task:
+    // …", which is what the dashboard then displayed.
+    //
+    // The rule that separates them without guessing at content: a title fits
+    // the display cap, and reasoning does not. So the first line short enough
+    // to *be* a title wins, and a reply with no such line falls back to the
+    // first line truncated - which is exactly what this did before.
+    let stripped = strip_reasoning(raw);
+    let lines: Vec<&str> = stripped
         .lines()
         .map(str::trim)
-        .find(|l| !l.is_empty())
-        .unwrap_or("");
-    let unquoted = first.trim_matches(['"', '\'', '`']).trim();
-    leviath_core::truncate_at_boundary(unquoted, TITLE_MAX_LEN)
+        .filter(|l| !l.is_empty())
+        .collect();
+    let unquote = |l: &str| l.trim_matches(['"', '\'', '`']).trim().to_string();
+    let chosen = lines
+        .iter()
+        .map(|l| unquote(l))
+        .find(|l| l.chars().count() <= TITLE_MAX_LEN)
+        .unwrap_or_else(|| lines.first().map(|l| unquote(l)).unwrap_or_default());
+    leviath_core::truncate_at_boundary(&chosen, TITLE_MAX_LEN)
         .trim_end()
         .to_string()
+}
+
+/// Drop a `<think>…</think>` block, which several models emit around their
+/// reasoning. An unclosed tag drops the rest, which is the safe reading: what
+/// follows an opening tag is reasoning until something says otherwise.
+fn strip_reasoning(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    let mut rest = raw;
+    // `split_once` rather than `find` plus a slice: the crate forbids string
+    // indexing, and this needs no indices anyway.
+    while let Some((before, after)) = rest.split_once("<think>") {
+        out.push_str(before);
+        match after.split_once("</think>") {
+            Some((_, tail)) => rest = tail,
+            None => return out,
+        }
+    }
+    out.push_str(rest);
+    out
 }
 
 /// What `dispatch_title` selects.
@@ -624,5 +658,38 @@ mod tests {
         );
         assert_eq!(request.messages.len(), 1);
         assert_eq!(request.messages[0].role, "user");
+    }
+
+    /// A reasoning model answers after thinking out loud, and the thinking is
+    /// not a title. This is the reply shape that actually reached a dashboard:
+    /// the first line was prose about the task, and it got displayed.
+    #[test]
+    fn sanitize_skips_reasoning_and_takes_the_line_that_is_a_title() {
+        let reply = "We need to generate a short title for the task. The task: \
+                     \"Research leviath.dev and report what the docs cover\" - so \
+                     something short and descriptive.\n\nLeviath Docs Coverage";
+        assert_eq!(sanitize_title(reply), "Leviath Docs Coverage");
+
+        // The same, wrapped in the tags several models use.
+        let tagged = "<think>The user wants a title. Keep it under eight words \
+                      and avoid punctuation at the end.</think>\nRetry Backoff \
+                      Refactor";
+        assert_eq!(sanitize_title(tagged), "Retry Backoff Refactor");
+
+        // An unclosed tag drops what follows: it is all reasoning until
+        // something says otherwise, and no title beats a wrong one.
+        assert_eq!(sanitize_title("<think>thinking with no end"), "");
+    }
+
+    /// A compliant reply is untouched, including one long enough to need
+    /// cutting - there is no shorter line to prefer, so it is still cut.
+    #[test]
+    fn sanitize_leaves_an_ordinary_reply_alone() {
+        assert_eq!(
+            sanitize_title("Tidy the kitchen sink"),
+            "Tidy the kitchen sink"
+        );
+        let long = "x".repeat(TITLE_MAX_LEN * 2);
+        assert_eq!(sanitize_title(&long).chars().count(), TITLE_MAX_LEN);
     }
 }


### PR DESCRIPTION
A reported `wide-researcher` run finished "complete" having done almost none of the work: `survey` ran, then `investigate` (the fan-out), `compare` and `deep_dive` were all skipped and it went straight to `summarize`. No sub-agents, no threads, and nothing on the run to say anything had been left out.

## Why

`survey` listed four transitions: `investigate`, `compare`, an escape to `summarize`, and the error edge.

That escape exists for exactly one case — every looping target out of revisits, so the run can move on instead of dead-ending — and `condition = "dead_end"` is how a blueprint says so. Without the condition it is an ordinary choice, offered on the menu every single turn, and a model that would rather finish takes it on the first one.

The lint's own fix text spells this out:

> add a `condition = "dead_end"` edge … It is taken only when the graph would otherwise strand, so it is **not a route the model can choose early** — unlike a plain edge to the same stage, which is offered on every visit.

Every bundled agent had the plain edge. The lint stayed quiet because a plain edge to an un-exhaustible stage is, technically, not a strand — so it silenced the check by adding the shortcut the check exists to avoid.

## The fix

Ten edges across six agents are now `dead_end`-gated. Two are left plain on purpose: `investigate -> deliverable` in both researchers is that stage's only edge, so it is the way forward rather than a way around.

**Proved live**, running a real daemon against a mock that answers every transition prompt with `"summarize"`, one blueprint apart:

| blueprint | `survey` went to | result |
|---|---|---|
| shipped | `summarize` | `compare`, `deep_dive`, `investigate` all skipped — the reported run |
| this PR | `compare` | shortcut not on the menu |

The new test is an invariant over whatever agents are installed rather than a list of names: a stage that can enter a fan-out must not also offer a plain edge to an output stage. It caught one case I had judged safe by hand and was not (`data-analyst`'s error stage), which is the point of writing it that way.

## Also: titles from reasoning models

The same run exposed a second thing. Its stored title was `"We need to generate a short title for the task. The task: …"` — the model's reasoning, not its answer. Reasoning models answer after thinking out loud, and `sanitize_title` took the first non-empty line.

A title fits the display cap and reasoning does not, so the first line short enough to *be* a title now wins, `<think>` blocks are dropped, and a reply with no such line is truncated exactly as before. Tested against the reply shape that actually reached a dashboard.

## Verification

`cargo test --workspace` green, `clippy --workspace --all-targets --all-features -D warnings` clean, `fmt` clean, `xtask docs` and `xtask structure` clean, coverage at 100% for `leviath-cli` and `leviath-runtime`. Every bundled blueprint still passes `lev validate`.

Both commits went through the pre-commit hook rather than around it.

## Note for anyone with these installed

`lev setup` (or `lev update`) reinstalls the bundled blueprints; a copy you have edited is left alone and keeps the old behaviour.
