### PR TITLE
feat(serve): say why a run is parked on the websocket, not just that it is

### DIFF
--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -236,6 +236,7 @@ fn status_event() -> WorldEvent {
         iteration: 1,
         tool_calls: 0,
         accepts_messages: false,
+        wait_reason: None,
     }
 }
 

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -62,6 +62,11 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     "logs.stream",
     "context.history.page",
     "runs.waiting_on",
+    // The same vocabulary on the websocket, not just on the run. Worth
+    // announcing separately: a client that has it can render a parked run's
+    // reason straight from the event stream, and one that doesn't has to
+    // re-fetch the run every time a status arrives.
+    "events.waiting_on",
     "blueprints.envelope",
     "blueprints.query",
     "blueprints.manifest",

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -1038,6 +1038,7 @@ model = "claude-sonnet-4-6"
             iteration: 5,
             tool_calls: 0,
             accepts_messages: true,
+            wait_reason: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"type\":\"agent_status\""));

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -95,6 +95,7 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
             iteration,
             tool_calls,
             accepts_messages,
+            wait_reason,
         } => ServerEvent::AgentStatus {
             agent_id,
             run_id,
@@ -103,6 +104,7 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
             iteration,
             tool_calls,
             accepts_messages,
+            wait_reason,
         },
         WorldEvent::Tokens {
             run_id,
@@ -343,6 +345,7 @@ mod tests {
     use crate::config::Config;
     use crate::runstate::{RunMeta, create_run};
     use leviath_core::interaction::InteractionRequest;
+    use leviath_core::run_meta::WaitReason;
     use leviath_runtime::control_socket::{ControlClient, bind_control_listener, control_id};
     use std::sync::Arc;
     use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -427,7 +430,8 @@ mod tests {
                 stage: "s".into(),
                 iteration: 1,
                 tool_calls: 0,
-                accepts_messages: true
+                accepts_messages: true,
+                wait_reason: None,
             }),
             "agent_status"
         );
@@ -541,9 +545,44 @@ mod tests {
                 iteration: 0,
                 tool_calls: 0,
                 accepts_messages: true,
+                wait_reason: None,
             },
         );
         assert_eq!(tag(&rx.try_recv().unwrap()), "agent_status");
+    }
+
+    /// The reason a run is parked has to survive the hop onto the websocket,
+    /// not just the status label. A subscriber that receives `waiting` with the
+    /// reason stripped is back to fetching the run to find out whether anyone
+    /// is needed, which is the guess this vocabulary exists to remove.
+    #[tokio::test]
+    async fn a_parked_run_carries_its_reason_onto_the_socket() {
+        let (state, mut rx) = state_with(no_daemon_client());
+        let client = reqwest::Client::new();
+        handle_event(
+            &state,
+            &client,
+            WorldEvent::Status {
+                run_id: "r".into(),
+                agent_id: "a".into(),
+                status: "waiting".into(),
+                stage: "s".into(),
+                iteration: 0,
+                tool_calls: 0,
+                accepts_messages: false,
+                wait_reason: Some(WaitReason::FanOutWorkers { outstanding: 3 }),
+            },
+        );
+        // Asserted on the serialized form rather than by destructuring, because
+        // the JSON is what a subscriber actually receives: this pins the field
+        // name and the tagging a client parses, not just that the value made it
+        // into the enum.
+        let sent = serde_json::to_value(rx.try_recv().unwrap()).unwrap();
+        assert_eq!(sent["type"], "agent_status");
+        assert_eq!(
+            sent["wait_reason"],
+            serde_json::json!({ "reason": "fan_out_workers", "outstanding": 3 })
+        );
     }
 
     #[tokio::test]
@@ -900,6 +939,7 @@ mod tests {
                 iteration: 0,
                 tool_calls: 0,
                 accepts_messages: true,
+                wait_reason: None,
             }],
         );
         let (state, mut rx) = state_with(control);
