### PR TITLE
fix(mcp): three faults a sweep of the other server shapes turned up

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mcp.rs
@@ -245,20 +245,27 @@ pub(super) async fn mcp_background_loop(
 }
 
 /// Load the configured server by name, or an error outcome.
-fn find_server(ctx: &McpContext, name: &str) -> Result<MCPServerConfig, McpOutcome> {
+/// The server entry plus the `${VAR}` allowlist that goes with it.
+///
+/// Both come out of the same config read. Returning only the server is what
+/// left the callers passing an empty allowlist, which refuses every `${VAR}`
+/// header and made a server that works for an agent fail here.
+fn find_server(ctx: &McpContext, name: &str) -> Result<(MCPServerConfig, Vec<String>), McpOutcome> {
     let config = Config::load_from_path_public(&ctx.config_path)
         .map_err(|e| fail(format!("Could not read config: {e}")))?;
+    let allow_env = config.security.allow_env_vars.clone();
     config
         .mcp_servers
         .into_iter()
         .find(|s| s.name == name)
+        .map(|server| (server, allow_env))
         .ok_or_else(|| fail(format!("No MCP server named '{name}'")))
 }
 
 /// Run the OAuth browser login for `name`.
 async fn run_login(ctx: &McpContext, name: &str) -> McpOutcome {
-    let server = match find_server(ctx, name) {
-        Ok(server) => server,
+    let (server, allow_env) = match find_server(ctx, name) {
+        Ok(found) => found,
         Err(outcome) => return outcome,
     };
     let url = match server.resolve() {
@@ -271,6 +278,7 @@ async fn run_login(ctx: &McpContext, name: &str) -> McpOutcome {
         .login(
             &url,
             &server.headers,
+            &allow_env,
             ctx.opener.clone(),
             (ctx.clock)(),
             reuse.as_deref(),
@@ -293,8 +301,8 @@ async fn run_login(ctx: &McpContext, name: &str) -> McpOutcome {
 
 /// Connect to `name` and report its tool count.
 async fn run_test(ctx: &McpContext, name: &str) -> McpOutcome {
-    let server = match find_server(ctx, name) {
-        Ok(server) => server,
+    let (server, allow_env) = match find_server(ctx, name) {
+        Ok(found) => found,
         Err(outcome) => return outcome,
     };
     let auth_header = match OAuthClient::new()
@@ -304,7 +312,7 @@ async fn run_test(ctx: &McpContext, name: &str) -> McpOutcome {
         Ok(header) => header,
         Err(e) => return fail(format!("Auth failed for '{name}': {e}")),
     };
-    match connect_and_count(&server, auth_header).await {
+    match connect_and_count(&server, auth_header, &allow_env).await {
         Ok(count) => ok(format!("'{name}' connected · {count} tool(s)")),
         Err(e) => fail(format!("'{name}' failed: {e}")),
     }
@@ -314,8 +322,9 @@ async fn run_test(ctx: &McpContext, name: &str) -> McpOutcome {
 async fn connect_and_count(
     server: &MCPServerConfig,
     auth_header: Option<(String, String)>,
+    allow_env: &[String],
 ) -> anyhow::Result<usize> {
-    let mut client = MCPClient::from_config_with_auth(server, auth_header, &[]).await?;
+    let mut client = MCPClient::from_config_with_auth(server, auth_header, allow_env).await?;
     client.connect().await?;
     let tools = client.list_tools().await?;
     let _ = client.shutdown().await;

--- a/crates/leviath-cli/src/commands/mcp.rs
+++ b/crates/leviath-cli/src/commands/mcp.rs
@@ -52,7 +52,12 @@ struct AddArgs {
     #[arg(long)]
     command: Option<String>,
     /// Argument to pass to the command (repeatable)
-    #[arg(long = "arg")]
+    ///
+    /// `allow_hyphen_values` because the arguments being passed through belong
+    /// to the *server's* command line, not to `lev`. Nearly every published MCP
+    /// server is launched as `npx -y <package>`, and without this the `-y` is
+    /// read as an unknown flag of ours and the whole command is rejected.
+    #[arg(long = "arg", allow_hyphen_values = true)]
     args: Vec<String>,
     /// Environment variable for the command, as KEY=VALUE (repeatable)
     #[arg(long = "env")]
@@ -215,6 +220,7 @@ async fn login(name: &str, env: &McpEnv) -> anyhow::Result<()> {
         .login(
             &url,
             &server.headers,
+            &env.allow_env_vars,
             env.opener.clone(),
             env.now,
             reuse.as_deref(),

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -233,6 +233,7 @@ pub(super) async fn login(
         .login(
             &url,
             &server.headers,
+            &config.security.allow_env_vars,
             admin.opener.clone(),
             (admin.clock)(),
             reuse.as_deref(),
@@ -301,7 +302,7 @@ pub(super) async fn test_server(
         Ok(header) => header,
         Err(e) => return err(StatusCode::BAD_GATEWAY, e.to_string()).into_response(),
     };
-    let result = connect_and_list(server, auth_header).await;
+    let result = connect_and_list(server, auth_header, &config.security.allow_env_vars).await;
     match result {
         Ok(tools) => Json(serde_json::json!({ "server": name, "tools": tools })).into_response(),
         Err(e) => err(StatusCode::BAD_GATEWAY, e.to_string()).into_response(),
@@ -317,8 +318,13 @@ pub(super) async fn test_server(
 async fn connect_and_list(
     server: &MCPServerConfig,
     auth_header: Option<(String, String)>,
+    allow_env: &[String],
 ) -> anyhow::Result<Vec<String>> {
-    let mut client = MCPClient::from_config_with_auth(server, auth_header, &[]).await?;
+    // The allowlist has to come from the config, not be an empty slice: an
+    // empty one refuses every `${VAR}` header, so testing a server whose token
+    // comes from the environment failed here while the same server worked for
+    // an agent.
+    let mut client = MCPClient::from_config_with_auth(server, auth_header, allow_env).await?;
     let listed = async {
         client.connect().await?;
         client.list_tools().await

--- a/crates/leviath-mcp/Cargo.toml
+++ b/crates/leviath-mcp/Cargo.toml
@@ -37,5 +37,7 @@ leviath-testkit = { workspace = true }
 toml = { workspace = true }
 async-stream = "0.3"
 axum = { workspace = true }
-temp-env = { workspace = true }
+# `async_closure` for the auth probe tests, which have to hold a variable set
+# across an await. `leviath-cli` already takes the same feature.
+temp-env = { workspace = true, features = ["async_closure"] }
 tempfile = "3"

--- a/crates/leviath-mcp/src/auth/mod.rs
+++ b/crates/leviath-mcp/src/auth/mod.rs
@@ -153,6 +153,7 @@ impl OAuthClient {
         &self,
         mcp_url: &str,
         headers: &HashMap<String, String>,
+        allow_env: &[String],
         opener: BrowserOpener,
         now: u64,
         reuse_client_id: Option<&str>,
@@ -163,7 +164,7 @@ impl OAuthClient {
         // An unreachable server still goes down the discovery path, which is
         // where the useful error message comes from. Only a live answer that
         // asked for nothing ends the flow here.
-        let www_authenticate = match self.probe_challenge(&mcp, headers).await {
+        let www_authenticate = match self.probe_challenge(&mcp, headers, allow_env).await {
             Probe::Satisfied => return Ok(LoginOutcome::NotRequired),
             Probe::Challenge(header) => header,
             Probe::Unreachable => None,
@@ -486,9 +487,20 @@ impl OAuthClient {
     /// The headers matter: a server configured with an API token of its own
     /// answers this request normally, and asking it to run a browser login
     /// afterwards is asking for a second credential it never wanted.
-    async fn probe_challenge(&self, mcp: &Url, headers: &HashMap<String, String>) -> Probe {
+    async fn probe_challenge(
+        &self,
+        mcp: &Url,
+        headers: &HashMap<String, String>,
+        allow_env: &[String],
+    ) -> Probe {
         let mut request = self.http.post(mcp.clone()).body("{}");
         for (name, value) in headers {
+            // Expand exactly as the transport will. Probing with a literal
+            // `${TOKEN}` asks the server a question about a credential nobody
+            // will ever send it, and a server that checks the value answers
+            // `401` - sending a correctly configured client into an OAuth flow
+            // it does not need.
+            let value = crate::transport::http::expand_env_allowing(value, allow_env);
             request = request.header(name, value);
         }
         let Ok(response) = request.send().await else {
@@ -1337,6 +1349,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 1_000,
                 None,
@@ -1360,6 +1373,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 Some("existing-client"),
@@ -1384,6 +1398,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1403,6 +1418,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1421,6 +1437,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1763,6 +1780,7 @@ mod tests {
             .login(
                 &format!("{base}/mcp"),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1800,6 +1818,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &headers,
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1824,6 +1843,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 failing_opener,
                 0,
                 None,
@@ -1841,6 +1861,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1858,6 +1879,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1877,6 +1899,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1897,6 +1920,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1916,6 +1940,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1932,6 +1957,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1951,6 +1977,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -1970,6 +1997,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2013,6 +2041,7 @@ mod tests {
             .login(
                 &format!("{base}/mcp"),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2033,6 +2062,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2056,6 +2086,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2073,6 +2104,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2092,6 +2124,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2115,6 +2148,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2147,6 +2181,7 @@ mod tests {
                 .login(
                     "http://mcp.example.invalid/mcp",
                     &HashMap::new(),
+                    &[],
                     auto_consent(),
                     0,
                     None,
@@ -2162,6 +2197,7 @@ mod tests {
                 .login(
                     &format!("{}/mcp", server.base),
                     &HashMap::new(),
+                    &[],
                     auto_consent(),
                     0,
                     None,
@@ -2177,6 +2213,7 @@ mod tests {
                 .login(
                     &format!("{}/mcp", server.base),
                     &HashMap::new(),
+                    &[],
                     auto_consent(),
                     0,
                     None,
@@ -2211,6 +2248,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2234,6 +2272,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2253,6 +2292,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2275,6 +2315,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 forge,
                 0,
                 None,
@@ -2364,7 +2405,7 @@ mod tests {
         let mcp = Url::parse("http://127.0.0.1:1/mcp").unwrap();
         assert_eq!(
             OAuthClient::new()
-                .probe_challenge(&mcp, &HashMap::new())
+                .probe_challenge(&mcp, &HashMap::new(), &[])
                 .await
                 .label(),
             "unreachable"
@@ -2397,7 +2438,10 @@ mod tests {
 
         // Same server, same endpoint: the headers are the only difference.
         assert_eq!(
-            client.probe_challenge(&mcp, &HashMap::new()).await.label(),
+            client
+                .probe_challenge(&mcp, &HashMap::new(), &[])
+                .await
+                .label(),
             "challenge",
             "no credentials, so the server should ask for some"
         );
@@ -2406,9 +2450,67 @@ mod tests {
             "Bearer configured-token".to_string(),
         )]);
         assert_eq!(
-            client.probe_challenge(&mcp, &headers).await.label(),
+            client.probe_challenge(&mcp, &headers, &[]).await.label(),
             "satisfied",
             "the configured header should be enough"
+        );
+    }
+
+    /// The probe has to send what the transport will send, `${VAR}` expanded
+    /// and all. A server that checks the *value* of the credential rejects a
+    /// literal `${TOKEN}`, and a correctly configured client was being sent
+    /// into an OAuth flow on the strength of that rejection.
+    #[tokio::test]
+    async fn the_probe_expands_variables_the_way_the_transport_will() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let app = Router::new().route(
+            "/mcp",
+            post(|headers: axum::http::HeaderMap| async move {
+                // Only the expanded value is accepted.
+                match headers
+                    .get(reqwest::header::AUTHORIZATION)
+                    .map(|v| v.as_bytes())
+                {
+                    Some(b"Bearer the-real-value") => StatusCode::OK,
+                    _ => StatusCode::UNAUTHORIZED,
+                }
+            }),
+        );
+        tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
+            listener, app,
+        )));
+
+        let mcp = Url::parse(&format!("{base}/mcp")).unwrap();
+        let headers = HashMap::from([(
+            "Authorization".to_string(),
+            "Bearer ${LEVIATH_PROBE_TEST_TOKEN}".to_string(),
+        )]);
+        let client = OAuthClient::new();
+        let allow = ["LEVIATH_PROBE_TEST_TOKEN".to_string()];
+
+        let (allowed, refused) = temp_env::async_with_vars(
+            [("LEVIATH_PROBE_TEST_TOKEN", Some("the-real-value"))],
+            async {
+                let allowed = client.probe_challenge(&mcp, &headers, &allow).await;
+                // The same header with no allowlist: the value is refused, so
+                // the server sees a credential it does not recognise and OAuth
+                // genuinely is the right answer.
+                let refused = client.probe_challenge(&mcp, &headers, &[]).await;
+                (allowed, refused)
+            },
+        )
+        .await;
+
+        assert_eq!(
+            allowed.label(),
+            "satisfied",
+            "an allowed variable expands, so the server accepts the request"
+        );
+        assert_eq!(
+            refused.label(),
+            "challenge",
+            "a refused variable leaves a credential the server rejects"
         );
     }
 
@@ -2429,6 +2531,7 @@ mod tests {
             .login(
                 &format!("{base}/mcp"),
                 &HashMap::from([("Authorization".to_string(), "Bearer tok".to_string())]),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2448,6 +2551,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2467,6 +2571,7 @@ mod tests {
             .login(
                 &format!("{}/mcp", server.base),
                 &HashMap::new(),
+                &[],
                 auto_consent(),
                 0,
                 None,
@@ -2500,7 +2605,7 @@ mod tests {
     #[tokio::test]
     async fn login_rejects_a_bad_mcp_url() {
         let err = OAuthClient::new()
-            .login("not a url", &HashMap::new(), auto_consent(), 0, None)
+            .login("not a url", &HashMap::new(), &[], auto_consent(), 0, None)
             .await
             .expect_err("bad url must fail");
         assert!(

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -41,11 +41,17 @@ lev mcp remove <name>
 `Name: value` form an HTTP header is usually written in, so `Authorization: Bearer ...` is rejected
 with `--header must be KEY=VALUE`.
 
+`--arg` passes its value through to the server's own command line, so an argument of its own that
+starts with `-` is fine: `--arg -y` is the `-y` that `npx` wants, not a flag of ours.
+
 There are two ways an HTTP server authenticates you, and Leviath picks between them by asking the
 server rather than by guessing. If a `--header` you configured is enough, as it is for a server that
 takes an API token of its own, `add` reports that no login is needed and stores nothing. If the
 server answers with a `401` instead, the OAuth flow runs and the tokens land in the credential
 store. `lev mcp login` on an already-satisfied server says so rather than failing.
+
+That question is asked with the headers as they will actually be sent, `${VAR}` references
+expanded, so a credential that comes from the environment is recognised as the credential it is.
 
 > [!NOTE]
 > GitHub's MCP server accepts either. A personal access token in an `Authorization` header needs no


### PR DESCRIPTION
A sweep of the MCP setups that were *not* the reported one, against real servers where one exists and a mock where one does not. Three more faults, all live-verified.

## 1. `--arg -y` was rejected outright

```
$ lev mcp add filesystem --command npx --arg -y --arg @modelcontextprotocol/server-filesystem --arg /path
error: unexpected argument '-y' found
```

clap read the `-y` as an unknown flag of ours, when it belongs to the command being wrapped. Nearly every published MCP server is launched as `npx -y <package>` — and that is verbatim the example in `mcp.md`, so **the documented way to add a stdio server could not be run at all**. Fixed with `allow_hyphen_values` on the pass-through field.

## 2. The login probe sent headers unexpanded

`${VAR}` is expanded by the transport but was not by the probe. So a server that checks the *value* of its credential answered `401` to a correctly configured client, and login went off into an OAuth flow it did not need. Same fault as the merged one, a level further in: the probe has to send what the transport will send.

Proved with a mock that accepts only the expanded value:

```
$ lev mcp test strict     →  ✓ connected · saw_Bearer_secret_value
$ lev mcp login strict    →  (before) fell into OAuth, reached client registration
                             (after)  'strict' does not need a login
```

## 3. Two `test` paths passed an empty allowlist

`connect_and_list` (API) and `connect_and_count` (dashboard) both passed `&[]`, which refuses every `${VAR}` header. A server whose token comes from the environment therefore **worked for an agent and failed the Test button**, in the dashboard and over the API. The dashboard's `find_server` now returns the allowlist alongside the entry, since both come from the config read it was already doing.

## What was exercised live

| Setup | Result |
|---|---|
| stdio, real `@modelcontextprotocol/server-filesystem` | 14 tools, protocol 2025-11-25 |
| HTTP, no auth | connects, no login attempted |
| HTTP, literal header (real GitHub) | 44 tools, `auth: header` |
| HTTP, `${VAR}` header, value-checking server | connects, no login attempted |
| OAuth, hinted `resource_metadata` | GitHub's own hint followed |
| OAuth, bare `401` with no hint | fetches `/.well-known/oauth-protected-resource/<path>`, gets through resource metadata and AS metadata to registration |
| `--no-login` | skips cleanly |
| unreachable server | names the URL |
| duplicate name / no transport / both transports / header without `=` | four distinct, accurate errors |
| **agent → daemon → MCP tool** | `[tool] read_text_file: hello from the fixture` |

That last row is the one that matters most: a real agent, running under the daemon against a mock inference endpoint, called a tool that lives on an npx-spawned MCP server and got the file contents back.

## Harness note

A mock that returns `401` without draining the POST body desyncs the next keep-alive request on that connection, which surfaces as a `501` on a URL that is perfectly fine. Cost me a detour; the URL was right all along.

Both changed crates pass the 100% gate. `cargo xtask docs` passes.
