### PR TITLE
docs: catch the reference up with what 0.3.5 actually does

### DIFF
--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -20,6 +20,10 @@ List agents running in the shared-world daemon.
 Columns: RUN, STATUS, STAGE (with position when the blueprint has several),
 ITER (iterations in the current stage), TOOLS (tool calls so far), and AGE.
 
+TITLE sits after RUN when at least one listed run has a generated title, on the
+same terms as READS below: a column nobody can fill costs every reader width and
+buys them nothing.
+
 READS appears only when some listed run's blueprint declares [read_paths], and
 reads granted/declared. A blueprint declaring paths outside its workdir is not
 the same as being allowed to read them: your config.toml has to grant them too,

--- a/docs/content/agent-catalog.md
+++ b/docs/content/agent-catalog.md
@@ -108,7 +108,7 @@ the numbers say. Reach for it when you want a dataset you can open, not a paragr
 ```mermaid
 flowchart TD
     scope --> split
-    scope -->|no further splitting is useful| build
+    scope -.->|only if splitting is exhausted| build
     split -->|fan out| gather_worker
     gather_worker --> build
     build --> present

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -374,13 +374,17 @@ See [Human-in-the-loop](/docs/interaction) for what raises these.
 ### Reading `lev ps`
 
 ```
-RUN                             STATUS                  STAGE         ITER   TOOLS  AGE
-solo-1785568852-9fa61fd279dd    waiting: tool approval  work          1      1      41s
-busy-1785568852-384bad04c9ac    active                  work          13824  13824  0s
-waiter-1785568852-7895a2209850  waiting: children(1)    delegate 1/2  2      1      41s
+RUN                             TITLE                  STATUS                  STAGE         ITER   TOOLS  AGE
+solo-1785568852-9fa61fd279dd    Retry backoff audit    waiting: tool approval  work          1      1      41s
+busy-1785568852-384bad04c9ac    Index the changelog    active                  work          13824  13824  0s
+waiter-1785568852-7895a2209850  Split the log sweep    waiting: children(1)    delegate 1/2  2      1      41s
 
 1 run needs an answer: lev respond
 ```
+
+`TITLE` is the [generated one-line title](/docs/configuration#title), and the column appears only
+when at least one listed run has one - a run whose titling was turned off or did not finish leaves
+the cell empty rather than widening every row for nothing.
 
 `AGE` is how long since the run last moved: a new iteration, a new stage, or a change of
 status. It is deliberately not `meta.json`'s `updated_at`, which also advances on a
@@ -594,7 +598,9 @@ per run, each capped at 64 output tokens; `--no-daemon` bills one.
 The interactive [provider](/docs/providers) wizard. Every credential and agent choice it asks for
 has a flag, so headless setup is scriptable. The wizard's Limits screen edits the
 [`[limits]`](/docs/configuration#limits) keys, which have no flags: script those by writing
-`config.toml` directly.
+`config.toml` directly. That screen is opt-in - every limit already has a working default, so it
+only appears once you turn on **Show advanced tuning** on the Defaults screen. Skipping it changes
+nothing about what gets written.
 
 | Flag | Purpose |
 |---|---|
@@ -630,6 +636,8 @@ Inside the wizard, the keys work the same way on every screen:
 | `↑` `↓` (or `k` `j`) | Move between rows |
 | `←` `→` (or `h` `l`) | Cycle a choice or the reasoning effort |
 | Space or Enter | Select the focused row; Enter also opens editors for typed values |
+| Enter on a default | Opens a searchable list of providers or models, with what the choice decides |
+| PgUp / PgDn, Home / End | Scroll a long screen; the selection moves with the view |
 | Enter on `[ Continue ]` | Move to the next screen (the button is the last row) |
 | Tab / Shift-Tab | Next / previous screen |
 | Esc | Previous screen, or cancel an edit or dialog |
@@ -637,7 +645,7 @@ Inside the wizard, the keys work the same way on every screen:
 | `o` | Open the provider's signup page |
 | Ctrl-R | Show or hide credentials |
 | Ctrl-S | Write the config and finish, from anywhere |
-| `?` | Help overlay |
+| `?` or F1 | Help overlay. It scrolls, so a long list is not cut off |
 | `q` / Ctrl-C | Quit without writing. If you changed anything, it asks first |
 
 Nothing is written until you confirm on the Review screen. Leaving the provider screen with
@@ -706,11 +714,11 @@ not something to start because somebody typed `lev update`.
 ```bash
 $ lev update --check
 
-lev 0.3.4, installed with Homebrew (formula leviath-beta, beta channel)
+lev 0.3.5, installed with Homebrew (formula leviath-beta, beta channel)
 
   binary   brew upgrade leviath-beta
   agents   1 of 7 would change
-             coder - update 0.0.1 → 0.0.2
+             data-analyst - update 0.0.1 → 0.0.2
   config   nothing to migrate
 ```
 

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -46,8 +46,12 @@ panel and answer. `lev respond` does the same from the shell.
 
 ## Keys
 
-The dashboard has two screens, and most keys only work on one of them. Press `?` on either for the
-same list in the app.
+Most keys work on one screen only. Press `?` for the list that applies to where you are, or `F1`
+where `?` would be typed as text: on the new-run screen every printable character goes into the
+filter or the task.
+
+Besides the main list and the detail view below, there is a screen for starting a run (`n`), one for
+MCP servers (`m`), and a stage explorer for branching agents (`g`, from the detail view).
 
 ### Main list
 
@@ -56,6 +60,7 @@ same list in the app.
 | `↑` / `↓` (or `k` / `j`) | Select a run |
 | `Home` / `End` (or `g` / `G`) | Jump to the first / last run |
 | `Enter` | Open detail view |
+| `n` | Start a run: pick an agent, write the task, press Enter |
 | `Tab` | Focus the log panel. Arrows scroll it, `End` resumes tailing, `Esc` comes back |
 | `/` | Filter runs by name or status |
 | `s` | Cycle the sort: start time (default), recent activity, or status groups |
@@ -68,6 +73,27 @@ same list in the app.
 
 By default runs are listed newest first and keep their row for their whole life, so nothing jumps
 around when a run finishes. The sort indicator sits in the table's top-right corner.
+
+### Starting a run (`n`)
+
+Agents on the left, the task on the right. Once it starts, the dashboard opens that run's page, and
+`Esc` from there goes back to the list rather than back into the form.
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` | Choose an agent. Any letter filters the list; `Backspace` shortens the filter |
+| `Tab` / `Enter` | Move from the agent list to the task |
+| `Enter` (in the task) | Start the run |
+| `Alt+Enter` | Newline, rather than starting the run |
+| `@` | Reference a file from the working directory, with completion |
+| `Ctrl-Y` | Run unattended, so the agent approves its own tool calls |
+| `F1` | Help. `?` types a question mark here |
+| `Esc` | Clear the filter, then close the screen |
+
+`Ctrl-Y` warns the first time you use it in a sitting, and the warning is worth reading: an
+unattended run approves its own file edits and shell commands, but it does **not** skip a checkpoint
+the blueprint asks a person for. Those still stop, and one nobody answers ends the run when the
+interaction timeout expires. The setting is off again every time the screen opens.
 
 ### Detail view
 


### PR DESCRIPTION
A fact-check of the docs against today's changes found six gaps, all of them my debt from this session rather than old drift.

- **dashboard.md** said the dashboard has two screens and never mentioned the one that starts runs. `n`, Ctrl-Y and F1 were undocumented, and F1 is the one that matters: on the new-run screen `?` is a question mark in a filter box, so it is the only way into the help. Adds a section for the screen, including what the unattended warning does and does not cover.
- **cli.md** said the wizard's Limits screen edits the `[limits]` keys without saying it is now opt-in behind the Defaults toggle; described Enter on a default as opening an editor when it opens a searchable chooser; and listed neither F1 nor the page keys.
- **cli.md** `lev ps` sample predated the TITLE column.
- **cli.md** `lev update --check` sample claimed `0.3.4` and attributed data-analyst's `0.0.1 → 0.0.2` bump to `coder`, which has never had a `0.0.x`.
- **agent-catalog.md** drew data-analyst's `scope -> build` as an ordinary routing choice. It is `dead_end`-gated now, which is exactly what the legend's dotted convention is for.
- **ps.rs** module doc still listed the old column set.

Everything else checked out: all six `lev update` flags match `UpdateArgs`, the install-method table matches `detect()`, the run-title docs are accurate now the fix has landed, "seven agents" and "five fan out" are right everywhere, and no documented key does the wrong thing.

## Not fixed here

The generated SVGs under `docs/assets/agents/` still draw all ten newly `dead_end`-gated edges as solid, which contradicts the README's own legend ("dotted edges fire automatically on a runtime condition"). The generator lives in the leviath.dev repo, so they need regenerating there — both the light and `-dark` variants.