### PR TITLE
feat(context): let an agent release what it is finished with

### DIFF
--- a/crates/leviath-core/src/error.rs
+++ b/crates/leviath-core/src/error.rs
@@ -70,6 +70,26 @@ pub enum Error {
         max: usize,
     },
 
+    /// A region under `admission = "reject"` is full, and the write was
+    /// refused rather than something else being dropped to fit it.
+    ///
+    /// Distinct from [`Error::TokenBudgetExceeded`] because the remedy is
+    /// different: that one says this single write is too big for the region,
+    /// this one says the region is full and the agent has to decide what it is
+    /// finished with.
+    #[error(
+        "Region '{region}' is full ({used}/{max} tokens) and does not evict automatically - \
+         release an entry before adding another"
+    )]
+    RegionFull {
+        /// The region that refused the write.
+        region: String,
+        /// Tokens the region currently holds.
+        used: usize,
+        /// The region's ceiling.
+        max: usize,
+    },
+
     /// Pinned regions alone exceed total token budget
     #[error("Pinned regions ({pinned_tokens}) exceed total budget ({total_budget})")]
     PinnedRegionsOverBudget {

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -522,6 +522,14 @@ pub struct RegionDefinition {
     #[serde(default = "default_true")]
     pub summarizable: bool,
 
+    /// What this region does when a write does not fit.
+    ///
+    /// Declared per region rather than per stage: whether losing the oldest
+    /// entry is acceptable is a property of what the region holds, and does not
+    /// change depending on which stage is writing to it.
+    #[serde(default)]
+    pub admission: crate::region::Admission,
+
     /// Optional custom message shown to the agent when this region is required
     /// but empty. Falls back to a generated default when `None`.
     #[serde(default)]
@@ -552,6 +560,7 @@ impl RegionDefinition {
             required: false,
             required_message: None,
             summarizable: true,
+            admission: crate::region::Admission::default(),
             seed: None,
         }
     }

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -209,6 +209,20 @@ pub(super) fn parse_region_layout(
             .and_then(|v| v.as_bool())
             .unwrap_or(true);
 
+        // Default `evict`: making room is what every region did before this
+        // setting existed, and it is right for the transcript regions that are
+        // the majority of them.
+        let admission = match region_value.get("admission").and_then(|v| v.as_str()) {
+            Some("reject") => crate::region::Admission::Reject,
+            Some("evict") | None => crate::region::Admission::Evict,
+            Some(other) => {
+                return Err(crate::error::Error::ValidationFailed(format!(
+                    "region '{region_name}' has admission = \"{other}\"; \
+                     expected \"evict\" or \"reject\""
+                )));
+            }
+        };
+
         let seed = parse_region_seed(region_name, region_value.get("seed"));
 
         // Percentage regions contribute their (unknown) size at resolution, so
@@ -221,6 +235,7 @@ pub(super) fn parse_region_layout(
             .with_budget(budget)
             .with_required(required, required_message);
         def.summarizable = summarizable;
+        def.admission = admission;
         if let Some(f) = compact_at_field {
             def = def.with_compact_at(f);
         }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -4763,6 +4763,65 @@ notes = { kind = "sliding_window", max_items = 20 }
     assert!(region("notes").summarizable, "and defaults to on");
 }
 
+/// `admission` parses, defaults to evicting, and refuses a value it does not
+/// know rather than falling back.
+///
+/// Falling back would be the dangerous reading: an author who typed
+/// `admission = "rejcet"` wants their curated region protected, and silently
+/// giving them the evicting default would drop the entries they were trying to
+/// keep, with nothing said.
+#[test]
+fn parse_manifest_reads_the_admission_setting() {
+    let toml = r#"
+[agent]
+name = "curator"
+
+[context.regions]
+sources = { kind = "temporary", max_tokens = 100, admission = "reject" }
+scratch = { kind = "temporary", max_tokens = 100, admission = "evict" }
+notes = { kind = "temporary", max_tokens = 100 }
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let region = |name: &str| {
+        bp.context_layout
+            .regions
+            .iter()
+            .find(|r| r.name == name)
+            .unwrap_or_else(|| panic!("{name} declared"))
+    };
+    assert_eq!(
+        region("sources").admission,
+        crate::region::Admission::Reject,
+        "the setting is read"
+    );
+    assert_eq!(
+        region("scratch").admission,
+        crate::region::Admission::Evict,
+        "and its other value"
+    );
+    assert_eq!(
+        region("notes").admission,
+        crate::region::Admission::Evict,
+        "and absence means the behaviour every region had before"
+    );
+
+    let bad = r#"
+[agent]
+name = "curator"
+
+[context.regions]
+sources = { kind = "temporary", max_tokens = 100, admission = "rejcet" }
+"#;
+    let err = parse_manifest(bad).expect_err("an unknown value is refused");
+    let message = err.to_string();
+    assert!(message.contains("sources"), "{message}");
+    assert!(
+        message.contains("rejcet"),
+        "names what was written: {message}"
+    );
+    assert!(message.contains("reject"), "and what was meant: {message}");
+}
+
 /// A region definition written before this field existed deserializes as
 /// summarizable, so an archived layout does not come back protected by
 /// accident - or, worse, unprotected when it was not.

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -456,7 +456,39 @@ pub struct Region {
     /// and kind cannot tell a transcript from a table of results (#369).
     #[serde(default = "crate::region::default_true")]
     pub summarizable: bool,
+
+    /// What this region does when a write does not fit. See [`Admission`].
+    #[serde(default)]
+    pub admission: Admission,
 }
+
+/// What a region does when a write does not fit.
+///
+/// The default is what every region did before this existed: make room. That
+/// is the right behaviour for a transcript, where the oldest turn is the least
+/// useful thing present and losing it costs nothing anyone will notice.
+///
+/// It is the wrong behaviour for a region holding material the agent chose to
+/// keep. There, silently dropping the oldest entry is a decision about what
+/// matters, taken by whichever write happened to arrive when the region was
+/// full - and the agent never learns it happened. [`Admission::Reject`] hands
+/// that decision back: the write fails, the agent is told the region is full,
+/// and it releases what it is finished with before adding more.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Admission {
+    /// Make room for the write - roll off the oldest entry, or let the
+    /// window-level cascade reclaim the region.
+    #[default]
+    Evict,
+    /// Refuse the write and say so. Nothing already in the region is lost to a
+    /// write the agent did not know would displace it.
+    Reject,
+}
+
+mod schema;
+
+pub use schema::{ContentFormat, RegionSchema, Validator};
 
 /// Serde default for a flag that is on unless a blueprint turns it off.
 pub(crate) fn default_true() -> bool {
@@ -476,6 +508,7 @@ impl Region {
             taint: None,
             needs_message_compaction: false,
             summarizable: true,
+            admission: Admission::default(),
         }
     }
 
@@ -516,14 +549,37 @@ impl Region {
         metadata: Option<serde_json::Value>,
         kind: EntryKind,
         taint_level: crate::taint::TaintLevel,
+        key: Option<&str>,
     ) -> crate::error::Result<()> {
         if let Some(schema) = &self.schema {
             schema.validate(&content)?;
         }
 
         if self.current_tokens + tokens > self.max_tokens {
+            // Which failure this is depends on whether anything would have been
+            // dropped to fit. A region that never evicts reports being full,
+            // because "release something" is advice the agent can act on;
+            // reporting the budget would invite it to retry a smaller write
+            // into a region that is not going to take one.
+            if self.admission == Admission::Reject && !self.content.is_empty() {
+                return Err(crate::error::Error::RegionFull {
+                    region: self.name.clone(),
+                    used: self.current_tokens,
+                    max: self.max_tokens,
+                });
+            }
             return Err(crate::error::Error::TokenBudgetExceeded {
                 used: self.current_tokens + tokens,
+                max: self.max_tokens,
+            });
+        }
+        // Checked before the push, not after: `enforce_sliding_window` runs on
+        // the way out and would already have dropped the oldest entry by the
+        // time anything could refuse.
+        if self.admission == Admission::Reject && self.would_roll_off() {
+            return Err(crate::error::Error::RegionFull {
+                region: self.name.clone(),
+                used: self.current_tokens,
                 max: self.max_tokens,
             });
         }
@@ -534,7 +590,7 @@ impl Region {
             timestamp: chrono::Utc::now().timestamp(),
             metadata,
             kind,
-            key: None,
+            key: key.map(str::to_string),
         });
         self.current_tokens += tokens;
 
@@ -550,6 +606,64 @@ impl Region {
         Ok(())
     }
 
+    /// Whether one more entry would push a sliding window past its item cap.
+    ///
+    /// Only sliding windows roll off by count; every other kind is bounded by
+    /// tokens alone and is answered by the budget check above.
+    fn would_roll_off(&self) -> bool {
+        match &self.kind {
+            RegionKind::SlidingWindow { max_items, .. } => self.content.len() + 1 > *max_items,
+            _ => false,
+        }
+    }
+
+    /// Add an entry under `key`, so the agent can name it again to release it.
+    ///
+    /// Distinct from [`upsert_by_key`](Self::upsert_by_key), which replaces:
+    /// appending two sources under one key should keep both halves, the way an
+    /// unkeyed append keeps everything appended before it.
+    pub fn add_keyed_entry(
+        &mut self,
+        key: &str,
+        content: String,
+        tokens: usize,
+    ) -> crate::error::Result<()> {
+        self.push_entry(
+            content,
+            tokens,
+            None,
+            EntryKind::default(),
+            crate::taint::TaintLevel::Public,
+            Some(key),
+        )
+    }
+
+    /// Remove the entry at `index`, counting from the oldest. Returns whether
+    /// there was one.
+    ///
+    /// The companion to keys, for entries that never had one: an agent that has
+    /// just listed a region can name a position in what it read back.
+    pub fn remove_at(&mut self, index: usize) -> bool {
+        if index >= self.content.len() {
+            return false;
+        }
+        let entry = self.content.remove(index);
+        self.current_tokens = self.current_tokens.saturating_sub(entry.tokens);
+        true
+    }
+
+    /// Drop the `n` oldest entries, returning how many were actually removed.
+    ///
+    /// Fewer than `n` when the region holds fewer, which is not an error: the
+    /// agent asked for room and got as much as there was.
+    pub fn release_oldest(&mut self, n: usize) -> usize {
+        let count = n.min(self.content.len());
+        for _ in 0..count {
+            self.remove_oldest();
+        }
+        count
+    }
+
     /// Add an entry with a taint level. Used when taint tracking is enabled.
     pub fn add_tainted_entry(
         &mut self,
@@ -557,7 +671,14 @@ impl Region {
         tokens: usize,
         taint_level: crate::taint::TaintLevel,
     ) -> crate::error::Result<()> {
-        self.push_entry(content, tokens, None, EntryKind::default(), taint_level)
+        self.push_entry(
+            content,
+            tokens,
+            None,
+            EntryKind::default(),
+            taint_level,
+            None,
+        )
     }
 
     /// Add a typed entry with a taint level.
@@ -575,7 +696,7 @@ impl Region {
         kind: EntryKind,
         taint_level: crate::taint::TaintLevel,
     ) -> crate::error::Result<()> {
-        self.push_entry(content, tokens, None, kind, taint_level)
+        self.push_entry(content, tokens, None, kind, taint_level, None)
     }
 
     /// Add a validation schema to this region.
@@ -595,6 +716,7 @@ impl Region {
             None,
             EntryKind::default(),
             crate::taint::TaintLevel::Public,
+            None,
         )
     }
 
@@ -611,6 +733,7 @@ impl Region {
             Some(metadata),
             EntryKind::default(),
             crate::taint::TaintLevel::Public,
+            None,
         )
     }
 
@@ -631,6 +754,7 @@ impl Region {
             None,
             kind,
             crate::taint::TaintLevel::Public,
+            None,
         )
     }
 
@@ -963,136 +1087,6 @@ pub struct RegionEntry {
 
 /// Validation schema for a region's content.
 ///
-/// Enforces that content matches expected format (e.g., mermaid diagrams only,
-/// JSON only, code only). Schemas can include multiple validators that are
-/// checked when content is added to a region.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct RegionSchema {
-    /// Expected content format
-    pub format: ContentFormat,
-
-    /// Optional custom validation script (Rhai)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub custom_script: Option<String>,
-}
-
-impl Clone for RegionSchema {
-    fn clone(&self) -> Self {
-        Self {
-            format: self.format.clone(),
-            custom_script: self.custom_script.clone(),
-        }
-    }
-}
-
-impl RegionSchema {
-    /// Create a new schema with the specified format.
-    pub fn new(format: ContentFormat) -> Self {
-        Self {
-            format,
-            custom_script: None,
-        }
-    }
-
-    /// Add a custom validation script.
-    pub fn with_custom_script(mut self, script: String) -> Self {
-        self.custom_script = Some(script);
-        self
-    }
-
-    /// Validate content against this schema.
-    pub fn validate(&self, content: &str) -> crate::error::Result<()> {
-        match &self.format {
-            ContentFormat::Json => {
-                serde_json::from_str::<serde_json::Value>(content).map_err(|e| {
-                    crate::error::Error::ValidationFailed(format!("Invalid JSON: {}", e))
-                })?;
-            }
-            ContentFormat::Mermaid => {
-                // Basic mermaid syntax validation
-                if !content.contains("graph")
-                    && !content.contains("sequenceDiagram")
-                    && !content.contains("classDiagram")
-                    && !content.contains("stateDiagram")
-                    && !content.contains("erDiagram")
-                    && !content.contains("journey")
-                    && !content.contains("gantt")
-                    && !content.contains("pie")
-                    && !content.contains("flowchart")
-                {
-                    return Err(crate::error::Error::ValidationFailed(
-                        "Mermaid diagrams must contain a valid diagram type (graph, sequenceDiagram, etc.)".to_string()
-                    ));
-                }
-            }
-            ContentFormat::Code { .. } => {
-                // Basic code validation - just check it's not empty
-                if content.trim().is_empty() {
-                    return Err(crate::error::Error::ValidationFailed(
-                        "Code cannot be empty".to_string(),
-                    ));
-                }
-            }
-            ContentFormat::Markdown => {
-                // Markdown is very permissive, just check it's not empty
-                if content.trim().is_empty() {
-                    return Err(crate::error::Error::ValidationFailed(
-                        "Markdown content cannot be empty".to_string(),
-                    ));
-                }
-            }
-            ContentFormat::Text | ContentFormat::Custom { .. } => {
-                // Text has no restrictions, Custom is handled by scripting layer
-            }
-        }
-
-        Ok(())
-    }
-}
-
-/// Content format types that can be enforced via schemas.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub enum ContentFormat {
-    /// Plain text, no formatting requirements
-    Text,
-
-    /// Valid JSON
-    Json,
-
-    /// Mermaid diagram syntax
-    Mermaid,
-
-    /// Source code in a specific language
-    Code {
-        /// The language label, used for the fence and nothing else - no
-        /// per-language parsing happens.
-        language: String,
-    },
-
-    /// Markdown formatted text
-    Markdown,
-
-    /// Custom format with user-defined validation
-    Custom {
-        /// The author's own name for the format, matched against the validator
-        /// registered for it.
-        format_name: String,
-    },
-}
-
-/// Trait for content validators.
-///
-/// Validators check whether content meets specific requirements before
-/// it's added to a region. This enables enforcing architectural constraints
-/// like "only mermaid diagrams in the architecture region".
-pub trait Validator: Send + Sync {
-    /// Validate content and return an error message if invalid.
-    fn validate(&self, content: &str) -> std::result::Result<(), crate::error::ValidationError>;
-
-    /// Get a description of what this validator checks.
-    fn description(&self) -> &str;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3342,5 +3336,175 @@ mod tests {
         region.evict_lru_entry();
         assert_eq!(region.entry_count(), 0);
         assert_eq!(region.current_tokens, 0);
+    }
+
+    /// Keys used to be a HashMap-only idea at the tool layer. The region API
+    /// never cared, so an entry on any kind can carry one - which is what makes
+    /// `context_delete` work on a sources region.
+    #[test]
+    fn a_keyed_entry_can_be_added_to_any_region_kind_and_found_again() {
+        for kind in [
+            RegionKind::Temporary,
+            RegionKind::Clearable,
+            RegionKind::Pinned,
+        ] {
+            let mut region = Region::new("r".to_string(), kind.clone(), 1000);
+            region
+                .add_keyed_entry("doc", "body".to_string(), 10)
+                .unwrap();
+            assert_eq!(
+                region.get_by_key("doc").map(|e| e.content.as_str()),
+                Some("body"),
+                "{kind:?}"
+            );
+            assert!(region.remove_by_key("doc"), "{kind:?}");
+            assert_eq!(region.current_tokens, 0, "{kind:?}");
+        }
+    }
+
+    /// Appending the same key twice keeps both, unlike `upsert_by_key`. Two
+    /// halves of one source are still both wanted; an append that quietly
+    /// replaced the first half would lose content the agent had gathered.
+    #[test]
+    fn appending_under_one_key_twice_keeps_both_entries() {
+        let mut region = Region::new("r".to_string(), RegionKind::Temporary, 1000);
+        region
+            .add_keyed_entry("doc", "first".to_string(), 5)
+            .unwrap();
+        region
+            .add_keyed_entry("doc", "second".to_string(), 5)
+            .unwrap();
+        assert_eq!(region.content.len(), 2);
+        assert_eq!(region.current_tokens, 10);
+    }
+
+    /// A refused write leaves nothing behind - notably no half-added entry
+    /// waiting to be given a key.
+    #[test]
+    fn a_refused_keyed_write_adds_nothing() {
+        let mut region = Region::new("r".to_string(), RegionKind::Temporary, 10);
+        assert!(
+            region
+                .add_keyed_entry("doc", "too big".to_string(), 99)
+                .is_err()
+        );
+        assert!(region.content.is_empty());
+        assert_eq!(region.current_tokens, 0);
+    }
+
+    /// Releasing by position, including the out-of-range answer an agent gets
+    /// when it names one that is not there.
+    #[test]
+    fn remove_at_releases_by_position_and_reports_a_miss() {
+        let mut region = Region::new("r".to_string(), RegionKind::Temporary, 1000);
+        for text in ["a", "b", "c"] {
+            region.add_entry(text.to_string(), 5).unwrap();
+        }
+        assert!(region.remove_at(1));
+        assert_eq!(region.current_tokens, 10);
+        let left: Vec<_> = region.content.iter().map(|e| e.content.as_str()).collect();
+        assert_eq!(left, vec!["a", "c"]);
+
+        assert!(!region.remove_at(9), "nothing at that position");
+        assert_eq!(region.content.len(), 2, "a miss changes nothing");
+    }
+
+    /// Asking for more than the region holds is not an error: the agent wanted
+    /// room and got as much as there was.
+    #[test]
+    fn release_oldest_takes_what_it_can_and_says_how_much() {
+        let mut region = Region::new("r".to_string(), RegionKind::Temporary, 1000);
+        for text in ["a", "b", "c"] {
+            region.add_entry(text.to_string(), 5).unwrap();
+        }
+        assert_eq!(region.release_oldest(2), 2);
+        assert_eq!(
+            region.content.first().map(|e| e.content.as_str()),
+            Some("c"),
+            "the oldest two went"
+        );
+        assert_eq!(region.release_oldest(10), 1, "only one was left");
+        assert_eq!(region.release_oldest(3), 0, "and now none");
+        assert_eq!(region.current_tokens, 0);
+    }
+
+    /// The two refusals a `reject` region can give, and the distinction between
+    /// them. An empty region reports the budget, because "release something"
+    /// would be advice with nothing to act on - the write is simply too big.
+    #[test]
+    fn a_reject_region_distinguishes_being_full_from_an_oversized_write() {
+        let mut region = Region::new("r".to_string(), RegionKind::Temporary, 100);
+        region.admission = Admission::Reject;
+
+        // Asserted through the message rather than the variant, because the
+        // message is what reaches the agent - and it carries the region, the
+        // usage and the ceiling, so it pins the payload too.
+        //
+        // Empty: nothing to release, so this is a budget problem.
+        let err = region
+            .add_entry("huge".to_string(), 500)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("exceeds token budget"), "{err}");
+
+        region.add_entry("fits".to_string(), 90).unwrap();
+        let err = region
+            .add_entry("more".to_string(), 50)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Region 'r' is full"), "{err}");
+        assert!(err.contains("90/100 tokens"), "{err}");
+        assert!(err.contains("release an entry"), "says what to do: {err}");
+    }
+
+    /// The count-based half: a sliding window under `reject` refuses rather
+    /// than rolling the oldest entry off. Checked before the push, because
+    /// `enforce_sliding_window` runs on the way out and would already have
+    /// dropped it.
+    #[test]
+    fn a_reject_sliding_window_refuses_rather_than_rolling_off() {
+        let mut region = Region::new(
+            "r".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 2,
+                eviction_strategy: EvictionStrategy::PerItem,
+            },
+            1000,
+        );
+        region.admission = Admission::Reject;
+        region.add_entry("one".to_string(), 5).unwrap();
+        region.add_entry("two".to_string(), 5).unwrap();
+
+        let err = region
+            .add_entry("three".to_string(), 5)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is full"), "{err}");
+        assert_eq!(region.content.len(), 2);
+        assert_eq!(
+            region.content.first().map(|e| e.content.as_str()),
+            Some("one"),
+            "the oldest survived"
+        );
+
+        // The same window under the default still rolls off, which is what
+        // every existing blueprint depends on.
+        let mut evicting = Region::new(
+            "r".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 2,
+                eviction_strategy: EvictionStrategy::PerItem,
+            },
+            1000,
+        );
+        for text in ["one", "two", "three"] {
+            evicting.add_entry(text.to_string(), 5).unwrap();
+        }
+        assert_eq!(evicting.content.len(), 2);
+        assert_eq!(
+            evicting.content.first().map(|e| e.content.as_str()),
+            Some("two"),
+            "the oldest rolled off as it always did"
+        );
     }
 }

--- a/crates/leviath-core/src/region/schema.rs
+++ b/crates/leviath-core/src/region/schema.rs
@@ -1,0 +1,137 @@
+//! What a region will accept: content-format schemas and their validators.
+//!
+//! Split out of `region.rs` because it is a separate question from how a region
+//! holds and evicts entries - this decides whether a write is well-formed at
+//! all, before any of that applies.
+
+use serde::{Deserialize, Serialize};
+
+/// Enforces that content matches expected format (e.g., mermaid diagrams only,
+/// JSON only, code only). Schemas can include multiple validators that are
+/// checked when content is added to a region.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegionSchema {
+    /// Expected content format
+    pub format: ContentFormat,
+
+    /// Optional custom validation script (Rhai)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub custom_script: Option<String>,
+}
+
+impl Clone for RegionSchema {
+    fn clone(&self) -> Self {
+        Self {
+            format: self.format.clone(),
+            custom_script: self.custom_script.clone(),
+        }
+    }
+}
+
+impl RegionSchema {
+    /// Create a new schema with the specified format.
+    pub fn new(format: ContentFormat) -> Self {
+        Self {
+            format,
+            custom_script: None,
+        }
+    }
+
+    /// Add a custom validation script.
+    pub fn with_custom_script(mut self, script: String) -> Self {
+        self.custom_script = Some(script);
+        self
+    }
+
+    /// Validate content against this schema.
+    pub fn validate(&self, content: &str) -> crate::error::Result<()> {
+        match &self.format {
+            ContentFormat::Json => {
+                serde_json::from_str::<serde_json::Value>(content).map_err(|e| {
+                    crate::error::Error::ValidationFailed(format!("Invalid JSON: {}", e))
+                })?;
+            }
+            ContentFormat::Mermaid => {
+                // Basic mermaid syntax validation
+                if !content.contains("graph")
+                    && !content.contains("sequenceDiagram")
+                    && !content.contains("classDiagram")
+                    && !content.contains("stateDiagram")
+                    && !content.contains("erDiagram")
+                    && !content.contains("journey")
+                    && !content.contains("gantt")
+                    && !content.contains("pie")
+                    && !content.contains("flowchart")
+                {
+                    return Err(crate::error::Error::ValidationFailed(
+                        "Mermaid diagrams must contain a valid diagram type (graph, sequenceDiagram, etc.)".to_string()
+                    ));
+                }
+            }
+            ContentFormat::Code { .. } => {
+                // Basic code validation - just check it's not empty
+                if content.trim().is_empty() {
+                    return Err(crate::error::Error::ValidationFailed(
+                        "Code cannot be empty".to_string(),
+                    ));
+                }
+            }
+            ContentFormat::Markdown => {
+                // Markdown is very permissive, just check it's not empty
+                if content.trim().is_empty() {
+                    return Err(crate::error::Error::ValidationFailed(
+                        "Markdown content cannot be empty".to_string(),
+                    ));
+                }
+            }
+            ContentFormat::Text | ContentFormat::Custom { .. } => {
+                // Text has no restrictions, Custom is handled by scripting layer
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Content format types that can be enforced via schemas.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum ContentFormat {
+    /// Plain text, no formatting requirements
+    Text,
+
+    /// Valid JSON
+    Json,
+
+    /// Mermaid diagram syntax
+    Mermaid,
+
+    /// Source code in a specific language
+    Code {
+        /// The language label, used for the fence and nothing else - no
+        /// per-language parsing happens.
+        language: String,
+    },
+
+    /// Markdown formatted text
+    Markdown,
+
+    /// Custom format with user-defined validation
+    Custom {
+        /// The author's own name for the format, matched against the validator
+        /// registered for it.
+        format_name: String,
+    },
+}
+
+/// Trait for content validators.
+///
+/// Validators check whether content meets specific requirements before
+/// it's added to a region. This enables enforcing architectural constraints
+/// like "only mermaid diagrams in the architecture region".
+pub trait Validator: Send + Sync {
+    /// Validate content and return an error message if invalid.
+    fn validate(&self, content: &str) -> std::result::Result<(), crate::error::ValidationError>;
+
+    /// Get a description of what this validator checks.
+    fn description(&self) -> &str;
+}

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -324,13 +324,32 @@ impl ContextWindow {
         content: String,
         tokens: usize,
     ) -> leviath_core::Result<()> {
+        self.add_to_region_keyed(region_name, None, content, tokens)
+    }
+
+    /// Add an entry that may carry a key, so the agent can name it again to
+    /// release it.
+    ///
+    /// Routed through the same private `write_to_region` tail
+    /// as the unkeyed path, so a keyed write still passes the region's
+    /// `on_write` hook and still gets `on_overflow` a chance to make room.
+    /// Writing keys through a shortcut instead is how they came to be honoured
+    /// on one region kind and dropped on the rest.
+    pub fn add_to_region_keyed(
+        &mut self,
+        region_name: &str,
+        key: Option<&str>,
+        content: String,
+        tokens: usize,
+    ) -> leviath_core::Result<()> {
         let Some((content, tokens)) =
             self.on_write_outcome(region_name, content, tokens, &leviath_core::EntryKind::Text)
         else {
             return Ok(()); // the region's script dropped the entry
         };
-        self.write_to_region(region_name, tokens, &mut |region, tokens| {
-            region.add_entry(content.clone(), tokens)
+        self.write_to_region(region_name, tokens, &mut |region, tokens| match key {
+            Some(k) => region.add_keyed_entry(k, content.clone(), tokens),
+            None => region.add_entry(content.clone(), tokens),
         })
     }
 
@@ -433,18 +452,26 @@ impl ContextWindow {
 
         let initial_tokens = self.current_tokens;
 
+        // A region under `admission = "reject"` is exempt from every phase
+        // below. Refusing writes to protect what a region holds would mean
+        // nothing if the window-level cascade could take the same entries a
+        // moment later - `reject` would only change which code did the silent
+        // dropping. The agent releases from these, or nothing does.
+        let evictable = |r: &Region| {
+            r.admission != leviath_core::region::Admission::Reject
+                && matches!(
+                    r.kind,
+                    RegionKind::Clearable
+                        | RegionKind::Temporary
+                        | RegionKind::Custom {
+                            persistent: false,
+                            ..
+                        }
+                )
+        };
+
         // Check if we have any evictable regions
-        let has_evictable = self.regions.iter().any(|r| {
-            matches!(
-                r.kind,
-                RegionKind::Clearable
-                    | RegionKind::Temporary
-                    | RegionKind::Custom {
-                        persistent: false,
-                        ..
-                    }
-            )
-        });
+        let has_evictable = self.regions.iter().any(evictable);
 
         if !has_evictable {
             tracing::warn!(
@@ -455,7 +482,10 @@ impl ContextWindow {
 
         // Phase 1: Clear Clearable regions (all-or-nothing)
         for region in &mut self.regions {
-            if matches!(region.kind, RegionKind::Clearable) && !region.content.is_empty() {
+            if matches!(region.kind, RegionKind::Clearable)
+                && region.admission != leviath_core::region::Admission::Reject
+                && !region.content.is_empty()
+            {
                 let freed = region.current_tokens;
                 region.clear();
                 self.current_tokens -= freed;
@@ -494,7 +524,8 @@ impl ContextWindow {
                     persistent: false,
                     ..
                 }
-            ) || region.content.is_empty()
+            ) || region.admission == leviath_core::region::Admission::Reject
+                || region.content.is_empty()
             {
                 continue;
             }
@@ -544,7 +575,8 @@ impl ContextWindow {
                             persistent: false,
                             ..
                         }
-                ) && let Some(entry) = region.remove_oldest()
+                ) && region.admission != leviath_core::region::Admission::Reject
+                    && let Some(entry) = region.remove_oldest()
                 {
                     let freed = entry.tokens;
                     self.current_tokens -= freed;

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -31,6 +31,7 @@ pub fn init_window_seeded(
             region_def.max_tokens,
         );
         region.summarizable = region_def.summarizable;
+        region.admission = region_def.admission;
         window.add_region(region);
     }
 
@@ -162,6 +163,7 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
             region_def.max_tokens,
         );
         new_region.summarizable = region_def.summarizable;
+        new_region.admission = region_def.admission;
 
         if let Some(existing) = window.get_region(&region_def.name) {
             // Carry entries verbatim - kind, metadata, key, timestamp survive
@@ -219,6 +221,7 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
             existing.max_tokens,
         );
         carried.summarizable = existing.summarizable;
+        carried.admission = existing.admission;
         // Verbatim, exactly as above: these are the regions whose typed turns
         // a rebuild would flatten.
         for entry in &existing.content {

--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -145,8 +145,11 @@ pub fn handle_context_tool(
                 // so a custom region's on_write hook sees the write.
                 region.clear();
                 window.current_tokens = window.calculate_tokens();
-                match window.add_to_region(region_name, content.to_string(), tokens) {
-                    Ok(()) => format!("Stored in '{region_name}' section."),
+                match window.add_to_region_keyed(region_name, key, content.to_string(), tokens) {
+                    Ok(()) => match key {
+                        Some(k) => format!("Stored in '{region_name}' section under key '{k}'."),
+                        None => format!("Stored in '{region_name}' section."),
+                    },
                     Err(e) => format!("[error] {e}"),
                 }
             }
@@ -189,9 +192,17 @@ pub fn handle_context_tool(
                     }
                 }
             } else {
-                // Same routing rationale as context_write above.
-                match window.add_to_region(region_name, content.to_string(), tokens) {
-                    Ok(()) => format!("Appended to '{region_name}' section."),
+                // Same routing rationale as context_write above. The key is
+                // honoured here rather than dropped: it was accepted on every
+                // region kind and only ever stored on HashMap ones, so an agent
+                // could name an entry that `context_delete` could never find.
+                match window.add_to_region_keyed(region_name, key, content.to_string(), tokens) {
+                    Ok(()) => match key {
+                        Some(k) => {
+                            format!("Appended to '{region_name}' section under key '{k}'.")
+                        }
+                        None => format!("Appended to '{region_name}' section."),
+                    },
                     Err(e) => format!("[error] {e}"),
                 }
             }
@@ -244,18 +255,49 @@ pub fn handle_context_tool(
             let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
                 return "[error] missing 'region' argument".to_string();
             };
-            let Some(key) = args.get("key").and_then(|v| v.as_str()) else {
-                return "[error] missing 'key' argument".to_string();
-            };
             if window.get_region(region_name).is_none() {
                 return region_not_found(region_name, window);
             }
+            let key = args.get("key").and_then(|v| v.as_str());
+            let index = args.get("index").and_then(serde_json::Value::as_u64);
+            let oldest = args.get("oldest").and_then(serde_json::Value::as_u64);
             let region = window.get_region_mut(region_name).expect("region present");
-            if region.remove_by_key(key) {
-                format!("Removed '{key}' from '{region_name}' section.")
-            } else {
-                format!("[not found] No entry with key '{key}' in region '{region_name}'")
-            }
+            // One selector at a time, checked in the order an agent is most
+            // likely to have meant. Naming none of them is the interesting
+            // error: "delete from this region" without saying what would have
+            // to guess, and guessing here destroys something.
+            let result = match (key, index, oldest) {
+                (Some(k), _, _) => {
+                    if region.remove_by_key(k) {
+                        format!("Released '{k}' from '{region_name}'.")
+                    } else {
+                        format!("[not found] No entry with key '{k}' in region '{region_name}'")
+                    }
+                }
+                (None, Some(i), _) => {
+                    let at = usize::try_from(i).unwrap_or(usize::MAX);
+                    if region.remove_at(at) {
+                        format!("Released entry {at} from '{region_name}'.")
+                    } else {
+                        format!(
+                            "[not found] Region '{}' has {} entries, so there is none at {}",
+                            region_name,
+                            region.content.len(),
+                            at
+                        )
+                    }
+                }
+                (None, None, Some(n)) => {
+                    let want = usize::try_from(n).unwrap_or(usize::MAX);
+                    let freed = region.release_oldest(want);
+                    format!("Released the {freed} oldest entries from '{region_name}'.")
+                }
+                (None, None, None) => {
+                    "[error] name what to release: 'key', 'index', or 'oldest'".to_string()
+                }
+            };
+            window.current_tokens = window.calculate_tokens();
+            result
         }
         "context_list" => {
             let region_name = args.get("region").and_then(|v| v.as_str());
@@ -264,11 +306,14 @@ pub fn handle_context_tool(
                     Some(r) => r,
                     None => return region_not_found(rname, window),
                 };
+                // Numbered, because the index is how an unkeyed entry is named
+                // to `context_delete`. Listing entries the agent then cannot
+                // refer to is what made release a keyed-only feature.
                 let mut lines = Vec::new();
-                for entry in &region.content {
+                for (i, entry) in region.content.iter().enumerate() {
                     match &entry.key {
-                        Some(k) => lines.push(format!("  {} ({} tokens)", k, entry.tokens)),
-                        None => lines.push(format!("  (entry, {} tokens)", entry.tokens)),
+                        Some(k) => lines.push(format!("  [{}] {} ({} tokens)", i, k, entry.tokens)),
+                        None => lines.push(format!("  [{}] ({} tokens)", i, entry.tokens)),
                     }
                 }
                 if lines.is_empty() {
@@ -765,8 +810,11 @@ mod tests {
     fn delete_branches() {
         let mut w = win();
         assert!(call(&mut w, "context_delete", json!({})).contains("missing 'region'"));
+        // Naming a region but nothing in it is the one case worth refusing:
+        // guessing what to release destroys something.
         assert!(
-            call(&mut w, "context_delete", json!({"region": "files"})).contains("missing 'key'")
+            call(&mut w, "context_delete", json!({"region": "files"}))
+                .contains("name what to release")
         );
         assert!(
             call(
@@ -797,7 +845,7 @@ mod tests {
                 "context_delete",
                 json!({"region": "files", "key": "k"})
             )
-            .contains("Removed 'k'")
+            .contains("Released 'k'")
         );
     }
 
@@ -815,13 +863,14 @@ mod tests {
             "context_write",
             json!({"region": "notes", "content": "n"}),
         );
-        assert!(call(&mut w, "context_list", json!({"region": "notes"})).contains("(entry,"));
+        // Numbered so the entry can be named back to context_delete.
+        assert!(call(&mut w, "context_list", json!({"region": "notes"})).contains("[0] ("));
         call(
             &mut w,
             "context_write",
             json!({"region": "files", "content": "c", "key": "a.rs"}),
         );
-        assert!(call(&mut w, "context_list", json!({"region": "files"})).contains("a.rs ("));
+        assert!(call(&mut w, "context_list", json!({"region": "files"})).contains("[0] a.rs ("));
 
         // All regions - covers every kind's label.
         let all = call(&mut w, "context_list", json!({}));
@@ -867,5 +916,245 @@ mod tests {
     fn unknown_tool_errors() {
         let mut w = win();
         assert!(call(&mut w, "context_frobnicate", json!({})).contains("Unknown context tool"));
+    }
+
+    /// The bug under the feature request. `key` was accepted on every region
+    /// and stored on HashMap ones only, so an agent could name an entry on a
+    /// `temporary` region - exactly the kind holding fetched sources - and then
+    /// never be able to release it.
+    #[test]
+    fn a_key_on_an_ordinary_region_can_be_used_to_release_the_entry() {
+        let mut w = win();
+        call(
+            &mut w,
+            "context_append",
+            json!({"region": "notes", "key": "rfc-9110", "content": "the raw spec text"}),
+        );
+        call(
+            &mut w,
+            "context_append",
+            json!({"region": "notes", "key": "blog", "content": "a second source"}),
+        );
+
+        let listed = call(&mut w, "context_list", json!({"region": "notes"}));
+        assert!(listed.contains("rfc-9110"), "{listed}");
+
+        let released = call(
+            &mut w,
+            "context_delete",
+            json!({"region": "notes", "key": "rfc-9110"}),
+        );
+        assert!(released.contains("Released 'rfc-9110'"), "{released}");
+        let after = call(&mut w, "context_list", json!({"region": "notes"}));
+        assert!(!after.contains("rfc-9110"), "{after}");
+        assert!(
+            after.contains("blog"),
+            "the other source is untouched: {after}"
+        );
+    }
+
+    /// `context_write` replaces a region's content, and a key given with it
+    /// names the replacement - so the entry a stage rewrites each pass can
+    /// still be released by name.
+    #[test]
+    fn context_write_names_its_entry_when_given_a_key() {
+        let mut w = win();
+        let out = call(
+            &mut w,
+            "context_write",
+            json!({"region": "notes", "key": "plan", "content": "v1"}),
+        );
+        assert!(out.contains("under key 'plan'"), "{out}");
+
+        // Rewriting replaces, and the key still finds it.
+        call(
+            &mut w,
+            "context_write",
+            json!({"region": "notes", "key": "plan", "content": "v2"}),
+        );
+        assert_eq!(w.get_region("notes").unwrap().content.len(), 1);
+        let released = call(
+            &mut w,
+            "context_delete",
+            json!({"region": "notes", "key": "plan"}),
+        );
+        assert!(released.contains("Released 'plan'"), "{released}");
+    }
+
+    /// Releasing an entry has to return its tokens, or "release something to
+    /// make room" is advice that does not work.
+    #[test]
+    fn releasing_an_entry_frees_its_tokens() {
+        let mut w = win();
+        call(
+            &mut w,
+            "context_append",
+            json!({"region": "notes", "key": "big", "content": "x".repeat(400)}),
+        );
+        let held = w.get_region("notes").unwrap().current_tokens;
+        assert!(held > 0);
+        let before_window = w.current_tokens;
+
+        call(
+            &mut w,
+            "context_delete",
+            json!({"region": "notes", "key": "big"}),
+        );
+
+        assert_eq!(w.get_region("notes").unwrap().current_tokens, 0);
+        assert!(w.current_tokens < before_window, "the window recounted");
+    }
+
+    /// Not everything the agent wants to release was written with a key -
+    /// tool output and seeded material arrive unkeyed. The position shown by
+    /// `context_list` is how those are named.
+    #[test]
+    fn an_unkeyed_entry_can_be_released_by_position_or_by_age() {
+        let mut w = win();
+        for text in ["first", "second", "third"] {
+            call(
+                &mut w,
+                "context_append",
+                json!({"region": "notes", "content": text}),
+            );
+        }
+
+        let out = call(
+            &mut w,
+            "context_delete",
+            json!({"region": "notes", "index": 1}),
+        );
+        assert!(out.contains("Released entry 1"), "{out}");
+        let listed = call(&mut w, "context_read", json!({"region": "notes"}));
+        assert!(!listed.contains("second"), "{listed}");
+        assert!(
+            listed.contains("first") && listed.contains("third"),
+            "{listed}"
+        );
+
+        let out = call(
+            &mut w,
+            "context_delete",
+            json!({"region": "notes", "oldest": 5}),
+        );
+        assert!(
+            out.contains("Released the 2 oldest"),
+            "asked for 5, had 2: {out}"
+        );
+        assert_eq!(w.get_region("notes").unwrap().content.len(), 0);
+    }
+
+    /// An index past the end names nothing. Reported rather than silently
+    /// ignored, so the agent does not believe it released something.
+    #[test]
+    fn releasing_a_position_that_does_not_exist_says_so() {
+        let mut w = win();
+        call(
+            &mut w,
+            "context_append",
+            json!({"region": "notes", "content": "only one"}),
+        );
+        let out = call(
+            &mut w,
+            "context_delete",
+            json!({"region": "notes", "index": 7}),
+        );
+        assert!(out.contains("[not found]"), "{out}");
+        assert!(
+            out.contains("1 entries"),
+            "says what is actually there: {out}"
+        );
+        assert_eq!(w.get_region("notes").unwrap().content.len(), 1);
+    }
+
+    /// The point of admission control: a full region refuses the write and says
+    /// what to do, instead of dropping whichever entry happened to be oldest.
+    /// The agent finds out, which under eviction it never did.
+    #[test]
+    fn a_reject_region_refuses_a_write_instead_of_dropping_something() {
+        let mut w = win();
+        let mut region = Region::new("curated".to_string(), RegionKind::Temporary, 200);
+        region.admission = leviath_core::region::Admission::Reject;
+        w.add_region(region);
+
+        call(
+            &mut w,
+            "context_append",
+            json!({"region": "curated", "key": "kept", "content": "x".repeat(600)}),
+        );
+        let held = w.get_region("curated").unwrap().content.len();
+        assert_eq!(held, 1);
+
+        let refused = call(
+            &mut w,
+            "context_append",
+            json!({"region": "curated", "key": "extra", "content": "y".repeat(600)}),
+        );
+        assert!(refused.contains("[error]"), "{refused}");
+        assert!(refused.contains("full"), "{refused}");
+        assert!(
+            refused.contains("release an entry"),
+            "says what to do: {refused}"
+        );
+        // Nothing was displaced to make room.
+        assert_eq!(w.get_region("curated").unwrap().content.len(), 1);
+        assert!(
+            w.get_region("curated")
+                .unwrap()
+                .get_by_key("kept")
+                .is_some(),
+            "the earlier entry survived the refused write"
+        );
+
+        // Release, and the same write now fits: the loop the agent is meant to
+        // run closes.
+        call(
+            &mut w,
+            "context_delete",
+            json!({"region": "curated", "key": "kept"}),
+        );
+        let accepted = call(
+            &mut w,
+            "context_append",
+            json!({"region": "curated", "key": "extra", "content": "y".repeat(600)}),
+        );
+        assert!(!accepted.contains("[error]"), "{accepted}");
+    }
+
+    /// A sliding window under `reject` refuses rather than rolling off, which
+    /// is the count-based half of the same guarantee.
+    #[test]
+    fn a_reject_sliding_window_refuses_instead_of_rolling_off() {
+        let mut w = win();
+        let mut region = Region::new(
+            "recent".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 2,
+                eviction_strategy: EvictionStrategy::PerItem,
+            },
+            5000,
+        );
+        region.admission = leviath_core::region::Admission::Reject;
+        w.add_region(region);
+
+        for text in ["one", "two"] {
+            let out = call(
+                &mut w,
+                "context_append",
+                json!({"region": "recent", "content": text}),
+            );
+            assert!(!out.contains("[error]"), "{out}");
+        }
+        let refused = call(
+            &mut w,
+            "context_append",
+            json!({"region": "recent", "content": "three"}),
+        );
+        assert!(refused.contains("full"), "{refused}");
+        let held = call(&mut w, "context_read", json!({"region": "recent"}));
+        assert!(
+            held.contains("one"),
+            "the oldest was not rolled off: {held}"
+        );
     }
 }

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -342,7 +342,7 @@ impl BuiltinTools {
                         },
                         "key": {
                             "type": "string",
-                            "description": "Key for the entry"
+                            "description": "Optional name for this entry. Naming it lets you release it later with context_delete once you are done with it - worth doing for anything bulky you expect to finish with, like a fetched source you plan to distill."
                         },
                         "content": {
                             "type": "string",
@@ -372,7 +372,7 @@ impl BuiltinTools {
             },
             Tool {
                 name: "context_delete".to_string(),
-                description: "Remove a specific keyed entry from a section of your context window.".to_string(),
+                description: "Release an entry you are finished with from a section of your context window, freeing its tokens. Use this when you have distilled what matters out of something bulky and no longer need the original - a source you have summarized, a file you have extracted from. Name the entry by 'key' if you gave it one, by 'index' as shown in context_list, or drop the oldest few with 'oldest'.".to_string(),
                 parameters: json!({
                     "type": "object",
                     "properties": {
@@ -382,10 +382,18 @@ impl BuiltinTools {
                         },
                         "key": {
                             "type": "string",
-                            "description": "Key of the entry to remove"
+                            "description": "Key of the entry to release, if it has one"
+                        },
+                        "index": {
+                            "type": "integer",
+                            "description": "Position of the entry to release, counting from 0 as the oldest, as shown by context_list"
+                        },
+                        "oldest": {
+                            "type": "integer",
+                            "description": "Release this many of the oldest entries. Use when you need room and the oldest material is the least useful."
                         }
                     },
-                    "required": ["region", "key"]
+                    "required": ["region"]
                 }),
             },
             Tool {

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -160,6 +160,7 @@ and pass on the first attempt, which looks exactly like a stage that finished it
 | `seed` | unset | What the region starts with. See below |
 | `required` | `false` | The stage re-runs rather than moving on while this region is empty |
 | `summarizable` | `true` | Set false to keep an edge `transform = "compact"` from paraphrasing this region. See [transforms](/docs/stages#carrying-context-across-an-edge) |
+| `admission` | `"evict"` | What happens when a write does not fit. `"reject"` refuses it instead of dropping something. See [letting the agent decide what to forget](#letting-the-agent-decide-what-to-forget) |
 | `required_message` | generated | What the model is told when a required region is empty. Supports `{region}` |
 
 **Resolved budget** is the phrase used for the number a region actually gets, once the percentage
@@ -286,6 +287,54 @@ flowchart TD
   T -->|compacting / compact_history| S["Summarize into a compact form"]
   T -->|clearable / temporary| CL["Trimmed or cleared under budget pressure"]
 ```
+
+## Letting the agent decide what to forget
+
+Everything above is reactive: a region crosses a threshold and the runtime makes room. That is the
+right default, and it has a blind spot. The runtime knows sizes; only the agent knows when it is
+*done* with something. A gather stage that fetches a spec, pulls out the three paragraphs that
+matter and writes them to a curated region has no further use for the raw text - but the raw text
+sits there until pressure happens to push it out, or, with a generous budget, until the run ends.
+
+An agent can release an entry the moment it is spent:
+
+```
+context_delete { region: "sources", key: "rfc-9110" }
+context_delete { region: "sources", index: 2 }
+context_delete { region: "sources", oldest: 3 }
+```
+
+Name the entry by `key` if it was written with one, by `index` as shown in `context_list`, or ask
+for the oldest few. Releasing returns the tokens immediately.
+
+Giving an entry a key when you write it is what makes the first form possible:
+
+```
+context_append { region: "sources", key: "rfc-9110", content: "<the raw spec>" }
+```
+
+### Making the agent choose
+
+By default a full region evicts, and the agent is never told. For a region holding material the
+agent curated, that is the wrong trade: whichever write arrives when the region is full silently
+decides what was least important.
+
+`admission = "reject"` hands that decision back:
+
+```toml
+[context.regions]
+sources = { kind = "temporary", budget = "30%", admission = "reject" }
+```
+
+Now a write that does not fit fails, and the agent is told the region is full and to release
+something first. Nothing already in the region is lost to a write the agent did not know would
+displace it. A region set this way is also exempt from the window-level eviction cascade - otherwise
+`reject` would only change which code did the silent dropping.
+
+This turns memory management into an explicit decision: *you must choose what to forget before you
+can read more*. It is a better failure mode than a silent omission the agent never learns about, and
+it is a genuinely different memory discipline from mechanical eviction - worth reaching for when the
+region holds findings rather than transcript.
 
 ## Routing tool output
 

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -110,7 +110,7 @@ back into the system prompt on later turns.
 | `context_write` | Store or replace a keyed entry in a named section. | `region`, `content`, `key` (optional) |
 | `context_append` | Add to a section without replacing existing content. | `region`, `content`, `key` (optional) |
 | `context_read` | Read a section, or a specific keyed entry within it. | `region`, `key` (optional) |
-| `context_delete` | Remove a specific keyed entry from a section. | `region`, `key` |
+| `context_delete` | Release an entry the agent is finished with, freeing its tokens. See [letting the agent decide what to forget](/docs/context#letting-the-agent-decide-what-to-forget). | `region`, and one of `key` / `index` / `oldest` |
 | `context_list` | List sections with their token counts and entry counts. | `region` (optional) |
 | `todo_add` | Add an open item to a [checklist region](/docs/context#tracking-work-with-a-checklist), returning its id. | `region`, `item` |
 | `todo_done` | Tick a checklist item off. | `region`, `id` |

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -374,6 +374,7 @@
         "min_tokens": { "type": "integer", "minimum": 0 },
         "required": { "type": "boolean", "default": false },
           "summarizable": { "type": "boolean", "default": true, "description": "Set false to keep an edge transform = \"compact\" from handing this region to the summarizer. Protects the region wherever it is used, and wins over an explicit compact list." },
+        "admission": { "enum": ["evict", "reject"], "default": "evict", "description": "What the region does when a write does not fit. \"evict\" makes room by dropping the oldest entry; \"reject\" refuses the write and tells the agent to release something first, so nothing is discarded without the agent knowing." },
         "required_message": {
           "type": "string",
           "description": "Shown when a required region is empty. `{region}` interpolates."


### PR DESCRIPTION
Closes #443. Both shapes the issue sketched, per @GEMISIS's call.

## The bug the issue didn't know was there

Deliberate release half-existed. `context_delete` removes an entry by key — but `context_append` and `context_write` only ever *stored* a key on HashMap regions. On every other kind the argument was read into a variable and dropped on the floor.

So the exact scenario in the issue was broken in the most confusing possible way:

```
context_append { region: "sources", key: "rfc-9110", content: "<raw spec>" }
  -> "Appended to 'sources' section."        # key silently discarded
context_delete { region: "sources", key: "rfc-9110" }
  -> "[not found] No entry with key 'rfc-9110' in region 'sources'"
```

No error, no warning, and an agent told its entry does not exist.

## Shape 1 — deliberate release

- **Keys mean the same thing on every region kind.** Threaded through `push_entry` rather than set after the fact, so a refused write leaves nothing behind.
- **`context_delete` also takes `index` or `oldest`.** Plenty of what an agent wants to release — tool output, seeded material — was never written with a key. `context_list` now numbers its entries so there is something to name.
- **Releasing recounts the window**, or "release something to make room" would be advice that doesn't work.
- Appending twice under one key keeps both halves, rather than the HashMap upsert-replace: two halves of one source are still both wanted.

## Shape 2 — admission control

```toml
[context.regions]
sources = { kind = "temporary", budget = "30%", admission = "reject" }
```

A write that doesn't fit now fails with a message saying the region is full and to release something first, instead of silently dropping whichever entry happened to be oldest.

Two details worth flagging:

- **Reject regions are exempt from the window-level eviction cascade too.** Otherwise `reject` would only change which code did the silent dropping — the cascade would take the same entries a moment later.
- **The count-based half is checked before the push.** `enforce_sliding_window` runs on the way out, so a check afterwards would find the oldest entry already gone.

An unknown value is refused at parse time rather than falling back to the default: an author who typed `admission = "rejcet"` wants their region protected, and quietly giving them eviction would drop the entries they were trying to keep.

## Compatibility

The default is unchanged. Every existing blueprint evicts exactly as it did, verified by a test that runs the same sliding window under both settings and asserts the default still rolls off.

## Tests

Eleven, covering the loop end to end — including that a refused write leaves the earlier entry intact, and that after releasing, the same write then fits. Plus the two error shapes a reject region distinguishes: an empty region reports the budget (the write is simply too big, and "release something" would be advice with nothing to act on), a full one reports being full.

Full workspace suite green; `leviath-core`, `leviath-runtime`, `leviath-cli` and `leviath-tools` each back at 100%.

## Note on the file split

`region.rs` crossed the 1200-line structure limit, so the content-format schemas moved to `region/schema.rs` — a separate question from how a region holds and evicts entries, since it decides whether a write is well-formed at all. Pure move, re-exported, no call sites changed.

## Docs

New [Letting the agent decide what to forget](docs/content/context.md) section, the `admission` row in the region options table, the blueprint JSON schema, and the `context_delete` row in the tools reference.
