### PR TITLE
feat(runtime): park a run whose fix is somebody else's, instead of ending it

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -103,6 +103,13 @@ impl Dashboard {
                     (AgentDisplayStatus::Waiting, Some(reason)) => {
                         format!("{GLYPH_WAITING}{reason}")
                     }
+                    // A run parked until the machine is fixed carries a reason
+                    // too, and it is the one row where a bare PAUSED would be
+                    // actively misleading: it reads as somebody's own decision
+                    // rather than something waiting on them.
+                    (AgentDisplayStatus::Paused, Some(reason)) => {
+                        format!("{GLYPH_PENDING}{reason}")
+                    }
                     (status, _) => status.to_string(),
                 };
                 let short_id = agent.id.split('-').next_back().unwrap_or("").to_string();
@@ -1271,6 +1278,56 @@ mod tests {
             // carry both, and the word is the half that says nothing.
             assert!(!buf.contains("WAITING"), "{buf}");
         }
+    }
+
+    /// A run parked until the machine is fixed says what it needs, rather than
+    /// showing a bare PAUSED that reads as somebody's own decision.
+    #[test]
+    fn a_parked_row_names_what_the_machine_is_missing() {
+        use leviath_core::run_meta::{SetupBlocker, WaitReason};
+
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Paused);
+        agent.wait_reason = Some(WaitReason::NeedsSetup {
+            blocker: SetupBlocker::ProviderMissing,
+            remedy: "add it to config.toml".to_string(),
+        });
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dash.draw_agent_table(f, area);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("needs provider"), "{buf}");
+        assert!(
+            !buf.contains("PAUSED"),
+            "the reason replaces the word: {buf}"
+        );
+    }
+
+    /// A run somebody paused themselves has no reason, and reads as it always
+    /// did.
+    #[test]
+    fn a_row_paused_by_a_person_reads_as_it_always_did() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("run-1", AgentDisplayStatus::Paused));
+        dash.update_display_indices();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dash.draw_agent_table(f, area);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("PAUSED"), "{buf}");
     }
 
     /// A run whose `meta.json` predates the field renders exactly as it did

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -258,6 +258,10 @@ pub fn format_offline(runs: &[OfflineRun], now: i64) -> Option<String> {
 fn status_cell(entry: &RunListEntry) -> String {
     match (&entry.status, &entry.wait_reason) {
         (AgentStatus::Waiting, Some(reason)) => format!("waiting: {reason}"),
+        // A run parked until the machine is fixed is the one that most needs
+        // explaining, so a bare `paused` would be the worst answer here: it
+        // reads as a deliberate pause somebody can undo whenever they like.
+        (AgentStatus::Paused, Some(reason)) => format!("paused: {reason}"),
         (status, _) if entry.empty_output => format!("{status} (no output)"),
         (status, _) => status.to_string(),
     }

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -50,6 +50,32 @@ fn status_cell_spells_out_why_a_run_is_waiting() {
     assert_eq!(status_cell(&e), "waiting: children(2)");
 }
 
+/// A run parked until the machine is fixed says so here too.
+///
+/// This is the row where a bare `paused` would be worst: it reads as somebody
+/// having stopped the run on purpose, when in fact the run is waiting on them.
+#[test]
+fn status_cell_spells_out_what_a_parked_run_needs() {
+    use leviath_core::run_meta::SetupBlocker;
+    let mut e = entry("run-a", AgentStatus::Paused);
+    e.wait_reason = Some(WaitReason::NeedsSetup {
+        blocker: SetupBlocker::CreditsExhausted,
+        remedy: "top up the account".to_string(),
+    });
+    assert_eq!(status_cell(&e), "paused: needs credits");
+
+    e.wait_reason = Some(WaitReason::NeedsSetup {
+        blocker: SetupBlocker::ProviderMissing,
+        remedy: "add it to config.toml".to_string(),
+    });
+    assert_eq!(status_cell(&e), "paused: needs provider");
+
+    // A run somebody paused themselves has no reason, and still reads as the
+    // deliberate thing it is.
+    e.wait_reason = None;
+    assert_eq!(status_cell(&e), "paused");
+}
+
 /// A `Waiting` the host could not attribute still has to render, and it must
 /// read as the bare status rather than as a half-written reason.
 #[test]

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -372,6 +372,26 @@ fn reload_one(
         &crate::runstate::read_stages_index_from(run_dir),
     );
 
+    // A run parked until the machine is fixed keeps its reason across a
+    // restart. Without this the marker is a live component nothing rebuilds,
+    // so the run returns as a bare `Paused` and the next persist tick computes
+    // `waiting_on` from markers that are no longer there and writes `null`
+    // over the recorded reason - the same shape as the stage ledger above,
+    // where not restoring did not merely lose the value but erased the file
+    // that held it. The run is not re-dispatched while paused, so nothing
+    // would recompute it either.
+    if let Some(leviath_core::run_meta::WaitReason::NeedsSetup { blocker, remedy }) =
+        &meta.waiting_on
+    {
+        world
+            .world_mut()
+            .entity_mut(entity)
+            .insert(leviath_runtime::pipeline::PausedForSetup {
+                blocker: *blocker,
+                remedy: remedy.clone(),
+            });
+    }
+
     // A tool batch was in flight when the daemon died and its results never
     // reached the window: replay what the journal recorded - real results for
     // completed calls, verify-first errors for interrupted ones - so the
@@ -1879,6 +1899,64 @@ mod tests {
     /// written straight over the real file on the next persist tick, and the
     /// run's whole per-stage history went with it while `meta.json` still
     /// looked healthy (issue #415).
+    /// A run parked until the machine is fixed keeps its reason across a
+    /// daemon restart.
+    ///
+    /// The marker is a live component, so without restoring it the run comes
+    /// back as a bare `Paused` and the next persist tick recomputes
+    /// `waiting_on` from markers that are gone - writing `null` over the
+    /// reason rather than merely failing to show it. Nothing recomputes it
+    /// either, because a paused run is never dispatched.
+    #[tokio::test]
+    async fn reload_keeps_the_reason_a_parked_run_was_parked_for() {
+        use leviath_core::run_meta::{SetupBlocker, WaitReason};
+
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let runs = tempfile::tempdir().unwrap();
+        write_run(
+            runs.path(),
+            "run-parked",
+            manifest.to_str().unwrap(),
+            RunStatus::Paused,
+            None,
+        );
+        // Rewrite meta with the reason the run stopped for.
+        let meta_path = runs.path().join("run-parked").join("meta.json");
+        let mut meta: leviath_core::run_meta::RunMeta =
+            serde_json::from_str(&std::fs::read_to_string(&meta_path).unwrap()).unwrap();
+        meta.waiting_on = Some(WaitReason::NeedsSetup {
+            blocker: SetupBlocker::ProviderMissing,
+            remedy: "add it to config.toml".to_string(),
+        });
+        std::fs::write(&meta_path, serde_json::to_string(&meta).unwrap()).unwrap();
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let restored = reload_persisted_agents(
+            &mut world,
+            crate::daemon::spawn::SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                hub: &hub,
+                now_secs: 999,
+                subagent_tx: sub_tx().clone(),
+            },
+            runs.path(),
+        );
+        assert_eq!(restored.len(), 1);
+
+        let parked = world
+            .world()
+            .get::<leviath_runtime::pipeline::PausedForSetup>(restored[0].1.entity())
+            .expect("the reason came back with the run");
+        assert_eq!(parked.blocker, SetupBlocker::ProviderMissing);
+        assert_eq!(parked.remedy, "add it to config.toml");
+    }
+
     #[tokio::test]
     async fn reload_restores_the_persisted_stage_ledger() {
         use leviath_core::run_meta::{StageRecord, StageRunStatus};

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -101,6 +101,71 @@ pub enum WaitReason {
         /// Children that have not reached a terminal status.
         outstanding: usize,
     },
+
+    /// Parked because something on the machine has to change before this run
+    /// can go on: a provider it needs is not configured, a key was rejected,
+    /// an account is out of credits.
+    ///
+    /// These used to end the run. They are all deterministic and all outside
+    /// the run's control, so ending it threw away everything it had done to
+    /// punish a person for a typo in `config.toml`. The run holds its place
+    /// instead, and `lev resume` picks it up once the machine is fixed.
+    ///
+    /// The distinction that matters is not "is there a fix" but "does the fix
+    /// let *this* run continue": a broken blueprint is equally deterministic
+    /// and equally fixable, and still cannot be resumed into, because the
+    /// blueprint was read at spawn.
+    NeedsSetup {
+        /// Which kind of problem, so a client can offer the right thing to do
+        /// rather than parse the sentence below.
+        blocker: SetupBlocker,
+        /// What to do about it, in a sentence, for whoever reads the run.
+        remedy: String,
+    },
+}
+
+/// What is stopping a [`WaitReason::NeedsSetup`] run, in a form a client can
+/// branch on.
+///
+/// One variant per remedy, not per error: these are the cases whose *fixes*
+/// differ. Topping up an account, adding a provider to `config.toml` and
+/// replacing a rejected key are three different screens, and a console that
+/// had only the sentence would be reduced to matching on its wording.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SetupBlocker {
+    /// The stage names a provider this install has not configured.
+    ProviderMissing,
+    /// The account behind the provider is out of credits.
+    CreditsExhausted,
+    /// The key was rejected.
+    AuthFailed,
+    /// The key is valid but not allowed to use the model.
+    Forbidden,
+    /// Every candidate is out of service, for reasons that do not agree or are
+    /// not known. The remedy names what was tried last.
+    ProvidersUnavailable,
+}
+
+impl std::fmt::Display for SetupBlocker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProviderMissing => f.write_str("provider"),
+            Self::CreditsExhausted => f.write_str("credits"),
+            Self::AuthFailed => f.write_str("key"),
+            Self::Forbidden => f.write_str("access"),
+            Self::ProvidersUnavailable => f.write_str("providers"),
+        }
+    }
+}
+
+/// What a parked run needs, gathered where the markers are visible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetupNeeded {
+    /// Which kind of problem it is.
+    pub blocker: SetupBlocker,
+    /// What to do about it.
+    pub remedy: String,
 }
 
 impl WaitReason {
@@ -120,6 +185,9 @@ impl std::fmt::Display for WaitReason {
             Self::InteractionPoint => f.write_str("checkpoint"),
             Self::FanOutWorkers { outstanding } => write!(f, "workers({outstanding})"),
             Self::Children { outstanding } => write!(f, "children({outstanding})"),
+            // The remedy is a sentence; this is a table cell. The blocker is
+            // the half that fits, and the half that says which screen to open.
+            Self::NeedsSetup { blocker, .. } => write!(f, "needs {blocker}"),
         }
     }
 }
