### PR TITLE
fix: a malformed fan-out split no longer kills the run, and the research stages are required

### DIFF
--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -47,12 +47,14 @@ web_fetch  = "sources"
 read_file  = "sources"
 list_dir   = "sources"
 
+# The only way forward. Investigating is what makes this a deep researcher, so
+# it is not a choice: an edge straight to `analyze` used to sit here for topics
+# that "turned out to be one question", and a model that took it produced a
+# report from the gather stage's sources alone while another model on the same
+# topic ran the full fan-out. A single sub-question is a fan-out of one, which
+# costs one worker; skipping the stage costs the whole investigation.
 [stages.gather.transitions.investigate]
-hint = "The topic breaks into sub-questions worth researching separately"
-transform = "direct"
-
-[stages.gather.transitions.analyze]
-hint = "Enough primary sources gathered, and the topic is one question rather than several"
+hint = "Primary sources gathered - break the topic into sub-questions and research them"
 transform = "direct"
 
 # Un-exhaustible escape (lint: dead-end-possible): when every looping
@@ -115,9 +117,12 @@ fine for a narrow topic.
 condition = "error"
 transform = "direct"
 
-# Un-exhaustible escape (lint: dead-end-possible).
+# Un-exhaustible escape (lint: dead-end-possible). Conditioned, like every
+# other escape here: an unconditioned edge is on the model's menu, so this one
+# let a fan-out stage answer "synthesize" and walk past its own workers.
 [stages.investigate.transitions.synthesize]
 hint = "Analysis is out of revisits - synthesize from what came back"
+condition = "dead_end"
 transform = "compact"
 
 # ─── Stage 2: Analyze ─────────────────────────────────────────────────────────

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -42,14 +42,12 @@ web_fetch  = "landscape"
 read_file  = "landscape"
 list_dir   = "landscape"
 
+# The only way forward. Covering the threads in parallel is what this blueprint
+# is for, so it is not a choice: an edge straight to `compare` used to sit here
+# for areas that "turned out to be narrow", and a model that took it compared a
+# landscape nothing had investigated. One thread is a fan-out of one.
 [stages.survey.transitions.investigate]
 hint = "Landscape mapped - the threads worth covering are identified"
-transform = "direct"
-
-# Still available when the survey found one thread rather than several: no point
-# spinning up a fan-out to cover a single topic.
-[stages.survey.transitions.compare]
-hint = "The area turned out to be narrow - one thread, no need to split it"
 transform = "direct"
 
 # Un-exhaustible escape (lint: dead-end-possible): when every looping
@@ -113,9 +111,12 @@ for a narrow area.
 condition = "error"
 transform = "direct"
 
-# Un-exhaustible escape (lint: dead-end-possible).
+# Un-exhaustible escape (lint: dead-end-possible). Conditioned, like every
+# other escape here: unconditioned, it sat on the model's menu and let a
+# fan-out stage answer "summarize" and walk past its own workers.
 [stages.investigate.transitions.summarize]
 hint = "Comparison is out of revisits - write the overview from what came back"
+condition = "dead_end"
 transform = "compact"
 
 # ─── Stage 2: Compare ─────────────────────────────────────────────────────────
