### PR TITLE
fix(mcp): stop pushing a header-authenticated server into an OAuth login

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mcp.rs
@@ -273,13 +273,16 @@ async fn run_login(ctx: &McpContext, name: &str) -> McpOutcome {
         )
         .await
     {
-        Ok(auth) => {
-            store.set(name, auth);
+        Ok(leviath_mcp::LoginOutcome::Authenticated(auth)) => {
+            store.set(name, *auth);
             match store.save(&ctx.store_path) {
                 Ok(()) => ok(format!("Authenticated with '{name}'")),
                 Err(e) => fail(format!("Login succeeded but saving failed: {e}")),
             }
         }
+        Ok(leviath_mcp::LoginOutcome::NotRequired) => ok(format!(
+            "'{name}' needs no login: it accepted the configured request"
+        )),
         Err(e) => fail(format!("Login failed for '{name}': {e}")),
     }
 }
@@ -767,6 +770,45 @@ mod tests {
         );
         let store = AuthStore::load(&ctx.store_path).unwrap();
         assert_eq!(store.get("navigator").unwrap().access_token, "tui-access");
+    }
+
+    /// Pressing login in the dashboard on a header-authenticated server reports
+    /// that none is needed, rather than a discovery failure it cannot act on.
+    #[tokio::test]
+    async fn background_login_says_so_when_no_login_is_needed() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        // Publishes no OAuth metadata, so an attempted discovery fails loudly.
+        let app = axum::Router::new().route(
+            "/mcp",
+            axum::routing::post(|| async { axum::http::StatusCode::OK }),
+        );
+        tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
+            listener, app,
+        )));
+
+        let dir = tempfile::tempdir().unwrap();
+        let ctx = ctx_at(dir.path(), no_browser);
+        let mut server = MCPServerConfig::http("hub", format!("{base}/mcp"));
+        server.headers.insert(
+            "Authorization".to_string(),
+            "Bearer configured-token".to_string(),
+        );
+        write_config(&ctx, server);
+
+        let outcome = run_login(&ctx, "hub").await;
+        assert!(outcome.ok, "got: {}", outcome.message);
+        assert!(
+            outcome.message.contains("needs no login"),
+            "got: {}",
+            outcome.message
+        );
+        assert!(
+            AuthStore::load(&ctx.store_path)
+                .unwrap()
+                .get("hub")
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/dashboard/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mcp.rs
@@ -193,6 +193,10 @@ fn auth_status(server: &MCPServerConfig, store: &AuthStore, now: u64) -> String 
     match store.get(&server.name) {
         Some(auth) if auth.is_expired_at(now) => "expired".to_string(),
         Some(_) => "authenticated".to_string(),
+        // A configured `Authorization` header is a credential too, and "none"
+        // in this column is what sends someone to press login on a server that
+        // needs none.
+        None if server.has_auth_header() => "header".to_string(),
         None => "none".to_string(),
     }
 }
@@ -803,12 +807,12 @@ mod tests {
             "got: {}",
             outcome.message
         );
-        assert!(
-            AuthStore::load(&ctx.store_path)
-                .unwrap()
-                .get("hub")
-                .is_none()
-        );
+        let store = AuthStore::load(&ctx.store_path).unwrap();
+        assert!(store.get("hub").is_none());
+
+        // The screen's own column agrees, so nobody presses login again.
+        let config = Config::load_from_path_public(&ctx.config_path).unwrap();
+        assert_eq!(auth_status(&config.mcp_servers[0], &store, 0), "header");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/mcp.rs
+++ b/crates/leviath-cli/src/commands/mcp.rs
@@ -6,7 +6,7 @@
 use clap::{Args, Subcommand};
 
 use crate::config::Config;
-use leviath_mcp::{AuthStore, MCPClient, MCPServerConfig, OAuthClient};
+use leviath_mcp::{AuthStore, LoginOutcome, MCPClient, MCPServerConfig, OAuthClient};
 
 /// Arguments for `lev mcp`.
 #[derive(Args)]
@@ -211,7 +211,7 @@ async fn login(name: &str, env: &McpEnv) -> anyhow::Result<()> {
     let mut store = AuthStore::load_with(&env.store_path, env.credential_store.as_deref())?;
     // Reuse a prior registration if we have one, so re-login doesn't re-register.
     let reuse = store.get(name).map(|a| a.client_id.clone());
-    let auth = OAuthClient::new()
+    let outcome = OAuthClient::new()
         .login(
             &url,
             &server.headers,
@@ -220,9 +220,16 @@ async fn login(name: &str, env: &McpEnv) -> anyhow::Result<()> {
             reuse.as_deref(),
         )
         .await?;
-    store.set(name, auth);
-    store.save_with(&env.store_path, env.credential_store.as_deref())?;
-    println!("✓ Authenticated with '{name}'.");
+    match outcome {
+        LoginOutcome::Authenticated(auth) => {
+            store.set(name, *auth);
+            store.save_with(&env.store_path, env.credential_store.as_deref())?;
+            println!("✓ Authenticated with '{name}'.");
+        }
+        LoginOutcome::NotRequired => {
+            println!("'{name}' does not need a login: it accepted the configured request.");
+        }
+    }
     Ok(())
 }
 
@@ -378,6 +385,10 @@ fn auth_status(server: &MCPServerConfig, store: &AuthStore, now: u64) -> String 
     match store.get(&server.name) {
         Some(auth) if auth.is_expired_at(now) => "expired".to_string(),
         Some(_) => "authenticated".to_string(),
+        // A configured `Authorization` header is a credential too. Calling it
+        // "none" reads as "log in here", which is the prompt that sends people
+        // into an OAuth flow their server never wanted.
+        None if server.has_auth_header() => "header".to_string(),
         None => "none".to_string(),
     }
 }
@@ -821,6 +832,77 @@ mod tests {
             let _ = reqwest::Client::new().get(&cb).send().await;
         });
         true
+    }
+
+    /// An MCP endpoint that takes its own API token and publishes no OAuth
+    /// metadata whatsoever, which is what a server like GitHub's looks like once
+    /// you have configured a header for it.
+    async fn mock_token_authenticated_server() -> String {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        // Answers everything, and publishes no OAuth metadata at all, so a login
+        // that goes looking for some fails loudly. That the header is what earns
+        // the `200` is `leviath-mcp`'s test to make; this one is about what the
+        // CLI does with the answer.
+        let app = Router::new().route("/mcp", post(|| async { StatusCode::OK }));
+        tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
+            listener, app,
+        )));
+        base
+    }
+
+    /// Adding a header-authenticated server must not chase an OAuth login it
+    /// cannot complete. Before this, `add` printed a discovery 404 and told the
+    /// user to run `lev mcp login`, which then printed the same 404 forever.
+    #[tokio::test]
+    async fn add_with_an_auth_header_does_not_chase_an_oauth_login() {
+        let base = mock_token_authenticated_server().await;
+        let dir = tempfile::tempdir().unwrap();
+        let env = env_at(dir.path(), auto_consent, 1_000);
+
+        let add = AddArgs {
+            name: "hub".to_string(),
+            url: Some(format!("{base}/mcp")),
+            command: None,
+            args: vec![],
+            env: vec![],
+            headers: vec!["Authorization=Bearer configured-token".to_string()],
+            no_login: false,
+        };
+        execute_with(
+            McpArgs {
+                command: McpCommand::Add(add),
+            },
+            &env,
+        )
+        .await
+        .expect("adding a header-authenticated server must succeed");
+
+        let config = Config::load_from_path_public(&env.config_path).unwrap();
+        assert_eq!(
+            config.mcp_servers[0].headers.get("Authorization").unwrap(),
+            "Bearer configured-token"
+        );
+        // Nothing to store: the header is the credential, and it stays in the
+        // config rather than being duplicated into the OAuth store.
+        let stored = AuthStore::load(&env.store_path).unwrap();
+        assert!(stored.get("hub").is_none());
+
+        // And an explicit login says so rather than failing.
+        login("hub", &env)
+            .await
+            .expect("an explicit login on such a server is a no-op, not an error");
+        assert!(
+            AuthStore::load(&env.store_path)
+                .unwrap()
+                .get("hub")
+                .is_none()
+        );
+
+        // The listing reports the header as the credential it is. "none" here
+        // is what tells a user to go and log in.
+        let store = AuthStore::load(&env.store_path).unwrap();
+        assert_eq!(auth_status(&config.mcp_servers[0], &store, 1_000), "header");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 use super::types::{AppState, err};
 use crate::config::Config;
-use leviath_mcp::{AuthStore, MCPClient, MCPServerConfig, OAuthClient};
+use leviath_mcp::{AuthStore, LoginOutcome, MCPClient, MCPServerConfig, OAuthClient};
 
 /// Where `lev serve` reads and writes MCP state, plus the seams the login flow
 /// needs. Cheap to clone (paths + fn pointers).
@@ -87,6 +87,10 @@ fn auth_status(server: &MCPServerConfig, store: &AuthStore, now: u64) -> String 
     match store.get(&server.name) {
         Some(auth) if auth.is_expired_at(now) => "expired".to_string(),
         Some(_) => "authenticated".to_string(),
+        // A configured `Authorization` header is a credential too, and calling
+        // it "none" is what puts a login button in front of a server that needs
+        // no login.
+        None if server.has_auth_header() => "header".to_string(),
         None => "none".to_string(),
     }
 }