@@ -942,6 +982,7 @@ mod tests {
                     iteration: 0,
                     tool_calls: 0,
                     accepts_messages: true,
+                    wait_reason: None,
                 })
                 .unwrap();
                 line.push('\n');

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -115,6 +115,14 @@ pub enum ServerEvent {
         /// stage that declared `accepts_messages = false`, and for a run that
         /// has finished.
         accepts_messages: bool,
+        /// Why the run is parked, when it is.
+        ///
+        /// Omitted for a run that is moving. Without it a subscriber sees a
+        /// run turn `waiting` or `paused` and has to fetch the run to learn
+        /// whether somebody is needed, which is the guess this vocabulary
+        /// exists to remove.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        wait_reason: Option<leviath_core::run_meta::WaitReason>,
     },
     /// How full the run's context window is, after a turn changed it.
     ContextUpdate {
@@ -1091,6 +1099,7 @@ mod tests {
             iteration: 5,
             tool_calls: 12,
             accepts_messages: true,
+            wait_reason: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"type\":\"agent_status\""));
@@ -1338,6 +1347,7 @@ mod tests {
                     iteration: 0,
                     tool_calls: 0,
                     accepts_messages: false,
+                    wait_reason: None,
                 },
                 "r1",
             ),

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -636,6 +636,7 @@ mod tests {
                 iteration: 1,
                 tool_calls: 0,
                 accepts_messages: true,
+                wait_reason: None,
             },
             ServerEvent::ContextUpdate {
                 agent_id: "a".to_string(),
@@ -1026,6 +1027,7 @@ mod tests {
             iteration: 1,
             tool_calls: 0,
             accepts_messages: true,
+            wait_reason: None,
         };
         assert_eq!(ev.run_id(), "run-123");
     }
