### PR TITLE
chore(release): 0.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,62 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## 0.3.7 - 2026-08-13
+
+- Fixed: a run whose provider account runs out of credits now pauses instead
+  of failing. The failure was terminal, so the one problem a top-up fixes was
+  also the only one a run could never come back from; the run now waits with
+  its retry staged, the stage log says why, and `lev resume` re-dispatches it.
+  Resuming also resets the provider circuit breakers, so the retry probes
+  immediately rather than sitting out a cooldown that predates the top-up.
+- Added: `lev validate` reports which inputs an agent accepts: each `--<flag>`,
+  the region it seeds when the names differ, whether it is required, and an
+  explicit note when `--task` is not among them. The JSON report carries the
+  same facts as `blueprint.accepts_task` and `blueprint.inputs`, so a harness
+  can check before spawning what `lev run` would refuse at spawn.
+- Fixed: a run that is paged back in keeps its per-stage token ledger. Nothing
+  rebuilt the ledger on restore, so every stage of a restored run was back at
+  zero and the next persist tick wrote those zeros over the real `stages.json`.
+  The run-level totals survived, so the run looked healthy while its per-stage
+  history was silently gone, and `lev stages` and the stages API served the
+  zeroed records. This hit an on-demand page-in as well as a daemon restart.
+- Fixed: a provider capacity refusal no longer kills a run in seven seconds.
+  Four attempts on a one-second base covers a network blip, not an overload
+  that lasts minutes, so a run that had already spent real money died
+  mid-stage on an HTTP 529. A 429 or 529 now backs off on its own longer
+  schedule and honours the provider's `Retry-After` when it sends one, bounded
+  by a cumulative ceiling so a run can never wait forever. An ordinary server
+  error keeps the old fast schedule.
+- Added: `[limits] inference_retry_attempts` and `inference_retry_base_ms` set
+  the inference retry schedule. Both default to what Leviath already used, so
+  nothing changes until you set them; raising the attempt count is the lever
+  for riding out a longer outage.
+- Changed: a structured agent's volatile context regions are cached in two
+  pieces rather than one. A provider that spends a cache breakpoint per run of
+  same-hint blocks gave the whole volatile tier a single entry, so mutating any
+  region in it re-billed every region behind it as a cache write. The blocks
+  ahead of the most recent change are now hinted separately, which puts them in
+  an entry of their own. Nothing about what the model reads changes: block order
+  and text are untouched, and the request stays within the four cache
+  breakpoints Anthropic allows.
+- Changed: for anyone using the crates as libraries,
+  `ProviderError::RateLimitExceeded` now carries the provider's `Retry-After`
+  value and so is a struct variant. Code that matches on that variant needs
+  updating; its displayed message is unchanged.
+- Fixed: the dashboard's Output pane shows a run's final output. A stage that
+  submits its result through `submit_output` writes the `final_output` record
+  rather than a stage output log, so the pane said "No output yet" for exactly
+  the stage that produced the answer.
+- Added: the dashboard can act on several runs at once. `space` marks or
+  unmarks the selected run, marked rows carry a check with a count in the pane
+  title, and `x`/`d` kill or delete every marked run behind one confirm
+  dialog. Nothing changes visually until the first mark.
+- Changed: labels say Agent Runs when they mean runs and Agent Blueprints
+  when they mean blueprints. The dashboard's run list is titled Agent Runs
+  with a Blueprint column, the new-run picker is titled Agent Blueprints,
+  `lev ps` answers "no agent runs active", and `lev list` offers to install
+  agent blueprints.
+
 ## 0.3.6 - 2026-08-13
 
 - Fixed: adding an MCP server that authenticates with a header no longer chases

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.6"
+version = "0.3.7"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.6" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.6" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.6" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.6" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.6" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.6" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.6" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.6" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.6" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.6" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.6" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.6" }
+leviath = { path = "crates/leviath", version = "0.3.7" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.7" }
+leviath-net = { path = "crates/leviath-net", version = "0.3.7" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.7" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.7" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.7" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.7" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.7" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.7" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.7" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.7" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.7" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.6", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.7", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }


### PR DESCRIPTION
Cuts 0.3.7, shipping the five `automate`-labeled fixes merged in #416.

- Out-of-credits runs pause and resume instead of failing terminally (#413).
- `lev validate` reports the inputs an agent accepts, in prose and in `--json` (#414).
- The dashboard's Output pane shows a run's final output (#410).
- `space` marks runs; `x`/`d` act on every marked run at once (#412).
- Labels say Agent Runs for runs and Agent Blueprints for blueprints (#411).

`cargo xtask version 0.3.7` moved every declaration and rolled the changelog; `--check` confirms every intra-workspace pin, both `[profile.release]` blocks, the publish list, and the coverage matrix agree.

Merging this to main cuts the alpha release. Beta follows by a manual `beta.yml` dispatch, since its cron is Mondays.

Needs the `allow-version-bump` label to clear the release guard.
