### PR TITLE
Fix the newer automate issues: #415, #417, #418

### DIFF
--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -56,6 +56,14 @@ fn default_interaction_timeout_secs() -> u64 {
     leviath_runtime::interaction_hub::DEFAULT_INTERACTION_TIMEOUT_SECS
 }
 
+fn default_inference_retry_attempts() -> u32 {
+    leviath_runtime::DEFAULT_RETRY_ATTEMPTS
+}
+
+fn default_inference_retry_base_ms() -> u64 {
+    leviath_runtime::DEFAULT_RETRY_BASE_DELAY_MS
+}
+
 /// Runtime resource limits with safe defaults baked in.
 ///
 /// Both fields default to a bounded value so a fresh install can't accidentally
@@ -223,6 +231,40 @@ pub struct LimitsConfig {
     #[serde(default = "default_interaction_timeout_secs")]
     pub interaction_timeout_secs: u64,
 
+    /// How many times an inference is attempted, the first try included,
+    /// before the agent is failed with whatever the provider last said.
+    ///
+    /// Only a transient failure is retried at all - a reset connection, a
+    /// timeout, a 429, a 5xx. An authentication error or an over-long request
+    /// fails on the first answer, since the second would be identical.
+    ///
+    /// Defaults to `4`, which is one try and three retries. `1` turns retrying
+    /// off. The wait between retries is `inference_retry_base_ms`, doubling each
+    /// time, so the default schedule is 1s, 2s, 4s.
+    ///
+    /// Raising it lengthens how long a run rides out a provider **overload**
+    /// (an Anthropic 529, or a 429), which is retried on its own much slower
+    /// schedule of 15s, 30s, then 60s per further attempt - that case is why the
+    /// key exists (issue #417). Whatever this is set to, the retries of one
+    /// request may sleep at most five minutes in total.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_inference_retry_attempts")]
+    pub inference_retry_attempts: u32,
+
+    /// The wait before the first inference retry, in milliseconds, doubling for
+    /// each retry after it. Defaults to `1000`, so the schedule is 1s, 2s, 4s.
+    ///
+    /// This is the *blip* schedule and is meant to stay short: a reset
+    /// connection or a 500 is usually gone by the next attempt. A provider
+    /// overload does not use it - see `inference_retry_attempts` - so raising
+    /// this to wait out an outage is the wrong lever and only delays ordinary
+    /// failures.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default = "default_inference_retry_base_ms")]
+    pub inference_retry_base_ms: u64,
+
     /// Most bytes one tool call may write to disk. Unset is unlimited.
     ///
     /// **Unset in code, set by `lev setup`.** How much an agent should write is
@@ -280,6 +322,8 @@ impl Default for LimitsConfig {
             provider_failures_before_open: default_provider_failures_before_open(),
             provider_circuit_cooldown_secs: default_provider_circuit_cooldown_secs(),
             interaction_timeout_secs: default_interaction_timeout_secs(),
+            inference_retry_attempts: default_inference_retry_attempts(),
+            inference_retry_base_ms: default_inference_retry_base_ms(),
             // Deliberately `None` here and concrete in `lev setup`: the code
             // imposes no ceiling on a user who never opened the config, and a
             // fresh install gets a number written where it can be seen and

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -1901,6 +1901,46 @@ some_custom_thing = \"forwarded to the script\"
         assert_eq!(disabled.limits.interaction_timeout_secs, 0);
     }
 
+    /// The retry schedule is the shipped one unless someone says otherwise, so
+    /// an existing install's behaviour does not change under it (issue #417).
+    #[test]
+    fn the_inference_retry_schedule_defaults_and_parses() {
+        let dir = tempfile::tempdir().unwrap();
+        let load = |name: &str, body: String| {
+            let path = dir.path().join(name);
+            std::fs::write(&path, body).unwrap();
+            with_tracing(|| Config::load_from_path(&path)).unwrap()
+        };
+
+        let old = load(
+            "old.toml",
+            format!(
+                "{}\n[limits]\nmax_concurrent_tools = 4\n",
+                config_toml_without_limits()
+            ),
+        );
+        assert_eq!(
+            old.limits.inference_retry_attempts,
+            leviath_runtime::DEFAULT_RETRY_ATTEMPTS
+        );
+        assert_eq!(
+            old.limits.inference_retry_base_ms,
+            leviath_runtime::DEFAULT_RETRY_BASE_DELAY_MS
+        );
+
+        // An operator riding out longer provider outages, on a slower blip
+        // schedule of their own choosing.
+        let tuned = load(
+            "tuned.toml",
+            format!(
+                "{}\n[limits]\ninference_retry_attempts = 8\ninference_retry_base_ms = 2000\n",
+                config_toml_without_limits()
+            ),
+        );
+        assert_eq!(tuned.limits.inference_retry_attempts, 8);
+        assert_eq!(tuned.limits.inference_retry_base_ms, 2000);
+    }
+
     #[test]
     fn exact_token_counting_parses_when_set() {
         let dir = tempfile::tempdir().unwrap();
@@ -3208,6 +3248,8 @@ enabled = false
                 provider_failures_before_open: 5,
                 provider_circuit_cooldown_secs: 120,
                 interaction_timeout_secs: 120,
+                inference_retry_attempts: 6,
+                inference_retry_base_ms: 250,
             },
             batch_tool_hint: true,
             shell_hint: false,
@@ -3323,6 +3365,8 @@ enabled = false
             Some("leviath-prod")
         );
         assert_eq!(deserialized.limits.default_max_iterations, Some(99));
