### PR TITLE
perf(anthropic): stop paying to cache a prefix that already churned

### DIFF
--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -410,6 +410,8 @@ async fn run_test_case(
         stage_name: stage.name.clone(),
         stage_iterations: 0,
         model: model_name.to_string(),
+        // One assembly, so there is no previous request to compare against.
+        previous_system_hash: None,
     });
     let caps = provider.capabilities(model_name);
     let remaining = window.max_tokens.saturating_sub(window.current_tokens);

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -72,6 +72,27 @@ pub struct AssembledContext {
     pub system_blocks: Vec<leviath_providers::SystemBlock>,
     /// Conversation messages with proper role typing.
     pub messages: Vec<leviath_providers::Message>,
+    /// Hash of the system prefix this assembly produced.
+    ///
+    /// Handed back so the caller can pass it as
+    /// [`crate::custom_region::AssembleMeta::previous_system_hash`] next time
+    /// and let the breakpoint decision below be made on evidence rather than
+    /// hope.
+    pub system_hash: u64,
+}
+
+/// A stable digest of the assembled system prefix.
+///
+/// Over the block texts in final order, which is exactly the byte sequence
+/// Anthropic prefix-matches against. Hints are excluded deliberately: they
+/// decide ordering, and ordering is already reflected in the sequence.
+fn system_prefix_hash(blocks: &[leviath_providers::SystemBlock]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for block in blocks {
+        block.text.hash(&mut hasher);
+    }
+    hasher.finish()
 }
 
 /// Sort priority for a system block's cache hint.
@@ -893,6 +914,8 @@ impl ContextWindow {
         // they form the cacheable prefix, with volatile blocks
         // (Compacting, Temporary, Clearable) after.
         system_blocks.sort_by_key(|block| cache_hint_sort_priority(block.cache_hint));
+        // After the sort, because the order is part of what Anthropic matches.
+        let system_hash = system_prefix_hash(&system_blocks);
 
         // ── Spend a cache breakpoint on the volatile boundary ────────────
         //
@@ -983,7 +1006,24 @@ impl ContextWindow {
         // [`MAX_SYSTEM_CACHE_RUNS`] caps those at 3 so this one always fits.
         // Place it on the 4th-from-last message to give a buffer for the
         // new messages added each iteration (typically 2-3).
-        if messages.len() >= 5 {
+        //
+        // Skipped entirely when the system prefix moved since the last request.
+        // Anthropic caches by prefix, so this breakpoint's entry covers every
+        // system block as well as the messages before it - and a prefix that
+        // changed has already invalidated that entry before it could be read.
+        // The 1.25x write is still charged. Measured on a run whose bulk region
+        // grew every turn: 3.3M cache-write tokens against 267k reads, a 0.074
+        // hit rate, for a prefix that was never going to match. Sending the
+        // churn at the base rate instead is the same request for less money.
+        //
+        // Re-armed the moment the prefix settles, so a steady-state run keeps
+        // the caching it was always getting.
+        let prefix_moved = meta
+            .previous_system_hash
+            .is_some_and(|previous| previous != system_hash);
+        if prefix_moved {
+            // Nothing to place: the entry could not be read back.
+        } else if messages.len() >= 5 {
             let bp_idx = messages.len() - 4;
             messages[bp_idx].cache_breakpoint = true;
         } else if messages.len() >= 2 {
@@ -1017,6 +1057,7 @@ impl ContextWindow {
         AssembledContext {
             system_blocks,
             messages,
+            system_hash,
         }
     }
 

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -2004,6 +2004,7 @@ mod tests {
             stage_name: "plan".to_string(),
             stage_iterations: 7,
             model: "m".to_string(),
+            previous_system_hash: None,
         });
         assert_eq!(assembled.system_blocks[0].text, "<brain iter=7>");
     }

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -27,6 +27,14 @@ pub struct AssembleMeta {
     pub stage_iterations: usize,
     /// Model id serving this stage.
     pub model: String,
+    /// Hash of the system prefix the *previous* request sent, when there was
+    /// one.
+    ///
+    /// Only the message breakpoint reads it, and only to decide whether writing
+    /// that cache entry can pay for itself. `None` means nobody is tracking (a
+    /// first request, or a caller with no state to keep), and the breakpoint is
+    /// placed as it always was.
+    pub previous_system_hash: Option<u64>,
 }
 
 /// What `on_write` decided about an incoming entry.
@@ -594,6 +602,7 @@ mod tests {
                         stage_name: "plan".to_string(),
                         stage_iterations: 2,
                         model: "m1".to_string(),
+                        previous_system_hash: None,
                     },
                     window_current: 50,
                     window_max: 2000,

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -87,12 +87,15 @@ pub(crate) fn build_request(
     provider: &Arc<dyn Provider>,
     stage_name: &str,
     stage_iterations: usize,
-) -> InferenceRequest {
+    previous_system_hash: Option<u64>,
+) -> (InferenceRequest, u64) {
     let assembled = window.assemble_with_meta(&crate::custom_region::AssembleMeta {
         stage_name: stage_name.to_string(),
         stage_iterations,
         model: stage.model.clone(),
+        previous_system_hash,
     });
+    let system_hash = assembled.system_hash;
     let remaining = window.max_tokens.saturating_sub(window.current_tokens);
     let caps = provider.capabilities(&stage.model);
     let output_cap = config
@@ -126,7 +129,7 @@ pub(crate) fn build_request(
     let mut system = hint_blocks(config, &filtered_tools, std::env::consts::OS);
     system.extend(assembled.system_blocks);
 
-    InferenceRequest {
+    let request = InferenceRequest {
         system,
         messages: assembled.messages,
         model: stage.model.clone(),
@@ -135,7 +138,8 @@ pub(crate) fn build_request(
         tools: filtered_tools,
         extra,
         request_timeout_secs: config.and_then(|c| c.request_timeout_secs),
-    }
+    };
+    (request, system_hash)
 }
 
 /// Build the [`RetryPolicy`] for a job from the operator's `[limits]` retry
@@ -223,7 +227,16 @@ type InferenceQuery = (
     Option<&'static InFlightWork>,
     Option<&'static StageProgress>,
     Option<&'static DispatchStall>,
+    Option<&'static SystemPrefixHash>,
 );
+
+/// The system prefix the last request sent, as a digest.
+///
+/// Kept per agent because that is the granularity Anthropic's prefix cache
+/// works at: one run's blocks, in one order. Absent before the first request,
+/// which is exactly when there is nothing to invalidate.
+#[derive(bevy_ecs::component::Component, Debug, Clone, Copy)]
+pub struct SystemPrefixHash(pub u64);
 
 /// Inference-dispatch system: for every `ReadyToInfer` agent, resolve its
 /// provider and, **if a per-model permit is free**, build the request, spawn the
@@ -259,7 +272,7 @@ pub fn dispatch_inference(
     let retry_tuning = retry.map(|r| *r).unwrap_or_default();
     let circuits = circuits.as_deref();
     agents.par_iter().for_each(
-        |(entity, state, window, config, si, in_flight, progress, stalled)| {
+        |(entity, state, window, config, si, in_flight, progress, stalled, prefix)| {
             crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
                 if state.status != AgentStatus::Active {
                     return; // paused / waiting / cancelled - don't start new work
@@ -307,14 +320,22 @@ pub fn dispatch_inference(
                     stall(StallReason::PoolFull);
                     return;
                 };
-                let request = build_request(
+                let (request, system_hash) = build_request(
                     window,
                     config,
                     si,
                     &provider,
                     &state.current_stage,
                     progress.map(|p| p.iterations).unwrap_or(0),
+                    prefix.map(|p| p.0),
                 );
+                // Remembered for the next request, which is the only way the
+                // breakpoint decision can be made on evidence.
+                par_commands.command_scope(|mut commands| {
+                    commands
+                        .entity(entity)
+                        .insert(SystemPrefixHash(system_hash));
+                });
                 let job = InferenceJob {
                     entity,
                     provider,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -109,7 +109,7 @@ fn build_request_threads_stage_meta_into_custom_region_render() {
         ),
     );
     let si = stage("model-x", vec![], None);
-    let req = build_request(&w, None, &si, &provider(true, 500), "implement", 4);
+    let req = build_request(&w, None, &si, &provider(true, 500), "implement", 4, None).0;
     assert!(
         req.system.iter().any(|b| b.text == "implement#4@model-x"),
         "system blocks: {:?}",
@@ -139,7 +139,9 @@ fn build_request_filters_tools_and_uses_config_overrides() {
         &provider(true, 9999),
         "test-stage",
         0,
-    );
+        None,
+    )
+    .0;
     assert_eq!(req.tools.len(), 1); // filtered to "keep"
     assert_eq!(req.tools[0].name, "keep");
     assert_eq!(req.max_tokens, 42); // config output cap wins
@@ -164,10 +166,21 @@ fn build_request_threads_per_stage_timeout() {
         &provider(true, 500),
         "test-stage",
         0,
-    );
+        None,
+    )
+    .0;
     assert_eq!(req.request_timeout_secs, Some(120));
 
-    let req_none = build_request(&window(), None, &si, &provider(true, 500), "test-stage", 0);
+    let req_none = build_request(
+        &window(),
+        None,
+        &si,
+        &provider(true, 500),
+        "test-stage",
+        0,
+        None,
+    )
+    .0;
     assert_eq!(req_none.request_timeout_secs, None);
 }
 
@@ -191,7 +204,9 @@ fn build_request_passes_through_extra_params() {
         &provider(true, 500),
         "test-stage",
         0,
-    );
+        None,
+    )
+    .0;
     assert_eq!(req.extra, serde_json::json!({ "top_p": 0.9 }));
 }
 
@@ -223,7 +238,9 @@ fn build_request_prepends_batch_hint_when_enabled() {
         &provider(true, 500),
         "test-stage",
         0,
-    );
+        None,
+    )
+    .0;
     // The hint is prepended ahead of the stage's own system block(s).
     assert_eq!(
         req.system.first().map(|b| b.text.as_str()),
@@ -257,7 +274,9 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
         &provider(true, 500),
         "test-stage",
         0,
-    );
+        None,
+    )
+    .0;
     assert!(!req.system.is_empty());
     assert!(req.system.iter().all(|b| b.text != BATCH_TOOL_HINT));
     // Absent config → no hint.
@@ -268,7 +287,9 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
         &provider(true, 500),
         "test-stage",
         0,
-    );
+        None,
+    )
+    .0;
     assert!(!req_none.system.is_empty());
     assert!(req_none.system.iter().all(|b| b.text != BATCH_TOOL_HINT));
 }
@@ -356,7 +377,9 @@ fn build_request_puts_the_hints_ahead_of_the_stage_context() {
         &provider(true, 500),
         "test-stage",
         0,
-    );
+        None,
+    )
+    .0;
     let hints = hint_blocks(Some(&cfg), &si.tools, std::env::consts::OS);
     for (i, hint) in hints.iter().enumerate() {
         assert_eq!(req.system[i].text, hint.text);
@@ -372,7 +395,16 @@ fn build_request_puts_the_hints_ahead_of_the_stage_context() {
 #[test]
 fn build_request_all_tools_default_temperature_no_config() {
     let si = stage("m", vec![tool("a"), tool("b")], None); // None filter = all
-    let req = build_request(&window(), None, &si, &provider(true, 500), "test-stage", 0);
+    let req = build_request(
+        &window(),
+        None,
+        &si,
+        &provider(true, 500),
+        "test-stage",
+        0,
+        None,
+    )
+    .0;
     assert_eq!(req.tools.len(), 2);
     assert_eq!(req.temperature, 0.7); // default when supported and no config
     assert_eq!(req.max_tokens, 500); // capability cap when no config override
@@ -381,7 +413,16 @@ fn build_request_all_tools_default_temperature_no_config() {
 #[test]
 fn build_request_empty_filter_is_all_and_no_temperature_when_unsupported() {
     let si = stage("m", vec![tool("a")], Some(vec![])); // empty filter = all
-    let req = build_request(&window(), None, &si, &provider(false, 500), "test-stage", 0);
+    let req = build_request(
+        &window(),
+        None,
+        &si,
+        &provider(false, 500),
+        "test-stage",
+        0,
+        None,
+    )
+    .0;
     assert_eq!(req.tools.len(), 1);
     assert_eq!(req.temperature, 0.0); // model doesn't support temperature
 }
@@ -13937,4 +13978,89 @@ async fn dispatch_tools_records_a_real_submission_with_the_blueprint_present() {
         .get::<crate::persistence::FinalOutput>(e)
         .expect("the answer was recorded");
     assert_eq!(recorded.0.content, "Three regressions, listed below.");
+}
+
+// ── the message cache breakpoint and a churning system prefix ──
+
+/// A window with one pinned region and enough conversation to earn a breakpoint.
+fn breakpoint_window(pinned: &str) -> ContextWindow {
+    let mut w = ContextWindow::new(100_000);
+    let mut region = Region::new("facts".to_string(), RegionKind::Pinned, 10_000);
+    let _ = region.add_entry(pinned.to_string(), 10);
+    w.add_region(region);
+    let mut conv = Region::new(
+        "conversation".to_string(),
+        RegionKind::SlidingWindow {
+            max_items: 50,
+            eviction_strategy: leviath_core::EvictionStrategy::PerItem,
+        },
+        10_000,
+    );
+    for i in 0..6 {
+        let _ = conv.add_entry(format!("turn {i}"), 5);
+    }
+    w.add_region(conv);
+    w
+}
+
+fn assembled_with_prev(
+    window: &ContextWindow,
+    previous: Option<u64>,
+) -> crate::components::AssembledContext {
+    window.assemble_with_meta(&crate::custom_region::AssembleMeta {
+        stage_name: "work".to_string(),
+        stage_iterations: 0,
+        model: "m".to_string(),
+        previous_system_hash: previous,
+    })
+}
+
+/// The first request has nothing to invalidate, so it caches as it always did.
+#[test]
+fn the_message_breakpoint_is_placed_when_nothing_came_before() {
+    let w = breakpoint_window("stable facts");
+    let out = assembled_with_prev(&w, None);
+    assert!(out.messages.iter().any(|m| m.cache_breakpoint));
+}
+
+/// The reported waste: the prefix moved, so the entry this breakpoint would
+/// write is invalidated before it can be read - and the 1.25x write is charged
+/// anyway. Measured at 3.3M write tokens against 267k reads on one run.
+#[test]
+fn the_message_breakpoint_is_skipped_when_the_system_prefix_moved() {
+    let first = assembled_with_prev(&breakpoint_window("facts as of turn 1"), None);
+    let churned = breakpoint_window("facts as of turn 2, now longer");
+    let second = assembled_with_prev(&churned, Some(first.system_hash));
+
+    assert_ne!(first.system_hash, second.system_hash, "the prefix moved");
+    assert!(
+        !second.messages.iter().any(|m| m.cache_breakpoint),
+        "writing a cache entry the next request cannot read is money for nothing"
+    );
+}
+
+/// Re-armed the moment the prefix settles, so a steady-state run keeps the
+/// caching it was always getting.
+#[test]
+fn the_message_breakpoint_returns_once_the_prefix_settles() {
+    let w = breakpoint_window("stable facts");
+    let first = assembled_with_prev(&w, None);
+    let second = assembled_with_prev(&w, Some(first.system_hash));
+
+    assert_eq!(first.system_hash, second.system_hash);
+    assert!(
+        second.messages.iter().any(|m| m.cache_breakpoint),
+        "an unchanged prefix is exactly what caching is for"
+    );
+}
+
+/// The digest is over the assembled prefix, so identical content assembles to
+/// the same number and different content does not.
+#[test]
+fn the_prefix_hash_tracks_the_prefix() {
+    let a = assembled_with_prev(&breakpoint_window("one"), None);
+    let b = assembled_with_prev(&breakpoint_window("one"), None);
+    let c = assembled_with_prev(&breakpoint_window("two"), None);
+    assert_eq!(a.system_hash, b.system_hash);
+    assert_ne!(a.system_hash, c.system_hash);
 }


### PR DESCRIPTION
Closes #441.

> **Stacked on #449** — the diff will read clean once that merges and this rebases.

## The waste

Anthropic caches by prefix, so the message-stream breakpoint's entry covers **every system block** as well as the messages before it. When a mutable region changed since the previous request, that entry is invalidated before it can ever be read — and the 1.25× write premium is charged anyway.

Measured on one benchmark cell:

| | |
|---|---|
| cache writes | **3.3M tokens** in 7 minutes |
| cache reads | ~267k (≈8.6k/request — exactly the stable pinned prefix) |
| effective hit rate | **0.074** |
| spend before the harness cap fired | $21.41 |

The reads that landed were the stable prefix. The writes were the doomed tail, bought again every request.

**The invalidation itself is not avoidable** — that is how prefix caching works, and the region really did change. Paying to write the entry is.

## The change

Skip the message breakpoint when the assembled system prefix moved since the last request: the same context goes out at the **base rate** instead of the write rate.

- **Re-armed the moment the prefix settles**, so a steady-state run keeps the caching it always had.
- **A first request caches exactly as before** — it has nothing to invalidate, and its write is what later reads hit.

Nothing about what is sent changes: same system blocks, same messages, same tools. Only whether one `cache_control` marker rides along.

## How it knows

A digest of the assembled system blocks, taken **after** the cache-hint sort — the order is part of what Anthropic matches — carried between requests on a per-agent component. Per agent because that is the granularity the prefix cache works at: one run's blocks, in one order.

`AssembleMeta::previous_system_hash` defaults to `None`, so every caller that does not track state behaves exactly as it did.

## Verified locally

- `cargo test -p leviath-runtime` — 1305 tests, all pass (4 new covering: first request, churned prefix, settled prefix, and that the digest tracks the prefix)
- `cargo clippy --workspace --all-targets` — clean
- `cargo xtask coverage --package leviath-runtime` — **100%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SJSMDWhGpWAXpkW7ZdTad9