### PR TITLE
chore(release): 0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
+## 0.3.5 - 2026-08-12
 
 - Fixed: the fan-out agents no longer skip their own fan-out. A
   `wide-researcher` run finished "complete" having run only its first stage:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.4" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.4" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.4" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.4" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.4" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.4" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.4" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.4" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.4" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.4" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.4" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.4" }
+leviath = { path = "crates/leviath", version = "0.3.5" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.5" }
+leviath-net = { path = "crates/leviath-net", version = "0.3.5" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.5" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.5" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.5" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.5" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.5" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.5" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.5" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.5" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.5" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.4", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.5", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }


### PR DESCRIPTION
Cuts 0.3.5. Merging this fires the alpha release; beta follows by dispatch, and stable is left alone.

Everything since 0.3.4, which is a lot of it user-reported:

**Setup wizard.** Every screen scrolls (the tuning screen's thirteen fields stopped at whatever row ran out of pane, Continue button included), the actions on the credential screen are clickable rows rather than shortcut keys in a footer, the tuning screen is opt-in, and the default provider and model are chosen from a searchable list that explains what the choice decides — including that `default_provider` does nothing at all until `default_model` is also set.

**`lev -v setup` no longer fills the wizard with debug text.** stderr is the same terminal the alternate screen is on, and raw mode staircased the lines with nothing ever painting over them. Log output is parked while a TUI holds the terminal and flushed when it lets go.

**Dashboard.** Start a run with `n`, with an agent filter, a task editor and `@` file completion; unattended runs with Ctrl-Y behind a warning that says what `--yolo` does *and* does not; the help overlay lists every key across every mode and scrolls; starting a run opens that run's page.

**`lev update`**, which updates Leviath with the installer that put it there and then offers to bring the bundled blueprints and the config along — checked every time, because `brew upgrade` leaves both behind.

**Two bugs worth naming.** Run titles never worked at all: the request used `role: "system"` inside `messages`, which Anthropic rejects with a 400, and Anthropic is the default for every shipped blueprint. And the fan-out agents skipped their own fan-out: the out-of-revisits escape edge was a plain transition, so it sat on the model's menu every turn and got taken on the first one.

The six blueprints whose transitions changed carry a new patch version.

## Note

This needs the `allow-version-bump` label.