+        assert_eq!(deserialized.limits.inference_retry_attempts, 6);
+        assert_eq!(deserialized.limits.inference_retry_base_ms, 250);
         assert_eq!(
             deserialized.providers.anthropic_api_key.as_deref(),
             Some("sk-ant-key")

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -8,8 +8,10 @@
 //! which skips the required-at-spawn region gate since the window is restored
 //! from a snapshot; restores the
 //! persisted context / stage / iteration / token totals via
-//! [`leviath_runtime::restore::restore_agent`], and preserves the original run
-//! metadata. Anything unreadable or un-reloadable is skipped (logged), never fatal.
+//! [`leviath_runtime::restore::restore_agent`], puts the run's per-stage ledger
+//! back from `stages.json` via
+//! [`leviath_runtime::restore::restore_stage_ledger`], and preserves the
+//! original run metadata. Anything unreadable or un-reloadable is skipped (logged), never fatal.
 //!
 //! One exception to the "re-issue inference" resume: a run that was parked at a
 //! stage-boundary interaction point (e.g. `plan_approval`) wrote an
@@ -257,7 +259,8 @@ fn is_terminal(status: &RunStatus) -> bool {
 }
 
 /// Reload one run: spawn it fresh from its blueprint, then overlay the persisted
-/// context / stage / totals and preserve the original run metadata.
+/// context / stage / totals / per-stage ledger and preserve the original run
+/// metadata.
 fn reload_one(
     world: &mut PipelineWorld,
     deps: SpawnDeps<'_>,
@@ -354,6 +357,19 @@ fn reload_one(
         stage_index,
         iteration,
         totals,
+    );
+
+    // Put the per-stage ledger back too. `build_agent_for_reload` seeds one
+    // all-zero record per blueprint stage, and the persist tick rewrites
+    // `stages.json` whole, so skipping this did not merely fail to restore the
+    // run's stage history - the next tick wrote zeros over the file that held
+    // it, while `meta.json`'s run totals went on looking correct (issue #415).
+    // No file (a run from before the ledger, or one that stopped before its
+    // first persist) leaves the seeded records as they are.
+    leviath_runtime::restore::restore_stage_ledger(
+        world.world_mut(),
+        entity,
+        &crate::runstate::read_stages_index_from(run_dir),
     );
 
     // A tool batch was in flight when the daemon died and its results never
@@ -1855,6 +1871,100 @@ mod tests {
                 .get::<TokenTotals>(restored[0].1.entity())
                 .is_some()
         );
+    }
+
+    /// A restart used to bring every stage back at zero: nothing rebuilt the
+    /// ledger from `stages.json`, so the blueprint-seeded (all-zero) one was
+    /// written straight over the real file on the next persist tick, and the
+    /// run's whole per-stage history went with it while `meta.json` still
+    /// looked healthy (issue #415).
+    #[tokio::test]
+    async fn reload_restores_the_persisted_stage_ledger() {
+        use leviath_core::run_meta::{StageRecord, StageRunStatus};
+        use leviath_runtime::pipeline::StageLedger;
+
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let runs = tempfile::tempdir().unwrap();
+        write_run(
+            runs.path(),
+            "run-stages",
+            manifest.to_str().unwrap(),
+            RunStatus::Running,
+            None,
+        );
+        // The ledger as the run left it: `analyze` ran and finished, the run
+        // stopped in `implement`, `review` was never reached. The trailing
+        // record names a stage this blueprint no longer has.
+        let mut analyze = StageRecord::new("analyze".to_string(), 0);
+        analyze.status = StageRunStatus::Complete;
+        analyze.entered = true;
+        analyze.prompt_tokens = 1_234;
+        analyze.completion_tokens = 56;
+        analyze.cached_tokens = 7;
+        analyze.cache_write_tokens = 8;
+        analyze.first_call_prompt_tokens = Some(400);
+        analyze.runaway_warned = true;
+        analyze
+            .region_tokens
+            .insert("conversation".to_string(), 900);
+        analyze.started_at = Some(10);
+        analyze.ended_at = Some(20);
+        let mut implement = StageRecord::new("implement".to_string(), 1);
+        implement.status = StageRunStatus::Active;
+        implement.entered = true;
+        implement.prompt_tokens = 77;
+        implement.started_at = Some(20);
+        let removed = StageRecord::new("removed_stage".to_string(), 7);
+        std::fs::write(
+            runs.path().join("run-stages").join("stages.json"),
+            serde_json::to_string(&vec![analyze, implement, removed]).unwrap(),
+        )
+        .unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
+            runs.path(),
+        );
+        assert_eq!(restored.len(), 1);
+
+        let ledger = world
+            .world()
+            .get::<StageLedger>(restored[0].1.entity())
+            .expect("a reloaded agent carries a stage ledger");
+        // One record per blueprint stage, in blueprint order: the record for a
+        // stage that no longer exists is dropped rather than appended.
+        let names: Vec<&str> = ledger.0.iter().map(|r| r.name.as_str()).collect();
+        assert_eq!(names, vec!["analyze", "implement", "review"]);
+        assert_eq!(ledger.0[0].prompt_tokens, 1_234);
+        assert_eq!(ledger.0[0].completion_tokens, 56);
+        assert_eq!(ledger.0[0].cached_tokens, 7);
+        assert_eq!(ledger.0[0].cache_write_tokens, 8);
+        assert_eq!(ledger.0[0].first_call_prompt_tokens, Some(400));
+        assert!(ledger.0[0].runaway_warned);
+        assert_eq!(ledger.0[0].region_tokens.get("conversation"), Some(&900));
+        assert_eq!(ledger.0[0].started_at, Some(10));
+        assert_eq!(ledger.0[0].ended_at, Some(20));
+        assert_eq!(ledger.0[0].status, StageRunStatus::Complete);
+        assert!(ledger.0[0].entered);
+        assert_eq!(ledger.0[1].prompt_tokens, 77);
+        assert!(ledger.0[1].entered);
+        // A stage with nothing persisted against it keeps the seeded record.
+        assert_eq!(ledger.0[2].prompt_tokens, 0);
+        assert!(!ledger.0[2].entered);
+        assert_eq!(ledger.0[2].index, 2);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -257,6 +257,14 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     world
         .world_mut()
         .init_resource::<leviath_runtime::pipeline::ProviderCircuits>();
+    // How hard a transient inference failure is retried before the agent is
+    // failed and its finished work discarded (issue #417).
+    world
+        .world_mut()
+        .insert_resource(leviath_runtime::pipeline::InferenceRetryTuning {
+            max_attempts: parts.config.limits.inference_retry_attempts,
+            base_delay_ms: parts.config.limits.inference_retry_base_ms,
+        });
     // Share the hub with the tick loop so a blocked agent's open prompt is
     // reflected into its status (Active ↔ Waiting) for the dashboard to surface.
     world.insert_interaction_hub(hub.clone());

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -798,8 +798,15 @@ fn write_stages_index_to(dir: &std::path::Path, stages: &[StageRecord]) -> anyho
 
 /// Read the stages index for a run, or return an empty vec on any error.
 pub fn read_stages_index(run_id: &str) -> Vec<StageRecord> {
-    let path = run_dir(run_id).join("stages.json");
-    let json = match std::fs::read_to_string(&path) {
+    read_stages_index_from(&run_dir(run_id))
+}
+
+/// [`read_stages_index`] for a run directory the caller already holds.
+///
+/// Restart recovery works from its configured runs directory rather than the
+/// home one, so it cannot resolve the path itself.
+pub fn read_stages_index_from(dir: &std::path::Path) -> Vec<StageRecord> {
+    let json = match std::fs::read_to_string(dir.join("stages.json")) {
         Ok(j) => j,
         Err(_) => return Vec::new(),
     };

--- a/crates/leviath-core/src/cache.rs
+++ b/crates/leviath-core/src/cache.rs
@@ -13,6 +13,16 @@ pub enum CacheHint {
     Always,
     /// Cache until content hash changes (compacting regions between compaction events).
     UntilChanged,
+    /// Same cacheability as [`CacheHint::UntilChanged`], and additionally marks
+    /// the start of the most recently changed stretch of that tier.
+    ///
+    /// A provider that spends one cache breakpoint per run of same-hint blocks
+    /// sees the change of hint as a run boundary, so the blocks ahead of the
+    /// mutation end up in a cache entry of their own instead of sharing one
+    /// with the block that just changed. Nothing else about the block differs:
+    /// assembly sorts it to the same position as `UntilChanged`, and its text
+    /// is untouched.
+    RecentlyChanged,
     /// Cache the stable prefix of a sliding window.
     /// `stable_fraction` is 0.0..1.0 (default 0.75 = oldest 75% of messages are stable).
     SlidingPrefix {
@@ -44,6 +54,14 @@ mod tests {
     #[test]
     fn cache_hint_until_changed_equality() {
         assert_eq!(CacheHint::UntilChanged, CacheHint::UntilChanged);
+    }
+
+    #[test]
+    fn cache_hint_recently_changed_is_distinct_from_until_changed() {
+        assert_eq!(CacheHint::RecentlyChanged, CacheHint::RecentlyChanged);
+        assert_ne!(CacheHint::RecentlyChanged, CacheHint::UntilChanged);
+        let dbg = format!("{:?}", CacheHint::RecentlyChanged);
+        assert!(dbg.contains("RecentlyChanged"));
     }
 
     #[test]
@@ -88,6 +106,7 @@ mod tests {
         let hints = vec![
             CacheHint::Always,
             CacheHint::UntilChanged,
+            CacheHint::RecentlyChanged,
             CacheHint::SlidingPrefix {
                 stable_fraction: 0.75,
             },

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -546,6 +546,10 @@ pub struct StageRecord {
     /// knows. Recorded as the largest each region reached while the stage was
     /// active, which is the number that decides whether a region is earning its
     /// place.
+    ///
+    /// Every region the window carries is measured, including the ones a stage
+    /// layout hides rather than declares, so a stage can list a region it never
+    /// assembled into a request.
     #[serde(default)]
     pub region_tokens: std::collections::BTreeMap<String, usize>,
     /// Prompt tokens billed by this stage's first call, the baseline the

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -2824,7 +2824,9 @@ mod tests {
         let err = provider.infer(&simple_request()).await.unwrap_err();
         assert_eq!(
             std::mem::discriminant(&err),
-            std::mem::discriminant(&ProviderError::RateLimitExceeded)
+            std::mem::discriminant(&ProviderError::RateLimitExceeded {
+                retry_after_secs: None,
+            })
         );
     }
 
@@ -2837,7 +2839,9 @@ mod tests {
         let err = provider.infer(&simple_request()).await.unwrap_err();
         assert_eq!(
             std::mem::discriminant(&err),
-            std::mem::discriminant(&ProviderError::RateLimitExceeded)
+            std::mem::discriminant(&ProviderError::RateLimitExceeded {
+                retry_after_secs: None,
+            })
         );
     }
 

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -345,7 +345,11 @@ fn classify_error(json: &serde_json::Value) -> ProviderError {
         || lowered.contains("too many requests")
         || lowered.contains("usage limit")
     {
-        return ProviderError::RateLimitExceeded;
+        // No hint to carry: this comes from the CLI's own text, and a
+        // subprocess has no response headers to read a `Retry-After` from.
+        return ProviderError::RateLimitExceeded {
+            retry_after_secs: None,
+        };
     }
 
     // Not authenticated: permanent until the user acts. `ApiError` carries none
@@ -832,7 +836,9 @@ mod tests {
             let err = classify(body);
             assert_eq!(
                 std::mem::discriminant(&err),
-                std::mem::discriminant(&ProviderError::RateLimitExceeded),
+                std::mem::discriminant(&ProviderError::RateLimitExceeded {
+                    retry_after_secs: None,
+                }),
                 "{body}"
             );
             assert!(err.is_transient(), "{body}");

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -37,7 +37,7 @@ pub use openrouter::OpenRouterProvider;
 pub use provider::{
     ContentBlock, DEFAULT_INFERENCE_TIMEOUT_SECS, FinishReason, InferenceRequest,
     InferenceResponse, Message, MessageContent, ModelCapabilities, ModelCapabilityOverride,
-    ModelInfo, Provider, ProviderConfig, ProviderError, RateLimitConfig, Result, SystemBlock,
-    TokenUsage, Tool, ToolCall, UnavailableReason, build_http_client,
+    ModelInfo, Provider, ProviderConfig, ProviderError, RateLimitConfig, Result, RetryAdvice,
+    SystemBlock, TokenUsage, Tool, ToolCall, UnavailableReason, build_http_client,
 };
 pub use rhai_provider::RhaiProvider;

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -167,7 +167,12 @@ pub enum ProviderError {
 
     /// Rate limit exceeded
     #[error("Rate limit exceeded")]
-    RateLimitExceeded,
+    RateLimitExceeded {
+        /// What the provider's `Retry-After` header asked for, in seconds, when
+        /// it sent one. Carried out of the provider layer so the retry loop can
+        /// wait as long as the server said instead of guessing (issue #417).
+        retry_after_secs: Option<u64>,
+    },
 
     /// Invalid response from provider
     #[error("Invalid response: {0}")]
@@ -187,7 +192,83 @@ pub enum ProviderError {
     Other(String),
 }
 
+/// The message fragments that mean "the provider has no capacity right now":
+/// a 429 rate limit, or Anthropic's 529 "overloaded".
+///
+/// Kept apart from [`SERVER_ERROR_SIGNALS`] because the two deserve different
+/// waits. A 500 or a dropped connection is a blip that a second or two clears;
+/// a capacity refusal is a window that lasts minutes, and retrying it on
+/// blip-sized backoff just spends the attempts without ever leaving the window
+/// (issue #417).
+const CAPACITY_SIGNALS: [&str; 5] = [
+    // Rate limiting (a provider that maps 429 to ApiError rather than
+    // RateLimitExceeded, e.g. Ollama).
+    "429",
+    "too many requests",
+    "rate limit",
+    // Anthropic returns 529 "overloaded" when the model is saturated.
+    "529",
+    "overloaded",
+];
+
+/// The message fragments that mean the server failed on its own account: an
+/// ordinary 5xx, which is usually gone by the next attempt.
+const SERVER_ERROR_SIGNALS: [&str; 8] = [
+    "500",
+    "502",
+    "503",
+    "504",
+    "internal server error",
+    "bad gateway",
+    "service unavailable",
+    "gateway timeout",
+];
+
+/// Whether a lowercased error message contains any of `signals`.
+fn mentions_any(message: &str, signals: &[&str]) -> bool {
+    signals.iter().any(|s| message.contains(s))
+}
+
+/// What the retry loop should do about a failed attempt, beyond the yes/no of
+/// [`ProviderError::is_transient`].
+///
+/// The provider layer is the only place that knows whether a failure was the
+/// provider running out of capacity and whether the server said when to come
+/// back, and neither survives being flattened into an error string. Carrying
+/// both here is what lets the dispatch layer honor a `Retry-After` and back off
+/// on a capacity-sized schedule rather than a blip-sized one (issue #417).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct RetryAdvice {
+    /// Whether the provider refused for want of capacity (429, or a 529
+    /// "overloaded"), as opposed to failing for its own reasons.
+    pub capacity: bool,
+    /// How many seconds the provider's `Retry-After` header asked the caller to
+    /// wait. `None` when it sent no hint, which is the usual case for a 529.
+    pub retry_after_secs: Option<u64>,
+}
+
 impl ProviderError {
+    /// What to do about this failure if it is retried: see [`RetryAdvice`].
+    ///
+    /// Only a capacity refusal ever carries advice. Everything else answers
+    /// with the default, which asks for the ordinary schedule.
+    pub fn retry_advice(&self) -> RetryAdvice {
+        match self {
+            ProviderError::RateLimitExceeded { retry_after_secs } => RetryAdvice {
+                capacity: true,
+                retry_after_secs: *retry_after_secs,
+            },
+            // A provider that reports 429/529 as a plain API error (Ollama, and
+            // Anthropic's 529) leaves only the message to read. The header is
+            // gone by then, so these get the capacity schedule with no hint.
+            ProviderError::ApiError(msg) => RetryAdvice {
+                capacity: mentions_any(&msg.to_ascii_lowercase(), &CAPACITY_SIGNALS),
+                retry_after_secs: None,
+            },
+            _ => RetryAdvice::default(),
+        }
+    }
+
     /// Whether this failure is worth retrying - a transient network or
     /// server-side issue (connection reset, timeout, 429, 5xx / "overloaded") -
     /// as opposed to a permanent one (auth, invalid request, token limit)
@@ -197,32 +278,14 @@ impl ProviderError {
             // Network-level failures: connection reset, timeout, DNS, TLS.
             ProviderError::RequestFailed(_) => true,
             // 429 - back off and retry.
-            ProviderError::RateLimitExceeded => true,
-            // We only have the message, so match the common server-side (5xx)
-            // signals - including Anthropic's 529 "overloaded". 4xx client
-            // errors carry none of these and stay permanent.
+            ProviderError::RateLimitExceeded { .. } => true,
+            // We only have the message, so match the common capacity and
+            // server-side (5xx) signals - including Anthropic's 529
+            // "overloaded". 4xx client errors carry none of these and stay
+            // permanent.
             ProviderError::ApiError(msg) => {
                 let m = msg.to_ascii_lowercase();
-                [
-                    // Rate limiting (a provider that maps 429 to ApiError rather
-                    // than RateLimitExceeded, e.g. Ollama).
-                    "429",
-                    "too many requests",
-                    "rate limit",
-                    // Server-side 5xx (and Anthropic's 529 "overloaded").
-                    "500",
-                    "502",
-                    "503",
-                    "504",
-                    "529",
-                    "overloaded",
-                    "internal server error",
-                    "bad gateway",
-                    "service unavailable",
-                    "gateway timeout",
-                ]
-                .iter()
-                .any(|s| m.contains(s))
+                mentions_any(&m, &CAPACITY_SIGNALS) || mentions_any(&m, &SERVER_ERROR_SIGNALS)
             }
             // A malformed response, an over-limit request, an unusable
             // provider, or an unknown error won't be fixed by retrying.
@@ -925,6 +988,20 @@ pub fn parse_openai_finish_reason(reason: &str) -> FinishReason {
     }
 }
 
+/// How long a response's `Retry-After` header asks the caller to wait.
+///
+/// Only the delta-seconds form is read. The header's other form is an HTTP
+/// date, which every provider API in use here answers with seconds instead, and
+/// reading it would mean trusting the server's clock against ours; an
+/// unparseable value is treated as no hint at all, which falls back to the
+/// caller's own backoff.
+fn retry_after_secs(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+    headers
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.trim().parse::<u64>().ok())
+}
+
 /// Check an HTTP response for errors and return it on success.
 ///
 /// - On 429 (rate limit): notifies the optional rate limiter and returns `RateLimitExceeded`.
@@ -940,15 +1017,16 @@ pub async fn check_http_response(
     let status = response.status();
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
         // Extract retry-after *before* consuming the response body.
-        let retry_after = response
-            .headers()
-            .get("retry-after")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<u64>().ok());
+        let retry_after = retry_after_secs(response.headers());
         if let Some(l) = limiter {
             l.handle_rate_limit(retry_after).await;
         }
-        return Err(ProviderError::RateLimitExceeded);
+        // The hint rides along on the error: the client-side limiter paces the
+        // *next* request, while the dispatch layer's retry loop is what decides
+        // how long this one waits before trying again (issue #417).
+        return Err(ProviderError::RateLimitExceeded {
+            retry_after_secs: retry_after,
+        });
     }
     if !status.is_success() {
         let error_body = response.text().await.unwrap_or_else(|e| e.to_string());
@@ -1151,7 +1229,12 @@ mod tests {
     fn provider_error_is_transient_classification() {
         // Network + rate-limit + 5xx / overloaded ⇒ retry.
         assert!(ProviderError::RequestFailed("connection reset".into()).is_transient());
-        assert!(ProviderError::RateLimitExceeded.is_transient());
+        assert!(
+            ProviderError::RateLimitExceeded {
+                retry_after_secs: None
+            }
+            .is_transient()
+        );
         assert!(ProviderError::ApiError("HTTP 503 Service Unavailable".into()).is_transient());
         assert!(ProviderError::ApiError("HTTP 429 Too Many Requests".into()).is_transient());
         assert!(ProviderError::ApiError("rate limit exceeded".into()).is_transient());
@@ -1174,6 +1257,69 @@ mod tests {
             }
             .is_transient()
         );
+    }
+
+    // ─── Retry advice (issue #417) ──────────────────────────────────────────
+
+    #[test]
+    fn a_capacity_refusal_is_told_apart_from_an_ordinary_server_failure() {
+        // The distinction the slow backoff hangs on: a 429 or a 529 describes a
+        // window that lasts minutes, a 500 or a reset connection a blip.
+        for err in [
+            ProviderError::RateLimitExceeded {
+                retry_after_secs: None,
+            },
+            ProviderError::ApiError("HTTP 529: {\"type\":\"overloaded_error\"}".into()),
+            ProviderError::ApiError("HTTP 429 Too Many Requests".into()),
+            ProviderError::ApiError("Overloaded".into()),
+            ProviderError::ApiError("rate limit exceeded".into()),
+        ] {
+            assert!(err.retry_advice().capacity, "{err}");
+        }
+        for err in [
+            ProviderError::ApiError("HTTP 500 Internal Server Error".into()),
+            ProviderError::ApiError("HTTP 502 Bad Gateway".into()),
+            ProviderError::RequestFailed("connection reset".into()),
+            ProviderError::Other("mystery".into()),
+            ProviderError::TokenLimitExceeded { used: 9, max: 8 },
+        ] {
+            assert!(!err.retry_advice().capacity, "{err}");
+        }
+    }
+
+    #[test]
+    fn only_a_rate_limit_carries_the_servers_own_answer() {
+        // The header exists on the 429 path and nowhere else, so every other
+        // error asks for the caller's own backoff rather than a wait it made up.
+        assert_eq!(
+            ProviderError::RateLimitExceeded {
+                retry_after_secs: Some(42),
+            }
+            .retry_advice()
+            .retry_after_secs,
+            Some(42)
+        );
+        assert_eq!(
+            ProviderError::ApiError("HTTP 529 overloaded".into())
+                .retry_advice()
+                .retry_after_secs,
+            None
+        );
+        assert_eq!(
+            ProviderError::RequestFailed("reset".into())
+                .retry_advice()
+                .retry_after_secs,
+            None
+        );
+    }
+
+    #[test]
+    fn no_advice_at_all_is_the_ordinary_schedule() {
+        // The default is what a permanent error and a plain blip both answer,
+        // and it must not accidentally read as "at capacity".
+        let advice = RetryAdvice::default();
+        assert!(!advice.capacity);
+        assert_eq!(advice.retry_after_secs, None);
     }
 
     // ─── Provider-fatal classification (issue #201) ─────────────────────────
@@ -1306,7 +1452,9 @@ mod tests {
         for err in [
             ProviderError::InvalidResponse("garbage".into()),
             ProviderError::TokenLimitExceeded { used: 9, max: 8 },
-            ProviderError::RateLimitExceeded,
+            ProviderError::RateLimitExceeded {
+                retry_after_secs: Some(5),
+            },
             ProviderError::Other("mystery".into()),
         ] {
             assert_eq!(err.unavailable_reason(), None, "{err}");
@@ -1371,7 +1519,11 @@ mod tests {
 
     #[test]
     fn provider_error_rate_limit_display() {
-        let err = ProviderError::RateLimitExceeded;
+        let err = ProviderError::RateLimitExceeded {
+            retry_after_secs: Some(30),
+        };
+        // The hint is for the retry loop, not for the reader: the message stays
+        // the one sentence a user needs.
         assert_eq!(err.to_string(), "Rate limit exceeded");
     }
 
@@ -1836,9 +1988,14 @@ mod tests {
     async fn check_http_response_rate_limited_without_limiter_returns_rate_limit_exceeded() {
         let response = spawn_mock_response(429, "Too Many Requests", &[], b"slow down").await;
         let err = check_http_response(response, None).await.unwrap_err();
+        // A 429 with no header is still a capacity refusal, with no hint to
+        // honor - the retry loop falls back to its own capacity backoff.
         assert_eq!(
-            std::mem::discriminant(&err),
-            std::mem::discriminant(&ProviderError::RateLimitExceeded)
+            err.retry_advice(),
+            RetryAdvice {
+                capacity: true,
+                retry_after_secs: None,
+            }
         );
     }
 
@@ -1859,9 +2016,15 @@ mod tests {
         let err = check_http_response(response, Some(&limiter))
             .await
             .unwrap_err();
+        // The header reaches the limiter *and* the error: the limiter paces the
+        // next request, the error tells the retry loop how long to wait before
+        // repeating this one (issue #417).
         assert_eq!(
-            std::mem::discriminant(&err),
-            std::mem::discriminant(&ProviderError::RateLimitExceeded)
+            err.retry_advice(),
+            RetryAdvice {
+                capacity: true,
+                retry_after_secs: Some(2),
+            }
         );
     }
 
@@ -1882,9 +2045,14 @@ mod tests {
         let err = check_http_response(response, Some(&limiter))
             .await
             .unwrap_err();
+        // An HTTP-date or any other unreadable value is no hint at all, which
+        // is the same answer as a missing header rather than a failure.
         assert_eq!(
-            std::mem::discriminant(&err),
-            std::mem::discriminant(&ProviderError::RateLimitExceeded)
+            err.retry_advice(),
+            RetryAdvice {
+                capacity: true,
+                retry_after_secs: None,
+            }
         );
     }
 

--- a/crates/leviath-providers/src/rhai_provider/convert.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert.rs
@@ -197,7 +197,12 @@ pub fn map_rhai_err(err: Box<EvalAltResult>) -> ProviderError {
                 .and_then(|d| d.as_bool().ok())
                 .unwrap_or(false);
             return match kind.as_deref() {
-                Some("rate_limited") => ProviderError::RateLimitExceeded,
+                // A script reports the kind and nothing else, so there is no
+                // `Retry-After` to carry; the retry loop falls back to its own
+                // capacity backoff.
+                Some("rate_limited") => ProviderError::RateLimitExceeded {
+                    retry_after_secs: None,
+                },
                 Some("transport") | Some("server") => ProviderError::RequestFailed(message),
                 // A script's `api` error is the same shape a built-in provider
                 // gets back from an HTTP call, so it classifies the same way:

--- a/crates/leviath-providers/src/rhai_provider/convert/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert/tests.rs
@@ -121,7 +121,7 @@ fn map_err_kinds() {
     };
     assert!(matches!(
         map_rhai_err(mk("rate_limited")),
-        ProviderError::RateLimitExceeded
+        ProviderError::RateLimitExceeded { .. }
     ));
     assert!(matches!(
         map_rhai_err(mk("transport")),
@@ -206,7 +206,10 @@ fn host_err_maps_round_trip() {
     let e = host_err_to_rhai(HostHttpError::RateLimited {
         retry_after: Some(5),
     });
-    assert!(matches!(map_rhai_err(e), ProviderError::RateLimitExceeded));
+    assert!(matches!(
+        map_rhai_err(e),
+        ProviderError::RateLimitExceeded { .. }
+    ));
     let e = host_err_to_rhai(HostHttpError::Api("HTTP 500: x".to_string()));
     assert!(matches!(map_rhai_err(e), ProviderError::ApiError(_)));
     let e = host_err_to_rhai(HostHttpError::Transport("reset".to_string()));
@@ -237,7 +240,10 @@ fn parse_inference_and_chunk_reject_unconvertible_dynamic() {
 #[test]
 fn host_err_rate_limited_without_retry_after() {
     let e = host_err_to_rhai(HostHttpError::RateLimited { retry_after: None });
-    assert!(matches!(map_rhai_err(e), ProviderError::RateLimitExceeded));
+    assert!(matches!(
+        map_rhai_err(e),
+        ProviderError::RateLimitExceeded { .. }
+    ));
 }
 
 #[test]

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -299,7 +299,7 @@ async fn infer_rate_limited_without_limiter() {
         FakeExecutor::with_responses(vec![Err(HostHttpError::RateLimited { retry_after: None })]);
     let p = build(&src, exec).unwrap();
     let err = p.infer(&request("m")).await.err().unwrap();
-    assert!(matches!(err, ProviderError::RateLimitExceeded));
+    assert!(matches!(err, ProviderError::RateLimitExceeded { .. }));
 }
 
 #[tokio::test]
@@ -348,7 +348,7 @@ async fn infer_http_429_maps_to_rate_limit() {
         }),
     );
     let err = p.infer(&request("m")).await.err().unwrap();
-    assert!(matches!(err, ProviderError::RateLimitExceeded));
+    assert!(matches!(err, ProviderError::RateLimitExceeded { .. }));
 }
 
 #[tokio::test]

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -84,7 +84,83 @@ pub(super) fn cache_hint_sort_priority(hint: leviath_core::CacheHint) -> u8 {
         CacheHint::Always => 0,               // Pinned, CompactHistory - most stable
         CacheHint::SlidingPrefix { .. } => 1, // Partially stable
         CacheHint::UntilChanged => 2,         // Compacting - changes on compaction
-        CacheHint::Never => 3,                // Temporary, Clearable - changes every iteration
+        // Same tier as UntilChanged on purpose: the hint marks where a cache
+        // breakpoint belongs, never where a block belongs in the prompt.
+        CacheHint::RecentlyChanged => 2,
+        CacheHint::Never => 3, // Temporary, Clearable - changes every iteration
+    }
+}
+
+/// The most cache breakpoints assembly will let the system blocks claim.
+///
+/// Anthropic allows four `cache_control` blocks across the whole request and
+/// the provider hands the system blocks first claim on that budget, so leaving
+/// one run unclaimed is what keeps a breakpoint available for the messages.
+const MAX_SYSTEM_CACHE_RUNS: usize = 3;
+
+/// Split the volatile tier of the system prompt at its most recently changed
+/// block, by retagging that block and every block after it as
+/// [`leviath_core::CacheHint::RecentlyChanged`].
+///
+/// Providers place one cache breakpoint per run of same-hint blocks, so with a
+/// single `UntilChanged` run the only breakpoint sits at the end of the tier.
+/// A block mutating in the middle of that run therefore invalidates the whole
+/// run, and every block after the mutation is re-sent as a cache write. Adding
+/// a boundary just before the changed block gives the unchanged head of the
+/// tier a cache entry of its own. Only the breakpoint metadata moves: block
+/// order and block text are both left exactly as the sort left them, and this
+/// runs after the sort so it cannot influence ordering at all. The effect on
+/// cache-write volume is not measurable inside this repository.
+///
+/// `recency` carries the newest entry timestamp of the region behind each
+/// `UntilChanged` block, in the order those blocks were assembled. The sort is
+/// stable and every block in the tier shares one sort priority, so that order
+/// is also the order the blocks appear in now.
+///
+/// Nothing is retagged when the newest block is already the first one (there is
+/// no stable head to protect), or when the blocks already fill the run budget.
+fn mark_recently_changed_run(blocks: &mut [leviath_providers::SystemBlock], recency: &[i64]) {
+    use leviath_core::CacheHint;
+
+    let mut volatile: Vec<usize> = Vec::new();
+    for (index, block) in blocks.iter().enumerate() {
+        if block.cache_hint == CacheHint::UntilChanged {
+            volatile.push(index);
+        }
+    }
+
+    // The first block carrying the newest timestamp. Ties resolve to the
+    // earliest block, which is the conservative choice: when two regions were
+    // written in the same second, both of them changed, and the boundary
+    // belongs ahead of the earlier one.
+    let mut boundary = 0usize;
+    let mut newest = i64::MIN;
+    for (position, &stamp) in recency.iter().enumerate() {
+        if stamp > newest {
+            newest = stamp;
+            boundary = position;
+        }
+    }
+    if boundary == 0 {
+        return;
+    }
+
+    // Count the breakpoints the provider would place today. Splitting the
+    // volatile tier adds exactly one, so refusing at the limit is what keeps
+    // the messages breakpoint from being squeezed out.
+    let mut runs = 0usize;
+    for index in 0..blocks.len() {
+        let hint = blocks[index].cache_hint;
+        if hint != CacheHint::Never && blocks.get(index + 1).map(|b| b.cache_hint) != Some(hint) {
+            runs += 1;
+        }
+    }
+    if runs >= MAX_SYSTEM_CACHE_RUNS {
+        return;
+    }
+
+    for &index in volatile.iter().skip(boundary) {
+        blocks[index].cache_hint = CacheHint::RecentlyChanged;
     }
 }
 
@@ -540,6 +616,10 @@ impl ContextWindow {
 
         let mut system_blocks = Vec::new();
         let mut messages: Vec<leviath_providers::Message> = Vec::new();
+        // One entry per `UntilChanged` system block, in assembly order, holding
+        // the newest entry timestamp of the region that produced it. Feeds the
+        // cache-breakpoint split after the sort.
+        let mut volatile_recency: Vec<i64> = Vec::new();
 
         for region in &self.regions {
             // A region this stage does not attend to is held but not shown.
@@ -554,6 +634,10 @@ impl ContextWindow {
             if region.content.is_empty() && !is_custom {
                 continue;
             }
+
+            // Where this region's system blocks begin, so the recency mapping
+            // below covers exactly the blocks this region adds.
+            let first_new_block = system_blocks.len();
 
             match &region.kind {
                 // System-level content → system blocks
@@ -784,6 +868,22 @@ impl ContextWindow {
                     });
                 }
             }
+
+            // The newest entry timestamp stands in for "when did this region
+            // last change". Regions are append-mostly and timestamps only move
+            // forward, so the block holding the newest entry is the one that
+            // mutated most recently.
+            let mut newest = i64::MIN;
+            for entry in &region.content {
+                if entry.timestamp > newest {
+                    newest = entry.timestamp;
+                }
+            }
+            for block in &system_blocks[first_new_block..] {
+                if block.cache_hint == CacheHint::UntilChanged {
+                    volatile_recency.push(newest);
+                }
+            }
         }
 
         // ── Sort system blocks for optimal prefix caching ────────────────
@@ -793,6 +893,12 @@ impl ContextWindow {
         // they form the cacheable prefix, with volatile blocks
         // (Compacting, Temporary, Clearable) after.
         system_blocks.sort_by_key(|block| cache_hint_sort_priority(block.cache_hint));
+
+        // ── Spend a cache breakpoint on the volatile boundary ────────────
+        //
+        // Runs strictly after the sort, so it can only change breakpoint
+        // metadata: the block order and the block text are already final.
+        mark_recently_changed_run(&mut system_blocks, &volatile_recency);
 
         // ── Sanitize orphaned tool_use / tool_result blocks ──────────────
         //
@@ -872,8 +978,9 @@ impl ContextWindow {
         // prompt caching. We place a cache breakpoint near the end of the
         // stable prefix to maximize cache hits.
         //
-        // Anthropic allows up to 4 breakpoints. We use 1 on messages
-        // (system blocks already have cache_control via CacheHint).
+        // Anthropic allows up to 4 breakpoints. Exactly 1 lands on the
+        // messages; the system blocks get theirs from their cache hints, and
+        // [`MAX_SYSTEM_CACHE_RUNS`] caps those at 3 so this one always fits.
         // Place it on the 4th-from-last message to give a buffer for the
         // new messages added each iteration (typically 2-3).
         if messages.len() >= 5 {
@@ -982,5 +1089,281 @@ impl ContextWindow {
             .iter()
             .filter_map(|r| r.taint_level().map(|t| (r.name.clone(), t)))
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::{CacheHint, Region, RegionKind};
+    use leviath_providers::SystemBlock;
+
+    /// A system block carrying only the hint under test.
+    fn block(hint: CacheHint) -> SystemBlock {
+        SystemBlock {
+            text: "x".to_string(),
+            cache_hint: hint,
+        }
+    }
+
+    /// The number of cache breakpoints the Anthropic provider would place on
+    /// these system blocks: one per contiguous run of same-hint cacheable
+    /// blocks. Mirrors `system_cache_breakpoints` so the ceiling can be
+    /// asserted from this side of the crate boundary.
+    fn provider_system_breakpoints(blocks: &[SystemBlock]) -> usize {
+        let mut runs = 0;
+        for (index, block) in blocks.iter().enumerate() {
+            let hint = block.cache_hint;
+            if hint != CacheHint::Never && blocks.get(index + 1).map(|b| b.cache_hint) != Some(hint)
+            {
+                runs += 1;
+            }
+        }
+        runs
+    }
+
+    /// A region holding one entry stamped at `timestamp`.
+    fn stamped_region(name: &str, kind: RegionKind, timestamp: i64) -> Region {
+        let mut region = Region::new(name.to_string(), kind, 10_000);
+        region.add_entry(format!("{name} contents"), 10).unwrap();
+        region.content[0].timestamp = timestamp;
+        region
+    }
+
+    fn hashmap_region(name: &str, timestamp: i64) -> Region {
+        stamped_region(
+            name,
+            RegionKind::HashMap {
+                max_entries: Some(16),
+            },
+            timestamp,
+        )
+    }
+
+    #[test]
+    fn recently_changed_sorts_with_until_changed() {
+        assert_eq!(
+            cache_hint_sort_priority(CacheHint::RecentlyChanged),
+            cache_hint_sort_priority(CacheHint::UntilChanged)
+        );
+        assert_eq!(cache_hint_sort_priority(CacheHint::RecentlyChanged), 2);
+    }
+
+    #[test]
+    fn mark_recently_changed_run_splits_at_the_newest_block() {
+        // Always, three volatile blocks, and a trailing uncacheable block. The
+        // third volatile block is the one that just changed.
+        let mut blocks = vec![
+            block(CacheHint::Always),
+            block(CacheHint::UntilChanged),
+            block(CacheHint::UntilChanged),
+            block(CacheHint::UntilChanged),
+            block(CacheHint::Never),
+        ];
+        mark_recently_changed_run(&mut blocks, &[10, 20, 90]);
+
+        let hints: Vec<CacheHint> = blocks.iter().map(|b| b.cache_hint).collect();
+        assert_eq!(
+            hints,
+            vec![
+                CacheHint::Always,
+                CacheHint::UntilChanged,
+                CacheHint::UntilChanged,
+                CacheHint::RecentlyChanged,
+                CacheHint::Never,
+            ]
+        );
+        // Always run, stable volatile head, changed volatile tail. The
+        // uncacheable trailing block claims nothing.
+        assert_eq!(provider_system_breakpoints(&blocks), 3);
+    }
+
+    #[test]
+    fn mark_recently_changed_run_retags_every_block_after_the_boundary() {
+        let mut blocks = vec![
+            block(CacheHint::UntilChanged),
+            block(CacheHint::UntilChanged),
+            block(CacheHint::UntilChanged),
+        ];
+        mark_recently_changed_run(&mut blocks, &[1, 7, 5]);
+
+        let hints: Vec<CacheHint> = blocks.iter().map(|b| b.cache_hint).collect();
+        assert_eq!(
+            hints,
+            vec![
+                CacheHint::UntilChanged,
+                CacheHint::RecentlyChanged,
+                CacheHint::RecentlyChanged,
+            ]
+        );
+    }
+
+    #[test]
+    fn mark_recently_changed_run_ties_resolve_to_the_earliest_block() {
+        // Two regions written in the same second both changed, so the boundary
+        // belongs ahead of the earlier one.
+        let mut blocks = vec![
+            block(CacheHint::UntilChanged),
+            block(CacheHint::UntilChanged),
+            block(CacheHint::UntilChanged),
+        ];
+        mark_recently_changed_run(&mut blocks, &[1, 9, 9]);
+
+        assert_eq!(blocks[0].cache_hint, CacheHint::UntilChanged);
+        assert_eq!(blocks[1].cache_hint, CacheHint::RecentlyChanged);
+        assert_eq!(blocks[2].cache_hint, CacheHint::RecentlyChanged);
+    }
+
+    #[test]
+    fn mark_recently_changed_run_leaves_a_headless_tier_alone() {
+        // The newest block is already first, so there is no stable head to put
+        // behind a breakpoint.
+        let mut blocks = vec![
+            block(CacheHint::UntilChanged),
+            block(CacheHint::UntilChanged),
+        ];
+        mark_recently_changed_run(&mut blocks, &[42, 1]);
+        assert!(
+            blocks
+                .iter()
+                .all(|b| b.cache_hint == CacheHint::UntilChanged)
+        );
+    }
+
+    #[test]
+    fn mark_recently_changed_run_leaves_a_tierless_prompt_alone() {
+        // No volatile blocks at all means an empty recency list.
+        let mut blocks = vec![block(CacheHint::Always), block(CacheHint::Never)];
+        mark_recently_changed_run(&mut blocks, &[]);
+        assert_eq!(blocks[0].cache_hint, CacheHint::Always);
+        assert_eq!(blocks[1].cache_hint, CacheHint::Never);
+    }
+
+    #[test]
+    fn mark_recently_changed_run_refuses_when_the_run_budget_is_full() {
+        // Always, SlidingPrefix and UntilChanged already claim three
+        // breakpoints. Splitting further would take the messages' one.
+        let mut blocks = vec![
+            block(CacheHint::Always),
+            block(CacheHint::SlidingPrefix {
+                stable_fraction: 0.75,
+            }),
+            block(CacheHint::UntilChanged),
+            block(CacheHint::UntilChanged),
+        ];
+        assert_eq!(provider_system_breakpoints(&blocks), 3);
+
+        mark_recently_changed_run(&mut blocks, &[1, 99]);
+
+        assert_eq!(blocks[2].cache_hint, CacheHint::UntilChanged);
+        assert_eq!(blocks[3].cache_hint, CacheHint::UntilChanged);
+        assert_eq!(provider_system_breakpoints(&blocks), 3);
+    }
+
+    #[test]
+    fn assemble_marks_the_volatile_tail_without_moving_any_block() {
+        let mut window = ContextWindow::new(100_000);
+        window.add_region(stamped_region("brief", RegionKind::Pinned, 1));
+        window.add_region(hashmap_region("spec", 100));
+        window.add_region(hashmap_region("data_preview", 200));
+        window.add_region(hashmap_region("results", 300));
+        window.add_region(stamped_region("scratch", RegionKind::Temporary, 400));
+
+        let assembled = window.assemble();
+
+        // Declaration order inside each tier is exactly what it was: the split
+        // only rewrites cache hints.
+        let texts: Vec<&str> = assembled
+            .system_blocks
+            .iter()
+            .map(|b| b.text.as_str())
+            .collect();
+        assert!(texts[0].contains("brief contents"));
+        assert!(texts[1].starts_with("[spec]:"));
+        assert!(texts[2].starts_with("[data_preview]:"));
+        assert!(texts[3].starts_with("[results]:"));
+        assert!(texts[4].starts_with("[scratch]:"));
+
+        let hints: Vec<CacheHint> = assembled
+            .system_blocks
+            .iter()
+            .map(|b| b.cache_hint)
+            .collect();
+        assert_eq!(
+            hints,
+            vec![
+                CacheHint::Always,
+                CacheHint::UntilChanged,
+                CacheHint::UntilChanged,
+                CacheHint::RecentlyChanged,
+                CacheHint::Never,
+            ]
+        );
+    }
+
+    #[test]
+    fn assemble_leaves_a_flat_window_untouched() {
+        // One pinned block and one working region: the flat shape that already
+        // caches well keeps a single volatile run and a single breakpoint.
+        let mut window = ContextWindow::new(100_000);
+        window.add_region(stamped_region("brief", RegionKind::Pinned, 1));
+        window.add_region(hashmap_region("results", 300));
+
+        let assembled = window.assemble();
+        let hints: Vec<CacheHint> = assembled
+            .system_blocks
+            .iter()
+            .map(|b| b.cache_hint)
+            .collect();
+        assert_eq!(hints, vec![CacheHint::Always, CacheHint::UntilChanged]);
+        assert_eq!(provider_system_breakpoints(&assembled.system_blocks), 2);
+    }
+
+    #[test]
+    fn assemble_stays_within_four_cache_breakpoints() {
+        let mut window = ContextWindow::new(1_000_000);
+        window.add_region(stamped_region("brief", RegionKind::Pinned, 1));
+        window.add_region(stamped_region(
+            "history",
+            RegionKind::CompactHistory {
+                source_region: "conversation".to_string(),
+            },
+            2,
+        ));
+        for (index, name) in ["spec", "data_preview", "scripts", "results"]
+            .iter()
+            .enumerate()
+        {
+            window.add_region(hashmap_region(name, 100 + index as i64));
+        }
+        window.add_region(stamped_region("scratch", RegionKind::Clearable, 500));
+
+        let mut conversation = Region::new(
+            "conversation".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 100,
+                eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+            },
+            100_000,
+        );
+        for turn in 0..8 {
+            conversation
+                .add_entry(format!("User: turn {turn}"), 10)
+                .unwrap();
+        }
+        window.add_region(conversation);
+
+        let assembled = window.assemble();
+        let system = provider_system_breakpoints(&assembled.system_blocks);
+        let message = assembled
+            .messages
+            .iter()
+            .filter(|m| m.cache_breakpoint)
+            .count();
+
+        assert!(system <= MAX_SYSTEM_CACHE_RUNS, "system runs: {system}");
+        assert_eq!(message, 1);
+        let total = system + message;
+        assert!(total <= 4, "total breakpoints: {total}");
     }
 }

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -23,12 +23,60 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::inference_pool::InferencePermit;
 
+/// Total attempts, including the first, for a transient inference failure.
+///
+/// Served from `[limits] inference_retry_attempts`, which defaults to this.
+pub const DEFAULT_RETRY_ATTEMPTS: u32 = 4;
+
+/// The first backoff, in milliseconds, after an ordinary transient failure.
+///
+/// Served from `[limits] inference_retry_base_ms`, which defaults to this. Each
+/// further retry doubles it, so the default schedule is 1s, 2s, 4s.
+pub const DEFAULT_RETRY_BASE_DELAY_MS: u64 = 1_000;
+
+/// The first backoff after a *capacity* failure (429, or a 529 "overloaded")
+/// the provider gave no `Retry-After` for, in seconds.
+///
+/// Deliberately much larger than [`DEFAULT_RETRY_BASE_DELAY_MS`]. An overload
+/// window lasts minutes, so a second of waiting only buys another refusal: the
+/// reported run (issue #417) spent all three of its retries inside one 529
+/// window and was failed with 44 iterations of finished work in hand.
+pub const CAPACITY_BASE_DELAY_SECS: u64 = 15;
+
+/// The longest one capacity backoff may last, in seconds, and the ceiling on a
+/// `Retry-After` the provider asks for.
+///
+/// A minute is long enough to leave most overload windows and short enough that
+/// a run still notices when the provider comes back. A server asking for longer
+/// than this is waited out a minute at a time instead, which costs an extra
+/// refusal but keeps one header from parking a run for an hour.
+pub const CAPACITY_MAX_DELAY_SECS: u64 = 60;
+
+/// The ceiling on the *cumulative* backoff of a single inference job, in
+/// seconds, across every retry it makes.
+///
+/// The overall bound on waiting, and the answer to "how long can a retrying job
+/// hold its pool slot": five minutes of sleeping, however the attempts,
+/// backoffs and `Retry-After` hints add up. Network time is on top of it and is
+/// bounded separately by [`RetryPolicy::job_timeout`].
+pub const MAX_TOTAL_BACKOFF_SECS: u64 = 300;
+
 /// How a transient inference failure is retried before the agent is failed.
 ///
 /// Transient errors (see [`ProviderError::is_transient`]) are retried with
 /// exponential backoff; a permanent error (auth, invalid request, token limit)
 /// fails immediately. This keeps a passing network blip from marking a stage
 /// `error` and carrying its half-finished work forward.
+///
+/// A *capacity* failure - a 429, or Anthropic's 529 "overloaded" - is retried on
+/// its own, much slower schedule (see [`Self::capacity_base_delay`]), because it
+/// describes a window that lasts minutes rather than a blip that clears in a
+/// second. When the provider said how long to wait, that answer is used instead
+/// of any of these numbers.
+///
+/// Every schedule is bounded twice over: by [`Self::max_attempts`], and by
+/// [`Self::max_total_backoff`] on the sum of the waits. A job can never retry
+/// forever.
 #[derive(Debug, Clone, Copy)]
 pub struct RetryPolicy {
     /// Total attempts including the first (e.g. `4` = one try + three retries).
@@ -36,6 +84,19 @@ pub struct RetryPolicy {
     /// Base backoff; the retry after attempt `n` waits `base_delay * 2^(n-1)`
     /// (so 1s, 2s, 4s, … for a 1s base).
     pub base_delay: Duration,
+    /// Base backoff for a capacity failure the provider gave no `Retry-After`
+    /// for, doubling per attempt exactly as [`Self::base_delay`] does and capped
+    /// at [`Self::capacity_max_delay`]. Defaults to
+    /// [`CAPACITY_BASE_DELAY_SECS`], so the default schedule is 15s, 30s, 60s.
+    pub capacity_base_delay: Duration,
+    /// Ceiling on one capacity backoff, and on an honored `Retry-After`.
+    /// Defaults to [`CAPACITY_MAX_DELAY_SECS`].
+    pub capacity_max_delay: Duration,
+    /// Ceiling on the sum of every backoff this job sleeps. Once it is spent the
+    /// job stops retrying and reports the last error, whatever
+    /// [`Self::max_attempts`] still allowed. Defaults to
+    /// [`MAX_TOTAL_BACKOFF_SECS`].
+    pub max_total_backoff: Duration,
     /// Hard ceiling on the total wall-clock time one job (all attempts +
     /// backoffs) may run before it is aborted and its pool slot freed.
     ///
@@ -54,8 +115,11 @@ pub struct RetryPolicy {
 impl Default for RetryPolicy {
     fn default() -> Self {
         Self {
-            max_attempts: 4,
-            base_delay: Duration::from_secs(1),
+            max_attempts: DEFAULT_RETRY_ATTEMPTS,
+            base_delay: Duration::from_millis(DEFAULT_RETRY_BASE_DELAY_MS),
+            capacity_base_delay: Duration::from_secs(CAPACITY_BASE_DELAY_SECS),
+            capacity_max_delay: Duration::from_secs(CAPACITY_MAX_DELAY_SECS),
+            max_total_backoff: Duration::from_secs(MAX_TOTAL_BACKOFF_SECS),
             // The unified default inference deadline. A stage's
             // `request_timeout_secs` overrides this per stage (see
             // `pipeline::retry_policy_for`); the providers apply the same value
@@ -104,6 +168,57 @@ fn flatten_request_text(request: &InferenceRequest) -> String {
         parts.push(tool.parameters.to_string());
     }
     parts.join("\n")
+}
+
+/// `base` doubled once per attempt already made: `base * 2^(attempt - 1)`.
+///
+/// Saturating throughout, and the exponent is clamped, so a policy with a large
+/// base or a job that somehow retried thousands of times yields a very long
+/// duration rather than an overflow panic.
+fn exponential(base: Duration, attempt: u32) -> Duration {
+    base.saturating_mul(2u32.saturating_pow(attempt.saturating_sub(1).min(16)))
+}
+
+/// How long to wait before retrying `error`, or `None` to stop and report it.
+///
+/// `attempt` is the attempt that just failed, counting from 1, and `spent` is
+/// the backoff this job has already slept. Pure, so the whole schedule - the
+/// ordinary one, the capacity one, an honored `Retry-After`, and both ceilings -
+/// is asserted in tests without a second of real waiting.
+///
+/// The order of the checks is the policy: a permanent error is never retried, an
+/// exhausted attempt count stops, an exhausted backoff budget stops, and only
+/// then does the kind of failure decide how long to wait.
+fn backoff_after(
+    policy: &RetryPolicy,
+    error: &ProviderError,
+    attempt: u32,
+    spent: Duration,
+) -> Option<Duration> {
+    if !error.is_transient() || attempt >= policy.max_attempts {
+        return None;
+    }
+    // The overall ceiling: once the job has slept its whole budget it stops,
+    // however many attempts were left. This is what guarantees a retrying run
+    // cannot wait forever, whatever a provider's `Retry-After` asks for.
+    let remaining = policy
+        .max_total_backoff
+        .checked_sub(spent)
+        .filter(|left| !left.is_zero())?;
+    let advice = error.retry_advice();
+    let delay = match (advice.capacity, advice.retry_after_secs) {
+        // The provider said when to come back, so come back then.
+        (true, Some(secs)) => Duration::from_secs(secs).min(policy.capacity_max_delay),
+        // At capacity with no hint: the slow schedule, since the window this
+        // failure describes outlasts a blip-sized wait (issue #417).
+        (true, None) => {
+            exponential(policy.capacity_base_delay, attempt).min(policy.capacity_max_delay)
+        }
+        // An ordinary blip - a reset connection, a 500 - keeps the fast
+        // schedule it has always had.
+        (false, _) => exponential(policy.base_delay, attempt),
+    };
+    Some(delay.min(remaining))
 }
 
 /// The completed result of an [`InferenceJob`], applied on a later tick by the
@@ -161,7 +276,10 @@ pub async fn run_inference_job(
     }
     // Retry transient failures (connection reset, timeout, 429, 5xx) with
     // exponential backoff, holding the permit across the backoff; a permanent
-    // error fails immediately. The whole thing is bounded by `job_timeout` so a
+    // error fails immediately. `backoff_after` decides each wait: a capacity
+    // refusal gets the slow schedule or the provider's own `Retry-After`, an
+    // ordinary blip the fast one. The whole thing is bounded by
+    // `max_total_backoff` on the sleeping and by `job_timeout` on the job, so a
     // never-completing (stalled-stream) call cannot hold the pool slot forever.
     //
     // `infer` borrows the request, so every attempt reuses the one assembled
@@ -169,14 +287,18 @@ pub async fn run_inference_job(
     // of every in-flight request for the whole (possibly minutes-long) call.
     let attempts = async {
         let mut attempt = 1u32;
+        let mut spent = Duration::ZERO;
         loop {
             match provider.infer(&request).await {
                 Ok(response) => break Ok(response),
-                Err(e) if e.is_transient() && attempt < retry.max_attempts => {
-                    tokio::time::sleep(retry.base_delay * 2u32.pow(attempt - 1)).await;
-                    attempt += 1;
-                }
-                Err(e) => break Err(e),
+                Err(e) => match backoff_after(&retry, &e, attempt, spent) {
+                    Some(delay) => {
+                        tokio::time::sleep(delay).await;
+                        spent = spent.saturating_add(delay);
+                        attempt += 1;
+                    }
+                    None => break Err(e),
+                },
             }
         }
     };
@@ -326,8 +448,8 @@ mod tests {
             // A job timeout far longer than the test: only the cancel can end it.
             RetryPolicy {
                 max_attempts: 1,
-                base_delay: Duration::ZERO,
                 job_timeout: Duration::from_secs(3600),
+                ..instant()
             },
             cancel.clone(),
         ));
@@ -372,8 +494,8 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let policy = RetryPolicy {
             max_attempts: 1,
-            base_delay: Duration::ZERO,
             job_timeout: Duration::from_millis(50),
+            ..instant()
         };
         run_inference_job(
             job,
@@ -614,6 +736,9 @@ mod tests {
     enum Step {
         Ok(String),
         Transient,
+        /// The reported failure: a 529 the provider reports as a plain API
+        /// error, which is a capacity refusal rather than a blip (issue #417).
+        Overloaded,
         Permanent,
         /// Never returns - a stalled/hung call, for the job-timeout test.
         Hang,
@@ -637,7 +762,12 @@ mod tests {
             let step = self.steps.lock().unwrap().pop_front();
             match step {
                 Some(Step::Ok(t)) => Ok(response(&t)),
-                Some(Step::Transient) => Err(ProviderError::RateLimitExceeded),
+                Some(Step::Transient) => Err(ProviderError::RateLimitExceeded {
+                    retry_after_secs: None,
+                }),
+                Some(Step::Overloaded) => {
+                    Err(ProviderError::ApiError("HTTP 529 Overloaded".to_string()))
+                }
                 Some(Step::Permanent) => Err(ProviderError::Other("permanent".to_string())),
                 Some(Step::Hang) => std::future::pending().await,
                 None => Err(ProviderError::Other("exhausted".to_string())),
@@ -657,11 +787,24 @@ mod tests {
         }
     }
 
+    /// A policy whose every backoff is zero, so a job-level test drives the
+    /// retry *loop* without sleeping. The schedule those durations would have
+    /// been is asserted against `backoff_after` directly, where no sleeping is
+    /// involved at all.
+    fn instant() -> RetryPolicy {
+        RetryPolicy {
+            base_delay: Duration::ZERO,
+            capacity_base_delay: Duration::ZERO,
+            capacity_max_delay: Duration::ZERO,
+            ..RetryPolicy::default()
+        }
+    }
+
     fn no_delay(max_attempts: u32) -> RetryPolicy {
         RetryPolicy {
             max_attempts,
-            base_delay: Duration::ZERO,
             job_timeout: Duration::from_secs(30),
+            ..instant()
         }
     }
 
@@ -738,6 +881,194 @@ mod tests {
         let outcome = rx.try_recv().expect("outcome sent");
         assert!(outcome.result.is_err());
         assert_eq!(*provider.calls.lock().unwrap(), 1); // no retry on a permanent error
+    }
+
+    // ── the retry schedule (issue #417) ──
+    //
+    // Asserted against `backoff_after` rather than by running a job and timing
+    // it: the schedule is minutes long, and a test that slept it would be a test
+    // nobody runs. The job-level tests above drive the same loop with every
+    // delay set to zero, which proves the loop and the schedule separately.
+
+    fn blip() -> ProviderError {
+        ProviderError::RequestFailed("connection reset by peer".to_string())
+    }
+
+    fn overloaded() -> ProviderError {
+        ProviderError::ApiError("HTTP 529 Overloaded".to_string())
+    }
+
+    #[test]
+    fn an_ordinary_blip_keeps_the_fast_schedule() {
+        // The common case must not get slower: 1s, 2s, 4s, then give up on the
+        // fourth attempt.
+        let policy = RetryPolicy::default();
+        let spent = Duration::ZERO;
+        assert_eq!(
+            backoff_after(&policy, &blip(), 1, spent),
+            Some(Duration::from_secs(1))
+        );
+        assert_eq!(
+            backoff_after(&policy, &blip(), 2, spent),
+            Some(Duration::from_secs(2))
+        );
+        assert_eq!(
+            backoff_after(&policy, &blip(), 3, spent),
+            Some(Duration::from_secs(4))
+        );
+        assert_eq!(backoff_after(&policy, &blip(), 4, spent), None);
+    }
+
+    #[test]
+    fn an_overload_waits_long_enough_to_leave_the_window() {
+        // The reported bug: three retries of 1s, 2s and 4s all landed inside the
+        // same 529 window, so a run with 44 iterations of finished work was
+        // failed after seven seconds of trying. The capacity schedule is 15s,
+        // 30s, 60s instead - 105 seconds of waiting on the same four attempts.
+        let policy = RetryPolicy::default();
+        let spent = Duration::ZERO;
+        assert_eq!(
+            backoff_after(&policy, &overloaded(), 1, spent),
+            Some(Duration::from_secs(15))
+        );
+        assert_eq!(
+            backoff_after(&policy, &overloaded(), 2, spent),
+            Some(Duration::from_secs(30))
+        );
+        // Capped, rather than the 60s the doubling would reach on its own; the
+        // next attempt would ask for 120s and gets the same minute.
+        assert_eq!(
+            backoff_after(&policy, &overloaded(), 3, spent),
+            Some(Duration::from_secs(60))
+        );
+        // A rate limit with no hint is the same kind of failure and waits the
+        // same way.
+        assert_eq!(
+            backoff_after(
+                &policy,
+                &ProviderError::RateLimitExceeded {
+                    retry_after_secs: None
+                },
+                1,
+                spent
+            ),
+            Some(Duration::from_secs(15))
+        );
+    }
+
+    #[test]
+    fn the_servers_own_answer_wins_and_is_capped() {
+        let policy = RetryPolicy::default();
+        let hint = |secs| ProviderError::RateLimitExceeded {
+            retry_after_secs: Some(secs),
+        };
+        // Told to come back in three seconds, come back in three - not the 15
+        // the schedule would have picked. This is what keeps a provider that
+        // answers precisely fast.
+        assert_eq!(
+            backoff_after(&policy, &hint(3), 1, Duration::ZERO),
+            Some(Duration::from_secs(3))
+        );
+        // An hour is not honored: one header may not park a run indefinitely.
+        assert_eq!(
+            backoff_after(&policy, &hint(3600), 1, Duration::ZERO),
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn a_permanent_error_is_never_retried() {
+        assert_eq!(
+            backoff_after(
+                &RetryPolicy::default(),
+                &ProviderError::TokenLimitExceeded { used: 9, max: 8 },
+                1,
+                Duration::ZERO
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn the_total_backoff_ceiling_bounds_however_long_a_provider_asks_for() {
+        // The promise the config docs make: whatever the attempts, the schedule
+        // and the provider's hints add up to, one request's retries sleep at
+        // most `max_total_backoff`.
+        let policy = RetryPolicy {
+            max_attempts: 100,
+            ..RetryPolicy::default()
+        };
+        // Most of the budget already slept: the next wait is trimmed to what is
+        // left rather than the full minute it would have been.
+        assert_eq!(
+            backoff_after(
+                &policy,
+                &overloaded(),
+                5,
+                policy.max_total_backoff - Duration::from_secs(2)
+            ),
+            Some(Duration::from_secs(2))
+        );
+        // Budget spent: stop, with attempts still on the clock.
+        assert_eq!(
+            backoff_after(&policy, &overloaded(), 5, policy.max_total_backoff),
+            None
+        );
+        assert_eq!(
+            backoff_after(
+                &policy,
+                &overloaded(),
+                5,
+                policy.max_total_backoff + Duration::from_secs(1)
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn a_long_schedule_saturates_rather_than_overflowing() {
+        // A large base and a high attempt count must not panic in a release
+        // build's arithmetic or wrap in a debug one; the ceiling catches the
+        // result either way.
+        let policy = RetryPolicy {
+            max_attempts: u32::MAX,
+            base_delay: Duration::from_secs(u64::MAX / 2),
+            ..RetryPolicy::default()
+        };
+        assert_eq!(
+            backoff_after(&policy, &blip(), u32::MAX - 1, Duration::ZERO),
+            Some(policy.max_total_backoff)
+        );
+    }
+
+    #[tokio::test]
+    async fn run_job_retries_an_overloaded_provider() {
+        // End to end through the loop: a 529 is retried, not reported. The
+        // policy's waits are zero here so the test costs nothing; how long they
+        // would have been is asserted above.
+        let provider = Arc::new(Scripted {
+            steps: std::sync::Mutex::new(
+                vec![
+                    Step::Overloaded,
+                    Step::Overloaded,
+                    Step::Ok("survived the overload".to_string()),
+                ]
+                .into(),
+            ),
+            calls: std::sync::Mutex::new(0),
+        });
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        run_inference_job(
+            job(provider.clone()),
+            tx,
+            Arc::new(Notify::new()),
+            no_delay(4),
+            crate::cancel::CancelToken::new(),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        assert_eq!(outcome.result.unwrap().content, "survived the overload");
+        assert_eq!(*provider.calls.lock().unwrap(), 3);
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -109,7 +109,10 @@ pub use embed::{
 };
 pub use fanout::{FanOutSpawner, FanOutSpawnerRes};
 pub use host::{ControlOp, SpawnArgs, WorldEvent, WorldHost};
-pub use inference_bridge::RetryPolicy;
+pub use inference_bridge::{
+    CAPACITY_BASE_DELAY_SECS, CAPACITY_MAX_DELAY_SECS, DEFAULT_RETRY_ATTEMPTS,
+    DEFAULT_RETRY_BASE_DELAY_MS, MAX_TOTAL_BACKOFF_SECS, RetryPolicy,
+};
 pub use inference_pool::{InferencePoolConfig, InferencePools};
 pub use interaction_hub::InteractionHub;
 pub use pipeline::{ModelDefaults, ResolvedStage, ToolService, is_stage_specific};

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -138,15 +138,26 @@ pub(crate) fn build_request(
     }
 }
 
-/// Build the [`RetryPolicy`] for a job, applying a stage's per-stage inference
-/// wall-clock cap when configured. Starts from the default policy and, when the
-/// stage set `request_timeout_secs` (from `[stages.<name>.model]`), overrides its
-/// `job_timeout`; otherwise the default job timeout stands. Pure so the override
-/// branch is unit-testable without driving the ECS dispatch.
+/// Build the [`RetryPolicy`] for a job from the operator's `[limits]` retry
+/// schedule, applying a stage's per-stage inference wall-clock cap when
+/// configured.
+///
+/// `tuning` carries the two configurable numbers (`[limits]
+/// inference_retry_attempts` and `inference_retry_base_ms`); everything else -
+/// the capacity schedule and the total-backoff ceiling - comes from the default
+/// policy. When the stage set `request_timeout_secs` (from
+/// `[stages.<name>.model]`) that overrides `job_timeout`; otherwise the default
+/// job timeout stands. Pure so both branches are unit-testable without driving
+/// the ECS dispatch.
 pub(crate) fn retry_policy_for(
     config: Option<&InferenceConfig>,
+    tuning: InferenceRetryTuning,
 ) -> crate::inference_bridge::RetryPolicy {
-    let mut policy = crate::inference_bridge::RetryPolicy::default();
+    let mut policy = crate::inference_bridge::RetryPolicy {
+        max_attempts: tuning.max_attempts,
+        base_delay: std::time::Duration::from_millis(tuning.base_delay_ms),
+        ..crate::inference_bridge::RetryPolicy::default()
+    };
     if let Some(secs) = config.and_then(|c| c.request_timeout_secs) {
         policy.job_timeout = std::time::Duration::from_secs(secs);
     }
@@ -225,6 +236,7 @@ pub fn dispatch_inference(
     providers: Res<Providers>,
     circuits: Option<Res<ProviderCircuits>>,
     policy: Option<Res<CircuitPolicy>>,
+    retry: Option<Res<InferenceRetryTuning>>,
     par_commands: ParallelCommands,
 ) {
     // Fan out across ready agents: request assembly (`build_request`) is the
@@ -242,6 +254,9 @@ pub fn dispatch_inference(
     crate::tick_scope::clear();
     let now = chrono::Utc::now().timestamp();
     let circuit_policy = policy.map(|p| *p).unwrap_or_default();
+    // The daemon inserts this from `[limits]`; a world that never set it (every
+    // embedded host, and most tests) gets the built-in schedule.
+    let retry_tuning = retry.map(|r| *r).unwrap_or_default();
     let circuits = circuits.as_deref();
     agents.par_iter().for_each(
         |(entity, state, window, config, si, in_flight, progress, stalled)| {
@@ -321,7 +336,7 @@ pub fn dispatch_inference(
                         job,
                         stage.outcomes.clone(),
                         stage.wake.clone(),
-                        retry_policy_for(config),
+                        retry_policy_for(config, retry_tuning),
                         cancel.clone(),
                     ),
                     move |message| {

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -131,6 +131,36 @@ pub struct StageInference {
 #[derive(Resource)]
 pub struct Providers(pub ProviderRegistry);
 
+/// The operator's retry schedule for inference, from `[limits]`.
+///
+/// A world resource rather than constants because the daemon serves it from
+/// `[limits] inference_retry_attempts` and `inference_retry_base_ms`. Absent
+/// means the built-in schedule, which is what these defaults are.
+///
+/// Only the two ordinary-failure numbers are configurable. The capacity
+/// schedule and the total-backoff ceiling stay fixed (see
+/// [`crate::inference_bridge::RetryPolicy`]): they exist to bound a provider
+/// outage, and a bound an operator can raise without limit is not one.
+#[derive(Resource, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InferenceRetryTuning {
+    /// Total attempts including the first. See
+    /// [`crate::inference_bridge::RetryPolicy::max_attempts`].
+    pub max_attempts: u32,
+    /// The first backoff after an ordinary transient failure, in milliseconds,
+    /// doubling per retry. See
+    /// [`crate::inference_bridge::RetryPolicy::base_delay`].
+    pub base_delay_ms: u64,
+}
+
+impl Default for InferenceRetryTuning {
+    fn default() -> Self {
+        Self {
+            max_attempts: crate::inference_bridge::DEFAULT_RETRY_ATTEMPTS,
+            base_delay_ms: crate::inference_bridge::DEFAULT_RETRY_BASE_DELAY_MS,
+        }
+    }
+}
+
 /// The plumbing the inference-dispatch system needs: the per-model pools, the
 /// channel to report outcomes on, the tick wake handle, and a runtime handle to
 /// spawn the (bounded, per-request) worker tasks onto.

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -179,9 +179,10 @@ pub fn reflect_interaction_status(
 /// Position used to stand in for "has run", which is only true of a linear
 /// blueprint. A graph reaches its stages in whatever order its edges describe,
 /// so every branch the run went past without taking was filed as `Complete`
-/// with an empty `region_tokens` - and since that map is a snapshot, an empty
-/// one in the middle of the sequence made the next real stage appear to have
-/// written every region from nothing (#372).
+/// with an empty `region_tokens` - and since that map holds the high-water mark
+/// each region reached rather than what the stage itself added, an empty one in
+/// the middle of the sequence made the next real stage appear to have written
+/// every region from nothing (#372).
 ///
 /// `started_at`/`ended_at` are stamped once and never overwritten, so repeated
 /// calls are idempotent.

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -152,6 +152,11 @@ pub fn collect_inference(
                     // number that is neither what it costs per call nor what it
                     // holds. The largest it reached is the one that says
                     // whether it is earning its place.
+                    //
+                    // Every region the window carries, not only the ones this
+                    // stage assembles: a stage layout hides the regions it does
+                    // not declare rather than dropping them, and they are
+                    // recorded here all the same.
                     for region in window.iter().flat_map(|w| w.regions.iter()) {
                         let seen = rec.region_tokens.entry(region.name.clone()).or_insert(0);
                         *seen = (*seen).max(region.current_tokens);

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -451,6 +451,32 @@ async fn dispatch_moves_agent_to_awaiting_and_runs_the_job() {
     assert!(outcome.result.is_ok());
 }
 
+/// The daemon's `[limits]` retry schedule reaches a dispatched job. A world
+/// that never inserts the resource takes the built-in one, which every other
+/// dispatch test here exercises (issue #417).
+#[tokio::test]
+async fn dispatch_uses_the_configured_retry_schedule() {
+    let (mut world, mut rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
+    world.insert_resource(InferenceRetryTuning {
+        max_attempts: 2,
+        base_delay_ms: 5,
+    });
+    let e = world
+        .spawn((
+            agent_state(),
+            window(),
+            stage("m", vec![], None),
+            ReadyToInfer,
+        ))
+        .id();
+
+    run(&mut world);
+
+    assert!(world.get::<AwaitingInference>(e).is_some());
+    let outcome = rx.recv().await.expect("outcome");
+    assert!(outcome.result.is_ok());
+}
+
 #[tokio::test]
 async fn dispatch_skips_when_pool_full() {
     let mut cfg = InferencePoolConfig::new();
@@ -1555,6 +1581,54 @@ fn dispatch_persistence_emits_stage_index_and_drains_io_buffer() {
     assert_eq!(job.log_appends, vec![(0, "[tool] x: y".to_string())]);
     // The buffer was drained in place.
     assert!(world.get::<StageIoBuffer>(e).unwrap().output.is_empty());
+}
+
+/// The persist tick rewrites `stages.json` whole, so what the reload leaves in
+/// the ledger is what lands on disk. A reload that left the spawn-seeded zeros
+/// there did not merely lose the run's stage history, it erased the copy that
+/// was still on disk (issue #415).
+#[test]
+fn a_restored_ledger_reaches_the_persist_tick_instead_of_the_seeded_zeros() {
+    let (mut world, mut rx) = world_with_persistence();
+    let e = world
+        .spawn((
+            run_metadata(),
+            agent_state(),
+            conv_window(),
+            StageCursor { index: 1 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            // What `spawn_agent` seeds: names and nothing else.
+            ledger2(),
+        ))
+        .id();
+
+    // The reload as it was: no ledger restore, so the tick ships zeros over the
+    // real record of the run's first stage.
+    run_dispatch_persistence(&mut world);
+    let before = snapshot_job(rx.try_recv().expect("job sent"));
+    assert_eq!(before.stages[0].prompt_tokens, 0);
+
+    // The reload as it is: the persisted records go back on first.
+    let mut plan = leviath_core::run_meta::StageRecord::new("plan".to_string(), 0);
+    plan.entered = true;
+    plan.prompt_tokens = 4_096;
+    plan.completion_tokens = 128;
+    crate::restore::restore_stage_ledger(&mut world, e, &[plan]);
+    world
+        .get_mut::<PersistWatermark>(e)
+        .expect("watermark present")
+        .backdate(0);
+
+    run_dispatch_persistence(&mut world);
+    let after = snapshot_job(rx.try_recv().expect("job sent"));
+    assert_eq!(after.stages[0].prompt_tokens, 4_096);
+    assert_eq!(after.stages[0].completion_tokens, 128);
+    assert_eq!(
+        after.stages[0].status,
+        leviath_core::run_meta::StageRunStatus::Complete,
+        "a stage the run had entered and left reconciles as complete, not skipped"
+    );
 }
 
 /// Every snapshot carries the answer's bytes whenever the agent holds them.
@@ -6337,9 +6411,13 @@ fn stage_setup_from_threads_request_timeout() {
 #[test]
 fn retry_policy_for_overrides_job_timeout_when_set() {
     let default = crate::inference_bridge::RetryPolicy::default();
+    let tuning = InferenceRetryTuning::default();
 
     // No config at all → default policy unchanged.
-    assert_eq!(retry_policy_for(None).job_timeout, default.job_timeout);
+    assert_eq!(
+        retry_policy_for(None, tuning).job_timeout,
+        default.job_timeout
+    );
 
     // Config present but no per-stage timeout → default still stands.
     let cfg_none = InferenceConfig {
@@ -6347,7 +6425,7 @@ fn retry_policy_for_overrides_job_timeout_when_set() {
         ..Default::default()
     };
     assert_eq!(
-        retry_policy_for(Some(&cfg_none)).job_timeout,
+        retry_policy_for(Some(&cfg_none), tuning).job_timeout,
         default.job_timeout
     );
 
@@ -6357,10 +6435,44 @@ fn retry_policy_for_overrides_job_timeout_when_set() {
         request_timeout_secs: Some(120),
         ..Default::default()
     };
-    let policy = retry_policy_for(Some(&cfg_some));
+    let policy = retry_policy_for(Some(&cfg_some), tuning);
     assert_eq!(policy.job_timeout, std::time::Duration::from_secs(120));
     assert_eq!(policy.max_attempts, default.max_attempts);
     assert_eq!(policy.base_delay, default.base_delay);
+}
+
+/// The `[limits]` retry schedule reaches the policy, and reaches only the two
+/// numbers it owns: the capacity backoff and the total-backoff ceiling are the
+/// runtime's own bound on a provider outage and are not an operator's to raise
+/// (issue #417).
+#[test]
+fn retry_policy_for_takes_the_configured_schedule() {
+    let default = crate::inference_bridge::RetryPolicy::default();
+    let policy = retry_policy_for(
+        None,
+        InferenceRetryTuning {
+            max_attempts: 9,
+            base_delay_ms: 250,
+        },
+    );
+    assert_eq!(policy.max_attempts, 9);
+    assert_eq!(policy.base_delay, std::time::Duration::from_millis(250));
+    assert_eq!(policy.capacity_base_delay, default.capacity_base_delay);
+    assert_eq!(policy.capacity_max_delay, default.capacity_max_delay);
+    assert_eq!(policy.max_total_backoff, default.max_total_backoff);
+}
+
+/// An unset resource is the shipped schedule, so an embedded host that never
+/// inserts one behaves exactly as the daemon's default config does.
+#[test]
+fn the_default_retry_tuning_is_the_shipped_schedule() {
+    let default = crate::inference_bridge::RetryPolicy::default();
+    let tuning = InferenceRetryTuning::default();
+    assert_eq!(tuning.max_attempts, default.max_attempts);
+    assert_eq!(
+        std::time::Duration::from_millis(tuning.base_delay_ms),
+        default.base_delay
+    );
 }
 
 #[test]

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -3,7 +3,8 @@
 //!
 //! When the daemon restarts, the CLI reloads each non-terminal run's blueprint
 //! and spawns a fresh agent, then calls [`restore_agent`] to overlay the persisted
-//! context, jump to the persisted stage + iteration, and restore token totals. The
+//! context, jump to the persisted stage + iteration, and restore token totals,
+//! plus [`restore_stage_ledger`] for the run's per-stage history. The
 //! agent keeps the `ReadyToInfer` marker `spawn_agent` set, so **any inference
 //! that was in flight when the daemon stopped is re-issued** on the next tick -
 //! nothing is left stuck awaiting a job that died with the old process.
@@ -190,6 +191,43 @@ pub fn restore_agent(
         state.status = AgentStatus::Active;
     }
     world.entity_mut(entity).insert(totals);
+}
+
+/// Put the persisted per-stage ledger back on a just-spawned `entity`, matching
+/// `records` (as read from the run's `stages.json`) onto the blueprint-seeded
+/// [`StageLedger`](crate::pipeline::StageLedger) **by stage name**.
+///
+/// Nothing else rebuilds this. `spawn_agent` seeds one all-zero record per
+/// blueprint stage, so without this a reloaded run came back with no tokens, no
+/// `entered` flags and no timestamps against any stage - and since the persist
+/// tick writes the whole ledger, the next one wrote those zeros over the real
+/// `stages.json`. The run-level totals in `meta.json` survived that, so the run
+/// looked healthy while `lev stages` and the stages API served zeroed records
+/// (issue #415).
+///
+/// The seeded shape wins: a persisted record whose stage the blueprint no longer
+/// has is dropped, and a stage with no persisted record keeps its zeroed one.
+/// Matching on name rather than position is what keeps a blueprint that gained
+/// or lost a stage from filing one stage's history under another; the seeded
+/// `index` is kept for the same reason.
+///
+/// Call after [`restore_agent`]. An agent without a ledger (a test world, or one
+/// spawned outside the blueprint path) is left alone.
+pub fn restore_stage_ledger(
+    world: &mut World,
+    entity: Entity,
+    records: &[leviath_core::run_meta::StageRecord],
+) {
+    let Some(mut ledger) = world.get_mut::<crate::pipeline::StageLedger>(entity) else {
+        return;
+    };
+    for rec in ledger.0.iter_mut() {
+        if let Some(saved) = records.iter().find(|saved| saved.name == rec.name) {
+            let index = rec.index;
+            *rec = saved.clone();
+            rec.index = index;
+        }
+    }
 }
 
 /// The synthesized result for a call whose completion never reached the journal.
@@ -446,6 +484,71 @@ mod tests {
         let taint = region.taint.as_ref().unwrap();
         assert_eq!(taint.entry_taint(0), Some(TaintLevel::Private));
         assert_eq!(taint.entry_taint(1), Some(TaintLevel::Public));
+    }
+
+    /// The per-stage ledger was the one piece of persisted state nothing
+    /// rebuilt, so a reloaded run came back with every stage at zero - and
+    /// because the persist tick rewrites `stages.json` whole, the next one
+    /// wrote those zeros over the run's real history (issue #415).
+    #[test]
+    fn restore_stage_ledger_overlays_the_persisted_records_by_name() {
+        use crate::pipeline::StageLedger;
+        use leviath_core::run_meta::{StageRecord, StageRunStatus};
+
+        let (mut world, entity) = agent_world();
+        // An agent with no ledger at all is left alone rather than panicking.
+        restore_stage_ledger(&mut world, entity, &[StageRecord::new("s0".to_string(), 0)]);
+        assert!(world.get::<StageLedger>(entity).is_none());
+
+        world.entity_mut(entity).insert(StageLedger(vec![
+            StageRecord::new("s0".to_string(), 0),
+            StageRecord::new("s1".to_string(), 1),
+        ]));
+        // `s1` as the run left it, filed under a stale index; plus a record for
+        // a stage this blueprint no longer has.
+        let mut saved = StageRecord::new("s1".to_string(), 4);
+        saved.status = StageRunStatus::Complete;
+        saved.entered = true;
+        saved.prompt_tokens = 900;
+        saved.completion_tokens = 30;
+        saved.cached_tokens = 12;
+        saved.cache_write_tokens = 4;
+        saved.first_call_prompt_tokens = Some(300);
+        saved.runaway_warned = true;
+        saved.region_tokens.insert("conversation".to_string(), 120);
+        saved.started_at = Some(5);
+        saved.ended_at = Some(9);
+        restore_stage_ledger(
+            &mut world,
+            entity,
+            &[saved, StageRecord::new("removed".to_string(), 9)],
+        );
+
+        let ledger = world.get::<StageLedger>(entity).unwrap();
+        assert_eq!(
+            ledger.0.len(),
+            2,
+            "a record for a stage the blueprint no longer has is dropped, not appended"
+        );
+        // Nothing persisted against `s0`: its seeded record stands.
+        assert_eq!(ledger.0[0].prompt_tokens, 0);
+        assert_eq!(ledger.0[0].status, StageRunStatus::Pending);
+        assert!(!ledger.0[0].entered);
+        // `s1` comes back whole, under its blueprint index rather than the
+        // stale persisted one.
+        assert_eq!(ledger.0[1].index, 1);
+        assert_eq!(ledger.0[1].name, "s1");
+        assert_eq!(ledger.0[1].prompt_tokens, 900);
+        assert_eq!(ledger.0[1].completion_tokens, 30);
+        assert_eq!(ledger.0[1].cached_tokens, 12);
+        assert_eq!(ledger.0[1].cache_write_tokens, 4);
+        assert_eq!(ledger.0[1].first_call_prompt_tokens, Some(300));
+        assert!(ledger.0[1].runaway_warned);
+        assert_eq!(ledger.0[1].region_tokens.get("conversation"), Some(&120));
+        assert_eq!(ledger.0[1].started_at, Some(5));
+        assert_eq!(ledger.0[1].ended_at, Some(9));
+        assert_eq!(ledger.0[1].status, StageRunStatus::Complete);
+        assert!(ledger.0[1].entered);
     }
 
     #[test]

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -121,6 +121,8 @@ wedge_timeout_secs        = 0    # fail a run nothing can reach any more; 0 is o
 provider_failures_before_open  = 3     # pull a provider after this many failures in a row
 provider_circuit_cooldown_secs = 300   # how long before it is tried again
 interaction_timeout_secs  = 3600 # release a prompt nobody answered
+inference_retry_attempts  = 4    # tries per inference, the first one included
+inference_retry_base_ms   = 1000 # first retry wait for an ordinary blip; it doubles
 max_tool_call_write_bytes = 2147483648   # 2 GiB; delete the line for no limit
 max_run_write_bytes       = 10737418240  # 10 GiB; delete the line for no limit
 ```
@@ -140,10 +142,12 @@ max_run_write_bytes       = 10737418240  # 10 GiB; delete the line for no limit
 | `provider_failures_before_open` | `3` | Failures in a row before a provider is pulled. See below |
 | `provider_circuit_cooldown_secs` | `300` | How long a pulled provider waits before one request tests it. A success restores it, a failure restarts the wait |
 | `interaction_timeout_secs` | `3600` | How long a prompt may go unanswered. See below |
+| `inference_retry_attempts` | `4` | Tries per inference, the first included. See below |
+| `inference_retry_base_ms` | `1000` | First retry wait for an ordinary blip, doubling each retry. See below |
 | `max_tool_call_write_bytes` | unset | Most one tool call may write. See below |
 | `max_run_write_bytes` | unset | Most a whole run may write. See below |
 
-Seven of those need more than a table cell.
+Eight of those need more than a table cell.
 
 **`exact_token_counting`** measures each assembled request before sending it and refuses one that
 would overflow the window. On providers with a remote counting endpoint that costs a network round
@@ -168,6 +172,22 @@ outside Leviath is tracking your slots. See [External work queues](/docs/work-qu
 or a rejected key, before that provider is taken out of service for every run. Three rather than one,
 because a single payment error can just be one oversized request. `0` disables it and leaves per-run
 failover to cope alone.
+
+**`inference_retry_attempts`** and **`inference_retry_base_ms`** set how hard a failed model call
+is retried before the agent is failed and its finished work is thrown away. Only a *transient*
+failure is retried at all: a reset connection, a timeout, a 429, a 5xx. A rejected key or an
+over-long request fails on the first answer, because the second would be the same.
+
+There are two schedules, and only the blip one is configurable. An ordinary blip waits
+`inference_retry_base_ms` and doubles, so the default four attempts are 1s, 2s, 4s. A **capacity**
+refusal - a 429, or Anthropic's 529 "overloaded" - waits 15s, 30s, then 60s per further attempt
+instead, because an overload window lasts minutes and a second of waiting only buys another refusal.
+When the provider sends a `Retry-After`, that answer wins over both, capped at a minute.
+
+Raising `inference_retry_attempts` is therefore how a run rides out a longer outage: `6` gives a
+capacity failure about four minutes of waiting rather than about one and a half. Whatever you set,
+the retries of a single request sleep **at most five minutes in total**, and the request itself is
+still bounded by its stage's `request_timeout_secs`, so a run can never wait indefinitely.
 
 **`interaction_timeout_secs`** puts a deadline on any prompt that waits on a person: `ask_user_*`,
 tool approvals, taint gates, and interaction points. When it expires the daemon resolves the prompt

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -39,6 +39,8 @@ wedge_timeout_secs = 0
 provider_failures_before_open = 3
 provider_circuit_cooldown_secs = 300
 interaction_timeout_secs = 3600
+inference_retry_attempts = 4
+inference_retry_base_ms = 1000
 # How much an agent may write to disk. Unset in code and written by `lev setup`:
 # delete either line to remove that limit. Running out of disk is refused
 # separately and is not configurable.

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -162,6 +162,18 @@
           "default": 3600,
           "description": "How long a prompt waits for a person before resolving as cancelled. `0` waits forever. This is what releases an interaction point that holds under --yolo, so the default means such a run sits for an hour looking dead."
         },
+        "inference_retry_attempts": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 4,
+          "description": "How many times an inference is attempted, the first try included, before the agent is failed. Only transient failures are retried. `1` turns retrying off. A provider overload (429, or Anthropic's 529) uses a slower schedule of 15s, 30s, then 60s per further attempt, so raising this is how a run rides out a longer outage. The retries of one request may sleep at most five minutes in total whatever this is set to."
+        },
+        "inference_retry_base_ms": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 1000,
+          "description": "The wait before the first inference retry, in milliseconds, doubling for each retry after it. This is the schedule for ordinary blips such as a reset connection or a 500; a provider overload does not use it."
+        },
         "max_tool_call_write_bytes": {
           "type": "integer",
           "minimum": 0,


### PR DESCRIPTION
Fixes the three newer `automate` issues: #415, #417, #418. One commit, because their tests share `pipeline/tests.rs` and split commits would not compile standalone.

## #415 - a restored run's stage ledger restarted at zero
Diagnosis confirmed: nothing rebuilt a `StageLedger` on restore, so a paged-in run read zero for every stage and the next persist tick wrote those zeros over the real `stages.json`. Run-level totals survived, so the run looked healthy while its per-stage history was gone.

Restore now overlays the persisted records onto the blueprint-seeded ledger **by stage name**, keeping the seeded index; a record for a stage the blueprint no longer has is dropped, a stage with no record keeps its zeroed one.

Two corrections to the report: the on-disk writer is `persistence_bridge.rs` (the cited `runstate.rs` function is `#[cfg(test)]`), and the loss hit on-demand page-in too, not only daemon restarts.

Proven with a failing-first test (`left: 0, right: 1234`) plus a discriminating pair that dispatches zeros before the restore call and real numbers after. The reporter's `region_tokens` note is addressed as documentation only: the stale "a snapshot" comment now says it is a high-water mark over every region the window carries, hidden ones included. The behaviour is unchanged, since changing it needs sign-off.

## #417 - a 529 outlasted the hardcoded 7 seconds of retry
Diagnosis confirmed, with one addition: `Retry-After` *was* already parsed in `check_http_response`, but only fed the client-side rate limiter and was then dropped before the retry loop could see it.

- Capacity refusals (429/529/overloaded) now back off 15s / 30s / 60s instead of 1s / 2s / 4s: about 105s of ride-out on the default four attempts rather than 7s. A 500/502/503/504 stays an ordinary blip on the old fast schedule.
- `Retry-After` is honoured verbatim when sent, clamped to 60s, so `retry-after: 1` still retries fast.
- A cumulative 300s ceiling per job bounds the total wait, and the job timeout still bounds everything.
- New `[limits] inference_retry_attempts` and `inference_retry_base_ms`, defaulting to today's 4 and 1000 so nothing changes for anyone who does not set them. Example config, JSON schema, and configuration docs updated together for the lockstep test.

Suggestion 3 (routing exhausted retries into `error_recovery`) is deliberately **not** done: it changes run control flow and wants its own decision.

**API note for library consumers:** `ProviderError::RateLimitExceeded` becomes a struct variant carrying `retry_after_secs`. `ProviderError` is not `#[non_exhaustive]`, so this is source-breaking for an external crate that pattern-matches that variant. Display text is unchanged.

## #418 - structured agents re-billed their whole volatile tier
The runtime never placed system breakpoints at all: the Anthropic provider derives them, one per run of same-hint blocks. With a single `UntilChanged` run, the only breakpoint sat at the **end** of the tier, so a mutation anywhere inside it re-billed every block behind it as a cache write. That is exactly the reported 5-20x write-to-read ratio.

The blocks from the most recently changed one onward now carry a distinct `RecentlyChanged` hint, which makes the unchanged head its own cache entry.

Scoped deliberately to metadata only:
- **Block order and text are untouched.** The retag runs strictly after the sort and writes only `cache_hint`, and the new variant carries the same sort priority as `UntilChanged`. It therefore cannot change what the model reads, only what is cached.
- The four-breakpoint ceiling is guarded three ways: the split is refused when the system blocks already claim three runs, splitting one run adds exactly one, and the provider caps at four regardless.
- It is a **no-op** when all regions share a timestamp, which is why the pre-existing runtime tests pass unchanged.

The reporter's other two directions (routing tool results into the message lane, reordering blocks by mutation frequency) both change what the model reads and stay open on the issue for a measured pass.

**This fix cannot be measured in this repository** - proving a cache-write improvement needs a real provider account and the reporter's separate benchmark harness. It is shipped on the grounds that it is safe by construction, not on a measured number, and no code comment claims otherwise.

## Validation
- Full workspace suite: **7417 passed, 0 failed**.
- `cargo clippy --all-targets --all-features -D warnings`, `cargo xtask docs`, `cargo xtask structure`: clean.
- Coverage gate at 100% for all four touched crates (`leviath-core`, `leviath-providers`, `leviath-runtime`, `leviath-cli`), each run serially - concurrent `llvm-cov` runs clobber a shared `target/llvm-cov-target`.
- Not exercised against a live provider: #417's capacity path needs a real 529 and #418's effect needs cache metrics, so both rest on unit tests and construction.

Closes #415, closes #417, closes #418.