@@ -145,6 +213,9 @@ pub struct WaitMarkers {
     /// Whether a hub request is holding it at all. Separate from the kind
     /// because the kind can be unknown while the block is real.
     pub awaiting_interaction: bool,
+    /// The run is parked until the machine is fixed, and this is what it
+    /// needs.
+    pub needs_setup: Option<SetupNeeded>,
 }
 
 /// Why a parked run is parked, or `None` when it is not parked or nothing has
@@ -154,9 +225,17 @@ pub struct WaitMarkers {
 /// stage checkpoint each open a hub request of their own, so both also look
 /// like a generic prompt; asking the specific markers first is what keeps them
 /// from all reporting as one.
-pub fn wait_reason_from(waiting: bool, markers: &WaitMarkers) -> Option<WaitReason> {
-    if !waiting {
+pub fn wait_reason_from(parked: bool, markers: &WaitMarkers) -> Option<WaitReason> {
+    if !parked {
         return None;
+    }
+    // First, because it outranks everything: a run whose provider is missing
+    // is not going to be unblocked by answering a prompt.
+    if let Some(need) = &markers.needs_setup {
+        return Some(WaitReason::NeedsSetup {
+            blocker: need.blocker,
+            remedy: need.remedy.clone(),
+        });
     }
     if markers.gate_prompt {
         return Some(WaitReason::TaintGate);
@@ -944,6 +1023,84 @@ mod tests {
             ),
             Some(WaitReason::FanOutWorkers { outstanding: 2 })
         );
+    }
+
+    /// A run parked until the machine is fixed says so before anything else.
+    ///
+    /// It outranks every other marker on purpose: answering a prompt does not
+    /// help a run whose provider is not configured, so sending someone to the
+    /// prompt would be sending them to the wrong screen.
+    #[test]
+    fn needing_setup_outranks_every_other_reason() {
+        let need = SetupNeeded {
+            blocker: SetupBlocker::ProviderMissing,
+            remedy: "add it to config.toml".to_string(),
+        };
+        let reason = wait_reason_from(
+            true,
+            &WaitMarkers {
+                needs_setup: Some(need.clone()),
+                // Everything else at once, so precedence is being tested
+                // rather than the absence of competition.
+                gate_prompt: true,
+                interaction_point: true,
+                fan_out_outstanding: Some(2),
+                children_outstanding: Some(3),
+                awaiting_interaction: true,
+                interaction: Some(crate::interaction::InteractionKind::ToolApproval),
+            },
+        );
+        assert_eq!(
+            reason,
+            Some(WaitReason::NeedsSetup {
+                blocker: SetupBlocker::ProviderMissing,
+                remedy: "add it to config.toml".to_string(),
+            })
+        );
+        assert!(
+            reason.unwrap().needs_a_person(),
+            "nothing resolves this without somebody"
+        );
+    }
+
+    /// Each blocker is its own value on the wire, so a console can offer the
+    /// right remedy instead of matching on the sentence.
+    #[test]
+    fn every_blocker_has_its_own_wire_name_and_label() {
+        for (blocker, wire, label) in [
+            (
+                SetupBlocker::ProviderMissing,
+                "provider_missing",
+                "provider",
+            ),
+            (
+                SetupBlocker::CreditsExhausted,
+                "credits_exhausted",
+                "credits",
+            ),
+            (SetupBlocker::AuthFailed, "auth_failed", "key"),
+            (SetupBlocker::Forbidden, "forbidden", "access"),
+            (
+                SetupBlocker::ProvidersUnavailable,
+                "providers_unavailable",
+                "providers",
+            ),
+        ] {
+            assert_eq!(serde_json::to_value(blocker).unwrap(), wire);
+            assert_eq!(blocker.to_string(), label);
+            let back: SetupBlocker = serde_json::from_value(serde_json::json!(wire)).unwrap();
+            assert_eq!(back, blocker);
+            // The row renders the kind, not the sentence: a remedy is a
+            // sentence and this is a table cell.
+            assert_eq!(
+                WaitReason::NeedsSetup {
+                    blocker,
+                    remedy: "a whole sentence that would not fit".to_string(),
+                }
+                .to_string(),
+                format!("needs {label}")
+            );
+        }
     }
 
     /// A generic hub block reports what kind of prompt it is, so "approve this

--- a/crates/leviath-runtime/src/host/listing.rs
+++ b/crates/leviath-runtime/src/host/listing.rs
@@ -30,7 +30,7 @@ impl WorldHost {
         // persistence system that writes the same answer to `meta.json`: two
         // copies of it would disagree the first time either was edited.
         leviath_core::run_meta::wait_reason_from(
-            state.status == AgentStatus::Waiting,
+            matches!(state.status, AgentStatus::Waiting | AgentStatus::Paused),
             &leviath_core::run_meta::WaitMarkers {
                 gate_prompt: world
                     .get::<crate::gate_prompt::AwaitingGatePrompt>(entity)
@@ -68,6 +68,12 @@ impl WorldHost {
                     .find(|(agent_id, _)| *agent_id == state.agent_id)
                     .map(|(_, req)| req.kind),
                 awaiting_interaction: world.get::<AwaitingInteraction>(entity).is_some(),
+                needs_setup: world
+                    .get::<crate::pipeline::PausedForSetup>(entity)
+                    .map(|p| leviath_core::run_meta::SetupNeeded {
+                        blocker: p.blocker,
+                        remedy: p.remedy.clone(),
+                    }),
             },
         )
     }

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -2930,6 +2930,45 @@ async fn wait_reason_is_none_unless_the_agent_is_waiting() {
     assert_eq!(host.wait_reason(e), None);
 }
 
+/// A run parked until the machine is fixed explains itself to `lev ps` too,
+/// not only to `meta.json`.
+///
+/// It is `Paused` rather than `Waiting`, which is the point: nothing is
+/// holding a prompt open for it, so the listing has to treat paused as parked
+/// or the one run that most needs explaining would be the one that says
+/// nothing.
+#[tokio::test]
+async fn wait_reason_explains_a_run_parked_until_the_machine_is_fixed() {
+    use leviath_core::run_meta::SetupBlocker;
+    let mut host = host_with(vec![]);
+    let e = spawn(&mut host, "run-a", "run-a");
+    {
+        let world = host.world_mut().world_mut();
+        world
+            .get_mut::<AgentState>(e.entity())
+            .expect("spawned agent has state")
+            .status = AgentStatus::Paused;
+        world
+            .entity_mut(e.entity())
+            .insert(crate::pipeline::PausedForSetup {
+                blocker: SetupBlocker::ProviderMissing,
+                remedy: "add it to config.toml".to_string(),
+            });
+    }
+
+    let reason = host
+        .wait_reason(e)
+        .expect("a parked run says what it needs");
+    assert_eq!(
+        reason,
+        WaitReason::NeedsSetup {
+            blocker: SetupBlocker::ProviderMissing,
+            remedy: "add it to config.toml".to_string(),
+        }
+    );
+    assert!(reason.needs_a_person());
+}
+
 /// An entity the world no longer holds cannot be explained either.
 #[tokio::test]
 async fn wait_reason_is_none_for_an_unknown_entity() {

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -371,7 +371,14 @@ pub fn build_run_meta(sources: RunMetaSources<'_>, at: RunPosition) -> RunMeta {
         yolo: md.unattended,
         read_paths: md.read_paths,
         final_output: final_output.map(|o| o.0.descriptor()),
-        waiting_on: wait_reason_from(state.status == AgentStatus::Waiting, &parked),
+        // Paused counts as parked here, not just Waiting: a run held until the
+        // machine is fixed is exactly the case where a reader most needs to be
+        // told why, and it is `Paused` rather than `Waiting` because nothing is
+        // holding a prompt open for it.
+        waiting_on: wait_reason_from(
+            matches!(state.status, AgentStatus::Waiting | AgentStatus::Paused),
+            &parked,
+        ),
         output_request: md.output_request.clone(),
     }
 }

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -263,6 +263,7 @@ type PersistenceQuery = (
         Option<&'static crate::gate_prompt::AwaitingGatePrompt>,
         Option<&'static super::WaitingForChildren>,
         Option<&'static crate::components::AwaitingInteraction>,
+        Option<&'static super::PausedForSetup>,
     ),
 );
 
@@ -302,6 +303,7 @@ pub fn dispatch_persistence(
             gate_prompt,
             waiting_for_children,
             awaiting_interaction,
+            paused_for_setup,
         ),
     ) in agents.iter_mut()
     {
@@ -407,6 +409,10 @@ pub fn dispatch_persistence(
                             .map(|(_, req)| req.kind)
                     }),
                     awaiting_interaction: awaiting_interaction.is_some(),
+                    needs_setup: paused_for_setup.map(|p| leviath_core::run_meta::SetupNeeded {
+                        blocker: p.blocker,
+                        remedy: p.remedy.clone(),
+                    }),
                 },
             },
             crate::persistence::RunPosition {

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -40,6 +40,7 @@ pub(crate) fn to_inference_result(
 /// lifetimes: the borrow is bound when the query is fetched.
 type InferenceQuery = (
     &'static mut AgentState,
+    Option<&'static crate::persistence::RunMetadata>,
     Option<&'static mut crate::persistence::TokenTotals>,
     Option<&'static StageCursor>,
     Option<&'static ContextWindow>,
@@ -65,8 +66,17 @@ pub fn collect_inference(
     let policy = policy.map(|p| *p).unwrap_or_default();
     let now = chrono::Utc::now().timestamp();
     while let Ok(outcome) = results.0.try_recv() {
-        let Ok((mut state, totals, cursor, window, mut ledger, buffer, mut inference, activity)) =
-            agents.get_mut(outcome.entity)
+        let Ok((
+            mut state,
+            md,
+            totals,
+            cursor,
+            window,
+            mut ledger,
+            buffer,
+            mut inference,
+            activity,
+        )) = agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
@@ -236,12 +246,18 @@ pub fn collect_inference(
                 // resumes. Failing here would make the run permanently
                 // unresumable, so it pauses instead, still pointed at the same
                 // inference, and a `lev resume` re-dispatches it (issue #413).
-                if err.unavailable_reason()
-                    == Some(leviath_providers::UnavailableReason::CreditsExhausted)
+                // Unattended is the exception: a scheduler or a benchmark is
+                // watching for a terminal status and would wait for ever for
+                // one that never comes, so for those a failure is the honest
+                // answer.
+                let attended = !md.is_some_and(|m| m.unattended);
+                if attended
+                    && err.unavailable_reason()
+                        == Some(leviath_providers::UnavailableReason::CreditsExhausted)
                 {
                     let message = format!(
-                        "out of credits ({err}); pausing this run - top up the \
-                         account, then `lev resume` it"
+                        "out of credits ({err}): top up the account, then \
+                         `lev resume` this run"
                     );
                     tracing::warn!(error = %err, "out of credits; pausing the run for a resume");
                     if let Some(mut buffer) = buffer {
@@ -252,6 +268,10 @@ pub fn collect_inference(
                         .entity(outcome.entity)
                         .remove::<AwaitingInference>()
                         .remove::<InFlightWork>()
+                        .insert(crate::pipeline::PausedForSetup {
+                            blocker: leviath_core::run_meta::SetupBlocker::CreditsExhausted,
+                            remedy: message,
+                        })
                         .insert(ReadyToInfer);
                     continue;
                 }

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -183,7 +183,23 @@ type StalledDispatchQuery = (
     &'static StageInference,
     &'static mut AgentState,
     Option<&'static mut StageIoBuffer>,
+    Option<&'static crate::persistence::RunMetadata>,
 );
+
+/// A run parked until the machine is fixed, and what to do about it.
+///
+/// The message is the same one that used to be the run's epitaph. It is now
+/// attached to a run that is still alive, which is the whole change: every
+/// reason this marker exists for is deterministic, outside the run's control,
+/// and undone by one edit somewhere else.
+#[derive(Component, Debug, Clone, PartialEq, Eq)]
+pub struct PausedForSetup {
+    /// Which kind of problem, so a client can offer the right remedy rather
+    /// than match on the sentence.
+    pub blocker: leviath_core::run_meta::SetupBlocker,
+    /// What a person has to do before `lev resume` will get anywhere.
+    pub remedy: String,
+}
 
 /// Dispatch-stall watchdog: fail any agent whose dispatch has been declining for
 /// an unresolvable reason longer than [`StallTimeout`].
@@ -217,7 +233,7 @@ pub fn fail_stalled_dispatch(
         return; // watchdog disabled
     }
     let now = clock.map_or_else(now_secs, |c| (c.0)());
-    for (entity, stall, si, mut state, buffer) in agents.iter_mut() {
+    for (entity, stall, si, mut state, buffer, md) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active || !stall.reason.needs_a_person() {
             continue;
@@ -234,48 +250,90 @@ pub fn fail_stalled_dispatch(
         if now.saturating_sub(stall.since) < limit as i64 {
             continue; // still inside the grace period
         }
-        // A circuit that opened because the account ran out of credits is an
-        // account state, not a dead end: pause the run for a resume instead of
-        // failing it, keeping `ReadyToInfer` so the retry is already staged
-        // (issue #413). Any other reason still fails below - a missing
-        // provider or a rejected key does not fix itself with a top-up.
-        let credits_out = stall.reason == StallReason::ProviderCircuitOpen
-            && circuits
-                .as_ref()
-                .and_then(|c| c.last_reason(&si.provider_name))
-                == Some(leviath_providers::UnavailableReason::CreditsExhausted);
-        if credits_out {
-            let message = format!(
-                "out of credits on '{}'; pausing this run - top up the account, \
-                 then `lev resume` it",
+        // Everything that reaches here is deterministic and outside the run's
+        // control: a provider that is not configured, a key that was rejected,
+        // an account with no credits. One edit elsewhere undoes any of them,
+        // and the run's context is intact, so ending it would throw the work
+        // away to punish somebody for a typo. It waits instead.
+        // Which kind of problem, from the breaker's own record of why each
+        // provider went out of service. The three have three different fixes,
+        // so they are three different answers rather than one "unavailable".
+        use leviath_core::run_meta::SetupBlocker;
+        let last_reason = circuits
+            .as_ref()
+            .and_then(|c| c.last_reason(&si.provider_name));
+        let blocker = match stall.reason {
+            StallReason::ProviderCircuitOpen => match last_reason {
+                Some(leviath_providers::UnavailableReason::CreditsExhausted) => {
+                    SetupBlocker::CreditsExhausted
+                }
+                Some(leviath_providers::UnavailableReason::AuthFailed) => SetupBlocker::AuthFailed,
+                Some(leviath_providers::UnavailableReason::Forbidden) => SetupBlocker::Forbidden,
+                // Unreachable, or nothing recorded: the account and the key
+                // are both fine as far as anyone knows, so neither screen is
+                // the right one to send somebody to.
+                _ => SetupBlocker::ProvidersUnavailable,
+            },
+            _ => SetupBlocker::ProviderMissing,
+        };
+        let message = match blocker {
+            SetupBlocker::CreditsExhausted => format!(
+                "out of credits on '{}': top up the account, then `lev resume` \
+                 this run",
                 si.provider_name
-            );
-            tracing::warn!(
+            ),
+            SetupBlocker::AuthFailed => format!(
+                "'{}' rejected the API key: replace it with `lev setup`, then \
+                 `lev resume` this run",
+                si.provider_name
+            ),
+            SetupBlocker::Forbidden => format!(
+                "'{}' will not serve this model to that key: check the account's \
+                 plan and model permissions, then `lev resume` this run",
+                si.provider_name
+            ),
+            _ => stall.reason.give_up_message(&si.provider_name),
+        };
+        // Unless nobody is there to read it. An unattended run was launched by
+        // a scheduler or a harness, which is watching for a terminal status
+        // and will wait for ever for one that never comes - so for those,
+        // failing is the honest answer and stays what it was.
+        let unattended = md.is_some_and(|m| m.unattended);
+        if unattended {
+            tracing::error!(
                 provider = %si.provider_name,
+                reason = stall.reason.label(),
                 stalled_secs = now.saturating_sub(stall.since),
-                "out of credits; pausing the run for a resume"
+                "failing an unattended run: nobody is there to fix it"
             );
             if let Some(mut buffer) = buffer {
-                buffer.logs.push((0, format!("[paused] {message}")));
+                buffer.logs.push((0, format!("[stalled] {message}")));
             }
-            state.status = AgentStatus::Paused;
-            commands.entity(entity).remove::<DispatchStall>();
+            state.status = AgentStatus::Error { message };
+            commands
+                .entity(entity)
+                .remove::<ReadyToInfer>()
+                .remove::<DispatchStall>();
             continue;
         }
-        let message = stall.reason.give_up_message(&si.provider_name);
-        tracing::error!(
+        tracing::warn!(
             provider = %si.provider_name,
             reason = stall.reason.label(),
             stalled_secs = now.saturating_sub(stall.since),
-            "failing a run whose provider will never resolve"
+            "pausing a run until the machine is fixed"
         );
         if let Some(mut buffer) = buffer {
-            buffer.logs.push((0, format!("[stalled] {message}")));
+            buffer.logs.push((0, format!("[paused] {message}")));
         }
-        state.status = AgentStatus::Error { message };
+        state.status = AgentStatus::Paused;
+        // `ReadyToInfer` stays on purpose: the retry is already staged, so a
+        // resume re-dispatches rather than rebuilding anything.
         commands
             .entity(entity)
-            .remove::<ReadyToInfer>()
+            .insert(PausedForSetup {
+                blocker,
+                remedy: message,
+            })
             .remove::<DispatchStall>();
     }
 }
@@ -323,6 +381,9 @@ mod tests {
     }
 
     /// Spawn an agent that has been stalled for `age` seconds for `reason`.
+    ///
+    /// Attended, because that is the ordinary case: a person started it and
+    /// can fix whatever is wrong. [`spawn_stalled_unattended`] is the other.
     fn spawn_stalled(world: &mut World, reason: StallReason, age: i64) -> Entity {
         world
             .spawn((
@@ -333,6 +394,52 @@ mod tests {
                 ReadyToInfer,
             ))
             .id()
+    }
+
+    /// The same, launched by something that is not watching.
+    fn spawn_stalled_unattended(world: &mut World, reason: StallReason, age: i64) -> Entity {
+        let e = spawn_stalled(world, reason, age);
+        world.entity_mut(e).insert(run_metadata(true));
+        e
+    }
+
+    /// Run metadata carrying only the field the watchdog reads.
+    fn run_metadata(unattended: bool) -> crate::persistence::RunMetadata {
+        crate::persistence::RunMetadata {
+            run_id: "r".to_string(),
+            agent_name: "a".to_string(),
+            agent_path: String::new(),
+            task: String::new(),
+            model: None,
+            workdir: String::new(),
+            num_stages: 1,
+            started_at: 0,
+            parent_run_id: None,
+            metadata: std::collections::HashMap::new(),
+            callback_url: None,
+            callback_secret: None,
+            title: None,
+            unattended,
+            read_paths: None,
+            output_request: None,
+        }
+    }
+
+    /// Assert a run is parked for setup, with `remedy` naming what to do.
+    fn assert_paused_for_setup(world: &World, e: Entity, remedy: &str) {
+        assert_eq!(
+            world.get::<AgentState>(e).unwrap().status,
+            AgentStatus::Paused,
+            "a fixable problem parks the run rather than ending it"
+        );
+        let marker = world
+            .get::<PausedForSetup>(e)
+            .expect("a parked run says what to do");
+        assert!(marker.remedy.contains(remedy), "{}", marker.remedy);
+        // The retry stays staged, so a resume re-dispatches rather than
+        // rebuilding anything.
+        assert!(world.get::<ReadyToInfer>(e).is_some());
+        assert!(world.get::<DispatchStall>(e).is_none());
     }
 
     /// Run the watchdog with the clock pinned to [`NOW`], so an age of `n` is
@@ -349,11 +456,33 @@ mod tests {
         schedule.run(world);
     }
 
+    /// A provider that is not configured is one config edit away from being
+    /// configured, so the run waits for that edit instead of dying for it.
     #[test]
-    fn a_provider_that_will_never_resolve_fails_the_run() {
+    fn a_provider_that_will_never_resolve_parks_the_run_for_a_person() {
         let mut world = World::new();
         world.insert_resource(StallTimeout(60));
         let e = spawn_stalled(&mut world, StallReason::ProviderMissing, 61);
+
+        run(&mut world);
+
+        assert_paused_for_setup(&world, e, "not configured");
+        // The operator sees why in the stage log the dashboard renders.
+        let logs = &world.get::<StageIoBuffer>(e).unwrap().logs;
+        assert!(
+            logs.iter().any(|(_, line)| line.starts_with("[paused]")),
+            "expected a [paused] log line, got: {logs:?}"
+        );
+    }
+
+    /// Unless nobody is watching. A scheduler polling for a terminal status
+    /// would wait for ever for one that never came, so an unattended run still
+    /// fails - the one case where an error is the more useful answer.
+    #[test]
+    fn an_unattended_run_still_fails_because_nobody_will_fix_it() {
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let e = spawn_stalled_unattended(&mut world, StallReason::ProviderMissing, 61);
 
         run(&mut world);
 
@@ -363,10 +492,8 @@ mod tests {
                 if message.contains("ghost") && message.contains("not configured")),
             "got: {status:?}"
         );
-        // Taken out of dispatch, and the stall record is spent.
         assert!(world.get::<ReadyToInfer>(e).is_none());
-        assert!(world.get::<DispatchStall>(e).is_none());
-        // The operator sees why in the stage log the dashboard renders.
+        assert!(world.get::<PausedForSetup>(e).is_none());
         let logs = &world.get::<StageIoBuffer>(e).unwrap().logs;
         assert!(
             logs.iter().any(|(_, line)| line.starts_with("[stalled]")),
@@ -400,11 +527,7 @@ mod tests {
 
         run(&mut world);
 
-        let status = &world.get::<AgentState>(e).unwrap().status;
-        assert!(
-            matches!(status, AgentStatus::Error { message } if message.contains("ghost")),
-            "got: {status:?}"
-        );
+        assert_paused_for_setup(&world, e, "ghost");
     }
 
     #[test]
@@ -429,11 +552,7 @@ mod tests {
 
         run_on_the_wall_clock(&mut world);
 
-        let status = &world.get::<AgentState>(e).unwrap().status;
-        assert!(
-            matches!(status, AgentStatus::Error { message } if message.contains("ghost")),
-            "got: {status:?}"
-        );
+        assert_paused_for_setup(&world, e, "ghost");
     }
 
     #[test]
@@ -488,11 +607,7 @@ mod tests {
             world.get::<AgentState>(inside).unwrap().status,
             AgentStatus::Active
         );
-        let status = &world.get::<AgentState>(past).unwrap().status;
-        assert!(
-            matches!(status, AgentStatus::Error { message } if message.contains("ghost")),
-            "got: {status:?}"
-        );
+        assert_paused_for_setup(&world, past, "ghost");
     }
 
     #[test]
@@ -526,11 +641,7 @@ mod tests {
 
         run(&mut world);
 
-        let status = &world.get::<AgentState>(e).unwrap().status;
-        assert!(
-            matches!(status, AgentStatus::Error { message } if message.contains("ghost")),
-            "got: {status:?}"
-        );
+        assert_paused_for_setup(&world, e, "ghost");
     }
 
     #[test]
@@ -613,13 +724,7 @@ mod tests {
 
         run(&mut world);
 
-        let status = &world.get::<AgentState>(e).unwrap().status;
-        assert!(
-            matches!(status, AgentStatus::Error { message }
-                if message.contains("out of service") && message.contains("fallback_order")),
-            "got: {status:?}"
-        );
-        assert!(world.get::<ReadyToInfer>(e).is_none());
+        assert_paused_for_setup(&world, e, "out of service");
     }
 
     #[test]
@@ -698,29 +803,93 @@ mod tests {
         );
     }
 
+    /// Each way a provider can go out of service gets its own answer, because
+    /// each has its own fix: top up, replace the key, or check the plan. A
+    /// client that had only "unavailable" would have to send everyone to the
+    /// same screen and hope.
     #[test]
-    fn a_circuit_open_for_a_dead_key_still_fails_the_run() {
-        // The pause is only for credits: a rejected key does not fix itself
-        // with a top-up, so any other recorded reason keeps today's failure.
+    fn each_kind_of_provider_failure_names_its_own_remedy() {
+        use leviath_core::run_meta::SetupBlocker;
+        let cases = [
+            (
+                leviath_providers::UnavailableReason::CreditsExhausted,
+                SetupBlocker::CreditsExhausted,
+                "top up",
+            ),
+            (
+                leviath_providers::UnavailableReason::AuthFailed,
+                SetupBlocker::AuthFailed,
+                "rejected the API key",
+            ),
+            (
+                leviath_providers::UnavailableReason::Forbidden,
+                SetupBlocker::Forbidden,
+                "will not serve this model",
+            ),
+            (
+                // Nothing anyone can point at: neither the account nor the key
+                // is known to be wrong, so neither screen is the right one.
+                leviath_providers::UnavailableReason::Unreachable,
+                SetupBlocker::ProvidersUnavailable,
+                "out of service",
+            ),
+        ];
+        for (reason, expected, remedy) in cases {
+            let mut world = World::new();
+            world.insert_resource(StallTimeout(60));
+            let mut circuits = super::super::circuit::ProviderCircuits::default();
+            let policy = super::super::circuit::CircuitPolicy::default();
+            circuits.record_failure("ghost", reason, NOW - 1, &policy);
+            world.insert_resource(circuits);
+            let e = spawn_stalled(&mut world, StallReason::ProviderCircuitOpen, 61);
+
+            run(&mut world);
+
+            assert_paused_for_setup(&world, e, remedy);
+            assert_eq!(
+                world.get::<PausedForSetup>(e).unwrap().blocker,
+                expected,
+                "{reason:?}"
+            );
+        }
+    }
+
+    /// `StageIoBuffer` is optional on the query, so the unattended failure has
+    /// to land even when there is no stage log to explain it in.
+    #[test]
+    fn an_unattended_failure_copes_without_a_stage_log_buffer() {
         let mut world = World::new();
         world.insert_resource(StallTimeout(60));
-        let mut circuits = super::super::circuit::ProviderCircuits::default();
-        let policy = super::super::circuit::CircuitPolicy::default();
-        circuits.record_failure(
-            "ghost",
-            leviath_providers::UnavailableReason::AuthFailed,
-            NOW - 1,
-            &policy,
-        );
-        world.insert_resource(circuits);
-        let e = spawn_stalled(&mut world, StallReason::ProviderCircuitOpen, 61);
+        let e = world
+            .spawn((
+                agent_state(),
+                stage_inference(),
+                stalled_for(StallReason::ProviderMissing, 61),
+                run_metadata(true),
+                ReadyToInfer,
+            ))
+            .id();
 
         run(&mut world);
 
-        let status = &world.get::<AgentState>(e).unwrap().status;
-        assert!(
-            matches!(status, AgentStatus::Error { message } if message.contains("out of service")),
-            "got: {status:?}"
+        let status = format!("{:?}", world.get::<AgentState>(e).unwrap().status);
+        assert!(status.contains("Error"), "{status}");
+    }
+
+    /// A provider that was never configured is a different fix again, and the
+    /// one case that does not go through the breaker at all.
+    #[test]
+    fn a_missing_provider_is_its_own_kind_of_blocker() {
+        use leviath_core::run_meta::SetupBlocker;
+        let mut world = World::new();
+        world.insert_resource(StallTimeout(60));
+        let e = spawn_stalled(&mut world, StallReason::ProviderMissing, 61);
+
+        run(&mut world);
+
+        assert_eq!(
+            world.get::<PausedForSetup>(e).unwrap().blocker,
+            SetupBlocker::ProviderMissing
         );
     }
 

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -925,6 +925,65 @@ fn an_exhausted_fallback_list_pauses_on_credits_instead_of_dying() {
     assert!(line.contains("lev resume"), "{line}");
 }
 
+/// An unattended run out of credits still fails.
+///
+/// Pausing is right for a person, who can top up and resume. It is wrong for
+/// a scheduler or a benchmark, which is watching for a terminal status and
+/// would wait for ever for one that never arrives - so the one case where an
+/// error is more useful than patience keeps getting one.
+#[test]
+fn an_unattended_run_out_of_credits_fails_rather_than_waiting_for_nobody() {
+    let (mut world, tx) = world_with_results();
+    let mut si = stage_with_fallback();
+    si.fallbacks.clear();
+    let mut md = run_metadata();
+    md.unattended = true;
+    let e = world.spawn((agent_state(), AwaitingInference, si, md)).id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    let status = format!("{:?}", world.get::<AgentState>(e).unwrap().status);
+    assert!(status.contains("Error"), "{status}");
+    assert!(world.get::<crate::pipeline::PausedForSetup>(e).is_none());
+    assert!(world.get::<ResolveTransition>(e).is_some());
+}
+
+/// The attended run says what to do, in a form a client can read rather than
+/// only a log line.
+#[test]
+fn a_credits_pause_records_the_remedy_on_the_run() {
+    let (mut world, tx) = world_with_results();
+    let mut si = stage_with_fallback();
+    si.fallbacks.clear();
+    let e = world
+        .spawn((agent_state(), AwaitingInference, si, run_metadata()))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(credits_exhausted()),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused
+    );
+    let parked = world
+        .get::<crate::pipeline::PausedForSetup>(e)
+        .expect("the run says what it needs");
+    assert!(parked.remedy.contains("top up"), "{}", parked.remedy);
+    assert!(parked.remedy.contains("lev resume"), "{}", parked.remedy);
+}
+
 #[test]
 fn the_credits_pause_copes_without_a_stage_log_buffer() {
     // `StageIoBuffer` is optional on the query, so the pause has to land even
@@ -1702,6 +1761,45 @@ fn dispatch_persistence_records_why_a_run_is_parked() {
     run_dispatch_persistence(&mut world);
     let moving = snapshot_job(rx.try_recv().expect("job sent"));
     assert_eq!(moving.meta.waiting_on, None);
+}
+
+/// A run parked until the machine is fixed says so in `meta.json`, with the
+/// kind of problem and what to do about it.
+///
+/// Through the real system rather than the mapper: the marker lives on the
+/// entity and the persist query is the only thing that can see it, so a query
+/// that forgot to select it would leave the field empty with every unit test
+/// still passing.
+#[test]
+fn dispatch_persistence_records_what_a_parked_run_needs() {
+    use leviath_core::run_meta::{SetupBlocker, WaitReason};
+
+    let (mut world, mut rx) = world_with_persistence();
+    let mut state = agent_state();
+    state.status = AgentStatus::Paused;
+    world.spawn((
+        run_metadata(),
+        state,
+        conv_window(),
+        StageCursor { index: 0 },
+        TokenTotals::default(),
+        PersistWatermark::default(),
+        crate::pipeline::PausedForSetup {
+            blocker: SetupBlocker::CreditsExhausted,
+            remedy: "top up the account, then `lev resume` this run".to_string(),
+        },
+    ));
+
+    run_dispatch_persistence(&mut world);
+    let job = snapshot_job(rx.try_recv().expect("job sent"));
+
+    // Paused, not errored: the run is still there to be resumed into.
+    assert_eq!(job.meta.status, leviath_core::run_meta::RunStatus::Paused);
+    let Some(WaitReason::NeedsSetup { blocker, remedy }) = job.meta.waiting_on else {
+        panic!("a parked run says what it needs: {:?}", job.meta.waiting_on);
+    };
+    assert_eq!(blocker, SetupBlocker::CreditsExhausted);
+    assert!(remedy.contains("top up"), "{remedy}");
 }
 
 /// Tool approvals are a person's to give, so a run holding them says so.

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -819,6 +819,13 @@ impl PipelineWorld {
     /// Resume a paused agent. `Idle` is also accepted (resume-as-nudge for an
     /// agent that has not ticked yet); anything else returns `false`.
     pub fn resume(&mut self, agent: AgentId) -> bool {
+        // Resolved once, up front. Doing it again inside the arm below would
+        // be a second check that cannot fail - the status lookup already
+        // proved the entity is here - and an arm nothing can reach is an arm
+        // nothing can test.
+        let Some(entity) = agent.resolve_in(&self.world) else {
+            return false;
+        };
         match self.agent_status(agent) {
             Some(AgentStatus::Paused | AgentStatus::Idle) => {
                 // An explicit resume says conditions have changed - most often
@@ -831,6 +838,13 @@ impl PipelineWorld {
                 {
                     circuits.reset();
                 }
+                // The run no longer claims to need setup. If the machine was
+                // not actually fixed the watchdog re-parks it a minute later
+                // with a fresh message, which is better than carrying a stale
+                // one that describes a problem somebody may have just solved.
+                self.world
+                    .entity_mut(entity)
+                    .remove::<crate::pipeline::PausedForSetup>();
                 self.set_status(agent, AgentStatus::Active)
             }
             _ => false,
@@ -1632,8 +1646,10 @@ mod tests {
         assert_eq!(stall.reason, crate::pipeline::StallReason::ProviderMissing);
 
         // Backdate it past the grace period, as the host's redrive timer would
-        // find it on a later tick, and the run fails with an answer rather than
-        // hanging.
+        // find it on a later tick. The run stops claiming to be working and
+        // says what it needs instead of hanging - and, since a missing
+        // provider is one config edit away from being present, it parks rather
+        // than dies, so the edit can be followed by `lev resume`.
         let past =
             chrono::Utc::now().timestamp() - crate::pipeline::DEFAULT_STALL_TIMEOUT_SECS as i64 - 1;
         world
@@ -1643,15 +1659,19 @@ mod tests {
             .since = past;
         world.run_to_fixed_point();
 
-        let status = world.agent_status(e);
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Paused));
+        let parked = world
+            .world()
+            .get::<crate::pipeline::PausedForSetup>(e.entity())
+            .expect("it says what to do");
         assert!(
-            matches!(status, Some(AgentStatus::Error { ref message })
-                if message.contains("script") && message.contains("not configured")),
-            "got: {status:?}"
+            parked.remedy.contains("script") && parked.remedy.contains("not configured"),
+            "{}",
+            parked.remedy
         );
         assert!(
-            world.world().get::<ReadyToInfer>(e.entity()).is_none(),
-            "and it is out of the dispatch systems"
+            world.world().get::<ReadyToInfer>(e.entity()).is_some(),
+            "the retry stays staged, so a resume re-dispatches it"
         );
     }
 
@@ -1977,6 +1997,53 @@ mod tests {
 
         assert!(world.resume(e));
         assert!(world.open_circuits().is_empty());
+    }
+
+    /// An id belonging to another world names a different agent here, so
+    /// resuming with one refuses rather than resuming whatever happens to sit
+    /// at that entity index. This is the check `AgentId` exists for.
+    #[tokio::test]
+    async fn resume_refuses_an_id_from_another_world() {
+        let mut theirs = build_world(registry_with(vec![text("t1")]));
+        let e = spawn(&mut theirs);
+        assert!(theirs.pause(e));
+
+        let mut ours = build_world(registry_with(vec![text("t1")]));
+        assert!(
+            !ours.resume(e),
+            "an id from elsewhere is not ours to resume"
+        );
+        // And the run it really names is untouched.
+        assert_eq!(theirs.agent_status(e), Some(AgentStatus::Paused));
+    }
+
+    /// Resuming drops the "needs setup" note.
+    ///
+    /// If the machine was not actually fixed the watchdog re-parks the run a
+    /// minute later with a fresh message, which is better than carrying a
+    /// stale one describing a problem somebody may have just solved.
+    #[tokio::test]
+    async fn resume_clears_the_note_saying_what_the_run_needed() {
+        let mut world = build_world(registry_with(vec![text("t1")]));
+        let e = spawn(&mut world);
+        assert!(world.pause(e));
+        world
+            .world_mut()
+            .entity_mut(e.entity())
+            .insert(crate::pipeline::PausedForSetup {
+                blocker: leviath_core::run_meta::SetupBlocker::ProviderMissing,
+                remedy: "add it to config.toml".to_string(),
+            });
+
+        assert!(world.resume(e));
+
+        assert!(
+            world
+                .world()
+                .get::<crate::pipeline::PausedForSetup>(e.entity())
+                .is_none(),
+            "a resumed run no longer claims to need setup"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Generalises the out-of-credits pause to the rest of its family: a run whose fix belongs to somebody else waits for that person instead of being thrown away.

## What changes

The stall watchdog used to fail a run after a minute when its provider was not configured, its key was rejected, its key lacked access to the model, or every candidate was out of service. All of those are deterministic, outside the run's control, and undone by one edit elsewhere - so ending the run discarded everything it had done in order to punish someone for a typo in `config.toml`. It now parks, keeping `ReadyToInfer` so the retry is already staged, and `lev resume` picks it up.

**The line is not "is there a deterministic fix" but "does the fix let this run continue."** A broken blueprint is equally deterministic and equally fixable, and still cannot be resumed into, because the blueprint is read at spawn. Those keep failing.

## Unattended runs still fail

The one case where an error is the more useful answer. A scheduler, an API caller or a benchmark cell is watching for a terminal status and would wait for ever for one that never arrives - this repo has been bitten by that shape before, with `ask_user` zombie runs. `RunMeta` already carried `unattended`, so the watchdog reads it and keeps today's behaviour for them. The same split now applies to the credits pause, which shipped without it.

## The pause is typed

Per review: a bare remedy string would make every client regex the sentence to decide whether to show "top up" or "open config". `SetupBlocker` names the kind:

| blocker | the fix |
|---|---|
| `provider_missing` | add it to `config.toml` |
| `credits_exhausted` | top up the account |
| `auth_failed` | replace the key |
| `forbidden` | check the plan and model permissions |
| `providers_unavailable` | nothing specific - neither the account nor the key is known to be wrong |

One variant per *remedy*, not per error: these are the cases whose fixes differ. The sentence still travels alongside for whoever has room to print it, and `Display` renders the kind (`needs credits`) because a table cell cannot hold a sentence.

## Where it surfaces

Through the vocabulary both surfaces already share, so nothing new had to be invented: `meta.json` carries it in `waiting_on`, and the live listing now answers for a **paused** run as well as a waiting one. That last part matters - the run that most needs explaining should not be the one that says nothing.

Resuming clears the note. If the machine was not really fixed, the watchdog re-parks the run a minute later with a fresh message, which beats carrying a stale one about a problem somebody may have just solved.

## A dead branch removed on the way

`resume` resolved the entity twice: once through the status lookup and again to clear the marker, and the second check could not fail. An arm nothing can reach is an arm nothing can test, so resolution moved up front where its `None` **is** reachable - an id belonging to another world - and is now covered by a test that also proves the run it really names is left alone.

## Validation
- **7523 workspace tests, 0 failures.** Coverage gate at 100% for `leviath-core`, `leviath-runtime` and `leviath-cli`; clippy, docs and structure clean.
- Six existing tests encoded the old fail-fast behaviour and were rewritten rather than deleted, including the end-to-end one in `world.rs` that drives the real schedule.
- Not exercised against a live provider: reproducing needs a genuinely misconfigured daemon. The behaviour is asserted through the watchdog, the collect system, the persist system and the live listing directly.
