### PR TITLE
fix(output): refuse a submission that is only the name of a stage

### DIFF
--- a/crates/leviath-runtime/src/output_tool.rs
+++ b/crates/leviath-runtime/src/output_tool.rs
@@ -45,9 +45,57 @@ pub const FINAL_OUTPUT_REGION_TOKENS: usize = 2_000;
 const MIRROR_TRUNCATION_MARKER: &str =
     "\n[...the full answer is on the run's final output, not in context]";
 
+/// The stage name a submission is really just naming, if it is doing that.
+///
+/// A stage entered by a `dead_end` edge sees a heavily compacted context and a
+/// prompt that has, moments earlier, been asking it which edge to take. Some
+/// models answer that older question: they call `submit_output` with the name of
+/// a stage. Every check in [`handle_output_tool`] passes - it is non-empty, it is
+/// valid text, no schema forbids it - and the run finishes `complete` with one
+/// word as its deliverable. That is worse than an error, because `complete`
+/// reads as success to every consumer: a benchmark harness scored such a run 0.0
+/// and carried it in a results matrix as finished until a person read the answer.
+///
+/// Matched against the blueprint's own stage names rather than a general "single
+/// short word" rule. A one-word answer is often perfectly legitimate - a
+/// classifier replying `positive`, a yes/no question - and refusing those would
+/// break working agents to catch this one. A submission that is exactly the name
+/// of a stage in the same blueprint is not a plausible answer to anything.
+///
+/// Case-insensitive because the token is being echoed by a model, and `Analyze`
+/// is the same mistake as `analyze`.
+fn routing_token<'a>(content: &str, stage_names: &'a [String]) -> Option<&'a str> {
+    let trimmed = content.trim();
+    stage_names
+        .iter()
+        .find(|name| name.eq_ignore_ascii_case(trimmed))
+        .map(String::as_str)
+}
+
 /// Whether a tool name is the final-output tool this module handles.
 pub fn is_output_tool(name: &str) -> bool {
     name == leviath_core::blueprint::SUBMIT_OUTPUT_TOOL
+}
+
+/// Everything a submission is judged against that is not the submission.
+///
+/// Grouped rather than threaded positionally: these five travel together, three
+/// of them are `Option<&_>`, and the two `&str`-ish ones sit adjacent - a
+/// transposition type-checks, and the compiler is the only thing that was ever
+/// going to notice. Adding the stage-name list as a seventh positional argument
+/// is what pushed this over the workspace's argument-count lint, which does not
+/// permit a suppression.
+pub struct OutputContext<'a> {
+    /// The shape this stage asked for: format, schema, validator.
+    pub spec: Option<&'a OutputSpec>,
+    /// The agent's own Rhai validators, by script name.
+    pub validators: Option<&'a crate::components::OutputValidators>,
+    /// The stage doing the submitting, recorded on the answer.
+    pub stage: &'a str,
+    /// Every stage name in this blueprint, for the routing-token guard.
+    pub stage_names: &'a [String],
+    /// Where relative artifact paths resolve from.
+    pub workdir: Option<&'a std::path::Path>,
 }
 
 /// Apply a `submit_output` call.
