### PR TITLE
fix(journal): stop advancing the diff baseline past a record that was never written

### DIFF
--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -2740,4 +2740,79 @@ mod tests {
         assert_eq!(folded.inference_count, written);
         assert_eq!(folded.inference_usage.len(), 1);
     }
+
+    /// Replaying a journal has to land on exactly the state the run was in.
+    ///
+    /// Issue #455 reports evictable regions drifting - a folded `logs` region
+    /// holding entries the live agent had already lost, and elsewhere fewer
+    /// than it held. This walks a region through the mutations a temporary
+    /// region actually performs (append, evict-oldest, evict-and-append in one
+    /// step, clear) and checks the digest -> delta -> apply chain reproduces
+    /// every intermediate state exactly.
+    #[test]
+    fn probe_replay_matches_every_step() {
+        fn region(name: &str, entries: &[(&str, usize)]) -> RegionSnapshot {
+            RegionSnapshot {
+                name: name.to_string(),
+                kind: "temporary".to_string(),
+                current_tokens: entries.iter().map(|(_, t)| *t).sum(),
+                max_tokens: 1000,
+                entries: entries
+                    .iter()
+                    .map(|(c, t)| RegionEntrySnapshot {
+                        content: c.to_string(),
+                        tokens: *t,
+                        key: None,
+                        kind: crate::region::EntryKind::Text,
+                        metadata: None,
+                        taint: crate::taint::TaintLevel::Public,
+                    })
+                    .collect(),
+            }
+        }
+        fn snap(entries: &[(&str, usize)]) -> ContextSnapshot {
+            let r = region("logs", entries);
+            ContextSnapshot {
+                stage_name: "s".to_string(),
+                total_tokens: r.current_tokens,
+                max_tokens: 1000,
+                regions: vec![r],
+            }
+        }
+
+        let steps: Vec<ContextSnapshot> = vec![
+            snap(&[]),
+            snap(&[("a", 10)]),
+            snap(&[("a", 10), ("b", 20)]),
+            snap(&[("a", 10), ("b", 20), ("c", 30)]),
+            // Evict oldest.
+            snap(&[("b", 20), ("c", 30)]),
+            // Evict and append in one step - what a temporary region does when
+            // an add pushes it over its bound.
+            snap(&[("c", 30), ("d", 40)]),
+            // Several evictions at once.
+            snap(&[("d", 40)]),
+            // Repeated identical content, the case a content hash cannot tell
+            // apart by value alone.
+            snap(&[("d", 40), ("x", 5)]),
+            snap(&[("x", 5), ("x", 5)]),
+            snap(&[("x", 5)]),
+            snap(&[]),
+        ];
+
+        // Fold exactly as the lane writes and the reader replays: retain a
+        // digest, diff the next snapshot against it, apply to the running base.
+        let mut base = steps[0].clone();
+        let mut digest = digest_context(&steps[0]);
+        for (i, next) in steps.iter().enumerate().skip(1) {
+            let delta = diff_context_digest(&digest, next);
+            apply_delta(&mut base, &delta);
+            assert_eq!(
+                base, *next,
+                "step {i}: replay drifted from the live state\n  delta was {:?}",
+                delta.regions
+            );
+            digest = digest_context(next);
+        }
+    }
 }

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -539,22 +539,20 @@ async fn append_run_archive(
         }
     }
 
-    match open_private_append(&path).await {
-        Ok(mut file) => {
-            // A partial write leaves a torn frame, which the lenient reader
-            // stops at - so the tail is lost either way and this must report
-            // failure, not success.
-            let written = file.write_all(&buf).await.is_ok() && file.flush().await.is_ok();
-            if !written {
-                tracing::warn!(run_id = %job.run_id, "persistence: run archive write failed");
-            }
-            written
-        }
-        Err(e) => {
-            tracing::warn!(run_id = %job.run_id, error = %e, "persistence: run archive append failed");
-            false
-        }
+    // Open and write share one outcome, because they share one meaning: either
+    // the record is on disk or it is not. A partial write counts as failure -
+    // it leaves a torn frame the lenient reader stops at, so the tail is lost
+    // either way.
+    let landed = match open_private_append(&path).await {
+        // `and` rather than `?`: the flush runs either way, which is harmless
+        // after a failed write, and the write's error is the one reported.
+        Ok(mut file) => file.write_all(&buf).await.and(file.flush().await),
+        Err(e) => Err(e),
+    };
+    if let Err(e) = &landed {
+        tracing::warn!(run_id = %job.run_id, error = %e, "persistence: run archive append failed");
     }
+    landed.is_ok()
 }
 
 /// Append one line (with a trailing newline) to `stages/<idx>/<file>` under the
@@ -1657,5 +1655,98 @@ mod tests {
 
         // context.json still written despite the meta.json rename conflict.
         assert!(run_dir.join("context.json").exists());
+    }
+
+    /// The archive append is best-effort, and the lane keeps a digest of the
+    /// last *archived* context so the next write can be a compact diff.
+    /// Advancing that digest for a record that never landed is unrecoverable:
+    /// every later delta is then relative to a state no reader can rebuild, so
+    /// the folded archive drifts from the run for the rest of its life while
+    /// `context.json` - written whole each time - stays correct (issue #455).
+    ///
+    /// A directory where `run.lvr` should be is the cheapest real append
+    /// failure: the open fails, the rest of the write still succeeds.
+    #[tokio::test]
+    async fn a_failed_archive_append_is_reported_so_the_baseline_can_stay_put() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let j = job_with_context("run-torn", 3);
+
+        // Nothing in the way: the record lands and the write says so.
+        let ok = write_snapshot(dir.path(), &j, "m", "w", None, None).await;
+        assert!(ok.archived, "an unobstructed append lands");
+
+        // Now make `run.lvr` unopenable and try again.
+        let blocked = tempfile::tempdir().expect("temp dir");
+        let run_dir = blocked.path().join(&j.run_id);
+        std::fs::create_dir_all(run_dir.join("run.lvr")).expect("occupy the archive path");
+        let failed = write_snapshot(blocked.path(), &j, "m", "w", None, None).await;
+        assert!(
+            !failed.archived,
+            "an append that could not open its file must not report success"
+        );
+        // The rest of the write is unaffected - this is why the failure is
+        // invisible without the flag, and why `context.json` stays right while
+        // the journal drifts.
+        assert!(
+            run_dir.join("context.json").exists(),
+            "the context snapshot is still written"
+        );
+    }
+
+    /// End to end through the lane: when the archive append fails, the digest
+    /// the next diff rebases on must stay where it was.
+    ///
+    /// Observable from the archive itself. The lane anchors with a full
+    /// `ContextCheckpoint` whenever it has no prior digest for a run, so if the
+    /// baseline were advanced past the failed write, the second snapshot would
+    /// be recorded as a compact `Progress` diff against a state that was never
+    /// written - and the archive would be unfoldable from its own contents.
+    /// Holding the baseline means the second write re-anchors instead.
+    #[tokio::test]
+    async fn a_run_whose_append_failed_re_anchors_instead_of_diffing_against_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        // Occupy the archive path so the first append cannot open it.
+        let run_dir = dir.path().join("run-torn");
+        std::fs::create_dir_all(run_dir.join("run.lvr")).unwrap();
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(PersistMsg::Snapshot(Box::new(job_with_context(
+            "run-torn", 2,
+        ))))
+        .unwrap();
+        drop(tx);
+        persistence_worker(Some(dir.path().to_path_buf()), rx).await;
+
+        // The context still landed; only the journal did not.
+        assert!(run_dir.join("context.json").exists());
+
+        // Free the path and send a second, different snapshot.
+        std::fs::remove_dir(run_dir.join("run.lvr")).unwrap();
+        let (tx, rx) = mpsc::unbounded_channel();
+        tx.send(PersistMsg::Snapshot(Box::new(job_with_context(
+            "run-torn", 5,
+        ))))
+        .unwrap();
+        drop(tx);
+        persistence_worker(Some(dir.path().to_path_buf()), rx).await;
+
+        let bytes = std::fs::read(run_dir.join("run.lvr")).unwrap();
+        let (_, records) =
+            leviath_core::run_archive::read_archive_lenient(&mut bytes.as_slice()).unwrap();
+        assert!(
+            records.iter().any(|r| matches!(
+                r,
+                leviath_core::run_archive::RunRecord::ContextCheckpoint { .. }
+            )),
+            "the second write re-anchored with a full snapshot: {records:?}"
+        );
+        // And the archive folds to the run's real state rather than to a
+        // diff against something absent.
+        let folded = leviath_core::run_archive::fold(&records).expect("has a header");
+        assert_eq!(
+            folded.context.regions[0].entries.len(),
+            5,
+            "folds to what the run actually held"
+        );
     }
 }

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -166,9 +166,10 @@ pub async fn persistence_worker(
                     // Record what the write actually put on disk, not what this
                     // job hoped to - deriving the watermark from the job rather
                     // than the write is the shape of the bug being fixed.
-                    if let Some(key) =
-                        write_snapshot(&runs_dir, &job, &machine_id, &world_id, prev, written).await
-                    {
+                    let outcome =
+                        write_snapshot(&runs_dir, &job, &machine_id, &world_id, prev, written)
+                            .await;
+                    if let Some(key) = outcome.output {
                         last_output.insert(job.run_id.clone(), key);
                     }
                     // Drop a fully-terminal run's cached digest (it won't be
@@ -178,7 +179,12 @@ pub async fn persistence_worker(
                     if is_terminal_run(&job.meta.status) {
                         last_context.remove(&job.run_id);
                         last_output.remove(&job.run_id);
-                    } else {
+                    } else if outcome.archived {
+                        // Only for a record that reached the file. If the append
+                        // failed, the digest stays at the last state a reader
+                        // can actually rebuild, so the next write diffs against
+                        // that instead - which re-records everything the failed
+                        // one carried and puts the archive back in step.
                         last_context.insert(
                             job.run_id.clone(),
                             run_archive::digest_context(&job.context),
@@ -327,6 +333,26 @@ fn load_or_create_machine_id(runs_dir: &Path) -> String {
 /// Write one job's `meta.json` + `context.json` under `<runs_dir>/<run_id>/`,
 /// each via a temp file + atomic rename. Best-effort: logs and returns on any
 /// error. Serialization is infallible for these plain serde structs, so a
+/// What one snapshot write actually managed to put on disk.
+///
+/// The two answers are independent and both matter to what the lane remembers
+/// next time. `output` is the sidecar watermark; `archived` says whether the
+/// journal record for this state reached `run.lvr`.
+#[derive(Default)]
+struct WriteOutcome {
+    /// The `final_output` sidecar this write landed, if it wrote one.
+    output: Option<(i64, usize)>,
+    /// Whether the run-archive record for this snapshot was durably appended.
+    ///
+    /// The lane keeps a digest of the last archived context so the next write
+    /// can be a compact diff. Advancing that digest for a record that never
+    /// landed is unrecoverable: every later diff is then relative to a state no
+    /// reader can reconstruct, so the folded archive drifts from the run for
+    /// the rest of its life - while `context.json`, written whole each time,
+    /// stays correct. One swallowed append error was enough (issue #455).
+    archived: bool,
+}
+
 /// serialize error is a bug rather than a runtime condition (`.expect`).
 async fn write_snapshot(
     runs_dir: &Path,
@@ -335,13 +361,13 @@ async fn write_snapshot(
     world_id: &str,
     prev_context: Option<&run_archive::ContextDigest>,
     written_output: Option<(i64, usize)>,
-) -> Option<(i64, usize)> {
+) -> WriteOutcome {
     let dir = runs_dir.join(&job.run_id);
     if let Err(e) = create_private_dir(&dir).await {
         tracing::warn!(run_id = %job.run_id, error = %e, "persistence: create run dir failed");
-        return None;
+        return WriteOutcome::default();
     }
-    append_run_archive(&dir, job, machine_id, world_id, prev_context).await;
+    let archived = append_run_archive(&dir, job, machine_id, world_id, prev_context).await;
     let meta_json = serde_json::to_string_pretty(&job.meta).expect("RunMeta always serializes");
     write_bytes_atomic(&dir.join("meta.json"), meta_json.into_bytes(), &job.run_id).await;
     // Compact, not pretty: the context is the largest file the lane writes and
@@ -435,7 +461,10 @@ async fn write_snapshot(
             let _ = tokio::fs::remove_file(&interactions_path).await;
         }
     }
-    wrote_output
+    WriteOutcome {
+        output: wrote_output,
+        archived,
+    }
 }
 
 /// Append this snapshot to the run's portable archive (`<run_dir>/run.lvr`).
@@ -457,7 +486,7 @@ async fn append_run_archive(
     machine_id: &str,
     world_id: &str,
     prev_context: Option<&run_archive::ContextDigest>,
-) {
+) -> bool {
     use leviath_core::run_archive::{RunIdentity, RunRecord};
 
     let path = dir.join("run.lvr");
@@ -512,11 +541,18 @@ async fn append_run_archive(
 
     match open_private_append(&path).await {
         Ok(mut file) => {
-            let _ = file.write_all(&buf).await;
-            let _ = file.flush().await;
+            // A partial write leaves a torn frame, which the lenient reader
+            // stops at - so the tail is lost either way and this must report
+            // failure, not success.
+            let written = file.write_all(&buf).await.is_ok() && file.flush().await.is_ok();
+            if !written {
+                tracing::warn!(run_id = %job.run_id, "persistence: run archive write failed");
+            }
+            written
         }
         Err(e) => {
             tracing::warn!(run_id = %job.run_id, error = %e, "persistence: run archive append failed");
+            false
         }
     }
 }


### PR DESCRIPTION
Addresses #455. The reported cause turned out not to hold; the drift is real and this fixes what I believe actually causes it. I've asked two confirming questions on the issue and would rather not close it until they're answered.

## Evictions were already journaled

`diff_context_digest` compares an incoming snapshot against a digest of the last archived one. An eviction drops entries from the front, which breaks the prefix test, so the region falls through to `RegionDelta::Set` — a full re-snapshot. That is what the 38 `Set` ops in the reported journal are. There is no missing op kind, and adding a `Remove` op would not have changed what gets recorded.

Verified rather than argued: the new `probe_replay_matches_every_step` walks a temporary region through append, evict-oldest, evict-and-append-in-one-step, multi-eviction, repeated identical content, and clear — running each step through the real `digest_context` → `diff_context_digest` → `apply_delta` chain and asserting the replay equals the live state at *every* step. It passes on all of them. `fold` applies `Progress` deltas correctly too.

Writer, differ and reader are each correct in isolation, which is why the drift is intermittent rather than affecting every evicting run.

## What actually breaks

The persistence lane keeps a per-run digest of the **last archived** context so the next write can be a compact diff. The archive append is best-effort — a failure is logged and swallowed — but the digest advanced regardless of whether that append landed.

One swallowed failure is therefore unrecoverable. Every later delta is computed against a state no reader can reconstruct, so the fold stays permanently offset from that point, while `context.json` — written whole each time — stays correct. It also explains the addendum: once the baseline is wrong the drift goes whichever way the missed record moved things, so reconstructing *fewer* entries than the final context is the same bug rather than a second one.

## The fix

`append_run_archive` now reports whether the record reached the file, and the lane only advances the retained digest for one that did. If an append fails, the next write diffs against the last state that *was* recorded — which re-records everything the failed one carried and puts the archive back in step by itself.

A partial write counts as failure, not success: it leaves a torn frame that the lenient reader stops at, so the tail is lost either way.

The verdict travels with the sidecar watermark in a small `WriteOutcome`, since both are answers about what this write actually put on disk and both feed what the lane remembers next time.

## What I have not shown

I have not reproduced the append failure that starts it. Under a benchmark fleet the plausible trigger is descriptor exhaustion on `open_private_append`, since the lane opens `run.lvr` per write and a fleet runs many runs concurrently — but that is a story, not evidence, so I have asked on the issue whether the affected runs' daemon logs carry `persistence: run archive append failed`, and whether the drift reproduces on a re-run.

The fix is correct either way — advancing a diff baseline past a record that was never written is wrong regardless of what makes the write fail — which is why it is worth landing now rather than waiting on the answer.
