### PR TITLE
feat(serve): tools listing, script editing, and custom gateways in the config API

### DIFF
--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -7,6 +7,33 @@ use axum::response::Json;
 use super::types::*;
 use crate::config::Config;
 
+/// Every `[model_providers]` entry as the API reports it, name-sorted.
+///
+/// Sorted because the config holds them in a `HashMap`, whose iteration order
+/// differs between two calls on one machine, and a list that reorders itself
+/// under a form is a list nobody can edit.
+fn gateways_of(c: &Config) -> Vec<GatewayInfo> {
+    let mut gateways: Vec<GatewayInfo> = c
+        .model_providers
+        .iter()
+        .map(|(name, p)| GatewayInfo {
+            name: name.clone(),
+            base_url: p.base_url.clone(),
+            has_api_key: p.api_key.is_some(),
+            script: p.script.clone(),
+            // Names only. See `GatewayInfo::extra_keys`: these values are
+            // forwarded into a script and routinely hold credentials.
+            extra_keys: {
+                let mut keys: Vec<String> = p.extra.keys().cloned().collect();
+                keys.sort();
+                keys
+            },
+        })
+        .collect();
+    gateways.sort_by(|a, b| a.name.cmp(&b.name));
+    gateways
+}
+
 /// Redacted view of a config — booleans for keys, never their values.
 fn redact(c: &Config) -> RedactedConfig {
     RedactedConfig {
@@ -16,6 +43,7 @@ fn redact(c: &Config) -> RedactedConfig {
         has_google_key: c.providers.google_api_key.is_some(),
         has_openrouter_key: c.openrouter_api_key.is_some(),
         ollama_base_url: c.ollama_base_url.clone(),
+        gateways: gateways_of(c),
         agent_paths: c.agent_paths.clone(),
         mcp_server_count: c.mcp_servers.len(),
         api_version: API_VERSION.to_string(),
@@ -64,6 +92,26 @@ pub(super) async fn put_config(
     if let Some(v) = req.ollama_base_url {
         config.ollama_base_url = Some(v);
     }
+    // Field by field, like everything above: a gateway names only what it is
+    // changing, so a console can edit a base URL without knowing the key or
+    // sending it back through the browser.
+    for gateway in req.gateways.unwrap_or_default() {
+        let entry = config.model_providers.entry(gateway.name).or_default();
+        if let Some(v) = gateway.base_url {
+            entry.base_url = Some(v);
+        }
+        if let Some(v) = gateway.api_key {
+            entry.api_key = Some(v);
+        }
+        if let Some(v) = gateway.script {
+            entry.script = Some(v);
+        }
+    }
+    // Removals run last, so one request that both edits and deletes cannot
+    // depend on which half was applied first.
+    for name in req.remove_gateways.unwrap_or_default() {
+        config.model_providers.remove(&name);
+    }
 
     config.save_to_path_public(path).map_err(|e| {
         err(
@@ -101,11 +149,47 @@ fn validate_key_format(provider: &str, key: &str) -> (bool, Option<String>) {
                 (true, None)
             }
         }
-        other => (false, Some(format!("Unknown provider `{other}`."))),
+        // A custom gateway is custom precisely because its key has no house
+        // format to check, so an unknown name is no longer a rejection: the
+        // only thing that can be said about the key is that it is not empty.
+        _ => match key.trim().is_empty() {
+            true => (false, Some("Key must not be empty.".to_string())),
+            false => (true, None),
+        },
+    }
+}
+
+/// Format-only check of a gateway's base URL.
+///
+/// Shape only, like the key check beside it: no request is made, because
+/// `POST /api/config/validate` promises not to touch the network and a form
+/// that hangs on an unreachable host is worse than one that says nothing. The
+/// scheme is what people actually get wrong - a bare `api.example.com`, or an
+/// `ollama serve` address pasted without one.
+fn validate_base_url(url: &str) -> (bool, Option<String>) {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return (false, Some("Base URL must not be empty.".to_string()));
+    }
+    match trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        true => (true, None),
+        false => (
+            false,
+            Some("Base URL must start with `http://` or `https://`.".to_string()),
+        ),
     }
 }
 
 pub(super) async fn validate_config_key(Json(req): Json<ValidateKeyReq>) -> Json<ValidateKeyResp> {
+    // The URL is checked first: a gateway with both wrong is more usefully
+    // told about the address than about the key, since the key cannot be
+    // judged beyond being present.
+    if let Some(base_url) = &req.base_url {
+        let (valid, message) = validate_base_url(base_url);
+        if !valid {
+            return Json(ValidateKeyResp { valid, message });
+        }
+    }
     let (valid, message) = validate_key_format(&req.provider, &req.key);
     Json(ValidateKeyResp { valid, message })
 }
@@ -432,6 +516,7 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: None,
+            gateways: Vec::new(),
             agent_paths: vec![],
             mcp_server_count: 2,
             api_version: API_VERSION.to_string(),
@@ -455,6 +540,7 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: Some("http://localhost:11434".to_string()),
+            gateways: Vec::new(),
             agent_paths: vec![],
             mcp_server_count: 0,
             api_version: API_VERSION.to_string(),
@@ -570,6 +656,90 @@ mod tests {
         );
     }
 
+    /// A gateway can be created, then edited field by field, then removed,
+    /// without the caller ever holding its key.
+    ///
+    /// This is the whole point of the partial update reaching gateways: a
+    /// browser form that had to send the key back to change a URL would have
+    /// to have been given the key, which `GET /api/config` deliberately never
+    /// does.
+    #[tokio::test]
+    async fn put_config_edits_a_gateway_without_being_told_its_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+        let state = || state_with_config_path(path.clone());
+
+        // Create.
+        let resp = put_config_request(
+            state(),
+            r#"{"gateways":[{"name":"groq","base_url":"https://api.groq.com","api_key":"sk-secret","script":"groq.rhai"}]}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert_eq!(
+            saved.model_providers["groq"].script.as_deref(),
+            Some("groq.rhai"),
+            "the script backing the gateway is written too"
+        );
+
+        // Edit only the URL. The key is not sent, and must survive.
+        let resp = put_config_request(
+            state(),
+            r#"{"gateways":[{"name":"groq","base_url":"https://eu.groq.com"}]}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let saved = Config::load_from_path_public(&path).unwrap();
+        let gateway = &saved.model_providers["groq"];
+        assert_eq!(gateway.base_url.as_deref(), Some("https://eu.groq.com"));
+        assert_eq!(
+            gateway.api_key.as_deref(),
+            Some("sk-secret"),
+            "an unsent key is left alone, not cleared"
+        );
+
+        // A second gateway leaves the first alone.
+        let resp = put_config_request(state(), r#"{"gateways":[{"name":"other"}]}"#).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert_eq!(saved.model_providers.len(), 2);
+
+        // Remove takes a list of its own, because omitting a gateway above
+        // means "leave it alone" and so can never mean "delete it".
+        let resp = put_config_request(state(), r#"{"remove_gateways":["other"]}"#).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert!(saved.model_providers.contains_key("groq"));
+        assert!(!saved.model_providers.contains_key("other"));
+    }
+
+    /// The response a write returns reports the gateway the same redacted way
+    /// a read does, so a form can render straight from it.
+    #[tokio::test]
+    async fn put_config_returns_the_gateway_redacted() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+
+        let resp = put_config_request(
+            state_with_config_path(path),
+            r#"{"gateways":[{"name":"groq","api_key":"sk-secret"}]}"#,
+        )
+        .await;
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["gateways"][0]["name"], serde_json::json!("groq"));
+        assert_eq!(json["gateways"][0]["has_api_key"], serde_json::json!(true));
+        assert!(
+            !String::from_utf8_lossy(&body).contains("sk-secret"),
+            "the write's own response must not hand the key back"
+        );
+    }
+
     #[tokio::test]
     async fn put_config_read_failure_is_500() {
         // config_path points at a directory, so reading it as a file fails.
@@ -601,7 +771,80 @@ mod tests {
         assert_eq!(validate_key_format("google", "g"), (true, None));
         assert!(!validate_key_format("google", "  ").0);
         assert_eq!(validate_key_format("openrouter", "or"), (true, None));
-        assert!(!validate_key_format("unknown", "x").0);
+        // A name this build does not know is a custom gateway, not a mistake.
+        // Its key has no house format, so the only judgement available is
+        // whether one was given at all.
+        assert_eq!(validate_key_format("my-gateway", "anything"), (true, None));
+        assert!(!validate_key_format("my-gateway", "   ").0);
+    }
+
+    // ─── custom gateways ──────────────────────────────────────────────────────
+
+    /// The key never leaves the process, and neither does anything in `extra`.
+    ///
+    /// `extra` is forwarded into a provider script, so people keep credentials
+    /// there. Reporting its names is what a form needs; reporting its values
+    /// would be the same disclosure the `has_*_key` booleans exist to prevent.
+    #[test]
+    fn a_gateways_secrets_are_reported_as_presence_not_value() {
+        let mut config = Config::default();
+        config.model_providers.insert(
+            "groq".to_string(),
+            crate::config::ModelProviderConfig {
+                script: Some("groq.rhai".to_string()),
+                api_key: Some("sk-secret-value".to_string()),
+                base_url: Some("https://api.groq.com".to_string()),
+                rate_limit: None,
+                extra: [(
+                    "signing_secret".to_string(),
+                    toml::Value::String("hunter2".to_string()),
+                )]
+                .into_iter()
+                .collect(),
+            },
+        );
+
+        let redacted = redact(&config);
+        let gateway = &redacted.gateways[0];
+        assert_eq!(gateway.name, "groq");
+        assert_eq!(gateway.base_url.as_deref(), Some("https://api.groq.com"));
+        assert!(gateway.has_api_key);
+        assert_eq!(gateway.extra_keys, vec!["signing_secret".to_string()]);
+
+        // The whole serialized document, because a leak anywhere in it is a
+        // leak: a field added later would otherwise carry the value silently.
+        let json = serde_json::to_string(&redacted).expect("serializes");
+        assert!(!json.contains("sk-secret-value"), "{json}");
+        assert!(!json.contains("hunter2"), "{json}");
+    }
+
+    /// Name-sorted, because the config holds gateways in a `HashMap` and a
+    /// list that reorders itself between two reads cannot be edited in a form.
+    #[test]
+    fn gateways_are_reported_in_a_stable_order() {
+        let mut config = Config::default();
+        for name in ["zulu", "alpha", "mike"] {
+            config
+                .model_providers
+                .insert(name.to_string(), Default::default());
+        }
+        let names: Vec<String> = gateways_of(&config).into_iter().map(|g| g.name).collect();
+        assert_eq!(names, vec!["alpha", "mike", "zulu"]);
+    }
+
+    #[test]
+    fn a_config_with_no_gateways_reports_none() {
+        assert_eq!(gateways_of(&Config::default()), Vec::new());
+    }
+
+    /// A base URL is checked for shape only, and the scheme is the part people
+    /// actually leave off.
+    #[test]
+    fn a_base_url_is_checked_for_its_scheme() {
+        assert_eq!(validate_base_url("https://api.example.com"), (true, None));
+        assert_eq!(validate_base_url("http://localhost:11434"), (true, None));
+        assert!(!validate_base_url("api.example.com").0);
+        assert!(!validate_base_url("  ").0);
     }
 
     #[tokio::test]
@@ -626,6 +869,62 @@ mod tests {
         let v: ValidateKeyResp = serde_json::from_slice(&bytes).unwrap();
         assert!(!v.valid);
         assert!(v.message.is_some());
+    }
+
+    /// A gateway is checked on its URL as well as its key, and the URL is what
+    /// answers when it is wrong.
+    #[tokio::test]
+    async fn validate_config_key_endpoint_checks_a_gateways_base_url() {
+        let check = |body: serde_json::Value| async move {
+            let app = Router::new().route(
+                "/api/config/validate",
+                axum::routing::post(validate_config_key),
+            );
+            let req = Request::builder()
+                .method("POST")
+                .uri("/api/config/validate")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            serde_json::from_slice::<ValidateKeyResp>(&bytes).unwrap()
+        };
+
+        // A URL with no scheme is rejected, and the message names the URL
+        // rather than the key, which is the part that is fine.
+        let bad = check(serde_json::json!({
+            "provider": "my-gateway",
+            "key": "anything",
+            "base_url": "api.example.com",
+        }))
+        .await;
+        assert!(!bad.valid);
+        assert!(
+            bad.message.unwrap_or_default().contains("Base URL"),
+            "the address is what is wrong"
+        );
+
+        // A good URL falls through to the key check, which for a custom
+        // gateway only asks that a key was given at all.
+        let good = check(serde_json::json!({
+            "provider": "my-gateway",
+            "key": "anything",
+            "base_url": "https://api.example.com",
+        }))
+        .await;
+        assert!(good.valid, "{:?}", good.message);
+
+        // And an empty key still fails once the URL is fine.
+        let empty = check(serde_json::json!({
+            "provider": "my-gateway",
+            "key": "  ",
+            "base_url": "https://api.example.com",
+        }))
+        .await;
+        assert!(!empty.valid);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -1,0 +1,216 @@
+//! Request and response shapes for the config endpoints.
+//!
+//! Split out of `types.rs` when custom gateways pushed that file over the
+//! production-line limit. The division is by concern rather than by size: the
+//! config surface is the one part of the API that describes the machine's own
+//! setup rather than a run, and it is the part that grows every time a new
+//! kind of provider becomes configurable.
+
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize)]
+pub(super) struct RedactedConfig {
+    pub(super) default_provider: String,
+    pub(super) has_anthropic_key: bool,
+    pub(super) has_openai_key: bool,
+    pub(super) has_google_key: bool,
+    pub(super) has_openrouter_key: bool,
+    pub(super) ollama_base_url: Option<String>,
+    /// Every custom gateway `[model_providers]` declares, name-sorted.
+    ///
+    /// The four fields above can only describe the providers that existed when
+    /// this struct was written, so a console could show the built-in four and
+    /// was blind to any gateway a user added - which is backwards, since the
+    /// people most likely to want a form for provider setup are the ones not
+    /// using a first-party provider.
+    pub(super) gateways: Vec<GatewayInfo>,
+    pub(super) agent_paths: Vec<PathBuf>,
+    pub(super) mcp_server_count: usize,
+    /// The API contract this server implements, matching `info.version` in
+    /// `docs/schema/openapi.json`. A test holds the two together.
+    pub(super) api_version: String,
+    /// What this server can do, so a client can light up features in one call.
+    ///
+    /// Before this, the console feature-detected by calling a route and reading
+    /// a 404 as "unsupported" - fragile, because a 404 also means "no such run",
+    /// and one round trip per feature.
+    pub(super) capabilities: Vec<String>,
+    pub(super) limits: ApiLimits,
+}
+
+/// The API contract version. Held equal to the OpenAPI spec's `info.version` by
+/// a test, because a version that can silently disagree with the document it
+/// names is worse than no version at all.
+pub(super) const API_VERSION: &str = "0.3.0";
+
+/// Every capability a client may check for.
+pub(super) const API_CAPABILITIES: &[&str] = &[
+    "runs.envelope",
+    "runs.cursor",
+    "runs.search",
+    "runs.search.context",
+    "runs.search.logs",
+    "runs.search.journal",
+    "runs.fields",
+    "runs.ids",
+    "runs.since",
+    "runs.files.listing",
+    "runs.files.workdir",
+    "runs.stages",
+    "logs.stage",
+    "logs.stream",
+    "context.history.page",
+    "runs.waiting_on",
+    "blueprints.envelope",
+    "blueprints.query",
+    "blueprints.manifest",
+    "blueprints.validate.name",
+    "tools.list",
+    "scripts.read",
+    // Announced whether or not `--allow-admin` was passed, which is a narrower
+    // claim than the others on this list: it says this build serves the write
+    // routes, not that this daemon has them mounted. `--allow-admin` decides
+    // that at router construction and is deliberately not carried in
+    // `ServeLimits` for a handler to read (see the note there), so a client
+    // finds out the same way it finds out about the MCP admin routes - by
+    // calling one and reading the status.
+    "scripts.write",
+    "config.gateways",
+];
+
+/// The server's numeric limits.
+///
+/// This is what makes capability discovery useful rather than decorative: a
+/// client that knows the feature exists still has to guess the page cap, the
+/// file-size cap and the tracked-file cap, and every one of those guesses would
+/// be hardcoded and eventually wrong.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ApiLimits {
+    /// Largest `limit` on `GET /api/runs`; larger values are clamped.
+    pub(super) max_limit: usize,
+    /// Most ids one `ids=` batch may name.
+    pub(super) max_ids: usize,
+    /// Largest file body `?path=` returns.
+    pub(super) max_file_bytes: u64,
+    /// Most entries one directory listing returns.
+    pub(super) max_listing_entries: usize,
+    /// How many runs a filesystem-reading search examines before reporting
+    /// `scan_truncated`.
+    pub(super) max_search_scan: usize,
+    /// How much of each stage log a search reads, from the end.
+    pub(super) search_log_tail_bytes: u64,
+    /// Largest `limit` on the context-history route.
+    pub(super) max_history_limit: usize,
+    /// How many distinct modified paths a run records before
+    /// `modified_files_truncated` is set.
+    pub(super) max_tracked_modified_files: usize,
+}
+
+impl ApiLimits {
+    /// Read from the constants the handlers actually use, so the two cannot
+    /// drift into disagreeing.
+    pub(super) fn current() -> Self {
+        Self {
+            max_limit: super::runs::MAX_LIMIT,
+            max_ids: super::runs::MAX_IDS,
+            max_file_bytes: super::agents::MAX_FILE_READ_BYTES,
+            max_listing_entries: super::agents::MAX_LISTING_ENTRIES,
+            max_search_scan: super::runs::MAX_SEARCH_SCAN,
+            search_log_tail_bytes: super::runs::SEARCH_LOG_TAIL_BYTES,
+            max_history_limit: super::agents::HISTORY_MAX_LIMIT,
+            max_tracked_modified_files: leviath_core::run_meta::MAX_TRACKED_MODIFIED_FILES,
+        }
+    }
+}
+
+/// Body of `PUT /api/config` (admin-only). Every field is optional; a present
+/// field is written, an absent one is left untouched. Mirrors what `lev setup`
+/// writes, so a newcomer can configure providers entirely from the browser.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct WriteConfigReq {
+    pub(super) default_provider: Option<String>,
+    pub(super) default_model: Option<String>,
+    pub(super) anthropic_key: Option<String>,
+    pub(super) openai_key: Option<String>,
+    pub(super) google_key: Option<String>,
+    pub(super) openrouter_key: Option<String>,
+    pub(super) ollama_base_url: Option<String>,
+    /// Gateways to add or update, by name. Absent means "change none", the
+    /// same partial-update rule every field above follows: a gateway this list
+    /// does not mention is left exactly as it was.
+    #[serde(default)]
+    pub(super) gateways: Option<Vec<GatewayWrite>>,
+    /// Gateways to remove, by name. Separate from the list above because
+    /// omitting a gateway there means "leave it alone", so there would
+    /// otherwise be no way to say "delete it" without sending the whole set
+    /// and reintroducing the read-modify-write hazard this endpoint avoids.
+    #[serde(default)]
+    pub(super) remove_gateways: Option<Vec<String>>,
+}
+
+/// One custom gateway as `GET /api/config` reports it.
+///
+/// The key is never served, only whether one is set, exactly like the
+/// `has_*_key` booleans beside it.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub(super) struct GatewayInfo {
+    /// The name an agent references, and the `[model_providers]` table key.
+    pub(super) name: String,
+    /// Where the gateway lives, when the entry sets one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) base_url: Option<String>,
+    /// Whether a key is configured for it.
+    pub(super) has_api_key: bool,
+    /// The Rhai provider script backing it, when the entry names one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) script: Option<String>,
+    /// The names of any extra keys the entry carries, without their values.
+    ///
+    /// `extra` is forwarded verbatim into the script's `initialize`, so people
+    /// put credentials in it: a second token, a signing secret. Serving those
+    /// values would leak precisely what `has_api_key` exists to avoid, so only
+    /// the names are reported - enough for a form to show that the fields are
+    /// there and not enough to disclose one.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(super) extra_keys: Vec<String>,
+}
+
+/// One custom gateway as `PUT /api/config` accepts it.
+#[derive(Debug, Deserialize)]
+pub(super) struct GatewayWrite {
+    /// Which gateway this is. Created when no entry has this name.
+    pub(super) name: String,
+    /// Absent leaves whatever the entry already had.
+    #[serde(default)]
+    pub(super) base_url: Option<String>,
+    /// Absent leaves the existing key in place, which is what lets a console
+    /// edit a gateway's URL without having to know its key or send it back.
+    #[serde(default)]
+    pub(super) api_key: Option<String>,
+    /// Absent leaves the existing script name.
+    #[serde(default)]
+    pub(super) script: Option<String>,
+}
+
+/// Body of `POST /api/config/validate` — a format-only key check (no network,
+/// no persistence), mirroring the `lev setup` wizard's inline validation.
+#[derive(Debug, Deserialize)]
+pub(super) struct ValidateKeyReq {
+    pub(super) provider: String,
+    pub(super) key: String,
+    /// A gateway's base URL, checked alongside the key when present.
+    ///
+    /// A custom gateway's key has no house format to check - that is what
+    /// makes it custom - so for one the useful pre-flight is the URL, which is
+    /// the field people actually get wrong.
+    #[serde(default)]
+    pub(super) base_url: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ValidateKeyResp {
+    pub(super) valid: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) message: Option<String>,
+}

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -7,6 +7,7 @@ mod agents;
 mod auth;
 mod blueprints;
 mod config;
