### PR TITLE
chore(release): 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,68 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## 0.3.10 - 2026-08-14
+
+- Fixed: a run now reports what it was actually billed. A run makes four kinds
+  of provider call - stage turns, region compaction, the call that names the
+  run, and the call that picks the next stage - and only the first was counted.
+  The other three dropped their token usage where their results were collected,
+  because each of those channels carried only the summary, title or stage name
+  its collector wanted. Measured against a provider serving known amounts, a
+  two-stage run with one compacting edge billed 12,000 prompt tokens and
+  reported 4,000. Runs that compact, title or branch will now report more than
+  they did, because they were always billed more than they reported.
+- Added: `run.lvr` records what each provider call cost, as it lands. The
+  cumulative counters on progress records mean two calls between two ticks
+  arrive downstream as their sum, so a chart of them shows a spike no single
+  call ever made - the reported case being a run pinned to a 32k window
+  appearing to make a 56k request. Each record names which kind of call it was,
+  so "this run cost double what its stages did because its edges compact" is
+  now answerable, and "no request ever exceeded the window" is provable from
+  the journal instead of inferred from region sizes.
+- Added: an agent can release a context entry it has finished with, rather than
+  waiting for something to be evicted. A stage that fetches a source, takes the
+  three paragraphs that matter and writes them somewhere curated has no further
+  use for the raw text - but the runtime only knows sizes, so the raw text sat
+  there until pressure happened to push it out. `context_delete` now names an
+  entry by key, by position, or as the oldest few, and `context_list` numbers
+  its entries so there is something to name.
+- Fixed: a key given to `context_append` or `context_write` is honoured on every
+  kind of region. It was only ever stored on key-value regions; everywhere else
+  the argument was accepted and discarded, so an agent could name an entry, see
+  a success message, and then be told that entry did not exist when it tried to
+  release it.
+- Added: `admission = "reject"` on a region refuses a write that does not fit,
+  instead of dropping whichever entry happened to be oldest. Silently evicting
+  is a decision about what matters, taken by whichever write arrived when the
+  region was full, and the agent never learned it happened. A region set this
+  way is also exempt from the window-wide eviction cascade, or the setting would
+  only change which part of the runtime did the dropping. The default is
+  unchanged.
+- Fixed: Anthropic runs stop paying to cache a prefix that already changed.
+  Caching works by prefix, so when a mutable region changed since the previous
+  request the cache entry is invalidated before it can ever be read - and the
+  write premium is charged anyway. One measured run bought 3.3M cache-write
+  tokens against 267k reads. The cache breakpoint is now skipped while the
+  prefix is moving and re-armed as soon as it settles, so a steady-state run
+  keeps the caching it always had.
+- Fixed: a stage's instructions get their own region even when the blueprint
+  does not declare one. Without it the prompt went to whichever pinned region
+  came first, usually the one holding the caller's task - sized for a sentence,
+  not for a stage's instructions - and a small window turned that into a spawn
+  failure that read as the caller's fault.
+- Added: `lev validate` warns when a region designed to evict is bounded by a
+  percentage. Eviction only runs at the bound, so the bound is the discipline,
+  and a percentage re-reads it every time somebody runs a bigger model: `38%`
+  written against a 200k window becomes a 380k ceiling that oldest-first
+  eviction never reaches, and the region hoards instead. The warning names the
+  resolved number, since that is the part worth acting on.
+- Fixed: a run can no longer finish by submitting the name of one of its own
+  stages as its answer. A run that dead-ended into its output stage submitted
+  the literal string `analyze` and reported `complete`, which reads as success
+  to every consumer there is. The submission is handed back to the model to
+  answer again rather than failing the run outright.
+
 ## 0.3.9 - 2026-08-14
 
 - Added: a parked run says what it is parked on. `WaitingInput` covered four

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.9"
+version = "0.3.10"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.9" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.9" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.9" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.9" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.9" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.9" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.9" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.9" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.9" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.9" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.9" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.9" }
+leviath = { path = "crates/leviath", version = "0.3.10" }
+leviath-core = { path = "crates/leviath-core", version = "0.3.10" }
+leviath-net = { path = "crates/leviath-net", version = "0.3.10" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.10" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.10" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.3.10" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.10" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.10" }
+leviath-package = { path = "crates/leviath-package", version = "0.3.10" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.3.10" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.3.10" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.10" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.9", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.3.10", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }


### PR DESCRIPTION
Cuts 0.3.10. Merging this to main publishes alpha; beta and stable follow by dispatch.

Six merged PRs since 0.3.9, mostly about cost — what a run spends, what it admits to spending, and what it wastes.

**Token accounting was short by two thirds.** A run makes four kinds of provider call and counted one; compaction, titling and routing each dropped their usage where their results were collected. A measured two-stage run billed 12,000 prompt tokens and reported 4,000. Now all four are counted, and `run.lvr` records what each individual call cost — so a boundary "spike" can be decomposed instead of guessed at.

**Two real cost leaks fixed.** Anthropic runs stop paying the cache-write premium on a prefix that already changed (one measured run bought 3.3M write tokens against 267k reads), and `lev validate` now warns when a region designed to evict is bounded by a percentage — the case where a 38% budget written for a 200k window silently becomes a 380k hoard on a 1M one.

**Agents can manage their own memory.** `context_delete` releases an entry by key, position, or age, and `admission = "reject"` lets a region refuse a write rather than silently dropping its oldest entry. Along the way: a key passed to `context_append` was being accepted and discarded on every region kind except key-value ones.

**Two correctness fixes.** A stage's instructions get their own region instead of landing in the caller's task region, and a run can no longer finish `complete` by submitting the name of one of its own stages as its answer.

⚠️ **Heads-up for consumers:** runs that compact, title or branch will report higher token totals than before. Nothing about what they spend changed — only what they admit to. Anything keyed on the old numbers will move.

Needs the `allow-version-bump` label.
