### PR TITLE
feat(runs): say why a run is parked, not just that it is

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -1020,6 +1020,7 @@ mod tests {
             cached_tokens: 0,
             iteration: 0,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -656,6 +656,7 @@ mod tests {
             cached_tokens: 0,
             iteration: 0,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -798,6 +798,7 @@ mod tests {
             cached_tokens: 10,
             iteration: 3,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -347,6 +347,7 @@ mod tests {
             cached_tokens: 0,
             iteration: 1,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/header.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/header.rs
@@ -185,6 +185,7 @@ mod tests {
             cached_tokens: 10,
             iteration: 3,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -237,6 +237,7 @@ mod tests {
             cached_tokens: 10,
             iteration: 3,
             waiting_prompt: Some("What should I do?".to_string()),
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -308,6 +308,7 @@ mod tests {
             cached_tokens: 10,
             iteration: 3,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -318,6 +318,7 @@ mod tests {
             cached_tokens: 10,
             iteration: 3,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -248,6 +248,7 @@ mod tests {
             cached_tokens: 10,
             iteration: 3,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -61,7 +61,14 @@ impl Dashboard {
                 let agent = &self.agents[idx];
                 // Tree-connector prefix (parent → child nesting); empty when flat.
                 let tree_prefix = self.tree_prefixes.get(pos).cloned().unwrap_or_default();
-                let status_color = agent.status.color();
+                // A parked run only wears the attention colour when a person is
+                // actually needed. A parent whose workers are still running is
+                // healthy, and colouring it like a question is what taught
+                // people to ignore the colour.
+                let status_color = match &agent.wait_reason {
+                    Some(reason) if !reason.needs_a_person() => C_DIM,
+                    _ => agent.status.color(),
+                };
                 let started_str = relative_time(agent.started_at);
                 let title_str = agent
                     .title
@@ -87,10 +94,16 @@ impl Dashboard {
                 } else {
                     truncate(&agent.stage, 14)
                 };
-                let status_str = if matches!(agent.status, AgentDisplayStatus::Active) {
-                    format!("{} ACTIVE", spinner_frame)
-                } else {
-                    agent.status.to_string()
+                let status_str = match (&agent.status, &agent.wait_reason) {
+                    (AgentDisplayStatus::Active, _) => format!("{} ACTIVE", spinner_frame),
+                    // The reason replaces the word rather than following it.
+                    // "WAITING" already means "parked", so it is the half that
+                    // says nothing, and this column is too narrow to carry
+                    // both without truncating the half that does.
+                    (AgentDisplayStatus::Waiting, Some(reason)) => {
+                        format!("{GLYPH_WAITING}{reason}")
+                    }
+                    (status, _) => status.to_string(),
                 };
                 let short_id = agent.id.split('-').next_back().unwrap_or("").to_string();
                 let mut title_spans = Vec::new();
@@ -574,6 +587,7 @@ mod tests {
             cached_tokens: 10,
             iteration: 3,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,
@@ -1223,6 +1237,62 @@ mod tests {
         let line = dash.build_detail_help_bar();
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(!text.contains("[i]"));
+    }
+
+    // ── Why a run is waiting ──────────────────────────────────────────────
+
+    /// A parked run says what it is parked on, so WAITING stops meaning four
+    /// different things.
+    #[test]
+    fn a_waiting_row_names_what_it_is_waiting_on() {
+        use leviath_core::run_meta::WaitReason;
+
+        for (reason, expected) in [
+            (WaitReason::ToolApproval, "tool approval"),
+            (WaitReason::FanOutWorkers { outstanding: 3 }, "workers(3)"),
+            (WaitReason::Children { outstanding: 2 }, "children(2)"),
+        ] {
+            let backend = TestBackend::new(120, 40);
+            let mut terminal = Terminal::new(backend).unwrap();
+            let mut dash = make_test_dashboard();
+            let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
+            agent.wait_reason = Some(reason);
+            dash.agents.push(agent);
+            dash.update_display_indices();
+            terminal
+                .draw(|f| {
+                    let area = f.area();
+                    dash.draw_agent_table(f, area);
+                })
+                .unwrap();
+            let buf = rendered_buffer(&terminal);
+            assert!(buf.contains(expected), "expected {expected}: {buf}");
+            // The reason replaces the bare word: this column is too narrow to
+            // carry both, and the word is the half that says nothing.
+            assert!(!buf.contains("WAITING"), "{buf}");
+        }
+    }
+
+    /// A run whose `meta.json` predates the field renders exactly as it did
+    /// before, rather than claiming a reason nobody recorded.
+    #[test]
+    fn a_waiting_row_without_a_reason_reads_as_it_always_did() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
+        agent.wait_reason = None;
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dash.draw_agent_table(f, area);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("WAITING"), "{buf}");
+        assert!(!buf.contains("workers("), "{buf}");
     }
 
     // ── Marks for group kill / delete ─────────────────────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/selection.rs
+++ b/crates/leviath-cli/src/commands/dashboard/selection.rs
@@ -311,6 +311,7 @@ mod tests {
             cached_tokens: 0,
             iteration: 0,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -749,6 +749,7 @@ impl Dashboard {
                             }
                             agent.waiting_prompt = waiting_prompt;
                             agent.pending_request = pending_request;
+                            agent.wait_reason = run.waiting_on.clone();
                         }
                     }
                 } else {
@@ -756,6 +757,9 @@ impl Dashboard {
                     agent.pending_request = None;
                     agent.last_answered_request_id = None;
                 }
+                // Read every tick, not only while waiting: a run that stops
+                // being parked must stop claiming a reason.
+                agent.wait_reason = run.waiting_on.clone();
             } else {
                 // New agent - toasts only after the initial sync (avoid flooding on startup)
                 if self.initial_sync_done {
@@ -796,6 +800,7 @@ impl Dashboard {
                     cached_tokens: run.cached_tokens,
                     iteration: run.iteration,
                     waiting_prompt,
+                    wait_reason: run.waiting_on.clone(),
                     pending_request,
                     last_answered_request_id: None,
                     context_snapshot,
@@ -1153,6 +1158,7 @@ mod tests {
             cached_tokens: 0,
             iteration: 0,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -239,6 +239,14 @@ pub struct DashboardAgent {
     pub iteration: usize,
     /// The question a waiting run is asking, in one line, for the list row.
     pub waiting_prompt: Option<String>,
+    /// Why a waiting run is parked, when `meta.json` says.
+    ///
+    /// WAITING on its own reads as "go and answer it", which is wrong for a
+    /// parent whose fan-out workers are still churning. `None` on a run that
+    /// is not parked, and on one written by a build from before the field
+    /// existed, which is why the row falls back to the bare status rather
+    /// than assuming.
+    pub wait_reason: Option<leviath_core::run_meta::WaitReason>,
     /// Full structured interaction request (populated for WaitingInput agents)
     pub pending_request: Option<interaction::InteractionRequest>,
     /// The request_id we most recently submitted a response for, used to suppress
@@ -555,6 +563,7 @@ mod tests {
             cached_tokens: 0,
             iteration: 1,
             waiting_prompt: None,
+            wait_reason: None,
             pending_request: None,
             last_answered_request_id: None,
             context_snapshot: None,

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1062,6 +1062,7 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     "blueprints.query",
     "blueprints.manifest",
     "blueprints.validate.name",
+    "runs.waiting_on",
 ];
 
 /// The server's numeric limits.

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -659,6 +659,7 @@ mod tests {
                 format: Some("a2ui".to_string()),
                 ..Default::default()
             }),
+            waiting_on: None,
         };
         std::fs::write(dir.join("meta.json"), serde_json::to_string(&meta).unwrap()).unwrap();
         // The answer's bytes live beside the descriptor, so a reload has

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -1518,6 +1518,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             yolo: false,
             read_paths: None,
             final_output: None,
+            waiting_on: None,
             output_request: None,
         };
         std::fs::write(
@@ -1617,6 +1618,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             yolo: false,
             read_paths: None,
             final_output: None,
+            waiting_on: None,
             output_request: None,
         };
         std::fs::write(

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -52,6 +52,35 @@ impl std::fmt::Display for RunStatus {
     }
 }
 
+/// Why a run is parked, for a run whose status is
+/// [`RunStatus::WaitingInput`].
+///
+/// That status means "this run is not moving", which is true of four quite
+/// different situations, only two of which a person can do anything about. A
+/// client with nothing but the status has to guess, and the guess most of them
+/// reach for - no pending interaction plus some visible children - is wrong
+/// whenever the children have paged out of view or the interaction fetch has
+/// not landed yet. Then a run that needs nobody is badged as needing you,
+/// which is how a badge worth interrupting someone for stops being one.
+///
+/// Deliberately a separate field rather than new [`RunStatus`] variants: the
+/// status is matched exhaustively across the codebase and serialized two ways
+/// on the wire, so splitting it would break every consumer to express
+/// something that is not a new state. The run really is waiting; this says on
+/// what.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum WaitingOn {
+    /// A person: an interaction point is holding for an answer.
+    User,
+    /// A person: one or more tool calls are holding for approval.
+    Approval,
+    /// Sub-agents this run spawned, at a `requires_children` boundary.
+    Children,
+    /// The workers of this run's own fan-out stage.
+    FanOut,
+}
+
 /// Metadata for a single background agent run.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct RunMeta {
@@ -192,6 +221,16 @@ pub struct RunMeta {
     /// run on every listing and must stay small no matter how long an answer is.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub final_output: Option<crate::output::FinalOutputDescriptor>,
+
+    /// Why this run is parked, when it is. `None` on every other status, and
+    /// on a run written before this field existed.
+    ///
+    /// Additive on purpose: `default` means a `meta.json` from an older build
+    /// still loads, and `skip_serializing_if` means a run that is not parked
+    /// writes exactly the file it wrote before, so an older build reading a
+    /// newer run sees nothing new either.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub waiting_on: Option<WaitingOn>,
     /// The output shape this run was launched asking for, when the caller
     /// overrode the blueprint's.
     ///
@@ -380,6 +419,7 @@ impl RunMeta {
             depth: 0,
             max_child_depth: 0,
             final_output: None,
+            waiting_on: None,
             output_request: None,
             flags: RunFlags::default(),
             yolo: false,
@@ -677,6 +717,64 @@ mod tests {
         m.updated_at = 0;
         m.touch();
         assert!(m.updated_at > 0);
+    }
+
+    /// A `meta.json` written before `waiting_on` existed still loads.
+    ///
+    /// This is the whole compatibility question for the field, and it is worth
+    /// a test rather than a reading of the serde attributes: every run already
+    /// on disk was written by a build that had never heard of it, and a
+    /// deserialize that insisted on the key would make every one of them
+    /// unreadable.
+    #[test]
+    fn a_run_written_before_waiting_on_existed_still_loads() {
+        let mut original = sample_meta();
+        original.status = RunStatus::WaitingInput;
+        let mut value = serde_json::to_value(&original).unwrap();
+        // Whatever the current build writes, an older file simply has no such
+        // key. Removing it reproduces that exactly.
+        value
+            .as_object_mut()
+            .expect("meta is an object")
+            .remove("waiting_on");
+        assert!(value.get("waiting_on").is_none(), "the old shape");
+
+        let back: RunMeta = serde_json::from_value(value).unwrap();
+        assert_eq!(back.waiting_on, None);
+        assert_eq!(back.status, RunStatus::WaitingInput);
+        assert_eq!(back.run_id, original.run_id);
+    }
+
+    /// A run that is not parked writes the file it always wrote, so an older
+    /// build reading a newer run sees nothing it does not understand.
+    #[test]
+    fn a_run_that_is_not_parked_writes_no_waiting_on_key() {
+        let mut m = sample_meta();
+        m.status = RunStatus::Running;
+        m.waiting_on = None;
+        let json = serde_json::to_value(&m).unwrap();
+        assert!(json.get("waiting_on").is_none(), "{json}");
+
+        m.waiting_on = Some(WaitingOn::FanOut);
+        let json = serde_json::to_value(&m).unwrap();
+        assert_eq!(json["waiting_on"], serde_json::json!("fan_out"));
+    }
+
+    /// Every variant is on the wire in snake_case, the way `RunStatus` is, and
+    /// round-trips.
+    #[test]
+    fn waiting_on_serializes_in_snake_case() {
+        for (variant, wire) in [
+            (WaitingOn::User, "user"),
+            (WaitingOn::Approval, "approval"),
+            (WaitingOn::Children, "children"),
+            (WaitingOn::FanOut, "fan_out"),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, format!("\"{wire}\""));
+            let back: WaitingOn = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, variant);
+        }
     }
 
     #[test]

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -52,33 +52,131 @@ impl std::fmt::Display for RunStatus {
     }
 }
 
-/// Why a run is parked, for a run whose status is
-/// [`RunStatus::WaitingInput`].
+/// Why a run's status is [`RunStatus::WaitingInput`].
 ///
-/// That status means "this run is not moving", which is true of four quite
-/// different situations, only two of which a person can do anything about. A
-/// client with nothing but the status has to guess, and the guess most of them
-/// reach for - no pending interaction plus some visible children - is wrong
-/// whenever the children have paged out of view or the interaction fetch has
-/// not landed yet. Then a run that needs nobody is badged as needing you,
-/// which is how a badge worth interrupting someone for stops being one.
+/// `WaitingInput` alone is several unrelated situations wearing one word, and
+/// they call for opposite responses: a fan-out parent whose workers are
+/// churning is healthy and needs nothing, while a run parked on a
+/// tool-approval prompt is stopped dead until a person answers it. Issue #184
+/// is what happens when the two are indistinguishable - an operator reading
+/// `waiting` across a factory concluded it had stalled and started killing
+/// healthy runs. Issue #431 is the same conflation reaching every client that
+/// reads `meta.json`.
 ///
-/// Deliberately a separate field rather than new [`RunStatus`] variants: the
-/// status is matched exhaustively across the codebase and serialized two ways
-/// on the wire, so splitting it would break every consumer to express
-/// something that is not a new state. The run really is waiting; this says on
-/// what.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "snake_case")]
-pub enum WaitingOn {
-    /// A person: an interaction point is holding for an answer.
-    User,
-    /// A person: one or more tool calls are holding for approval.
-    Approval,
-    /// Sub-agents this run spawned, at a `requires_children` boundary.
-    Children,
-    /// The workers of this run's own fan-out stage.
-    FanOut,
+/// Derived on demand from markers the engine already sets, by
+/// [`wait_reason_from`]; nothing tracks it separately, so it cannot fall out of
+/// sync with the status it explains. It lives here rather than in the runtime
+/// because it is both reported live over the control socket and written to
+/// `meta.json`, and one vocabulary across those two is the whole point.
+///
+/// Deliberately not new [`RunStatus`] variants: the status is matched
+/// exhaustively across the codebase and serialized two ways on the wire, so
+/// splitting it would break every consumer to express something that is not a
+/// new state. The run really is waiting; this says on what.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "reason")]
+pub enum WaitReason {
+    /// Blocked on a tool-approval prompt. Needs a person (or `--yolo`).
+    ToolApproval,
+
+    /// Blocked on a question the agent itself asked (`ask_user_*`,
+    /// `present_for_review`). Needs a person.
+    UserPrompt,
+
+    /// Blocked on a taint-gate clearance prompt. Needs a person.
+    TaintGate,
+
+    /// Blocked on a blueprint stage-boundary checkpoint. Needs a person.
+    InteractionPoint,
+
+    /// Parked while fan-out workers run. Healthy; resolves on its own.
+    FanOutWorkers {
+        /// Workers still to finish, counting both running and not-yet-started.
+        outstanding: usize,
+    },
+
+    /// Parked while spawned sub-agents run (`requires_children`). Healthy;
+    /// resolves on its own.
+    Children {
+        /// Children that have not reached a terminal status.
+        outstanding: usize,
+    },
+}
+
+impl WaitReason {
+    /// Whether clearing this needs a person. `false` means the run is parked on
+    /// other work and will move on by itself.
+    pub fn needs_a_person(&self) -> bool {
+        !matches!(self, Self::FanOutWorkers { .. } | Self::Children { .. })
+    }
+}
+
+impl std::fmt::Display for WaitReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ToolApproval => f.write_str("tool approval"),
+            Self::UserPrompt => f.write_str("user prompt"),
+            Self::TaintGate => f.write_str("taint gate"),
+            Self::InteractionPoint => f.write_str("checkpoint"),
+            Self::FanOutWorkers { outstanding } => write!(f, "workers({outstanding})"),
+            Self::Children { outstanding } => write!(f, "children({outstanding})"),
+        }
+    }
+}
+
+/// The parking markers an agent carries, gathered by whoever can see them.
+///
+/// The live listing reads these straight off the world; the persistence system
+/// reads them off its query. Both then hand them here, so the precedence below
+/// is written once instead of once per surface - two copies of it would
+/// disagree the first time either was edited.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct WaitMarkers {
+    /// A taint-gate clearance prompt is outstanding.
+    pub gate_prompt: bool,
+    /// A blueprint stage-boundary checkpoint is holding.
+    pub interaction_point: bool,
+    /// Fan-out workers still to finish, when this run is a fan-out parent.
+    pub fan_out_outstanding: Option<usize>,
+    /// Sub-agents still running, when this run is held for its children.
+    pub children_outstanding: Option<usize>,
+    /// The kind of hub request holding this run, when one is.
+    pub interaction: Option<crate::interaction::InteractionKind>,
+    /// Whether a hub request is holding it at all. Separate from the kind
+    /// because the kind can be unknown while the block is real.
+    pub awaiting_interaction: bool,
+}
+
+/// Why a parked run is parked, or `None` when it is not parked or nothing has
+/// claimed it.
+///
+/// Order matters, and it is the specific claim first. A taint-gate block and a
+/// stage checkpoint each open a hub request of their own, so both also look
+/// like a generic prompt; asking the specific markers first is what keeps them
+/// from all reporting as one.
+pub fn wait_reason_from(waiting: bool, markers: &WaitMarkers) -> Option<WaitReason> {
+    if !waiting {
+        return None;
+    }
+    if markers.gate_prompt {
+        return Some(WaitReason::TaintGate);
+    }
+    if markers.interaction_point {
+        return Some(WaitReason::InteractionPoint);
+    }
+    if let Some(outstanding) = markers.fan_out_outstanding {
+        return Some(WaitReason::FanOutWorkers { outstanding });
+    }
+    if let Some(outstanding) = markers.children_outstanding {
+        return Some(WaitReason::Children { outstanding });
+    }
+    if markers.awaiting_interaction {
+        return Some(match markers.interaction {
+            Some(crate::interaction::InteractionKind::ToolApproval) => WaitReason::ToolApproval,
+            _ => WaitReason::UserPrompt,
+        });
+    }
+    None
 }
 
 /// Metadata for a single background agent run.
@@ -223,14 +321,16 @@ pub struct RunMeta {
     pub final_output: Option<crate::output::FinalOutputDescriptor>,
 
     /// Why this run is parked, when it is. `None` on every other status, and
-    /// on a run written before this field existed.
+    /// on a run written before this field existed. Same vocabulary the live
+    /// listing reports, so `lev ps` and a client reading this file describe a
+    /// run the same way.
     ///
     /// Additive on purpose: `default` means a `meta.json` from an older build
     /// still loads, and `skip_serializing_if` means a run that is not parked
     /// writes exactly the file it wrote before, so an older build reading a
     /// newer run sees nothing new either.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub waiting_on: Option<WaitingOn>,
+    pub waiting_on: Option<WaitReason>,
     /// The output shape this run was launched asking for, when the caller
     /// overrode the blueprint's.
     ///
@@ -755,26 +855,175 @@ mod tests {
         let json = serde_json::to_value(&m).unwrap();
         assert!(json.get("waiting_on").is_none(), "{json}");
 
-        m.waiting_on = Some(WaitingOn::FanOut);
+        m.waiting_on = Some(WaitReason::FanOutWorkers { outstanding: 3 });
         let json = serde_json::to_value(&m).unwrap();
-        assert_eq!(json["waiting_on"], serde_json::json!("fan_out"));
+        assert_eq!(
+            json["waiting_on"],
+            serde_json::json!({"reason": "fan_out_workers", "outstanding": 3})
+        );
     }
 
     /// Every variant is on the wire in snake_case, the way `RunStatus` is, and
-    /// round-trips.
+    /// round-trips. The counted ones carry their number with them, which is
+    /// what lets a client say "waiting on 3 of them" rather than "waiting".
     #[test]
-    fn waiting_on_serializes_in_snake_case() {
+    fn wait_reason_serializes_in_snake_case() {
         for (variant, wire) in [
-            (WaitingOn::User, "user"),
-            (WaitingOn::Approval, "approval"),
-            (WaitingOn::Children, "children"),
-            (WaitingOn::FanOut, "fan_out"),
+            (WaitReason::ToolApproval, "tool_approval"),
+            (WaitReason::UserPrompt, "user_prompt"),
+            (WaitReason::TaintGate, "taint_gate"),
+            (WaitReason::InteractionPoint, "interaction_point"),
+            (
+                WaitReason::FanOutWorkers { outstanding: 3 },
+                "fan_out_workers",
+            ),
+            (WaitReason::Children { outstanding: 1 }, "children"),
         ] {
-            let json = serde_json::to_string(&variant).unwrap();
-            assert_eq!(json, format!("\"{wire}\""));
-            let back: WaitingOn = serde_json::from_str(&json).unwrap();
+            let json = serde_json::to_value(&variant).unwrap();
+            assert_eq!(json["reason"], serde_json::json!(wire));
+            let back: WaitReason = serde_json::from_value(json).unwrap();
             assert_eq!(back, variant);
         }
+    }
+
+    /// Each marker names its own reason, and the counted ones carry the count.
+    ///
+    /// The precedence is the specific claim first: a taint gate and a
+    /// checkpoint each open a hub request of their own, so a generic-prompt
+    /// answer would swallow both.
+    #[test]
+    fn each_marker_names_its_own_reason_specific_first() {
+        let cases = [
+            (
+                WaitMarkers {
+                    gate_prompt: true,
+                    awaiting_interaction: true,
+                    ..Default::default()
+                },
+                WaitReason::TaintGate,
+            ),
+            (
+                WaitMarkers {
+                    interaction_point: true,
+                    awaiting_interaction: true,
+                    ..Default::default()
+                },
+                WaitReason::InteractionPoint,
+            ),
+            (
+                WaitMarkers {
+                    fan_out_outstanding: Some(5),
+                    ..Default::default()
+                },
+                WaitReason::FanOutWorkers { outstanding: 5 },
+            ),
+            (
+                WaitMarkers {
+                    children_outstanding: Some(4),
+                    ..Default::default()
+                },
+                WaitReason::Children { outstanding: 4 },
+            ),
+        ];
+        for (markers, expected) in cases {
+            assert_eq!(
+                wait_reason_from(true, &markers),
+                Some(expected),
+                "{markers:?}"
+            );
+        }
+        // A parent holding both kinds of sub-work reports the more specific one.
+        assert_eq!(
+            wait_reason_from(
+                true,
+                &WaitMarkers {
+                    fan_out_outstanding: Some(2),
+                    children_outstanding: Some(9),
+                    ..Default::default()
+                }
+            ),
+            Some(WaitReason::FanOutWorkers { outstanding: 2 })
+        );
+    }
+
+    /// A generic hub block reports what kind of prompt it is, so "approve this
+    /// tool call" and "answer this question" are not the same row.
+    #[test]
+    fn a_hub_block_reports_the_kind_of_prompt_holding_it() {
+        let held = |kind| WaitMarkers {
+            awaiting_interaction: true,
+            interaction: kind,
+            ..Default::default()
+        };
+        assert_eq!(
+            wait_reason_from(
+                true,
+                &held(Some(crate::interaction::InteractionKind::ToolApproval))
+            ),
+            Some(WaitReason::ToolApproval)
+        );
+        // Anything else the agent asked for is a question for a person. The
+        // kind can also be unknown while the block is real, which reads the
+        // same way: somebody is being waited on.
+        assert_eq!(
+            wait_reason_from(
+                true,
+                &held(Some(crate::interaction::InteractionKind::FreeText))
+            ),
+            Some(WaitReason::UserPrompt)
+        );
+        assert_eq!(
+            wait_reason_from(true, &held(None)),
+            Some(WaitReason::UserPrompt)
+        );
+    }
+
+    /// Parked with nothing claiming it: the field is left off rather than
+    /// filled with a guess, and a run that is not parked never has one.
+    #[test]
+    fn nothing_claiming_a_parked_run_reports_no_reason() {
+        assert_eq!(wait_reason_from(true, &WaitMarkers::default()), None);
+        assert_eq!(
+            wait_reason_from(
+                false,
+                &WaitMarkers {
+                    gate_prompt: true,
+                    ..Default::default()
+                }
+            ),
+            None,
+            "a run that is not waiting is not waiting on anything"
+        );
+    }
+
+    /// The rendered form every text surface uses, counts included. Narrow
+    /// enough for a table column, which is why it is not the variant name.
+    #[test]
+    fn every_reason_renders_for_a_narrow_column() {
+        assert_eq!(WaitReason::ToolApproval.to_string(), "tool approval");
+        assert_eq!(WaitReason::UserPrompt.to_string(), "user prompt");
+        assert_eq!(WaitReason::TaintGate.to_string(), "taint gate");
+        assert_eq!(WaitReason::InteractionPoint.to_string(), "checkpoint");
+        assert_eq!(
+            WaitReason::FanOutWorkers { outstanding: 3 }.to_string(),
+            "workers(3)"
+        );
+        assert_eq!(
+            WaitReason::Children { outstanding: 2 }.to_string(),
+            "children(2)"
+        );
+    }
+
+    /// Only the two engine-side reasons resolve on their own; the rest are a
+    /// person's to clear. This is the predicate a badge should be built on.
+    #[test]
+    fn only_the_engine_side_reasons_need_nobody() {
+        assert!(WaitReason::ToolApproval.needs_a_person());
+        assert!(WaitReason::UserPrompt.needs_a_person());
+        assert!(WaitReason::TaintGate.needs_a_person());
+        assert!(WaitReason::InteractionPoint.needs_a_person());
+        assert!(!WaitReason::FanOutWorkers { outstanding: 2 }.needs_a_person());
+        assert!(!WaitReason::Children { outstanding: 2 }.needs_a_person());
     }
 
     #[test]

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -179,67 +179,10 @@ impl std::fmt::Display for AgentStatus {
 
 /// Why an agent's status is [`AgentStatus::Waiting`].
 ///
-/// `Waiting` alone is four unrelated situations wearing one word, and they call
-/// for opposite responses from an operator: a fan-out parent whose workers are
-/// churning is healthy and needs nothing, while a run parked on a tool-approval
-/// prompt is stopped dead until a person answers it. Issue #184 is what happens
-/// when the two are indistinguishable - an operator reading `waiting` across a
-/// factory concluded it had stalled and started killing healthy runs.
-///
-/// Derived on demand from markers the engine already sets (see
-/// [`WorldHost::wait_reason`](crate::host::WorldHost::wait_reason)); nothing
-/// tracks it separately, so it cannot fall out of sync with the status it
-/// explains.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case", tag = "reason")]
-pub enum WaitReason {
-    /// Blocked on a tool-approval prompt. Needs a person (or `--yolo`).
-    ToolApproval,
-
-    /// Blocked on a question the agent itself asked (`ask_user_*`,
-    /// `present_for_review`). Needs a person.
-    UserPrompt,
-
-    /// Blocked on a taint-gate clearance prompt. Needs a person.
-    TaintGate,
-
-    /// Blocked on a blueprint stage-boundary checkpoint. Needs a person.
-    InteractionPoint,
-
-    /// Parked while fan-out workers run. Healthy; resolves on its own.
-    FanOutWorkers {
-        /// Workers still to finish, counting both running and not-yet-started.
-        outstanding: usize,
-    },
-
-    /// Parked while spawned sub-agents run (`requires_children`). Healthy;
-    /// resolves on its own.
-    Children {
-        /// Children that have not reached a terminal status.
-        outstanding: usize,
-    },
-}
-
-impl WaitReason {
-    /// Whether clearing this needs a person. `false` means the run is parked on
-    /// other work and will move on by itself.
-    pub fn needs_a_person(&self) -> bool {
-        !matches!(self, Self::FanOutWorkers { .. } | Self::Children { .. })
-    }
-}
-
-impl std::fmt::Display for WaitReason {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::ToolApproval => f.write_str("tool approval"),
-            Self::UserPrompt => f.write_str("user prompt"),
-            Self::TaintGate => f.write_str("taint gate"),
-            Self::InteractionPoint => f.write_str("checkpoint"),
-            Self::FanOutWorkers { outstanding } => write!(f, "workers({outstanding})"),
-            Self::Children { outstanding } => write!(f, "children({outstanding})"),
-        }
-    }
-}
+/// Lives in `leviath-core` because it is written to `meta.json` as well as
+/// reported live over the control socket, and re-exported here so every
+/// existing `components::WaitReason` path keeps working.
+pub use leviath_core::run_meta::WaitReason;
 
 // The context window, which was two thirds of this file. Glob re-exported so
 // every existing `components::ContextWindow` path keeps working.

--- a/crates/leviath-runtime/src/host/listing.rs
+++ b/crates/leviath-runtime/src/host/listing.rs
@@ -26,62 +26,50 @@ impl WorldHost {
         // report that one's wait reason as this run's.
         let entity = agent.resolve_in(world)?;
         let state = world.get::<AgentState>(entity)?;
-        if state.status != AgentStatus::Waiting {
-            return None;
-        }
-        if world
-            .get::<crate::gate_prompt::AwaitingGatePrompt>(entity)
-            .is_some()
-        {
-            return Some(WaitReason::TaintGate);
-        }
-        if world
-            .get::<crate::interaction_points::AwaitingInteractionPoint>(entity)
-            .is_some()
-        {
-            return Some(WaitReason::InteractionPoint);
-        }
-        if let Some(fanout) = world.get::<crate::fanout::FanOutWaiting>(entity) {
-            return Some(WaitReason::FanOutWorkers {
-                outstanding: fanout.outstanding(),
-            });
-        }
-        if world
-            .get::<crate::pipeline::WaitingForChildren>(entity)
-            .is_some()
-        {
-            let outstanding = world
-                .get::<SubAgentChildren>(entity)
-                .map(|c| {
-                    c.children
-                        .iter()
-                        .filter(|&&child| {
-                            world
-                                .get::<AgentState>(child)
-                                .is_some_and(|s| !crate::pipeline::is_terminal_status(&s.status))
-                        })
-                        .count()
-                })
-                .unwrap_or(0);
-            return Some(WaitReason::Children { outstanding });
-        }
-        if world.get::<AwaitingInteraction>(entity).is_some() {
-            // The hub is keyed by agent id, and one agent can only be parked on
-            // one prompt at a time, so the first match is the one blocking it.
-            let kind = self
-                .interactions
-                .pending()
-                .into_iter()
-                .find(|(agent_id, _)| *agent_id == state.agent_id)
-                .map(|(_, req)| req.kind);
-            return Some(match kind {
-                Some(leviath_core::interaction::InteractionKind::ToolApproval) => {
-                    WaitReason::ToolApproval
-                }
-                _ => WaitReason::UserPrompt,
-            });
-        }
-        None
+        // The precedence itself lives in `leviath_core`, shared with the
+        // persistence system that writes the same answer to `meta.json`: two
+        // copies of it would disagree the first time either was edited.
+        leviath_core::run_meta::wait_reason_from(
+            state.status == AgentStatus::Waiting,
+            &leviath_core::run_meta::WaitMarkers {
+                gate_prompt: world
+                    .get::<crate::gate_prompt::AwaitingGatePrompt>(entity)
+                    .is_some(),
+                interaction_point: world
+                    .get::<crate::interaction_points::AwaitingInteractionPoint>(entity)
+                    .is_some(),
+                fan_out_outstanding: world
+                    .get::<crate::fanout::FanOutWaiting>(entity)
+                    .map(|f| f.outstanding()),
+                children_outstanding: world
+                    .get::<crate::pipeline::WaitingForChildren>(entity)
+                    .map(|_| {
+                        world
+                            .get::<SubAgentChildren>(entity)
+                            .map(|c| {
+                                c.children
+                                    .iter()
+                                    .filter(|&&child| {
+                                        world.get::<AgentState>(child).is_some_and(|s| {
+                                            !crate::pipeline::is_terminal_status(&s.status)
+                                        })
+                                    })
+                                    .count()
+                            })
+                            .unwrap_or(0)
+                    }),
+                // The hub is keyed by agent id, and one agent can only be
+                // parked on one prompt at a time, so the first match is the
+                // one blocking it.
+                interaction: self
+                    .interactions
+                    .pending()
+                    .into_iter()
+                    .find(|(agent_id, _)| *agent_id == state.agent_id)
+                    .map(|(_, req)| req.kind),
+                awaiting_interaction: world.get::<AwaitingInteraction>(entity).is_some(),
+            },
+        )
     }
 
     /// One listing row for a run, read off the live world.

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -11,6 +11,7 @@ use bevy_ecs::prelude::*;
 use leviath_core::RegionKind;
 use leviath_core::run_meta::{
     ContextSnapshot, RegionEntrySnapshot, RegionSnapshot, RunMeta, RunStatus, StageRunStatus,
+    WaitingOn,
 };
 
 use crate::components::{AgentState, AgentStatus, ContextWindow};
@@ -281,6 +282,59 @@ pub struct RunMetaSources<'a> {
     pub flags: &'a RunOutcomeFlags,
     /// The submitted answer, when the run has produced one.
     pub final_output: Option<&'a FinalOutput>,
+    /// Which of the four parking markers the agent is carrying, if any. Read
+    /// off the entity by the caller, which is where they are queryable.
+    pub parked: ParkedBy,
+}
+
+/// The parking markers an agent carries, as plain booleans.
+///
+/// Booleans rather than the components themselves so the mapping below stays a
+/// pure function with no ECS in it: the caller is the one system that can see
+/// these, and this is the shape it hands over.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ParkedBy {
+    /// An interaction point is holding for an answer.
+    pub interaction: bool,
+    /// One or more tool calls are holding for approval.
+    pub approval: bool,
+    /// A fan-out stage's workers are still running.
+    pub fan_out: bool,
+    /// Spawned sub-agents are still running.
+    pub children: bool,
+}
+
+/// Why a parked run is parked, or `None` when it is not parked.
+///
+/// Only ever set alongside [`AgentStatus::Waiting`]: every other status either
+/// moves on its own or has ended, and answering "waiting on a person" for a
+/// finished run would be worse than saying nothing.
+///
+/// The order is what a person can act on first. A run holding a question and a
+/// fan-out at once is one somebody can unblock right now, so the question
+/// wins; between the two engine-side reasons, a fan-out is the more specific
+/// claim (its parent is held by its own workers, not by sub-agents it spawned
+/// at a stage boundary), so it is reported ahead of the general one.
+pub fn waiting_on_from(status: &AgentStatus, parked: ParkedBy) -> Option<WaitingOn> {
+    if *status != AgentStatus::Waiting {
+        return None;
+    }
+    if parked.interaction {
+        return Some(WaitingOn::User);
+    }
+    if parked.approval {
+        return Some(WaitingOn::Approval);
+    }
+    if parked.fan_out {
+        return Some(WaitingOn::FanOut);
+    }
+    if parked.children {
+        return Some(WaitingOn::Children);
+    }
+    // Waiting with no marker: the status was set by something that has since
+    // dropped its marker, and inventing a reason would be worse than leaving
+    // the field off.
+    None
 }
 
 /// Where the run has got to, and when.
@@ -314,6 +368,7 @@ pub fn build_run_meta(sources: RunMetaSources<'_>, at: RunPosition) -> RunMeta {
         totals,
         flags,
         final_output,
+        parked,
     } = sources;
     let RunPosition {
         stage_index,
@@ -366,6 +421,7 @@ pub fn build_run_meta(sources: RunMetaSources<'_>, at: RunPosition) -> RunMeta {
         yolo: md.unattended,
         read_paths: md.read_paths,
         final_output: final_output.map(|o| o.0.descriptor()),
+        waiting_on: waiting_on_from(&state.status, parked),
         output_request: md.output_request.clone(),
     }
 }
@@ -611,6 +667,147 @@ mod tests {
         assert_eq!(t.cache_write_tokens, 1);
     }
 
+    /// Each marker names its own reason, and only while the run is parked.
+    #[test]
+    fn each_parking_marker_names_its_own_reason() {
+        let cases = [
+            (
+                ParkedBy {
+                    interaction: true,
+                    ..Default::default()
+                },
+                WaitingOn::User,
+            ),
+            (
+                ParkedBy {
+                    approval: true,
+                    ..Default::default()
+                },
+                WaitingOn::Approval,
+            ),
+            (
+                ParkedBy {
+                    fan_out: true,
+                    ..Default::default()
+                },
+                WaitingOn::FanOut,
+            ),
+            (
+                ParkedBy {
+                    children: true,
+                    ..Default::default()
+                },
+                WaitingOn::Children,
+            ),
+        ];
+        for (parked, expected) in cases {
+            assert_eq!(
+                waiting_on_from(&AgentStatus::Waiting, parked),
+                Some(expected),
+                "{parked:?}"
+            );
+            // The same markers on a run that is not parked say nothing: an
+            // active or finished run is not waiting on anybody.
+            for status in [
+                AgentStatus::Active,
+                AgentStatus::Complete,
+                AgentStatus::Cancelled,
+            ] {
+                assert_eq!(waiting_on_from(&status, parked), None, "{status:?}");
+            }
+        }
+    }
+
+    /// The whole point of the field: a fan-out parent is not waiting on a
+    /// person, and must not be reported as if it were.
+    #[test]
+    fn a_fan_out_parent_is_never_reported_as_waiting_on_a_person() {
+        let parent = ParkedBy {
+            fan_out: true,
+            ..Default::default()
+        };
+        let reason = waiting_on_from(&AgentStatus::Waiting, parent);
+        assert_eq!(reason, Some(WaitingOn::FanOut));
+        assert_ne!(reason, Some(WaitingOn::User));
+        assert_ne!(reason, Some(WaitingOn::Approval));
+    }
+
+    /// A run holding a question *and* engine-side work reports the question:
+    /// it is the half somebody can act on now.
+    #[test]
+    fn a_question_outranks_the_engine_side_reasons() {
+        let both = ParkedBy {
+            interaction: true,
+            approval: true,
+            fan_out: true,
+            children: true,
+        };
+        assert_eq!(
+            waiting_on_from(&AgentStatus::Waiting, both),
+            Some(WaitingOn::User)
+        );
+        // Without the question, an approval is still a person's to give.
+        assert_eq!(
+            waiting_on_from(
+                &AgentStatus::Waiting,
+                ParkedBy {
+                    interaction: false,
+                    ..both
+                }
+            ),
+            Some(WaitingOn::Approval)
+        );
+        // And between the two engine-side reasons, the specific one wins.
+        assert_eq!(
+            waiting_on_from(
+                &AgentStatus::Waiting,
+                ParkedBy {
+                    fan_out: true,
+                    children: true,
+                    ..Default::default()
+                }
+            ),
+            Some(WaitingOn::FanOut)
+        );
+    }
+
+    /// Parked with no marker at all: the field is left off rather than filled
+    /// with a guess.
+    #[test]
+    fn waiting_with_no_marker_reports_nothing() {
+        assert_eq!(
+            waiting_on_from(&AgentStatus::Waiting, ParkedBy::default()),
+            None
+        );
+    }
+
+    /// The reason reaches `meta.json`, which is the file every client reads.
+    #[test]
+    fn build_run_meta_records_why_a_run_is_parked() {
+        let meta = build_run_meta(
+            RunMetaSources {
+                md: &metadata(),
+                state: &state(AgentStatus::Waiting),
+                totals: &TokenTotals::default(),
+                flags: &RunOutcomeFlags::default(),
+                final_output: None,
+                parked: ParkedBy {
+                    children: true,
+                    ..Default::default()
+                },
+            },
+            RunPosition {
+                stage_index: 0,
+                now_secs: 0,
+                last_progress_at: None,
+                depth: 0,
+                max_child_depth: 0,
+            },
+        );
+        assert_eq!(meta.status, RunStatus::WaitingInput);
+        assert_eq!(meta.waiting_on, Some(WaitingOn::Children));
+    }
+
     #[test]
     fn build_run_meta_fills_dynamic_and_static_fields() {
         let md = metadata();
@@ -630,6 +827,7 @@ mod tests {
                 totals: &totals,
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
+                parked: ParkedBy::default(),
             },
             RunPosition {
                 stage_index: 1,
@@ -679,6 +877,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
+                parked: ParkedBy::default(),
             },
             RunPosition {
                 stage_index: 1,
@@ -703,6 +902,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &flags,
                 final_output: None,
+                parked: ParkedBy::default(),
             },
             RunPosition {
                 stage_index: 0,
@@ -730,6 +930,7 @@ mod tests {
                     totals: &TokenTotals::default(),
                     flags: &flags,
                     final_output: None,
+                    parked: ParkedBy::default(),
                 },
                 RunPosition {
                     stage_index: 0,
@@ -752,6 +953,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &wrote,
                 final_output: None,
+                parked: ParkedBy::default(),
             },
             RunPosition {
                 stage_index: 0,
@@ -775,6 +977,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &incapable,
                 final_output: None,
+                parked: ParkedBy::default(),
             },
             RunPosition {
                 stage_index: 0,
@@ -799,6 +1002,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
+                parked: ParkedBy::default(),
             },
             RunPosition {
                 stage_index: 2,
@@ -832,6 +1036,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: Some(&submitted),
+                parked: ParkedBy::default(),
             },
             RunPosition {
                 stage_index: 0,
@@ -866,6 +1071,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
+                parked: ParkedBy::default(),
             },
             RunPosition {
                 stage_index: 0,

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -11,7 +11,7 @@ use bevy_ecs::prelude::*;
 use leviath_core::RegionKind;
 use leviath_core::run_meta::{
     ContextSnapshot, RegionEntrySnapshot, RegionSnapshot, RunMeta, RunStatus, StageRunStatus,
-    WaitingOn,
+    WaitMarkers, wait_reason_from,
 };
 
 use crate::components::{AgentState, AgentStatus, ContextWindow};
@@ -282,59 +282,9 @@ pub struct RunMetaSources<'a> {
     pub flags: &'a RunOutcomeFlags,
     /// The submitted answer, when the run has produced one.
     pub final_output: Option<&'a FinalOutput>,
-    /// Which of the four parking markers the agent is carrying, if any. Read
-    /// off the entity by the caller, which is where they are queryable.
-    pub parked: ParkedBy,
-}
-
-/// The parking markers an agent carries, as plain booleans.
-///
-/// Booleans rather than the components themselves so the mapping below stays a
-/// pure function with no ECS in it: the caller is the one system that can see
-/// these, and this is the shape it hands over.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub struct ParkedBy {
-    /// An interaction point is holding for an answer.
-    pub interaction: bool,
-    /// One or more tool calls are holding for approval.
-    pub approval: bool,
-    /// A fan-out stage's workers are still running.
-    pub fan_out: bool,
-    /// Spawned sub-agents are still running.
-    pub children: bool,
-}
-
-/// Why a parked run is parked, or `None` when it is not parked.
-///
-/// Only ever set alongside [`AgentStatus::Waiting`]: every other status either
-/// moves on its own or has ended, and answering "waiting on a person" for a
-/// finished run would be worse than saying nothing.
-///
-/// The order is what a person can act on first. A run holding a question and a
-/// fan-out at once is one somebody can unblock right now, so the question
-/// wins; between the two engine-side reasons, a fan-out is the more specific
-/// claim (its parent is held by its own workers, not by sub-agents it spawned
-/// at a stage boundary), so it is reported ahead of the general one.
-pub fn waiting_on_from(status: &AgentStatus, parked: ParkedBy) -> Option<WaitingOn> {
-    if *status != AgentStatus::Waiting {
-        return None;
-    }
-    if parked.interaction {
-        return Some(WaitingOn::User);
-    }
-    if parked.approval {
-        return Some(WaitingOn::Approval);
-    }
-    if parked.fan_out {
-        return Some(WaitingOn::FanOut);
-    }
-    if parked.children {
-        return Some(WaitingOn::Children);
-    }
-    // Waiting with no marker: the status was set by something that has since
-    // dropped its marker, and inventing a reason would be worse than leaving
-    // the field off.
-    None
+    /// The parking markers the agent is carrying, read off the entity by the
+    /// caller, which is where they are queryable.
+    pub parked: WaitMarkers,
 }
 
 /// Where the run has got to, and when.
@@ -421,7 +371,7 @@ pub fn build_run_meta(sources: RunMetaSources<'_>, at: RunPosition) -> RunMeta {
         yolo: md.unattended,
         read_paths: md.read_paths,
         final_output: final_output.map(|o| o.0.descriptor()),
-        waiting_on: waiting_on_from(&state.status, parked),
+        waiting_on: wait_reason_from(state.status == AgentStatus::Waiting, &parked),
         output_request: md.output_request.clone(),
     }
 }
@@ -430,6 +380,7 @@ pub fn build_run_meta(sources: RunMetaSources<'_>, at: RunPosition) -> RunMeta {
 mod tests {
     use super::*;
     use leviath_core::Region;
+    use leviath_core::run_meta::WaitReason;
     use leviath_providers::TokenUsage;
 
     fn state(status: AgentStatus) -> AgentState {
@@ -668,53 +619,51 @@ mod tests {
     }
 
     /// Each marker names its own reason, and only while the run is parked.
+    ///
+    /// The precedence itself is `leviath_core`'s, shared with the live
+    /// listing; this pins that the persistence path feeds it the right
+    /// markers.
     #[test]
     fn each_parking_marker_names_its_own_reason() {
         let cases = [
             (
-                ParkedBy {
-                    interaction: true,
+                WaitMarkers {
+                    gate_prompt: true,
                     ..Default::default()
                 },
-                WaitingOn::User,
+                WaitReason::TaintGate,
             ),
             (
-                ParkedBy {
-                    approval: true,
+                WaitMarkers {
+                    interaction_point: true,
                     ..Default::default()
                 },
-                WaitingOn::Approval,
+                WaitReason::InteractionPoint,
             ),
             (
-                ParkedBy {
-                    fan_out: true,
+                WaitMarkers {
+                    fan_out_outstanding: Some(3),
                     ..Default::default()
                 },
-                WaitingOn::FanOut,
+                WaitReason::FanOutWorkers { outstanding: 3 },
             ),
             (
-                ParkedBy {
-                    children: true,
+                WaitMarkers {
+                    children_outstanding: Some(2),
                     ..Default::default()
                 },
-                WaitingOn::Children,
+                WaitReason::Children { outstanding: 2 },
             ),
         ];
-        for (parked, expected) in cases {
+        for (markers, expected) in cases {
             assert_eq!(
-                waiting_on_from(&AgentStatus::Waiting, parked),
-                Some(expected),
-                "{parked:?}"
+                wait_reason_from(true, &markers),
+                Some(expected.clone()),
+                "{markers:?}"
             );
             // The same markers on a run that is not parked say nothing: an
             // active or finished run is not waiting on anybody.
-            for status in [
-                AgentStatus::Active,
-                AgentStatus::Complete,
-                AgentStatus::Cancelled,
-            ] {
-                assert_eq!(waiting_on_from(&status, parked), None, "{status:?}");
-            }
+            assert_eq!(wait_reason_from(false, &markers), None, "{markers:?}");
         }
     }
 
@@ -722,62 +671,18 @@ mod tests {
     /// person, and must not be reported as if it were.
     #[test]
     fn a_fan_out_parent_is_never_reported_as_waiting_on_a_person() {
-        let parent = ParkedBy {
-            fan_out: true,
-            ..Default::default()
-        };
-        let reason = waiting_on_from(&AgentStatus::Waiting, parent);
-        assert_eq!(reason, Some(WaitingOn::FanOut));
-        assert_ne!(reason, Some(WaitingOn::User));
-        assert_ne!(reason, Some(WaitingOn::Approval));
-    }
-
-    /// A run holding a question *and* engine-side work reports the question:
-    /// it is the half somebody can act on now.
-    #[test]
-    fn a_question_outranks_the_engine_side_reasons() {
-        let both = ParkedBy {
-            interaction: true,
-            approval: true,
-            fan_out: true,
-            children: true,
-        };
-        assert_eq!(
-            waiting_on_from(&AgentStatus::Waiting, both),
-            Some(WaitingOn::User)
-        );
-        // Without the question, an approval is still a person's to give.
-        assert_eq!(
-            waiting_on_from(
-                &AgentStatus::Waiting,
-                ParkedBy {
-                    interaction: false,
-                    ..both
-                }
-            ),
-            Some(WaitingOn::Approval)
-        );
-        // And between the two engine-side reasons, the specific one wins.
-        assert_eq!(
-            waiting_on_from(
-                &AgentStatus::Waiting,
-                ParkedBy {
-                    fan_out: true,
-                    children: true,
-                    ..Default::default()
-                }
-            ),
-            Some(WaitingOn::FanOut)
-        );
-    }
-
-    /// Parked with no marker at all: the field is left off rather than filled
-    /// with a guess.
-    #[test]
-    fn waiting_with_no_marker_reports_nothing() {
-        assert_eq!(
-            waiting_on_from(&AgentStatus::Waiting, ParkedBy::default()),
-            None
+        let reason = wait_reason_from(
+            true,
+            &WaitMarkers {
+                fan_out_outstanding: Some(8),
+                ..Default::default()
+            },
+        )
+        .expect("a parked parent has a reason");
+        assert_eq!(reason, WaitReason::FanOutWorkers { outstanding: 8 });
+        assert!(
+            !reason.needs_a_person(),
+            "its workers are still going; nobody is needed"
         );
     }
 
@@ -791,8 +696,8 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
-                parked: ParkedBy {
-                    children: true,
+                parked: WaitMarkers {
+                    children_outstanding: Some(2),
                     ..Default::default()
                 },
             },
@@ -805,7 +710,10 @@ mod tests {
             },
         );
         assert_eq!(meta.status, RunStatus::WaitingInput);
-        assert_eq!(meta.waiting_on, Some(WaitingOn::Children));
+        assert_eq!(
+            meta.waiting_on,
+            Some(WaitReason::Children { outstanding: 2 })
+        );
     }
 
     #[test]
@@ -827,7 +735,7 @@ mod tests {
                 totals: &totals,
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
-                parked: ParkedBy::default(),
+                parked: WaitMarkers::default(),
             },
             RunPosition {
                 stage_index: 1,
@@ -877,7 +785,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
-                parked: ParkedBy::default(),
+                parked: WaitMarkers::default(),
             },
             RunPosition {
                 stage_index: 1,
@@ -902,7 +810,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &flags,
                 final_output: None,
-                parked: ParkedBy::default(),
+                parked: WaitMarkers::default(),
             },
             RunPosition {
                 stage_index: 0,
@@ -930,7 +838,7 @@ mod tests {
                     totals: &TokenTotals::default(),
                     flags: &flags,
                     final_output: None,
-                    parked: ParkedBy::default(),
+                    parked: WaitMarkers::default(),
                 },
                 RunPosition {
                     stage_index: 0,
@@ -953,7 +861,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &wrote,
                 final_output: None,
-                parked: ParkedBy::default(),
+                parked: WaitMarkers::default(),
             },
             RunPosition {
                 stage_index: 0,
@@ -977,7 +885,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &incapable,
                 final_output: None,
-                parked: ParkedBy::default(),
+                parked: WaitMarkers::default(),
             },
             RunPosition {
                 stage_index: 0,
@@ -1002,7 +910,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
-                parked: ParkedBy::default(),
+                parked: WaitMarkers::default(),
             },
             RunPosition {
                 stage_index: 2,
@@ -1036,7 +944,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: Some(&submitted),
-                parked: ParkedBy::default(),
+                parked: WaitMarkers::default(),
             },
             RunPosition {
                 stage_index: 0,
@@ -1071,7 +979,7 @@ mod tests {
                 totals: &TokenTotals::default(),
                 flags: &RunOutcomeFlags::default(),
                 final_output: None,
-                parked: ParkedBy::default(),
+                parked: WaitMarkers::default(),
             },
             RunPosition {
                 stage_index: 0,

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -257,11 +257,12 @@ type PersistenceQuery = (
         Option<&'static crate::interaction_points::InteractionPointRounds>,
         Option<&'static crate::persistence::RunOutcomeFlags>,
         Option<&'static crate::persistence::FinalOutput>,
-        // The other two reasons a run can be parked. Read here because this is
+        // The remaining reasons a run can be parked. Read here because this is
         // where they are queryable, and recorded on `meta.json` so a client
         // does not have to reconstruct them from what it can see.
         Option<&'static crate::gate_prompt::AwaitingGatePrompt>,
         Option<&'static super::WaitingForChildren>,
+        Option<&'static crate::components::AwaitingInteraction>,
     ),
 );
 
@@ -300,6 +301,7 @@ pub fn dispatch_persistence(
             final_output,
             gate_prompt,
             waiting_for_children,
+            awaiting_interaction,
         ),
     ) in agents.iter_mut()
     {
@@ -389,11 +391,22 @@ pub fn dispatch_persistence(
                 totals,
                 flags: &flags,
                 final_output,
-                parked: crate::persistence::ParkedBy {
-                    interaction: awaiting_point.is_some(),
-                    approval: gate_prompt.is_some_and(|g| g.0 > 0),
-                    fan_out: fan_out_waiting.is_some(),
-                    children: waiting_for_children.is_some(),
+                parked: leviath_core::run_meta::WaitMarkers {
+                    gate_prompt: gate_prompt.is_some_and(|g| g.0 > 0),
+                    interaction_point: awaiting_point.is_some(),
+                    fan_out_outstanding: fan_out_waiting.map(|f| f.outstanding()),
+                    // The count needs each child's status, which this query
+                    // cannot reach; the listing computes it live. Recording
+                    // the reason without the number is the honest half.
+                    children_outstanding: waiting_for_children
+                        .map(|_| children.map(|c| c.children.len()).unwrap_or(0)),
+                    interaction: hub.as_ref().and_then(|h| {
+                        h.pending()
+                            .into_iter()
+                            .find(|(agent_id, _)| *agent_id == state.agent_id)
+                            .map(|(_, req)| req.kind)
+                    }),
+                    awaiting_interaction: awaiting_interaction.is_some(),
                 },
             },
             crate::persistence::RunPosition {

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -257,6 +257,11 @@ type PersistenceQuery = (
         Option<&'static crate::interaction_points::InteractionPointRounds>,
         Option<&'static crate::persistence::RunOutcomeFlags>,
         Option<&'static crate::persistence::FinalOutput>,
+        // The other two reasons a run can be parked. Read here because this is
+        // where they are queryable, and recorded on `meta.json` so a client
+        // does not have to reconstruct them from what it can see.
+        Option<&'static crate::gate_prompt::AwaitingGatePrompt>,
+        Option<&'static super::WaitingForChildren>,
     ),
 );
 
@@ -287,7 +292,15 @@ pub fn dispatch_persistence(
         parent_ref,
         children,
         fan_out_waiting,
-        (awaiting_point, ip_cursor, ip_rounds, outcome_flags, final_output),
+        (
+            awaiting_point,
+            ip_cursor,
+            ip_rounds,
+            outcome_flags,
+            final_output,
+            gate_prompt,
+            waiting_for_children,
+        ),
     ) in agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
@@ -376,6 +389,12 @@ pub fn dispatch_persistence(
                 totals,
                 flags: &flags,
                 final_output,
+                parked: crate::persistence::ParkedBy {
+                    interaction: awaiting_point.is_some(),
+                    approval: gate_prompt.is_some_and(|g| g.0 > 0),
+                    fan_out: fan_out_waiting.is_some(),
+                    children: waiting_for_children.is_some(),
+                },
             },
             crate::persistence::RunPosition {
                 stage_index: cursor.index,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1644,6 +1644,87 @@ fn a_restored_ledger_reaches_the_persist_tick_instead_of_the_seeded_zeros() {
 /// Not writing the same quarter-megabyte file on every heartbeat is still worth
 /// doing; it now happens in the lane, past the coalescing, where whether a job
 /// was written is a fact rather than an assumption.
+/// The reason a run is parked reaches `meta.json` through the real system, not
+/// just through the mapper.
+///
+/// Worth going through the whole system rather than calling the mapper: the
+/// markers live on the entity and the persist query is the only place that can
+/// see them, so a query that forgot to select one would leave the field empty
+/// with every unit test still passing.
+#[test]
+fn dispatch_persistence_records_why_a_run_is_parked() {
+    use leviath_core::run_meta::WaitingOn;
+
+    // A parent held by its own fan-out: waiting, and needing nobody.
+    let (mut world, mut rx) = world_with_persistence();
+    let mut state = agent_state();
+    state.status = AgentStatus::Waiting;
+    let e = world
+        .spawn((
+            run_metadata(),
+            state,
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            crate::pipeline::WaitingForChildren,
+        ))
+        .id();
+
+    run_dispatch_persistence(&mut world);
+    let job = snapshot_job(rx.try_recv().expect("job sent"));
+    assert_eq!(
+        job.meta.status,
+        leviath_core::run_meta::RunStatus::WaitingInput
+    );
+    assert_eq!(
+        job.meta.waiting_on,
+        Some(WaitingOn::Children),
+        "a run held for its sub-agents says so"
+    );
+
+    // The same run once it is moving again reports no reason at all.
+    world
+        .get_mut::<AgentState>(e)
+        .expect("state present")
+        .status = AgentStatus::Active;
+    world
+        .get_mut::<PersistWatermark>(e)
+        .expect("watermark present")
+        .backdate(0);
+    run_dispatch_persistence(&mut world);
+    let moving = snapshot_job(rx.try_recv().expect("job sent"));
+    assert_eq!(moving.meta.waiting_on, None);
+}
+
+/// Tool approvals are a person's to give, so a run holding them says so.
+///
+/// The count is what decides it rather than the marker's presence: a prompt
+/// record with nothing outstanding is not something to interrupt anybody for.
+#[test]
+fn dispatch_persistence_reports_outstanding_tool_approvals() {
+    use leviath_core::run_meta::WaitingOn;
+
+    for (outstanding, expected) in [(2usize, Some(WaitingOn::Approval)), (0, None)] {
+        let (mut world, mut rx) = world_with_persistence();
+        let mut state = agent_state();
+        state.status = AgentStatus::Waiting;
+        world.spawn((
+            run_metadata(),
+            state,
+            conv_window(),
+            StageCursor { index: 0 },
+            TokenTotals::default(),
+            PersistWatermark::default(),
+            crate::gate_prompt::AwaitingGatePrompt(outstanding),
+        ));
+
+        run_dispatch_persistence(&mut world);
+        let job = snapshot_job(rx.try_recv().expect("job sent"));
+        assert_eq!(job.meta.waiting_on, expected, "{outstanding} outstanding");
+    }
+}
+
 #[test]
 fn dispatch_persistence_always_carries_the_answer_for_the_lane_to_judge() {
     let (mut world, mut rx) = world_with_persistence();

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1653,10 +1653,13 @@ fn a_restored_ledger_reaches_the_persist_tick_instead_of_the_seeded_zeros() {
 /// with every unit test still passing.
 #[test]
 fn dispatch_persistence_records_why_a_run_is_parked() {
-    use leviath_core::run_meta::WaitingOn;
+    use leviath_core::run_meta::WaitReason;
 
     // A parent held by its own fan-out: waiting, and needing nobody.
     let (mut world, mut rx) = world_with_persistence();
+    // Two spawned children, so the recorded count is a real number rather
+    // than the no-children fallback.
+    let kids: Vec<Entity> = (0..2).map(|_| world.spawn_empty().id()).collect();
     let mut state = agent_state();
     state.status = AgentStatus::Waiting;
     let e = world
@@ -1668,6 +1671,10 @@ fn dispatch_persistence_records_why_a_run_is_parked() {
             TokenTotals::default(),
             PersistWatermark::default(),
             crate::pipeline::WaitingForChildren,
+            crate::components::SubAgentChildren {
+                children: kids,
+                max_child_depth: 3,
+            },
         ))
         .id();
 
@@ -1679,7 +1686,7 @@ fn dispatch_persistence_records_why_a_run_is_parked() {
     );
     assert_eq!(
         job.meta.waiting_on,
-        Some(WaitingOn::Children),
+        Some(WaitReason::Children { outstanding: 2 }),
         "a run held for its sub-agents says so"
     );
 
@@ -1703,9 +1710,9 @@ fn dispatch_persistence_records_why_a_run_is_parked() {
 /// record with nothing outstanding is not something to interrupt anybody for.
 #[test]
 fn dispatch_persistence_reports_outstanding_tool_approvals() {
-    use leviath_core::run_meta::WaitingOn;
+    use leviath_core::run_meta::WaitReason;
 
-    for (outstanding, expected) in [(2usize, Some(WaitingOn::Approval)), (0, None)] {
+    for (outstanding, expected) in [(2usize, Some(WaitReason::TaintGate)), (0, None)] {
         let (mut world, mut rx) = world_with_persistence();
         let mut state = agent_state();
         state.status = AgentStatus::Waiting;


### PR DESCRIPTION
Fixes #431.

## The fault
`RunStatus::WaitingInput` covers four situations, only two of which anybody can act on: a question for a person, tool calls held for approval, a parent held by its own fan-out, and a parent held for sub-agents at a `requires_children` boundary. The runtime tracks all four as separate marker components and then collapses them at one line in `run_status_from`. So a fan-out parent whose children are still working showed as **"Needs you"** in every client.

As the issue notes, the runtime was already paying for the conflation internally: `reflect_interaction_status` carries a `Without<FanOutWaiting>, Without<WaitingForChildren>` filter for exactly this reason. Consumers outside the ECS got no such filter and had to guess.

## The shape
`RunMeta` gains `waiting_on: Option<WaitingOn>` with `WaitingOn = { User, Approval, Children, FanOut }`, filled in the persist system where the markers are queryable.

**Not new `RunStatus` variants**, as the issue argued: the status is matched exhaustively across the codebase and serialized two ways on the wire, so splitting it would break every consumer to express something that is not a new state. `waiting_input` stays true for all four. This says *on what*.

Announced as `runs.waiting_on`.

## Not breaking previous runs
This was the explicit requirement, so it is tested in both directions rather than argued from the serde attributes:

- **Old file, new build:** `#[serde(default)]` means a `meta.json` written before this field existed still loads, with `waiting_on: None`. Test: `a_run_written_before_waiting_on_existed_still_loads` removes the key from a serialized meta and deserializes it.
- **New file, old build:** `skip_serializing_if` means a run that is not parked writes byte-identical output to before, so nothing new appears for an older reader. Test: `a_run_that_is_not_parked_writes_no_waiting_on_key`.

The field matches the convention `final_output` already set for exactly this reason.

## Precedence
Where several markers are present, the report is what a person can act on first: a question outranks an approval, and both outrank the two engine-side reasons. Between the engine-side pair, fan-out is the more specific claim, so it is reported ahead of `children`. A run somehow parked with no marker reports nothing rather than a guess.

## Validation
- Full workspace suite: **7439 passed, 0 failed**. Coverage gate at 100% for `leviath-core`, `leviath-runtime` and `leviath-cli`; clippy, fmt and `cargo xtask docs` clean.
- Tested through the **real persist system**, not only the mapper: the markers live on the entity and the persist query is the only place that can see them, so a query that forgot to select one would leave the field empty with every unit test still passing. `dispatch_persistence_records_why_a_run_is_parked` and `dispatch_persistence_reports_outstanding_tool_approvals` go through `dispatch_persistence` and read the resulting `meta`.
- The approval case is decided by the outstanding count, not the marker's presence, and both the non-zero and zero cases are covered.

## Deliberately not done
- **`lev ps` and the TUI still render as before.** They are named in the issue as consumers that reinvent the guess, but changing their output is a user-visible change that wants its own call. The data is now there for them.
- **Fan-out progress counts** ("waiting on 3 of 8 sub-agents"). `FanOutWaiting` does carry `pending`/`active`, and this is a good follow-up, but it is a second field with its own shape question rather than part of the fix.