@@ -225,7 +229,7 @@ pub(super) async fn login(
 
     let mut store = AuthStore::load(&admin.store_path).unwrap_or_default();
     let reuse = store.get(&name).map(|a| a.client_id.clone());
-    let auth = match OAuthClient::new()
+    let outcome = match OAuthClient::new()
         .login(
             &url,
             &server.headers,
@@ -235,10 +239,17 @@ pub(super) async fn login(
         )
         .await
     {
-        Ok(auth) => auth,
+        Ok(outcome) => outcome,
         Err(e) => return err(StatusCode::BAD_GATEWAY, e.to_string()).into_response(),
     };
-    store.set(&name, auth);
+    // A server that answered the probe wants no OAuth, so there is nothing to
+    // store. Reporting it as an error would be wrong: the caller asked whether a
+    // login was needed, and the answer is no.
+    let LoginOutcome::Authenticated(auth) = outcome else {
+        return Json(serde_json::json!({ "status": "not_required", "server": name }))
+            .into_response();
+    };
+    store.set(&name, *auth);
     if let Err(e) = store.save(&admin.store_path) {
         return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
@@ -603,6 +614,44 @@ mod tests {
         // Now status shows authenticated.
         let (_, body) = send(&app, "GET", "/api/mcp/servers/navigator/status", None).await;
         assert_eq!(body["auth"], "authenticated");
+    }
+
+    /// The website's login button on a header-authenticated server. It used to
+    /// surface the discovery 404 as a bad gateway; the honest answer is that no
+    /// login is needed.
+    #[tokio::test]
+    async fn login_reports_not_required_when_headers_already_satisfy_the_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        // Publishes no OAuth metadata, so an attempted discovery fails loudly.
+        let mcp =
+            axum::Router::new().route("/mcp", axum::routing::post(|| async { StatusCode::OK }));
+        tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
+            listener, mcp,
+        )));
+
+        let dir = tempfile::tempdir().unwrap();
+        let app = router(state_at(dir.path(), never_opens));
+        send(
+            &app,
+            "POST",
+            "/api/mcp/servers",
+            Some(serde_json::json!({
+                "name": "hub",
+                "url": format!("{base}/mcp"),
+                "headers": { "Authorization": "Bearer configured-token" },
+            })),
+        )
+        .await;
+
+        let (status_code, body) = send(&app, "POST", "/api/mcp/servers/hub/login", None).await;
+        assert_eq!(status_code, StatusCode::OK, "login body: {body}");
+        assert_eq!(body["status"], "not_required");
+        // `never_opens` would have failed the flow had discovery been attempted.
+
+        // And the listing calls it credentialed, so no UI offers a login here.
+        let (_, body) = send(&app, "GET", "/api/mcp/servers/hub/status", None).await;
+        assert_eq!(body["auth"], "header");
     }
 
     #[tokio::test]

--- a/crates/leviath-mcp/src/auth/metadata.rs
+++ b/crates/leviath-mcp/src/auth/metadata.rs
@@ -58,13 +58,31 @@ pub(crate) fn resource_metadata_url(www_authenticate: Option<&str>) -> Option<St
 
 /// The well-known protected-resource metadata URL for an MCP endpoint.
 ///
-/// Per RFC 9728 the document lives at the *origin*, so any path on the MCP URL
-/// is dropped.
+/// RFC 9728 §3.1 inserts `/.well-known/oauth-protected-resource` *between* the
+/// host and the resource's path, rather than replacing the path. So the
+/// metadata for `https://host/mcp/` lives at
+/// `https://host/.well-known/oauth-protected-resource/mcp/`, and only a
+/// resource at the root has its document at the bare well-known path.
+///
+/// Dropping the path instead is what made every path-hosted server 404 here
+/// whenever it did not send a `resource_metadata` hint. GitHub's MCP server is
+/// the case that surfaced it: it serves the document at the suffixed URL, and
+/// nothing at the bare one.
 pub(crate) fn well_known_resource_url(mcp_url: &Url) -> Url {
-    // Joining a constant, valid path onto an already-parsed URL cannot fail.
-    mcp_url
-        .join("/.well-known/oauth-protected-resource")
-        .expect("well-known path is always joinable")
+    let mut url = mcp_url.clone();
+    // A path of "/" is the root case, where the suffix would add a stray
+    // trailing slash the spec does not ask for.
+    let suffix = match mcp_url.path() {
+        "/" | "" => String::new(),
+        path => path.to_string(),
+    };
+    // Clearing these matters: the metadata document is addressed by path alone,
+    // and carrying the resource's query string over would ask for a URL the
+    // server never advertised.
+    url.set_query(None);
+    url.set_fragment(None);
+    url.set_path(&format!("/.well-known/oauth-protected-resource{suffix}"));
+    url
 }
 
 /// Whether a discovery URL is safe to fetch.