@@ -57,18 +105,22 @@ pub fn is_output_tool(name: &str) -> bool {
 /// been told why, so the caller must leave any previously submitted output in
 /// place: a rejected correction should not erase a good answer.
 ///
-/// `spec` is the shape resolved for this stage (agent, stage, and caller
+/// `ctx.spec` is the shape resolved for this stage (agent, stage, and caller
 /// combined). `None` means no level asked for a particular shape, which is not
 /// an error - the stage still wanted an answer, just not a specific form.
 pub fn handle_output_tool(
     args: &serde_json::Value,
-    spec: Option<&OutputSpec>,
-    validators: Option<&crate::components::OutputValidators>,
-    stage: &str,
+    ctx: &OutputContext<'_>,
     now: i64,
-    workdir: Option<&std::path::Path>,
     window: &mut ContextWindow,
 ) -> (String, Option<FinalOutput>) {
+    let OutputContext {
+        spec,
+        validators,
+        stage,
+        stage_names,
+        workdir,
+    } = *ctx;
     let Some(content) = args.get("content").and_then(|v| v.as_str()) else {
         return ("[error] missing 'content' argument".to_string(), None);
     };
@@ -76,6 +128,17 @@ pub fn handle_output_tool(
         return (
             "[error] final output is empty - submit the answer itself, not a placeholder"
                 .to_string(),
+            None,
+        );
+    }
+
+    // A routing token is not an answer, however well-formed it is.
+    if let Some(token) = routing_token(content, stage_names) {
+        return (
+            format!(
+                "[error] '{token}' is the name of a stage in this agent, not an answer. \
+                 Submit the finished work itself - the whole thing, as the reader will see it."
+            ),
             None,
         );
     }

--- a/crates/leviath-runtime/src/output_tool/tests.rs
+++ b/crates/leviath-runtime/src/output_tool/tests.rs
@@ -53,11 +53,14 @@ fn a_submission_is_recorded_verbatim_and_mirrored_into_the_region() {
     let mut w = win();
     let (ack, output) = handle_output_tool(
         &json!({"content": "Renamed two helpers and updated their callers."}),
-        Some(&spec(Some("markdown"), None)),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("markdown"), None)),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         1234,
-        None,
         &mut w,
     );
     let output = output.expect("the submission was accepted");
@@ -81,11 +84,14 @@ fn an_unrecognized_format_is_carried_through_without_inspection() {
     let a2ui = r#"{"root":{"component":"Card","children":[{"component":"Text"}]}}"#;
     let (_, output) = handle_output_tool(
         &json!({ "content": a2ui }),
-        Some(&spec(Some("a2ui"), None)),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("a2ui"), None)),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     let output = output.expect("accepted");
@@ -100,11 +106,14 @@ fn a_format_with_no_schema_never_parses_the_content() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({"content": "<report><finding>one</finding></report>"}),
-        Some(&spec(Some("xml"), None)),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("xml"), None)),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert_eq!(
@@ -122,11 +131,14 @@ fn a_format_checks_well_formedness_but_not_shape() {
     // Parses, but has nothing anyone asked for. Accepted: no schema was given.
     let (_, output) = handle_output_tool(
         &json!({"content": r#"{"totally":"unexpected"}"#}),
-        Some(&spec(Some("json"), None)),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("json"), None)),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_some(), "shape is not the format check's business");
@@ -134,11 +146,14 @@ fn a_format_checks_well_formedness_but_not_shape() {
     // Does not parse. Refused, with no schema involved.
     let (message, refused) = handle_output_tool(
         &json!({"content": "this is not JSON at all"}),
-        Some(&spec(Some("json"), None)),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("json"), None)),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(refused.is_none());
@@ -150,11 +165,14 @@ fn no_spec_at_all_still_records_an_answer() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({"content": "done"}),
-        None,
-        None,
-        "summary",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     let output = output.expect("accepted");
@@ -172,11 +190,14 @@ fn a_submission_matching_its_schema_is_accepted() {
     });
     let (_, output) = handle_output_tool(
         &json!({"content": r#"{"summary":"two files changed"}"#}),
-        Some(&spec(Some("json"), Some(schema))),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("json"), Some(schema))),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_some());
@@ -192,11 +213,14 @@ fn a_submission_violating_its_schema_is_refused_and_records_nothing() {
     });
     let (message, output) = handle_output_tool(
         &json!({"content": r#"{"nope":1}"#}),
-        Some(&spec(Some("json"), Some(schema))),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("json"), Some(schema))),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_none(), "nothing recorded");
@@ -215,11 +239,14 @@ fn content_that_is_not_json_fails_a_schema_check_with_a_readable_reason() {
     let mut w = win();
     let (message, output) = handle_output_tool(
         &json!({"content": "plain prose"}),
-        Some(&spec(None, Some(json!({"type": "object"})))),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(None, Some(json!({"type": "object"})))),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_none());
@@ -233,13 +260,16 @@ fn an_uncompilable_schema_records_the_submission_unchecked() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({"content": "anything"}),
-        // A misspelled `type` is the schema this workspace already uses to mean
+        &OutputContext {
+            spec: // A misspelled `type` is the schema this workspace already uses to mean
         // "will not compile" (a typo'd Rhai `@param n strng` produces exactly it).
         Some(&spec(None, Some(json!({"type": "strng"})))),
-        None,
-        "summary",
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_some(), "a broken schema does not block the run");
@@ -248,7 +278,18 @@ fn an_uncompilable_schema_records_the_submission_unchecked() {
 #[test]
 fn a_missing_content_argument_is_refused() {
     let mut w = win();
-    let (message, output) = handle_output_tool(&json!({}), None, None, "summary", 0, None, &mut w);
+    let (message, output) = handle_output_tool(
+        &json!({}),
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
+        0,
+        &mut w,
+    );
     assert!(output.is_none());
     assert!(message.starts_with("[error]"), "{message}");
     assert!(message.contains("content"), "{message}");
@@ -260,11 +301,14 @@ fn a_blank_submission_is_refused() {
     for blank in ["", "   ", "\n\t "] {
         let (message, output) = handle_output_tool(
             &json!({ "content": blank }),
-            None,
-            None,
-            "summary",
+            &OutputContext {
+                spec: None,
+                validators: None,
+                stage: "summary",
+                stage_names: &[],
+                workdir: None,
+            },
             0,
-            None,
             &mut w,
         );
         assert!(output.is_none(), "{blank:?} should not count as an answer");
@@ -278,11 +322,14 @@ fn an_oversized_submission_is_truncated_and_the_model_is_told() {
     let huge = "x".repeat(leviath_core::output::MAX_FINAL_OUTPUT_BYTES + 10);
     let (ack, output) = handle_output_tool(
         &json!({ "content": huge }),
-        None,
-        None,
-        "summary",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     let output = output.expect("accepted, just shortened");
@@ -301,21 +348,27 @@ fn a_second_submission_replaces_the_first() {
     let mut w = win();
     let (_, first) = handle_output_tool(
         &json!({"content": "draft"}),
-        None,
-        None,
-        "summary",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         1,
-        None,
         &mut w,
     );
     assert_eq!(first.expect("accepted").content, "draft");
     let (_, second) = handle_output_tool(
         &json!({"content": "final"}),
-        None,
-        None,
-        "summary",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         2,
-        None,
         &mut w,
     );
     assert_eq!(second.expect("accepted").content, "final");
@@ -330,11 +383,14 @@ fn a_window_without_the_region_still_records_the_output() {
     bare.add_region(Region::new("task".to_string(), RegionKind::Pinned, 1_000));
     let (_, output) = handle_output_tool(
         &json!({"content": "done"}),
-        None,
-        None,
-        "summary",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut bare,
     );
     assert_eq!(output.expect("accepted").content, "done");
@@ -355,11 +411,14 @@ fn artifacts_inside_the_workdir_are_recorded() {
             "content": "2 rows gathered, written to results.csv",
             "artifacts": ["results.csv", "notes/summary.md"],
         }),
-        None,
-        None,
-        "present",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "present",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+        },
         0,
-        Some(dir.path()),
         &mut w,
     );
     let output = output.expect("accepted");
@@ -377,11 +436,14 @@ fn an_artifact_outside_the_workdir_refuses_the_whole_submission() {
     let mut w = win();
     let (message, output) = handle_output_tool(
         &json!({ "content": "done", "artifacts": ["../../etc/passwd"] }),
-        None,
-        None,
-        "present",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "present",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+        },
         0,
-        Some(dir.path()),
         &mut w,
     );
     assert!(output.is_none(), "nothing recorded");
@@ -395,11 +457,14 @@ fn no_artifacts_argument_records_an_empty_list() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({ "content": "done" }),
-        None,
-        None,
-        "present",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "present",
+            stage_names: &[],
+            workdir: Some(dir.path()),
+        },
         0,
-        Some(dir.path()),
         &mut w,
     );
     assert!(output.expect("accepted").artifacts.is_empty());
@@ -412,11 +477,14 @@ fn artifacts_with_no_workdir_are_refused() {
     let mut w = win();
     let (message, output) = handle_output_tool(
         &json!({ "content": "done", "artifacts": ["results.csv"] }),
-        None,
-        None,
-        "present",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "present",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_none());
@@ -433,11 +501,14 @@ fn a_long_answer_is_mirrored_as_a_bounded_preview() {
     let long = "y".repeat(200_000);
     let (_, output) = handle_output_tool(
         &json!({ "content": long }),
-        None,
-        None,
-        "summary",
+        &OutputContext {
+            spec: None,
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     // The component keeps the whole thing.
@@ -464,11 +535,14 @@ fn a_submission_that_is_not_the_format_it_claims_is_refused() {
     let mut w = win();
     let (message, output) = handle_output_tool(
         &json!({ "content": "```json\n{\"a\":1}\n```" }),
-        Some(&spec(Some("json"), None)),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("json"), None)),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_none(), "nothing recorded");
@@ -480,11 +554,14 @@ fn a_well_formed_submission_in_a_known_format_is_accepted() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({ "content": "<report><finding/></report>" }),
-        Some(&spec(Some("xml"), None)),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("xml"), None)),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_some());
@@ -497,11 +574,14 @@ fn an_unknown_format_is_still_never_inspected() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({ "content": "anything at all, really" }),
-        Some(&spec(Some("a2ui"), None)),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(Some("a2ui"), None)),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_some());
@@ -514,14 +594,17 @@ fn the_format_check_reports_before_the_schema_check() {
     let mut w = win();
     let (message, output) = handle_output_tool(
         &json!({ "content": "not json at all" }),
-        Some(&spec(
-            Some("json"),
-            Some(json!({"type": "object", "required": ["summary"]})),
-        )),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec(
+                Some("json"),
+                Some(json!({"type": "object", "required": ["summary"]})),
+            )),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_none());
@@ -564,11 +647,14 @@ fn an_agent_supplied_validator_rejects_a_bad_answer() {
     let mut w = win();
     let (message, output) = handle_output_tool(
         &json!({"content": r#"{"nope":1}"#}),
-        Some(&spec_with_validator("a2ui")),
-        Some(&vals),
-        "summary",
+        &OutputContext {
+            spec: Some(&spec_with_validator("a2ui")),
+            validators: Some(&vals),
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_none(), "nothing recorded");
@@ -589,11 +675,14 @@ fn an_agent_supplied_validator_accepts_a_good_answer() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({"content": r#"{"root":{"component":"Card"}}"#}),
-        Some(&spec_with_validator("a2ui")),
-        Some(&vals),
-        "summary",
+        &OutputContext {
+            spec: Some(&spec_with_validator("a2ui")),
+            validators: Some(&vals),
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_some());
@@ -607,11 +696,14 @@ fn a_broken_validator_records_the_submission_unchecked() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({"content": "the agent's perfectly good answer"}),
-        Some(&spec_with_validator("a2ui")),
-        Some(&vals),
-        "summary",
+        &OutputContext {
+            spec: Some(&spec_with_validator("a2ui")),
+            validators: Some(&vals),
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(
@@ -627,11 +719,14 @@ fn a_named_validator_with_nothing_compiled_is_skipped() {
     let mut w = win();
     let (_, output) = handle_output_tool(
         &json!({"content": "anything"}),
-        Some(&spec_with_validator("a2ui")),
-        None,
-        "summary",
+        &OutputContext {
+            spec: Some(&spec_with_validator("a2ui")),
+            validators: None,
+            stage: "summary",
+            stage_names: &[],
+            workdir: None,
+        },
         0,
-        None,
         &mut w,
     );
     assert!(output.is_some());
@@ -660,4 +755,109 @@ fn a_region_with_room_keeps_what_it_can_and_says_it_was_cut() {
 #[test]
 fn an_answer_that_fits_is_mirrored_whole() {
     assert_eq!(fit_to_region("short", 100), "short");
+}
+
+/// Everything a submission is judged against, with no blueprint behind it.
+fn ctx<'a>(stage: &'a str, stage_names: &'a [String]) -> OutputContext<'a> {
+    OutputContext {
+        spec: None,
+        validators: None,
+        stage,
+        stage_names,
+        workdir: None,
+    }
+}
+
+/// The reported failure, reproduced: a dead-ended run completing `complete`
+/// with a routing token as its whole deliverable.
+///
+/// A benchmark run exhausted its report stage's iterations, dead-ended into the
+/// output stage with a heavily compacted context, and submitted the literal
+/// string `analyze` - one of the blueprint's transition-choice tokens. Every
+/// check passed, so the run reported success with a one-word answer, scored 0.0,
+/// and sat in a results matrix as finished until a person read it.
+#[test]
+fn a_transition_token_is_refused_rather_than_recorded_as_the_answer() {
+    let mut w = win();
+    let stages = ["gather", "analyze", "report"].map(str::to_string);
+    let (message, output) = handle_output_tool(
+        &json!({"content": "analyze"}),
+        &ctx("report", &stages),
+        0,
+        &mut w,
+    );
+    assert!(output.is_none(), "a stage name is not an answer");
+    assert!(message.starts_with("[error]"), "{message}");
+    assert!(message.contains("analyze"), "{message}");
+    assert!(message.contains("name of a stage"), "{message}");
+    // Nothing reached the region either: a refused submission records nothing.
+    assert_eq!(region_text(&w), "");
+}
+
+#[test]
+fn a_routing_token_is_caught_whatever_its_case_or_padding() {
+    // The model is echoing a token it half-remembers, so it arrives however it
+    // arrives.
+    let mut w = win();
+    let stages = ["analyze".to_string()];
+    for content in ["Analyze", "  analyze\n", "ANALYZE"] {
+        let (message, output) = handle_output_tool(
+            &json!({ "content": content }),
+            &ctx("report", &stages),
+            0,
+            &mut w,
+        );
+        assert!(output.is_none(), "{content} should be refused");
+        assert!(message.starts_with("[error]"), "{message}");
+    }
+}
+
+/// The guard is deliberately narrow: it knows this blueprint's stage names, not
+/// "short answers are suspicious".
+#[test]
+fn a_one_word_answer_that_is_not_a_stage_name_is_still_an_answer() {
+    // A classifier answering `positive`, a yes/no question. Refusing these to
+    // catch the routing case would break working agents.
+    let mut w = win();
+    let stages = ["gather", "analyze"].map(str::to_string);
+    let (_, output) = handle_output_tool(
+        &json!({"content": "positive"}),
+        &ctx("classify", &stages),
+        0,
+        &mut w,
+    );
+    assert_eq!(
+        output.expect("a one-word answer is accepted").content,
+        "positive"
+    );
+}
+
+/// A submission that merely *contains* a stage name is untouched: the guard is
+/// for a reply that is nothing but the token.
+#[test]
+fn a_real_answer_mentioning_a_stage_name_is_recorded() {
+    let mut w = win();
+    let stages = ["analyze".to_string()];
+    let content = "The analyze stage found three regressions, listed below.";
+    let (_, output) = handle_output_tool(
+        &json!({ "content": content }),
+        &ctx("report", &stages),
+        0,
+        &mut w,
+    );
+    assert_eq!(output.expect("accepted").content, content);
+}
+
+/// With no blueprint in hand there is nothing to compare against, and the
+/// submission is taken at face value - the pre-existing behaviour.
+#[test]
+fn without_stage_names_a_submission_is_accepted_as_before() {
+    let mut w = win();
+    let (_, output) = handle_output_tool(
+        &json!({"content": "analyze"}),
+        &ctx("report", &[]),
+        0,
+        &mut w,
+    );
+    assert_eq!(output.expect("accepted").content, "analyze");
 }

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -13862,3 +13862,79 @@ fn not_summarizable_does_not_protect_a_region_from_clear() {
         "clear still clears it"
     );
 }
+
+/// A `submit_output` whose whole content is the name of another stage is
+/// refused where the blueprint is in hand to notice.
+///
+/// The reported run dead-ended into its output stage and submitted the literal
+/// string `analyze` - a transition-choice token - which passed every check and
+/// became the deliverable. `complete` with a one-word answer is worse than an
+/// error: a benchmark harness scored it 0.0 and carried it as finished.
+#[tokio::test]
+async fn dispatch_tools_refuses_a_submission_that_is_only_a_stage_name() {
+    let (jtx, _jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let mut call = tc("c1", leviath_core::blueprint::SUBMIT_OUTPUT_TOOL);
+    call.arguments = serde_json::json!({ "content": "analyze" });
+    let (_, result) = infer_with(vec![call]);
+    let bp = blueprint(vec![
+        stage_named("gather", None, false, None),
+        stage_named("analyze", None, false, None),
+        stage_named("report", None, true, None),
+    ]);
+    let e = world
+        .spawn((
+            agent_state(),
+            offering(&[leviath_core::blueprint::SUBMIT_OUTPUT_TOOL]),
+            result,
+            conv_window(),
+            AgentBlueprint(bp),
+            ReadyForTools,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    // Nothing went to the async lane, so the window is the only record.
+    let refusal = conversation_text(&world, e);
+    assert!(refusal.contains("name of a stage"), "{refusal}");
+    // And nothing was recorded as the run's answer.
+    assert!(world.get::<crate::persistence::FinalOutput>(e).is_none());
+}
+
+/// The same call with a real answer still lands, so the guard is not simply
+/// refusing everything a dead-ended stage submits.
+#[tokio::test]
+async fn dispatch_tools_records_a_real_submission_with_the_blueprint_present() {
+    let (jtx, _jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let mut call = tc("c1", leviath_core::blueprint::SUBMIT_OUTPUT_TOOL);
+    call.arguments = serde_json::json!({ "content": "Three regressions, listed below." });
+    let (_, result) = infer_with(vec![call]);
+    let bp = blueprint(vec![stage_named("analyze", None, true, None)]);
+    let e = world
+        .spawn((
+            agent_state(),
+            offering(&[leviath_core::blueprint::SUBMIT_OUTPUT_TOOL]),
+            result,
+            conv_window(),
+            AgentBlueprint(bp),
+            ReadyForTools,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    let recorded = world
+        .get::<crate::persistence::FinalOutput>(e)
+        .expect("the answer was recorded");
+    assert_eq!(recorded.0.content, "Three regressions, listed below.");
+}

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -283,6 +283,9 @@ type DispatchToolsQuery = (
     Option<&'static StageCursor>,
     Option<&'static RunMetadata>,
     Option<&'static crate::components::OutputValidators>,
+    // For the submit_output guard: a submission that is exactly the name of a
+    // stage in this blueprint is a routing token, not an answer.
+    Option<&'static crate::pipeline::transition::AgentBlueprint>,
 );
 
 /// The resources the daemon installs, which a bare world does not have.
@@ -358,6 +361,7 @@ pub fn dispatch_tools(
         cursor,
         metadata,
         validators,
+        blueprint,
     ) in agents.iter_mut()
     {
         crate::tick_scope::enter(entity);
@@ -429,13 +433,19 @@ pub fn dispatch_tools(
             // async lane can reach. Recorded here and committed after the loop,
             // because `commands` cannot be borrowed inside it.
             if crate::output_tool::is_output_tool(&c.name) {
+                let stage_names: Vec<String> = blueprint
+                    .map(|bp| bp.0.stages.iter().map(|s| s.name.clone()).collect())
+                    .unwrap_or_default();
                 let (text, output) = crate::output_tool::handle_output_tool(
                     &c.arguments,
-                    stage_inf.output.as_ref(),
-                    validators,
-                    &state.current_stage,
+                    &crate::output_tool::OutputContext {
+                        spec: stage_inf.output.as_ref(),
+                        validators,
+                        stage: &state.current_stage,
+                        stage_names: &stage_names,
+                        workdir: metadata.map(|m| std::path::Path::new(&m.workdir)),
+                    },
                     chrono::Utc::now().timestamp(),
-                    metadata.map(|m| std::path::Path::new(&m.workdir)),
                     &mut window,
                 );
                 // A refused submission leaves any earlier one alone: a bad


### PR DESCRIPTION
Closes #446.

## Reproduced

A run dead-ended into its output stage, submitted the literal string `analyze` — one of its own transition-choice tokens — and finished `complete`. Every check passed: non-empty, valid text, no schema forbidding it. So the run reported **success with one word as its whole deliverable**, scored 0.0, and sat in a results matrix as finished until a person read the answer file.

`complete` with a wrong answer is worse than an error, because `complete` reads as success to every consumer there is.

Five unit tests plus two driving `dispatch_tools` end to end, including one that pins the *accepting* path so the guard can't quietly start refusing everything.

## Refused back to the model, not failed

Same shape as the empty-content guard beside it. A stage entered by a `dead_end` edge sees a heavily compacted context and a prompt that was, moments earlier, asking it to choose an edge — a model that answers the older question deserves the chance to answer the current one.

If it never does, the existing required-output machinery records `output_forced` and the run ends with no answer. That is honest, and consumers can already detect it via `produced_output: false`. Both guards the issue proposed would work; this one keeps a recoverable mistake recoverable.

**If you'd rather it hard-fail the run**, that's a one-line policy change on top of this — say the word.

## Narrow on purpose

Matched against the blueprint's own stage names, **not** a general "single short word" rule. A one-word answer is often legitimate — a classifier replying `positive`, a yes/no question — and refusing those to catch this would break working agents. A submission that is exactly the name of a stage in the same blueprint is not a plausible answer to anything.

Case-insensitive and trimmed, because the token is being echoed by a model.

## One structural change

The stage-name list made `handle_output_tool` an eight-argument function, which the workspace's argument-count lint refuses and the no-suppressions rule leaves no way around. The five judged-against parameters are now an `OutputContext`, following `SpawnDeps` — and for the reason that doc gives: three are `Option<&_>` and two adjacent ones are `&str`-ish, so a transposition type-checks and the compiler was never going to notice.

## Verified locally

- `cargo test -p leviath-runtime` — 1318 tests, all pass
- `cargo clippy --all-targets` — clean
- `cargo xtask structure`, `cargo xtask docs` — clean
- `cargo xtask coverage --package leviath-runtime` — **100%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJSMDWhGpWAXpkW7ZdTad9