### PR TITLE
feat(journal): record what each provider call cost, and count the ones nobody was counting

### DIFF
--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -714,6 +714,7 @@ fn journal_highlights(meta: &RunMeta, q: &str) -> Option<Highlight> {
             | RunRecord::OwnershipChanged { .. }
             | RunRecord::StatusChanged { .. }
             | RunRecord::Inference { .. }
+            | RunRecord::InferenceUsage { .. }
             | RunRecord::ToolCallDone { .. }
             | RunRecord::Message { .. } => None,
         }

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -172,6 +172,47 @@ pub struct ContextDelta {
     pub regions: Vec<RegionDelta>,
 }
 
+/// Which provider call a [`RunRecord::InferenceUsage`] belongs to.
+///
+/// A run bills for more than its stage turns, and the three auxiliary kinds are
+/// invisible in every other surface: they do not appear in the stage ledger and
+/// nothing else names them. Recording which kind spent the tokens is what turns
+/// a total into an explanation - "this run cost double what its stages did
+/// because its edges compact" is a sentence the journal can now support.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InferenceKind {
+    /// An ordinary stage turn: the agent thinking or calling tools. The default
+    /// so a journal written before this field existed reads back as stage work,
+    /// which is what every record in one is.
+    #[default]
+    Stage,
+    /// A region-summarizing call, from memory pressure or an edge transform.
+    Compaction,
+    /// The one-off call that names the run.
+    Title,
+    /// A call asking the model which stage to move to next.
+    Routing,
+}
+
+impl InferenceKind {
+    /// A short stable label, for logs and wire formats that want a string.
+    pub fn label(&self) -> &'static str {
+        match self {
+            InferenceKind::Stage => "stage",
+            InferenceKind::Compaction => "compaction",
+            InferenceKind::Title => "title",
+            InferenceKind::Routing => "routing",
+        }
+    }
+
+    /// Whether this call is stage work the agent asked for, as opposed to
+    /// machinery the runtime ran on its behalf.
+    pub fn is_stage_work(&self) -> bool {
+        matches!(self, InferenceKind::Stage)
+    }
+}
+
 /// One entry in the run journal. Folding the sequence reconstructs the run.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub enum RunRecord {
@@ -201,6 +242,44 @@ pub enum RunRecord {
         request: InferenceRequestRecord,
         /// The response.
         response: InferenceResponseRecord,
+        /// Unix seconds.
+        at: i64,
+    },
+    /// What one provider call cost, written as it lands.
+    ///
+    /// [`RunRecord::Progress`] carries cumulative counters, so two calls between
+    /// two ticks are indistinguishable downstream: their sum arrives as one
+    /// number, and a chart of it shows a spike no single call ever made. This
+    /// record is per call, so token-over-time telemetry is exact and "no request
+    /// ever exceeded the window" is provable from the journal rather than
+    /// inferred from region-size checkpoints.
+    ///
+    /// Deliberately lighter than [`RunRecord::Inference`], which carries the
+    /// full request and response: every call re-sends the whole window, so
+    /// journaling those bodies for each of them would multiply the file by the
+    /// context size. The window is already recoverable from the surrounding
+    /// [`RunRecord::ContextCheckpoint`] and [`RunRecord::ContextDiff`] records.
+    InferenceUsage {
+        /// Which kind of call this was.
+        #[serde(default)]
+        kind: InferenceKind,
+        /// The stage the run was in. Empty for a call with no stage of its own
+        /// (the title call, which runs once at spawn).
+        stage: String,
+        /// The stage-local iteration index.
+        iteration: usize,
+        /// The provider that served the call.
+        provider: String,
+        /// The model the call targeted.
+        model: String,
+        /// Prompt tokens billed.
+        prompt_tokens: usize,
+        /// Completion tokens billed.
+        completion_tokens: usize,
+        /// Tokens read from provider cache.
+        cached_tokens: usize,
+        /// Tokens written to provider cache.
+        cache_write_tokens: usize,
         /// Unix seconds.
         at: i64,
     },
@@ -656,6 +735,34 @@ pub struct PendingToolBatch {
     pub calls: Vec<ToolCallRecord>,
 }
 
+/// One provider call's cost, as folded out of the journal.
+///
+/// The flattened form of [`RunRecord::InferenceUsage`], so a consumer walking a
+/// folded run does not have to match the record enum to read a number.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InferenceUsageRecord {
+    /// Which kind of call this was.
+    pub kind: InferenceKind,
+    /// The stage the run was in, empty for the title call.
+    pub stage: String,
+    /// The stage-local iteration index.
+    pub iteration: usize,
+    /// The provider that served the call.
+    pub provider: String,
+    /// The model the call targeted.
+    pub model: String,
+    /// Prompt tokens billed.
+    pub prompt_tokens: usize,
+    /// Completion tokens billed.
+    pub completion_tokens: usize,
+    /// Tokens read from provider cache.
+    pub cached_tokens: usize,
+    /// Tokens written to provider cache.
+    pub cache_write_tokens: usize,
+    /// Unix seconds.
+    pub at: i64,
+}
+
 /// The state reconstructed from a run journal - enough to resume or inspect the
 /// run at its latest recorded point.
 #[derive(Debug, Clone, PartialEq)]
@@ -670,6 +777,13 @@ pub struct FoldedRun {
     pub messages: Vec<MessageRecord>,
     /// Number of inferences recorded.
     pub inference_count: usize,
+    /// Per-call usage, in the order the calls landed.
+    ///
+    /// The point of keeping every entry rather than a running sum: a sum is
+    /// already available from [`RunMeta`], and what it cannot answer is whether
+    /// any single call exceeded the window, or which kind of call the spend went
+    /// to.
+    pub inference_usage: Vec<InferenceUsageRecord>,
     /// Number of tool calls recorded.
     pub tool_call_count: usize,
     /// A dispatched tool batch whose results never made it into the context
@@ -715,6 +829,7 @@ pub fn fold(records: &[RunRecord]) -> Option<FoldedRun> {
         },
         messages: Vec::new(),
         inference_count: 0,
+        inference_usage: Vec::new(),
         tool_call_count: 0,
         pending_batch: None,
     };
@@ -733,6 +848,35 @@ pub fn fold(records: &[RunRecord]) -> Option<FoldedRun> {
                 folded.identity.world_id = world_id.clone();
             }
             RunRecord::Inference { .. } => folded.inference_count += 1,
+            RunRecord::InferenceUsage {
+                kind,
+                stage,
+                iteration,
+                provider,
+                model,
+                prompt_tokens,
+                completion_tokens,
+                cached_tokens,
+                cache_write_tokens,
+                at,
+            } => {
+                // Counted alongside the heavy variant: both name one provider
+                // call, and a consumer asking "how many calls" should not have
+                // to know which of the two the writer chose.
+                folded.inference_count += 1;
+                folded.inference_usage.push(InferenceUsageRecord {
+                    kind: *kind,
+                    stage: stage.clone(),
+                    iteration: *iteration,
+                    provider: provider.clone(),
+                    model: model.clone(),
+                    prompt_tokens: *prompt_tokens,
+                    completion_tokens: *completion_tokens,
+                    cached_tokens: *cached_tokens,
+                    cache_write_tokens: *cache_write_tokens,
+                    at: *at,
+                });
+            }
             RunRecord::ToolBatch {
                 calls,
                 stage_index,
@@ -951,9 +1095,13 @@ impl PointFolder {
                 apply_delta(&mut self.context, delta);
                 *at
             }
-            // Non-context records don't add a timeline point.
+            // Non-context records don't add a timeline point. Usage included:
+            // it says what a call cost, not what the window then held, and
+            // emitting a point per call would double the timeline with entries
+            // whose context is identical to their neighbour's.
             RunRecord::OwnershipChanged { .. }
             | RunRecord::Inference { .. }
+            | RunRecord::InferenceUsage { .. }
             | RunRecord::ToolBatch { .. }
             | RunRecord::ToolCallDone { .. }
             | RunRecord::Message { .. } => return ControlFlow::Continue(()),
@@ -1495,6 +1643,18 @@ mod tests {
                 },
                 at: 102,
             },
+            RunRecord::InferenceUsage {
+                kind: InferenceKind::Compaction,
+                stage: "plan".to_string(),
+                iteration: 2,
+                provider: "anthropic".to_string(),
+                model: "claude-sonnet-5".to_string(),
+                prompt_tokens: 7000,
+                completion_tokens: 70,
+                cached_tokens: 12,
+                cache_write_tokens: 34,
+                at: 102,
+            },
             RunRecord::ToolBatch {
                 calls: vec![ToolCallRecord {
                     id: "c1".to_string(),
@@ -1810,8 +1970,10 @@ mod tests {
         // Ownership was reassigned mid-journal.
         assert_eq!(folded.identity.machine_id, "machine-b");
         assert_eq!(folded.identity.world_id, "world-y");
-        // Counters.
-        assert_eq!(folded.inference_count, 1);
+        // Counters. Two inferences: the fixture carries one record of each
+        // kind, and both name one provider call.
+        assert_eq!(folded.inference_count, 2);
+        assert_eq!(folded.inference_usage.len(), 1);
         assert_eq!(folded.tool_call_count, 1);
         // One inbound message recorded.
         assert_eq!(folded.messages.len(), 1);
@@ -2429,5 +2591,153 @@ mod tests {
         assert_eq!(points.len(), 1);
         assert_eq!(points[0].context.stage_name, "review");
         assert_eq!(points[0].context.regions[0].entries[0].tokens, 4);
+    }
+
+    /// Each kind has to survive the wire under its own name: the label is what
+    /// a consumer groups a token chart by, so a rename that silently reordered
+    /// the enum would re-attribute somebody's spend.
+    #[test]
+    fn every_inference_kind_has_a_distinct_label_and_serialized_name() {
+        let all = [
+            (InferenceKind::Stage, "stage"),
+            (InferenceKind::Compaction, "compaction"),
+            (InferenceKind::Title, "title"),
+            (InferenceKind::Routing, "routing"),
+        ];
+        for (kind, label) in all {
+            assert_eq!(kind.label(), label);
+            assert_eq!(serde_json::to_value(kind).unwrap(), label);
+        }
+        let labels: std::collections::HashSet<_> = all.iter().map(|(k, _)| k.label()).collect();
+        assert_eq!(labels.len(), all.len(), "labels must not collide");
+    }
+
+    /// Only stage turns are work the agent asked for. The other three are
+    /// machinery the runtime ran on its behalf, which is the split anything
+    /// reporting "what did my agent actually do" needs.
+    #[test]
+    fn only_a_stage_turn_counts_as_stage_work() {
+        assert!(InferenceKind::Stage.is_stage_work());
+        for kind in [
+            InferenceKind::Compaction,
+            InferenceKind::Title,
+            InferenceKind::Routing,
+        ] {
+            assert!(
+                !kind.is_stage_work(),
+                "{kind:?} is machinery, not stage work"
+            );
+        }
+    }
+
+    /// A journal written before the field existed has to read back as stage
+    /// work rather than failing to parse - every record in one is a stage turn,
+    /// because nothing else was ever written.
+    #[test]
+    fn a_usage_record_without_a_kind_reads_back_as_stage_work() {
+        let json = serde_json::json!({
+            "InferenceUsage": {
+                "stage": "plan",
+                "iteration": 1,
+                "provider": "anthropic",
+                "model": "claude-sonnet-5",
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+                "cached_tokens": 0,
+                "cache_write_tokens": 0,
+                "at": 5,
+            }
+        });
+        // Compared whole rather than destructured: the point is that the
+        // missing field defaults and every present one still lands, and a
+        // destructure that pulled out `kind` alone would pass even if the rest
+        // had been dropped.
+        let record: RunRecord = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            record,
+            RunRecord::InferenceUsage {
+                kind: InferenceKind::Stage,
+                stage: "plan".to_string(),
+                iteration: 1,
+                provider: "anthropic".to_string(),
+                model: "claude-sonnet-5".to_string(),
+                prompt_tokens: 10,
+                completion_tokens: 2,
+                cached_tokens: 0,
+                cache_write_tokens: 0,
+                at: 5,
+            }
+        );
+    }
+
+    /// The point of the record. Folding keeps every call in order, so a
+    /// consumer can ask what any single one cost - which the cumulative
+    /// counters cannot answer, because two calls between two ticks arrive as
+    /// their sum.
+    #[test]
+    fn folding_keeps_each_call_separate_instead_of_summing_them() {
+        let usage = |kind, prompt, at| RunRecord::InferenceUsage {
+            kind,
+            stage: "plan".to_string(),
+            iteration: 1,
+            provider: "anthropic".to_string(),
+            model: "claude-sonnet-5".to_string(),
+            prompt_tokens: prompt,
+            completion_tokens: 1,
+            cached_tokens: 0,
+            cache_write_tokens: 0,
+            at,
+        };
+        // The shape the issue reported: a compaction call and a stage call
+        // landing between the same two progress ticks.
+        let folded = fold(&[
+            header(),
+            usage(InferenceKind::Compaction, 7000, 1),
+            usage(InferenceKind::Stage, 21_000, 2),
+        ])
+        .unwrap();
+
+        assert_eq!(folded.inference_count, 2);
+        let seen: Vec<_> = folded
+            .inference_usage
+            .iter()
+            .map(|u| (u.kind, u.prompt_tokens))
+            .collect();
+        assert_eq!(
+            seen,
+            vec![
+                (InferenceKind::Compaction, 7000),
+                (InferenceKind::Stage, 21_000)
+            ]
+        );
+        // The whole reason this exists: their sum is 28k, and a reader of the
+        // cumulative counter alone would see one 28k request and reasonably ask
+        // whether a 32k window had been violated. Neither call came close.
+        assert!(
+            folded
+                .inference_usage
+                .iter()
+                .all(|u| u.prompt_tokens < 32_000),
+            "no single call exceeded the window, and the journal can now prove it"
+        );
+    }
+
+    /// The heavy variant and the light one both name one provider call, so a
+    /// consumer counting calls should not have to know which the writer chose.
+    #[test]
+    fn both_inference_record_kinds_count_as_one_call_each() {
+        let records = all_record_kinds();
+        let folded = fold(&records).unwrap();
+        let written = records
+            .iter()
+            .filter(|r| {
+                matches!(
+                    r,
+                    RunRecord::Inference { .. } | RunRecord::InferenceUsage { .. }
+                )
+            })
+            .count();
+        assert_eq!(folded.inference_count, written);
+        assert_eq!(folded.inference_usage.len(), 1);
     }
 }

--- a/crates/leviath-runtime/src/compaction_bridge.rs
+++ b/crates/leviath-runtime/src/compaction_bridge.rs
@@ -29,6 +29,11 @@ pub struct CompactionJob {
     pub entity: Entity,
     /// The compaction provider (resolved for the compaction model).
     pub provider: Arc<dyn Provider>,
+    /// The name of that provider, for the usage records. The trait object above
+    /// cannot answer for itself which registry entry it came from.
+    pub provider_name: String,
+    /// The model the requests target, for the usage records.
+    pub model: String,
     /// One `(region_name, request)` per region to summarize.
     pub requests: Vec<(String, InferenceRequest)>,
     /// The per-model pool permit, held for the whole batch.
@@ -42,6 +47,18 @@ pub struct CompactionOutcome {
     pub entity: Entity,
     /// Per-region summaries, or the error compaction failed with.
     pub result: Result<Vec<(String, String)>, ProviderError>,
+    /// What each completed call billed, one entry per region actually
+    /// summarized.
+    ///
+    /// Carried separately from `result` because the two do not have the same
+    /// length when a batch fails partway: the summaries are discarded whole
+    /// (compaction is all-or-nothing for the window), but the calls that
+    /// already ran were still billed and still have to be counted.
+    pub usage: Vec<leviath_providers::TokenUsage>,
+    /// The provider that served the batch.
+    pub provider_name: String,
+    /// The model the batch targeted.
+    pub model: String,
 }
 
 /// Run one compaction job: summarize each region sequentially with the permit
@@ -60,15 +77,21 @@ pub async fn run_compaction_job(
     let CompactionJob {
         entity,
         provider,
+        provider_name,
+        model,
         requests,
         permit,
     } = job;
 
     let mut summaries = Vec::new();
+    let mut usage = Vec::new();
     let mut result = Ok(());
     for (region, request) in requests {
         match tokio::time::timeout(deadline, provider.infer(&request)).await {
-            Ok(Ok(response)) => summaries.push((region, response.content)),
+            Ok(Ok(response)) => {
+                usage.push(response.tokens_used);
+                summaries.push((region, response.content));
+            }
             Ok(Err(e)) => {
                 result = Err(e);
                 break;
@@ -88,6 +111,9 @@ pub async fn run_compaction_job(
     let outcome = CompactionOutcome {
         entity,
         result: result.map(|()| summaries),
+        usage,
+        provider_name,
+        model,
     };
     let _ = results.send(outcome);
     wake.notify_one();
@@ -210,6 +236,8 @@ mod tests {
             entity: Entity::from_raw_u32(3)
                 .expect("a small literal index is always a valid entity id"),
             provider,
+            provider_name: "p".to_string(),
+            model: "m".to_string(),
             requests: regions
                 .into_iter()
                 .map(|r| (r.to_string(), request()))

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -149,6 +149,8 @@ pub fn dispatch_content_summary(
             CompactionJob {
                 entity,
                 provider,
+                provider_name: config.provider.clone(),
+                model: config.model.clone(),
                 requests,
                 permit,
             },
@@ -809,6 +811,9 @@ mod tests {
         // A successful summary replaces the region's content.
         tx.send(CompactionOutcome {
             entity: e,
+            usage: Vec::new(),
+            provider_name: "p".to_string(),
+            model: "m".to_string(),
             result: Ok(vec![("task".to_string(), "SHORT".to_string())]),
         })
         .unwrap();
@@ -831,6 +836,9 @@ mod tests {
             .id();
         tx.send(CompactionOutcome {
             entity: e2,
+            usage: Vec::new(),
+            provider_name: "p".to_string(),
+            model: "m".to_string(),
             result: Err(leviath_providers::ProviderError::Other("x".to_string())),
         })
         .unwrap();
@@ -838,6 +846,9 @@ mod tests {
         tx.send(CompactionOutcome {
             entity: Entity::from_raw_u32(9999)
                 .expect("a small literal index is always a valid entity id"),
+            usage: Vec::new(),
+            provider_name: "p".to_string(),
+            model: "m".to_string(),
             result: Ok(vec![("task".to_string(), "ignored".to_string())]),
         })
         .unwrap();

--- a/crates/leviath-runtime/src/inference_usage.rs
+++ b/crates/leviath-runtime/src/inference_usage.rs
@@ -1,0 +1,235 @@
+//! What one provider call cost, recorded where it lands.
+//!
+//! A run bills for four kinds of call and, until this module existed, counted
+//! one of them. Stage turns went into [`TokenTotals`];
+//! the compaction, title, and routing lanes each threw their usage away at the
+//! outcome boundary, because each channel carried only the payload its collector
+//! wanted - a summary, a title, a stage name - and usage was not it.
+//!
+//! Two things follow from putting the accounting in one place rather than
+//! repeating it per lane. The cumulative totals finally cover every call, so a
+//! run's reported spend is what the provider actually billed. And each call
+//! writes a [`RunRecord::InferenceUsage`] as it lands, which is the part
+//! [`RunRecord::Progress`] cannot do: progress counters are cumulative, so two
+//! calls between two ticks arrive as their sum, and a chart of that sum shows a
+//! spike no single call ever made.
+
+use leviath_core::run_archive::{InferenceKind, RunRecord};
+
+use crate::persistence::{RunMetadata, TokenTotals};
+use crate::persistence_bridge::PersistMsg;
+use crate::pipeline::PersistenceStage;
+
+/// Everything one call needs to report itself.
+///
+/// Passed as a struct rather than eight arguments because the four token counts
+/// are trivially transposable at a call site and the compiler would not catch
+/// it.
+pub struct CallUsage<'a> {
+    /// Which kind of call this was.
+    pub kind: InferenceKind,
+    /// The stage the run was in; empty for the title call, which has none.
+    pub stage: &'a str,
+    /// The stage-local iteration index.
+    pub iteration: usize,
+    /// The provider that served the call.
+    pub provider: &'a str,
+    /// The model the call targeted.
+    pub model: &'a str,
+    /// What the provider billed.
+    pub usage: &'a leviath_providers::TokenUsage,
+}
+
+/// Fold one call into the run's cumulative totals and journal what it cost.
+///
+/// Both halves are optional and independent: a world with no `TokenTotals` (a
+/// bare test agent) still journals, and a world with no persistence lane or run
+/// metadata - tests, unpersisted agents - still counts. Neither absence is an
+/// error, which is why this takes options rather than making callers branch.
+pub fn record_call(
+    totals: Option<&mut TokenTotals>,
+    persist: Option<&PersistenceStage>,
+    metadata: Option<&RunMetadata>,
+    call: &CallUsage<'_>,
+) {
+    if let Some(totals) = totals {
+        totals.add_usage(call.usage);
+    }
+    let (Some(persist), Some(md)) = (persist, metadata) else {
+        return;
+    };
+    let record = RunRecord::InferenceUsage {
+        kind: call.kind,
+        stage: call.stage.to_string(),
+        iteration: call.iteration,
+        provider: call.provider.to_string(),
+        model: call.model.to_string(),
+        prompt_tokens: call.usage.prompt_tokens,
+        completion_tokens: call.usage.completion_tokens,
+        cached_tokens: call.usage.cached_tokens,
+        cache_write_tokens: call.usage.cache_write_tokens,
+        at: chrono::Utc::now().timestamp(),
+    };
+    // No ack: a usage record is telemetry, and nothing downstream waits on it
+    // the way the tool lane waits on its batch record being durable before
+    // anything can run.
+    let _ = persist.0.send(PersistMsg::Append {
+        run_id: md.run_id.clone(),
+        record: Box::new(record),
+        ack: None,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage() -> leviath_providers::TokenUsage {
+        leviath_providers::TokenUsage {
+            prompt_tokens: 100,
+            completion_tokens: 20,
+            cached_tokens: 3,
+            cache_write_tokens: 4,
+            total_tokens: 120,
+        }
+    }
+
+    fn metadata() -> RunMetadata {
+        RunMetadata {
+            run_id: "run-u".to_string(),
+            agent_name: "a".to_string(),
+            agent_path: "/a".to_string(),
+            task: "t".to_string(),
+            model: None,
+            workdir: "/w".to_string(),
+            num_stages: 1,
+            started_at: 0,
+            parent_run_id: None,
+            metadata: Default::default(),
+            callback_url: None,
+            callback_secret: None,
+            title: None,
+            unattended: false,
+            read_paths: None,
+            output_request: None,
+        }
+    }
+
+    fn call(kind: InferenceKind, u: &leviath_providers::TokenUsage) -> CallUsage<'_> {
+        CallUsage {
+            kind,
+            stage: "plan",
+            iteration: 2,
+            provider: "anthropic",
+            model: "claude-sonnet-5",
+            usage: u,
+        }
+    }
+
+    /// The two halves are independent by design, so the four combinations of
+    /// "has totals" and "has a journal" all have to behave. A world missing
+    /// either is ordinary - tests and unpersisted agents run that way - and an
+    /// absence must not cost the half that is present.
+    #[test]
+    fn counting_and_journaling_are_independent() {
+        let u = usage();
+
+        // Both present: counted and written.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let tx_for_noise = tx.clone();
+        let mut totals = TokenTotals::default();
+        record_call(
+            Some(&mut totals),
+            Some(&PersistenceStage(tx)),
+            Some(&metadata()),
+            &call(InferenceKind::Compaction, &u),
+        );
+        assert_eq!(totals.prompt_tokens, 100);
+        // The persistence channel carries snapshots and buffered log lines on
+        // the same wire, so the drain has to pick ours out of mixed traffic
+        // rather than assume the next message is it.
+        let _ = tx_for_noise.send(crate::persistence_bridge::PersistMsg::StageLines {
+            run_id: "run-u".to_string(),
+            output_appends: vec![],
+            log_appends: vec![],
+        });
+        let mut appended: Vec<(String, RunRecord)> = Vec::new();
+        while let Ok(msg) = rx.try_recv() {
+            if let crate::persistence_bridge::PersistMsg::Append { run_id, record, .. } = msg {
+                appended.push((run_id, *record));
+            }
+        }
+        assert_eq!(appended.len(), 1, "one call, one record");
+        let (run_id, record) = appended.remove(0);
+        assert_eq!(run_id, "run-u");
+        // Asserted on the serialized form with the wall-clock stamp lifted out,
+        // so this pins the field names a journal reader parses without pinning
+        // the one value that cannot be known ahead of time.
+        let mut value = serde_json::to_value(&record).unwrap();
+        let fields = value["InferenceUsage"].as_object_mut().unwrap();
+        assert!(fields.remove("at").is_some(), "a call is stamped");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "InferenceUsage": {
+                    "kind": "compaction",
+                    "stage": "plan",
+                    "iteration": 2,
+                    "provider": "anthropic",
+                    "model": "claude-sonnet-5",
+                    "prompt_tokens": 100,
+                    "completion_tokens": 20,
+                    "cached_tokens": 3,
+                    "cache_write_tokens": 4,
+                }
+            })
+        );
+
+        // No journal: still counted.
+        let mut totals = TokenTotals::default();
+        record_call(
+            Some(&mut totals),
+            None,
+            Some(&metadata()),
+            &call(InferenceKind::Stage, &u),
+        );
+        assert_eq!(totals.prompt_tokens, 100);
+
+        // A journal but no run metadata: nothing to address the record to, so
+        // nothing is written - and the count still lands.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut totals = TokenTotals::default();
+        record_call(
+            Some(&mut totals),
+            Some(&PersistenceStage(tx)),
+            None,
+            &call(InferenceKind::Title, &u),
+        );
+        assert_eq!(totals.prompt_tokens, 100);
+        assert!(rx.try_recv().is_err());
+
+        // Neither: a no-op that must not panic.
+        record_call(None, None, None, &call(InferenceKind::Routing, &u));
+    }
+
+    /// Totals accumulate across calls rather than being overwritten - the bug
+    /// that made a run report its last call instead of its bill would pass a
+    /// single-call test.
+    #[test]
+    fn repeated_calls_accumulate() {
+        let u = usage();
+        let mut totals = TokenTotals::default();
+        for _ in 0..3 {
+            record_call(
+                Some(&mut totals),
+                None,
+                None,
+                &call(InferenceKind::Stage, &u),
+            );
+        }
+        assert_eq!(totals.prompt_tokens, 300);
+        assert_eq!(totals.completion_tokens, 60);
+        assert_eq!(totals.cached_tokens, 9);
+        assert_eq!(totals.cache_write_tokens, 12);
+    }
+}

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -78,6 +78,7 @@ pub(crate) mod gate_prompt;
 pub mod host;
 pub(crate) mod inference_bridge;
 pub mod inference_pool;
+pub mod inference_usage;
 pub mod interaction_hub;
 pub mod interaction_points;
 pub(crate) mod lane_supervisor;

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -48,6 +48,11 @@ fn spawn_supervised_compaction(stage: &InferenceStage, entity: Entity, job: Comp
             let _ = lost_outcomes.send(CompactionOutcome {
                 entity,
                 result: Err(leviath_providers::ProviderError::Other(message)),
+                // A job that never ran billed nothing. Empty rather than
+                // absent: there is no call to attribute, not an unknown cost.
+                usage: Vec::new(),
+                provider_name: String::new(),
+                model: String::new(),
             });
             lost_wake.notify_one();
         },
@@ -136,6 +141,8 @@ pub fn dispatch_compaction(
             CompactionJob {
                 entity,
                 provider,
+                provider_name: config.provider.clone(),
+                model: config.model.clone(),
                 requests,
                 permit,
             },
@@ -147,6 +154,18 @@ pub fn dispatch_compaction(
     }
 }
 
+/// What `collect_compaction` selects.
+///
+/// `&'static` is bevy's `WorldQuery` convention, not a claim about
+/// lifetimes: the borrow is bound when the query is fetched.
+type CollectCompactionQuery = (
+    &'static mut ContextWindow,
+    Option<&'static mut crate::telemetry::StageActivity>,
+    Option<&'static mut crate::persistence::TokenTotals>,
+    Option<&'static crate::persistence::RunMetadata>,
+    Option<&'static AgentState>,
+);
+
 /// Compaction-collect system: drain finished compaction jobs and apply each
 /// summary into its paired `CompactHistory` region, clearing the summarized
 /// source region. A provider error leaves the context untouched (best-effort).
@@ -154,18 +173,14 @@ pub fn dispatch_compaction(
 /// of `AgentEngine::compact_region`.)
 pub fn collect_compaction(
     mut results: ResMut<CompactionResults>,
-    mut agents: Query<
-        (
-            &mut ContextWindow,
-            Option<&mut crate::telemetry::StageActivity>,
-        ),
-        With<AwaitingCompaction>,
-    >,
+    mut agents: Query<CollectCompactionQuery, With<AwaitingCompaction>>,
+    persist: Option<Res<crate::pipeline::PersistenceStage>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
-        let Ok((mut window, activity)) = agents.get_mut(outcome.entity) else {
+        let Ok((mut window, activity, mut totals, md, state)) = agents.get_mut(outcome.entity)
+        else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
         crate::tick_scope::enter(outcome.entity);
@@ -175,6 +190,28 @@ pub fn collect_compaction(
                 .push(crate::telemetry::ActivityRecord::Compaction {
                     success: outcome.result.is_ok(),
                 });
+        }
+        // One record per call, not one per batch. A batch summarizes a region
+        // each, so folding them into a single number would recreate downstream
+        // exactly the ambiguity this record exists to remove.
+        //
+        // Counted even when the batch failed partway: the calls that already
+        // ran were billed, and the summaries being discarded is a decision
+        // about the window, not about the invoice.
+        for usage in &outcome.usage {
+            crate::inference_usage::record_call(
+                totals.as_deref_mut(),
+                persist.as_deref(),
+                md,
+                &crate::inference_usage::CallUsage {
+                    kind: leviath_core::run_archive::InferenceKind::Compaction,
+                    stage: state.map_or("", |s| s.current_stage.as_str()),
+                    iteration: state.map_or(0, |s| s.iteration),
+                    provider: &outcome.provider_name,
+                    model: &outcome.model,
+                    usage,
+                },
+            );
         }
         if let Ok(summaries) = outcome.result {
             for (region_name, summary) in summaries {
@@ -392,6 +429,8 @@ pub fn dispatch_edge_compact(
                     CompactionJob {
                         entity,
                         provider,
+                        provider_name: config.provider.clone(),
+                        model: config.model.clone(),
                         requests,
                         permit,
                     },

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -60,6 +60,7 @@ pub fn collect_inference(
     mut agents: Query<InferenceQuery, With<AwaitingInference>>,
     mut circuits: Option<ResMut<ProviderCircuits>>,
     policy: Option<Res<CircuitPolicy>>,
+    persist: Option<Res<crate::pipeline::persist::PersistenceStage>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
@@ -69,7 +70,7 @@ pub fn collect_inference(
         let Ok((
             mut state,
             md,
-            totals,
+            mut totals,
             cursor,
             window,
             mut ledger,
@@ -148,9 +149,19 @@ pub fn collect_inference(
         match outcome.result {
             Ok(response) => {
                 state.iteration += 1;
-                if let Some(mut totals) = totals {
-                    totals.add_usage(&response.tokens_used);
-                }
+                crate::inference_usage::record_call(
+                    totals.as_deref_mut(),
+                    persist.as_deref(),
+                    md,
+                    &crate::inference_usage::CallUsage {
+                        kind: leviath_core::run_archive::InferenceKind::Stage,
+                        stage: &state.current_stage,
+                        iteration: state.iteration,
+                        provider: &called_provider,
+                        model: &called_model,
+                        usage: &response.tokens_used,
+                    },
+                );
                 // Accrue this iteration's tokens against the current stage record.
                 if let Some(rec) = ledger.as_deref_mut().and_then(|l| l.0.get_mut(idx)) {
                     rec.prompt_tokens += response.tokens_used.prompt_tokens;

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -9775,6 +9775,9 @@ fn collect_compaction_stores_summary_and_clears_source() {
     let e = world.spawn((compacting_window(), AwaitingCompaction)).id();
     tx.send(CompactionOutcome {
         entity: e,
+        usage: Vec::new(),
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
         result: Ok(vec![("conv".to_string(), "the summary".to_string())]),
     })
     .unwrap();
@@ -9786,6 +9789,91 @@ fn collect_compaction_stores_summary_and_clears_source() {
     assert!(w.get_region("history").unwrap().current_tokens > 0); // summary stored
     assert!(world.get::<ReadyToInfer>(e).is_some());
     assert!(world.get::<AwaitingCompaction>(e).is_none());
+}
+
+/// Compaction is the largest uncounted cost a run had: a summarize call sees
+/// a whole region, so it can be the most expensive request in the run, and its
+/// outcome channel carried only the summaries. A run that compacted reported a
+/// fraction of what it was billed.
+#[test]
+fn compaction_calls_are_counted_one_record_per_region() {
+    let (mut world, tx) = world_with_compaction_results();
+    // Carries a stage, so each record is attributed to the stage that paid for
+    // it. The failing-batch test below deliberately has none, which is the
+    // stage-less path.
+    let e = world
+        .spawn((
+            compacting_window(),
+            AwaitingCompaction,
+            crate::persistence::TokenTotals::default(),
+            AgentState {
+                current_stage: "analyze".to_string(),
+                iteration: 3,
+                ..agent_state()
+            },
+        ))
+        .id();
+    let usage = |prompt| leviath_providers::TokenUsage {
+        prompt_tokens: prompt,
+        completion_tokens: 10,
+        cached_tokens: 0,
+        cache_write_tokens: 0,
+        total_tokens: prompt + 10,
+    };
+    tx.send(CompactionOutcome {
+        entity: e,
+        // Two regions summarized: two calls, two costs.
+        usage: vec![usage(7000), usage(3000)],
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
+        result: Ok(vec![("conv".to_string(), "the summary".to_string())]),
+    })
+    .unwrap();
+
+    run_collect_compaction(&mut world);
+
+    let totals = world.get::<crate::persistence::TokenTotals>(e).unwrap();
+    assert_eq!(totals.prompt_tokens, 10_000);
+    assert_eq!(totals.completion_tokens, 20);
+}
+
+/// A batch that failed partway still billed for the calls that ran before it
+/// gave up. Discarding the summaries is a decision about the window; it does
+/// not un-bill the requests.
+#[test]
+fn a_failed_compaction_batch_still_counts_the_calls_that_ran() {
+    let (mut world, tx) = world_with_compaction_results();
+    let e = world
+        .spawn((
+            compacting_window(),
+            AwaitingCompaction,
+            crate::persistence::TokenTotals::default(),
+        ))
+        .id();
+    tx.send(CompactionOutcome {
+        entity: e,
+        usage: vec![leviath_providers::TokenUsage {
+            prompt_tokens: 4000,
+            completion_tokens: 40,
+            cached_tokens: 0,
+            cache_write_tokens: 0,
+            total_tokens: 4040,
+        }],
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
+        result: Err(leviath_providers::ProviderError::Other("boom".to_string())),
+    })
+    .unwrap();
+
+    run_collect_compaction(&mut world);
+
+    assert_eq!(
+        world
+            .get::<crate::persistence::TokenTotals>(e)
+            .unwrap()
+            .prompt_tokens,
+        4000
+    );
 }
 
 #[test]
@@ -9800,6 +9888,9 @@ fn collect_compaction_error_leaves_context_and_readies() {
         .current_tokens;
     tx.send(CompactionOutcome {
         entity: e,
+        usage: Vec::new(),
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
         result: Err(leviath_providers::ProviderError::Other("boom".to_string())),
     })
     .unwrap();
@@ -9825,6 +9916,9 @@ fn collect_compaction_drops_stale_outcome() {
     let ghost = world.spawn_empty().id();
     tx.send(CompactionOutcome {
         entity: ghost,
+        usage: Vec::new(),
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
         result: Ok(vec![]),
     })
     .unwrap();
@@ -9850,6 +9944,9 @@ fn collect_compaction_summary_for_unpaired_region_is_skipped() {
     let e = world.spawn((w, AwaitingCompaction)).id();
     tx.send(CompactionOutcome {
         entity: e,
+        usage: Vec::new(),
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
         // "lone" exists but is unpaired (history None); "gone" doesn't exist
         // at all (get_region_mut None) - both no-op branches.
         result: Ok(vec![
@@ -10588,6 +10685,53 @@ fn collect_choice_enters_chosen_stage() {
     assert_eq!(world.get::<AgentState>(e).unwrap().current_stage, "b");
 }
 
+/// Routing calls are short but not free, and a branching run makes one at
+/// every stage boundary. The response was already in hand here with its usage
+/// on it; nothing read it, so the whole class went unbilled.
+#[test]
+fn a_routing_call_is_counted_against_the_run() {
+    let (mut world, tx) = world_with_transition_results();
+    let bp = blueprint(vec![
+        stage_named("a", None, false, None),
+        stage_named("b", None, false, None),
+    ]);
+    let e = spawn_responding_agent(
+        &mut world,
+        bp,
+        vec![si("m0"), si("m1")],
+        vec![plain_edge("b")],
+    );
+    world
+        .entity_mut(e)
+        .insert(crate::persistence::TokenTotals::default());
+    let mut response = resp("b");
+    response.tokens_used = leviath_providers::TokenUsage {
+        prompt_tokens: 300,
+        completion_tokens: 3,
+        cached_tokens: 1,
+        cache_write_tokens: 2,
+        total_tokens: 303,
+    };
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Ok(response),
+    })
+    .unwrap();
+
+    run_collect_transition(&mut world);
+
+    let totals = world
+        .get::<crate::persistence::TokenTotals>(e)
+        .expect("totals");
+    assert_eq!(totals.prompt_tokens, 300);
+    assert_eq!(totals.completion_tokens, 3);
+    assert_eq!(totals.cached_tokens, 1);
+    assert_eq!(totals.cache_write_tokens, 2);
+    // The routing decision still lands - counting it changed nothing else.
+    assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+}
+
 /// A transition choice that lands after the run was cancelled is discarded.
 /// Notably the no-match arm sets `Complete` unconditionally, which would
 /// report a cancelled run as having finished normally.
@@ -10959,6 +11103,9 @@ fn collect_compaction_records_success_and_failure() {
         .id();
     tx.send(CompactionOutcome {
         entity: e,
+        usage: Vec::new(),
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
         result: Ok(vec![("conv".to_string(), "summary".to_string())]),
     })
     .unwrap();
@@ -10973,6 +11120,9 @@ fn collect_compaction_records_success_and_failure() {
         .id();
     tx.send(CompactionOutcome {
         entity: e2,
+        usage: Vec::new(),
+        provider_name: "p".to_string(),
+        model: "m".to_string(),
         result: Err(leviath_providers::ProviderError::Other("boom".to_string())),
     })
     .unwrap();

--- a/crates/leviath-runtime/src/pipeline/transition_choice.rs
+++ b/crates/leviath-runtime/src/pipeline/transition_choice.rs
@@ -258,6 +258,7 @@ type CollectTransitionChoiceQuery = (
     &'static AwaitingTransitionResponse,
     Option<&'static mut crate::persistence::RunOutcomeFlags>,
     Option<&'static crate::persistence::RunMetadata>,
+    Option<&'static mut crate::persistence::TokenTotals>,
 );
 
 /// Transition-choice collect: drain completed routing inferences, match each to a
@@ -268,6 +269,7 @@ pub fn collect_transition_choice(
     mut results: ResMut<TransitionResults>,
     mut agents: Query<CollectTransitionChoiceQuery>,
     sink: Option<Res<crate::host::WorldEventSink>>,
+    persist: Option<Res<crate::pipeline::PersistenceStage>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
@@ -284,6 +286,7 @@ pub fn collect_transition_choice(
             resp,
             mut flags,
             metadata,
+            mut totals,
         )) = agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
@@ -311,6 +314,28 @@ pub fn collect_transition_choice(
                 continue;
             }
         };
+
+        // Routing calls are short but not free, and one fires at every stage
+        // boundary of every branching run. Read off the stage's own inference
+        // config, which is what dispatch resolved the provider from.
+        //
+        // Indexed rather than looked up, like the `bp.0.stages[cursor.index]`
+        // below it: `StageInferences` is built one entry per stage at spawn, so
+        // a cursor that could miss here would already have panicked there.
+        let si = &stage_infs.0[cursor.index];
+        crate::inference_usage::record_call(
+            totals.as_deref_mut(),
+            persist.as_deref(),
+            metadata,
+            &crate::inference_usage::CallUsage {
+                kind: leviath_core::run_archive::InferenceKind::Routing,
+                stage: &state.current_stage,
+                iteration: state.iteration,
+                provider: &si.provider_name,
+                model: &si.model,
+                usage: &response.tokens_used,
+            },
+        );
 
         let choice = response.content.trim().to_string();
         let tokens = leviath_core::estimate_tokens(&choice);

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -206,6 +206,8 @@ pub fn dispatch_title(
             TitleJob {
                 entity,
                 provider,
+                provider_name: provider_name.clone(),
+                model: model.clone(),
                 request: title_request(&meta.task, &model),
                 permit,
             },
@@ -220,20 +222,52 @@ pub fn dispatch_title(
     }
 }
 
+/// What `collect_title` selects.
+///
+/// `&'static` is bevy's `WorldQuery` convention, not a claim about
+/// lifetimes: the borrow is bound when the query is fetched.
+type CollectTitleQuery = (
+    &'static mut RunMetadata,
+    Option<&'static mut crate::persistence::TokenTotals>,
+);
+
 /// Collect system: store each finished title into its run's metadata. A
 /// provider error or empty reply changes nothing; either way the in-flight
-/// marker comes off.
+/// marker comes off. What the call billed is counted either way - see the note
+/// in the body.
 pub fn collect_title(
     mut results: ResMut<TitleResults>,
-    mut agents: Query<&mut RunMetadata, With<AwaitingTitle>>,
+    mut agents: Query<CollectTitleQuery, With<AwaitingTitle>>,
+    persist: Option<Res<crate::pipeline::PersistenceStage>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
-        let Ok(mut meta) = agents.get_mut(outcome.entity) else {
+        let Ok((mut meta, mut totals)) = agents.get_mut(outcome.entity) else {
             continue; // stale: agent cancelled/despawned since dispatch
         };
         crate::tick_scope::enter(outcome.entity);
+        // Counted before the reply is examined. A title the sanitizer rejects
+        // was still served and still billed, and a run that reports less
+        // because its title came back empty would be reporting the one thing
+        // this cannot depend on.
+        if let Some(usage) = &outcome.usage {
+            crate::inference_usage::record_call(
+                totals.as_deref_mut(),
+                persist.as_deref(),
+                Some(&meta),
+                &crate::inference_usage::CallUsage {
+                    kind: leviath_core::run_archive::InferenceKind::Title,
+                    // No stage of its own: titling runs once at spawn, beside
+                    // the run rather than inside any of its stages.
+                    stage: "",
+                    iteration: 0,
+                    provider: &outcome.provider_name,
+                    model: &outcome.model,
+                    usage,
+                },
+            );
+        }
         if let Ok(raw) = outcome.result {
             let title = sanitize_title(&raw);
             if !title.is_empty() {
@@ -400,6 +434,8 @@ mod tests {
             TitleJob {
                 entity: bevy_ecs::entity::Entity::PLACEHOLDER,
                 provider: Arc::new(Hang),
+                provider_name: "mock".to_string(),
+                model: "m".to_string(),
                 request: title_request("task", "m"),
                 permit: pools.try_acquire("m").expect("free"),
             },
@@ -484,6 +520,9 @@ mod tests {
         tx.send(TitleOutcome {
             entity: ghost,
             result: Ok("t".to_string()),
+            usage: None,
+            provider_name: "mock".to_string(),
+            model: "m".to_string(),
         })
         .unwrap();
         world.insert_resource(TitleResults(rx));
@@ -691,5 +730,125 @@ mod tests {
         );
         let long = "x".repeat(TITLE_MAX_LEN * 2);
         assert_eq!(sanitize_title(&long).chars().count(), TITLE_MAX_LEN);
+    }
+
+    /// The title call bills like any other and used to be counted like none:
+    /// its outcome channel carried the reply the collector wanted and dropped
+    /// the usage nobody read, so a run's reported spend was short by one call
+    /// it had definitely made.
+    #[test]
+    fn a_title_call_is_counted_against_the_run_that_paid_for_it() {
+        let mut world = World::new();
+        let entity = world
+            .spawn((
+                metadata(Some("mock/m")),
+                AwaitingTitle,
+                crate::persistence::TokenTotals::default(),
+            ))
+            .id();
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(TitleOutcome {
+            entity,
+            result: Ok("Release notes".to_string()),
+            usage: Some(leviath_providers::TokenUsage {
+                prompt_tokens: 900,
+                completion_tokens: 12,
+                cached_tokens: 3,
+                cache_write_tokens: 4,
+                total_tokens: 912,
+            }),
+            provider_name: "mock".to_string(),
+            model: "m".to_string(),
+        })
+        .unwrap();
+        world.insert_resource(TitleResults(rx));
+        run_collect(&mut world);
+
+        let totals = world
+            .get::<crate::persistence::TokenTotals>(entity)
+            .expect("totals");
+        assert_eq!(totals.prompt_tokens, 900);
+        assert_eq!(totals.completion_tokens, 12);
+        assert_eq!(totals.cached_tokens, 3);
+        assert_eq!(totals.cache_write_tokens, 4);
+        // And the reply still lands - counting it did not cost the feature.
+        assert_eq!(
+            world.get::<RunMetadata>(entity).unwrap().title.as_deref(),
+            Some("Release notes")
+        );
+    }
+
+    /// A reply the sanitizer throws away was still served and still billed.
+    /// Counting only titles that survive would make a run's reported cost
+    /// depend on whether the model happened to answer usefully.
+    #[test]
+    fn a_rejected_title_is_still_counted() {
+        let mut world = World::new();
+        let entity = world
+            .spawn((
+                metadata(Some("mock/m")),
+                AwaitingTitle,
+                crate::persistence::TokenTotals::default(),
+            ))
+            .id();
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(TitleOutcome {
+            entity,
+            // Sanitizes to nothing, so no title is stored.
+            result: Ok("   ".to_string()),
+            usage: Some(leviath_providers::TokenUsage {
+                prompt_tokens: 500,
+                completion_tokens: 1,
+                cached_tokens: 0,
+                cache_write_tokens: 0,
+                total_tokens: 501,
+            }),
+            provider_name: "mock".to_string(),
+            model: "m".to_string(),
+        })
+        .unwrap();
+        world.insert_resource(TitleResults(rx));
+        run_collect(&mut world);
+
+        assert!(world.get::<RunMetadata>(entity).unwrap().title.is_none());
+        assert_eq!(
+            world
+                .get::<crate::persistence::TokenTotals>(entity)
+                .unwrap()
+                .prompt_tokens,
+            500
+        );
+    }
+
+    /// A call that never reached a provider has nothing to attribute. Reporting
+    /// a zero-token call would put a point on a token chart for a request that
+    /// was never made.
+    #[test]
+    fn a_failed_title_call_adds_nothing() {
+        let mut world = World::new();
+        let entity = world
+            .spawn((
+                metadata(Some("mock/m")),
+                AwaitingTitle,
+                crate::persistence::TokenTotals::default(),
+            ))
+            .id();
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(TitleOutcome {
+            entity,
+            result: Err(ProviderError::Other("down".to_string())),
+            usage: None,
+            provider_name: "mock".to_string(),
+            model: "m".to_string(),
+        })
+        .unwrap();
+        world.insert_resource(TitleResults(rx));
+        run_collect(&mut world);
+
+        let totals = world
+            .get::<crate::persistence::TokenTotals>(entity)
+            .expect("totals");
+        assert_eq!(totals.prompt_tokens, 0);
+        assert_eq!(totals.completion_tokens, 0);
     }
 }

--- a/crates/leviath-runtime/src/title_bridge.rs
+++ b/crates/leviath-runtime/src/title_bridge.rs
@@ -25,6 +25,11 @@ pub struct TitleJob {
     pub entity: Entity,
     /// The provider resolved for the title model.
     pub provider: Arc<dyn Provider>,
+    /// The name of that provider, for the usage record. The trait object above
+    /// cannot answer for itself which registry entry it came from.
+    pub provider_name: String,
+    /// The model the request targets, for the usage record.
+    pub model: String,
     /// The one-shot titling request.
     pub request: InferenceRequest,
     /// The per-model pool permit, held for the call.
@@ -38,6 +43,13 @@ pub struct TitleOutcome {
     pub entity: Entity,
     /// The raw model reply (sanitized by the collect system), or the error.
     pub result: Result<String, ProviderError>,
+    /// What the call billed, when it completed. `None` for a call that failed
+    /// or timed out, which is the only case where nothing was served.
+    pub usage: Option<leviath_providers::TokenUsage>,
+    /// The provider that served the call.
+    pub provider_name: String,
+    /// The model the call targeted.
+    pub model: String,
 }
 
 /// Run one title job: make the call with the permit held, release the slot,
@@ -56,19 +68,35 @@ pub async fn run_title_job(
     let TitleJob {
         entity,
         provider,
+        provider_name,
+        model,
         request,
         permit,
     } = job;
 
-    let result = match tokio::time::timeout(deadline, provider.infer(&request)).await {
-        Ok(outcome) => outcome.map(|r| r.content),
-        Err(_) => Err(leviath_providers::ProviderError::Other(format!(
-            "title generation exceeded the {}s deadline and was aborted to free the pool slot",
-            deadline.as_secs()
-        ))),
+    // The usage travels beside the reply rather than being folded into it: the
+    // collect system wants the title, the run's accounting wants the tokens,
+    // and dropping the half this channel had no use for is how the title call
+    // came to be billed and counted nowhere.
+    let (result, usage) = match tokio::time::timeout(deadline, provider.infer(&request)).await {
+        Ok(Ok(r)) => (Ok(r.content), Some(r.tokens_used)),
+        Ok(Err(e)) => (Err(e), None),
+        Err(_) => (
+            Err(leviath_providers::ProviderError::Other(format!(
+                "title generation exceeded the {}s deadline and was aborted to free the pool slot",
+                deadline.as_secs()
+            ))),
+            None,
+        ),
     };
     drop(permit); // free the pool slot before the collect system runs
 
-    let _ = results.send(TitleOutcome { entity, result });
+    let _ = results.send(TitleOutcome {
+        entity,
+        result,
+        usage,
+        provider_name,
+        model,
+    });
     wake.notify_one();
 }


### PR DESCRIPTION
Closes #445.

## What the issue asked for

`Progress` carries cumulative counters, so two calls between two ticks arrive downstream as their sum. A chart of that sum shows a spike no single call ever made — the reported case being a run pinned to a 32k window showing a 56k "request" at a stage boundary, with no way to prove from the journal that each call was under the pin.

## What reproducing it found

I drove a two-stage run with one compacting edge against a mock provider serving known, distinct amounts per call kind. Six provider calls went out; the run reported four.

| call | billed | counted before |
|---|---|---|
| 4 × stage turn | 4,000 | ✅ |
| run-title generation | 1,000 | ❌ |
| edge compaction | 7,000 | ❌ |
| **total** | **12,000** | **4,000 reported** |

A run makes four kinds of provider call and was counting one. The compaction, title, and routing lanes each dropped usage at the outcome boundary, because each channel carried only the payload its collector wanted — a summary, a title, a stage name — and usage was not it.

That also means the issue's stated mechanism was the wrong way round: compaction was not summing into the spike, it was **absent from the total entirely**. A 56k boundary spike is two ordinary stage calls landing in one tick, and the compaction spend beside them was never on the chart at all.

## The change

The accounting moves into one place. `record_call` folds a call into the run's cumulative totals and writes a `RunRecord::InferenceUsage`, and all four lanes go through it.

- **Cumulative totals now cover every call.** `meta.json` reports 12,000/120 for the probe above, matching what the provider served.
- **Per-call records make token-over-time exact**, and "no request ever exceeded the window" provable from the journal rather than inferred from region checkpoints.

Each record carries an `InferenceKind` (`stage` / `compaction` / `title` / `routing`), because "this run cost double what its stages did because its edges compact" is the sentence a bare total cannot say.

The record is deliberately lighter than the existing `RunRecord::Inference`, which carries full request and response bodies: every call re-sends the whole window, so journaling those per call would multiply the file by the context size, and the window is already recoverable from the surrounding checkpoint and diff records.

## Heads-up: reported costs go up

This is the one behaviour change, and it is deliberate — @GEMISIS chose it over the additive-only option. Runs that compact, title, or branch will report more than they did, because they were always billed more than they reported. Nothing about what a run *spends* changes; only what it *admits to*. Anything keyed on the old numbers will see them move.

## Compatibility

`kind` defaults, so a journal written before the field existed reads back as stage work — which every record in one is. Verified by a test that deserializes a record with the field absent.

## Verification

Live, against a real daemon: six calls out, six `InferenceUsage` records back, correctly kinded and attributed, and the totals close exactly.

```
usage: "kind":"stage","stage":"ingest","iteration":1,...,"prompt_tokens":1000
usage: "kind":"title","stage":"","iteration":0,...,"prompt_tokens":1000
usage: "kind":"stage","stage":"ingest","iteration":2,...,"prompt_tokens":1000
usage: "kind":"compaction","stage":"analyze",...,"prompt_tokens":7000
usage: "kind":"stage","stage":"analyze","iteration":3,...,"prompt_tokens":1000
usage: "kind":"stage","stage":"analyze","iteration":4,...,"prompt_tokens":1000
```

Plus unit tests per lane — including that a title the sanitizer rejects is still counted, and that a compaction batch failing partway still counts the calls that ran. Full workspace suite green; `leviath-core`, `leviath-runtime` and `leviath-cli` each back at 100%.
