### PR TITLE
ci(prod): drop the leviath.dev trigger, which cannot do anything

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -360,47 +360,6 @@ jobs:
   # the tap has to be told what just shipped, or `brew upgrade` never fires.
   # Its own job, not a step on `deploy`: a failure here must be loud without
   # retroactively failing a release that did publish.
-  notify-site:
-    name: Refresh leviath.dev
-    needs: [deploy, check-beta]
-    if: needs.check-beta.outputs.skip != 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Ask leviath.dev to redeploy
-        env:
-          # Same token and the same reason as the tap bump below: GITHUB_TOKEN is
-          # scoped to this repo, so reaching another one needs the PAT. It needs
-          # leviath.dev added to its repository access with `Actions: read and
-          # write` - see the note below for why Actions and not Contents.
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          VERSION: ${{ needs.check-beta.outputs.version }}
-        run: |
-          set -euo pipefail
-
-          # What this does and does not refresh. The site takes the version it
-          # prints from leviath-dist's Homebrew formula, not from this release,
-          # because every install route it offers resolves there and taking the
-          # number from here is what let it advertise 0.3.7 while `brew upgrade`
-          # was still a no-op on 0.2.0. So this cannot move the version: the tap
-          # has not bumped yet by definition. It refreshes the release notes,
-          # and it is a second chance if the tap's own dispatch never arrives.
-          #
-          # `workflow run` rather than a repository dispatch, because a
-          # fine-grained PAT carries one permission set across every repository
-          # selected for it. A repository dispatch needs Contents: write, which
-          # would also hand this token write access to this repository's
-          # contents; starting a workflow needs Actions: write, which is enough
-          # to run the deploy and not enough to push anything.
-          if ! err=$(gh workflow run deploy.yml --repo GEMISIS/leviath.dev 2>&1); then
-            # A warning, not a failure. The release itself is fine and the site
-            # keeps a daily refresh, so this costs freshness rather than
-            # correctness - failing the promotion over it would be a lie about
-            # what went wrong.
-            echo "::warning::Could not start the leviath.dev deploy; it will refresh on its daily run instead. Give RELEASE_TOKEN access to GEMISIS/leviath.dev with 'Actions: read and write'. GitHub said: ${err}"
-            exit 0
-          fi
-          echo "Asked leviath.dev to redeploy after $VERSION."
-
   bump-tap:
     name: Bump tap manifests (stable)
     needs: [deploy, check-beta]


### PR DESCRIPTION
Reverts the job added in #422 and adjusted in #423. It was built on a premise that stopped being true while it was in flight, and keeping it means giving a contents-write token access to the website repository in exchange for nothing. My mistake — I should have caught this when the premise changed.

## It cannot refresh anything

leviath.dev now takes the version it prints from **leviath-dist's Homebrew formula**, not from this repository's release, because every install route it offers resolves there. So consider what this job can refresh at the moment it runs — immediately after a promotion, and therefore *before* the tap bump:

| what the site shows | where it comes from | at this moment |
|---|---|---|
| the version | the tap's formula | not bumped yet → **unchanged** |
| the release notes | the `CHANGELOG.md` section **for the tap's version** | still the old version → **unchanged** |

The deploy it triggers is byte-identical to the one already published.

It is not a backstop either. leviath-dist triggers the site when its bump lands — the event that actually changes the answer — and the site keeps a daily refresh under that.

## And it is not free

`RELEASE_TOKEN` must carry **Contents: write**: it publishes releases here and dispatches to the tap. A fine-grained PAT applies **one permission set to every repository selected for it**. So adding leviath.dev to its access list grants **contents write on leviath.dev** — whose `main` branch has no active ruleset (its "Main Branch Protection" is `enforcement: disabled`), and which **deploys on push**.

That is push access to a live website, held for a deploy that changes nothing.

Granting `Actions: read and write` instead does not avoid this, which is what I missed when I suggested it: the token already carries Contents: write for its other jobs, and the permission set is per-token, not per-repository.

## After this merges

**Remove `GEMISIS/leviath.dev` from `RELEASE_TOKEN`'s repository access.** Nothing in this repository needs it. `RELEASE_TOKEN` goes back to leviath + leviath-dist, which is what its other jobs require.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJSMDWhGpWAXpkW7ZdTad9