### PR TITLE
chore(release): 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## 0.3.8 - 2026-08-13
+
+- Fixed: a fan-out split whose answer is not a JSON array no longer ends the
+  run. The split asked the model for one exact shape and parsed the reply
+  once, so a stage that answered in prose, or a reasoning model that answered
+  with nothing at all, killed a run that had already done real work. The model
+  is now handed back its own answer with a correction and asked again, twice,
+  the way every other stage treats a reply it cannot use. When the corrections
+  are spent the run does fail, and the message now quotes what came back
+  rather than only naming the rule it broke.
+- Changed: `deep-researcher` and `wide-researcher` require the stages that do
+  their research. Both blueprints offered a way straight past their own
+  investigation, so which stages ran came down to which model was driving:
+  the same topic produced a full parallel investigation on one model and a
+  report from the first stage's sources on another. `deep-researcher` now goes
+  from `gather` to `investigate`, and `wide-researcher` runs `survey` to
+  `investigate` to `compare` to `deep_dive`. A topic that turns out to be one
+  question is a fan-out of one worker, which is far cheaper than skipping the
+  investigation.
+- Changed: `wide-researcher` decides whether it needs more material after
+  `deep_dive` rather than after `compare`, since that is the first stage to
+  have read a thread properly rather than surveyed it. From there it can pick
+  another thread, go back for more breadth, or write the overview.
+- Fixed: the fan-out stages of both researchers can no longer skip their own
+  workers. Each had an escape edge to its write-up stage that its own comment
+  described as a last resort, but neither was conditioned on being one, so it
+  sat on the model's menu as an ordinary choice.
+
 ## 0.3.7 - 2026-08-13
 
 - Fixed: a run whose provider account runs out of credits now pauses instead

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.7"
+version = "0.3.8"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.7" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.7" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.7" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.7" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.7" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.7" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.7" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.7" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.7" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.7" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.7" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.7" }
+leviath = { path = "crates/leviath", version = "0.3.8" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.8" }
+leviath-net = { path = "crates/leviath-net", version = "0.3.8" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.8" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.8" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.8" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.8" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.8" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.8" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.8" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.8" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.8" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.7", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.8", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }


### PR DESCRIPTION
Cuts 0.3.8, shipping the two deep-researcher faults reported from a live run (#425).

- A fan-out split whose answer is not a JSON array is corrected and retried rather than ending the run, and the failure message now quotes what came back.
- `deep-researcher` and `wide-researcher` require the stages that do their research; `wide-researcher` decides on further gathering after `deep_dive`.
- Both fan-out stages' escape edges are conditioned, so a fan-out can no longer skip its own workers.

`cargo xtask version 0.3.8` moved every declaration and rolled the changelog; `--check` confirms every intra-workspace pin, both `[profile.release]` blocks, the publish list, and the coverage matrix agree.

Merging this to main cuts the alpha release; beta and prod follow by manual dispatch.

Needs the `allow-version-bump` label to clear the release guard.
