### PR TITLE
ci: build the feature-off path so it stops rotting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,35 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+  # Optional features, with every one of them off. Every other job here builds
+  # with `--all-features`, so the configuration an embedder actually gets was
+  # the one configuration nothing compiled. It had already rotted: a doc
+  # comment in ungated code linked into the feature-gated `control_socket`
+  # module, so `cargo doc -p leviath-runtime` failed for anyone who ran it
+  # outside the workspace.
+  #
+  # `-p <crate>` rather than `--workspace` is the whole point. A workspace
+  # build unifies features, and `leviath-cli` turns `control-socket` on, which
+  # is exactly how the off path stayed invisible.
+  default-features:
+    name: Build with default features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        with:
+          toolchain: stable
+      - name: Check the runtime without its optional features
+        run: cargo check -p leviath-runtime --all-targets
+      - name: Check the facade without its optional features
+        run: cargo check -p leviath
+      # The rot this job exists to catch was in the docs, not the build, so
+      # checking only compilation would not have caught it.
+      - name: Document the runtime without its optional features
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc -p leviath-runtime --no-deps
+
   # Supply chain. Leviath ships a binary that executes model-chosen tool calls on
   # a user's machine, so its ~370 transitive crates are part of the attack
   # surface. This job is what makes that graph reviewable:

--- a/crates/leviath-runtime/src/host/types.rs
+++ b/crates/leviath-runtime/src/host/types.rs
@@ -92,10 +92,12 @@ pub struct SpawnArgs {
     pub output: Option<leviath_core::output::OutputSpec>,
 }
 
-/// One row of a run listing ([`ControlRequest::List`]): a live run, its status,
+/// One row of a run listing (`ControlRequest::List`): a live run, its status,
 /// and enough context to judge whether that status is a problem.
 ///
-/// [`ControlRequest::List`]: crate::control_socket::ControlRequest::List
+/// The request type is named rather than linked because it lives behind the
+/// `control-socket` feature while this type does not, and an intra-doc link
+/// into a module that may not be compiled fails the docs build.
 ///
 /// `lev ps` used to be a run id and a status word, which is why issue #184
 /// happened: `waiting` on its own says nothing about whether a person is needed,


### PR DESCRIPTION
Keeps the `control-socket` feature flag, and makes it mean something.

## Why
The flag is defensible: `lev` always ships the control socket (`leviath-cli` enables it unconditionally), and it exists so an embedder driving `AgentWorld` in-process does not compile a daemon transport plus a `rand` dependency it will never call. It is also a single clean gate - exactly one `#[cfg(feature = "control-socket")]` in the tree.

The problem was that nothing enforced it. Every CI job builds `--all-features`, including the per-package coverage jobs, so the configuration an embedder actually gets was the one configuration nothing ever compiled. It had already rotted: `host/types.rs` is ungated but its doc comment linked into the gated module, so

```
cargo doc -p leviath-runtime
error: unresolved link to `crate::control_socket::ControlRequest::List`
   = no item named `control_socket` in module `leviath_runtime`
```

failed for anyone running it outside the workspace. This was pre-existing on main, not from the 0.3.7 work; it surfaced while diagnosing an unrelated docs failure.

## What
- The link is now a plain name with a comment saying why it is not a link. Gating the link with `cfg_attr` would leave the shorthand unresolved in the off build, which is the same failure again.
- A new `Build with default features` job checks and documents `leviath-runtime` and `leviath` with their optional features off.

It builds **and documents**, because the rot was in the docs and a compile check alone would have sailed past it. It uses `-p <crate>` rather than `--workspace` deliberately: a workspace build unifies features and `leviath-cli` turns `control-socket` on, which is exactly how this stayed invisible.

## Validation
Both new commands verified locally: `cargo check -p leviath-runtime --all-targets` and `cargo check -p leviath` are clean, and `cargo doc -p leviath-runtime --no-deps` under `-D warnings` now passes where it failed before this change. The full pre-commit suite (fmt, clippy, workspace docs, ast-grep, structure) passed on the commit.