@@ -163,12 +181,60 @@ mod tests {
 
     // ─── well-known derivation ────────────────────────────────────────────
 
+    /// RFC 9728 §3.1: the path is *kept*, after the well-known segment. This is
+    /// the derivation GitHub's MCP server actually publishes, and the bare
+    /// origin form it 404s.
     #[test]
-    fn well_known_resource_drops_the_mcp_path() {
+    fn well_known_resource_keeps_the_mcp_path() {
         let url = Url::parse("https://mcp.example.com/some/mcp").unwrap();
         assert_eq!(
             well_known_resource_url(&url).as_str(),
-            "https://mcp.example.com/.well-known/oauth-protected-resource"
+            "https://mcp.example.com/.well-known/oauth-protected-resource/some/mcp"
+        );
+    }
+
+    /// A trailing slash is part of the path and survives, because the resource
+    /// identifier it belongs to is a different string without it.
+    #[test]
+    fn well_known_resource_preserves_a_trailing_slash() {
+        let url = Url::parse("https://api.githubcopilot.com/mcp/").unwrap();
+        assert_eq!(
+            well_known_resource_url(&url).as_str(),
+            "https://api.githubcopilot.com/.well-known/oauth-protected-resource/mcp/"
+        );
+    }
+
+    /// A resource at the root has no path to append, so the document sits at the
+    /// bare well-known path with no trailing slash bolted on.
+    #[test]
+    fn well_known_resource_at_the_root_has_no_suffix() {
+        for root in ["https://mcp.example.com", "https://mcp.example.com/"] {
+            assert_eq!(
+                well_known_resource_url(&u(root)).as_str(),
+                "https://mcp.example.com/.well-known/oauth-protected-resource",
+                "{root}"
+            );
+        }
+    }
+
+    /// The query belongs to the MCP endpoint, not to its metadata document.
+    #[test]
+    fn well_known_resource_drops_query_and_fragment() {
+        let url = Url::parse("https://mcp.example.com/mcp?tenant=a#frag").unwrap();
+        assert_eq!(
+            well_known_resource_url(&url).as_str(),
+            "https://mcp.example.com/.well-known/oauth-protected-resource/mcp"
+        );
+    }
+
+    /// The port is part of the origin and has to survive, or discovery leaves
+    /// the server entirely.
+    #[test]
+    fn well_known_resource_keeps_a_nonstandard_port() {
+        let url = Url::parse("https://mcp.example.com:8443/mcp").unwrap();
+        assert_eq!(
+            well_known_resource_url(&url).as_str(),
+            "https://mcp.example.com:8443/.well-known/oauth-protected-resource/mcp"
         );
     }
 

--- a/crates/leviath-mcp/src/auth/mod.rs
+++ b/crates/leviath-mcp/src/auth/mod.rs
@@ -62,6 +62,59 @@ struct RegistrationResponse {
     client_id: String,
 }
 
+/// What an MCP endpoint said when asked, with the configured headers, whether
+/// it wants credentials.
+enum Probe {
+    /// It asked for credentials: a `401`/`403`, a `WWW-Authenticate`, or both.
+    /// The header, when present, names where the metadata lives.
+    Challenge(Option<String>),
+    /// It answered the request as it stood, so nothing needs logging in. Either
+    /// the server is open, or the headers already configured for it are enough.
+    Satisfied,
+    /// It did not answer at all. Says nothing either way, so the caller carries
+    /// on to discovery, where a failure produces a message worth reading.
+    Unreachable,
+}
+
+#[cfg(test)]
+impl Probe {
+    /// A one-word name for the variant, so a test can assert on it with
+    /// `assert_eq!` rather than a `matches!` whose other arm never runs.
+    fn label(&self) -> &'static str {
+        match self {
+            Self::Challenge(_) => "challenge",
+            Self::Satisfied => "satisfied",
+            Self::Unreachable => "unreachable",
+        }
+    }
+}
+
+/// The result of [`OAuthClient::login`].
+#[derive(Debug)]
+pub enum LoginOutcome {
+    /// The browser flow ran and produced credentials worth storing.
+    ///
+    /// Boxed because it is much larger than the other variant, and every caller
+    /// stores it rather than reading it in place.
+    Authenticated(Box<ServerAuth>),
+    /// The server does not want an OAuth login. There is nothing to store, and
+    /// nothing went wrong.
+    NotRequired,
+}
+
+impl LoginOutcome {
+    /// The credentials this login produced, or `None` if none were needed.
+    ///
+    /// For a caller that only wants to store what came back and has nothing to
+    /// say about the other case.
+    pub fn authenticated(self) -> Option<ServerAuth> {
+        match self {
+            Self::Authenticated(auth) => Some(*auth),
+            Self::NotRequired => None,
+        }
+    }
+}
+
 /// Drives OAuth against one MCP server's authorization server.
 pub struct OAuthClient {
     http: reqwest::Client,
@@ -84,7 +137,13 @@ impl OAuthClient {
         Self { http }
     }
 
-    /// Run the full interactive login for `mcp_url` and return the tokens.
+    /// Run the full interactive login for `mcp_url`.
+    ///
+    /// Returns [`LoginOutcome::NotRequired`] when the server answers a probe
+    /// carrying `headers` without demanding credentials. A server configured
+    /// with its own API token is the ordinary case: there is no OAuth flow to
+    /// run, and pushing one anyway is what sent every such server into a
+    /// discovery request it does not serve.
     ///
     /// `now` (Unix seconds) is passed in rather than read from the clock so the
     /// computed `expires_at` is deterministic under test. `reuse_client_id`
@@ -97,11 +156,20 @@ impl OAuthClient {
         opener: BrowserOpener,
         now: u64,
         reuse_client_id: Option<&str>,
-    ) -> anyhow::Result<ServerAuth> {
+    ) -> anyhow::Result<LoginOutcome> {
         let mcp = Url::parse(mcp_url)
             .map_err(|e| anyhow::anyhow!("Invalid MCP server url '{}': {}", mcp_url, e))?;
 
-        let (resource, server_meta) = self.discover(&mcp, headers).await?;
+        // An unreachable server still goes down the discovery path, which is
+        // where the useful error message comes from. Only a live answer that
+        // asked for nothing ends the flow here.
+        let www_authenticate = match self.probe_challenge(&mcp, headers).await {
+            Probe::Satisfied => return Ok(LoginOutcome::NotRequired),
+            Probe::Challenge(header) => header,
+            Probe::Unreachable => None,
+        };
+
+        let (resource, server_meta) = self.discover(&mcp, www_authenticate.as_deref()).await?;
 
         // Bind the loopback listener first, so its port is known before both
         // registration (which needs the redirect URI) and the authorize URL.
@@ -160,13 +228,13 @@ impl OAuthClient {
             )
             .await?;
 
-        Ok(build_server_auth(
+        Ok(LoginOutcome::Authenticated(Box::new(build_server_auth(
             resource,
             &server_meta,
             client_id,
             token,
             now,
-        ))
+        ))))
     }
 
     /// Refresh `auth` non-interactively. Never opens a browser.
@@ -265,12 +333,9 @@ impl OAuthClient {
     async fn discover(
         &self,
         mcp: &Url,
-        headers: &HashMap<String, String>,
+        www_authenticate: Option<&str>,
     ) -> anyhow::Result<(String, AuthServerMetadata)> {
-        // A probe request surfaces the WWW-Authenticate hint; a server that
-        // answers it without auth still yields the well-known document.
-        let www_authenticate = self.probe_challenge(mcp, headers).await;
-        let hinted = metadata::resource_metadata_url(www_authenticate.as_deref());
+        let hinted = metadata::resource_metadata_url(www_authenticate);
         // The hint comes out of a header the *remote server* wrote, and whatever
         // it names is then fetched by us, from inside the user's network. Bind it
         // to the MCP server's own origin: a server may point at its own metadata
@@ -415,25 +480,37 @@ impl OAuthClient {
         Ok(serde_json::from_value(value)?)
     }
 
-    /// Probe the MCP endpoint and return its `WWW-Authenticate` header, if any.
+    /// Probe the MCP endpoint with the configured headers to see whether it
+    /// demands OAuth at all.
     ///
-    /// A network failure here is not fatal: discovery falls back to the
-    /// well-known path, so a `None` simply means "no hint".
-    async fn probe_challenge(
-        &self,
-        mcp: &Url,
-        headers: &HashMap<String, String>,
-    ) -> Option<String> {
+    /// The headers matter: a server configured with an API token of its own
+    /// answers this request normally, and asking it to run a browser login
+    /// afterwards is asking for a second credential it never wanted.
+    async fn probe_challenge(&self, mcp: &Url, headers: &HashMap<String, String>) -> Probe {
         let mut request = self.http.post(mcp.clone()).body("{}");
         for (name, value) in headers {
             request = request.header(name, value);
         }
-        let response = request.send().await.ok()?;
-        response
+        let Ok(response) = request.send().await else {
+            return Probe::Unreachable;
+        };
+        let challenge = response
             .headers()
             .get(reqwest::header::WWW_AUTHENTICATE)
             .and_then(|v| v.to_str().ok())
-            .map(str::to_string)
+            .map(str::to_string);
+        // A 401 or 403 is the server asking for credentials, whether or not it
+        // bothered to describe how. Anything else, with no challenge attached,
+        // means the request was accepted as it stood.
+        let demands_auth = matches!(
+            response.status(),
+            reqwest::StatusCode::UNAUTHORIZED | reqwest::StatusCode::FORBIDDEN
+        );
+        match (challenge, demands_auth) {
+            (Some(header), _) => Probe::Challenge(Some(header)),
+            (None, true) => Probe::Challenge(None),
+            (None, false) => Probe::Satisfied,
+        }
     }
 
     /// Register this client dynamically (RFC 7591), returning its id.
@@ -1265,7 +1342,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("login should complete");
+            .expect("login should complete")
+            .authenticated()
+            .expect("the flow should have produced credentials");
 
         assert_eq!(auth.access_token, "new-access");
         assert_eq!(auth.refresh_token.as_deref(), Some("new-refresh"));
@@ -1286,7 +1365,9 @@ mod tests {
                 Some("existing-client"),
             )
             .await
-            .expect("login should complete");
+            .expect("login should complete")
+            .authenticated()
+            .expect("the flow should have produced credentials");
         assert_eq!(
             server.registrations.load(Ordering::SeqCst),
             0,
@@ -1308,7 +1389,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("openid recovery should work");
+            .expect("openid recovery should work")
+            .authenticated()
+            .expect("the flow should have produced credentials");
         assert_eq!(auth.access_token, "new-access");
     }
 
@@ -1325,7 +1408,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("openid fallback should work");
+            .expect("openid fallback should work")
+            .authenticated()
+            .expect("the flow should have produced credentials");
         assert_eq!(auth.access_token, "new-access");
     }
 
@@ -1624,16 +1709,19 @@ mod tests {
         assert!(err.to_string().contains("refresh failed"), "got: {err}");
     }
 
+    /// A server that demands auth but does not say where its metadata lives.
+    /// The fallback URL has to be the RFC 9728 one, which keeps the resource's
+    /// path after the well-known segment. Serving the document *only* at the
+    /// suffixed path is what makes this test fail if the path is dropped, which
+    /// is exactly how GitHub's MCP server behaves.
     #[tokio::test]
-    async fn discovery_without_a_www_authenticate_uses_the_well_known_path() {
-        // A server that answers the probe *without* a challenge still resolves
-        // via the well-known document.
+    async fn a_bare_challenge_falls_back_to_the_path_suffixed_well_known_url() {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let base = format!("http://{}", listener.local_addr().unwrap());
         let app = Router::new()
-            .route("/mcp", post(|| async { StatusCode::OK }))
+            .route("/mcp", post(|| async { StatusCode::UNAUTHORIZED }))
             .route(
-                "/.well-known/oauth-protected-resource",
+                "/.well-known/oauth-protected-resource/mcp",
                 get({
                     let base = base.clone();
                     move || {
@@ -1680,7 +1768,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("well-known discovery should work");
+            .expect("well-known discovery should work")
+            .authenticated()
+            .expect("the flow should have produced credentials");
         assert_eq!(auth.access_token, "at");
     }
 
@@ -1715,7 +1805,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("login with probe headers should complete");
+            .expect("login with probe headers should complete")
+            .authenticated()
+            .expect("the flow should have produced credentials");
     }
 
     #[tokio::test]
@@ -1737,7 +1829,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("login should complete even without a browser");
+            .expect("login should complete even without a browser")
+            .authenticated()
+            .expect("the flow should have produced credentials");
     }
 
     #[tokio::test]
@@ -1752,7 +1846,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("login should complete with default scopes");
+            .expect("login should complete with default scopes")
+            .authenticated()
+            .expect("the flow should have produced credentials");
     }
 
     #[tokio::test]
@@ -1767,7 +1863,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("login should complete");
+            .expect("login should complete")
+            .authenticated()
+            .expect("the flow should have produced credentials");
         // The resource identifier defaulted to the MCP URL itself.
         assert_eq!(auth.resource, format!("{}/mcp", server.base));
     }
@@ -2022,7 +2120,9 @@ mod tests {
                 None,
             )
             .await
-            .expect("an absent issuer is not itself a failure");
+            .expect("an absent issuer is not itself a failure")
+            .authenticated()
+            .expect("the flow should have produced credentials");
         assert!(!auth.access_token.is_empty());
     }
 
@@ -2260,13 +2360,84 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn probe_challenge_of_a_dead_server_is_none() {
+    async fn probe_of_a_dead_server_is_unreachable() {
         let mcp = Url::parse("http://127.0.0.1:1/mcp").unwrap();
-        assert!(
+        assert_eq!(
             OAuthClient::new()
                 .probe_challenge(&mcp, &HashMap::new())
                 .await
-                .is_none()
+                .label(),
+            "unreachable"
+        );
+    }
+
+    /// The case this whole path exists for. A server holding its own API token
+    /// answers the probe normally, so there is no OAuth flow to run, and the
+    /// old code went looking for a discovery document such a server does not
+    /// publish.
+    #[tokio::test]
+    async fn probe_with_headers_the_server_accepts_is_satisfied() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let app = Router::new().route(
+            "/mcp",
+            post(|headers: axum::http::HeaderMap| async move {
+                match headers.get(reqwest::header::AUTHORIZATION) {
+                    Some(_) => StatusCode::OK,
+                    None => StatusCode::UNAUTHORIZED,
+                }
+            }),
+        );
+        tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
+            listener, app,
+        )));
+
+        let mcp = Url::parse(&format!("{base}/mcp")).unwrap();
+        let client = OAuthClient::new();
+
+        // Same server, same endpoint: the headers are the only difference.
+        assert_eq!(
+            client.probe_challenge(&mcp, &HashMap::new()).await.label(),
+            "challenge",
+            "no credentials, so the server should ask for some"
+        );
+        let headers = HashMap::from([(
+            "Authorization".to_string(),
+            "Bearer configured-token".to_string(),
+        )]);
+        assert_eq!(
+            client.probe_challenge(&mcp, &headers).await.label(),
+            "satisfied",
+            "the configured header should be enough"
+        );
+    }
+
+    /// End to end through `login`: a server the headers already satisfy must
+    /// come back as "nothing to do" rather than being dragged into discovery.
+    /// The endpoint below serves no metadata at all, so a login that tries to
+    /// discover fails loudly here.
+    #[tokio::test]
+    async fn login_is_not_required_when_the_configured_headers_suffice() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let app = Router::new().route("/mcp", post(|| async { StatusCode::OK }));
+        tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
+            listener, app,
+        )));
+
+        let outcome = OAuthClient::new()
+            .login(
+                &format!("{base}/mcp"),
+                &HashMap::from([("Authorization".to_string(), "Bearer tok".to_string())]),
+                auto_consent(),
+                0,
+                None,
+            )
+            .await
+            .expect("a server that wants nothing is not a login failure");
+        assert!(
+            outcome.authenticated().is_none(),
+            "there are no credentials to store"
         );
     }
 

