### PR TITLE
feat(lint): warn when an evicting region's bound scales with the model

### DIFF
--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -783,6 +783,7 @@ mod tests {
             available_providers: None,
             read_paths: None,
             safe_commands_granted: None,
+            model_windows: crate::commands::models::builtin_model_windows(),
         }
     }
 

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -112,6 +112,23 @@ pub fn closed_catalog_models() -> Vec<(String, String)> {
         .collect()
 }
 
+/// Context-window size per `(provider, model)`, from the same table.
+///
+/// Every provider, not only the closed catalogs: the question here is "how big
+/// is this window", and an OpenRouter row that names a size is as useful as an
+/// Anthropic one. A model absent from the table simply is not consulted.
+pub fn builtin_model_windows() -> std::collections::HashMap<(String, String), usize> {
+    builtin_table()
+        .into_iter()
+        .map(|e| {
+            (
+                (e.provider.to_string(), e.model_id.to_string()),
+                e.caps.max_context_tokens,
+            )
+        })
+        .collect()
+}
+
 /// Hard-coded capability table for well-known models.
 ///
 /// This is used when the provider API is not reachable or `--remote` is not

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -595,3 +595,114 @@ pub(super) fn lint_compacted_deliverables(blueprint: &Blueprint) -> Vec<LintFind
         })
         .collect()
 }
+
+/// A region that evicts, bounded by a share of a window nobody has measured.
+///
+/// Percentage budgets exist so an author's intent survives a change of model:
+/// "35%" means the same thing whatever the window. For a *fixed* region that
+/// holds. For one whose whole design is to evict, it does not - because eviction
+/// only ever runs at the bound, so the bound is the discipline, and a percentage
+/// re-reads that discipline every time the model changes.
+///
+/// The bundled researcher declares `raw_findings = { kind = "temporary", budget
+/// = "38%" }`. Written against ~200k windows that means "hold the last ~76k of
+/// raw source material" - sane. Resolved against a 1M window the same line means
+/// a 380k ceiling: oldest-first eviction exists, and never triggers, because the
+/// bound is never reached. A measured run grew monotonically from 3k to 196k
+/// tokens per request over 31 requests and burned 3.3M cache-write tokens
+/// without finishing. `max_tokens = 24000` fixed it completely.
+///
+/// Nothing errored, which is the point. The failure is invisible until the bill
+/// arrives, so it is worth saying out loud at the only moment somebody is
+/// looking at the blueprint.
+///
+/// Warned once per region name however many layouts declare it: the fix is on
+/// the declaration.
+pub(super) fn lint_unbounded_percentage(blueprint: &Blueprint, env: &LintEnv) -> Vec<LintFinding> {
+    let Some((model, window)) = widest_declared_window(blueprint, env) else {
+        // No window in hand means no number to put in the sentence, and the
+        // sentence is the whole value: "38% might be large" is not actionable.
+        return Vec::new();
+    };
+
+    let mut named: Vec<(&str, usize, f64)> = Vec::new();
+    for layout in std::iter::once(&blueprint.context_layout).chain(
+        blueprint
+            .stages
+            .iter()
+            .filter_map(|s| s.context_layout.as_ref()),
+    ) {
+        for region in &layout.regions {
+            let leviath_core::layout::BudgetSpec::Percent {
+                percent, max: None, ..
+            } = region.budget
+            else {
+                continue;
+            };
+            if !evicts_at_its_bound(&region.kind) {
+                continue;
+            }
+            if named.iter().any(|(name, _, _)| *name == region.name) {
+                continue;
+            }
+            named.push((&region.name, region.budget.resolve(window), percent));
+        }
+    }
+
+    named
+        .into_iter()
+        .map(|(region, ceiling, percent)| {
+            LintFinding::new(
+                LintSeverity::Warning,
+                "unbounded-percentage-budget",
+                format!(
+                    "region '{region}' evicts at its bound, and its budget \
+                     \"{pct:.0}%\" resolves to {ceiling} tokens on {model} \
+                     ({window} window) - a bound that large may never be reached, \
+                     so the region hoards instead of evicting",
+                    pct = percent * 100.0,
+                ),
+            )
+            .with_fix(format!(
+                "add max_tokens to [context.regions] {region} - the percentage \
+                 still applies on smaller windows, and the guard keeps eviction \
+                 running on larger ones"
+            ))
+        })
+        .collect()
+}
+
+/// The largest context window among the models this blueprint names, and which
+/// model that is.
+///
+/// The largest rather than the average: it is the one that turns a modest
+/// percentage into a hoard, and the blueprint will meet it as soon as anybody
+/// runs a stage on it.
+fn widest_declared_window<'a>(blueprint: &Blueprint, env: &'a LintEnv) -> Option<(&'a str, usize)> {
+    blueprint
+        .stages
+        .iter()
+        .flat_map(|stage| stage.model.models.iter())
+        .filter_map(|m| {
+            env.model_windows
+                .get_key_value(&(m.provider.clone(), m.model.clone()))
+                .map(|((_, model), window)| (model.as_str(), *window))
+        })
+        .max_by_key(|(_, window)| *window)
+}
+
+/// Whether this kind of region drops content when it reaches its ceiling.
+///
+/// The kinds that do are the ones the warning is about: a bound they cannot
+/// reach is a mechanism that never runs. Everything else either holds what it is
+/// given (`Pinned`, `Checklist`) or is bounded by something other than a token
+/// count, and a percentage there is exactly as intended.
+fn evicts_at_its_bound(kind: &leviath_core::RegionKind) -> bool {
+    matches!(
+        kind,
+        leviath_core::RegionKind::Temporary
+            | leviath_core::RegionKind::Clearable
+            | leviath_core::RegionKind::SlidingWindow { .. }
+            | leviath_core::RegionKind::Compacting { .. }
+    )
+}

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -159,6 +159,15 @@ pub struct LintEnv {
     /// granted is the interesting part, a safe-commands block is honoured whole
     /// or not at all.
     pub safe_commands_granted: Option<bool>,
+
+    /// Context-window size per `(provider, model)`, for the models this build
+    /// ships a capability row for.
+    ///
+    /// Only needed to say what a percentage budget *resolves to*: "38%" is not
+    /// alarming until you know the denominator is a million. Empty skips the
+    /// unbounded-percentage check, because a warning that cannot name a number
+    /// is a warning nobody acts on.
+    pub model_windows: HashMap<(String, String), usize>,
 }
 
 impl LintEnv {
@@ -186,6 +195,7 @@ impl LintEnv {
             available_providers: None,
             read_paths: None,
             safe_commands_granted: None,
+            model_windows: crate::commands::models::builtin_model_windows(),
         }
     }
 
@@ -262,6 +272,7 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
     findings.extend(lint_output_reachable(blueprint));
     findings.extend(lint_dead_end_possible(blueprint));
     findings.extend(lint_compacted_deliverables(blueprint));
+    findings.extend(lint_unbounded_percentage(blueprint, env));
 
     let agent_permissions = blueprint.agent_tool_permissions();
 

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -18,6 +18,17 @@ conversation = {{ kind = "sliding_window", max_items = 50, max_tokens = 10000 }}
     )
 }
 
+impl LintEnv {
+    /// A default env that also knows how big the shipped models' windows are,
+    /// which is what the percentage-budget check needs to say a number.
+    fn default_with_windows() -> Self {
+        Self {
+            model_windows: crate::commands::models::builtin_model_windows(),
+            ..Self::default()
+        }
+    }
+}
+
 /// Lint a manifest whose text and blueprint come from the same source, which is
 /// the only pairing production ever passes.
 fn lint(content: &str, env: &LintEnv) -> Vec<LintFinding> {
@@ -1823,4 +1834,149 @@ max_iterations = 5
         "{:?}",
         codes(&findings)
     );
+}
+
+/// A manifest whose region layout is spelled out, so a budget can be varied.
+fn manifest_with_regions(regions: &str) -> String {
+    format!(
+        r#"
+[agent]
+name = "lint-fixture"
+version = "0.1.0"
+description = "a fixture"
+
+[stages.work]
+mode = "autonomous"
+model = {{ models = [{{ provider = "anthropic", model = "claude-sonnet-5" }}] }}
+max_iterations = 10
+allow_complete = true
+
+[context.regions]
+system = {{ kind = "pinned", max_tokens = 1000 }}
+conversation = {{ kind = "sliding_window", max_items = 50, max_tokens = 10000 }}
+{regions}
+"#
+    )
+}
+
+/// The reported case, reproduced with the bundled researcher's own numbers.
+///
+/// `raw_findings = {{ kind = "temporary", budget = "38%" }}` means "hold the last
+/// ~76k of raw source material" against a 200k window. Against a 1M window the
+/// same line is a 380k ceiling that oldest-first eviction never reaches, so the
+/// region hoards. A measured run grew 3k -> 196k tokens per request and burned
+/// 3.3M cache-write tokens without finishing.
+#[test]
+fn a_percentage_budget_on_an_evicting_region_is_warned_with_the_resolved_ceiling() {
+    let toml = manifest_with_regions(r#"raw_findings = { kind = "temporary", budget = "38%" }"#);
+    let findings = lint(&toml, &LintEnv::default_with_windows());
+    let found = findings
+        .iter()
+        .find(|f| f.code == "unbounded-percentage-budget")
+        .expect("the region is warned about");
+    assert_eq!(found.severity, LintSeverity::Warning);
+    // The number is the whole point: "38%" is not alarming until the
+    // denominator is named.
+    assert!(found.message.contains("380000"), "{}", found.message);
+    assert!(
+        found.message.contains("claude-sonnet-5"),
+        "{}",
+        found.message
+    );
+    assert!(found.message.contains("1000000"), "{}", found.message);
+    assert!(
+        found
+            .fix
+            .as_deref()
+            .unwrap_or_default()
+            .contains("max_tokens"),
+        "{found:?}"
+    );
+}
+
+#[test]
+fn a_percentage_budget_with_a_max_guard_is_left_alone() {
+    // The fix the issue reports as working completely.
+    let toml = manifest_with_regions(
+        r#"raw_findings = { kind = "temporary", budget = "38%", max_tokens = 24000 }"#,
+    );
+    assert!(
+        !codes(&lint(&toml, &LintEnv::default_with_windows()))
+            .contains(&"unbounded-percentage-budget")
+    );
+}
+
+#[test]
+fn an_absolute_budget_is_never_warned_about() {
+    let toml =
+        manifest_with_regions(r#"raw_findings = { kind = "temporary", max_tokens = 24000 }"#);
+    assert!(
+        !codes(&lint(&toml, &LintEnv::default_with_windows()))
+            .contains(&"unbounded-percentage-budget")
+    );
+}
+
+/// A region that holds what it is given has no bound to fail to reach, so a
+/// percentage there means exactly what its author intended.
+#[test]
+fn a_pinned_region_with_a_percentage_budget_is_fine() {
+    let toml = manifest_with_regions(r#"notes = { kind = "pinned", budget = "38%" }"#);
+    assert!(
+        !codes(&lint(&toml, &LintEnv::default_with_windows()))
+            .contains(&"unbounded-percentage-budget")
+    );
+}
+
+#[test]
+fn every_evicting_kind_is_covered_not_just_temporary() {
+    for decl in [
+        r#"r = { kind = "clearable", budget = "38%" }"#,
+        r#"r = { kind = "sliding_window", max_items = 20, budget = "38%" }"#,
+        r#"r = { kind = "compacting", compact_at = 0.8, budget = "38%" }"#,
+    ] {
+        let toml = manifest_with_regions(decl);
+        assert!(
+            codes(&lint(&toml, &LintEnv::default_with_windows()))
+                .contains(&"unbounded-percentage-budget"),
+            "{decl}"
+        );
+    }
+}
+
+/// Without a window there is no number to report, and a warning that cannot say
+/// what "38%" comes to is one nobody acts on.
+#[test]
+fn nothing_is_said_when_no_declared_model_has_a_known_window() {
+    let toml = manifest_with_regions(r#"raw_findings = { kind = "temporary", budget = "38%" }"#);
+    assert!(!codes(&lint(&toml, &LintEnv::default())).contains(&"unbounded-percentage-budget"));
+}
+
+/// One warning per region, not per layout that declares it: the fix is on the
+/// declaration.
+#[test]
+fn a_region_declared_in_two_layouts_is_named_once() {
+    let toml = r#"
+[agent]
+name = "lint-fixture"
+version = "0.1.0"
+description = "a fixture"
+
+[stages.work]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 10
+allow_complete = true
+
+[stages.work.context.regions]
+raw_findings = { kind = "temporary", budget = "38%" }
+
+[context.regions]
+system = { kind = "pinned", max_tokens = 1000 }
+raw_findings = { kind = "temporary", budget = "38%" }
+"#;
+    let hits = codes(&lint(toml, &LintEnv::default_with_windows()))
+        .into_iter()
+        .filter(|c| *c == "unbounded-percentage-budget")
+        .count();
+    assert_eq!(hits, 1);
 }


### PR DESCRIPTION
Closes #442.

## The reasoning

Percentage budgets exist so an author's intent survives a change of model: `"35%"` means the same thing whatever the window. For a **fixed** region that holds. For one whose whole design is to evict it does not — because eviction only ever runs *at the bound*, so the bound **is** the discipline, and a percentage re-reads that discipline every time somebody drops in a bigger model.

| `raw_findings = { kind = "temporary", budget = "38%" }` | means |
|---|---|
| against a 200k window | hold the last ~76k of raw source — sane |
| against a 1M window | a **380k ceiling** oldest-first eviction never reaches |

The measured run grew monotonically 3k → 196k tokens per request over 31 requests and burned 3.3M cache-write tokens without finishing. Nothing errored, which is the point: the failure is invisible until the bill arrives.

## The warning names the number

```
warning: region 'raw_findings' evicts at its bound, and its budget "38%"
resolves to 380000 tokens on claude-sonnet-5 (1000000 window) - a bound that
large may never be reached, so the region hoards instead of evicting
  fix: add max_tokens to [context.regions] raw_findings - the percentage still
  applies on smaller windows, and the guard keeps eviction running on larger ones
```

That is the whole value. "38% might be large" is not actionable; the resolved figure is. Resolved against the **widest** window among the models the blueprint declares — that is the one that turns a modest percentage into a hoard, and the blueprint meets it as soon as anybody runs a stage there. **With no window known the check says nothing**, rather than warning without a number.

## Scope

Only the kinds that drop content at their ceiling: `temporary`, `clearable`, `sliding_window`, `compacting`. A `pinned` region has no bound to fail to reach, and a percentage there means exactly what its author intended. A region already carrying `max_tokens` is left alone — that's the fix the issue reports as working completely.

One warning per region however many layouts declare it, since the fix is on the declaration.

## `LintEnv` gains a window table

Built from the capability rows the model catalog already ships, for **every** provider rather than only the closed ones: the question here is how big a window is, and an OpenRouter row that names a size answers it as well as an Anthropic one.

## No bundled agent trips it

The researcher already carries `max_tokens = 40000` beside its percentage — so this guards the *next* blueprint written rather than fixing a shipped one. The existing "no bundled agent is called broken" test now runs with windows populated, so a future regression there fails CI.

## Verified locally

- `cargo test -p leviath-cli` — 3459 tests, all pass (7 new)
- `cargo clippy --all-targets` — clean
- `cargo xtask coverage --package leviath-cli` — **100%**
- `cargo xtask structure`, `docs` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJSMDWhGpWAXpkW7ZdTad9