### PR TITLE
docs: take the prose out of the crate map's node labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,19 +311,19 @@ Every platform-specific system call lives in one crate, `leviath-sys`, behind a 
 
 ```mermaid
 graph TD
-    CLI["leviath-cli<br/><i>the lev binary: args, TUI, daemon, serve</i>"]
-    LIB["leviath<br/><i>library facade for embedding the runtime</i>"]
-    RT["leviath-runtime<br/><i>ECS engine (bevy_ecs) + stage-run orchestration</i>"]
-    TOOLS["leviath-tools<br/><i>built-in tool implementations</i>"]
-    PROV["leviath-providers<br/><i>Anthropic · OpenAI · Google<br/>OpenRouter · Ollama · Claude Code</i>"]
-    CORE["leviath-core<br/><i>regions, layouts, blueprints, manifest, run metadata</i>"]
-    MCP["leviath-mcp<br/><i>MCP tool servers (stdio + HTTP/SSE)</i>"]
-    ACP["leviath-agent-client<br/><i>Agent Client Protocol wire types (JSON-RPC/stdio)</i>"]
-    PKG["leviath-package<br/><i>agent bundling and install</i>"]
-    SCRIPT["leviath-scripting<br/><i>Rhai sandbox</i>"]
-    TELEM["leviath-telemetry<br/><i>OpenTelemetry export</i>"]
-    NET["leviath-net<br/><i>outbound request policy + shared HTTP client</i>"]
-    SYS["leviath-sys<br/><i>all OS-specific syscalls (perms, signals, TTY)</i>"]
+    CLI["leviath-cli"]
+    LIB["leviath"]
+    RT["leviath-runtime"]
+    TOOLS["leviath-tools"]
+    PROV["leviath-providers"]
+    CORE["leviath-core"]
+    MCP["leviath-mcp"]
+    ACP["leviath-agent-client"]
+    PKG["leviath-package"]
+    SCRIPT["leviath-scripting"]
+    TELEM["leviath-telemetry"]
+    NET["leviath-net"]
+    SYS["leviath-sys"]
 
     CLI --> RT
     CLI --> MCP
@@ -350,7 +350,23 @@ graph TD
     TELEM --> CORE
 ```
 
-Two leaves round it out: `leviath-alloc`, one audited mimalloc option call for the binary, and `leviath-testkit`, shared test support.
+| Crate | What it holds |
+|---|---|
+| `leviath-cli` | The `lev` binary: args, TUI, daemon, serve |
+| `leviath` | Library facade for embedding the runtime |
+| `leviath-runtime` | ECS engine (bevy_ecs) and stage-run orchestration |
+| `leviath-core` | Regions, layouts, blueprints, manifest, run metadata |
+| `leviath-tools` | Built-in tool implementations |
+| `leviath-providers` | Anthropic, OpenAI, Google, OpenRouter, Ollama, Claude Code |
+| `leviath-mcp` | MCP tool servers over stdio and HTTP/SSE |
+| `leviath-agent-client` | Agent Client Protocol wire types (JSON-RPC over stdio) |
+| `leviath-package` | Agent bundling and install |
+| `leviath-scripting` | Rhai sandbox |
+| `leviath-telemetry` | OpenTelemetry export |
+| `leviath-net` | Outbound request policy and the shared HTTP client |
+| `leviath-sys` | Every OS-specific syscall (permissions, signals, TTY) |
+| `leviath-alloc` | One audited mimalloc option call for the binary |
+| `leviath-testkit` | Shared test support |
 
 </details>
 


### PR DESCRIPTION
Every node in the crate map carried a full sentence, wrapped in `<i>` and split with `<br/>`. That made the picture depend on a renderer honouring two HTML tags inside an SVG label. Nodes are crate names now; the descriptions moved to a table underneath, which reads the same everywhere and scans better than thirteen boxes of small italic text.

## What I measured first

"Line breaks are broken" is worth checking rather than acting on, so I rendered the docs site's exact pipeline in headless Chrome: escaped source in `pre.mermaid` driven through `mermaid.run()` with the site's own config (mermaid 11.16, `securityLevel: 'strict'`, `flowchart.htmlLabels: false`).

Labels come out as:

```
<p>one<br>two</p>
<p>agent's label<br><i>italic</i></p>
```

inside a `foreignObject`. The break is real, the italics are real, and an apostrophe survives the double escape. **The published docs pages render line breaks correctly** — this is not another `&#39;`-style escaping bug, and `docs/content/*.md` is left untouched on purpose.

That leaves a renderer that strips `foreignObject` from the SVG it is handed, where an HTML-shaped label has nothing to fall back to. Short labels have nothing to lose there, which is what this change buys.

Worth recording for next time: jsdom cannot lay mermaid out, so two earlier attempts at this measurement returned empty tspans and proved nothing either way. Chrome was the only way to see real output.

## Also checked

No HTML tags remain inside any mermaid fence in the README. The new crate table renders as a real `<table>` inside the `<details>` block, confirmed through GitHub's own `/markdown` endpoint, and the mermaid fence still comes back tagged `highlight-source-mermaid` so GitHub's client renderer picks it up.

`cargo xtask docs` passes.