--- a/crates/leviath-mcp/src/discovery.rs
+++ b/crates/leviath-mcp/src/discovery.rs
@@ -176,6 +176,18 @@ impl MCPServerConfig {
             .map(|_| ())
             .map_err(|e| anyhow::anyhow!("mcp_servers entry '{}' {}", self.name, e))
     }
+
+    /// Whether a credential is configured as a request header.
+    ///
+    /// Such a server carries its own authentication and wants no OAuth login,
+    /// so a listing that reported it as unauthenticated would be pointing the
+    /// user at a flow that does not apply. HTTP header names are
+    /// case-insensitive, and this comparison is too.
+    pub fn has_auth_header(&self) -> bool {
+        self.headers
+            .keys()
+            .any(|k| k.eq_ignore_ascii_case("authorization"))
+    }
 }
 
 /// Tool discovery service that aggregates tools from multiple MCP servers.
@@ -259,6 +271,38 @@ impl Default for ToolDiscovery {
 mod tests {
     use super::*;
     use crate::test_support::always_on_tracing_guard;
+
+    // --- configured credentials ---
+
+    /// The distinction that decides whether anything offers the user a login.
+    #[test]
+    fn an_authorization_header_counts_as_a_configured_credential() {
+        let mut server = MCPServerConfig::http("s", "https://mcp.example.com/mcp");
+        assert!(!server.has_auth_header(), "no headers at all");
+
+        server
+            .headers
+            .insert("X-Trace".to_string(), "on".to_string());
+        assert!(!server.has_auth_header(), "an unrelated header is not one");
+
+        server
+            .headers
+            .insert("Authorization".to_string(), "Bearer t".to_string());
+        assert!(server.has_auth_header());
+    }
+
+    /// HTTP header names are case-insensitive, and a config written
+    /// `authorization = "..."` is the same credential.
+    #[test]
+    fn the_authorization_header_is_matched_case_insensitively() {
+        for spelling in ["authorization", "AUTHORIZATION", "AuThOrIzAtIoN"] {
+            let mut server = MCPServerConfig::http("s", "https://mcp.example.com/mcp");
+            server
+                .headers
+                .insert(spelling.to_string(), "Bearer t".to_string());
+            assert!(server.has_auth_header(), "{spelling}");
+        }
+    }
 
     // --- ToolMetadata serde ---
 

--- a/crates/leviath-mcp/src/lib.rs
+++ b/crates/leviath-mcp/src/lib.rs
@@ -18,7 +18,9 @@ pub mod transport;
 #[cfg(test)]
 mod test_support;
 
-pub use auth::{AuthStore, BrowserOpener, OAuthClient, ServerAuth, StoredTokenRefresher};
+pub use auth::{
+    AuthStore, BrowserOpener, LoginOutcome, OAuthClient, ServerAuth, StoredTokenRefresher,
+};
 pub use client::{EmbeddedResource, MCPClient, ToolResult};
 pub use discovery::{MCPServerConfig, MCPTransport, ResolvedTransport, ToolDiscovery};
 pub use execution::ToolExecutor;

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -41,6 +41,16 @@ lev mcp remove <name>
 `Name: value` form an HTTP header is usually written in, so `Authorization: Bearer ...` is rejected
 with `--header must be KEY=VALUE`.
 
+There are two ways an HTTP server authenticates you, and Leviath picks between them by asking the
+server rather than by guessing. If a `--header` you configured is enough, as it is for a server that
+takes an API token of its own, `add` reports that no login is needed and stores nothing. If the
+server answers with a `401` instead, the OAuth flow runs and the tokens land in the credential
+store. `lev mcp login` on an already-satisfied server says so rather than failing.
+
+> [!NOTE]
+> GitHub's MCP server accepts either. A personal access token in an `Authorization` header needs no
+> login at all, and the same endpoint runs the browser flow if you configure no header.
+
 Or configure in `~/.leviath/config.toml`:
 
 ```toml

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -905,12 +905,13 @@
         "tags": [
           "mcp"
         ],
-        "summary": "Begin the OAuth flow for this server",
+        "summary": "Begin the OAuth flow for this server, or report that it needs no login",
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
           }
-        }
+        },
+        "description": "Returns `{\"status\": \"authenticated\"}` when the browser flow completed and credentials were stored, or `{\"status\": \"not_required\"}` when the server answered a probe carrying its configured headers, which means there is no OAuth flow to run."
       }
     },
     "/api/mcp/servers/{name}/test": {


### PR DESCRIPTION
Adding an MCP server with an `Authorization` header ended in `failed to fetch resource metadata: HTTP 404 Not Found` — from `lev mcp add`, from `lev mcp login`, and from the login button in the browser console. The header worked the whole time. Only the login did not.

Two faults, and the header hid the second behind the first.

## 1. Login ran for servers that never asked for one

`login` started the OAuth flow for every HTTP server, and the probe that opens the flow sends the configured headers. A server holding its own API token answers that probe normally, with no `WWW-Authenticate` to read, so discovery fell through to a well-known URL and 404ed.

There was never a login to run: the credential was already configured. The probe now reports whether the server actually asked for anything:

| Probe result | Meaning | Login does |
|---|---|---|
| `401`/`403`, or a `WWW-Authenticate` | wants credentials | runs the OAuth flow |
| anything else | accepted the request as it stood | returns `NotRequired` |
| no answer | says nothing | falls through to discovery, where the error is worth reading |

`add` prints that instead of a failure, `POST /api/mcp/servers/{name}/login` answers `{"status": "not_required"}`, and the dashboard says the same.

## 2. The well-known fallback URL dropped the path

RFC 9728 §3.1 inserts `/.well-known/oauth-protected-resource` *between* the host and the resource's path. This code replaced the path instead — and a test asserted the dropping, so the behaviour looked intentional. Any server whose endpoint is not at the root, and which does not send the `resource_metadata` hint, could not be discovered at all.

Measured against the live server:

```
https://api.githubcopilot.com/.well-known/oauth-protected-resource      404
https://api.githubcopilot.com/.well-known/oauth-protected-resource/mcp  200
```

The second is what GitHub's own `WWW-Authenticate` advertises. The regression test serves the document *only* at the suffixed path, so dropping it fails the test.

## 3. `auth: none` on a server that has a credential

`lev mcp list` reported a header-authenticated server as `none`, which reads as "log in here" and is what points a user at the flow that cannot work. It reports `header` now — in the CLI, over the API, and on the dashboard screen, which keeps its own third copy of that logic.

## Verified live, not only against mocks

Against the real GitHub MCP server with the reporter's own config:

```
$ lev mcp login GitHub
'GitHub' does not need a login: it accepted the configured request.

$ lev mcp list
mcp  GitHub  http  header  https://api.githubcopilot.com/mcp

$ lev mcp test GitHub
✓ 'GitHub' connected · 44 tool(s)
```

Both changed crates pass the 100% gate. `cargo xtask docs` passes. The MCP docs page and the OpenAPI summary now describe both authentication routes.

## One for the coverage notes

The obvious mock — `401` without the header, `200` with it — leaves its own `401` arm unrun in the three CLI tests, because they only ever send the header. That mock earns its keep once, in `leviath-mcp`, where a test probes the same endpoint both ways; the CLI mocks answer unconditionally.