+mod config_types;
 mod cursor;
 mod doctor;
 mod fs;
@@ -14,10 +15,12 @@ mod interactions;
 mod mcp;
 mod polling;
 mod runs;
+mod scripts;
 mod search;
 #[cfg(test)]
 mod testutil;
 mod tls;
+mod tools;
 mod tree;
 mod types;
 mod websocket;
@@ -121,6 +124,15 @@ fn api_router() -> Router<AppState> {
         .route("/api/doctor", get(doctor::run_doctor))
         // Filesystem - directory browsing for the console's folder picker.
         .route("/api/fs/dirs", get(fs::list_dirs))
+        // Tools - what an agent on this machine can actually call. Read-only:
+        // there is nothing to write, since a tool is either built in or a file
+        // the scripts routes below own.
+        .route("/api/tools", get(tools::list_tools))
+        // Scripts - the read half of the Rhai surface. The write half is
+        // mounted by `execute_with_shutdown`, behind `--allow-admin`.
+        .route("/api/scripts", get(scripts::list_scripts))
+        .route("/api/scripts/validate", post(scripts::validate_script))
+        .route("/api/scripts/{kind}/{name}", get(scripts::get_script))
         // Config
         .route("/api/config", get(config::get_config))
         .route("/api/config/validate", post(config::validate_config_key))
@@ -327,7 +339,16 @@ async fn execute_with_shutdown(
             .route("/api/mcp/servers/{name}", delete(mcp::remove_server))
             // Config-write persists provider secrets to disk, so it is gated the
             // same way as MCP admin: unmounted (404) unless --allow-admin.
-            .route("/api/config", put(config::put_config)),
+            .route("/api/config", put(config::put_config))
+            // A `.rhai` file is executable code every agent then runs, so
+            // writing one is the same category of act as adding an MCP server
+            // rather than the same category as saving a blueprint. Unmounted
+            // (404) unless --allow-admin; the GET half above stays open so an
+            // editor degrades to read-only instead of disappearing.
+            .route(
+                "/api/scripts/{kind}/{name}",
+                put(scripts::put_script).delete(scripts::delete_script),
+            ),
         false => app,
     };
 
@@ -1965,6 +1986,84 @@ system_prompt = "Run"
                     false => assert_eq!(status, 405, "the admin route must not be mounted"),
                     true => assert_ne!(status, 405, "the admin route must be mounted"),
                 }
+
+                let _ = stop_tx.send(());
+                let _ = server.await;
+            }
+        })
+        .await;
+    }
+
+    /// The script write routes are mounted only with `--allow-admin`, for the
+    /// same reason the MCP ones are: a `.rhai` file is executable code every
+    /// agent then runs, so a browser session that can `PUT` one can run code on
+    /// the host. The `GET` half stays mounted either way, so an editor degrades
+    /// to read-only instead of disappearing.
+    ///
+    /// `LEVIATH_HOME` is redirected alongside the config path because the
+    /// mounted case really does write a file, and it must not be a developer's
+    /// own `~/.leviath/tools`. One `temp_env` call, since it serializes
+    /// process-wide and holds its lock across the future.
+    #[tokio::test]
+    async fn the_script_write_routes_are_mounted_only_with_allow_admin() {
+        let home = tempfile::tempdir().expect("a temp dir");
+        let root = home.path().to_path_buf();
+        let mut vars = crate::config::config_isolation_vars(&root);
+        vars.push(("LEVIATH_HOME", Some(root.clone().into_os_string())));
+
+        temp_env::async_with_vars(vars, async move {
+            for allow_admin in [false, true] {
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: None,
+                    token: Some("t".to_string()),
+                    allow_admin,
+                    workdir_root: None,
+                    no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
+                };
+                let server = tokio::spawn(execute_with_shutdown(
+                    args,
+                    no_daemon_control(),
+                    Box::pin(async move {
+                        let _ = stop_rx.await;
+                    }),
+                    Some(ready_tx),
+                ));
+                let addr = ready_rx.await.expect("bound");
+                let client = reqwest::Client::new();
+
+                let write = client
+                    .put(format!("http://{addr}/api/scripts/tool/gate"))
+                    .bearer_auth("t")
+                    .json(&serde_json::json!({ "content": "// @tool gate\n1" }))
+                    .send()
+                    .await
+                    .expect("request")
+                    .status()
+                    .as_u16();
+                // 405 is the signature of "this path exists for GET but PUT is
+                // not mounted", the same reading the MCP test above relies on.
+                match allow_admin {
+                    false => assert_eq!(write, 405, "the write route must not be mounted"),
+                    true => assert_ne!(write, 405, "the write route must be mounted"),
+                }
+
+                // The read half answers either way. Nothing was written when
+                // admin was off, so a 404 is as much a mounted route as a 200.
+                let read = client
+                    .get(format!("http://{addr}/api/scripts"))
+                    .bearer_auth("t")
+                    .send()
+                    .await
+                    .expect("request")
+                    .status()
+                    .as_u16();
+                assert_eq!(read, 200, "the read routes are never gated");
 
                 let _ = stop_tx.send(());
                 let _ = server.await;

--- a/crates/leviath-cli/src/commands/serve/scripts.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts.rs
@@ -1,0 +1,673 @@
+//! Read and write the Rhai scripts an agent runs.
+//!
+//! Four extension points share one API because they share one editor: a script
+//! tool, a region hook, a stage hook and an output validator are all a `.rhai`
+//! file in the agent's directory, and only the `kind` says which compiler has to
+//! accept it.
+//!
+//! # Where each kind actually lives
+//!
+//! Only **script tools** have a directory convention: `<agent>/tools/*.rhai`,
+//! scanned at spawn, plus the global `~/.leviath/tools/` every agent gets. The
+//! other three are named by path in the manifest and resolved relative to the
+//! agent's own directory, with `resolve_*_scripts` in the daemon refusing any
+//! that lands outside it. There is no `hooks/` or `validators/` directory to
+//! list, so the listing derives those three from what the manifest declares,
+//! and the read/write routes address them at `<agent>/<name>.rhai` - the path a
+//! bare declared filename already resolves to. There is likewise no global
+//! directory for them: a hook only ever loads from beside the agent that
+//! declares it.
+//!
+//! # Why the write half is gated
+//!
+//! A blueprint is declarative. A `.rhai` file is executable code every agent
+//! then runs, so `PUT` and `DELETE` are the same category of act as adding an
+//! MCP server, and they are mounted the same way: absent entirely, 404, unless
+//! `lev serve --allow-admin`. The `GET` routes stay open so an editor degrades
+//! to read-only instead of disappearing.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Component, Path, PathBuf};
+
+use axum::extract::{Path as AxumPath, Query};
+use axum::http::StatusCode;
+use axum::response::Json;
+use serde::{Deserialize, Serialize};
+
+use super::tools::{ApiError, agent_dir};
+use super::types::err;
+
+/// Which extension point a script plugs into, and so which compiler decides
+/// whether it is valid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) enum ScriptKind {
+    /// A tool the model may call, discovered from a `tools/` directory.
+    Tool,
+    /// A custom region's `render`/`on_write`/`on_overflow`.
+    RegionHook,
+    /// A stage lifecycle hook.
+    StageHook,
+    /// A validator that decides whether an agent's output may be handed back.
+    OutputValidator,
+}
+
+impl ScriptKind {
+    /// The wire spelling, which is also the `{kind}` path segment.
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Tool => "tool",
+            Self::RegionHook => "region_hook",
+            Self::StageHook => "stage_hook",
+            Self::OutputValidator => "output_validator",
+        }
+    }
+
+    /// Parse a `{kind}` segment. `None` for anything else, which the routes turn
+    /// into a 400 rather than guessing a kind and compiling with the wrong rules.
+    fn parse(raw: &str) -> Option<Self> {
+        match raw {
+            "tool" => Some(Self::Tool),
+            "region_hook" => Some(Self::RegionHook),
+            "stage_hook" => Some(Self::StageHook),
+            "output_validator" => Some(Self::OutputValidator),
+            _ => None,
+        }
+    }
+}
+
+/// The global drop-in directory, `~/.leviath/tools`.
+///
+/// Empty when no home resolves. That is deliberately not a special case: an
+/// empty base cannot be shown to contain anything, so [`guard`] refuses it, and
+/// a write lands nowhere rather than in the process's working directory.
+fn global_tools_dir() -> PathBuf {
+    leviath_core::tools_dir().unwrap_or_default()
+}
+
+/// One resolved script file: which directory owns it, what it is called there,
+/// and whose it is.
+#[derive(Debug, Clone)]
+struct Target {
+    kind: ScriptKind,
+    /// The directory the file must live in, and nothing below it.
+    dir: PathBuf,
+    /// `<dir>/<name>.rhai`.
+    path: PathBuf,
+    /// `agent` or `global`.
+    scope: &'static str,
+    /// The agent that owns it, absent for the global directory.
+    agent: Option<String>,
+}
+
+/// Resolve `{kind}/{name}` plus an optional `?agent=` into the one file the
+/// request may touch.
+///
+/// Both `name` and `agent` arrive in a URL and are joined onto a directory, so
+/// both go through [`leviath_core::is_safe_path_component`] first, the way
+/// `blueprint_dir` does in `blueprints.rs`: `Path::join` neither normalizes
+/// `..` nor resists an absolute path, and the bug that check exists for was a
+/// REST route writing attacker-chosen content outside the directory it meant to
+/// and then recursively deleting whatever it had landed on.
+///
+/// The `.rhai` extension is fixed here rather than taken from the caller, so no
+/// request can ask for a `.toml`, a manifest, or anything else in the agent's
+/// directory. A `name` that already carries the extension is accepted and means
+/// the same file, since that is how the listing spells a path back.
+fn resolve(kind: &str, name: &str, agent: Option<&str>) -> Result<Target, ApiError> {
+    let Some(kind) = ScriptKind::parse(kind) else {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Unknown script kind '{kind}': expected tool, region_hook, stage_hook \
+                 or output_validator"
+            ),
+        ));
+    };
+    let stem = name.strip_suffix(".rhai").unwrap_or(name);
+    if !leviath_core::is_safe_path_component(stem) {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Invalid script name '{name}': names may contain only letters, digits, \
+                 '.', '_' and '-'"
+            ),
+        ));
+    }
+
+    let (dir, scope, owner) = match agent {
+        Some(agent) => {
+            let base = agent_dir(agent)?;
+            // Tools are scanned out of `tools/`; a hook or validator is named by
+            // a manifest path that resolves against the agent's own directory.
+            let dir = match kind {
+                ScriptKind::Tool => base.join("tools"),
+                _ => base,
+            };
+            (dir, "agent", Some(agent.to_string()))
+        }
+        None => match kind {
+            ScriptKind::Tool => (global_tools_dir(), "global", None),
+            _ => {
+                return Err(err(
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "A {} is only ever loaded from beside the agent that declares it, \
+                         so this route needs ?agent=<name>",
+                        kind.as_str()
+                    ),
+                ));
+            }
+        },
+    };
+
+    let path = dir.join(format!("{stem}.rhai"));
+    Ok(Target {
+        kind,
+        dir,
+        path,
+        scope,
+        agent: owner,
+    })
+}
+
+/// Whether the target has to exist already.
+#[derive(Debug, Clone, Copy)]
+enum Presence {
+    /// A read or a delete: no file, no request.
+    Required,
+    /// A write: the file may be new.
+    Optional,
+}
+
+/// The containment gate every read and write passes through.
+///
+/// The name is already a single safe component joined onto a fixed directory,
+/// so nothing the caller wrote can carry the path elsewhere. What is left is
+/// what the *filesystem* can do: a symlink planted at that exact name would
+/// send a read or a write straight through it, outside the directory this route
+/// is fenced to. `symlink_metadata` does not follow, so anything that is not a
+/// plain file is refused before it is opened, and the resolved path is then
+/// checked against the directory it came from.
+///
+/// The existence check runs first on purpose. Containment canonicalizes, and a
+/// directory that does not exist yet cannot be canonicalized, so asking that
+/// question about a missing file would answer "forbidden" on the platforms
+/// where the temporary directory is itself a symlink and "not found" everywhere
+/// else.
+fn guard(target: &Target, presence: Presence) -> Result<(), ApiError> {
+    match (std::fs::symlink_metadata(&target.path), presence) {
+        (Ok(meta), _) if !meta.is_file() => {
+            return Err(err(
+                StatusCode::FORBIDDEN,
+                format!(
+                    "'{}' is not a plain file, so it will not be read or written through",
+                    target.path.display()
+                ),
+            ));
+        }
+        (Err(_), Presence::Required) => {
+            return Err(err(
+                StatusCode::NOT_FOUND,
+                format!("No such script: {}", target.path.display()),
+            ));
+        }
+        _ => {}
+    }
+    match leviath_core::resolves_within(&target.path, &target.dir) {
+        true => Ok(()),
+        false => Err(err(
+            StatusCode::FORBIDDEN,
+            format!(
+                "'{}' does not resolve inside {}",
+                target.path.display(),
+                target.dir.display()
+            ),
+        )),
+    }
+}
+
+/// Compile `content` as `kind` and say only whether it worked.
+///
+/// Each arm is the same compiler the daemon uses at spawn, so a script this
+/// accepts is one a run will accept. `hooks` is what a stage-hook file was named
+/// for; an empty slice asks only that it compiles, which is all that can be
+/// asked of a file no manifest points at yet.
+fn compile_status(
+    kind: ScriptKind,
+    label: &str,
+    content: &str,
+    hooks: &[&str],
+) -> Result<(), String> {
+    let outcome = match kind {
+        ScriptKind::Tool => leviath_scripting::tool::check_source(label, content).map(drop),
+        ScriptKind::RegionHook => leviath_scripting::region_hook::compile(label, content).map(drop),
+        ScriptKind::StageHook => {
+            leviath_scripting::stage_hook::compile(label, content, hooks).map(drop)
+        }
+        ScriptKind::OutputValidator => {
+            leviath_scripting::output_validator::compile(label, content).map(drop)
+        }
+    };
+    match outcome {
+        Ok(()) => Ok(()),
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+/// Flatten a compile outcome into the pair the wire types carry.
+fn status_pair(status: Result<(), String>) -> (bool, Option<String>) {
+    match status {
+        Ok(()) => (true, None),
+        Err(reason) => (false, Some(reason)),
+    }
+}
+
+// ─── Wire types ─────────────────────────────────────────────────────────────
+
+/// The `?agent=` every script route takes.
+#[derive(Debug, Deserialize)]
+pub(super) struct ScriptQuery {
+    /// Scope to this agent's own directory. Absent means the global tools
+    /// directory, which only holds script tools.
+    agent: Option<String>,
+}
+
+/// One script in the listing.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ScriptItem {
+    /// `tool`, `region_hook`, `stage_hook` or `output_validator`.
+    pub(super) kind: String,
+    /// The `{name}` the read and write routes address it by.
+    pub(super) name: String,
+    /// `agent` when it belongs to one agent, `global` when every agent gets it.
+    pub(super) source: String,
+    /// Which agent, for an agent-scoped script.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) agent: Option<String>,
+    /// The file on disk.
+    pub(super) path: String,
+    /// Whether it compiles right now.
+    pub(super) compiles: bool,
+    /// Why not, when it does not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) error: Option<String>,
+}
+
+/// The body of `GET /api/scripts`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ScriptsResp {
+    /// Every script this scope can see, agent-owned first.
+    pub(super) scripts: Vec<ScriptItem>,
+}
+
+/// The body of `GET /api/scripts/{kind}/{name}`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ScriptSource {
+    /// Which extension point this file plugs into.
+    pub(super) kind: String,
+    /// The `{name}` it is addressed by.
+    pub(super) name: String,
+    /// `agent` or `global`.
+    pub(super) source: String,
+    /// Which agent, for an agent-scoped script.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) agent: Option<String>,
+    /// The file on disk.
+    pub(super) path: String,
+    /// The script text.
+    pub(super) content: String,
+    /// Whether it compiles right now.
+    pub(super) compiles: bool,
+    /// Why not, when it does not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) error: Option<String>,
+}
+
+/// The body of `PUT /api/scripts/{kind}/{name}`.
+#[derive(Debug, Deserialize)]
+pub(super) struct WriteScriptReq {
+    /// The script text to write.
+    content: String,
+}
+
+/// What a write reports back.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ScriptWritten {
+    /// Where it landed.
+    pub(super) path: String,
+    /// Whether what was saved compiles. A file that does not is still written:
+    /// an editor is allowed to save work in progress, and a tool that does not
+    /// compile is skipped at spawn rather than breaking the agent.
+    pub(super) compiles: bool,
+    /// Why not, when it does not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) error: Option<String>,
+}
+
+/// The body of `POST /api/scripts/validate`.
+#[derive(Debug, Deserialize)]
+pub(super) struct ValidateScriptReq {
+    /// Which extension point to compile it as.
+    kind: String,
+    /// The script text.
+    content: String,
+    /// For a stage hook, the hook names the blueprint would name this file for.
+    /// A file that does not define one it is named for is a spawn error, so an
+    /// editor can ask about that here rather than at the start of a run.
+    #[serde(default)]
+    hooks: Vec<String>,
+}
+
+/// What `POST /api/scripts/validate` reports.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ValidateScriptResp {
+    /// Whether the compiler for this kind accepts the text.
+    pub(super) valid: bool,
+    /// The compiler's complaint, when it does not.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) error: Option<String>,
+}
+
+// ─── Listing ────────────────────────────────────────────────────────────────
+
+/// The `{name}` these routes would address a declared script by, or `None` when
+/// the manifest declared something they cannot address.
+///
+/// A manifest may name any path inside the agent's directory, a subdirectory
+/// included. These routes address `<agent>/<name>.rhai`: one component, one
+/// fixed extension. Anything else is left out of the listing rather than listed
+/// under a name that would fetch a different file or none at all.
+fn addressable_name(declared: &str) -> Option<String> {
+    let mut components = Path::new(declared).components();
+    let (Some(Component::Normal(only)), None) = (components.next(), components.next()) else {
+        return None;
+    };
+    let file = only.to_string_lossy();
+    let stem = file.strip_suffix(".rhai")?;
+    match leviath_core::is_safe_path_component(stem) {
+        true => Some(stem.to_string()),
+        false => None,
+    }
+}
+
+/// Every hook and validator the manifest declares, keyed by kind and declared
+/// path, carrying the stage-hook names each file was named for.
+///
+/// This is the only way to know a `.rhai` beside a manifest is a region hook
+/// rather than a stage hook: nothing about the file says so, the declaration
+/// does. A file written but not yet declared is therefore not listed, which is
+/// the honest answer - nothing would load it either.
+fn declared_scripts(bp: &leviath_core::Blueprint) -> BTreeMap<(ScriptKind, String), Vec<String>> {
+    let mut declared: BTreeMap<(ScriptKind, String), Vec<String>> = BTreeMap::new();
+
+    let layouts = std::iter::once(&bp.context_layout).chain(
+        bp.stages
+            .iter()
+            .filter_map(|stage| stage.context_layout.as_ref()),
+    );
+    for layout in layouts {
+        for region in &layout.regions {
+            if let leviath_core::RegionKind::Custom { script, .. } = &region.kind {
+                declared
+                    .entry((ScriptKind::RegionHook, script.clone()))
+                    .or_default();
+            }
+        }
+    }
+
+    for stage in &bp.stages {
+        for (hook, path) in stage.hooks.declared() {
+            declared
+                .entry((ScriptKind::StageHook, path.to_string()))
+                .or_default()
+                .push(hook.to_string());
+        }
+    }
+
+    let outputs = bp
+        .output
+        .iter()
+        .chain(bp.stages.iter().filter_map(|stage| stage.output.as_ref()));
+    for spec in outputs {
+        if let Some(validator) = spec.validator.as_deref() {
+            declared
+                .entry((ScriptKind::OutputValidator, validator.to_string()))
+                .or_default();
+        }
+    }
+
+    declared
+}
+
+/// List the `.rhai` files in one tools directory, with the compile verdict
+/// `discover` already reached for each.
+///
+/// `discover` is what the daemon runs at spawn, so a file it skips is a file no
+/// agent will get. Running it once over the directory and matching by path is
+/// what makes the reported status the real one, `tool.toml` overrides included.
+fn collect_tools(dir: &Path, scope: &'static str, agent: Option<&str>, out: &mut Vec<ScriptItem>) {
+    let (_, failed) = leviath_scripting::ScriptToolSet::discover(&[dir.to_path_buf()]);
+    let reasons: HashMap<PathBuf, String> =
+        failed.into_iter().map(|f| (f.path, f.reason)).collect();
+
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "rhai"))
+        .collect();
+    paths.sort();
+
+    for path in paths {
+        let (compiles, error) = match reasons.get(&path) {
+            Some(reason) => (false, Some(reason.clone())),
+            None => (true, None),
+        };
+        out.push(ScriptItem {
+            kind: ScriptKind::Tool.as_str().to_string(),
+            name: path
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into(),
+            source: scope.to_string(),
+            agent: agent.map(str::to_string),
+            path: path.display().to_string(),
+            compiles,
+            error,
+        });
+    }
+}
+
+/// List the hooks and validators the agent's manifest declares.
+///
+/// An agent with no manifest, or one that will not parse, contributes nothing:
+/// the blueprint routes are where a broken manifest is reported, and a script
+/// listing that failed outright would take the tools down with it.
+fn collect_declared(dir: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
+    let Ok(text) = std::fs::read_to_string(dir.join("agent.leviath")) else {
+        return;
+    };
+    let Ok(bp) = leviath_core::manifest::parse_manifest(&text) else {
+        return;
+    };
+
+    for ((kind, declared), hooks) in declared_scripts(&bp) {
+        let Some(name) = addressable_name(&declared) else {
+            continue;
+        };
+        // `name` is a single safe component, so this join cannot leave `dir`.
+        let path = dir.join(format!("{name}.rhai"));
+        let hook_refs: Vec<&str> = hooks.iter().map(String::as_str).collect();
+        let (compiles, error) = match std::fs::read_to_string(&path) {
+            Ok(content) => status_pair(compile_status(kind, &declared, &content, &hook_refs)),
+            Err(e) => (
+                false,
+                Some(format!("cannot read '{}': {e}", path.display())),
+            ),
+        };
+        out.push(ScriptItem {
+            kind: kind.as_str().to_string(),
+            name,
+            source: "agent".to_string(),
+            agent: Some(agent.to_string()),
+            path: path.display().to_string(),
+            compiles,
+            error,
+        });
+    }
+}
+
+// ─── Handlers ───────────────────────────────────────────────────────────────
+
+/// `GET /api/scripts[?agent=<name>]`: every script this scope can see.
+///
+/// With an agent, that is the agent's own `tools/`, the hooks and validators its
+/// manifest declares, and the global tools directory. Without one, the global
+/// directory alone. `source` is what separates "this agent has it" from
+/// "everything on this machine has it".
+pub(super) async fn list_scripts(
+    Query(q): Query<ScriptQuery>,
+) -> Result<Json<ScriptsResp>, ApiError> {
+    let mut scripts = Vec::new();
+    if let Some(name) = q.agent.as_deref() {
+        let dir = agent_dir(name)?;
+        collect_tools(&dir.join("tools"), "agent", Some(name), &mut scripts);
+        collect_declared(&dir, name, &mut scripts);
+    }
+    collect_tools(&global_tools_dir(), "global", None, &mut scripts);
+    Ok(Json(ScriptsResp { scripts }))
+}
+
+/// `GET /api/scripts/{kind}/{name}[?agent=<name>]`: the source text.
+pub(super) async fn get_script(
+    AxumPath((kind, name)): AxumPath<(String, String)>,
+    Query(q): Query<ScriptQuery>,
+) -> Result<Json<ScriptSource>, ApiError> {
+    let target = resolve(&kind, &name, q.agent.as_deref())?;
+    guard(&target, Presence::Required)?;
+    read_script(&target)
+}
+
+/// Read a script that [`guard`] has already accepted.
+fn read_script(target: &Target) -> Result<Json<ScriptSource>, ApiError> {
+    let content = match std::fs::read_to_string(&target.path) {
+        Ok(content) => content,
+        Err(e) => {
+            return Err(err(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("cannot read '{}': {e}", target.path.display()),
+            ));
+        }
+    };
+    let label = target.path.display().to_string();
+    let (compiles, error) = status_pair(compile_status(target.kind, &label, &content, &[]));
+    Ok(Json(ScriptSource {
+        kind: target.kind.as_str().to_string(),
+        name: stem_of(&target.path),
+        source: target.scope.to_string(),
+        agent: target.agent.clone(),
+        path: label,
+        content,
+        compiles,
+        error,
+    }))
+}
+
+/// The `{name}` a resolved path is addressed by. The path was built by joining
+/// that name onto a directory, so the stem is always there to take back.
+fn stem_of(path: &Path) -> String {
+    path.file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into()
+}
+
+/// `PUT /api/scripts/{kind}/{name}[?agent=<name>]` (admin only): write it.
+///
+/// Mounted only under `--allow-admin`, because what this writes is code every
+/// agent on the machine may then execute.
+pub(super) async fn put_script(
+    AxumPath((kind, name)): AxumPath<(String, String)>,
+    Query(q): Query<ScriptQuery>,
+    Json(body): Json<WriteScriptReq>,
+) -> Result<Json<ScriptWritten>, ApiError> {
+    let target = resolve(&kind, &name, q.agent.as_deref())?;
+    if let Err(e) = std::fs::create_dir_all(&target.dir) {
+        return Err(err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("cannot create '{}': {e}", target.dir.display()),
+        ));
+    }
+    // After the directory exists, so containment is asked of a path that can be
+    // canonicalized rather than of one that merely might be.
+    guard(&target, Presence::Optional)?;
+    write_script(&target, &body.content)
+}
+
+/// Write a script that [`guard`] has already accepted.
+fn write_script(target: &Target, content: &str) -> Result<Json<ScriptWritten>, ApiError> {
+    if let Err(e) = std::fs::write(&target.path, content) {
+        return Err(err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("cannot write '{}': {e}", target.path.display()),
+        ));
+    }
+    let label = target.path.display().to_string();
+    let (compiles, error) = status_pair(compile_status(target.kind, &label, content, &[]));
+    Ok(Json(ScriptWritten {
+        path: label,
+        compiles,
+        error,
+    }))
+}
+
+/// `DELETE /api/scripts/{kind}/{name}[?agent=<name>]` (admin only): remove it.
+pub(super) async fn delete_script(
+    AxumPath((kind, name)): AxumPath<(String, String)>,
+    Query(q): Query<ScriptQuery>,
+) -> Result<StatusCode, ApiError> {
+    let target = resolve(&kind, &name, q.agent.as_deref())?;
+    guard(&target, Presence::Required)?;
+    remove_script(&target)
+}
+
+/// Remove a script that [`guard`] has already accepted.
+fn remove_script(target: &Target) -> Result<StatusCode, ApiError> {
+    match std::fs::remove_file(&target.path) {
+        Ok(()) => Ok(StatusCode::NO_CONTENT),
+        Err(e) => Err(err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("cannot delete '{}': {e}", target.path.display()),
+        )),
+    }
+}
+
+/// `POST /api/scripts/validate`: compile without writing.
+///
+/// The only other way to find out whether a script compiles was to save it and
+/// wait for an agent to fail, which is not much of an improvement on editing the
+/// file over SSH. Ungated: compiling text in memory writes nothing and runs
+/// nothing, since every compiler here stops at the AST.
+pub(super) async fn validate_script(
+    Json(body): Json<ValidateScriptReq>,
+) -> Result<Json<ValidateScriptResp>, ApiError> {
+    let Some(kind) = ScriptKind::parse(&body.kind) else {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Unknown script kind '{}': expected tool, region_hook, stage_hook \
+                 or output_validator",
+                body.kind
+            ),
+        ));
+    };
+    let hooks: Vec<&str> = body.hooks.iter().map(String::as_str).collect();
+    let (valid, error) = status_pair(compile_status(kind, "script", &body.content, &hooks));
+    Ok(Json(ValidateScriptResp { valid, error }))
+}
+
+#[cfg(test)]
+#[path = "scripts_tests.rs"]
+mod tests;

--- a/crates/leviath-cli/src/commands/serve/scripts_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts_tests.rs
@@ -1,0 +1,820 @@
+//! Tests for the script read/write routes.
+
+use super::*;
+use crate::commands::serve::testutil::with_home;
+use axum::Router;
+use axum::body::Body;
+use axum::http::Request;
+use axum::routing::{get, post};
+use tower::ServiceExt;
+
+/// Write a file, creating its directory first.
+fn write(path: &Path, body: &str) {
+    std::fs::create_dir_all(path.parent().expect("a parent")).expect("the directory");
+    std::fs::write(path, body).expect("the file");
+}
+
+/// The agents directory under a scratch `LEVIATH_HOME`.
+fn agent_root(home: &Path, name: &str) -> PathBuf {
+    home.join(".leviath").join("agents").join(name)
+}
+
+/// The global tools directory under a scratch `LEVIATH_HOME`.
+fn global_root(home: &Path) -> PathBuf {
+    home.join(".leviath").join("tools")
+}
+
+/// Every script route, mounted the way production mounts them under
+/// `--allow-admin`, so a test drives the real handlers.
+fn admin_router() -> Router {
+    Router::new()
+        .route("/api/scripts", get(list_scripts))
+        .route("/api/scripts/validate", post(validate_script))
+        .route(
+            "/api/scripts/{kind}/{name}",
+            get(get_script).put(put_script).delete(delete_script),
+        )
+}
+
+async fn call(req: Request<Body>) -> (StatusCode, serde_json::Value) {
+    let resp = admin_router().oneshot(req).await.expect("a response");
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("a body");
+    // A 204 has no body, and `Value::Null` stands in for it so a caller that
+    // only asserts on the status needs no second shape.
+    let json = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
+async fn get_json(uri: &str) -> (StatusCode, serde_json::Value) {
+    call(
+        Request::builder()
+            .uri(uri)
+            .body(Body::empty())
+            .expect("a request"),
+    )
+    .await
+}
+
+async fn send(method: &str, uri: &str, body: serde_json::Value) -> (StatusCode, serde_json::Value) {
+    call(
+        Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("content-type", "application/json")
+            .body(Body::from(serde_json::to_vec(&body).expect("json")))
+            .expect("a request"),
+    )
+    .await
+}
+
+/// A tool script that compiles.
+const GOOD_TOOL: &str = "// @tool summarize\n// @description sums up\n\"ok\"";
+
+// ─── ScriptKind ─────────────────────────────────────────────────────────────
+
+#[test]
+fn every_kind_round_trips_through_its_wire_spelling() {
+    for kind in [
+        ScriptKind::Tool,
+        ScriptKind::RegionHook,
+        ScriptKind::StageHook,
+        ScriptKind::OutputValidator,
+    ] {
+        assert_eq!(ScriptKind::parse(kind.as_str()), Some(kind));
+    }
+    assert_eq!(ScriptKind::parse("provider"), None);
+}
+
+// ─── compile_status ─────────────────────────────────────────────────────────
+
+/// One arm per kind, so the compiler each one reaches is the one it names.
+#[test]
+fn each_kind_is_compiled_by_its_own_compiler() {
+    assert!(compile_status(ScriptKind::Tool, "t", GOOD_TOOL, &[]).is_ok());
+    assert!(
+        compile_status(
+            ScriptKind::RegionHook,
+            "r",
+            "fn render(ctx) { \"out\" }",
+            &[]
+        )
+        .is_ok()
+    );
+    assert!(
+        compile_status(
+            ScriptKind::StageHook,
+            "h",
+            "fn on_stage_enter(ctx) { () }",
+            &["on_stage_enter"]
+        )
+        .is_ok()
+    );
+    assert!(
+        compile_status(
+            ScriptKind::OutputValidator,
+            "v",
+            "fn validate(content) { #{ valid: true } }",
+            &[]
+        )
+        .is_ok()
+    );
+}
+
+/// A stage hook named for a hook it does not define is a spawn error, so it is
+/// an error here too rather than something a run discovers.
+#[test]
+fn a_stage_hook_that_is_missing_the_hook_it_was_named_for_fails() {
+    let status = compile_status(
+        ScriptKind::StageHook,
+        "h",
+        "fn on_stage_exit(ctx) { () }",
+        &["on_stage_enter"],
+    );
+    let reason = status.expect_err("the named hook is absent");
+    assert!(reason.contains("on_stage_enter"), "{reason}");
+}
+
+#[test]
+fn status_pairs_flatten_both_outcomes() {
+    assert_eq!(status_pair(Ok(())), (true, None));
+    assert_eq!(
+        status_pair(Err("boom".to_string())),
+        (false, Some("boom".to_string()))
+    );
+}
+
+// ─── resolve ────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_tool_resolves_into_the_agents_tools_directory() {
+    with_home(|home| async move {
+        let target = resolve("tool", "summarize", Some("researcher")).expect("resolves");
+        assert_eq!(target.dir, agent_root(&home, "researcher").join("tools"));
+        assert_eq!(target.scope, "agent");
+        assert_eq!(target.agent.as_deref(), Some("researcher"));
+        assert!(target.path.ends_with("summarize.rhai"));
+    })
+    .await;
+}
+
+/// A hook has no directory of its own: the manifest names it relative to the
+/// agent's own directory, so that is where these routes put it.
+#[tokio::test]
+async fn a_hook_resolves_beside_the_manifest_not_under_tools() {
+    with_home(|home| async move {
+        let target = resolve("stage_hook", "hooks", Some("researcher")).expect("resolves");
+        assert_eq!(target.dir, agent_root(&home, "researcher"));
+        assert_eq!(
+            target.path,
+            agent_root(&home, "researcher").join("hooks.rhai")
+        );
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn a_global_tool_resolves_into_the_shared_directory() {
+    with_home(|home| async move {
+        let target = resolve("tool", "summarize", None).expect("resolves");
+        assert_eq!(target.dir, global_root(&home));
+        assert_eq!(target.scope, "global");
+        assert!(target.agent.is_none());
+    })
+    .await;
+}
+
+/// The name is spelled back with its extension by the listing, so it is
+/// accepted with one and means the same file.
+#[tokio::test]
+async fn a_name_that_already_carries_the_extension_is_the_same_file() {
+    with_home(|home| async move {
+        let bare = resolve("tool", "summarize", None).expect("resolves");
+        let dotted = resolve("tool", "summarize.rhai", None).expect("resolves");
+        assert_eq!(bare.path, dotted.path);
+        assert!(bare.path.starts_with(global_root(&home)));
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn an_unknown_kind_is_refused() {
+    with_home(|_home| async move {
+        let (status, _) = resolve("provider", "x", None).expect_err("no such kind");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn a_traversing_script_name_is_refused() {
+    with_home(|_home| async move {
+        let (status, _) = resolve("tool", "../../evil", None).expect_err("a traversal");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn a_traversing_agent_name_is_refused() {
+    with_home(|_home| async move {
+        let (status, _) = resolve("tool", "x", Some("../../etc")).expect_err("a traversal");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+/// Only tools have a machine-wide directory. A hook without an agent has no
+/// directory at all, and inventing one would be inventing a layout.
+#[tokio::test]
+async fn a_hook_without_an_agent_is_refused() {
+    with_home(|_home| async move {
+        let (status, body) = resolve("region_hook", "x", None).expect_err("no scope");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.0.error.contains("?agent="), "{}", body.0.error);
+    })
+    .await;
+}
+
+// ─── guard ──────────────────────────────────────────────────────────────────
+
+/// With no home to resolve, the base directory is empty, and an empty base
+/// cannot be shown to contain anything. The write is refused rather than
+/// landing in the process's working directory.
+#[test]
+fn a_path_that_cannot_be_shown_to_be_contained_is_refused() {
+    let target = Target {
+        kind: ScriptKind::Tool,
+        dir: PathBuf::new(),
+        path: PathBuf::from("no-such-file-for-the-guard-test.rhai"),
+        scope: "global",
+        agent: None,
+    };
+    let (status, _) = guard(&target, Presence::Optional).expect_err("nothing contains it");
+    assert_eq!(status, StatusCode::FORBIDDEN);
+}
+
+// ─── the fallible filesystem helpers ────────────────────────────────────────
+
+/// The write helper reports the failure rather than the route pretending the
+/// file landed. Reached with a path two directories deep, which the routes
+/// themselves never build but which stands in for any write the filesystem
+/// refuses.
+#[tokio::test]
+async fn a_write_the_filesystem_refuses_is_reported() {
+    with_home(|home| async move {
+        let dir = global_root(&home);
+        std::fs::create_dir_all(&dir).expect("the directory");
+        let target = Target {
+            kind: ScriptKind::Tool,
+            dir: dir.clone(),
+            path: dir.join("missing").join("x.rhai"),
+            scope: "global",
+            agent: None,
+        };
+        let (status, _) = write_script(&target, GOOD_TOOL).expect_err("no such directory");
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn a_delete_the_filesystem_refuses_is_reported() {
+    with_home(|home| async move {
+        let dir = global_root(&home);
+        let path = dir.join("adirectory.rhai");
+        std::fs::create_dir_all(&path).expect("the directory");
+        let target = Target {
+            kind: ScriptKind::Tool,
+            dir,
+            path,
+            scope: "global",
+            agent: None,
+        };
+        let (status, _) = remove_script(&target).expect_err("a directory is not a file");
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    })
+    .await;
+}
+
+// ─── addressable_name ───────────────────────────────────────────────────────
+
+#[test]
+fn only_a_bare_rhai_filename_is_addressable() {
+    assert_eq!(addressable_name("hooks.rhai"), Some("hooks".to_string()));
+    // A subdirectory, a traversal, a missing extension and a name that is not a
+    // safe component are all things these routes cannot address.
+    assert_eq!(addressable_name("nested/hooks.rhai"), None);
+    assert_eq!(addressable_name("../hooks.rhai"), None);
+    assert_eq!(addressable_name("hooks.txt"), None);
+    assert_eq!(addressable_name("..rhai"), None);
+}
+
+// ─── GET /api/scripts ───────────────────────────────────────────────────────
+
+/// A manifest declaring one of each hook kind, so the listing has something to
+/// classify beyond tools.
+fn manifest_with_hooks() -> &'static str {
+    r#"
+[agent]
+name = "researcher"
+version = "0.1.0"
+description = "d"
+
+[agent.output]
+validator = "check.rhai"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Main"
+max_iterations = 5
+
+[stages.main.hooks]
+on_stage_enter = "hooks.rhai"
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+notes = { kind = "custom", script = "notes.rhai", max_tokens = 500 }
+"#
+}
+
+/// Both scopes and all four kinds in one answer, which is the listing's whole
+/// job: what is here, what it plugs into, and whether it works.
+#[tokio::test]
+async fn the_listing_carries_every_kind_and_both_scopes() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "researcher");
+        write(&agent.join("agent.leviath"), manifest_with_hooks());
+        write(&agent.join("tools").join("web_search.rhai"), GOOD_TOOL);
+        write(&agent.join("hooks.rhai"), "fn on_stage_enter(ctx) { () }");
+        write(&agent.join("notes.rhai"), "fn render(ctx) { \"n\" }");
+        write(
+            &agent.join("check.rhai"),
+            "fn validate(content) { #{ valid: true } }",
+        );
+        write(&global_root(&home).join("shared.rhai"), GOOD_TOOL);
+
+        let (status, body) = get_json("/api/scripts?agent=researcher").await;
+        assert_eq!(status, StatusCode::OK);
+        let scripts = body["scripts"].as_array().expect("a scripts array");
+
+        let find = |kind: &str, name: &str| {
+            scripts
+                .iter()
+                .find(|s| s["kind"] == kind && s["name"] == name)
+                .expect("the script is listed")
+        };
+        assert_eq!(find("tool", "web_search")["source"], "agent");
+        assert_eq!(find("tool", "web_search")["agent"], "researcher");
+        assert_eq!(find("stage_hook", "hooks")["compiles"], true);
+        assert_eq!(find("region_hook", "notes")["compiles"], true);
+        assert_eq!(find("output_validator", "check")["compiles"], true);
+        assert_eq!(find("tool", "shared")["source"], "global");
+        assert!(find("tool", "shared").get("agent").is_none());
+    })
+    .await;
+}
+
+/// A file that will not compile is listed with the reason, because an editor
+/// that cannot see why a script is missing is no better than the shell.
+#[tokio::test]
+async fn the_listing_says_why_a_script_does_not_compile() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "broken");
+        write(&agent.join("tools").join("bad.rhai"), "// nothing\nlet");
+        let (status, body) = get_json("/api/scripts?agent=broken").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let scripts = body["scripts"].as_array().expect("a scripts array");
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0]["compiles"], false);
+        assert!(!scripts[0]["error"].as_str().expect("a reason").is_empty());
+    })
+    .await;
+}
+
+/// A hook the manifest declares but nobody wrote is listed as not compiling,
+/// which is the state a run would fail on.
+#[tokio::test]
+async fn a_declared_hook_with_no_file_is_listed_as_failing() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "researcher");
+        write(&agent.join("agent.leviath"), manifest_with_hooks());
+        let (status, body) = get_json("/api/scripts?agent=researcher").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let scripts = body["scripts"].as_array().expect("a scripts array");
+        let hook = scripts
+            .iter()
+            .find(|s| s["name"] == "hooks")
+            .expect("the declared hook");
+        assert_eq!(hook["compiles"], false);
+        let reason = hook["error"].as_str().expect("a reason");
+        assert!(reason.contains("cannot read"), "{reason}");
+    })
+    .await;
+}
+
+/// A hook declared in a subdirectory is outside what these routes can address,
+/// so it is left out rather than listed under a name that fetches nothing.
+#[tokio::test]
+async fn a_hook_declared_in_a_subdirectory_is_left_out() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "nested");
+        let manifest = r#"
+[agent]
+name = "nested"
+version = "0.1.0"
+description = "d"
+
+# An output spec that names a format and no validator, which is the common case:
+# an output block is not a declaration that a script exists.
+[agent.output]
+format = "markdown"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Main"
+max_iterations = 5
+
+[stages.main.hooks]
+on_stage_enter = "hooks/deep.rhai"
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+"#;
+        write(&agent.join("agent.leviath"), manifest);
+        let (status, body) = get_json("/api/scripts?agent=nested").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(body["scripts"].as_array().expect("an array").is_empty());
+    })
+    .await;
+}
+
+/// A manifest that will not parse takes nothing else down with it: the tools
+/// still list, and the blueprint routes are where a broken manifest is reported.
+#[tokio::test]
+async fn a_manifest_that_will_not_parse_leaves_the_tools_listed() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "mangled");
+        write(&agent.join("agent.leviath"), "this is not toml =");
+        write(&agent.join("tools").join("web_search.rhai"), GOOD_TOOL);
+        let (status, body) = get_json("/api/scripts?agent=mangled").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let scripts = body["scripts"].as_array().expect("a scripts array");
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0]["name"], "web_search");
+    })
+    .await;
+}
+
+/// Without an agent the answer is the machine-wide directory alone.
+#[tokio::test]
+async fn the_listing_without_an_agent_is_the_global_directory() {
+    with_home(|home| async move {
+        write(&global_root(&home).join("shared.rhai"), GOOD_TOOL);
+        let (status, body) = get_json("/api/scripts").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let scripts = body["scripts"].as_array().expect("a scripts array");
+        assert_eq!(scripts.len(), 1);
+        assert_eq!(scripts[0]["source"], "global");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn the_listing_refuses_a_traversing_agent_name() {
+    with_home(|_home| async move {
+        let (status, _) = get_json("/api/scripts?agent=..%2F..%2Fetc").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+// ─── GET /api/scripts/{kind}/{name} ─────────────────────────────────────────
+
+#[tokio::test]
+async fn reading_a_script_returns_its_text_and_its_verdict() {
+    with_home(|home| async move {
+        write(
+            &agent_root(&home, "researcher")
+                .join("tools")
+                .join("web_search.rhai"),
+            GOOD_TOOL,
+        );
+        let (status, body) = get_json("/api/scripts/tool/web_search?agent=researcher").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["content"], GOOD_TOOL);
+        assert_eq!(body["kind"], "tool");
+        assert_eq!(body["name"], "web_search");
+        assert_eq!(body["source"], "agent");
+        assert_eq!(body["agent"], "researcher");
+        assert_eq!(body["compiles"], true);
+        assert!(body.get("error").is_none());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reading_a_script_that_does_not_compile_still_returns_it() {
+    with_home(|home| async move {
+        write(&global_root(&home).join("bad.rhai"), "// nothing\nlet");
+        let (status, body) = get_json("/api/scripts/tool/bad").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["compiles"], false);
+        assert!(!body["error"].as_str().expect("a reason").is_empty());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reading_a_script_that_is_not_there_is_a_404() {
+    with_home(|_home| async move {
+        let (status, _) = get_json("/api/scripts/tool/absent").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    })
+    .await;
+}
+
+/// A directory sitting where a script should be is refused rather than read
+/// through. That is the same refusal a planted symlink meets, and it is the one
+/// that can be arranged portably in a test.
+#[tokio::test]
+async fn a_target_that_is_not_a_plain_file_is_refused() {
+    with_home(|home| async move {
+        std::fs::create_dir_all(global_root(&home).join("odd.rhai")).expect("the directory");
+        let (status, body) = get_json("/api/scripts/tool/odd").await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        let message = body["error"].as_str().expect("a message");
+        assert!(message.contains("not a plain file"), "{message}");
+    })
+    .await;
+}
+
+/// Text that is not UTF-8 is not a script, and the read says so instead of
+/// returning half of it.
+#[tokio::test]
+async fn a_file_that_is_not_text_is_reported_rather_than_returned() {
+    with_home(|home| async move {
+        let path = global_root(&home).join("binary.rhai");
+        std::fs::create_dir_all(path.parent().expect("a parent")).expect("the directory");
+        std::fs::write(&path, [0xff, 0xfe, 0x00]).expect("the file");
+        let (status, _) = get_json("/api/scripts/tool/binary").await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reading_with_an_unknown_kind_is_a_400() {
+    with_home(|_home| async move {
+        let (status, _) = get_json("/api/scripts/provider/x").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+// ─── PUT /api/scripts/{kind}/{name} ─────────────────────────────────────────
+
+#[tokio::test]
+async fn writing_a_script_creates_it_and_reports_the_verdict() {
+    with_home(|home| async move {
+        let (status, body) = send(
+            "PUT",
+            "/api/scripts/tool/summarize?agent=researcher",
+            serde_json::json!({ "content": GOOD_TOOL }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["compiles"], true);
+        let path = agent_root(&home, "researcher")
+            .join("tools")
+            .join("summarize.rhai");
+        assert_eq!(std::fs::read_to_string(&path).expect("the file"), GOOD_TOOL);
+    })
+    .await;
+}
+
+/// Work in progress is still saved: a tool that does not compile is skipped at
+/// spawn rather than breaking the agent, so refusing the write would only cost
+/// the author their draft.
+#[tokio::test]
+async fn writing_a_script_that_does_not_compile_saves_it_and_says_so() {
+    with_home(|home| async move {
+        let (status, body) = send(
+            "PUT",
+            "/api/scripts/tool/draft?agent=researcher",
+            serde_json::json!({ "content": "// nothing\nlet" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["compiles"], false);
+        assert!(!body["error"].as_str().expect("a reason").is_empty());
+        assert!(
+            agent_root(&home, "researcher")
+                .join("tools")
+                .join("draft.rhai")
+                .exists()
+        );
+    })
+    .await;
+}
+
+/// A hook is written beside the manifest, not under `tools/`, because that is
+/// where the manifest's own path would resolve it.
+#[tokio::test]
+async fn writing_a_hook_puts_it_beside_the_manifest() {
+    with_home(|home| async move {
+        let (status, _) = send(
+            "PUT",
+            "/api/scripts/stage_hook/hooks?agent=researcher",
+            serde_json::json!({ "content": "fn on_stage_enter(ctx) { () }" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(agent_root(&home, "researcher").join("hooks.rhai").exists());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn writing_over_a_directory_is_refused() {
+    with_home(|home| async move {
+        std::fs::create_dir_all(global_root(&home).join("odd.rhai")).expect("the directory");
+        let (status, _) = send(
+            "PUT",
+            "/api/scripts/tool/odd",
+            serde_json::json!({ "content": GOOD_TOOL }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    })
+    .await;
+}
+
+/// A directory that cannot be created is reported rather than swallowed. An
+/// ordinary file where the agent's directory should be is the portable way to
+/// arrange that.
+#[tokio::test]
+async fn a_directory_that_cannot_be_created_is_reported() {
+    with_home(|home| async move {
+        let agent = agent_root(&home, "afile");
+        write(&agent, "this is a file, not a directory");
+        let (status, _) = send(
+            "PUT",
+            "/api/scripts/tool/x?agent=afile",
+            serde_json::json!({ "content": GOOD_TOOL }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn writing_with_a_traversing_name_is_refused() {
+    with_home(|_home| async move {
+        let (status, _) = send(
+            "PUT",
+            "/api/scripts/tool/..%2F..%2Fevil",
+            serde_json::json!({ "content": GOOD_TOOL }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+// ─── DELETE /api/scripts/{kind}/{name} ──────────────────────────────────────
+
+#[tokio::test]
+async fn deleting_a_script_removes_it() {
+    with_home(|home| async move {
+        let path = global_root(&home).join("gone.rhai");
+        write(&path, GOOD_TOOL);
+        let (status, _) = send("DELETE", "/api/scripts/tool/gone", serde_json::Value::Null).await;
+
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        assert!(!path.exists());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn deleting_a_script_that_is_not_there_is_a_404() {
+    with_home(|_home| async move {
+        let (status, _) = send(
+            "DELETE",
+            "/api/scripts/tool/absent",
+            serde_json::Value::Null,
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn deleting_with_a_traversing_name_is_refused() {
+    with_home(|_home| async move {
+        let (status, _) = send(
+            "DELETE",
+            "/api/scripts/tool/..%2F..%2Fevil",
+            serde_json::Value::Null,
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+// ─── POST /api/scripts/validate ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn validating_good_text_writes_nothing_and_says_it_is_valid() {
+    with_home(|home| async move {
+        let (status, body) = send(
+            "POST",
+            "/api/scripts/validate",
+            serde_json::json!({ "kind": "tool", "content": GOOD_TOOL }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["valid"], true);
+        assert!(body.get("error").is_none());
+        assert!(!global_root(&home).exists(), "validation writes nothing");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn validating_broken_text_reports_the_compilers_complaint() {
+    with_home(|_home| async move {
+        let (status, body) = send(
+            "POST",
+            "/api/scripts/validate",
+            serde_json::json!({ "kind": "region_hook", "content": "fn render(ctx) {" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["valid"], false);
+        assert!(!body["error"].as_str().expect("a reason").is_empty());
+    })
+    .await;
+}
+
+/// The hook names a blueprint would name the file for are checked too, so an
+/// editor can ask the question a spawn would ask.
+#[tokio::test]
+async fn validating_a_stage_hook_checks_the_hooks_it_was_named_for() {
+    with_home(|_home| async move {
+        let (status, body) = send(
+            "POST",
+            "/api/scripts/validate",
+            serde_json::json!({
+                "kind": "stage_hook",
+                "content": "fn on_stage_exit(ctx) { () }",
+                "hooks": ["on_stage_enter"],
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["valid"], false);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn validating_an_unknown_kind_is_a_400() {
+    with_home(|_home| async move {
+        let (status, _) = send(
+            "POST",
+            "/api/scripts/validate",
+            serde_json::json!({ "kind": "provider", "content": "1" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}

--- a/crates/leviath-cli/src/commands/serve/testutil.rs
+++ b/crates/leviath-cli/src/commands/serve/testutil.rs
@@ -8,6 +8,27 @@ use leviath_runtime::control_socket::{
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::task::JoinHandle;
 
+/// Run `f` with `LEVIATH_HOME` redirected at a fresh scratch root, handing it
+/// that root.
+///
+/// Every path the tools and scripts routes touch - the installed agents
+/// directory and the global `.rhai` directory - hangs off that variable, so a
+/// test that did not set it would read (and, for the write routes, *write*) a
+/// developer's real `~/.leviath`. One `temp_env` call rather than a nested one:
+/// it serializes process-wide and holds its lock across the future.
+pub(super) async fn with_home<R, Fut>(f: impl FnOnce(std::path::PathBuf) -> Fut) -> R
+where
+    Fut: std::future::Future<Output = R>,
+{
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let root = dir.path().to_path_buf();
+    temp_env::async_with_vars(
+        [("LEVIATH_HOME", Some(root.clone().into_os_string()))],
+        f(root),
+    )
+    .await
+}
+
 /// A control client pointing at an address with no daemon - used by tests that
 /// never exercise agent actions (read/websocket/polling/config paths).
 pub(super) fn no_daemon_client() -> ControlClient {

--- a/crates/leviath-cli/src/commands/serve/tools.rs
+++ b/crates/leviath-cli/src/commands/serve/tools.rs
@@ -1,0 +1,262 @@
+//! `GET /api/tools`: what tools an agent on this machine can actually use.
+//!
+//! Nothing else in the API answered that, so a client building a tool picker
+//! had to ship a list, and a shipped list is wrong in both directions: a global
+//! `.rhai` the user wrote never appears, and a tool the list names may not exist
+//! on the machine the client is talking to.
+//!
+//! The discovery itself lives in [`crate::tool_inventory`], shared with the
+//! blueprint lint, because both are asking the same question and a second copy
+//! of the rules would have drifted.
+
+use std::path::PathBuf;
+
+use axum::extract::Query;
+use axum::http::StatusCode;
+use axum::response::Json;
+use serde::{Deserialize, Serialize};
+
+use super::types::{ErrorResponse, err};
+use crate::tool_inventory::ToolInventory;
+
+/// The `(status, body)` pair every fallible handler in this module returns.
+pub(super) type ApiError = (StatusCode, Json<ErrorResponse>);
+
+/// Resolve `<agents_dir>/<name>`, refusing a name that is not a single safe
+/// path component.
+///
+/// The same gate, on the same directory, that `blueprint_dir` applies in
+/// `blueprints.rs`: `Path::join` neither normalizes `..` nor resists an
+/// absolute path, and this name arrives in a query string. Shared from here
+/// because the tools and scripts routes both take an `?agent=` and both would
+/// otherwise write their own copy of the check.
+pub(super) fn agent_dir(name: &str) -> Result<PathBuf, ApiError> {
+    match leviath_core::is_safe_path_component(name) {
+        true => Ok(super::blueprints::agents_dir().join(name)),
+        false => Err(err(
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Invalid agent name '{name}': names may contain only letters, digits, \
+                 '.', '_' and '-'"
+            ),
+        )),
+    }
+}
+
+/// Query parameters for `GET /api/tools`.
+#[derive(Debug, Deserialize)]
+pub(super) struct ToolsQuery {
+    /// Include this agent's own `tools/` alongside the built-ins and the global
+    /// directory. Absent means the machine-wide answer.
+    agent: Option<String>,
+}
+
+/// One tool in the listing.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ToolItem {
+    /// The name a blueprint lists in `available_tools` and the model calls.
+    pub(super) name: String,
+    /// `builtin`, `subagent`, `agent` or `global`.
+    pub(super) source: String,
+    /// The `.rhai` file behind it, for script-backed tools only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) path: Option<String>,
+    /// The agent that owns it, for agent-scoped tools only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) agent: Option<String>,
+}
+
+/// One `.rhai` file that was found and could not be offered.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct SkippedItem {
+    /// The file that was passed over.
+    pub(super) path: String,
+    /// Why: a compile error, bad annotations, or a name already taken.
+    pub(super) reason: String,
+    /// Which directory it was found in, `agent` or `global`.
+    pub(super) source: String,
+}
+
+/// The body of `GET /api/tools`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ToolsResp {
+    /// Everything that will work if a blueprint names it.
+    pub(super) tools: Vec<ToolItem>,
+    /// Everything that looked like a tool and will not work, with the reason.
+    /// A tool missing because its file has a syntax error is exactly what a
+    /// picker should be able to show, and the reason is the only thing that
+    /// tells it apart from a tool nobody ever wrote.
+    pub(super) skipped: Vec<SkippedItem>,
+}
+
+/// `GET /api/tools[?agent=<name>]`: the tool inventory of this machine.
+///
+/// MCP tools are deliberately absent. They depend on a server being reachable
+/// rather than on anything installed here, and `/api/mcp/servers/{name}`
+/// already answers for them.
+pub(super) async fn list_tools(Query(q): Query<ToolsQuery>) -> Result<Json<ToolsResp>, ApiError> {
+    let dir = match q.agent.as_deref() {
+        Some(name) => Some(agent_dir(name)?),
+        None => None,
+    };
+    let inventory = ToolInventory::discover(dir.as_deref(), q.agent.as_deref());
+
+    let tools = inventory
+        .tools
+        .into_iter()
+        .map(|t| ToolItem {
+            name: t.name,
+            source: t.source.as_str().to_string(),
+            path: t.path.map(|p| p.display().to_string()),
+            agent: t.agent,
+        })
+        .collect();
+    let skipped = inventory
+        .skipped
+        .into_iter()
+        .map(|s| SkippedItem {
+            path: s.path.display().to_string(),
+            reason: s.reason,
+            source: s.source.as_str().to_string(),
+        })
+        .collect();
+
+    Ok(Json(ToolsResp { tools, skipped }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use std::path::Path;
+    use tower::ServiceExt;
+
+    use super::super::testutil::with_home;
+
+    fn write_tool(dir: &Path, file: &str, body: &str) {
+        std::fs::create_dir_all(dir).expect("the directory");
+        std::fs::write(dir.join(file), body).expect("the script");
+    }
+
+    async fn get_tools(uri: &str) -> (StatusCode, serde_json::Value) {
+        let app = Router::new().route("/api/tools", get(list_tools));
+        let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&bytes).unwrap())
+    }
+
+    /// With no `?agent=`, the answer is about the machine: built-ins, sub-agent
+    /// tools, and whatever is in the global directory.
+    #[tokio::test]
+    async fn listing_without_an_agent_covers_the_machine() {
+        with_home(|home| async move {
+            write_tool(
+                &home.join(".leviath").join("tools"),
+                "summarize.rhai",
+                "// @tool summarize\n// @description sums\n1",
+            );
+            let (status, body) = get_tools("/api/tools").await;
+
+            assert_eq!(status, StatusCode::OK);
+            let tools = body["tools"].as_array().expect("a tools array");
+            let summarize = tools
+                .iter()
+                .find(|t| t["name"] == "summarize")
+                .expect("the global tool");
+            assert_eq!(summarize["source"], "global");
+            let path = summarize["path"].as_str().expect("a path");
+            assert!(path.ends_with("summarize.rhai"), "{path}");
+            assert!(tools.iter().any(|t| t["source"] == "builtin"));
+            assert!(tools.iter().any(|t| t["source"] == "subagent"));
+            assert!(tools.iter().all(|t| t["source"] != "agent"));
+            // A built-in has no file behind it, so it carries no `path`.
+            let builtin = tools
+                .iter()
+                .find(|t| t["source"] == "builtin")
+                .expect("a built-in");
+            assert!(builtin.get("path").is_none());
+            assert!(builtin.get("agent").is_none());
+        })
+        .await;
+    }
+
+    /// `?agent=` adds that agent's own `tools/`, labelled with the agent it
+    /// belongs to - which is the difference between "everything here has this"
+    /// and "only this agent does".
+    #[tokio::test]
+    async fn listing_with_an_agent_adds_that_agents_own_tools() {
+        with_home(|home| async move {
+            let agent = home.join(".leviath").join("agents").join("researcher");
+            write_tool(
+                &agent.join("tools"),
+                "web_search.rhai",
+                "// @tool web_search\n// @description searches\n1",
+            );
+            let (status, body) = get_tools("/api/tools?agent=researcher").await;
+
+            assert_eq!(status, StatusCode::OK);
+            let tools = body["tools"].as_array().expect("a tools array");
+            let own = tools
+                .iter()
+                .find(|t| t["name"] == "web_search")
+                .expect("the agent's own tool");
+            assert_eq!(own["source"], "agent");
+            assert_eq!(own["agent"], "researcher");
+            let path = own["path"].as_str().expect("a path");
+            assert!(path.ends_with("web_search.rhai"), "{path}");
+        })
+        .await;
+    }
+
+    /// A script that will not compile is reported rather than dropped, because
+    /// "your file has a syntax error" and "you never wrote that file" look
+    /// identical from outside the daemon.
+    #[tokio::test]
+    async fn a_script_that_fails_to_compile_is_reported_as_skipped() {
+        with_home(|home| async move {
+            let agent = home.join(".leviath").join("agents").join("broken");
+            write_tool(&agent.join("tools"), "bad.rhai", "// no directive\nlet");
+            let (status, body) = get_tools("/api/tools?agent=broken").await;
+
+            assert_eq!(status, StatusCode::OK);
+            let skipped = body["skipped"].as_array().expect("a skipped array");
+            assert_eq!(skipped.len(), 1);
+            let path = skipped[0]["path"].as_str().expect("a path");
+            assert!(path.ends_with("bad.rhai"), "{path}");
+            assert_eq!(skipped[0]["source"], "agent");
+            assert!(!skipped[0]["reason"].as_str().expect("a reason").is_empty());
+            let tools = body["tools"].as_array().expect("a tools array");
+            assert!(tools.iter().all(|t| t["name"] != "bad"));
+        })
+        .await;
+    }
+
+    /// The agent name is joined onto a directory, so it goes through the same
+    /// component check the blueprint routes use. `..` is a traversal, not a name.
+    #[tokio::test]
+    async fn a_traversing_agent_name_is_rejected() {
+        with_home(|_home| async move {
+            let (status, body) = get_tools("/api/tools?agent=..%2F..%2Fetc").await;
+            assert_eq!(status, StatusCode::BAD_REQUEST);
+            let message = body["error"].as_str().expect("an error message");
+            assert!(message.contains("Invalid agent name"), "{message}");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn agent_dir_accepts_a_plain_name() {
+        with_home(|home| async move {
+            let dir = agent_dir("researcher").expect("a plain name resolves");
+            assert!(dir.starts_with(home.join(".leviath").join("agents")));
+        })
+        .await;
+    }
+}

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1013,131 +1013,10 @@ pub(super) struct SendMessageReq {
 }
 
 // ─── Config types ───────────────────────────────────────────────────────────
-
-#[derive(Serialize, Deserialize)]
-pub(super) struct RedactedConfig {
-    pub(super) default_provider: String,
-    pub(super) has_anthropic_key: bool,
-    pub(super) has_openai_key: bool,
-    pub(super) has_google_key: bool,
-    pub(super) has_openrouter_key: bool,
-    pub(super) ollama_base_url: Option<String>,
-    pub(super) agent_paths: Vec<PathBuf>,
-    pub(super) mcp_server_count: usize,
-    /// The API contract this server implements, matching `info.version` in
-    /// `docs/schema/openapi.json`. A test holds the two together.
-    pub(super) api_version: String,
-    /// What this server can do, so a client can light up features in one call.
-    ///
-    /// Before this, the console feature-detected by calling a route and reading
-    /// a 404 as "unsupported" - fragile, because a 404 also means "no such run",
-    /// and one round trip per feature.
-    pub(super) capabilities: Vec<String>,
-    pub(super) limits: ApiLimits,
-}
-
-/// The API contract version. Held equal to the OpenAPI spec's `info.version` by
-/// a test, because a version that can silently disagree with the document it
-/// names is worse than no version at all.
-pub(super) const API_VERSION: &str = "0.3.0";
-
-/// Every capability a client may check for.
-pub(super) const API_CAPABILITIES: &[&str] = &[
-    "runs.envelope",
-    "runs.cursor",
-    "runs.search",
-    "runs.search.context",
-    "runs.search.logs",
-    "runs.search.journal",
-    "runs.fields",
-    "runs.ids",
-    "runs.since",
-    "runs.files.listing",
-    "runs.files.workdir",
-    "runs.stages",
-    "logs.stage",
-    "logs.stream",
-    "context.history.page",
-    "blueprints.envelope",
-    "blueprints.query",
-    "blueprints.manifest",
-    "blueprints.validate.name",
-    "runs.waiting_on",
-];
-
-/// The server's numeric limits.
-///
-/// This is what makes capability discovery useful rather than decorative: a
-/// client that knows the feature exists still has to guess the page cap, the
-/// file-size cap and the tracked-file cap, and every one of those guesses would
-/// be hardcoded and eventually wrong.
-#[derive(Debug, Serialize, Deserialize)]
-pub(super) struct ApiLimits {
-    /// Largest `limit` on `GET /api/runs`; larger values are clamped.
-    pub(super) max_limit: usize,
-    /// Most ids one `ids=` batch may name.
-    pub(super) max_ids: usize,
-    /// Largest file body `?path=` returns.
-    pub(super) max_file_bytes: u64,
-    /// Most entries one directory listing returns.
-    pub(super) max_listing_entries: usize,
-    /// How many runs a filesystem-reading search examines before reporting
-    /// `scan_truncated`.
-    pub(super) max_search_scan: usize,
-    /// How much of each stage log a search reads, from the end.
-    pub(super) search_log_tail_bytes: u64,
-    /// Largest `limit` on the context-history route.
-    pub(super) max_history_limit: usize,
-    /// How many distinct modified paths a run records before
-    /// `modified_files_truncated` is set.
-    pub(super) max_tracked_modified_files: usize,
-}
-
-impl ApiLimits {
-    /// Read from the constants the handlers actually use, so the two cannot
-    /// drift into disagreeing.
-    pub(super) fn current() -> Self {
-        Self {
-            max_limit: super::runs::MAX_LIMIT,
-            max_ids: super::runs::MAX_IDS,
-            max_file_bytes: super::agents::MAX_FILE_READ_BYTES,
-            max_listing_entries: super::agents::MAX_LISTING_ENTRIES,
-            max_search_scan: super::runs::MAX_SEARCH_SCAN,
-            search_log_tail_bytes: super::runs::SEARCH_LOG_TAIL_BYTES,
-            max_history_limit: super::agents::HISTORY_MAX_LIMIT,
-            max_tracked_modified_files: leviath_core::run_meta::MAX_TRACKED_MODIFIED_FILES,
-        }
-    }
-}
-
-/// Body of `PUT /api/config` (admin-only). Every field is optional; a present
-/// field is written, an absent one is left untouched. Mirrors what `lev setup`
-/// writes, so a newcomer can configure providers entirely from the browser.
-#[derive(Debug, Default, Deserialize)]
-pub(super) struct WriteConfigReq {
-    pub(super) default_provider: Option<String>,
-    pub(super) default_model: Option<String>,
-    pub(super) anthropic_key: Option<String>,
-    pub(super) openai_key: Option<String>,
-    pub(super) google_key: Option<String>,
-    pub(super) openrouter_key: Option<String>,
-    pub(super) ollama_base_url: Option<String>,
-}
-
-/// Body of `POST /api/config/validate` — a format-only key check (no network,
-/// no persistence), mirroring the `lev setup` wizard's inline validation.
-#[derive(Debug, Deserialize)]
-pub(super) struct ValidateKeyReq {
-    pub(super) provider: String,
-    pub(super) key: String,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub(super) struct ValidateKeyResp {
-    pub(super) valid: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(super) message: Option<String>,
-}
+//
+// Moved to `config_types.rs` (this file was over the production-line limit) and
+// re-exported here, so every `use super::types::*` still reaches them.
+pub(super) use super::config_types::*;
 
 #[derive(Serialize)]
 pub(super) struct ModelEntry {
@@ -1348,6 +1227,7 @@ mod tests {
             has_google_key: false,
             has_openrouter_key: false,
             ollama_base_url: None,
+            gateways: Vec::new(),
             agent_paths: vec![],
             mcp_server_count: 0,
             api_version: API_VERSION.to_string(),

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -27,6 +27,7 @@ pub mod runstate;
 pub mod shell_keys;
 #[cfg(test)]
 mod test_support;
+pub mod tool_inventory;
 pub mod tools;
 pub mod tui;
 pub mod workdir_guard;

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -26,7 +26,7 @@
 //! [`Blueprint::validate`]: leviath_core::Blueprint::validate
 
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use leviath_core::Blueprint;
 use leviath_core::blueprint::StageMode;
@@ -173,22 +173,12 @@ impl LintEnv {
     /// cost a registry build per agent to say something the spawn will say
     /// louder a moment later.
     pub fn offline(agent_dir: &Path) -> Self {
-        let mut known_tools: HashSet<String> = leviath_tools::BuiltinTools::new(
-            leviath_tools::ToolContext::new(agent_dir.to_path_buf()),
-        )
-        .names()
-        .into_iter()
-        .collect();
-        known_tools.extend(leviath_tools::BuiltinTools::subagent_tool_names());
-
-        // The agent's own `tools/`, plus the global one every agent gets.
-        let dirs: Vec<PathBuf> = [Some(agent_dir.join("tools")), leviath_core::tools_dir()]
-            .into_iter()
-            .flatten()
-            .filter(|d| d.is_dir())
-            .collect();
-        let (set, _skipped) = leviath_scripting::ScriptToolSet::discover(&dirs);
-        known_tools.extend(set.names());
+        // The four discovery rules live in `tool_inventory` rather than here,
+        // because `GET /api/tools` has to answer the same question and two
+        // copies of "where does a tool come from" would not have stayed equal.
+        // The lint wants only the names; the endpoint wants the sources too.
+        let known_tools =
+            crate::tool_inventory::ToolInventory::discover(Some(agent_dir), None).names();
 
         Self {
             known_tools,

--- a/crates/leviath-cli/src/tool_inventory.rs
+++ b/crates/leviath-cli/src/tool_inventory.rs
@@ -1,0 +1,361 @@
+//! What tools an agent on this machine can actually use, and where each one
+//! came from.
+//!
+//! One answer, two callers. The lint asks "is this name a tool" when it checks a
+//! blueprint's `available_tools`, and `GET /api/tools` asks "what may I pick"
+//! on behalf of an editor. Those were the same four discovery rules - built-ins,
+//! sub-agent tools, the agent's own `tools/`, and the global drop-in directory -
+//! and a second copy of them would have drifted from the first the moment either
+//! side gained a source.
+//!
+//! The compile failures come out with the tools rather than being dropped. A
+//! script missing because its file has a syntax error looks exactly like a
+//! script that was never written, and only one of those is worth telling
+//! somebody about.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Where a tool comes from, which is the part that answers "will this work if I
+/// pick it".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolSource {
+    /// Compiled into this build of Leviath. Available to every agent, always.
+    Builtin,
+    /// A sub-agent tool, offered to an agent that may spawn children.
+    Subagent,
+    /// A `.rhai` script in the agent's own `tools/` directory, so it travels
+    /// with that agent and no other.
+    Agent,
+    /// A `.rhai` script in the global tools directory, so every agent on this
+    /// machine gets it.
+    Global,
+}
+
+impl ToolSource {
+    /// The wire name for this source, as the REST API spells it.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Builtin => "builtin",
+            Self::Subagent => "subagent",
+            Self::Agent => "agent",
+            Self::Global => "global",
+        }
+    }
+}
+
+/// One tool an agent may name in `available_tools`.
+#[derive(Debug, Clone)]
+pub struct ToolEntry {
+    /// The name the model calls and a blueprint lists.
+    pub name: String,
+    /// Where the tool comes from.
+    pub source: ToolSource,
+    /// The `.rhai` file behind it, for the script-backed sources only.
+    pub path: Option<PathBuf>,
+    /// Which agent owns it, for [`ToolSource::Agent`] only.
+    pub agent: Option<String>,
+}
+
+/// A `.rhai` file that was found but did not become a usable tool.
+#[derive(Debug, Clone)]
+pub struct SkippedScript {
+    /// The file that was passed over.
+    pub path: PathBuf,
+    /// Why, in the words the compiler or the shadowing rule used.
+    pub reason: String,
+    /// Which directory it was found in.
+    pub source: ToolSource,
+}
+
+/// The full tool inventory for one scope: an agent plus the global directory,
+/// or the global directory alone.
+#[derive(Debug, Clone, Default)]
+pub struct ToolInventory {
+    /// Every usable tool, built-ins first, then the agent's scripts, then the
+    /// global ones.
+    pub tools: Vec<ToolEntry>,
+    /// Every `.rhai` file that was found and could not be offered.
+    pub skipped: Vec<SkippedScript>,
+}
+
+impl ToolInventory {
+    /// Discover everything an agent rooted at `agent_dir` could call.
+    ///
+    /// `agent_dir` is `None` for a question about the machine rather than about
+    /// one agent: built-ins and the global directory, with no agent scripts.
+    /// `agent_name` only labels the agent-scoped entries, so a caller that has
+    /// a directory but no name (the daemon's own offline lint) may leave it out.
+    ///
+    /// A script whose name is already taken - by a built-in, by a sub-agent
+    /// tool, or by the agent's own copy shadowing a global one - is reported in
+    /// [`skipped`](Self::skipped) rather than listed twice. That mirrors what
+    /// the daemon does at spawn: the earlier directory wins and a core tool is
+    /// never shadowed, so listing the loser as available would be a lie.
+    pub fn discover(agent_dir: Option<&Path>, agent_name: Option<&str>) -> Self {
+        let ctx_dir = agent_dir.map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+        let builtins = leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(ctx_dir));
+
+        let mut tools: Vec<ToolEntry> = Vec::new();
+        for name in builtins.names() {
+            tools.push(ToolEntry {
+                name,
+                source: ToolSource::Builtin,
+                path: None,
+                agent: None,
+            });
+        }
+        for name in leviath_tools::BuiltinTools::subagent_tool_names() {
+            tools.push(ToolEntry {
+                name,
+                source: ToolSource::Subagent,
+                path: None,
+                agent: None,
+            });
+        }
+
+        let mut taken: HashSet<String> = tools.iter().map(|t| t.name.clone()).collect();
+        let mut skipped: Vec<SkippedScript> = Vec::new();
+
+        // The agent's own `tools/` first, then the global one every agent gets:
+        // the same order, and so the same precedence, the daemon scans in.
+        let scopes = [
+            (ToolSource::Agent, agent_dir.map(|d| d.join("tools"))),
+            (ToolSource::Global, leviath_core::tools_dir()),
+        ];
+        for (source, dir) in scopes {
+            let Some(dir) = dir else {
+                continue;
+            };
+            let (set, failed) = leviath_scripting::ScriptToolSet::discover(&[dir]);
+            for f in failed {
+                skipped.push(SkippedScript {
+                    path: f.path,
+                    reason: f.reason,
+                    source,
+                });
+            }
+            for (meta, path) in set.sources() {
+                if taken.contains(&meta.name) {
+                    skipped.push(SkippedScript {
+                        path,
+                        reason: format!(
+                            "the name '{}' is already taken by a tool that wins over this one",
+                            meta.name
+                        ),
+                        source,
+                    });
+                    continue;
+                }
+                taken.insert(meta.name.clone());
+                let agent = match source {
+                    ToolSource::Agent => agent_name.map(str::to_string),
+                    _ => None,
+                };
+                tools.push(ToolEntry {
+                    name: meta.name,
+                    source,
+                    path: Some(path),
+                    agent,
+                });
+            }
+        }
+
+        Self { tools, skipped }
+    }
+
+    /// Just the names, which is all the lint needs to answer "is this a tool".
+    pub fn names(&self) -> HashSet<String> {
+        self.tools.iter().map(|t| t.name.clone()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Point the global tools directory at a scratch root, so a developer's real
+    /// `~/.leviath/tools` never decides what these assert.
+    fn with_home<R>(f: impl FnOnce(&Path) -> R) -> R {
+        let dir = tempfile::tempdir().expect("a temp dir");
+        temp_env::with_var("LEVIATH_HOME", Some(dir.path()), || f(dir.path()))
+    }
+
+    /// The global tools directory under a `LEVIATH_HOME` scratch root.
+    fn global_tools(home: &Path) -> PathBuf {
+        let dir = home.join(".leviath").join("tools");
+        std::fs::create_dir_all(&dir).expect("the global tools dir");
+        dir
+    }
+
+    fn write_tool(dir: &Path, file: &str, body: &str) {
+        std::fs::create_dir_all(dir).expect("the tools dir");
+        std::fs::write(dir.join(file), body).expect("the script");
+    }
+
+    #[test]
+    fn source_names_are_the_wire_spelling() {
+        assert_eq!(ToolSource::Builtin.as_str(), "builtin");
+        assert_eq!(ToolSource::Subagent.as_str(), "subagent");
+        assert_eq!(ToolSource::Agent.as_str(), "agent");
+        assert_eq!(ToolSource::Global.as_str(), "global");
+    }
+
+    /// All four sources in one inventory, which is the whole point of the
+    /// `source` field: three different answers to whether a name will work.
+    #[test]
+    fn every_source_appears_with_the_path_behind_it() {
+        with_home(|home| {
+            let agent = home.join("agents").join("researcher");
+            write_tool(
+                &agent.join("tools"),
+                "web_search.rhai",
+                "// @tool web_search\n// @description searches\n1",
+            );
+            write_tool(
+                &global_tools(home),
+                "summarize.rhai",
+                "// @tool summarize\n// @description sums\n2",
+            );
+
+            let inv = ToolInventory::discover(Some(&agent), Some("researcher"));
+
+            let own = inv
+                .tools
+                .iter()
+                .find(|t| t.name == "web_search")
+                .expect("the agent's own tool");
+            assert_eq!(own.source, ToolSource::Agent);
+            assert_eq!(own.agent.as_deref(), Some("researcher"));
+            assert_eq!(
+                own.path.as_deref(),
+                Some(agent.join("tools").join("web_search.rhai").as_path())
+            );
+
+            let global = inv
+                .tools
+                .iter()
+                .find(|t| t.name == "summarize")
+                .expect("the global tool");
+            assert_eq!(global.source, ToolSource::Global);
+            assert!(global.agent.is_none());
+            assert!(global.path.is_some());
+
+            assert!(inv.tools.iter().any(|t| t.source == ToolSource::Builtin));
+            assert!(inv.tools.iter().any(|t| t.source == ToolSource::Subagent));
+            assert!(
+                inv.tools
+                    .iter()
+                    .all(|t| t.source != ToolSource::Builtin || t.path.is_none())
+            );
+            assert!(inv.skipped.is_empty());
+        });
+    }
+
+    /// Without a name, an agent-scoped entry still resolves; it just cannot say
+    /// whose it is. That is the daemon's own offline lint, which has the
+    /// directory and never had a name.
+    #[test]
+    fn an_unnamed_scope_still_finds_the_agents_own_tools() {
+        with_home(|home| {
+            let agent = home.join("agents").join("nameless");
+            write_tool(&agent.join("tools"), "local.rhai", "// @tool local\n1");
+
+            let inv = ToolInventory::discover(Some(&agent), None);
+            let own = inv
+                .tools
+                .iter()
+                .find(|t| t.name == "local")
+                .expect("the agent's own tool");
+            assert_eq!(own.source, ToolSource::Agent);
+            assert!(own.agent.is_none());
+        });
+    }
+
+    /// No agent means no agent scripts, and the global directory still answers.
+    #[test]
+    fn without_an_agent_only_the_machine_wide_scripts_are_listed() {
+        with_home(|home| {
+            write_tool(
+                &global_tools(home),
+                "summarize.rhai",
+                "// @tool summarize\n1",
+            );
+
+            let inv = ToolInventory::discover(None, None);
+            assert!(inv.tools.iter().any(|t| t.name == "summarize"));
+            assert!(inv.tools.iter().all(|t| t.source != ToolSource::Agent));
+        });
+    }
+
+    /// A file that will not compile is reported instead of quietly vanishing.
+    #[test]
+    fn a_script_that_does_not_compile_is_reported_with_its_reason() {
+        with_home(|home| {
+            let agent = home.join("agents").join("broken");
+            write_tool(&agent.join("tools"), "bad.rhai", "// no directive\nlet");
+
+            let inv = ToolInventory::discover(Some(&agent), Some("broken"));
+            assert_eq!(inv.skipped.len(), 1);
+            assert!(inv.skipped[0].path.ends_with("bad.rhai"));
+            assert_eq!(inv.skipped[0].source, ToolSource::Agent);
+            assert!(!inv.skipped[0].reason.is_empty());
+        });
+    }
+
+    /// A script named after a built-in never routes, so it is reported as
+    /// skipped rather than listed twice under two sources.
+    #[test]
+    fn a_script_shadowed_by_a_builtin_is_skipped_not_listed_twice() {
+        with_home(|home| {
+            let agent = home.join("agents").join("shadow");
+            write_tool(
+                &agent.join("tools"),
+                "read_file.rhai",
+                "// @tool read_file\n1",
+            );
+
+            let inv = ToolInventory::discover(Some(&agent), Some("shadow"));
+            let listed: Vec<_> = inv.tools.iter().filter(|t| t.name == "read_file").collect();
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].source, ToolSource::Builtin);
+            assert_eq!(inv.skipped.len(), 1);
+            assert!(inv.skipped[0].reason.contains("already taken"));
+        });
+    }
+
+    /// The agent's own copy wins over the global one of the same name, and the
+    /// global copy is reported so a picker can explain why it is not the one
+    /// that will run.
+    #[test]
+    fn an_agents_own_script_wins_over_the_global_one() {
+        with_home(|home| {
+            let agent = home.join("agents").join("winner");
+            write_tool(&agent.join("tools"), "dup.rhai", "// @tool dup\n1");
+            write_tool(&global_tools(home), "dup.rhai", "// @tool dup\n2");
+
+            let inv = ToolInventory::discover(Some(&agent), Some("winner"));
+            let listed: Vec<_> = inv.tools.iter().filter(|t| t.name == "dup").collect();
+            assert_eq!(listed.len(), 1);
+            assert_eq!(listed[0].source, ToolSource::Agent);
+            assert_eq!(inv.skipped.len(), 1);
+            assert_eq!(inv.skipped[0].source, ToolSource::Global);
+        });
+    }
+
+    /// The set the lint checks `available_tools` against carries every listed
+    /// name and nothing that was skipped.
+    #[test]
+    fn names_carry_the_builtins_and_the_scripts_that_compiled() {
+        with_home(|home| {
+            let agent = home.join("agents").join("named");
+            write_tool(&agent.join("tools"), "ok.rhai", "// @tool ok\n1");
+            write_tool(&agent.join("tools"), "bad.rhai", "// nothing\nlet");
+
+            let names = ToolInventory::discover(Some(&agent), Some("named")).names();
+            assert!(names.contains("ok"));
+            assert!(names.contains("read_file"));
+            assert!(!names.contains("bad"));
+        });
+    }
+}

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -387,6 +387,21 @@ impl ScriptToolSet {
         self.tools.values().map(|t| t.meta.clone()).collect()
     }
 
+    /// The metadata of every tool paired with the file it was compiled from.
+    ///
+    /// [`metas`](Self::metas) answers what a tool advertises; a caller listing
+    /// tools for a picker also has to say *where* each one came from, because
+    /// "the agent's own file" and "a global drop-in every agent gets" are
+    /// different answers to whether the tool travels with the agent. Recovering
+    /// the path through [`get`](Self::get) would mean a lookup whose miss arm
+    /// can never be taken.
+    pub fn sources(&self) -> Vec<(ScriptToolMeta, PathBuf)> {
+        self.tools
+            .values()
+            .map(|t| (t.meta.clone(), t.source_path.clone()))
+            .collect()
+    }
+
     /// Number of tools in the set.
     pub fn len(&self) -> usize {
         self.tools.len()
@@ -396,6 +411,25 @@ impl ScriptToolSet {
     pub fn is_empty(&self) -> bool {
         self.tools.is_empty()
     }
+}
+
+/// Answer "would this text become a tool" for source that has no file yet.
+///
+/// [`ScriptToolSet::discover`] asks the same two questions of files already on
+/// disk: are the annotations parseable, and does Rhai accept the script. An
+/// editor has to be able to ask before saving, and the only alternative was
+/// writing the candidate into a directory every agent executes from and reading
+/// the answer back out of the skipped list.
+///
+/// `label` is what the error message names the source as, since there is no
+/// path to name. A sibling `tool.toml` cannot apply here for the same reason:
+/// nothing is on disk to sit beside.
+pub fn check_source(label: &str, source: &str) -> Result<ScriptToolMeta> {
+    let meta = parse_annotations(source)?;
+    Engine::new()
+        .compile(source)
+        .map_err(|e| Error::CompilationFailed(format!("{label}: {e}")))?;
+    Ok(meta)
 }
 
 /// Compile a single `.rhai` file into a [`ScriptTool`], resolving metadata from a
@@ -1173,6 +1207,48 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         assert_eq!(skipped.len(), 1);
         assert!(skipped[0].path.ends_with("broken.rhai"));
         assert!(!skipped[0].reason.is_empty());
+    }
+
+    /// `sources` pairs each tool with the file it came from, which is what a
+    /// caller needs to say whether a name is the agent's own script or a global
+    /// drop-in. The two dirs hold the same tool name, so this also pins that the
+    /// winner's path is reported rather than the shadowed one's.
+    #[test]
+    fn sources_pairs_each_tool_with_the_file_it_came_from() {
+        let dir_a = tempfile::tempdir().unwrap();
+        let dir_b = tempfile::tempdir().unwrap();
+        std::fs::write(dir_a.path().join("dup.rhai"), "// @tool dup\n1").unwrap();
+        std::fs::write(dir_b.path().join("dup.rhai"), "// @tool dup\n2").unwrap();
+
+        let (set, _) =
+            ScriptToolSet::discover(&[dir_a.path().to_path_buf(), dir_b.path().to_path_buf()]);
+        let sources = set.sources();
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].0.name, "dup");
+        assert_eq!(sources[0].1, dir_a.path().join("dup.rhai"));
+    }
+
+    // ── check_source ──
+
+    #[test]
+    fn check_source_accepts_a_script_that_would_become_a_tool() {
+        let meta = check_source("draft", "// @tool draft\n// @description d\n1").unwrap();
+        assert_eq!(meta.name, "draft");
+        assert_eq!(meta.description, "d");
+    }
+
+    #[test]
+    fn check_source_rejects_missing_annotations() {
+        let err = check_source("draft", "1").unwrap_err();
+        assert!(err.to_string().contains("@tool"), "{err}");
+    }
+
+    /// The annotations parse but Rhai does not accept the body, which is the
+    /// half `parse_annotations` alone would let through.
+    #[test]
+    fn check_source_rejects_a_script_rhai_will_not_compile() {
+        let err = check_source("draft", "// @tool draft\nlet").unwrap_err();
+        assert!(err.to_string().contains("draft"), "{err}");
     }
 
     #[test]

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -173,6 +173,8 @@ Base path `/api`; all JSON unless noted.
 | `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q` |
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
 | `GET /api/models` | Enumerate models |
+| `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
+| `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the agent's Rhai. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
 | `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
@@ -333,6 +335,47 @@ in the response says where the window actually began. That is what keeps the pie
 offset past the end of the file returns 416 rather than an empty window, so a loop cannot spin.
 
 A whole-file read serializes exactly as it always has. `offset` is omitted when it is zero.
+
+## Tools and scripts
+
+`GET /api/tools` answers what an agent on **this** machine can call, which is not a question a
+client can answer for itself. Every entry carries a `source`:
+
+| `source` | Means |
+|---|---|
+| `builtin` | Compiled into this Leviath. Every agent has it |
+| `subagent` | A sub-agent tool, for an agent that may spawn children |
+| `agent` | A `.rhai` in that agent's own `tools/`. Only that agent has it |
+| `global` | A `.rhai` in `~/.leviath/tools/`. Every agent on the machine has it |
+
+Pass `?agent=<name>` to include the fourth. Script-backed entries also carry the `path` they came
+from. A separate `skipped` list carries the `.rhai` files that were found and cannot be offered,
+with the reason each was passed over, so a file with a syntax error does not simply look like a file
+nobody wrote. MCP tools are not here: they depend on a server being reachable rather than on
+anything installed, and `/api/mcp/servers/{name}` already answers for them.
+
+`GET /api/scripts` is the same ground from the editor's side, over the four kinds of Rhai an agent
+can carry: `tool`, `region_hook`, `stage_hook` and `output_validator`. Only tools have a directory of
+their own (`<agent>/tools/`, plus the global one); the other three are named by path in the manifest
+and resolved against the agent's own directory, so the listing derives them from what the manifest
+declares and the read and write routes address them at `<agent>/<name>.rhai`. A hook a manifest
+declares inside a subdirectory is outside what `{name}` can address, and is left out rather than
+listed under a name that would fetch nothing.
+
+`GET/PUT/DELETE /api/scripts/{kind}/{name}` reads and writes one file, scoped by `?agent=<name>` or,
+with no `agent`, the global tools directory. `POST /api/scripts/validate` takes `kind` and `content`
+and compiles without writing, so an editor can check before saving instead of saving and waiting for
+a run to fail.
+
+> [!WARNING]
+> `PUT` and `DELETE` are **not mounted at all** without `lev serve --allow-admin`, exactly like the
+> MCP add/remove routes and `PUT /api/config`. A `.rhai` file is executable code every agent then
+> runs, so a session that can write one can run code on the host. The `GET` routes stay open, so an
+> editor degrades to read-only rather than disappearing.
+
+A write that does not compile is still saved, with `compiles: false` and the compiler's complaint in
+the response. A draft is worth keeping, and a tool that does not compile is skipped at spawn rather
+than breaking the agent.
 
 ## Feature detection
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -43,6 +43,9 @@
     },
     {
       "name": "events"
+    },
+    {
+      "name": "scripts"
     }
   ],
   "paths": {
@@ -1119,6 +1122,204 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/api/tools": {
+      "get": {
+        "tags": [
+          "scripts"
+        ],
+        "summary": "Tools an agent on this machine can call",
+        "description": "Built-ins, sub-agent tools, the named agent's own `tools/*.rhai` and the global ones, each with a `source`. `skipped` carries the `.rhai` files that were found and could not be offered, with the reason. MCP tools are not included; `/api/mcp/servers/{name}` answers for those.",
+        "parameters": [
+          {
+            "name": "agent",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Scope to this agent's own directory."
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          }
+        }
+      }
+    },
+    "/api/scripts": {
+      "get": {
+        "tags": [
+          "scripts"
+        ],
+        "summary": "Rhai scripts this scope can see",
+        "description": "Script tools from the agent's `tools/` and the global directory, plus the region hooks, stage hooks and output validators the agent's manifest declares. Each entry carries its kind, its source (`agent` or `global`) and whether it compiles right now.",
+        "parameters": [
+          {
+            "name": "agent",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Scope to this agent's own directory."
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          }
+        }
+      }
+    },
+    "/api/scripts/validate": {
+      "post": {
+        "tags": [
+          "scripts"
+        ],
+        "summary": "Compile a script without writing it",
+        "description": "Takes `kind` and `content`, plus `hooks` for a stage hook, and answers with `valid` and the compiler's complaint. Writes nothing and runs nothing: every compiler here stops at the AST.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          }
+        }
+      }
+    },
+    "/api/scripts/{kind}/{name}": {
+      "get": {
+        "tags": [
+          "scripts"
+        ],
+        "summary": "A script's source text",
+        "parameters": [
+          {
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "tool",
+                "region_hook",
+                "stage_hook",
+                "output_validator"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The file's name without its `.rhai` extension."
+          },
+          {
+            "name": "agent",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Scope to this agent's own directory."
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "scripts"
+        ],
+        "summary": "Write a script",
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because a `.rhai` file is executable code every agent then runs. A file that does not compile is still written, and the response says so.",
+        "parameters": [
+          {
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "tool",
+                "region_hook",
+                "stage_hook",
+                "output_validator"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The file's name without its `.rhai` extension."
+          },
+          {
+            "name": "agent",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Scope to this agent's own directory."
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "scripts"
+        ],
+        "summary": "Delete a script",
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed.",
+        "parameters": [
+          {
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "tool",
+                "region_hook",
+                "stage_hook",
+                "output_validator"
+              ]
+            }
+          },
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The file's name without its `.rhai` extension."
+          },
+          {
+            "name": "agent",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Scope to this agent's own directory."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted."
           }
         }
       }


### PR DESCRIPTION
Closes #433, #434 and #435 - the three Lair-support gaps.

## #433 - `GET /api/tools`
The console shipped a hardcoded list derived from four bundled manifests, so a global tool you wrote was never offered and a tool that *was* offered might not exist (`web_search` showed up and did nothing).

The daemon already computed this for the lint, so rather than a second copy the four discovery rules moved into a new `tool_inventory` module; `LintEnv::offline` now calls it and takes `.names()`, leaving the lint's tool set byte-identical.

Each entry carries its `source` - `builtin`, `subagent`, `agent`, `global` - because that is the answer to *will this work if I pick it*. `skipped` reports scripts that failed to compile (the `Vec<SkippedTool>` `discover` always returned and the call site always dropped) plus scripts shadowed by a built-in or by the agent's own copy, which the daemon drops at spawn - listing those as available would be a lie.

## #434 - `/api/scripts`
Read and write Rhai by `kind`, scoped to an agent or to the machine-wide directory.

**Reported honestly rather than invented:** only `tool` has a directory convention. `region_hook`, `stage_hook` and `output_validator` are named by path in the manifest and resolved against the agent's own directory, so the listing derives those three from what the manifest *declares* (that is the only thing that says a `.rhai` is a stage hook rather than a region hook), the read/write routes address them where a bare declared filename resolves, and `?agent=` omitted with a non-tool kind is a **400 rather than an invented `~/.leviath/hooks/`**. A hook declared inside a subdirectory is not listed rather than listed under a name that would fetch nothing. All documented in the module header and `docs/content/api.md`.

**Security.** `PUT`/`DELETE` are *unmounted* without `--allow-admin`, in the same block that gates the MCP admin routes and `PUT /api/config`; `GET` stays available so an editor degrades to read-only. A `.rhai` is executable code every agent then runs, which is a category change from a blueprint that merely declares. Both `name` and `agent` go through `is_safe_path_component` before any join, the extension is fixed by the code rather than the caller, and every path is checked for containment and refused unless it is a plain file (`symlink_metadata`, no follow) so a planted symlink cannot redirect a write outside the directory. With no resolvable home the base is empty and a write lands nowhere rather than in the process CWD - tested.

`validate` compiles without writing, via a new `check_source` that needs no directory: writing a candidate into a directory every agent executes from is not an acceptable way to answer "does this compile".

## #435 - custom gateways in the config API
You said to ignore #332 and define a shape. **Nothing needed inventing** - `[model_providers]` already holds custom gateways as a keyed collection with `base_url`, `api_key`, `rate_limit`, `script` and `extra`. Building on it means the API describes the file users already write, instead of a second parallel shape that would collide the moment both were used.

`GET /api/config` enumerates them name-sorted (the config holds a `HashMap`, and a list that reorders itself between reads cannot be edited in a form). `PUT` adds/edits by name and removes via a separate list, keeping partial-update semantics - which is what lets a browser change a gateway's URL **without ever being handed its key**, asserted end to end.

**Disclosure:** `extra` is forwarded verbatim into a provider script and routinely holds a second credential, so only its key *names* are served, never values. A test serializes the whole document and asserts neither the key nor an `extra` value appears anywhere in it - a field added later would otherwise leak silently. `POST /api/config/validate` now accepts `base_url` and checks its scheme, staying format-only as it promises; an unknown provider name is no longer a rejection, since a custom gateway's key has no house format to check.

## Structure
`serve/types.rs` went over the 1200-line limit, so the config request/response shapes moved to `config_types.rs` and are re-exported from where they were. The gate's own message says split by concern rather than raise the cap.

## Validation
- **7496 workspace tests, 0 failures.** Coverage gate at 100% for `leviath-cli` and `leviath-scripting`; clippy, `cargo xtask docs` and `cargo xtask structure` all clean.
- `docs/schema/openapi.json` gained the new paths (a router-drift test enforces this) and `docs/content/api.md` a Tools and scripts section.
- Not exercised against a live Lair or a real browser: the routes are asserted in-process through the axum router, which is this module's established pattern.
