### PR TITLE
Fix the automate-labeled issues: #410-#414

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -111,6 +111,7 @@ impl Dashboard {
             should_quit: false,
             pending_confirm: None,
             sort_mode: SortMode::StartedAt,
+            marked: std::collections::HashSet::new(),
             main_focus: MainPane::RunList,
             log_scroll: crate::tui::widgets::scroll::ScrollState::default(),
             pane_rects: Vec::new(),

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -131,8 +131,21 @@ impl Dashboard {
             ConfirmOutcome::Pending => self.pending_confirm = Some((action, dialog)),
             ConfirmOutcome::No => self.add_log("Cancelled".to_string()),
             ConfirmOutcome::Yes => match action {
-                ConfirmAction::Kill { run_id } => self.perform_kill(&run_id),
-                ConfirmAction::Delete { run_id } => self.perform_delete(&run_id),
+                ConfirmAction::Kill { run_ids } => {
+                    for run_id in &run_ids {
+                        // Un-mark first: a killed row stays in the list, and a
+                        // mark that survived the kill would silently pull the
+                        // run into the next group action.
+                        self.marked.remove(run_id);
+                        self.perform_kill(run_id);
+                    }
+                }
+                ConfirmAction::Delete { run_ids } => {
+                    for run_id in &run_ids {
+                        self.marked.remove(run_id);
+                        self.perform_delete(run_id);
+                    }
+                }
                 ConfirmAction::McpRemove { name } => self.mcp_remove_named(&name),
                 // The box is read off the dialog rather than carried in the
                 // outcome: whether to ask again is a note about future
@@ -701,13 +714,30 @@ impl Dashboard {
 
     fn handle_main_list_key(&mut self, key_code: KeyCode) {
         match key_code {
-            // Esc dismisses (the filter); it does not quit - `q` quits, the
-            // same as every other Leviath TUI.
+            // Esc dismisses: the filter first, then the marks. It does not
+            // quit - `q` quits, the same as every other Leviath TUI.
             KeyCode::Esc => {
                 if !self.list_search_query.is_empty() {
                     self.list_search_query.clear();
                     self.selected = 0;
                     self.update_display_indices();
+                } else if !self.marked.is_empty() {
+                    self.marked.clear();
+                }
+            }
+            // Space marks or unmarks the selected run for a group kill or
+            // delete, then moves down one row so repeated presses sweep the
+            // list.
+            KeyCode::Char(' ') => {
+                if let Some(agent) = self.selected_agent() {
+                    let id = agent.id.clone();
+                    if !self.marked.remove(&id) {
+                        self.marked.insert(id);
+                    }
+                    if self.selected < self.display_indices.len() - 1 {
+                        self.selected += 1;
+                        self.table_state.select(Some(self.selected));
+                    }
                 }
             }
             KeyCode::Char('q') => self.should_quit = true,
@@ -3853,5 +3883,212 @@ mod tests {
         assert!(dash.pending_open_run.is_none());
         dash.open_pending_run();
         assert!(!dash.detail_view);
+    }
+
+    // ── Marking runs with Space for group kill / delete ──────────────────
+
+    #[test]
+    fn space_marks_the_selected_run_and_advances() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        let first_id = dash.selected_agent().unwrap().id.clone();
+        dash.handle_key(key(KeyCode::Char(' ')));
+        assert!(dash.marked.contains(&first_id));
+        assert_eq!(dash.selected, 1, "space moves down like the Down key");
+    }
+
+    #[test]
+    fn space_on_a_marked_run_unmarks_it() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char(' ')));
+        dash.handle_key(key(KeyCode::Up));
+        dash.handle_key(key(KeyCode::Char(' ')));
+        assert!(dash.marked.is_empty(), "the second press toggles it off");
+    }
+
+    #[test]
+    fn space_on_the_last_row_keeps_the_selection() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char(' ')));
+        assert_eq!(dash.marked.len(), 1);
+        assert_eq!(dash.selected, 0, "nothing below to advance to");
+    }
+
+    #[test]
+    fn space_with_no_runs_is_a_noop() {
+        let mut dash = make_test_dashboard();
+        dash.handle_key(key(KeyCode::Char(' ')));
+        assert!(dash.marked.is_empty());
+    }
+
+    #[test]
+    fn esc_clears_marks_when_no_filter_is_set() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char(' ')));
+        assert_eq!(dash.marked.len(), 1);
+        dash.handle_key(key(KeyCode::Esc));
+        assert!(dash.marked.is_empty());
+        assert!(!dash.should_quit);
+    }
+
+    #[test]
+    fn esc_clears_the_filter_before_the_marks() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Char(' ')));
+        dash.list_search_query = "test".to_string();
+        dash.handle_key(key(KeyCode::Esc));
+        assert!(dash.list_search_query.is_empty());
+        assert_eq!(dash.marked.len(), 1, "the first Esc only drops the filter");
+        dash.handle_key(key(KeyCode::Esc));
+        assert!(dash.marked.is_empty());
+    }
+
+    #[test]
+    fn marked_delete_confirm_carries_all_ids_and_removes_them() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Complete));
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Complete));
+        dash.agents
+            .push(make_test_agent("run-3", AgentDisplayStatus::Complete));
+        dash.update_display_indices();
+        dash.marked.insert("run-1".to_string());
+        dash.marked.insert("run-2".to_string());
+        dash.handle_key(key(KeyCode::Char('d')));
+
+        let (action, dialog) = dash.pending_confirm.clone().expect("d opens the dialog");
+        assert_eq!(
+            action,
+            ConfirmAction::Delete {
+                run_ids: vec!["run-1".to_string(), "run-2".to_string()],
+            }
+        );
+        assert!(
+            format!("{:?}", dialog.body).contains("Delete 2 runs"),
+            "the body states the count: {:?}",
+            dialog.body
+        );
+
+        dash.handle_key(key(KeyCode::Char('y')));
+        assert_eq!(dash.agents.len(), 1, "both marked runs are gone");
+        assert_eq!(dash.agents[0].id, "run-3");
+        assert!(dash.marked.is_empty(), "acted-on ids leave the mark set");
+    }
+
+    #[test]
+    fn marked_delete_of_one_run_uses_the_singular_noun() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Complete));
+        dash.update_display_indices();
+        dash.marked.insert("run-1".to_string());
+        dash.handle_key(key(KeyCode::Char('d')));
+        let (_, dialog) = dash.pending_confirm.clone().expect("d opens the dialog");
+        assert!(
+            format!("{:?}", dialog.body).contains("Delete 1 run and its"),
+            "{:?}",
+            dialog.body
+        );
+    }
+
+    #[test]
+    fn marked_kill_skips_finished_runs_and_unmarks_only_the_killed() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Complete));
+        dash.update_display_indices();
+        dash.marked.insert("run-1".to_string());
+        dash.marked.insert("run-2".to_string());
+        dash.handle_key(key(KeyCode::Char('x')));
+
+        let (action, dialog) = dash.pending_confirm.clone().expect("x opens the dialog");
+        assert_eq!(
+            action,
+            ConfirmAction::Kill {
+                run_ids: vec!["run-1".to_string()],
+            },
+            "the finished run is not on the kill list"
+        );
+        assert!(
+            format!("{:?}", dialog.body).contains("Cancel 1 run?"),
+            "{:?}",
+            dialog.body
+        );
+
+        dash.handle_key(key(KeyCode::Char('y')));
+        assert_cancelled(&dash.agents[0].status);
+        assert_eq!(
+            cmd_rx.try_recv().unwrap(),
+            DaemonCommand::Cancel {
+                run_id: "run-1".to_string()
+            }
+        );
+        assert!(cmd_rx.try_recv().is_err(), "run-2 was never cancelled");
+        assert!(!dash.marked.contains("run-1"), "the killed run is unmarked");
+        assert!(
+            dash.marked.contains("run-2"),
+            "the skipped run stays marked"
+        );
+    }
+
+    #[test]
+    fn marked_kill_of_several_runs_cancels_each() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Waiting));
+        dash.update_display_indices();
+        dash.marked.insert("run-1".to_string());
+        dash.marked.insert("run-2".to_string());
+        dash.handle_key(key(KeyCode::Char('x')));
+
+        let (_, dialog) = dash.pending_confirm.clone().expect("x opens the dialog");
+        assert!(
+            format!("{:?}", dialog.body).contains("Cancel 2 runs?"),
+            "{:?}",
+            dialog.body
+        );
+
+        dash.handle_key(key(KeyCode::Char('y')));
+        assert_cancelled(&dash.agents[0].status);
+        assert_cancelled(&dash.agents[1].status);
+        assert!(cmd_rx.try_recv().is_ok());
+        assert!(cmd_rx.try_recv().is_ok());
+        assert!(dash.marked.is_empty());
+    }
+
+    #[test]
+    fn marked_kill_with_only_finished_runs_opens_no_dialog() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Complete));
+        dash.update_display_indices();
+        dash.marked.insert("run-1".to_string());
+        dash.handle_key(key(KeyCode::Char('x')));
+        assert!(dash.pending_confirm.is_none());
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -267,7 +267,7 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
         spawn_outcome_tx,
     ));
 
-    dashboard.add_log("Dashboard started. Press `n` to start a run.".to_string());
+    dashboard.add_log("Dashboard started. Press `n` to start an agent run.".to_string());
 
     dashboard
 }
@@ -639,7 +639,7 @@ mod tests {
         // An empty dashboard still draws its chrome. Without this the test
         // would pass just as happily against a `draw` that returned early.
         let buf = crate::commands::dashboard::test_support::rendered_buffer(&terminal);
-        assert!(buf.contains("Runs"), "{buf}");
+        assert!(buf.contains("Agent Runs"), "{buf}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -267,7 +267,7 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
         spawn_outcome_tx,
     ));
 
-    dashboard.add_log("Dashboard started. Press `n` to start an agent.".to_string());
+    dashboard.add_log("Dashboard started. Press `n` to start a run.".to_string());
 
     dashboard
 }
