### PR TITLE
ci(prod): tell leviath.dev when stable ships

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -360,6 +360,32 @@ jobs:
   # the tap has to be told what just shipped, or `brew upgrade` never fires.
   # Its own job, not a step on `deploy`: a failure here must be loud without
   # retroactively failing a release that did publish.
+  notify-site:
+    name: Refresh leviath.dev
+    needs: [deploy, check-beta]
+    if: needs.check-beta.outputs.skip != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to leviath.dev
+        env:
+          # Same token and the same reason as the tap bump below: GITHUB_TOKEN is
+          # scoped to this repo, so reaching another one needs the PAT. It only
+          # needs leviath.dev added to its repository access (Contents: read and
+          # write, which is what a dispatch requires) - no new secret.
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          VERSION: ${{ needs.check-beta.outputs.version }}
+        run: |
+          set -euo pipefail
+          # The site reports the stable channel: the version beside its install
+          # command and the release notes behind it are both generated from this
+          # release and this repo's CHANGELOG.md. It refreshed on a daily timer,
+          # which has no relationship to when a promotion lands - 0.3.7 shipped at
+          # 18:34 and the day's refresh had run at 07:53, so the site advertised
+          # 0.2.0 for eleven hours over a command that installed 0.3.7.
+          jq -nc --arg version "$VERSION"             '{event_type:"release-stable",
+              client_payload:{channel:"stable", version:$version}}'             | gh api repos/GEMISIS/leviath.dev/dispatches --input -
+          echo "Asked leviath.dev to refresh for $VERSION."
+
   bump-tap:
     name: Bump tap manifests (stable)
     needs: [deploy, check-beta]


### PR DESCRIPTION
The sending half of making the website update itself. The receiving half is [leviath.dev#47](https://github.com/GEMISIS/leviath.dev/pull/47), which adds a `release-stable` repository-dispatch trigger to its deploy.

## Why

leviath.dev generates the version beside its install command, and the release notes behind it, from **this repo's stable release and CHANGELOG.md**. It had no way to know when either changed, so it refreshed on a daily cron — and a cron and a release schedule have no relationship to each other.

Today they missed by eleven hours:

| | |
|---|---|
| 0.3.7 promoted | 18:34 |
| site's daily refresh | 07:53 |

So leviath.dev advertised **0.2.0 over a command that installs 0.3.7** until it was noticed. Running the cron more often only narrows that window and deploys a website all day to catch an event that happens weekly.

## What this adds

One job, modelled exactly on the `bump-tap` job below it — same token, same reason (GITHUB_TOKEN is scoped to this repo, so reaching another one needs the PAT), and gated on the same `skip` output so a promotion that finds nothing new does not deploy a website for no reason.

`RELEASE_TOKEN` only needs **leviath.dev added to its repository access** — no new secret. Until that access is granted the job fails visibly, which is the right failure: the site keeps refreshing daily meanwhile, because the cron stays as a floor on the other side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJSMDWhGpWAXpkW7ZdTad9