### PR TITLE
chore(release): 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,32 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## 0.3.6 - 2026-08-13
+
+- Fixed: adding an MCP server that authenticates with a header no longer chases
+  an OAuth login it cannot complete. `lev mcp add --header "Authorization=..."`,
+  `lev mcp login`, and the browser console's login button all ended in
+  `failed to fetch resource metadata: HTTP 404 Not Found`, while the header
+  itself worked the whole time. Leviath now asks the server whether it wants
+  credentials before starting a flow, and says so when it does not.
+- Fixed: `lev mcp add --arg -y` was rejected as an unknown flag. The arguments
+  after `--arg` belong to the server's command line, not to `lev`, so the
+  documented way to add a stdio server (`npx -y <package>`, which is how most
+  MCP servers are published) failed at the first command.
+- Fixed: OAuth discovery finds the metadata document for a server hosted at a
+  path. RFC 9728 puts it at `/.well-known/oauth-protected-resource/<path>`;
+  Leviath dropped the path and asked for the bare well-known URL, which such a
+  server does not serve. A server that sends a `resource_metadata` hint was
+  unaffected, which is why this went unnoticed.
+- Fixed: a `${VAR}` credential in an MCP header is expanded everywhere it is
+  used. The login probe sent the reference literally, so a server that checks
+  the value refused it and Leviath concluded an OAuth login was needed; the
+  Test action in the dashboard and over the API refused the variable outright,
+  so a server that worked for an agent failed its own test.
+- Changed: `lev mcp list` reports a server holding a configured `Authorization`
+  header as `header` rather than `none`. Reading as unauthenticated is what
+  pointed people at a login that does not apply.
+
 ## 0.3.5 - 2026-08-12
 
 - Fixed: the fan-out agents no longer skip their own fan-out. A

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.5" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.5" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.5" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.5" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.5" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.5" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.5" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.5" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.5" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.5" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.5" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.5" }
+leviath = { path = "crates/leviath", version = "0.3.6" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.6" }
+leviath-net = { path = "crates/leviath-net", version = "0.3.6" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.6" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.6" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.6" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.6" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.6" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.6" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.6" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.6" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.6" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.5", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.6", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }


### PR DESCRIPTION
Cuts 0.3.6 on merge.

Six MCP fixes, five of which anyone using MCP would have hit:

- Header-authenticated servers no longer pushed into an OAuth login they cannot complete (the reported bug: a `404` from `add`, from `login`, and from the browser console).
- **`lev mcp add --arg -y` was rejected as an unknown flag**, so the documented way to add a stdio server — `npx -y <package>`, how nearly every MCP server is published — failed at the first command. This one had nothing to do with the report; it turned up in the wider sweep.
- OAuth discovery now finds the metadata document for a server hosted at a path (RFC 9728 §3.1 keeps the path; we dropped it).
- `${VAR}` credentials in headers are expanded everywhere they are used, including the login probe and both Test actions.
- `lev mcp list` calls a configured `Authorization` header a credential rather than reporting `none`.

Verified live against the real GitHub MCP server (44 tools), the real filesystem server over stdio (14 tools), and a full agent → daemon → MCP tool round trip.