### PR TITLE
chore(release): 0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,72 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## 0.3.9 - 2026-08-14
+
+- Added: a parked run says what it is parked on. `WaitingInput` covered four
+  different situations - a question for a person, tool calls held for
+  approval, a parent held by its own fan-out, and a parent held for
+  sub-agents - and only the first two are anybody's to act on, so a parent
+  whose children were still working showed as "needs you" in every client.
+  `meta.json` now carries `waiting_on`, `lev ps` and the dashboard print it
+  in place of the bare status word, and only a run somebody can actually
+  unblock wears the warning colour. The field is skipped when absent, so a
+  run that is not parked writes the file it always wrote.
+- Added: the same reason rides the websocket. A subscriber watching live had
+  to fetch the run to find out whether `waiting` meant "go and answer
+  something" or "its workers are still going". `agent_status` now carries
+  it, and because the reason is part of the change key, a parent whose
+  outstanding-worker count falls sends a fresh event instead of leaving a
+  subscriber on a stale count.
+- Changed: a run whose provider is not configured, whose key was rejected,
+  whose key lacks access, or whose account is empty now parks instead of
+  failing. Every one of those is deterministic, outside the run's control,
+  and undone by one edit somewhere else, so ending the run threw away
+  everything it had done to punish somebody for a typo. It parks with its
+  retry still staged and `lev resume` picks it up once the machine is fixed.
+  The pause is typed rather than a sentence, since a missing provider and an
+  empty account are different screens to send somebody to. Unattended runs
+  still fail, because a scheduler watching for a terminal status would wait
+  for ever for one that never came.
+- Fixed: `lev update` refreshes its package index before upgrading, so a
+  version published minutes earlier is found instead of requiring a manual
+  `brew update` first. Alpha and beta are handled alongside stable.
+- Fixed: the reason a run was parked survives a daemon restart. The marker
+  lived only in the world, so a reloaded run came back as a bare `Paused` and
+  the next persist tick wrote null over the recorded reason - and nothing
+  would have recomputed it, because a paused run is never dispatched again.
+- Fixed: every code stage has a local model it can actually reach. `coder`
+  and `reviewer` named `devstral:24b` as their only ollama candidate, so
+  somebody running locally with `qwen3.5:9b` - what every other stage asks
+  for - had six stages fall through the whole candidate list and find
+  nothing. The specialist is still tried first.
+- Changed: one local model across every bundled blueprint. The ollama entry
+  was the only one that switched model family between tiers, so a local run
+  needed two unrelated pulls to use one agent. Standardised on `qwen3.5:9b`,
+  already 31 of the 37 entries.
+- Added: `GET /api/tools` lists what an agent on this machine can actually
+  use, with each tool's source, so a console no longer ships a hardcoded
+  list that omits the tools you wrote and offers ones that do not exist. It
+  reports the scripts that failed to compile too.
+- Added: `/api/scripts` reads and writes script files by kind, scoped to an
+  agent or to the machine-wide directory, so they no longer have to be
+  edited on the box. Writes sit behind `--allow-admin` and are unmounted
+  without it, because a `.rhai` file is executable code every agent then
+  runs.
+- Added: `GET /api/config` enumerates custom gateways and `PUT` adds, edits
+  and removes them by name, which lets a browser change a gateway's URL
+  without ever being handed its key. The people most likely to want a form
+  for provider setup were the ones the config API could not describe.
+- Added: `GET /api/blueprints/{name}` returns the agent's manifest text. A
+  browser could name the file it was editing but not read it, so it fell
+  back to a draft in local storage or a copy bundled at build time, which on
+  a second machine could be many versions behind what is installed.
+- Fixed: blueprint validation lints against the agent's own directory rather
+  than the daemon's working directory, so an agent's `tools/*.rhai` resolves
+  and its tools stop coming back as `unknown-tool`. A console using this as
+  a pre-flight could not save any agent with script tools, bundled ones
+  included.
+
 ## 0.3.8 - 2026-08-13
 
 - Fixed: a fan-out split whose answer is not a JSON array no longer ends the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.8"
+version = "0.3.9"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.8" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.8" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.8" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.8" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.8" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.8" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.8" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.8" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.8" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.8" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.8" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.8" }
+leviath = { path = "crates/leviath", version = "0.3.9" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.9" }
+leviath-net = { path = "crates/leviath-net", version = "0.3.9" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.9" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.9" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.9" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.9" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.9" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.9" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.9" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.9" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.9" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.8", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.9", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }


### PR DESCRIPTION
Cuts 0.3.9. Merging this to main publishes alpha; beta and stable follow by dispatch.

Twelve merged PRs since 0.3.8, in three groups.

**A parked run now says what it is parked on.** `waiting_on` on `meta.json`, printed by `lev ps` and the dashboard, carried on the `agent_status` websocket event, and preserved across a daemon restart. Only a run somebody can actually unblock wears the warning colour.

**A run whose fix is somebody else's parks instead of failing.** An unconfigured provider, a rejected key, a key without access, an empty account: deterministic, outside the run's control, and undone by one edit elsewhere. The run keeps its retry staged and `lev resume` picks it up. Unattended runs still fail, since a scheduler needs a terminal status.

**The Lair can manage the machine it points at.** Tool listing, script read/write, custom gateway config, blueprint manifests, and validation rooted at the agent's own directory.

Plus `lev update` refreshing its package index before upgrading, and one local model (`qwen3.5:9b`) reachable from every stage of every bundled blueprint.

Needs the `allow-version-bump` label.