@@ -639,7 +639,7 @@ mod tests {
         // An empty dashboard still draws its chrome. Without this the test
         // would pass just as happily against a `draw` that returned early.
         let buf = crate::commands::dashboard::test_support::rendered_buffer(&terminal);
-        assert!(buf.contains("Agents"), "{buf}");
+        assert!(buf.contains("Runs"), "{buf}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -136,7 +136,7 @@ impl Dashboard {
     /// row shows up in the list the user is returned to.
     pub(super) fn submit_new_run(&mut self) {
         let Some(agent) = self.new_run_selected_agent().cloned() else {
-            self.toast("Pick an agent first", ToastLevel::Error);
+            self.toast("Pick an agent blueprint first", ToastLevel::Error);
             return;
         };
         let task = self.new_run_task.lines().join("\n").trim().to_string();
@@ -415,7 +415,7 @@ fn yolo_warning() -> Confirm {
         "Run unattended?",
         vec![
             Line::from(
-                "Runs started from this screen will approve their own tool calls: \
+                "Agent runs started from this screen will approve their own tool calls: \
                  editing files, running shell commands, fetching URLs, whatever \
                  the agent's permissions allow, without stopping to ask you.",
             ),

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -203,14 +203,19 @@ impl Dashboard {
         let is_context = self.stage_content_mode == StageContentMode::Context;
         let is_output = self.stage_content_mode == StageContentMode::Output;
 
-        // Build content lines
-        let (all_lines, context_cursor_line): (Vec<Line>, Option<usize>) = if is_context {
-            self.build_context_lines(agent, render_width)
+        // Build content lines. `showing_final_output` records whether the
+        // Output pane fell back to the run's final answer, so the file-path
+        // hint below can point at the file actually being shown.
+        let (all_lines, context_cursor_line, showing_final_output): (
+            Vec<Line>,
+            Option<usize>,
+            bool,
+        ) = if is_context {
+            let (lines, cursor) = self.build_context_lines(agent, render_width);
+            (lines, cursor, false)
         } else {
-            (
-                self.build_output_lines(agent, is_output, render_width),
-                None,
-            )
+            let (lines, showing_final) = self.build_output_lines(agent, is_output, render_width);
+            (lines, None, showing_final)
         };
 
         // ── Error / Cancelled banner ─────────────────────────────────────
@@ -408,15 +413,24 @@ impl Dashboard {
 
         // Bottom-left file path hint
         let file_path_hint = {
-            let file_name = match self.stage_content_mode {
-                StageContentMode::Output => "output.log",
-                StageContentMode::Logs => "logs.log",
-                StageContentMode::Context => "context.json",
+            let raw = if showing_final_output {
+                // The pane fell back to the run's final answer, which lives in
+                // the `final_output` sidecar beside `meta.json` rather than in
+                // the stage's `output.log`; name the file actually shown.
+                runstate::final_output_path(&runstate::run_dir(&agent.id))
+                    .to_string_lossy()
+                    .to_string()
+            } else {
+                let file_name = match self.stage_content_mode {
+                    StageContentMode::Output => "output.log",
+                    StageContentMode::Logs => "logs.log",
+                    StageContentMode::Context => "context.json",
+                };
+                runstate::stage_dir(&agent.id, self.selected_stage)
+                    .join(file_name)
+                    .to_string_lossy()
+                    .to_string()
             };
-            let raw = runstate::stage_dir(&agent.id, self.selected_stage)
-                .join(file_name)
-                .to_string_lossy()
-                .to_string();
             // Display-only `~` abbreviation of the OS home directory;
             // deliberately NOT the LEVIATH_HOME-aware resolver (see the
             // header's workdir line for the same choice).
@@ -655,25 +669,63 @@ impl Dashboard {
         }
     }
 
+    /// The run's final answer, when the selected stage is the one that
+    /// submitted it.
+    ///
+    /// A `mode = "output"` stage answers through `submit_output`, which lands
+    /// in the run's `final_output` sidecar rather than the stage's
+    /// `output.log`. The descriptor records which stage submitted, so the
+    /// answer only stands in for that stage's otherwise empty Output pane -
+    /// every other stage keeps its honest empty state.
+    fn final_output_for_selected_stage(&self, agent: &DashboardAgent) -> Option<String> {
+        let final_output = crate::runstate::read_final_output(&agent.id)?;
+        let selected_name = agent.stages.get(self.selected_stage)?.name.as_str();
+        if final_output.stage == selected_name {
+            Some(final_output.content)
+        } else {
+            None
+        }
+    }
+
+    /// The Output or Logs view's lines, plus whether the Output view fell back
+    /// to the run's final answer (so the file-path hint can name that file
+    /// instead of the stage's `output.log`).
     fn build_output_lines(
         &self,
         agent: &DashboardAgent,
         is_output: bool,
         render_width: u16,
-    ) -> Vec<Line<'static>> {
+    ) -> (Vec<Line<'static>>, bool) {
+        let mut showing_final_output = false;
         let content = if is_output {
             // When a document is up for review (a pending interaction's body,
             // e.g. the plan being approved), show just that current instance -
             // not the full accumulated output history. `[l]` still shows logs.
             match self.reviewing_body() {
                 Some(body) => body,
-                None => runstate::tail_stage_output(&agent.id, self.selected_stage, 131_072),
+                None => {
+                    let tail = runstate::tail_stage_output(&agent.id, self.selected_stage, 131_072);
+                    if tail.is_empty() {
+                        // Nothing in the stage's output.log. If this stage
+                        // submitted the run's final answer, show that instead
+                        // of a permanent "No output yet" (issue #410).
+                        match self.final_output_for_selected_stage(agent) {
+                            Some(answer) => {
+                                showing_final_output = true;
+                                answer
+                            }
+                            None => tail,
+                        }
+                    } else {
+                        tail
+                    }
+                }
             }
         } else {
             runstate::tail_stage_log(&agent.id, self.selected_stage, 131_072)
         };
 
-        if is_output && !content.is_empty() {
+        let lines = if is_output && !content.is_empty() {
             crate::render::markdown_to_text(&content, render_width).lines
         } else if !is_output {
             content
@@ -711,7 +763,8 @@ impl Dashboard {
                 .collect()
         } else {
             Vec::new()
-        }
+        };
+        (lines, showing_final_output)
     }
 }
 
@@ -1172,6 +1225,60 @@ mod tests {
         make_test_agent(run_id, AgentDisplayStatus::Active)
     }
 
+    /// Seed a run whose answer arrived through `submit_output`: the
+    /// `final_output` descriptor in `meta.json` plus the sidecar beside it,
+    /// submitted by `stage`, with no `output.log` anywhere. Returns an agent
+    /// pointed at that run.
+    fn setup_run_state_agent_with_final_output(
+        run_id: &str,
+        stage: &str,
+        content: &str,
+    ) -> DashboardAgent {
+        // Same defensive cleanup as `setup_run_state_agent_with_logs`: a stale
+        // directory from an earlier panicked test must not leak in.
+        let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+        let answer = leviath_core::output::FinalOutput::new(
+            content,
+            Some("markdown".to_string()),
+            stage.to_string(),
+            42,
+        );
+        let mut meta = runstate::RunMeta::new(
+            run_id.to_string(),
+            "agent".to_string(),
+            "/p".to_string(),
+            "task".to_string(),
+            None,
+            "/tmp".to_string(),
+            1,
+        );
+        meta.final_output = Some(answer.descriptor());
+        runstate::create_run(&meta).unwrap();
+        runstate::write_final_output(&runstate::run_dir(run_id), &answer.content).unwrap();
+
+        make_test_agent(run_id, AgentDisplayStatus::Complete)
+    }
+
+    /// A minimal stage record carrying just the name the final-output fallback
+    /// compares against.
+    fn make_stage_record(name: &str) -> crate::runstate::StageRecord {
+        crate::runstate::StageRecord {
+            name: name.to_string(),
+            index: 0,
+            status: crate::runstate::StageRunStatus::Active,
+            entered: true,
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            cached_tokens: 0,
+            cache_write_tokens: 0,
+            region_tokens: Default::default(),
+            first_call_prompt_tokens: None,
+            runaway_warned: false,
+            started_at: None,
+            ended_at: None,
+        }
+    }
+
     #[test]
     fn render_content_pane_logs_mode_shows_tool_count_badge() {
         crate::runstate::with_isolated_runs_dir(
@@ -1293,7 +1400,7 @@ mod tests {
                 );
 
                 let dash = make_test_dashboard();
-                let lines = dash.build_output_lines(&agent, false, 100);
+                let (lines, _showing_final) = dash.build_output_lines(&agent, false, 100);
                 let text: String = lines
                     .iter()
                     .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1321,8 +1428,11 @@ mod tests {
                     setup_run_state_agent_with_logs(run_id, &[], Some("# Heading\n\nbody text"));
 
                 let dash = make_test_dashboard();
-                let lines = dash.build_output_lines(&agent, true, 100);
+                let (lines, showing_final) = dash.build_output_lines(&agent, true, 100);
                 assert!(!lines.is_empty());
+                // A non-empty output.log is the real stage output, not the
+                // final-answer fallback.
+                assert!(!showing_final);
                 let text: String = lines
                     .iter()
                     .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1330,6 +1440,154 @@ mod tests {
                     .join("\n");
                 assert!(text.contains("Heading"));
                 assert!(text.contains("body text"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
+        );
+    }
+
+    #[test]
+    fn build_output_lines_falls_back_to_final_output_for_the_submitting_stage() {
+        crate::runstate::with_isolated_runs_dir(
+            "build_output_lines_falls_back_to_final_output_for_the_submitting_stage",
+            |_d| {
+                let run_id = "test-content-final-output-match";
+                // A `mode = "output"` stage writes nothing to output.log; its
+                // answer lives only in the final_output sidecar (issue #410).
+                let mut agent = setup_run_state_agent_with_final_output(
+                    run_id,
+                    "present",
+                    "# The Answer\n\nall done",
+                );
+                agent.stages = vec![make_stage_record("present")];
+
+                let dash = make_test_dashboard();
+                let (lines, showing_final) = dash.build_output_lines(&agent, true, 100);
+                assert!(showing_final);
+                let text: String = lines
+                    .iter()
+                    .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(text.contains("The Answer"));
+                assert!(text.contains("all done"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
+        );
+    }
+
+    #[test]
+    fn build_output_lines_ignores_final_output_submitted_by_another_stage() {
+        crate::runstate::with_isolated_runs_dir(
+            "build_output_lines_ignores_final_output_submitted_by_another_stage",
+            |_d| {
+                let run_id = "test-content-final-output-other-stage";
+                let mut agent =
+                    setup_run_state_agent_with_final_output(run_id, "present", "the answer");
+                // The selected stage (index 0) is not the one that submitted,
+                // so its Output pane keeps the honest empty state.
+                agent.stages = vec![make_stage_record("draft")];
+
+                let backend = TestBackend::new(120, 40);
+                let mut terminal = Terminal::new(backend).unwrap();
+                let mut dash = make_test_dashboard();
+                let (lines, showing_final) = dash.build_output_lines(&agent, true, 100);
+                assert!(lines.is_empty());
+                assert!(!showing_final);
+
+                dash.stage_content_mode = StageContentMode::Output;
+                terminal
+                    .draw(|f| {
+                        let area = Rect::new(0, 0, 100, 20);
+                        dash.render_content_pane(f, area, &agent, 100);
+                    })
+                    .unwrap();
+                let buf = rendered_buffer(&terminal);
+                assert!(buf.contains("No output yet for draft"), "{buf}");
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
+        );
+    }
+
+    #[test]
+    fn build_output_lines_ignores_final_output_without_a_stage_record() {
+        crate::runstate::with_isolated_runs_dir(
+            "build_output_lines_ignores_final_output_without_a_stage_record",
+            |_d| {
+                let run_id = "test-content-final-output-no-record";
+                // No stage records at all: the selected stage has no name to
+                // compare against the descriptor's, so nothing substitutes.
+                let agent =
+                    setup_run_state_agent_with_final_output(run_id, "present", "the answer");
+                assert!(agent.stages.is_empty());
+
+                let dash = make_test_dashboard();
+                let (lines, showing_final) = dash.build_output_lines(&agent, true, 100);
+                assert!(lines.is_empty());
+                assert!(!showing_final);
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
+        );
+    }
+
+    #[test]
+    fn build_output_lines_prefers_stage_output_over_final_output() {
+        crate::runstate::with_isolated_runs_dir(
+            "build_output_lines_prefers_stage_output_over_final_output",
+            |_d| {
+                let run_id = "test-content-final-output-tail-wins";
+                let mut agent =
+                    setup_run_state_agent_with_final_output(run_id, "present", "the answer");
+                agent.stages = vec![make_stage_record("present")];
+                // The stage also wrote real output, which always wins over the
+                // final-answer fallback.
+                runstate::append_stage_output(run_id, 0, "streamed stage output");
+
+                let dash = make_test_dashboard();
+                let (lines, showing_final) = dash.build_output_lines(&agent, true, 100);
+                assert!(!showing_final);
+                let text: String = lines
+                    .iter()
+                    .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(text.contains("streamed stage output"));
+                assert!(!text.contains("the answer"));
+
+                let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+            },
+        );
+    }
+
+    #[test]
+    fn render_content_pane_final_output_fallback_names_the_final_output_file() {
+        crate::runstate::with_isolated_runs_dir(
+            "render_content_pane_final_output_fallback_names_the_final_output_file",
+            |_d| {
+                let run_id = "test-content-final-output-hint";
+                let mut agent =
+                    setup_run_state_agent_with_final_output(run_id, "present", "the answer");
+                agent.stages = vec![make_stage_record("present")];
+
+                let backend = TestBackend::new(120, 40);
+                let mut terminal = Terminal::new(backend).unwrap();
+                let mut dash = make_test_dashboard();
+                dash.stage_content_mode = StageContentMode::Output;
+                terminal
+                    .draw(|f| {
+                        let area = Rect::new(0, 0, 100, 20);
+                        dash.render_content_pane(f, area, &agent, 100);
+                    })
+                    .unwrap();
+                let buf = rendered_buffer(&terminal);
+                assert!(buf.contains("the answer"), "{buf}");
+                // The hint names the file actually shown, not the stage's
+                // (empty) output.log.
+                assert!(buf.contains(leviath_core::FINAL_OUTPUT_FILE), "{buf}");
+                assert!(!buf.contains("output.log"), "{buf}");
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
             },
@@ -1503,9 +1761,11 @@ mod tests {
     fn build_output_lines_non_run_state() {
         let dash = make_test_dashboard();
         let agent = make_test_agent("run-nrs", AgentDisplayStatus::Active);
-        // is_run_state is false, so content will be empty
-        let lines = dash.build_output_lines(&agent, true, 80);
+        // is_run_state is false, so content will be empty; there is no run on
+        // disk either, so the final-answer fallback finds nothing.
+        let (lines, showing_final) = dash.build_output_lines(&agent, true, 80);
         assert!(lines.is_empty());
+        assert!(!showing_final);
     }
 
     #[test]
@@ -1971,7 +2231,7 @@ mod tests {
         let dash = make_test_dashboard();
         let agent = make_test_agent("run-logs-nrs", AgentDisplayStatus::Active);
         // non-run-state, is_output = false
-        let lines = dash.build_output_lines(&agent, false, 80);
+        let (lines, _showing_final) = dash.build_output_lines(&agent, false, 80);
         // Should be empty because no disk content
         assert!(lines.is_empty());
     }

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -105,7 +105,7 @@ impl Dashboard {
         let agent = match self.selected_agent() {
             Some(a) => a.clone(),
             None => {
-                let msg = ratatui::widgets::Paragraph::new("No agent selected.").block(
+                let msg = ratatui::widgets::Paragraph::new("No run selected.").block(
                     ratatui::widgets::Block::default()
                         .borders(ratatui::widgets::Borders::ALL)
                         .title(" Detail "),

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -105,7 +105,7 @@ impl Dashboard {
         let agent = match self.selected_agent() {
             Some(a) => a.clone(),
             None => {
-                let msg = ratatui::widgets::Paragraph::new("No run selected.").block(
+                let msg = ratatui::widgets::Paragraph::new("No agent run selected.").block(
                     ratatui::widgets::Block::default()
                         .borders(ratatui::widgets::Borders::ALL)
                         .title(" Detail "),
@@ -667,7 +667,7 @@ mod tests {
         dash.show_help = true;
         terminal.draw(|f| dash.draw(f)).unwrap();
         let buf = rendered_buffer(&terminal);
-        assert!(buf.contains("Run list"), "{buf}");
+        assert!(buf.contains("Agent run list"), "{buf}");
     }
 
     #[test]
@@ -1027,7 +1027,7 @@ mod tests {
         terminal.draw(|f| dash.draw(f)).unwrap();
         assert!(
             crate::commands::dashboard::test_support::rendered_buffer(&terminal)
-                .contains("New run: agents")
+                .contains("New run: agent blueprints")
         );
 
         dash.show_help = false;

--- a/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
@@ -37,7 +37,7 @@ impl Dashboard {
 
     fn draw_new_run_agents(&self, frame: &mut Frame, area: Rect) {
         let visible = self.filtered_new_run_agents();
-        let header = Row::new(["Agent", "Source", "Description"].into_iter().map(|h| {
+        let header = Row::new(["Blueprint", "Source", "Description"].into_iter().map(|h| {
             Cell::from(Span::styled(
                 h,
                 Style::default().add_modifier(Modifier::BOLD),
@@ -64,9 +64,9 @@ impl Dashboard {
         // The filter reads as part of the title, the way the main list's does,
         // so there is no separate line to notice.
         let title = match self.new_run_filter.is_empty() {
-            true => format!(" Agents ({}) ", visible.len()),
+            true => format!(" Agent Blueprints ({}) ", visible.len()),
             false => format!(
-                " Agents  /{}▌  {}/{} ",
+                " Agent Blueprints  /{}▌  {}/{} ",
                 self.new_run_filter,
                 visible.len(),
                 self.new_run_agents.len()
@@ -103,8 +103,10 @@ impl Dashboard {
 
         if visible.is_empty() {
             let hint = match self.new_run_filter.is_empty() {
-                true => "No agents found. `lev setup` installs the bundled ones.".to_string(),
-                false => format!("No agents match \"{}\".", self.new_run_filter),
+                true => {
+                    "No agent blueprints found. `lev setup` installs the bundled ones.".to_string()
+                }
+                false => format!("No agent blueprints match \"{}\".", self.new_run_filter),
             };
             frame.render_widget(
                 Paragraph::new(Line::from(Span::styled(hint, Style::default().fg(C_DIM)))),
@@ -123,7 +125,7 @@ impl Dashboard {
         let agent = self
             .new_run_selected_agent()
             .map(|a| a.name.clone())
-            .unwrap_or_else(|| "no agent selected".to_string());
+            .unwrap_or_else(|| "no agent blueprint selected".to_string());
         self.new_run_task.set_block(
             Block::default()
                 .borders(Borders::ALL)
@@ -288,7 +290,7 @@ mod tests {
     fn the_screen_lists_agents_with_their_source() {
         let mut dash = screen();
         let out = rendered(&mut dash);
-        assert!(out.contains("Agents (2)"), "{out}");
+        assert!(out.contains("Agent Blueprints (2)"), "{out}");
         assert!(out.contains("alpha"), "{out}");
         assert!(out.contains("installed"), "{out}");
         assert!(out.contains("bundled"), "{out}");
@@ -310,9 +312,12 @@ mod tests {
         let mut dash = make_test_dashboard();
         dash.new_run_screen = true;
         let out = rendered(&mut dash);
-        assert!(out.contains("No agents found"), "{out}");
+        assert!(out.contains("No agent blueprints found"), "{out}");
         assert!(out.contains("lev setup"), "{out}");
-        assert!(out.contains("no agent selected"), "task title: {out}");
+        assert!(
+            out.contains("no agent blueprint selected"),
+            "task title: {out}"
+        );
     }
 
     #[test]
@@ -320,7 +325,7 @@ mod tests {
         let mut dash = screen();
         dash.new_run_filter = "zzz".to_string();
         let out = rendered(&mut dash);
-        assert!(out.contains("No agents match"), "{out}");
+        assert!(out.contains("No agent blueprints match"), "{out}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -88,7 +88,7 @@ impl Dashboard {
 /// The run list: the screen `lev dash` opens on.
 fn run_list_sections() -> Vec<HelpSection> {
     vec![HelpSection {
-        title: "Run list",
+        title: "Agent run list",
         entries: vec![
             ("↑ ↓ / k j", "select a run"),
             ("home / end (g / G)", "first / last run"),
@@ -140,8 +140,8 @@ fn detail_sections() -> Vec<HelpSection> {
                 ("home / end (b / e)", "top / bottom"),
                 ("/", "search; n / N step through matches"),
                 ("y", "copy this pane to the clipboard"),
-                ("i", "respond, or send a message to a running agent"),
-                ("g", "stage explorer (branching agents only)"),
+                ("i", "respond, or send a message to a running agent run"),
+                ("g", "stage explorer (branching agent runs only)"),
                 (", / .", "older / newer context point; opens Context"),
                 ("x", "kill the run (asks first)"),
                 ("p / r", "pause / resume"),
@@ -193,7 +193,7 @@ fn detail_sections() -> Vec<HelpSection> {
 fn new_run_sections() -> Vec<HelpSection> {
     vec![
         HelpSection {
-            title: "New run: agents",
+            title: "New run: agent blueprints",
             entries: vec![
                 ("↑ ↓", "select an agent"),
                 ("any letter", "filter the list"),
@@ -410,7 +410,7 @@ mod tests {
             })
             .unwrap();
         let buf = rendered_buffer(&terminal);
-        assert!(buf.contains("Run list"), "{buf}");
+        assert!(buf.contains("Agent run list"), "{buf}");
     }
 
     #[test]
@@ -424,7 +424,7 @@ mod tests {
             })
             .unwrap();
         let buf = rendered_buffer(&terminal);
-        assert!(buf.contains("Run list"), "{buf}");
+        assert!(buf.contains("Agent run list"), "{buf}");
     }
 
     #[test]
@@ -473,7 +473,7 @@ mod tests {
             .unwrap();
 
         let rendered = rendered_buffer(&terminal);
-        assert!(rendered.contains("Run list"));
+        assert!(rendered.contains("Agent run list"));
         assert!(rendered.contains("cycle sort"));
         assert!(rendered.contains("kill the run (asks first)"));
         assert!(!rendered.contains("Detail view"));
@@ -499,7 +499,7 @@ mod tests {
         // their own: `?` is unbound once you are typing, so the only place to
         // read them is before you press `i`.
         assert!(rendered.contains("Writing a response"));
-        assert!(!rendered.contains("Run list"));
+        assert!(!rendered.contains("Agent run list"));
         assert!(!rendered.contains("cycle sort"));
     }
 
@@ -551,7 +551,7 @@ mod tests {
         terminal.draw(|f| dash.draw_help_overlay(f)).unwrap();
 
         let rendered = rendered_buffer(&terminal);
-        assert!(rendered.contains("New run: agents"), "{rendered}");
+        assert!(rendered.contains("New run: agent blueprints"), "{rendered}");
         assert!(rendered.contains("New run: task"));
         assert!(rendered.contains("reference a file"));
         assert!(rendered.contains("New run: unattended"));

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -100,8 +100,12 @@ fn run_list_sections() -> Vec<HelpSection> {
             ("p / r", "pause / resume the selected run"),
             ("x", "kill the run (asks first)"),
             ("d", "delete the run and its files (asks first)"),
+            (
+                "space",
+                "mark/unmark the run (marked runs are killed/deleted together)",
+            ),
             ("m", "manage MCP servers"),
-            ("esc", "clear the filter"),
+            ("esc", "clear the filter, then the marks"),
             ("q", "quit"),
         ],
     }]

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -24,7 +24,7 @@ impl Dashboard {
                 Style::default().add_modifier(Modifier::BOLD),
             )),
             Cell::from(Span::styled(
-                "Agent",
+                "Blueprint",
                 Style::default().add_modifier(Modifier::BOLD),
             )),
             Cell::from(Span::styled(
@@ -121,24 +121,27 @@ impl Dashboard {
             .collect();
 
         let empty_state_msg: Option<String> = if self.agents.is_empty() {
-            Some("  No runs yet. Press `n` to start one.".to_string())
+            Some("  No agent runs yet. Press `n` to start one.".to_string())
         } else if self.display_indices.is_empty() {
-            Some(format!("  No runs match \"{}\".", self.list_search_query))
+            Some(format!(
+                "  No agent runs match \"{}\".",
+                self.list_search_query
+            ))
         } else {
             None
         };
 
         let mut list_title = if !self.list_search_query.is_empty() {
             format!(
-                " Runs  /{}/  {}/{} ",
+                " Agent Runs  /{}/  {}/{} ",
                 self.list_search_query,
                 self.display_indices.len(),
                 self.agents.len()
             )
         } else if self.list_search_mode {
-            format!(" Runs  /{}▌ ", self.list_search_query)
+            format!(" Agent Runs  /{}▌ ", self.list_search_query)
         } else {
-            " Runs ".to_string()
+            " Agent Runs ".to_string()
         };
         if any_marked {
             list_title = format!("{} {} marked ", list_title.trim_end(), self.marked.len());

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -49,6 +49,10 @@ impl Dashboard {
 
         let spinner_frame = SPINNER[(self.tick_count as usize) % SPINNER.len()];
 
+        // A mark column appears only while at least one run is marked, so the
+        // table looks exactly as before until the feature is used.
+        let any_marked = !self.marked.is_empty();
+
         let rows: Vec<Row> = self
             .display_indices
             .iter()
@@ -89,11 +93,22 @@ impl Dashboard {
                     agent.status.to_string()
                 };
                 let short_id = agent.id.split('-').next_back().unwrap_or("").to_string();
-                let title_cell = Cell::from(Line::from(vec![
-                    Span::styled(tree_prefix, Style::default().fg(C_DIM)),
-                    Span::styled(title_str, Style::default().fg(C_WHITE)),
-                    Span::styled(format!(" #{}", short_id), Style::default().fg(C_DIM)),
-                ]));
+                let mut title_spans = Vec::new();
+                if any_marked {
+                    if self.marked.contains(&agent.id) {
+                        title_spans.push(Span::styled("✓ ", Style::default().fg(C_ACCENT)));
+                    } else {
+                        // Unmarked rows get the same width, so titles stay aligned.
+                        title_spans.push(Span::raw("  "));
+                    }
+                }
+                title_spans.push(Span::styled(tree_prefix, Style::default().fg(C_DIM)));
+                title_spans.push(Span::styled(title_str, Style::default().fg(C_WHITE)));
+                title_spans.push(Span::styled(
+                    format!(" #{}", short_id),
+                    Style::default().fg(C_DIM),
+                ));
+                let title_cell = Cell::from(Line::from(title_spans));
                 Row::new(vec![
                     title_cell,
                     Cell::from(agent.blueprint_name.clone()),
@@ -106,25 +121,28 @@ impl Dashboard {
             .collect();
 
         let empty_state_msg: Option<String> = if self.agents.is_empty() {
-            Some("  No agents running. Press `n` to start one.".to_string())
+            Some("  No runs yet. Press `n` to start one.".to_string())
         } else if self.display_indices.is_empty() {
-            Some(format!("  No agents match \"{}\".", self.list_search_query))
+            Some(format!("  No runs match \"{}\".", self.list_search_query))
         } else {
             None
         };
 
-        let list_title = if !self.list_search_query.is_empty() {
+        let mut list_title = if !self.list_search_query.is_empty() {
             format!(
-                " Agents  /{}/  {}/{} ",
+                " Runs  /{}/  {}/{} ",
                 self.list_search_query,
                 self.display_indices.len(),
                 self.agents.len()
             )
         } else if self.list_search_mode {
-            format!(" Agents  /{}▌ ", self.list_search_query)
+            format!(" Runs  /{}▌ ", self.list_search_query)
         } else {
-            " Agents ".to_string()
+            " Runs ".to_string()
         };
+        if any_marked {
+            list_title = format!("{} {} marked ", list_title.trim_end(), self.marked.len());
+        }
 
         // Register for wheel hit-testing and show which pane holds focus.
         self.pane_rects.push((PaneId::RunTable, area));
@@ -508,6 +526,8 @@ impl Dashboard {
             Span::raw(" sort  "),
             Span::styled("[d]", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" delete  "),
+            Span::styled("[space]", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" mark  "),
         ];
         if can_kill {
             spans.push(Span::styled(
@@ -1200,5 +1220,58 @@ mod tests {
         let line = dash.build_detail_help_bar();
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(!text.contains("[i]"));
+    }
+
+    // ── Marks for group kill / delete ─────────────────────────────────────
+
+    #[test]
+    fn marked_rows_show_a_check_and_the_title_counts_them() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.marked.insert("run-1".to_string());
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dash.draw_agent_table(f, area);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("✓ My Test #1"), "{buf}");
+        assert!(!buf.contains("✓ My Test #2"), "{buf}");
+        assert!(buf.contains("My Test #2"), "the unmarked row still renders");
+        assert!(buf.contains("1 marked"), "{buf}");
+    }
+
+    #[test]
+    fn table_without_marks_shows_no_check_or_count() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dash.draw_agent_table(f, area);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(!buf.contains('✓'), "{buf}");
+        assert!(!buf.contains("marked"), "{buf}");
+    }
+
+    #[test]
+    fn main_list_help_bar_offers_the_mark_key() {
+        let dash = make_test_dashboard();
+        let line = dash.build_main_list_help_bar();
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("[space] mark"), "{text}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -33,6 +33,11 @@ pub(crate) struct Dashboard {
     pub(super) pending_confirm: Option<(ConfirmAction, crate::tui::widgets::confirm::Confirm)>,
     /// How the run list is ordered; `s` cycles it.
     pub(super) sort_mode: SortMode,
+    /// Run ids marked with Space on the main list, so a kill or delete can act
+    /// on several runs at once. Keyed by id rather than row position, so marks
+    /// survive re-sorting and filtering; ids whose runs disappear are pruned by
+    /// [`update_display_indices`](Self::update_display_indices).
+    pub(super) marked: std::collections::HashSet<String>,
     /// Which main-screen pane holds keyboard focus (Tab toggles).
     pub(super) main_focus: MainPane,
     /// Scroll position of the log panel (tail-anchored; End resumes tailing).
@@ -242,6 +247,10 @@ impl Dashboard {
     /// list_search_query. Every mode's order is total (id tie-break), so a
     /// status change alone never reshuffles rows.
     pub(super) fn update_display_indices(&mut self) {
+        // Drop marks whose runs no longer exist, so a deleted or vanished run
+        // cannot linger in a later group kill or delete.
+        let agents = &self.agents;
+        self.marked.retain(|id| agents.iter().any(|a| a.id == *id));
         let query = self.list_search_query.to_lowercase();
         let status_priority = |s: &AgentDisplayStatus| -> u8 {
             match s {
@@ -648,7 +657,7 @@ impl Dashboard {
                         };
                         Self::push_toast(
                             &mut self.toasts,
-                            format!("Agent '{}' failed{}", name, preview),
+                            format!("Run '{}' failed{}", name, preview),
                             ToastLevel::Error,
                             50,
                         );
@@ -658,7 +667,7 @@ impl Dashboard {
                     ) {
                         Self::push_toast(
                             &mut self.toasts,
-                            format!("Agent '{}' completed", name),
+                            format!("Run '{}' completed", name),
                             ToastLevel::Info,
                             35,
                         );
@@ -733,7 +742,7 @@ impl Dashboard {
                                     .unwrap_or(truncate(&agent.blueprint_name, 20));
                                 Self::push_toast(
                                     &mut self.toasts,
-                                    format!("Agent '{}' needs input", name),
+                                    format!("Run '{}' needs input", name),
                                     ToastLevel::Warning,
                                     35,
                                 );
@@ -757,7 +766,7 @@ impl Dashboard {
                         let name = run.title.clone().unwrap_or(truncate(&run.agent_name, 20));
                         Self::push_toast(
                             &mut self.toasts,
-                            format!("Agent '{}' needs input", name),
+                            format!("Run '{}' needs input", name),
                             ToastLevel::Warning,
                             35,
                         );
@@ -769,7 +778,7 @@ impl Dashboard {
                         let name = run.title.clone().unwrap_or(truncate(&run.agent_name, 20));
                         Self::push_toast(
                             &mut self.toasts,
-                            format!("Agent '{}' completed", name),
+                            format!("Run '{}' completed", name),
                             ToastLevel::Info,
                             35,
                         );
@@ -860,10 +869,33 @@ impl Dashboard {
         self.update_display_indices();
     }
 
-    /// Open the kill confirmation for the selected agent, if it is killable.
+    /// Open the kill confirmation. Acts on every marked run that is killable
+    /// when any are marked, else on the selected run if it is killable.
     pub(super) fn request_kill(&mut self) {
         use crate::tui::widgets::confirm::Confirm;
         use ratatui::text::Line;
+        if !self.marked.is_empty() {
+            // Marked but already-finished runs are skipped, the same way `x`
+            // on a finished run does nothing.
+            let run_ids: Vec<String> = self
+                .agents
+                .iter()
+                .filter(|a| self.marked.contains(&a.id) && a.status.is_killable())
+                .map(|a| a.id.clone())
+                .collect();
+            if run_ids.is_empty() {
+                return;
+            }
+            let body = if run_ids.len() == 1 {
+                "Cancel 1 run? Its state stays on disk.".to_string()
+            } else {
+                format!("Cancel {} runs? Their state stays on disk.", run_ids.len())
+            };
+            let dialog =
+                Confirm::new("Kill runs?", vec![Line::from(body)], "Kill", "Cancel").danger();
+            self.pending_confirm = Some((ConfirmAction::Kill { run_ids }, dialog));
+            return;
+        }
         let Some(agent) = self.selected_agent() else {
             return;
         };
@@ -885,13 +917,42 @@ impl Dashboard {
             "Cancel",
         )
         .danger();
-        self.pending_confirm = Some((ConfirmAction::Kill { run_id }, dialog));
+        self.pending_confirm = Some((
+            ConfirmAction::Kill {
+                run_ids: vec![run_id],
+            },
+            dialog,
+        ));
     }
 
-    /// Open the delete confirmation for the selected agent.
+    /// Open the delete confirmation. Acts on every marked run when any are
+    /// marked, else on the selected run.
     pub(super) fn request_delete(&mut self) {
         use crate::tui::widgets::confirm::Confirm;
         use ratatui::text::Line;
+        if !self.marked.is_empty() {
+            // Every marked id names a live run: `update_display_indices` prunes
+            // marks whenever the agent list changes, so no emptiness check is
+            // needed here.
+            let run_ids: Vec<String> = self
+                .agents
+                .iter()
+                .filter(|a| self.marked.contains(&a.id))
+                .map(|a| a.id.clone())
+                .collect();
+            let body = if run_ids.len() == 1 {
+                "Delete 1 run and its on-disk state? This is permanent.".to_string()
+            } else {
+                format!(
+                    "Delete {} runs and their on-disk state? This is permanent.",
+                    run_ids.len()
+                )
+            };
+            let dialog =
+                Confirm::new("Delete runs?", vec![Line::from(body)], "Delete", "Cancel").danger();
+            self.pending_confirm = Some((ConfirmAction::Delete { run_ids }, dialog));
+            return;
+        }
         let Some(agent) = self.selected_agent() else {
             return;
         };
@@ -906,7 +967,12 @@ impl Dashboard {
             "Cancel",
         )
         .danger();
-        self.pending_confirm = Some((ConfirmAction::Delete { run_id }, dialog));
+        self.pending_confirm = Some((
+            ConfirmAction::Delete {
+                run_ids: vec![run_id],
+            },
+            dialog,
+        ));
     }
 
     /// Ask the daemon to cancel `run_id` and mark the row cancelled. The one
@@ -2279,7 +2345,7 @@ mod tests {
         let mut meta = runstate::RunMeta::new(
             run_id.to_string(),
             // Use the (unique-per-test) run_id as the agent name too, so toast
-            // messages ("Agent '<name>' ...") can be unambiguously matched even
+            // messages ("Run '<name>' ...") can be unambiguously matched even
             // when tests run concurrently against the shared real runs dir.
             run_id.to_string(),
             "/nonexistent/agent/path".to_string(),
@@ -3400,5 +3466,47 @@ mod tests {
         dash.sync_interactions(&ControlClient::new(control_id(&dir.path().join("nope"))))
             .await;
         assert!(dash.pending_interactions.is_empty());
+    }
+
+    // ── Marks for group kill / delete ─────────────────────────────────────
+
+    #[test]
+    fn stale_marks_are_pruned_when_their_run_disappears() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("run-2", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.marked.insert("run-1".to_string());
+        dash.marked.insert("run-2".to_string());
+        dash.agents.retain(|a| a.id != "run-2");
+        dash.update_display_indices();
+        assert!(dash.marked.contains("run-1"), "the live run stays marked");
+        assert!(!dash.marked.contains("run-2"), "the gone run is pruned");
+    }
+
+    #[test]
+    fn marks_survive_filtering_and_resorting() {
+        let mut dash = make_test_dashboard();
+        let mut hidden = make_test_agent("run-1", AgentDisplayStatus::Active);
+        hidden.blueprint_name = "alpha".to_string();
+        dash.agents.push(hidden);
+        let mut shown = make_test_agent("run-2", AgentDisplayStatus::Complete);
+        shown.blueprint_name = "beta".to_string();
+        dash.agents.push(shown);
+        dash.update_display_indices();
+        dash.marked.insert("run-1".to_string());
+
+        // A filter that hides the marked run does not drop its mark.
+        dash.list_search_query = "beta".to_string();
+        dash.update_display_indices();
+        assert_eq!(dash.display_indices.len(), 1);
+        assert!(dash.marked.contains("run-1"));
+
+        // Neither does re-sorting: marks key by id, not row.
+        dash.list_search_query.clear();
+        dash.cycle_sort_mode();
+        assert!(dash.marked.contains("run-1"));
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -657,7 +657,7 @@ impl Dashboard {
                         };
                         Self::push_toast(
                             &mut self.toasts,
-                            format!("Run '{}' failed{}", name, preview),
+                            format!("Agent run '{}' failed{}", name, preview),
                             ToastLevel::Error,
                             50,
                         );
@@ -667,7 +667,7 @@ impl Dashboard {
                     ) {
                         Self::push_toast(
                             &mut self.toasts,
-                            format!("Run '{}' completed", name),
+                            format!("Agent run '{}' completed", name),
                             ToastLevel::Info,
                             35,
                         );
@@ -742,7 +742,7 @@ impl Dashboard {
                                     .unwrap_or(truncate(&agent.blueprint_name, 20));
                                 Self::push_toast(
                                     &mut self.toasts,
-                                    format!("Run '{}' needs input", name),
+                                    format!("Agent run '{}' needs input", name),
                                     ToastLevel::Warning,
                                     35,
                                 );
@@ -766,7 +766,7 @@ impl Dashboard {
                         let name = run.title.clone().unwrap_or(truncate(&run.agent_name, 20));
                         Self::push_toast(
                             &mut self.toasts,
-                            format!("Run '{}' needs input", name),
+                            format!("Agent run '{}' needs input", name),
                             ToastLevel::Warning,
                             35,
                         );
@@ -778,7 +778,7 @@ impl Dashboard {
                         let name = run.title.clone().unwrap_or(truncate(&run.agent_name, 20));
                         Self::push_toast(
                             &mut self.toasts,
-                            format!("Run '{}' completed", name),
+                            format!("Agent run '{}' completed", name),
                             ToastLevel::Info,
                             35,
                         );
@@ -2345,7 +2345,7 @@ mod tests {
         let mut meta = runstate::RunMeta::new(
             run_id.to_string(),
             // Use the (unique-per-test) run_id as the agent name too, so toast
-            // messages ("Run '<name>' ...") can be unambiguously matched even
+            // messages ("Agent run '<name>' ...") can be unambiguously matched even
             // when tests run concurrently against the shared real runs dir.
             run_id.to_string(),
             "/nonexistent/agent/path".to_string(),

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -126,10 +126,12 @@ pub(super) struct ContextTreeState {
 /// A destructive action waiting on its confirmation dialog.
 #[derive(Debug, Clone, PartialEq)]
 pub(super) enum ConfirmAction {
-    /// Cancel the run via the daemon (the row stays, marked cancelled).
-    Kill { run_id: String },
-    /// Cancel and permanently delete the run's on-disk state.
-    Delete { run_id: String },
+    /// Cancel the runs via the daemon (the rows stay, marked cancelled).
+    /// Carries one id for the selected run, several when runs are marked.
+    Kill { run_ids: Vec<String> },
+    /// Cancel and permanently delete the runs' on-disk state.
+    /// Carries one id for the selected run, several when runs are marked.
+    Delete { run_ids: Vec<String> },
     /// Remove an MCP server from the config.
     McpRemove { name: String },
     /// Turn on unattended runs for the new-run screen.

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -366,9 +366,9 @@ fn print_agent_listing(
     // and telling someone to run `lev setup` because they asked to see the
     // catalog would be a non sequitur.
     if filter.shows_agents() && !found_runnable {
-        println!("No agents installed yet.");
+        println!("No agent blueprints installed yet.");
         println!();
-        println!("To install the bundled agents:");
+        println!("To install the bundled agent blueprints:");
         println!("  lev setup");
         println!();
         println!("To create your own:");

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -1,4 +1,4 @@
-//! `lev ps` - list the agents running in the shared-world daemon.
+//! `lev ps` - list the runs in the shared-world daemon.
 //!
 //! Queries the daemon over its control socket and prints one line per run. The
 //! query + formatting cores are tested here; the socket-path resolution + connect
@@ -15,7 +15,7 @@ use crate::runstate;
 
 /// `lev ps --help`. Every status an operator can see, and what to do about it.
 pub const PS_LONG_ABOUT: &str = "\
-List agents running in the shared-world daemon.
+List runs in the shared-world daemon.
 
 Columns: RUN, STATUS, STAGE (with position when the blueprint has several),
 ITER (iterations in the current stage), TOOLS (tool calls so far), and AGE.
@@ -394,14 +394,14 @@ pub fn format_runs(
     now: i64,
 ) -> String {
     if runs.is_empty() && finished.is_empty() {
-        // "no agents running" on its own is the most misleading thing this
+        // "no runs active" on its own is the most misleading thing this
         // command can say while a provider is down: it is what an operator sees
         // once even the finished records have aged out, and it reads as an idle
         // daemon rather than a factory that cannot start anything (issue #201).
         // Say why the list is empty.
         return match providers_footer(health) {
-            Some(footer) => format!("no agents running\n\n{footer}"),
-            None => "no agents running".to_string(),
+            Some(footer) => format!("no runs active\n\n{footer}"),
+            None => "no runs active".to_string(),
         };
     }
     // READS only appears when some run has `[read_paths]` to report, which is

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -1,4 +1,4 @@
-//! `lev ps` - list the runs in the shared-world daemon.
+//! `lev ps` - list the agent runs in the shared-world daemon.
 //!
 //! Queries the daemon over its control socket and prints one line per run. The
 //! query + formatting cores are tested here; the socket-path resolution + connect
@@ -15,7 +15,7 @@ use crate::runstate;
 
 /// `lev ps --help`. Every status an operator can see, and what to do about it.
 pub const PS_LONG_ABOUT: &str = "\
-List runs in the shared-world daemon.
+List agent runs in the shared-world daemon.
 
 Columns: RUN, STATUS, STAGE (with position when the blueprint has several),
 ITER (iterations in the current stage), TOOLS (tool calls so far), and AGE.
@@ -394,14 +394,14 @@ pub fn format_runs(
     now: i64,
 ) -> String {
     if runs.is_empty() && finished.is_empty() {
-        // "no runs active" on its own is the most misleading thing this
+        // "no agent runs active" on its own is the most misleading thing this
         // command can say while a provider is down: it is what an operator sees
         // once even the finished records have aged out, and it reads as an idle
         // daemon rather than a factory that cannot start anything (issue #201).
         // Say why the list is empty.
         return match providers_footer(health) {
-            Some(footer) => format!("no runs active\n\n{footer}"),
-            None => "no runs active".to_string(),
+            Some(footer) => format!("no agent runs active\n\n{footer}"),
+            None => "no agent runs active".to_string(),
         };
     }
     // READS only appears when some run has `[read_paths]` to report, which is

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -139,12 +139,12 @@ fn stage_cell_shows_position_only_for_multi_stage_blueprints() {
 fn format_runs_handles_empty() {
     assert_eq!(
         format_runs(&[], &[], &healthy_daemon(), 0),
-        "no runs active"
+        "no agent runs active"
     );
 }
 
 /// Issue #205: a scheduler spawns a run, the run dies on its first inference,
-/// and the daemon unloads it. Nothing is running, but "no runs active" is the
+/// and the daemon unloads it. Nothing is running, but "no agent runs active" is the
 /// answer that cost forty minutes of spawn-and-revert, because it reads exactly
 /// like a run that was never spawned. The row has to be there, with the reason.
 #[test]
@@ -158,7 +158,7 @@ fn format_runs_shows_a_finished_run_when_nothing_is_running() {
     died.last_progress_at = Some(1_140);
 
     let out = format_runs(&[], &[died], &healthy_daemon(), 1_200);
-    assert_ne!(out, "no runs active");
+    assert_ne!(out, "no agent runs active");
     let lines: Vec<&str> = out.lines().collect();
     assert!(lines[0].starts_with("RUN"), "header row: {out}");
     assert!(lines[1].contains("worker-1785616492"), "{out}");
@@ -183,7 +183,7 @@ fn format_runs_lists_finished_runs_after_the_live_ones() {
 }
 
 /// An empty listing while a provider is down is the reporter's end state:
-/// every run dead and reaped, and `lev ps` saying only "no runs active",
+/// every run dead and reaped, and `lev ps` saying only "no agent runs active",
 /// which reads as an idle daemon rather than one that cannot start anything.
 #[test]
 fn an_empty_listing_still_says_why_nothing_is_running() {
@@ -195,7 +195,7 @@ fn an_empty_listing_still_says_why_nothing_is_running() {
         ..healthy_daemon()
     };
     let out = format_runs(&[], &[], &health, 0);
-    assert!(out.starts_with("no runs active"), "{out}");
+    assert!(out.starts_with("no agent runs active"), "{out}");
     assert!(out.contains("1 provider is out of service:"), "{out}");
     assert!(out.contains("openrouter (credits-exhausted"), "{out}");
 }

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -139,12 +139,12 @@ fn stage_cell_shows_position_only_for_multi_stage_blueprints() {
 fn format_runs_handles_empty() {
     assert_eq!(
         format_runs(&[], &[], &healthy_daemon(), 0),
-        "no agents running"
+        "no runs active"
     );
 }
 
 /// Issue #205: a scheduler spawns a run, the run dies on its first inference,
-/// and the daemon unloads it. Nothing is running, but "no agents running" is the
+/// and the daemon unloads it. Nothing is running, but "no runs active" is the
 /// answer that cost forty minutes of spawn-and-revert, because it reads exactly
 /// like a run that was never spawned. The row has to be there, with the reason.
 #[test]
@@ -158,7 +158,7 @@ fn format_runs_shows_a_finished_run_when_nothing_is_running() {
     died.last_progress_at = Some(1_140);
 
     let out = format_runs(&[], &[died], &healthy_daemon(), 1_200);
-    assert_ne!(out, "no agents running");
+    assert_ne!(out, "no runs active");
     let lines: Vec<&str> = out.lines().collect();
     assert!(lines[0].starts_with("RUN"), "header row: {out}");
     assert!(lines[1].contains("worker-1785616492"), "{out}");
@@ -183,7 +183,7 @@ fn format_runs_lists_finished_runs_after_the_live_ones() {
 }
 
 /// An empty listing while a provider is down is the reporter's end state:
-/// every run dead and reaped, and `lev ps` saying only "no agents running",
+/// every run dead and reaped, and `lev ps` saying only "no runs active",
 /// which reads as an idle daemon rather than one that cannot start anything.
 #[test]
 fn an_empty_listing_still_says_why_nothing_is_running() {
@@ -195,7 +195,7 @@ fn an_empty_listing_still_says_why_nothing_is_running() {
         ..healthy_daemon()
     };
     let out = format_runs(&[], &[], &health, 0);
-    assert!(out.starts_with("no agents running"), "{out}");
+    assert!(out.starts_with("no runs active"), "{out}");
     assert!(out.contains("1 provider is out of service:"), "{out}");
     assert!(out.contains("openrouter (credits-exhausted"), "{out}");
 }

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -36,6 +36,91 @@ pub struct BlueprintSummary {
     pub entry_stage: Option<String>,
     /// Stage names in blueprint order.
     pub stages: Vec<String>,
+    /// Whether `lev run <agent> --task <text>` is accepted. False means a run
+    /// handing this agent a task is refused at spawn, so a harness can check
+    /// here instead of discovering it from the run-time error (issue #414).
+    pub accepts_task: bool,
+    /// Every caller-settable input, in declaration order: which flag seeds
+    /// which region, and whether a run can start without it.
+    pub inputs: Vec<InputSummary>,
+}
+
+/// One caller-settable input: a `--<key>` flag on `lev run` (equally the
+/// `regions.<key>` field over the API, or an ACP `---region:<key>---` block)
+/// and the region its value seeds.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct InputSummary {
+    /// The caller key. `task` is the `--task` flag; anything else is a
+    /// blueprint-defined `--<key>` flag.
+    pub key: String,
+    /// The region the value lands in. Often the same as `key`, but a seed may
+    /// name a shorter key for a longer region (`criteria` for
+    /// `review_criteria`).
+    pub region: String,
+    /// True when the region is required, so a spawn without this input fails.
+    pub required: bool,
+}
+
+/// The caller-settable inputs a blueprint declares, in declaration order.
+///
+/// The prose and JSON halves of the report both read from this one walk, so
+/// they cannot disagree about what the agent takes.
+fn input_summaries(blueprint: &leviath_core::Blueprint) -> Vec<InputSummary> {
+    blueprint
+        .context_layout
+        .regions
+        .iter()
+        .filter_map(|r| match &r.seed {
+            Some(leviath_core::layout::RegionSeed::CallerInput { name }) => Some(InputSummary {
+                key: name.clone(),
+                region: r.name.clone(),
+                required: r.required,
+            }),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The "Inputs:" lines `print_success` shows, answering at validate time what
+/// `lev run` would otherwise only reveal by refusing at spawn (issue #414):
+/// which flags this agent takes, and explicitly that `--task` is not among
+/// them when no region is seeded from the task.
+fn input_lines(blueprint: &leviath_core::Blueprint) -> Vec<String> {
+    let inputs = input_summaries(blueprint);
+    if inputs.is_empty() {
+        return vec![
+            "  Inputs: none - this agent takes no --task or other caller input".to_string(),
+        ];
+    }
+    let flags: Vec<String> = inputs
+        .iter()
+        .map(|i| {
+            let mut flag = format!("--{}", i.key);
+            let mut notes = Vec::new();
+            if i.required {
+                notes.push("required".to_string());
+            }
+            if i.key != i.region {
+                notes.push(format!("seeds region '{}'", i.region));
+            }
+            if !notes.is_empty() {
+                flag.push_str(&format!(" ({})", notes.join(", ")));
+            }
+            flag
+        })
+        .collect();
+    let mut lines = vec![format!("  Inputs: {}", flags.join(", "))];
+    if !blueprint.accepts_task() {
+        lines.push(format!(
+            "  Note: this agent takes no --task; give it input via {}",
+            inputs
+                .iter()
+                .map(|i| format!("--{}", i.key))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+    }
+    lines
 }
 
 /// What `lev validate --json` prints.
@@ -81,6 +166,8 @@ impl ValidateReport {
                 description: blueprint.description.clone(),
                 entry_stage: blueprint.entry_stage.clone(),
                 stages: blueprint.stages.iter().map(|s| s.name.clone()).collect(),
+                accepts_task: blueprint.accepts_task(),
+                inputs: input_summaries(blueprint),
             }),
             error: None,
             errors,
@@ -197,6 +284,9 @@ fn print_success(blueprint: &leviath_core::Blueprint) {
         blueprint.stages.len(),
         blueprint.version
     );
+    for line in input_lines(blueprint) {
+        println!("{line}");
+    }
 
     // Check if graph mode
     let is_graph = blueprint.stages.iter().any(|s| s.transitions.is_some());
@@ -563,6 +653,109 @@ max_iterations = 5
         print_success(&bp);
     }
 
+    // ─── input_lines / input_summaries ───────────────────────────────────
+
+    /// A reviewer-shaped manifest: no task region, one required input whose
+    /// key differs from its region, one optional renamed input, and one bare
+    /// optional input. Together the flags exercise every annotation
+    /// combination the formatter has.
+    const NAMED_INPUTS_MANIFEST: &str = r#"
+[agent]
+name = "inputs-agent"
+version = "0.1.0"
+description = "Named inputs"
+
+[stages.main]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-5" }
+description = "Main"
+max_iterations = 5
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+patch = { kind = "pinned", max_tokens = 2000, required = true, seed = "diff" }
+review_criteria = { kind = "pinned", max_tokens = 1000, seed = "criteria" }
+focus = { kind = "pinned", max_tokens = 500, seed = "input" }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+"#;
+
+    /// The point of issue #414: validate now says what `lev run` would accept,
+    /// including that `--task` is not among the flags.
+    #[test]
+    fn input_lines_name_every_flag_and_the_missing_task() {
+        let lines = input_lines(&parse(NAMED_INPUTS_MANIFEST));
+        assert_eq!(
+            lines,
+            vec![
+                "  Inputs: --diff (required, seeds region 'patch'), \
+                 --criteria (seeds region 'review_criteria'), --focus"
+                    .to_string(),
+                "  Note: this agent takes no --task; give it input via --diff, \
+                 --criteria, --focus"
+                    .to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn input_lines_of_a_task_taking_agent_skip_the_refusal_note() {
+        let toml = CLEAN_MANIFEST.replace(
+            "[context.regions]",
+            "[context.regions]\ntask = { kind = \"pinned\", max_tokens = 2000, \
+             required = true, seed = \"task\" }",
+        );
+        let blueprint = parse(&toml);
+        assert!(blueprint.accepts_task());
+        assert_eq!(
+            input_lines(&blueprint),
+            vec!["  Inputs: --task (required)".to_string()],
+            "an agent that takes a task needs no note about refusing one"
+        );
+    }
+
+    #[test]
+    fn input_lines_without_any_caller_input_say_so() {
+        assert_eq!(
+            input_lines(&parse(CLEAN_MANIFEST)),
+            vec!["  Inputs: none - this agent takes no --task or other caller input".to_string()]
+        );
+    }
+
+    /// The summaries feed the JSON report, so a harness can check an agent's
+    /// inputs before spawning it instead of discovering the refusal at run
+    /// time.
+    #[test]
+    fn input_summaries_carry_key_region_and_required() {
+        let summaries = input_summaries(&parse(NAMED_INPUTS_MANIFEST));
+        assert_eq!(
+            summaries,
+            vec![
+                InputSummary {
+                    key: "diff".to_string(),
+                    region: "patch".to_string(),
+                    required: true,
+                },
+                InputSummary {
+                    key: "criteria".to_string(),
+                    region: "review_criteria".to_string(),
+                    required: false,
+                },
+                InputSummary {
+                    key: "focus".to_string(),
+                    region: "focus".to_string(),
+                    required: false,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn print_success_prints_the_input_lines_without_panicking() {
+        // The formatting is asserted in the input_lines tests; this pins the
+        // wiring, so the lines cannot silently drop out of the report.
+        print_success(&parse(NAMED_INPUTS_MANIFEST));
+    }
+
     // ─── print_findings ──────────────────────────────────────────────────
 
     /// One finding of each severity: the counts returned are errors and
@@ -801,6 +994,8 @@ system = { kind = "pinned", max_tokens = 1000 }
         let summary = report.blueprint.expect("a parsed manifest has a summary");
         assert_eq!(summary.name, "ok-agent");
         assert_eq!(summary.stages, vec!["main".to_string()]);
+        assert!(!summary.accepts_task);
+        assert_eq!(summary.inputs, Vec::new());
         assert_eq!((report.errors, report.warnings, report.notes), (0, 0, 0));
     }
 
@@ -863,6 +1058,25 @@ system = { kind = "pinned", max_tokens = 1000 }
             serde_json::json!("unknown-tool")
         );
         assert_eq!(value["findings"][0]["severity"], serde_json::json!("error"));
+    }
+
+    /// The JSON half of issue #414: a harness reads the accepted inputs off
+    /// the report instead of parsing the run-time refusal.
+    #[test]
+    fn json_report_names_the_accepted_inputs() {
+        let blueprint = parse(NAMED_INPUTS_MANIFEST);
+        let report = ValidateReport::linted(&blueprint, Vec::new(), false);
+        let value: serde_json::Value =
+            serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
+        assert_eq!(value["blueprint"]["accepts_task"], serde_json::json!(false));
+        assert_eq!(
+            value["blueprint"]["inputs"][0],
+            serde_json::json!({"key": "diff", "region": "patch", "required": true})
+        );
+        assert_eq!(
+            value["blueprint"]["inputs"][1]["key"],
+            serde_json::json!("criteria")
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -33,7 +33,7 @@ pub enum Commands {
     /// Run an agent
     Run(commands::run::RunArgs),
 
-    /// List agents running in the shared-world daemon
+    /// List runs in the shared-world daemon
     #[command(long_about = commands::ps::PS_LONG_ABOUT)]
     Ps(commands::ps::PsArgs),
 

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -33,7 +33,7 @@ pub enum Commands {
     /// Run an agent
     Run(commands::run::RunArgs),
 
-    /// List runs in the shared-world daemon
+    /// List agent runs in the shared-world daemon
     #[command(long_about = commands::ps::PS_LONG_ABOUT)]
     Ps(commands::ps::PsArgs),
 

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -1005,8 +1005,17 @@ mod tests {
         }
     }
 
+    /// The instant the fixture pretends it is, on every construction.
+    ///
+    /// Arbitrary, and deliberately not the wall clock: `RunMeta::new` stamps
+    /// `started_at`/`updated_at` from it, and these tests build the fixture
+    /// once to write and again to compare against. Two reads straddling a
+    /// second boundary produced two unequal `RunMeta`s, which failed whichever
+    /// round-trip assertion happened to span the tick.
+    const FIXTURE_NOW: i64 = 1_700_000_000;
+
     fn meta() -> RunMeta {
-        RunMeta::new(
+        let mut meta = RunMeta::new(
             "run-1".to_string(),
             "coder".to_string(),
             "/agents/coder".to_string(),
@@ -1014,7 +1023,28 @@ mod tests {
             Some("anthropic/claude".to_string()),
             "/work".to_string(),
             2,
-        )
+        );
+        meta.started_at = FIXTURE_NOW;
+        meta.updated_at = FIXTURE_NOW;
+        meta
+    }
+
+    /// Two constructions of the fixture are equal however much time passes
+    /// between them. This is the property every round-trip assertion in this
+    /// module rests on, and the one a wall-clock stamp quietly broke.
+    #[test]
+    fn the_fixture_does_not_move_with_the_clock() {
+        let first = meta();
+        let mut later = meta();
+        // Rather than sleeping across a real second boundary, move the clock
+        // the way it would have moved: an unpinned fixture differs by exactly
+        // this, and a pinned one is rebuilt identically.
+        assert_eq!(first, later, "the fixture is rebuilt identically");
+        later.started_at += 1;
+        assert_ne!(
+            first, later,
+            "and the comparison is sensitive to the field that used to drift"
+        );
     }
 
     fn entry(content: &str, tokens: usize) -> RegionEntrySnapshot {

--- a/crates/leviath-runtime/src/pipeline/circuit.rs
+++ b/crates/leviath-runtime/src/pipeline/circuit.rs
@@ -129,6 +129,24 @@ impl ProviderCircuits {
         self.0.remove(provider);
     }
 
+    /// The reason of the last recorded failure for `provider`, open or not.
+    ///
+    /// The stall watchdog asks this to tell "out of credits" apart from the
+    /// other ways a provider leaves service: the former pauses the run for a
+    /// resume instead of failing it (issue #413).
+    pub fn last_reason(&self, provider: &str) -> Option<UnavailableReason> {
+        self.0.get(provider).map(|c| c.reason)
+    }
+
+    /// Forget every recorded failure, so the next dispatch is a real probe.
+    ///
+    /// Called on an explicit resume: the operator is saying conditions have
+    /// changed (most often a top-up after credits ran out), and holding the
+    /// retry until a cooldown lapses would make the resume look ignored.
+    pub fn reset(&mut self) {
+        self.0.clear();
+    }
+
     /// Whether `provider` should be skipped right now.
     ///
     /// False once the cooldown has elapsed, which is what makes the next
@@ -270,6 +288,33 @@ mod tests {
         // And the count restarts, so one later failure does not re-open it.
         assert!(!fail(&mut circuits, 10));
         assert!(!circuits.is_open("openrouter", 10, &policy()));
+    }
+
+    #[test]
+    fn last_reason_reports_the_most_recent_failure_or_nothing() {
+        let mut circuits = ProviderCircuits::default();
+        assert_eq!(circuits.last_reason("p"), None);
+        circuits.record_failure("p", UnavailableReason::CreditsExhausted, 0, &policy());
+        assert_eq!(
+            circuits.last_reason("p"),
+            Some(UnavailableReason::CreditsExhausted),
+            "one failure is enough for the reason, open or not"
+        );
+    }
+
+    #[test]
+    fn reset_forgets_every_circuit() {
+        // What an explicit resume relies on: after a reset the next dispatch
+        // is a real probe rather than a wait for the cooldown (issue #413).
+        let mut circuits = ProviderCircuits::default();
+        let mut now = 0;
+        while !fail(&mut circuits, now) {
+            now += 1;
+        }
+        assert!(circuits.is_open("openrouter", now, &policy()));
+        circuits.reset();
+        assert!(!circuits.is_open("openrouter", now, &policy()));
+        assert_eq!(circuits.last_reason("openrouter"), None);
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -226,6 +226,30 @@ pub fn collect_inference(
                         .insert(ReadyToInfer);
                     continue;
                 }
+                // Running out of credits with no candidate left is an account
+                // state, not a defect in the run: the operator tops up and
+                // resumes. Failing here would make the run permanently
+                // unresumable, so it pauses instead, still pointed at the same
+                // inference, and a `lev resume` re-dispatches it (issue #413).
+                if err.unavailable_reason()
+                    == Some(leviath_providers::UnavailableReason::CreditsExhausted)
+                {
+                    let message = format!(
+                        "out of credits ({err}); pausing this run - top up the \
+                         account, then `lev resume` it"
+                    );
+                    tracing::warn!(error = %err, "out of credits; pausing the run for a resume");
+                    if let Some(mut buffer) = buffer {
+                        buffer.logs.push((idx, format!("[paused] {message}")));
+                    }
+                    state.status = AgentStatus::Paused;
+                    commands
+                        .entity(outcome.entity)
+                        .remove::<AwaitingInference>()
+                        .remove::<InFlightWork>()
+                        .insert(ReadyToInfer);
+                    continue;
+                }
                 if let Some(mut buffer) = buffer {
                     buffer.logs.push((idx, format!("[error] {err}")));
                 }

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -665,6 +665,40 @@ mod tests {
     }
 
     #[test]
+    fn the_credits_pause_copes_without_a_stage_log_buffer() {
+        // `StageIoBuffer` is optional on the query, so the pause has to land
+        // even when there is no stage log to explain it in.
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let mut circuits = super::super::circuit::ProviderCircuits::default();
+        let policy = super::super::circuit::CircuitPolicy::default();
+        for i in 0..3 {
+            circuits.record_failure(
+                "ghost",
+                leviath_providers::UnavailableReason::CreditsExhausted,
+                NOW - 3 + i,
+                &policy,
+            );
+        }
+        world.insert_resource(circuits);
+        let e = world
+            .spawn((
+                agent_state(),
+                stage_inference(),
+                stalled_for(StallReason::ProviderCircuitOpen, 61),
+                ReadyToInfer,
+            ))
+            .id();
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Paused
+        );
+    }
+
+    #[test]
     fn a_circuit_open_for_a_dead_key_still_fails_the_run() {
         // The pause is only for credits: a rejected key does not fix itself
         // with a top-up, so any other recorded reason keeps today's failure.

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -208,6 +208,7 @@ pub fn fail_stalled_dispatch(
     mut agents: Query<StalledDispatchQuery>,
     timeout: Option<Res<StallTimeout>>,
     clock: Option<Res<StallClock>>,
+    circuits: Option<Res<super::circuit::ProviderCircuits>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
@@ -232,6 +233,34 @@ pub fn fail_stalled_dispatch(
         }
         if now.saturating_sub(stall.since) < limit as i64 {
             continue; // still inside the grace period
+        }
+        // A circuit that opened because the account ran out of credits is an
+        // account state, not a dead end: pause the run for a resume instead of
+        // failing it, keeping `ReadyToInfer` so the retry is already staged
+        // (issue #413). Any other reason still fails below - a missing
+        // provider or a rejected key does not fix itself with a top-up.
+        let credits_out = stall.reason == StallReason::ProviderCircuitOpen
+            && circuits
+                .as_ref()
+                .and_then(|c| c.last_reason(&si.provider_name))
+                == Some(leviath_providers::UnavailableReason::CreditsExhausted);
+        if credits_out {
+            let message = format!(
+                "out of credits on '{}'; pausing this run - top up the account, \
+                 then `lev resume` it",
+                si.provider_name
+            );
+            tracing::warn!(
+                provider = %si.provider_name,
+                stalled_secs = now.saturating_sub(stall.since),
+                "out of credits; pausing the run for a resume"
+            );
+            if let Some(mut buffer) = buffer {
+                buffer.logs.push((0, format!("[paused] {message}")));
+            }
+            state.status = AgentStatus::Paused;
+            commands.entity(entity).remove::<DispatchStall>();
+            continue;
         }
         let message = stall.reason.give_up_message(&si.provider_name);
         tracing::error!(
@@ -591,6 +620,74 @@ mod tests {
             "got: {status:?}"
         );
         assert!(world.get::<ReadyToInfer>(e).is_none());
+    }
+
+    #[test]
+    fn a_run_out_of_credits_is_paused_for_a_resume_not_failed() {
+        // Issue #413: exhausted credits are an account state the operator can
+        // fix, so the watchdog pauses the run instead of ending it. The
+        // `ReadyToInfer` marker stays, so a resume re-dispatches the same
+        // inference.
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let mut circuits = super::super::circuit::ProviderCircuits::default();
+        let policy = super::super::circuit::CircuitPolicy::default();
+        for i in 0..3 {
+            circuits.record_failure(
+                "ghost",
+                leviath_providers::UnavailableReason::CreditsExhausted,
+                NOW - 3 + i,
+                &policy,
+            );
+        }
+        world.insert_resource(circuits);
+        let e = spawn_stalled(&mut world, StallReason::ProviderCircuitOpen, 61);
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Paused
+        );
+        assert!(
+            world.get::<ReadyToInfer>(e).is_some(),
+            "the retry is staged"
+        );
+        assert!(world.get::<DispatchStall>(e).is_none());
+        let logs = &world.get::<StageIoBuffer>(e).unwrap().logs;
+        let line = logs
+            .iter()
+            .map(|(_, l)| l.as_str())
+            .find(|l| l.starts_with("[paused]"))
+            .expect("the pause is written to the stage log");
+        assert!(line.contains("out of credits"), "{line}");
+        assert!(line.contains("lev resume"), "{line}");
+    }
+
+    #[test]
+    fn a_circuit_open_for_a_dead_key_still_fails_the_run() {
+        // The pause is only for credits: a rejected key does not fix itself
+        // with a top-up, so any other recorded reason keeps today's failure.
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let mut circuits = super::super::circuit::ProviderCircuits::default();
+        let policy = super::super::circuit::CircuitPolicy::default();
+        circuits.record_failure(
+            "ghost",
+            leviath_providers::UnavailableReason::AuthFailed,
+            NOW - 1,
+            &policy,
+        );
+        world.insert_resource(circuits);
+        let e = spawn_stalled(&mut world, StallReason::ProviderCircuitOpen, 61);
+
+        run(&mut world);
+
+        let status = &world.get::<AgentState>(e).unwrap().status;
+        assert!(
+            matches!(status, AgentStatus::Error { message } if message.contains("out of service")),
+            "got: {status:?}"
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -900,6 +900,30 @@ fn an_exhausted_fallback_list_pauses_on_credits_instead_of_dying() {
 }
 
 #[test]
+fn the_credits_pause_copes_without_a_stage_log_buffer() {
+    // `StageIoBuffer` is optional on the query, so the pause has to land even
+    // when there is no stage log to explain it in.
+    let (mut world, tx) = world_with_results();
+    let mut si = stage_with_fallback();
+    si.fallbacks.clear();
+    let e = world.spawn((agent_state(), AwaitingInference, si)).id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused
+    );
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+}
+
+#[test]
 fn an_exhausted_fallback_list_still_terminates_on_a_dead_key() {
     // A rejected key does not fix itself with a top-up, so every
     // provider-fatal reason other than exhausted credits still ends the run

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -852,9 +852,58 @@ fn failover_is_recorded_in_the_stage_log() {
 }
 
 #[test]
-fn an_exhausted_fallback_list_still_terminates() {
-    // Last provider standing: the run ends, but with the readable message
-    // rather than the raw JSON body the issue reported.
+fn an_exhausted_fallback_list_pauses_on_credits_instead_of_dying() {
+    // Last provider standing and the account is out of credits: that is an
+    // account state, not a defect in the run, so the run pauses for a
+    // `lev resume` instead of ending (issue #413). The retry stays staged.
+    let (mut world, tx) = world_with_results();
+    let mut si = stage_with_fallback();
+    si.fallbacks.clear();
+    let e = world
+        .spawn((
+            agent_state(),
+            AwaitingInference,
+            si,
+            StageIoBuffer::default(),
+        ))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert!(
+        world.get::<ReadyToInfer>(e).is_some(),
+        "the retry is staged"
+    );
+    assert!(world.get::<AwaitingInference>(e).is_none());
+    assert!(world.get::<ResolveTransition>(e).is_none());
+    assert!(world.get::<StageOutcome>(e).is_none());
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused
+    );
+    // The stage log says why the run stopped moving, since `lev ps` alone
+    // only shows PAUSED.
+    let logs = &world.get::<StageIoBuffer>(e).unwrap().logs;
+    let line = logs
+        .iter()
+        .map(|(_, l)| l.as_str())
+        .find(|l| l.starts_with("[paused]"))
+        .expect("the pause is written to the stage log");
+    assert!(line.contains("out of credits"), "{line}");
+    assert!(line.contains("lev resume"), "{line}");
+}
+
+#[test]
+fn an_exhausted_fallback_list_still_terminates_on_a_dead_key() {
+    // A rejected key does not fix itself with a top-up, so every
+    // provider-fatal reason other than exhausted credits still ends the run
+    // with the readable message rather than the raw JSON body.
     let (mut world, tx) = world_with_results();
     let mut si = stage_with_fallback();
     si.fallbacks.clear();
@@ -862,7 +911,10 @@ fn an_exhausted_fallback_list_still_terminates() {
     tx.send(InferenceOutcome {
         latency: std::time::Duration::ZERO,
         entity: e,
-        result: Err(credits_exhausted()),
+        result: Err(leviath_providers::ProviderError::Unavailable {
+            reason: leviath_providers::UnavailableReason::AuthFailed,
+            detail: "HTTP 401 Unauthorized".to_string(),
+        }),
     })
     .unwrap();
 
@@ -873,7 +925,7 @@ fn an_exhausted_fallback_list_still_terminates() {
     let AgentStatus::Error { message } = &world.get::<AgentState>(e).unwrap().status else {
         panic!("an exhausted chain is a terminal error");
     };
-    assert!(message.starts_with("out of credits:"), "{message}");
+    assert!(message.starts_with("the API key was rejected"), "{message}");
 }
 
 #[test]
@@ -1009,13 +1061,18 @@ fn collect_works_without_the_breaker_installed() {
 #[test]
 fn an_unusable_provider_without_a_stage_component_still_terminates() {
     // `StageInference` is optional on the query, so the failover branch has to
-    // cope with its absence rather than assuming one is attached.
+    // cope with its absence rather than assuming one is attached. A dead key
+    // rather than dead credits, because exhausted credits pause instead of
+    // terminating (issue #413).
     let (mut world, tx) = world_with_results();
     let e = world.spawn((agent_state(), AwaitingInference)).id();
     tx.send(InferenceOutcome {
         latency: std::time::Duration::ZERO,
         entity: e,
-        result: Err(credits_exhausted()),
+        result: Err(leviath_providers::ProviderError::Unavailable {
+            reason: leviath_providers::UnavailableReason::AuthFailed,
+            detail: "HTTP 401 Unauthorized".to_string(),
+        }),
     })
     .unwrap();
 

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -821,6 +821,16 @@ impl PipelineWorld {
     pub fn resume(&mut self, agent: AgentId) -> bool {
         match self.agent_status(agent) {
             Some(AgentStatus::Paused | AgentStatus::Idle) => {
+                // An explicit resume says conditions have changed - most often
+                // a top-up after a run paused on exhausted credits (issue
+                // #413). A tripped breaker would otherwise hold the retry
+                // until its cooldown lapses, making the resume look ignored.
+                if let Some(mut circuits) = self
+                    .world
+                    .get_resource_mut::<crate::pipeline::ProviderCircuits>()
+                {
+                    circuits.reset();
+                }
                 self.set_status(agent, AgentStatus::Active)
             }
             _ => false,
@@ -1939,6 +1949,34 @@ mod tests {
         assert!(world.resume(e));
         world.run_until_idle(30).await;
         assert_eq!(world.agent_status(e), Some(AgentStatus::Complete));
+    }
+
+    #[tokio::test]
+    async fn resume_resets_the_provider_circuits() {
+        // Issue #413: a run paused on exhausted credits comes back through an
+        // explicit resume. If the breaker kept its state, the retry would sit
+        // out the rest of the cooldown and the resume would look ignored.
+        let mut world = build_world(registry_with(vec![text("t1")]));
+        let e = spawn(&mut world);
+        assert!(world.pause(e));
+
+        let policy = crate::pipeline::CircuitPolicy {
+            failures_before_open: 1,
+            cooldown_secs: 300,
+        };
+        let mut circuits = crate::pipeline::ProviderCircuits::default();
+        circuits.record_failure(
+            "openrouter",
+            leviath_providers::UnavailableReason::CreditsExhausted,
+            chrono::Utc::now().timestamp(),
+            &policy,
+        );
+        world.world_mut().insert_resource(circuits);
+        world.world_mut().insert_resource(policy);
+        assert_eq!(world.open_circuits().len(), 1);
+
+        assert!(world.resume(e));
+        assert!(world.open_circuits().is_empty());
     }
 
     #[tokio::test]

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -33,7 +33,7 @@ panel and answer. `lev respond` does the same from the shell.
 
 ## What's on screen
 
-- **Agent table**: title and run id, blueprint, stage, status, tokens, and start time, with
+- **Run table**: title and run id, blueprint, stage, status, tokens, and start time, with
   sub-agents nested under their parent. Titles are auto-generated per run. The model, iteration,
   and context-window occupancy live in the detail view.
 - **Detail view**: per-stage tabs or a graph view of the workflow, a context-window visualization,
@@ -66,13 +66,19 @@ MCP servers (`m`), and a stage explorer for branching agents (`g`, from the deta
 | `s` | Cycle the sort: start time (default), recent activity, or status groups |
 | `x` | Kill the selected run. Asks first |
 | `d` | Delete the run. Permanent, and asks first |
+| `Space` | Mark or unmark the selected run, then move down a row |
 | `p` / `r` | Pause / resume the selected run |
 | `m` | Manage MCP servers |
-| `Esc` | Clear the filter |
+| `Esc` | Clear the filter, or clear the marks once no filter is set |
 | `q` / `Ctrl-C` | Quit |
 
 By default runs are listed newest first and keep their row for their whole life, so nothing jumps
 around when a run finishes. The sort indicator sits in the table's top-right corner.
+
+Marking selects several runs at once: press `Space` on each run, then `x` or `d` acts on all of
+them behind one confirmation. Marked rows show a check mark, the pane title counts them, and marks
+follow the run rather than the row, so sorting or filtering never changes what is marked. A kill
+skips marked runs that have already finished.
 
 ### Starting a run (`n`)
 

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -33,7 +33,7 @@ panel and answer. `lev respond` does the same from the shell.
 
 ## What's on screen
 
-- **Run table**: title and run id, blueprint, stage, status, tokens, and start time, with
+- **Agent run table**: title and run id, blueprint, stage, status, tokens, and start time, with
   sub-agents nested under their parent. Titles are auto-generated per run. The model, iteration,
   and context-window occupancy live in the detail view.
 - **Detail view**: per-stage tabs or a graph view of the workflow, a context-window visualization,
@@ -82,7 +82,7 @@ skips marked runs that have already finished.
 
 ### Starting a run (`n`)
 
-Agents on the left, the task on the right. Once it starts, the dashboard opens that run's page, and
+Agent blueprints on the left, the task on the right. Once it starts, the dashboard opens that run's page, and
 `Esc` from there goes back to the list rather than back into the form.
 
 | Key | Action |


### PR DESCRIPTION
Fixes every open issue labeled `automate`: #410, #411, #412, #413, #414. One commit per issue.

## #413 - out of credits pauses the run instead of killing it
Exhausted credits used to end a run at `Error`, which the daemon never pages back in, so the one failure a top-up fixes was also the only one that could never be resumed. Both give-up sites (the no-fallback arm of `collect_inference`, and the stall watchdog when the open circuit's recorded reason is `CreditsExhausted`) now set the run `Paused` with the retry still staged, and write a `[paused] out of credits ... lev resume` line to the stage log. An explicit resume also resets the provider circuit breakers so the retry probes immediately. Every other provider-fatal reason (dead key, forbidden, unreachable) still fails the run.

## #414 - `lev validate` names the inputs an agent accepts
`lev validate reviewer` now prints:
```
  Inputs: --diff (required), --criteria (seeds region 'review_criteria')
  Note: this agent takes no --task; give it input via --diff, --criteria
```
and `--json` carries the same facts as `blueprint.accepts_task` / `blueprint.inputs`, so a harness can check inputs before spawning a fleet. Verified live against the bundled reviewer (no task) and coder (`--task (required), --constraints`).

## #410 - the Output pane shows the run's final output
`submit_output` writes the `final_output` sidecar, never `stages/<i>/output.log`, so the pane stayed on "No output yet" for exactly the stage that produced the answer. Empty tail + selected stage == the submitting stage now falls back to the final output, and the file hint names the sidecar.

## #411 - Agent Runs vs Agent Blueprints, spelled out
Per review: runs say "Agent Runs" and blueprints say "Agent Blueprints" everywhere a label could be ambiguous. The run list is titled `Agent Runs` (with a `Blueprint` column), toasts and empty states say agent run, `lev ps` answers "no agent runs active", the new-run picker is titled `Agent Blueprints`, and `lev list` offers to install agent blueprints.

## #412 - mark several runs, kill or delete them together
`space` marks/unmarks (id-keyed, survives sort/filter, stale marks pruned), `x`/`d` act on all marked runs with a counting confirm dialog, marked rows carry a check and the pane title counts them. Zero visual change until the first mark.

## Validation
- Full workspace test suite green locally (1248 runtime, 3374 cli, plus the rest).
- #414 verified against the shipped blueprints with the built binary.
- #410/#412 are TestBackend-rendered and key-event tested; a live TUI pass was skipped for time, the render tests assert the drawn buffers.
- #413's pause/resume round trip is asserted at the world level (`resume_resets_the_provider_circuits`, `paused_agent_does_not_progress_until_resumed`) plus both give-up sites; not exercised against a live daemon since that needs a drained account.

Closes #410, closes #411, closes #412, closes #413, closes #414.
