### PR TITLE
fix(update): refresh the package index before upgrading

### DIFF
--- a/crates/leviath-cli/src/commands/update.rs
+++ b/crates/leviath-cli/src/commands/update.rs
@@ -362,8 +362,13 @@ pub const MIGRATIONS: &[Migration] = &[];
 /// What to do about the binary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BinaryStep {
-    /// Run this, argv-style.
-    Run(Vec<String>),
+    /// Run these, argv-style, in order, stopping at the first failure.
+    ///
+    /// A sequence rather than one command because a package manager will not
+    /// see a release published minutes ago until its own index is refreshed,
+    /// so the refresh and the upgrade are two commands that only make sense
+    /// together.
+    Run(Vec<Vec<String>>),
     /// There is nothing to run here. Tell the user this instead.
     Advise(String),
 }
@@ -403,19 +408,40 @@ pub enum ConfigState {
     Unreadable(String),
 }
 
-/// The upgrade step for an install method: a command, or the reason there
-/// isn't one.
+/// One line naming every command a [`BinaryStep::Run`] will run, in order.
+///
+/// Joined with `&&` because that is both how the sequence behaves (each
+/// command only runs if the one before it succeeded) and what a user would
+/// paste into a shell to do it themselves.
+pub fn render_commands(commands: &[Vec<String>]) -> String {
+    commands
+        .iter()
+        .map(|argv| argv.join(" "))
+        .collect::<Vec<_>>()
+        .join(" && ")
+}
+
+/// The upgrade step for an install method: the commands to run, or the reason
+/// there are none.
 pub fn binary_step(method: &InstallMethod) -> BinaryStep {
     match method {
+        // `brew update` first, every time. Homebrew upgrades against the tap
+        // metadata it already has, so a formula published minutes ago is
+        // invisible to `brew upgrade` on its own and the command cheerfully
+        // reports the installed version as the latest. That is what sent
+        // people to `brew update && brew upgrade leviath` by hand. The formula
+        // name carries the channel, so this is the same two steps for
+        // `leviath`, `leviath-alpha` and `leviath-beta`.
         InstallMethod::Homebrew { formula } => BinaryStep::Run(vec![
-            "brew".to_string(),
-            "upgrade".to_string(),
-            formula.clone(),
+            vec!["brew".to_string(), "update".to_string()],
+            vec!["brew".to_string(), "upgrade".to_string(), formula.clone()],
         ]),
+        // Scoop has the same shape: a bare `scoop update` refreshes the
+        // buckets, and `scoop update <app>` upgrades against whatever the
+        // buckets already said.
         InstallMethod::Scoop { package } => BinaryStep::Run(vec![
-            "scoop".to_string(),
-            "update".to_string(),
-            package.clone(),
+            vec!["scoop".to_string(), "update".to_string()],
+            vec!["scoop".to_string(), "update".to_string(), package.clone()],
         ]),
         // Deliberately not run. `cargo install` rebuilds the whole workspace
         // from source, which is minutes of CPU nobody asked for by typing
@@ -429,14 +455,14 @@ pub fn binary_step(method: &InstallMethod) -> BinaryStep {
         // One shell, one pipeline. `LEVIATH_CHANNEL=beta curl ... | sh` is the
         // form to never generate: the assignment belongs to `curl`, the piped
         // shell never sees it, and the installer silently takes stable.
-        InstallMethod::Script { channel } => BinaryStep::Run(vec![
+        InstallMethod::Script { channel } => BinaryStep::Run(vec![vec![
             "sh".to_string(),
             "-c".to_string(),
             format!(
                 "curl -fsSL {INSTALL_URL} | sh -s -- --channel {}",
                 channel.id()
             ),
-        ]),
+        ]]),
         InstallMethod::Unknown { path } => BinaryStep::Advise(format!(
             "`lev` is at {}, which is not where any installer Leviath ships puts it. \
              Update it the way you installed it, or re-install with \
@@ -517,7 +543,9 @@ pub fn format_plan(plan: &UpdatePlan, version: &str) -> String {
     );
 
     match &plan.binary {
-        BinaryStep::Run(argv) => out.push_str(&format!("  binary   {}\n", argv.join(" "))),
+        BinaryStep::Run(commands) => {
+            out.push_str(&format!("  binary   {}\n", render_commands(commands)));
+        }
         BinaryStep::Advise(text) => out.push_str(&format!("  binary   {text}\n")),
     }
 
@@ -568,7 +596,15 @@ pub fn format_plan(plan: &UpdatePlan, version: &str) -> String {
 /// shape is explicit and does not move when a type gains a field.
 pub fn plan_json(plan: &UpdatePlan, version: &str) -> serde_json::Value {
     let binary = match &plan.binary {
-        BinaryStep::Run(argv) => serde_json::json!({ "action": "run", "command": argv }),
+        // `commands` is a list of argv lists. The old `command` key held a
+        // single argv and is kept alongside it, holding the last command (the
+        // upgrade itself), so a script reading it still sees the step that
+        // does the work rather than the index refresh in front of it.
+        BinaryStep::Run(commands) => serde_json::json!({
+            "action": "run",
+            "commands": commands,
+            "command": commands.last(),
+        }),
         BinaryStep::Advise(text) => serde_json::json!({ "action": "advise", "message": text }),
     };
     let agents: Vec<serde_json::Value> = plan
@@ -681,14 +717,17 @@ fn agreed(args: &UpdateArgs, env: &UpdateEnv, question: &str) -> bool {
 
 /// Step one: the binary.
 fn update_binary(args: &UpdateArgs, env: &UpdateEnv, plan: &UpdatePlan) -> anyhow::Result<()> {
-    let argv = match &plan.binary {
+    let commands = match &plan.binary {
         BinaryStep::Advise(text) => {
             println!("  {text}");
             return Ok(());
         }
-        BinaryStep::Run(argv) => argv,
+        BinaryStep::Run(commands) => commands,
     };
-    let shown = argv.join(" ");
+    // Asked about as one question, because they are one action: refreshing a
+    // package index without then upgrading would be a strange thing to agree
+    // to on its own.
+    let shown = render_commands(commands);
     if !agreed(args, env, &format!("Run `{shown}`?")) {
         println!("  left the binary alone");
         return Ok(());
@@ -697,7 +736,10 @@ fn update_binary(args: &UpdateArgs, env: &UpdateEnv, plan: &UpdatePlan) -> anyho
         println!("  would run: {shown}");
         return Ok(());
     }
-    (env.runner)(argv)
+    for argv in commands {
+        (env.runner)(argv)?;
+    }
+    Ok(())
 }
 
 /// Step two: the bundled blueprints.

--- a/crates/leviath-cli/src/commands/update/tests.rs
+++ b/crates/leviath-cli/src/commands/update/tests.rs
@@ -362,17 +362,25 @@ fn script_destinations_grow_by_two_when_a_home_resolves() {
 
 // ─── The command per method ───────────────────────────────────────────────────
 
-/// The exact command each method runs, and the two that run nothing.
+/// The exact commands each method runs, and the two that run nothing.
+///
+/// Both package managers refresh their index first. Without it they answer
+/// from metadata they already had, so a release published minutes earlier is
+/// invisible and the upgrade reports the installed version as the newest one -
+/// which is what sent people to `brew update && brew upgrade leviath` by hand.
 #[test]
-fn each_install_method_maps_to_one_command() {
+fn each_install_method_maps_to_its_commands() {
     assert_eq!(
         binary_step(&InstallMethod::Homebrew {
             formula: "leviath-beta".to_string()
         }),
         BinaryStep::Run(vec![
-            "brew".to_string(),
-            "upgrade".to_string(),
-            "leviath-beta".to_string()
+            vec!["brew".to_string(), "update".to_string()],
+            vec![
+                "brew".to_string(),
+                "upgrade".to_string(),
+                "leviath-beta".to_string()
+            ]
         ])
     );
     assert_eq!(
@@ -380,9 +388,12 @@ fn each_install_method_maps_to_one_command() {
             package: "leviath-alpha".to_string()
         }),
         BinaryStep::Run(vec![
-            "scoop".to_string(),
-            "update".to_string(),
-            "leviath-alpha".to_string()
+            vec!["scoop".to_string(), "update".to_string()],
+            vec![
+                "scoop".to_string(),
+                "update".to_string(),
+                "leviath-alpha".to_string()
+            ]
         ])
     );
     // A cargo install is a compile. It is described, never started.
@@ -399,6 +410,55 @@ fn each_install_method_maps_to_one_command() {
     assert!(unknown.contains("/somewhere/odd/lev"), "{unknown}");
 }
 
+/// The plan shows every command it will run, joined the way a user would type
+/// them, so `--check` and the confirmation prompt name the refresh as well as
+/// the upgrade.
+#[test]
+fn the_rendered_commands_read_as_one_shell_line() {
+    assert_eq!(
+        render_commands(&[
+            vec!["brew".to_string(), "update".to_string()],
+            vec![
+                "brew".to_string(),
+                "upgrade".to_string(),
+                "leviath".to_string()
+            ],
+        ]),
+        "brew update && brew upgrade leviath"
+    );
+    // One command renders as itself, with no stray separator.
+    assert_eq!(
+        render_commands(&[vec!["scoop".to_string(), "update".to_string()]]),
+        "scoop update"
+    );
+}
+
+/// A failed index refresh stops there. Upgrading against metadata that failed
+/// to refresh is the situation this whole change exists to avoid, so it must
+/// not happen quietly as a second command.
+#[test]
+fn a_failed_first_command_does_not_run_the_second() {
+    with_tracing(|| {
+        let fixture = Fixture::new();
+        let args = UpdateArgs {
+            yes: true,
+            ..UpdateArgs::default()
+        };
+        // `false` makes every runner call fail, so the first one does.
+        let env = fixture.env("/opt/homebrew/Cellar/leviath/0.3.4/bin/lev", false, false);
+
+        let err =
+            execute_with(&args, &env, "0.3.4").expect_err("a failed refresh fails the update");
+
+        assert!(err.to_string().contains("failed"), "{err}");
+        assert_eq!(
+            fixture.recorder.ran(),
+            vec![vec!["brew".to_string(), "update".to_string()]],
+            "the upgrade never ran"
+        );
+    });
+}
+
 /// The installer invocation, which is the one command here that is easy to get
 /// silently wrong.
 ///
@@ -410,9 +470,13 @@ fn each_install_method_maps_to_one_command() {
 #[test]
 fn the_install_script_is_invoked_with_the_channel_as_an_argument() {
     for channel in [Channel::Stable, Channel::Beta, Channel::Alpha] {
-        let BinaryStep::Run(argv) = binary_step(&InstallMethod::Script { channel }) else {
+        let BinaryStep::Run(commands) = binary_step(&InstallMethod::Script { channel }) else {
             panic!("the script method runs a command");
         };
+        // The installer fetches what it needs itself, so there is nothing to
+        // refresh in front of it: one command, not two.
+        assert_eq!(commands.len(), 1);
+        let argv = &commands[0];
         assert_eq!(argv[0], "sh");
         assert_eq!(argv[1], "-c");
         assert_eq!(
@@ -761,13 +825,19 @@ fn yes_and_install_agents_run_the_command_and_install_the_blueprints() {
 
         execute_with(&args, &env, "0.3.4").expect("the whole flow succeeds");
 
+        // Both commands actually reach the runner, in order. The refresh is
+        // the half that was missing, so asserting only the upgrade would pass
+        // against the bug this fixes.
         assert_eq!(
             fixture.recorder.ran(),
-            vec![vec![
-                "brew".to_string(),
-                "upgrade".to_string(),
-                "leviath-beta".to_string()
-            ]]
+            vec![
+                vec!["brew".to_string(), "update".to_string()],
+                vec![
+                    "brew".to_string(),
+                    "upgrade".to_string(),
+                    "leviath-beta".to_string()
+                ]
+            ]
         );
         assert!(
             fixture.recorder.asked().is_empty(),
@@ -1010,7 +1080,8 @@ fn a_blueprint_that_cannot_be_installed_warns_rather_than_aborting() {
 
         execute_with(&args, &env, "0.3.4").expect("a failed install is a warning");
 
-        assert_eq!(fixture.recorder.ran().len(), 1, "the binary still updated");
+        // Two: the index refresh and the upgrade itself.
+        assert_eq!(fixture.recorder.ran().len(), 2, "the binary still updated");
     });
 }
 


### PR DESCRIPTION
`lev update` could not see a release that had just shipped.

## The fault
`binary_step` emitted `brew upgrade <formula>` and nothing else. Homebrew resolves that against the tap metadata it already has on disk, so a formula pushed minutes earlier is invisible and the upgrade cheerfully reports the installed version as the newest one. That is why people were falling back to `brew update && brew upgrade leviath` by hand, which is precisely the pair this now runs.

Scoop had the same shape and the same fault: a bare `scoop update` refreshes the buckets, and `scoop update <app>` upgrades against whatever the buckets already said. It gets the same pair.

## Channels
No special handling was needed once the refresh was in place: the Homebrew formula and Scoop package names already carry the channel (`leviath`, `leviath-alpha`, `leviath-beta`), and detection reads it off the Cellar/apps path. So this is the same two steps on all three channels, and the `each_install_method_maps_to_its_commands` test pins a beta formula and an alpha package specifically.

I checked the alpha and beta formulae in `leviath-dist` while verifying this: they carry channel-suffixed versions (`0.3.8-alpha`, `0.3.8-beta`) that move whenever the workspace version moves, so `brew upgrade` does see a real version change on those channels once the metadata is fresh.

The install-script method is deliberately left at one command: the installer fetches what it needs itself, so there is no index in front of it.

## Shape change
`BinaryStep::Run` now holds a sequence of commands rather than one.

- They are **asked about together**, as one question, because agreeing to refresh a package index without then upgrading would be a strange thing to say yes to on its own.
- They **run in order and stop at the first failure**. Upgrading against a refresh that failed is the exact situation this change exists to prevent, so it must not happen quietly as a second command.
- `--json` gains a `commands` array of argv lists and keeps `command` holding the **last** command (the upgrade), so a script reading the old key still sees the step that does the work rather than the refresh in front of it.

## Validation
- Full `leviath-cli` suite: **3406 passed, 0 failed**; coverage gate at 100%; clippy and fmt clean.
- Two existing tests asserted the single-command behaviour and were updated rather than deleted: one pinned the exact argv, the other counted runner invocations, and both encoded the missing refresh.
- New tests cover the rendered `&&` line (including the single-command case, which must not grow a stray separator) and that a failed refresh aborts before the upgrade.
- Not exercised against a real Homebrew: the runner and the prompt are injected seams, so the tests assert the commands that would run without spawning a process. That is this module's established pattern, but it does mean the fix rests on `brew update` being the right refresh, which is what the manual workaround already demonstrated.