@@ -147,16 +148,19 @@ If `error_report` says a previous stage hit its iteration cap, that stage was cu
 off before finishing - treat its coverage as incomplete when judging the field.
 """
 
-[stages.compare.transitions.survey]
-hint = "Coverage gaps - survey additional areas"
-transform = "compact"
-
+# One way forward: a thread worth comparing is worth reading properly before the
+# overview is written, so `deep_dive` is required rather than offered. The "do we
+# need more" decision now lives in `deep_dive`, which is the first stage to have
+# actually read a thread in depth and can judge whether the landscape is thin.
 [stages.compare.transitions.deep_dive]
-hint = "An interesting thread deserves a focused deep read"
+hint = "Threads compared - read the most significant one in depth"
 transform = "compact"
 
+# Un-exhaustible escape (lint: dead-end-possible): once `deep_dive` has spent its
+# revisits there is nowhere else to go, and the overview still gets written.
 [stages.compare.transitions.summarize]
-hint = "Comparison complete - write the overview"
+hint = "Deep dives are out of revisits - write the overview from the comparison"
+condition = "dead_end"
 transform = "compact"
 
 [stages.compare.transitions.error_recovery]
@@ -186,16 +190,19 @@ web_search = "landscape"
 web_fetch  = "landscape"
 read_file  = "landscape"
 
+# This is where the run decides whether it has enough, because it is the first
+# stage that has read a thread properly rather than surveyed it. Three ways out:
+# another thread, more breadth, or the deliverable.
 [stages.deep_dive.transitions.compare]
-hint = "Thread explored - resume comparing"
+hint = "Thread explored - compare again to pick the next one worth reading"
 transform = "compact"
 
-# Un-exhaustible escape (lint: dead-end-possible): when every looping
-# target has spent its max_revisits budget, the run can still move forward
-# to the deliverable instead of dead-ending.
+[stages.deep_dive.transitions.survey]
+hint = "This depth exposed gaps in the landscape - survey additional areas"
+transform = "compact"
+
 [stages.deep_dive.transitions.summarize]
-hint = "Comparison is out of revisits - write the overview with this depth"
-condition = "dead_end"
+hint = "The significant threads have been read in depth - write the overview"
 transform = "compact"
 
 [stages.deep_dive.transitions.error_recovery]

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -30,6 +30,62 @@ use crate::pipeline::{AgentBlueprint, ProcessResponse, ResolveTransition, StageC
 /// Depth cap for fan-out workers when the parent's blueprint doesn't set one.
 const DEFAULT_FANOUT_DEPTH: usize = 3;
 
+/// How many times a malformed split is sent back to the model before the run
+/// fails.
+///
+/// A split asks for one exact shape, and a model that answers with prose or an
+/// apology has not failed at the work, only at the format. Failing the run on
+/// the first such answer throws away everything the parent has done, which is
+/// what a deep-researcher run reported: one non-conforming response ended it.
+/// Two corrections is enough to clear a formatting slip without letting a model
+/// that cannot produce the shape loop for ever.
+const MAX_SPLIT_RETRIES: usize = 2;
+
+/// How many corrective attempts a parent's split has already had.
+///
+/// Absent until the first malformed split, so a split that parses first time
+/// costs nothing.
+#[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SplitAttempts(pub usize);
+
+/// What the model is told after a split that could not be parsed.
+///
+/// It names the failure and restates the shape rather than repeating the
+/// original instruction, because the original instruction is what just did not
+/// work.
+fn split_correction(reason: &str) -> String {
+    format!(
+        "Your previous response could not be used: {reason}. Reply with the JSON \
+         array of work items and nothing else - no prose before or after it, no \
+         markdown fences, no explanation. It must start with `[` and end with `]`."
+    )
+}
+
+/// The first `MAX_SPLIT_SNIPPET` characters of what the model actually said,
+/// for the failure message.
+///
+/// The old message named the rule that was broken but never what came back, so
+/// an operator reading `split output is not a JSON array` could not tell a
+/// refusal from an empty response from prose. Bounded because a split response
+/// can be long, and truncated on a character boundary because model output is
+/// arbitrary UTF-8.
+fn response_snippet(response: &str) -> String {
+    let trimmed = response.trim();
+    if trimmed.is_empty() {
+        return "the response was empty".to_string();
+    }
+    // Taken as characters rather than bytes: a byte ceiling can land inside a
+    // character, and model output is arbitrary UTF-8.
+    let kept: String = trimmed.chars().take(MAX_SPLIT_SNIPPET).collect();
+    match kept.len() < trimmed.len() {
+        true => format!("the response began: {kept}…"),
+        false => format!("the response was: {kept}"),
+    }
+}
+
+/// How much of a failed split response the error message carries, in characters.
+const MAX_SPLIT_SNIPPET: usize = 200;
+
 /// One unit of work produced by a fan-out split.
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
 pub struct WorkItem {
@@ -241,13 +297,69 @@ pub fn fan_out_split(world: &mut World) {
                 set_status(world, parent, AgentStatus::Waiting);
             }
             Err(message) => {
-                set_status(
-                    world,
-                    parent,
-                    AgentStatus::Error {
-                        message: format!("fan_out split failed: {message}"),
-                    },
-                );
+                // A split that did not parse is a formatting miss, not a dead
+                // run: send the model its own answer plus a correction and ask
+                // again, the way every other stage handles a response it cannot
+                // use. Only once the corrections are spent does the run fail.
+                let attempts = world.get::<SplitAttempts>(parent).map_or(0, |a| a.0);
+                // Correcting needs somewhere to put the correction, so an agent
+                // with no context window falls through to the failure below
+                // rather than looping without ever being told anything.
+                let corrected = match attempts < MAX_SPLIT_RETRIES {
+                    false => false,
+                    true => {
+                        let mut entity = world.entity_mut(parent);
+                        match entity.get_mut::<ContextWindow>() {
+                            None => false,
+                            Some(mut window) => {
+                                // The model sees what it said before the
+                                // correction, so "reply with only the array"
+                                // has something to correct.
+                                let tokens = leviath_core::estimate_tokens(&response);
+                                let _ = window.add_typed_entry(
+                                    "conversation",
+                                    leviath_core::EntryKind::AssistantTurn {
+                                        tool_calls: Vec::new(),
+                                    },
+                                    response.clone(),
+                                    tokens,
+                                );
+                                crate::pipeline::inject_system_nudge(
+                                    &mut window,
+                                    &split_correction(&message),
+                                );
+                                true
+                            }
+                        }
+                    }
+                };
+                if corrected {
+                    tracing::warn!(
+                        attempt = attempts + 1,
+                        max = MAX_SPLIT_RETRIES,
+                        error = %message,
+                        "fan_out split did not parse; asking the model again"
+                    );
+                    world
+                        .entity_mut(parent)
+                        .insert(SplitAttempts(attempts + 1))
+                        .insert(crate::pipeline::ReadyToInfer);
+                } else {
+                    // Name what came back as well as the rule it broke: the
+                    // rule alone cannot tell a refusal from an empty response
+                    // from prose.
+                    set_status(
+                        world,
+                        parent,
+                        AgentStatus::Error {
+                            message: format!(
+                                "fan_out split failed after {attempts} correction(s): \
+                                 {message} ({})",
+                                response_snippet(&response)
+                            ),
+                        },
+                    );
+                }
             }
         }
     }
@@ -1006,15 +1118,181 @@ mod tests {
 
     #[test]
     fn split_errors_on_non_array_output() {
+        // The corrections have to be spent before the run dies, so this drives
+        // the split until they are. Failing on the first answer is the bug the
+        // retry exists to fix.
         let mut world = World::new();
         let e = spawn_parent(
             &mut world,
             fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
             "definitely not a json array",
         );
-        fan_out_split(&mut world);
+        for _ in 0..=MAX_SPLIT_RETRIES {
+            fan_out_split(&mut world);
+            redrive_split(&mut world, e, "definitely not a json array");
+        }
         assert!(world.get::<FanOutWaiting>(e).is_none());
         assert_errored(&world, e);
+    }
+
+    /// Put the parent back where a fresh inference would leave it, so the split
+    /// can be driven a second and third time without a real provider.
+    fn redrive_split(world: &mut World, e: Entity, response: &str) {
+        world
+            .entity_mut(e)
+            .remove::<crate::pipeline::ReadyToInfer>()
+            .insert(InferenceResult {
+                response: response.to_string(),
+                tool_calls: vec![],
+                tokens_used: 0,
+                timestamp: 0,
+            })
+            .insert(ProcessResponse);
+    }
+
+    fn conversation_text(world: &World, e: Entity) -> String {
+        world
+            .get::<ContextWindow>(e)
+            .unwrap()
+            .get_region("conversation")
+            .unwrap()
+            .content
+            .iter()
+            .map(|entry| entry.content.clone())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The fix for the deep-researcher report: a split that comes back as prose
+    /// is a formatting miss, and the run gets to correct it instead of dying.
+    #[test]
+    fn a_split_that_is_not_an_array_is_corrected_rather_than_fatal() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "Sure! I will research these topics for you.",
+        );
+
+        fan_out_split(&mut world);
+
+        assert_eq!(status_of(&world, e), AgentStatus::Active, "still running");
+        assert_eq!(world.get::<SplitAttempts>(e), Some(&SplitAttempts(1)));
+        assert!(
+            world.get::<crate::pipeline::ReadyToInfer>(e).is_some(),
+            "the parent is queued for another attempt"
+        );
+        assert!(world.get::<FanOutWaiting>(e).is_none());
+        let convo = conversation_text(&world, e);
+        assert!(
+            convo.contains("Sure! I will research"),
+            "the model sees its own answer: {convo}"
+        );
+        assert!(
+            convo.contains("[System]") && convo.contains("start with `[`"),
+            "and the correction: {convo}"
+        );
+    }
+
+    /// A correction that works is the whole point: the second answer parses and
+    /// the run carries on into its fan-out.
+    #[test]
+    fn a_corrected_split_proceeds_to_the_fan_out() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "no array here",
+        );
+        fan_out_split(&mut world);
+        redrive_split(&mut world, e, r#"[{"id":"a","context":{}}]"#);
+
+        fan_out_split(&mut world);
+
+        assert!(world.get::<FanOutWaiting>(e).is_some(), "the split took");
+        assert_eq!(status_of(&world, e), AgentStatus::Waiting);
+    }
+
+    /// Once the corrections are spent the run does fail, and the message names
+    /// what came back rather than only the rule it broke.
+    #[test]
+    fn the_failure_message_quotes_what_the_model_actually_said() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "I cannot help with that request.",
+        );
+        for _ in 0..=MAX_SPLIT_RETRIES {
+            fan_out_split(&mut world);
+            redrive_split(&mut world, e, "I cannot help with that request.");
+        }
+        // Read through Debug rather than a pattern: the arm a passing run does
+        // not take reads to llvm-cov as an uncovered region.
+        let status = format!("{:?}", status_of(&world, e));
+        assert!(status.contains("Error"), "{status}");
+        assert!(status.contains("I cannot help with that"), "{status}");
+        assert!(status.contains("correction(s)"), "{status}");
+    }
+
+    /// No context window means nowhere to put a correction, so the run fails on
+    /// the first malformed split rather than looping while being told nothing.
+    #[test]
+    fn a_split_with_nowhere_to_put_a_correction_fails_at_once() {
+        let mut world = World::new();
+        let e = world
+            .spawn((
+                AgentBlueprint(fanout_blueprint(cfg(
+                    None,
+                    2,
+                    WorkerFailurePolicy::Continue,
+                ))),
+                StageCursor { index: 0 },
+                parent_state(),
+                StageProgress::default(),
+                StageInferences(vec![stage_inf(), stage_inf()]),
+                StageSetups(vec![setup(), setup()]),
+                VisitCounts::default(),
+                InferenceResult {
+                    response: "not an array".to_string(),
+                    tool_calls: vec![],
+                    tokens_used: 0,
+                    timestamp: 0,
+                },
+                ProcessResponse,
+            ))
+            .id();
+
+        fan_out_split(&mut world);
+
+        assert_errored(&world, e);
+        assert!(world.get::<SplitAttempts>(e).is_none());
+    }
+
+    #[test]
+    fn the_snippet_reports_an_empty_response_as_empty() {
+        assert_eq!(response_snippet("   \n "), "the response was empty");
+    }
+
+    #[test]
+    fn the_snippet_quotes_a_short_response_whole() {
+        assert_eq!(response_snippet("  nope  "), "the response was: nope");
+    }
+
+    #[test]
+    fn the_snippet_truncates_a_long_response_on_a_character_boundary() {
+        // Three bytes per character on purpose: cutting model output at a byte
+        // offset is how a panic gets shipped, so the ceiling counts characters
+        // and this proves no character was split.
+        let long = "€".repeat(MAX_SPLIT_SNIPPET + 10);
+        let snippet = response_snippet(&long);
+        assert!(snippet.starts_with("the response began: "), "{snippet}");
+        assert!(snippet.ends_with('…'), "{snippet}");
+        let kept = snippet
+            .trim_start_matches("the response began: ")
+            .trim_end_matches('…');
+        assert_eq!(kept.chars().count(), MAX_SPLIT_SNIPPET);
+        assert!(kept.chars().all(|c| c == '€'), "no character was split");
     }
 
     #[test]


### PR DESCRIPTION
Two reported faults from a live deep-researcher run, plus the same latent bug in wide-researcher.

## 1. `fan_out split failed: split output is not a JSON array`

A fan-out split asked the model for a JSON array and parsed the answer **exactly once** (`fanout.rs`): anything else set the run to `Error` on the spot. That is the only place in the pipeline that treats a single badly-shaped response as fatal, and it discarded everything the parent had already done. The reporting stage grants no tools (`available_tools = []`), so the model had simply answered in prose - which is also what an empty response from a reasoning model looks like.

The split now does what every other stage does with a response it cannot use: hand the model back its own answer plus a correction naming the required shape, and ask again, bounded at two corrections, through the same `inject_system_nudge` path the empty-response and required-region nudges already use. Only once the corrections are spent does the run fail.

The failure message now also quotes what came back. The old one named the rule that was broken but never the answer that broke it, so a refusal, an empty response, and prose all read identically - which is exactly the position the report left us in.

An agent with no context window has nowhere to put a correction, so it still fails on the first malformed split rather than looping in silence.

## 2. The investigation stages were optional

A live run went straight from `gather` to `analyze` and reported on the gather stage's sources alone, while another model on the same topic ran the full fan-out. That was not the model misbehaving: `gather -> analyze` was a legitimate unconditioned edge on its menu.

- **deep-researcher**: `gather -> analyze` removed, so `gather` leads to `investigate` and nothing else. A topic that turns out to be one question is a fan-out of one, which costs a single worker; skipping the stage costs the whole investigation. (`analyze -> gather` already existed for the "need more sources" loop.)
- **wide-researcher**: `survey -> compare` removed for the same reason, and `compare` now leads only to `deep_dive`. The "do we need more" decision moves to `deep_dive`, the first stage that has read a thread properly rather than surveyed it; from there it can return to `compare` for another thread, back to `survey` for more breadth, or write the overview. Required path: `survey -> investigate -> compare -> deep_dive`.

## 3. Both fan-out escapes were unconditioned

`investigate -> synthesize` (deep-researcher) and `investigate -> summarize` (wide-researcher) were each described in their own comment as an un-exhaustible escape, but neither carried `condition = "dead_end"`. Unconditioned, they sat on the model's menu and let a fan-out stage answer "write it up" and walk past its own workers - the same class of bug fixed in the 0.3.5 batch, missed in these two. Both now carry the condition, like every other escape in these graphs.

## Validation
- `lev validate` on both blueprints is clean; the printed graphs confirm the required paths.
- Full workspace suite: **7424 passed, 0 failed**. Coverage gate at 100% for `leviath-runtime`. Clippy, `cargo xtask docs`, and the pre-commit suite all clean.
- The existing `split_errors_on_non_array_output` test encoded the old fail-fast behaviour and was rewritten to drive the corrections to exhaustion; new tests cover the retry, a correction that succeeds, the quoted failure, the no-context-window path, and the snippet's empty/short/truncated cases.
- Not exercised against a live provider: reproducing needs a model that answers a split in prose. The behaviour is asserted at the system level instead, driving `fan_out_split` directly.