@@ -1108,6 +1110,7 @@ mod tests {
             iteration: 1,
             tool_calls: 0,
             accepts_messages: true,
+            wait_reason: None,
         };
         let non_matching = ServerEvent::AgentStatus {
             agent_id: "a".to_string(),
@@ -1117,6 +1120,7 @@ mod tests {
             iteration: 1,
             tool_calls: 0,
             accepts_messages: true,
+            wait_reason: None,
         };
 
         assert_eq!(matching.run_id(), filter);
@@ -1133,6 +1137,7 @@ mod tests {
             iteration: 3,
             tool_calls: 0,
             accepts_messages: false,
+            wait_reason: None,
         };
         let json = serde_json::to_string(&ev).unwrap();
         assert!(json.contains("\"type\":\"agent_status\""));

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -73,7 +73,7 @@ impl std::fmt::Display for RunStatus {
 /// exhaustively across the codebase and serialized two ways on the wire, so
 /// splitting it would break every consumer to express something that is not a
 /// new state. The run really is waiting; this says on what.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "reason")]
 pub enum WaitReason {
     /// Blocked on a tool-approval prompt. Needs a person (or `--yolo`).
@@ -131,7 +131,7 @@ pub enum WaitReason {
 /// differ. Topping up an account, adding a provider to `config.toml` and
 /// replacing a rejected key are three different screens, and a console that
 /// had only the sentence would be reduced to matching on its wording.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SetupBlocker {
     /// The stage names a provider this install has not configured.

--- a/crates/leviath-runtime/src/host/emit.rs
+++ b/crates/leviath-runtime/src/host/emit.rs
@@ -76,6 +76,7 @@ impl WorldHost {
                     cache_write_tokens: totals.cache_write_tokens,
                     context_tokens,
                     terminal,
+                    wait_reason: self.wait_reason(agent),
                 }
             };
             let max_tokens = self
@@ -107,8 +108,13 @@ impl WorldHost {
                     e.iteration,
                     e.tool_calls,
                     e.accepts_messages,
+                    e.wait_reason.clone(),
                 )
             };
+            // The reason is part of the key, so a parent whose worker count
+            // falls sends an event: that is progress, and a subscriber that
+            // only heard "waiting" once would show a stale count for the rest
+            // of the fan-out. Bounded by the number of workers.
             if prev.as_ref().map(status_key) != Some(status_key(&cur)) {
                 let _ = self.events.send(WorldEvent::Status {
                     run_id: run_id.clone(),
@@ -118,6 +124,7 @@ impl WorldHost {
                     iteration: cur.iteration,
                     tool_calls: cur.tool_calls,
                     accepts_messages: cur.accepts_messages,
+                    wait_reason: cur.wait_reason.clone(),
                 });
             }
 

--- a/crates/leviath-runtime/src/host/events.rs
+++ b/crates/leviath-runtime/src/host/events.rs
@@ -52,6 +52,13 @@ pub enum WorldEvent {
         tool_calls: usize,
         /// Whether the current stage accepts messages.
         accepts_messages: bool,
+        /// Why the run is parked, when it is.
+        ///
+        /// A subscriber watching live otherwise sees a run turn `waiting` or
+        /// `paused` and has to fetch the run to learn whether that means "go
+        /// and answer something" or "its workers are still going" - which is
+        /// the guess this vocabulary exists to remove.
+        wait_reason: Option<leviath_core::run_meta::WaitReason>,
     },
     /// A run's token totals changed.
     Tokens {
@@ -214,4 +221,7 @@ pub(super) struct Emitted {
     pub(super) cache_write_tokens: usize,
     pub(super) context_tokens: usize,
     pub(super) terminal: bool,
+    /// Why the run is parked, so a change of reason counts as a change worth
+    /// telling subscribers about.
+    pub(super) wait_reason: Option<leviath_core::run_meta::WaitReason>,
 }

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -2379,6 +2379,49 @@ async fn emit_events_broadcasts_agent_changes() {
     );
 }
 
+/// A subscriber watching live gets the same vocabulary `lev ps` and the
+/// dashboard use, so it never has to fetch the run to find out whether a parked
+/// run needs a person. And because the reason is part of the change key, a
+/// parked run that swaps one blocker for another sends a fresh event rather
+/// than sitting on the stale one: the status label is `waiting` either way.
+#[tokio::test]
+async fn a_status_event_carries_why_a_run_is_parked_and_re_fires_when_that_changes() {
+    let mut host = host_with(vec![text("done")]);
+    let mut rx = host.subscribe();
+    let entity = spawn(&mut host, "run-a", "agent-a");
+    {
+        let world = host.world_mut().world_mut();
+        let mut agent = world.entity_mut(entity.entity());
+        agent.get_mut::<AgentState>().unwrap().status = AgentStatus::Waiting;
+        agent.insert(crate::gate_prompt::AwaitingGatePrompt(1));
+    }
+
+    host.emit_events();
+    let reason = std::iter::from_fn(|| rx.try_recv().ok())
+        .find_map(|e| match e {
+            WorldEvent::Status { wait_reason, .. } => wait_reason,
+            _ => None,
+        })
+        .expect("a waiting run's status event should say why");
+    assert_eq!(reason, leviath_core::run_meta::WaitReason::TaintGate);
+
+    // Same status, same stage, same iteration: only the blocker moves.
+    {
+        let world = host.world_mut().world_mut();
+        let mut agent = world.entity_mut(entity.entity());
+        agent.remove::<crate::gate_prompt::AwaitingGatePrompt>();
+        agent.insert(crate::interaction_points::AwaitingInteractionPoint);
+    }
+    host.emit_events();
+    let reason = std::iter::from_fn(|| rx.try_recv().ok())
+        .find_map(|e| match e {
+            WorldEvent::Status { wait_reason, .. } => wait_reason,
+            _ => None,
+        })
+        .expect("a run that swapped blockers should send the new one");
+    assert_eq!(reason, leviath_core::run_meta::WaitReason::InteractionPoint);
+}
+
 #[tokio::test]
 async fn emit_events_unloads_terminal_agents_when_safe() {
     let mut host = host_with(vec![]);
@@ -3341,6 +3384,7 @@ fn every_world_event_variant_carries_its_run_id() {
             iteration: 1,
             tool_calls: 0,
             accepts_messages: false,
+            wait_reason: None,
         },
         WorldEvent::Tokens {
             run_id: rid.clone(),


### PR DESCRIPTION
## What

`WorldEvent::Status` told a websocket subscriber that a run had turned `waiting` or `paused`. It did not say why, so a client watching live had to fetch the run to learn whether that meant "go and answer something" or "its workers are still going" — the exact guess the wait-reason vocabulary exists to remove. The REST run object has carried the reason since #432; the event stream had not caught up, which left the cheapest way to watch a fleet as also the least informed.

The reason now rides the event, from the host's emitted snapshot through the serve mapper out to `agent_status` on the socket.

## The change key

`wait_reason` is part of the snapshot's change key, not just its payload. That has two consequences worth calling out:

- A parent whose outstanding-worker count falls sends a fresh event. Without it, a subscriber that heard `waiting` once would show a stale count for the rest of the fan-out. The extra traffic is bounded by the number of workers.
- A run that swaps one blocker for another sends a fresh event too, since the status label is `waiting` either way.

The reason is also part of the health digest, because it is part of the snapshot that digest covers.

## Compatibility

The field is `Option`, defaulted and skipped when absent, so an older client parses the new events unchanged and a moving run's event is byte-identical to before.

`events.waiting_on` is announced separately from `runs.waiting_on`: a client can have one without the other, and this says which.

## Tests

- `a_status_event_carries_why_a_run_is_parked_and_re_fires_when_that_changes` (runtime) drives a parked run through two different blockers and asserts both reach the event, the second one proving the change key works.
- `a_parked_run_carries_its_reason_onto_the_socket` (cli) asserts on the serialized JSON rather than by destructuring, so it pins the field name and the tagging a client actually parses.

Full workspace suite green; `leviath-core`, `leviath-runtime` and `leviath-cli` each back at 100%.
