### PR TITLE
fix(spawn): give stage prompts their own region even when nobody declared one

### DIFF
--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -237,6 +237,70 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
     window.current_tokens = window.calculate_tokens();
 }
 
+/// Give the stage prompts a region of their own when the blueprint did not.
+///
+/// [`STAGE_INSTRUCTIONS_REGION`] is, in this file's own words further up, "the
+/// runtime's to fill, not something an author has to remember to re-declare".
+/// It was only ever *used* when an author declared it, though - and when they
+/// did not, the prompt went into whatever pinned region happened to be first.
+/// That is usually `task`, whose budget is sized for a sentence from the caller
+/// and not for a stage's instructions.
+///
+/// Under window pressure that is a spawn failure rather than a squeeze:
+///
+/// ```text
+/// stage system prompt does not fit region 'task' (2887 > 2560)
+/// ```
+///
+/// The workaround is to floor every `task` declaration with a `min_tokens` sized
+/// for the largest *stage prompt* - which couples an unrelated region's floor to
+/// prompt lengths, and only shows up at spawn on a small window, so it reads as
+/// the caller's fault rather than as routing.
+///
+/// Sized to the largest prompt the blueprint actually carries, because that is
+/// the one that has to fit and anything beyond it is budget taken from the work.
+/// A blueprint whose stages have no prompts gets no region: there would be
+/// nothing to put in it.
+///
+/// Capped at a quarter of the window, which is what keeps
+/// this from turning a real failure into a silent one. A prompt larger than the
+/// whole window cannot be made to fit by giving it a bigger region, and a spawn
+/// that says so is right to. What changes is only which region the message
+/// names: `stage_instructions`, which is where the prompt was going, rather than
+/// `task`, which is the caller's.
+///
+/// [`STAGE_INSTRUCTIONS_REGION`]: leviath_core::layout::STAGE_INSTRUCTIONS_REGION
+pub fn ensure_stage_instructions_region(window: &mut ContextWindow, prompts: &[Option<String>]) {
+    let declared = leviath_core::layout::STAGE_INSTRUCTIONS_REGION;
+    if window.get_region(declared).is_some() {
+        return;
+    }
+    // The wrapper travels with the prompt, so it is measured with it.
+    let widest = prompts
+        .iter()
+        .flatten()
+        .map(|p| leviath_core::estimate_tokens(&format!("[Stage instructions: {p}]")))
+        .max();
+    let Some(widest) = widest.filter(|t| *t > 0) else {
+        return;
+    };
+    let ceiling = window.max_tokens / INSTRUCTIONS_SHARE_OF_WINDOW;
+    window.add_region(Region::new(
+        declared.to_string(),
+        RegionKind::Pinned,
+        widest.min(ceiling),
+    ));
+}
+
+/// The largest share of the window an auto-created instructions region may take,
+/// as a divisor: a quarter.
+///
+/// Only ever a ceiling - the region is sized to the prompt it has to hold, and
+/// this is what it may not exceed. A quarter is generous for instructions and
+/// still leaves the window mostly for the work; a prompt that will not fit in it
+/// is one no region size was going to rescue.
+const INSTRUCTIONS_SHARE_OF_WINDOW: usize = 4;
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/crates/leviath-runtime/src/pipeline/spawn.rs
+++ b/crates/leviath-runtime/src/pipeline/spawn.rs
@@ -309,6 +309,10 @@ pub fn spawn_agent_seeded(world: &mut World, spawn: SeededSpawn) -> Result<Entit
     // pass through each region's on_write hook like any other entry.
     window.region_scripts = region_scripts;
     crate::context_setup::init_window_seeded(&mut window, &blueprint, seeds);
+    // Before stage 0's prompt is injected, so it has somewhere of its own to go
+    // rather than being charged to whichever pinned region came first.
+    let prompts: Vec<Option<String>> = setups.iter().map(|s| s.system_prompt.clone()).collect();
+    crate::context_setup::ensure_stage_instructions_region(&mut window, &prompts);
     apply_stage_context(&setups[0], &mut window)?;
 
     let stage0_name = blueprint.stages[0].name.clone();
@@ -380,4 +384,336 @@ pub fn spawn_agent_seeded(world: &mut World, spawn: SeededSpawn) -> Result<Entit
             .insert(crate::components::ToolResultRoutingComponent { routing });
     }
     Ok(entity)
+}
+
+#[cfg(test)]
+mod stage_instructions_fit_tests {
+    //! The reported spawn failure, reproduced end to end.
+
+    /// A layout shaped like the reported blueprint: a small `task` region and a
+    /// dedicated `stage_instructions` region with room for a stage prompt.
+    fn layout(window: usize) -> leviath_core::layout::ContextLayout {
+        use leviath_core::layout::{BudgetSpec, ContextLayout, RegionDefinition};
+        let pct = |p: f64| BudgetSpec::Percent {
+            percent: p,
+            min: None,
+            max: None,
+        };
+        let mut task =
+            RegionDefinition::new("task".to_string(), leviath_core::RegionKind::Pinned, 0);
+        task.budget = pct(0.02);
+        let mut instr = RegionDefinition::new(
+            leviath_core::layout::STAGE_INSTRUCTIONS_REGION.to_string(),
+            leviath_core::RegionKind::Pinned,
+            0,
+        );
+        instr.budget = pct(0.03);
+        ContextLayout::new(vec![task, instr], window).resolved(window)
+    }
+
+    /// A ~2.9k-token stage prompt: too big for 2% of a 128k window, comfortable
+    /// in 3%.
+    fn big_prompt() -> String {
+        "word ".repeat(2_600)
+    }
+
+    #[test]
+    fn a_stage_prompt_measured_at_spawn_uses_the_declared_region() {
+        let window_tokens = 128_000;
+        let layout = layout(window_tokens);
+        let task_max = layout
+            .regions
+            .iter()
+            .find(|r| r.name == "task")
+            .expect("task")
+            .max_tokens;
+        let instr_max = layout
+            .regions
+            .iter()
+            .find(|r| r.name == leviath_core::layout::STAGE_INSTRUCTIONS_REGION)
+            .expect("stage_instructions")
+            .max_tokens;
+        let prompt = big_prompt();
+        let tokens = leviath_core::estimate_tokens(&format!("[Stage instructions: {prompt}]"));
+        assert!(
+            tokens > task_max && tokens < instr_max,
+            "the fixture must reproduce the reported shape: {tokens} vs task {task_max} / \
+             stage_instructions {instr_max}"
+        );
+
+        let bp = leviath_core::Blueprint::new(
+            "t".to_string(),
+            "d".to_string(),
+            vec![leviath_core::Stage::new(
+                "work".to_string(),
+                leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+            )],
+            layout,
+        );
+        let mut window = crate::components::ContextWindow::new(window_tokens);
+        crate::context_setup::init_window_seeded(
+            &mut window,
+            &bp,
+            &std::collections::HashMap::new(),
+        );
+        let setup = crate::pipeline::transition::StageSetup {
+            inference_config: crate::components::InferenceConfig {
+                temperature: None,
+                max_output_tokens: None,
+                extra_params: Default::default(),
+                batch_tool_hint: false,
+                shell_hint: false,
+                request_timeout_secs: None,
+            },
+            routing: None,
+            accepts_messages: true,
+            context_layout: None,
+            system_prompt: Some(prompt),
+            output: None,
+        };
+        crate::pipeline::transition::apply_stage_context(&setup, &mut window)
+            .expect("the prompt fits the region declared for it");
+
+        let instr = window
+            .get_region(leviath_core::layout::STAGE_INSTRUCTIONS_REGION)
+            .expect("region exists");
+        assert!(
+            instr.content.iter().any(|e| e.content.contains("word")),
+            "the prompt landed in stage_instructions"
+        );
+    }
+
+    /// The reported failure itself: a blueprint that declares no
+    /// `stage_instructions` region at all.
+    ///
+    /// Its prompt went to `task` - the first pinned region, sized for a sentence
+    /// from the caller - and on a small window the spawn died with
+    /// `stage system prompt does not fit region 'task'`. The workaround was to
+    /// floor every task region with a `min_tokens` sized for the largest stage
+    /// prompt, coupling an unrelated region to prompt lengths.
+    #[test]
+    fn a_blueprint_that_declares_no_region_still_gets_one() {
+        use leviath_core::layout::{BudgetSpec, ContextLayout, RegionDefinition};
+        let window_tokens = 128_000;
+        let prompt = big_prompt();
+
+        // Only `task`, at 2% - exactly the reported declaration.
+        let mut task =
+            RegionDefinition::new("task".to_string(), leviath_core::RegionKind::Pinned, 0);
+        task.budget = BudgetSpec::Percent {
+            percent: 0.02,
+            min: None,
+            max: None,
+        };
+        let only_task = ContextLayout::new(vec![task], window_tokens).resolved(window_tokens);
+        let bp = leviath_core::Blueprint::new(
+            "t".to_string(),
+            "d".to_string(),
+            vec![leviath_core::Stage::new(
+                "work".to_string(),
+                leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+            )],
+            only_task,
+        );
+
+        let mut window = crate::components::ContextWindow::new(window_tokens);
+        crate::context_setup::init_window_seeded(
+            &mut window,
+            &bp,
+            &std::collections::HashMap::new(),
+        );
+        let prompts = vec![Some(prompt.clone())];
+        crate::context_setup::ensure_stage_instructions_region(&mut window, &prompts);
+
+        let setup = crate::pipeline::transition::StageSetup {
+            inference_config: crate::components::InferenceConfig {
+                temperature: None,
+                max_output_tokens: None,
+                extra_params: Default::default(),
+                batch_tool_hint: false,
+                shell_hint: false,
+                request_timeout_secs: None,
+            },
+            routing: None,
+            accepts_messages: true,
+            context_layout: None,
+            system_prompt: Some(prompt),
+            output: None,
+        };
+        crate::pipeline::transition::apply_stage_context(&setup, &mut window)
+            .expect("the prompt no longer has to fit the caller's task region");
+
+        let task_region = window.get_region("task").expect("task");
+        assert!(
+            task_region.content.is_empty(),
+            "the task region is left for the caller's task"
+        );
+        let instr = window
+            .get_region(leviath_core::layout::STAGE_INSTRUCTIONS_REGION)
+            .expect("the runtime made one");
+        assert!(instr.content.iter().any(|e| e.content.contains("word")));
+    }
+
+    /// Nothing to hold means no region: an empty pinned region is budget taken
+    /// from the work for nothing.
+    #[test]
+    fn no_region_is_made_when_no_stage_has_a_prompt() {
+        let mut window = crate::components::ContextWindow::new(1_000);
+        crate::context_setup::ensure_stage_instructions_region(&mut window, &[None, None]);
+        assert!(
+            window
+                .get_region(leviath_core::layout::STAGE_INSTRUCTIONS_REGION)
+                .is_none()
+        );
+    }
+
+    /// A declared region is left exactly as the author sized it.
+    #[test]
+    fn a_declared_region_is_not_resized() {
+        let mut window = crate::components::ContextWindow::new(100_000);
+        window.add_region(leviath_core::Region::new(
+            leviath_core::layout::STAGE_INSTRUCTIONS_REGION.to_string(),
+            leviath_core::RegionKind::Pinned,
+            4_242,
+        ));
+        crate::context_setup::ensure_stage_instructions_region(&mut window, &[Some(big_prompt())]);
+        assert_eq!(
+            window
+                .get_region(leviath_core::layout::STAGE_INSTRUCTIONS_REGION)
+                .expect("declared")
+                .max_tokens,
+            4_242
+        );
+    }
+
+    /// A prompt bigger than the window is still a spawn failure - it was always
+    /// going to be. What changes is that the message names the region the prompt
+    /// was going to, rather than the caller's task region.
+    #[test]
+    fn an_impossible_prompt_is_still_refused_and_names_the_right_region() {
+        let mut window = crate::components::ContextWindow::new(1_000);
+        window.add_region(leviath_core::Region::new(
+            "task".to_string(),
+            leviath_core::RegionKind::Pinned,
+            40,
+        ));
+        let prompt = "z".repeat(100_000);
+        crate::context_setup::ensure_stage_instructions_region(
+            &mut window,
+            &[Some(prompt.clone())],
+        );
+        // Capped at a quarter of the window rather than sized to the prompt.
+        assert_eq!(
+            window
+                .get_region(leviath_core::layout::STAGE_INSTRUCTIONS_REGION)
+                .expect("made")
+                .max_tokens,
+            250
+        );
+
+        let setup = crate::pipeline::transition::StageSetup {
+            inference_config: crate::components::InferenceConfig {
+                temperature: None,
+                max_output_tokens: None,
+                extra_params: Default::default(),
+                batch_tool_hint: false,
+                shell_hint: false,
+                request_timeout_secs: None,
+            },
+            routing: None,
+            accepts_messages: true,
+            context_layout: None,
+            system_prompt: Some(prompt),
+            output: None,
+        };
+        let err = crate::pipeline::transition::apply_stage_context(&setup, &mut window)
+            .expect_err("a prompt larger than the window cannot be housed");
+        assert!(
+            err.contains(leviath_core::layout::STAGE_INSTRUCTIONS_REGION),
+            "{err}"
+        );
+    }
+
+    /// Sized for the largest prompt in the blueprint, not the first stage's:
+    /// every stage's instructions pass through the same region.
+    #[test]
+    fn the_region_is_sized_for_the_widest_prompt() {
+        let mut window = crate::components::ContextWindow::new(100_000);
+        let small = "word ".repeat(10);
+        let large = big_prompt();
+        let expected = leviath_core::estimate_tokens(&format!("[Stage instructions: {large}]"));
+        crate::context_setup::ensure_stage_instructions_region(
+            &mut window,
+            &[Some(small), Some(large)],
+        );
+        assert_eq!(
+            window
+                .get_region(leviath_core::layout::STAGE_INSTRUCTIONS_REGION)
+                .expect("made")
+                .max_tokens,
+            expected
+        );
+    }
+
+    /// The reported shape: the stage carries its own `[context.regions]`, which
+    /// does not re-declare `stage_instructions`.
+    #[test]
+    fn a_scoped_stage_layout_still_routes_to_the_declared_region() {
+        use leviath_core::layout::{BudgetSpec, ContextLayout, RegionDefinition};
+        let window_tokens = 128_000;
+        let prompt = big_prompt();
+
+        // The stage narrows what it attends to and says nothing about
+        // stage_instructions - the region is the runtime's to fill.
+        let mut scoped_task =
+            RegionDefinition::new("task".to_string(), leviath_core::RegionKind::Pinned, 0);
+        scoped_task.budget = BudgetSpec::Percent {
+            percent: 0.02,
+            min: None,
+            max: None,
+        };
+        let scoped = ContextLayout::new(vec![scoped_task], window_tokens).resolved(window_tokens);
+
+        let bp = leviath_core::Blueprint::new(
+            "t".to_string(),
+            "d".to_string(),
+            vec![leviath_core::Stage::new(
+                "work".to_string(),
+                leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+            )],
+            layout(window_tokens),
+        );
+
+        let mut window = crate::components::ContextWindow::new(window_tokens);
+        crate::context_setup::init_window_seeded(
+            &mut window,
+            &bp,
+            &std::collections::HashMap::new(),
+        );
+        let setup = crate::pipeline::transition::StageSetup {
+            inference_config: crate::components::InferenceConfig {
+                temperature: None,
+                max_output_tokens: None,
+                extra_params: Default::default(),
+                batch_tool_hint: false,
+                shell_hint: false,
+                request_timeout_secs: None,
+            },
+            routing: None,
+            accepts_messages: true,
+            context_layout: Some(scoped),
+            system_prompt: Some(prompt),
+            output: None,
+        };
+        crate::pipeline::transition::apply_stage_context(&setup, &mut window)
+            .expect("the prompt fits the region declared for it");
+
+        let instr = window
+            .get_region(leviath_core::layout::STAGE_INSTRUCTIONS_REGION)
+            .expect("carried through the scoped layout");
+        assert!(
+            instr.content.iter().any(|e| e.content.contains("word")),
+            "the prompt landed in stage_instructions, not in the scoped task region"
+        );
+    }
 }


### PR DESCRIPTION
Closes #444.

## What was already right

Worth saying first, because it shaped the fix. When a `stage_instructions` region **is** declared, routing to it already worked — at spawn and on every transition, under flat and scoped layouts alike. Two of the tests here pin exactly that, since it is what the reported blueprint was expected to hit.

The gap was that **nothing ever created the region**.

## The failure

`stage_instructions` is, in `context_setup.rs`'s own words, *"the runtime's to fill, not something an author has to remember to re-declare"*. Without a declaration the prompt went to whichever pinned region came first — usually `task`, whose budget is sized for a sentence from the caller, not for a stage's instructions.

Under window pressure that is a spawn failure rather than a squeeze:

```
stage system prompt does not fit region 'task' (2887 > 2560)
```

The workaround was flooring every `task` declaration with a `min_tokens` sized for the largest *stage prompt* — coupling an unrelated region to prompt lengths, and only visible at spawn on a small window, which makes it read as the caller's fault rather than as routing.

## The fix

Create the region at spawn when the blueprint declares none, sized to the **largest prompt the blueprint carries** — that is the one that has to fit, and every stage's instructions pass through the same region.

**Capped at a quarter of the window**, and that cap is load-bearing: a prompt larger than the window cannot be housed by giving it a bigger region, and a spawn that says so is right to. Three existing tests assert exactly that failure and still pass. What changes for them is only which region the message names — `stage_instructions`, where the prompt was going, instead of `task`, which is the caller's.

A blueprint whose stages carry no prompts gets no region: an empty pinned region is budget taken from the work for nothing.

## Net effect on context

Zero. Those tokens were already being spent — they were just charged to `task`, which is why the per-region numbers were misleading and why the failure looked like a task-region problem.

## Verified locally

- `cargo test -p leviath-runtime` — 1308 tests, all pass (7 new)
- `cargo clippy --all-targets` — clean
- `cargo xtask coverage --package leviath-runtime` — **100%**
- `cargo xtask structure`, `docs` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJSMDWhGpWAXpkW7ZdTad9