### PR TITLE
feat(mcp)!: name every tool for the server it came from

### DIFF
--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -551,7 +551,7 @@ for line in sys.stdin:
             // A stdio server has no OAuth bearer (the `None` auth path).
             let defs = pool.ensure(&cfg).await;
             assert_eq!(defs.len(), 1);
-            assert_eq!(defs[0].name, "echo");
+            assert_eq!(defs[0].name, "s__echo");
             // Second ensure of the same signature hits the cache (no reconnect).
             let again = pool.ensure(&cfg).await;
             assert_eq!(again.len(), 1);
@@ -645,7 +645,7 @@ for line in sys.stdin:
         })
         .await;
         assert_eq!(defs.len(), 1);
-        assert_eq!(defs[0].name, "remote_tool");
+        assert_eq!(defs[0].name, "remote__remote_tool");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -1109,7 +1109,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
         );
         let defs = pool.cached_defs_for(&servers);
         assert_eq!(defs.len(), 1);
-        assert_eq!(defs[0].name, "stub_search");
+        assert_eq!(defs[0].name, "search__stub_search");
     }
 
     #[tokio::test]
@@ -1159,7 +1159,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
         );
         let defs = pool.cached_defs_for(&servers);
         assert_eq!(defs.len(), 1);
-        assert_eq!(defs[0].name, "stub_search");
+        assert_eq!(defs[0].name, "search__stub_search");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -2780,11 +2780,11 @@ for line in sys.stdin:
     async fn mcp_allow_ok_success_returns_text() {
         let hub = InteractionHub::new();
         let mut allow = HashMap::new();
-        allow.insert("stub_mcp_tool".to_string(), ToolPolicy::Allow);
+        allow.insert("stub__stub_mcp_tool".to_string(), ToolPolicy::Allow);
         let state = state_with(&hub, mcp_with_stub(MCP_STUB_SUCCESS).await, allow);
         let out = dispatch_tools(
             state,
-            vec![call("c1", "stub_mcp_tool", serde_json::json!({}))],
+            vec![call("c1", "stub__stub_mcp_tool", serde_json::json!({}))],
             noop_progress(),
         )
         .await;
@@ -2795,11 +2795,11 @@ for line in sys.stdin:
     async fn mcp_allow_ok_error_result_is_prefixed() {
         let hub = InteractionHub::new();
         let mut allow = HashMap::new();
-        allow.insert("stub_mcp_tool".to_string(), ToolPolicy::Allow);
+        allow.insert("stub__stub_mcp_tool".to_string(), ToolPolicy::Allow);
         let state = state_with(&hub, mcp_with_stub(MCP_STUB_ERROR).await, allow);
         let out = dispatch_tools(
             state,
-            vec![call("c1", "stub_mcp_tool", serde_json::json!({}))],
+            vec![call("c1", "stub__stub_mcp_tool", serde_json::json!({}))],
             noop_progress(),
         )
         .await;

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -69,9 +69,11 @@ pub(super) fn lint_tools(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lint
 
     if !env.known_tools.is_empty() {
         for tool in &stage.available_tools {
-            // `server__tool` is an MCP name. It resolves only once that server
-            // is installed and connected, which is not a property of the
-            // manifest, so it is never this check's business.
+            // `server__tool` is an MCP name, and every MCP name has that shape:
+            // advertised names are always server-qualified, so the test is
+            // exact rather than a heuristic. Such a name resolves only once
+            // that server is installed and connected, which is not a property
+            // of the manifest, so it is never this check's business.
             if tool.contains("__") || env.known_tools.contains(tool) {
                 continue;
             }

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -701,17 +701,17 @@ for line in sys.stdin:
         .await;
 
         assert_eq!(registry.mcp_tool_defs.len(), 1);
-        assert_eq!(registry.mcp_tool_defs[0].name, "echo");
+        assert_eq!(registry.mcp_tool_defs[0].name, "stub-server__echo");
 
         registry.shutdown().await;
     }
 
     #[tokio::test]
-    async fn build_advertises_two_servers_and_namespaces_a_collision() {
-        // Two stdio servers each exposing an `echo` tool. The second is
-        // advertised under a namespaced name so the LLM never sees a duplicate,
-        // and the reserved-name closure (which reads already-advertised names)
-        // runs on the second server.
+    async fn build_advertises_two_servers_under_their_own_names() {
+        // Two stdio servers each exposing an `echo` tool. Both are advertised
+        // server-qualified, so the LLM never sees a duplicate and neither name
+        // depends on config order. The reserved-name closure (which reads
+        // already-advertised names) still runs on the second server.
         with_tracing(|| {});
         let registry = with_temp_home(|| async {
             let config = Config {
@@ -738,8 +738,9 @@ for line in sys.stdin:
             .iter()
             .map(|t| t.name.as_str())
             .collect();
-        // First server keeps `echo`; the second is disambiguated.
-        assert!(names.contains(&"echo"), "names: {names:?}");
+        // Both are server-qualified: neither keeps the bare `echo`, so which
+        // server registered first does not decide who owns the plain name.
+        assert!(names.contains(&"alpha__echo"), "names: {names:?}");
         assert!(names.contains(&"beta__echo"), "names: {names:?}");
         registry.shutdown().await;
     }
@@ -813,7 +814,7 @@ for line in sys.stdin:
         .await;
 
         assert_eq!(registry.mcp_tool_defs.len(), 1);
-        assert_eq!(registry.mcp_tool_defs[0].name, "remote_tool");
+        assert_eq!(registry.mcp_tool_defs[0].name, "remote__remote_tool");
         registry.shutdown().await;
     }
 

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -86,14 +86,16 @@ impl ToolExecutor {
             let name = self.unique_advertised_name(&tool.name, &server_name, reserved);
             self.aliases
                 .insert(name.clone(), (server_name.clone(), tool.name.clone()));
-            if name != tool.name {
-                tracing::debug!(
-                    server = %server_name,
-                    original = %tool.name,
-                    advertised = %name,
-                    "Renamed MCP tool to satisfy provider naming rules"
-                );
-            }
+            // Unconditional: every advertised name is server-qualified, so it
+            // never equals the original and there is nothing to compare
+            // against. The line is what ties the name the model sees back to
+            // the name the server knows.
+            tracing::debug!(
+                server = %server_name,
+                original = %tool.name,
+                advertised = %name,
+                "advertising MCP tool under its server-qualified name"
+            );
             advertised.push(ToolMetadata {
                 name,
                 description: tool.description.clone(),
@@ -120,9 +122,27 @@ impl ToolExecutor {
 
     /// Compute a unique, provider-safe advertised name for `original`.
     ///
-    /// Prefers the sanitized name; on a clash with `reserved` or an existing
-    /// alias, prefixes with the server name; if that still clashes, appends a
-    /// numeric suffix.
+    /// **Always** `<server>__<tool>`, sanitized. The server is part of the name
+    /// whether or not anything would have collided, because the alternative -
+    /// bare name, prefixed only on a clash - made the name a function of
+    /// registration order. Two servers both advertising `search` gave the bare
+    /// name to whichever appeared first in `config.toml`, so a blueprint saying
+    /// `available_tools = ["search"]` meant a different server's tool depending
+    /// on the order of a file it does not control, and reordering that file
+    /// silently re-pointed the grant.
+    ///
+    /// Qualifying every name removes the question. `alpha__search` and
+    /// `beta__search` say which server they came from, and neither depends on
+    /// who registered first.
+    ///
+    /// `__` rather than the `.` this reads more naturally as: the advertised
+    /// name has to match `^[A-Za-z0-9_-]{1,64}$` or the provider rejects the
+    /// whole request, and [`sanitize_tool_name`] would rewrite a dot to `_`
+    /// anyway - so a manifest written with one would match nothing.
+    ///
+    /// A numeric suffix still resolves the residual case: two servers whose
+    /// *names* sanitize to the same thing, or a qualified name that collides
+    /// with a reserved built-in.
     fn unique_advertised_name(
         &self,
         original: &str,
@@ -131,17 +151,13 @@ impl ToolExecutor {
     ) -> String {
         let free = |name: &str| !reserved.contains(name) && !self.aliases.contains_key(name);
 
-        let base = sanitize_tool_name(original);
-        if free(&base) {
-            return base;
-        }
-        let prefixed = sanitize_tool_name(&format!("{server}__{original}"));
-        if free(&prefixed) {
-            return prefixed;
+        let qualified = sanitize_tool_name(&format!("{server}__{original}"));
+        if free(&qualified) {
+            return qualified;
         }
         let mut n = 2;
         loop {
-            let candidate = sanitize_tool_name(&format!("{prefixed}_{n}"));
+            let candidate = sanitize_tool_name(&format!("{qualified}_{n}"));
             if free(&candidate) {
                 return candidate;
             }
@@ -151,11 +167,14 @@ impl ToolExecutor {
 
     /// Which server advertises each tool: advertised name -> server name.
     ///
-    /// The routing table read the other way round. A blueprint that grants a
+    /// The routing table read the other way round: a blueprint that grants a
     /// whole server needs to turn that server's name into the set of tools it
-    /// covers, and the advertised name cannot answer for itself - see
-    /// `unique_advertised_name`, which prefers the bare tool name and only
-    /// prefixes with the server on a collision.
+    /// covers.
+    ///
+    /// Advertised names are server-qualified, so most of them carry the answer
+    /// in the string - but not reliably enough to parse it back out. A server
+    /// named `my.server` sanitizes to `my_server`, and a collision appends
+    /// `_2`, so splitting on `__` is a guess where this is a fact.
     pub fn tool_owners(&self) -> HashMap<String, String> {
         self.aliases
             .iter()
@@ -531,7 +550,9 @@ for line in sys.stdin:
         assert!(executor.remove_client("nope").is_none());
         let mut taken = executor.remove_client("server1").expect("was registered");
         assert_eq!(executor.server_count(), 0);
-        let result = executor.execute("echo", serde_json::json!({})).await;
+        let result = executor
+            .execute("server1__echo", serde_json::json!({}))
+            .await;
         assert!(result.is_err(), "the removed server's tools route nowhere");
         // The caller owns the shutdown; this is what ends the child process.
         taken.shutdown().await.expect("shutdown is best-effort Ok");
@@ -545,7 +566,7 @@ for line in sys.stdin:
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor
-            .execute("echo", serde_json::json!({"text": "hi"}))
+            .execute("server1__echo", serde_json::json!({"text": "hi"}))
             .await
             .expect("execute should succeed");
         assert!(result.success);
@@ -579,7 +600,7 @@ for line in sys.stdin:
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor
-            .execute("echo", serde_json::json!({}))
+            .execute("server1__echo", serde_json::json!({}))
             .await
             .expect("execute should succeed");
         assert!(result.success);
@@ -821,13 +842,22 @@ for line in sys.stdin:
 
     // ─── unique_advertised_name ───────────────────────────────────────────
 
+    /// Every advertised name carries its server, whether or not anything would
+    /// have collided. The old scheme handed out the bare name first, which made
+    /// it depend on which server registered earliest.
     #[test]
-    fn unique_name_prefers_the_sanitized_base() {
+    fn unique_name_always_qualifies_with_the_server() {
         let exec = ToolExecutor::new();
         let reserved = HashSet::new();
         assert_eq!(
             exec.unique_advertised_name("github.search", "gh", &reserved),
-            "github_search"
+            "gh__github_search",
+            "qualified, and the dot sanitized to satisfy the provider rule"
+        );
+        assert_eq!(
+            exec.unique_advertised_name("search", "alpha", &reserved),
+            "alpha__search",
+            "qualified even with nothing to collide with"
         );
     }
 
@@ -923,12 +953,12 @@ for line in sys.stdin:
         let mut executor = ToolExecutor::new();
         let client = spawn_named("github.search").await;
         let advertised = executor.add_client_advertised("gh".to_string(), client, &HashSet::new());
-        assert_eq!(advertised[0].name, "github_search");
+        assert_eq!(advertised[0].name, "gh__github_search");
 
         // The LLM calls the advertised name; the server is called with its
         // original name ("github.search").
         let result = executor
-            .execute("github_search", serde_json::json!({}))
+            .execute("gh__github_search", serde_json::json!({}))
             .await
             .expect("advertised name routes");
         assert!(result.success);
@@ -942,7 +972,7 @@ for line in sys.stdin:
 
         let a = spawn_named("search").await;
         let a_names = executor.add_client_advertised("alpha".to_string(), a, &HashSet::new());
-        assert_eq!(a_names[0].name, "search");
+        assert_eq!(a_names[0].name, "alpha__search");
 
         let b = spawn_named("search").await;
         // Reserve what alpha already advertised.
@@ -953,7 +983,7 @@ for line in sys.stdin:
         // Both route to their own server with the original name "search".
         assert!(
             executor
-                .execute("search", serde_json::json!({}))
+                .execute("alpha__search", serde_json::json!({}))
                 .await
                 .unwrap()
                 .success
@@ -968,10 +998,9 @@ for line in sys.stdin:
     }
 
     /// A blueprint granting a whole connector needs to turn a server's name
-    /// into the tools it covers, and the advertised name cannot answer for
-    /// itself: the first server's tool keeps its bare name, and only the
-    /// second gets a `beta__` prefix. So the table has to say who owns what,
-    /// including for the one whose name carries no hint at all.
+    /// into the tools it covers. The advertised name usually carries it, but
+    /// parsing it back out is a guess - a server named `my.server` sanitizes to
+    /// `my_server`, and a collision appends `_2` - so the table answers instead.
     #[tokio::test]
     async fn tool_owners_names_the_server_behind_each_advertised_tool() {
         let _guard = always_on_tracing_guard();
@@ -985,9 +1014,9 @@ for line in sys.stdin:
 
         let owners = executor.tool_owners();
         assert_eq!(
-            owners.get("search").map(String::as_str),
+            owners.get("alpha__search").map(String::as_str),
             Some("alpha"),
-            "the bare name belongs to whoever claimed it first, which no prefix records"
+            "each name says which server it came from, whoever registered first"
         );
         assert_eq!(owners.get("beta__search").map(String::as_str), Some("beta"));
         assert_eq!(owners.len(), 2);
@@ -1001,7 +1030,7 @@ for line in sys.stdin:
         let _ = executor.add_client_advertised("s".to_string(), client, &HashSet::new());
         assert!(
             executor
-                .execute("plain", serde_json::json!({}))
+                .execute("s__plain", serde_json::json!({}))
                 .await
                 .unwrap()
                 .success

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -141,6 +141,27 @@ Naming a tool here also settles the `blocking-tool-in-autonomous-stage` lint for
 it is how you say you meant it. See
 [human-in-the-loop tools](/docs/tools#these-tools-need-someone-there).
 
+#### Naming a tool from an MCP server
+
+An MCP tool is always named `<server>__<tool>` - the server it came from, two underscores, the tool
+the server calls it:
+
+```toml
+available_tools = ["read_file", "github__create_issue"]
+```
+
+The server is part of the name whether or not anything would have collided, so two servers that both
+offer `search` are `github__search` and `gitlab__search`, and a grant means the same thing however
+your `config.toml` is ordered.
+
+The separator is `__` rather than a dot because the name is passed to the model provider, and
+providers only accept `[A-Za-z0-9_-]`. A dot anywhere in a server or tool name is rewritten to `_`
+for the same reason, so a server called `my.tools` offering `find.all` is advertised as
+`my_tools__find_all`.
+
+To grant a server's whole set instead of naming its tools one at a time, see
+[granting a whole server](/docs/mcp#granting-a-whole-server).
+
 ## Context regions
 
 `[context.regions]` defines the memory layout. There are nine region kinds (the default is

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -74,7 +74,28 @@ headers = { Authorization = "Bearer ${MY_TOKEN}" }   # ${VAR} is expanded
 ## Discovery and invocation
 
 On connect, Leviath discovers the server's tools and exposes them to any stage whose
-`available_tools` includes them:
+`available_tools` includes them.
+
+### How an MCP tool is named
+
+Always `<server>__<tool>`: the name you gave the server, two underscores, the name the server gives
+the tool. A `github` server offering `create_issue` is advertised as `github__create_issue`.
+
+The server is always part of the name, not only when something would clash. Two servers that both
+offer `search` become `github__search` and `gitlab__search`, so a grant says which one it means and
+keeps meaning that however your `config.toml` is ordered.
+
+> [!NOTE]
+> The separator is `__`, not a dot. The advertised name goes to the model provider, which accepts
+> only `[A-Za-z0-9_-]` and rejects the whole request otherwise - so any other character, a dot
+> included, is rewritten to `_`. A server named `my.tools` offering `find.all` is advertised as
+> `my_tools__find_all`. In the rare case two servers' names sanitize to the same string, the second
+> gets a `_2` suffix.
+
+Calls route back to the owning server under the tool's original name, so the server never sees the
+qualified form.
+
+
 
 ```mermaid
 sequenceDiagram
@@ -100,9 +121,13 @@ Name the server instead:
 
 ```toml
 [stages.triage]
-available_tools = ["read_file"]
+available_tools = ["read_file", "gitlab__create_issue"]
 available_connectors = ["github"]
 ```
+
+That stage gets the built-in `read_file`, one named tool from `gitlab`, and everything `github`
+advertises. The two forms mix freely, and a tool named individually *and* covered by a connector is
+granted once.
 
 The connector is resolved at spawn against what the server actually advertises then, and merged
 with `available_tools`, so the two mix freely. A tool the server gains next month is offered
@@ -118,11 +143,11 @@ through the same `tool_permissions`, the same taint gate, and the same approval 
 you named by hand.
 
 > [!NOTE]
-> There is no wildcard form of `available_tools` and cannot usefully be one. An MCP tool's
-> advertised name does not reliably carry its server - Leviath prefers the bare tool name and only
-> prefixes with the server on a collision, so `github`'s `create_issue` is usually advertised as
-> just `create_issue`. There is no prefix a pattern could match on, which is why a grant names the
-> server and Leviath answers for what it owns.
+> There is no wildcard form of `available_tools`, and a connector grant is not sugar for one.
+> Names are server-qualified, so `github__*` would *usually* work - but not reliably enough to
+> build on: a server named `my.tools` sanitizes to `my_tools`, and a name collision appends `_2`,
+> so matching the string is a guess where the connector grant is a fact. `available_connectors`
+> asks Leviath which tools a server owns rather than inferring it from how they are spelled.
 
 ## OAuth, safely
 


### PR DESCRIPTION
Every MCP tool is now advertised as `<server>__<tool>`, always — `alpha__search` and `beta__search`, never a bare `search`.

## Why

The old rule was "bare name, prefixed only on a collision", which made the name a function of registration order. Registration follows `config.toml` order, so two servers both offering `search` gave the bare name to whichever was listed first. A blueprint saying `available_tools = ["search"]` therefore meant a different server's tool depending on the order of a file the blueprint does not control — and reordering that file silently re-pointed the grant.

Qualifying every name removes the question. Neither name depends on who registered first, and a grant means the same thing however the config is ordered.

## On the separator

`__` rather than the `.` this reads more naturally as, and that is not a preference. The advertised name is passed to the model provider, which accepts only `[A-Za-z0-9_-]` and **rejects the entire request** otherwise — which is what `sanitize_tool_name` exists for. It would rewrite `alpha.search` to `alpha_search` before the name ever reached the wire, so a manifest written with dots would match nothing.

Dots inside server or tool names get the same treatment: `my.tools` offering `find.all` is advertised as `my_tools__find_all`. Where two servers' names sanitize to the same string, the second still gets a `_2` suffix.

## ⚠️ Breaking

A blueprint naming a bare MCP tool (`available_tools = ["search"]`) stops matching, and by exactly the silent-omission mechanism #454 was about: the tool is simply not offered. Anything naming MCP tools needs the server prefix added.

Blast radius, measured rather than assumed:

- **No bundled agent is affected** — none of the seven names an MCP tool. (`web_search`/`web_fetch` in the researchers are the agents' own Rhai script tools, not MCP.)
- **Eleven tests across `leviath-mcp` and `leviath-cli`** were pinning bare names, which is a fair proxy for how visible this is to anyone who had written one.

Two things I'd like a decision on before merge, both noted in the conversation:

1. Whether to add a compatibility shim — a bare name matching when exactly one connected server advertises a tool with that original name. Unambiguous, and it stops existing manifests failing silently. The alternative is the clean break.
2. Whether this ships as **0.4.0** rather than a patch, since it changes a name users write in manifests.

## Side effect worth noting

The linter skips `available_tools` entries containing `__`, on the grounds that they are MCP names it cannot resolve. That test used to be a heuristic — a bare MCP name would fall through and be reported as `unknown-tool`. Now that every MCP name is qualified, the test is exact.

## Docs

- **`docs/content/mcp.md`** — a "How an MCP tool is named" section where discovery is explained, with the two-servers example and a note on why the separator is not a dot.
- **`docs/content/agents.md`** — a "Naming a tool from an MCP server" subsection under *Which tools a stage gets*, which is where someone writing `available_tools` is actually looking, cross-linked to the connector grant.
- The wildcard note in the MCP page is corrected: it previously said advertised names do not carry their server, which is no longer true. It now says they usually do, but that matching the string is still a guess where a connector grant is a fact — because sanitization and the `_2` suffix can both alter it.

Builds on #457, which adds `available_connectors`.
