### PR TITLE
feat(journal)!: read past a record kind this build does not know

### DIFF
--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -168,7 +168,10 @@ impl<T> StatCache<T> {
 pub fn read_run_archive(run_id: &str) -> Option<Vec<leviath_core::run_archive::RunRecord>> {
     let path = run_dir(run_id).join("run.lvr");
     let bytes = std::fs::read(&path).ok()?;
-    leviath_core::run_archive::read_archive(&mut bytes.as_slice())
+    // Lenient, not strict: this reads an archive some other build may have
+    // written, so a record kind added later must be stepped over rather than
+    // rejecting the file (or, worse, truncating it silently).
+    leviath_core::run_archive::read_archive_lenient(&mut bytes.as_slice())
         .ok()
         .map(|(_version, records)| records)
 }
@@ -185,7 +188,12 @@ pub fn visit_run_records(
     let file = std::fs::File::open(&path).ok()?;
     let mut reader = std::io::BufReader::with_capacity(64 * 1024, file);
     leviath_core::run_archive::read_archive_start(&mut reader).ok()?;
-    while let Ok(Some(record)) = leviath_core::run_archive::read_record(&mut reader) {
+    // A frame this build cannot parse is skipped, not treated as the end: it
+    // was written by a later version and the records after it are still ours.
+    while let Ok(Some(frame)) = leviath_core::run_archive::read_frame(&mut reader) {
+        let leviath_core::run_archive::Frame::Record(record) = frame else {
+            continue;
+        };
         if visit(&record).is_break() {
             break;
         }

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -2024,6 +2024,61 @@ mod tests {
         });
     }
 
+    /// A record kind written by a later build is stepped over, so the records
+    /// after it still reach the caller.
+    ///
+    /// This is the CLI half of the guarantee. The reader here has its own loop
+    /// over frames, separate from the ones in `leviath-core`, so "every reader
+    /// skips" is a claim that has to be checked per reader rather than assumed
+    /// from the primitive being right.
+    #[test]
+    fn streaming_records_steps_over_a_record_kind_from_a_later_build() {
+        with_isolated_runs_dir("visit-records-unknown-kind", |_dir| {
+            use leviath_core::run_archive::{self, RunRecord};
+
+            let run_id = "unknown-kind";
+            std::fs::create_dir_all(run_dir(run_id)).unwrap();
+            write_minimal_archive(run_id);
+
+            // Append a well-framed record this build has no variant for, then
+            // one it does.
+            let mut extra = Vec::new();
+            let payload =
+                serde_json::to_vec(&serde_json::json!({ "FromTheFuture": { "x": 1 } })).unwrap();
+            extra.extend_from_slice(&(payload.len() as u64).to_be_bytes());
+            extra.extend_from_slice(&payload);
+            run_archive::write_record(
+                &mut extra,
+                &RunRecord::Message {
+                    message: leviath_core::run_archive::MessageRecord {
+                        role: "user".to_string(),
+                        content: "after the gap".to_string(),
+                    },
+                    at: 2,
+                },
+            )
+            .unwrap();
+            let path = run_dir(run_id).join("run.lvr");
+            let mut bytes = std::fs::read(&path).unwrap();
+            bytes.extend_from_slice(&extra);
+            std::fs::write(&path, bytes).unwrap();
+
+            let seen = std::cell::RefCell::new(Vec::new());
+            let visited = visit_run_records(run_id, &mut |record| {
+                if let RunRecord::Message { message, .. } = record {
+                    seen.borrow_mut().push(message.content.clone());
+                }
+                std::ops::ControlFlow::Continue(())
+            });
+            assert!(visited.is_some());
+            assert_eq!(
+                seen.into_inner(),
+                vec!["after the gap".to_string()],
+                "the readable record past the unknown one still arrives"
+            );
+        });
+    }
+
     /// Write a two-record archive (Header + one ContextCheckpoint) for `run_id`.
     fn write_minimal_archive(run_id: &str) {
         use leviath_core::run_archive::{self, RunIdentity, RunRecord};

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -38,18 +38,12 @@
 //! region). [`diff_context`]/[`apply_delta`] compute and replay those diffs, and
 //! [`fold`] reconstructs the current state from the whole journal.
 
-use std::io::{self, Read, Write};
+use std::io::{self, Read};
 use std::ops::ControlFlow;
 
 use serde::{Deserialize, Serialize};
 
 use crate::run_meta::{ContextSnapshot, RegionEntrySnapshot, RegionSnapshot, RunMeta, RunStatus};
-
-/// File magic identifying a leviath run archive (`b"LVR1"`).
-pub const RUN_ARCHIVE_MAGIC: &[u8; 4] = b"LVR1";
-
-/// The archive format version this build writes.
-pub const RUN_ARCHIVE_VERSION: u16 = 1;
 
 /// Identity + ownership of a run.
 ///
@@ -590,132 +584,12 @@ pub fn apply_delta(base: &mut ContextSnapshot, delta: &ContextDelta) {
     }
 }
 
-// ─── codec ──────────────────────────────────────────────────────────────────
+mod codec;
 
-/// Write the archive preamble (magic + version). Call once at file start.
-pub fn write_archive_start(w: &mut dyn Write, version: u16) -> io::Result<()> {
-    w.write_all(RUN_ARCHIVE_MAGIC)?;
-    w.write_all(&version.to_be_bytes())?;
-    Ok(())
-}
-
-/// Read + validate the archive preamble, returning the format version.
-pub fn read_archive_start(r: &mut dyn Read) -> io::Result<u16> {
-    let mut magic = [0u8; 4];
-    r.read_exact(&mut magic)?;
-    if &magic != RUN_ARCHIVE_MAGIC {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            "not a leviath run archive (bad magic)",
-        ));
-    }
-    let mut version = [0u8; 2];
-    r.read_exact(&mut version)?;
-    Ok(u16::from_be_bytes(version))
-}
-
-/// Append one framed record. The frame length is a `u64` so it can never
-/// overflow the prefix (a `RunRecord` always serializes to JSON).
-pub fn write_record(w: &mut dyn Write, record: &RunRecord) -> io::Result<()> {
-    let payload = serde_json::to_vec(record).expect("a RunRecord always serializes to JSON");
-    let len = payload.len() as u64;
-    w.write_all(&len.to_be_bytes())?;
-    w.write_all(&payload)?;
-    Ok(())
-}
-
-/// Fill `buf` from `r`, returning `false` on a clean end-of-stream (zero bytes
-/// available at the call) and erroring only on a *partial* read (truncation).
-fn read_exact_or_eof(r: &mut dyn Read, buf: &mut [u8]) -> io::Result<bool> {
-    let mut filled = 0;
-    while filled < buf.len() {
-        match r.read(&mut buf[filled..])? {
-            0 => {
-                if filled == 0 {
-                    return Ok(false); // clean EOF at a record boundary
-                }
-                return Err(io::Error::new(
-                    io::ErrorKind::UnexpectedEof,
-                    "truncated run-archive frame",
-                ));
-            }
-            n => filled += n,
-        }
-    }
-    Ok(true)
-}
-
-/// The largest a single archive frame may claim to be.
-///
-/// Generous by design - a record holds one context snapshot, and 256 MiB is far
-/// past anything a real run writes - because this is a sanity bound on a length
-/// prefix, not a size policy. What it rules out is a torn or corrupt prefix
-/// being taken at its word and turned straight into an allocation.
-const MAX_RECORD_BYTES: u64 = 256 * 1024 * 1024;
-
-/// Read the next framed record, or `None` at a clean end-of-stream.
-pub fn read_record(r: &mut dyn Read) -> io::Result<Option<RunRecord>> {
-    let mut len_bytes = [0u8; 8];
-    if !read_exact_or_eof(r, &mut len_bytes)? {
-        return Ok(None);
-    }
-    let len = u64::from_be_bytes(len_bytes);
-    // A torn tail is the reason `read_archive_lenient` exists, and a torn
-    // *length prefix* is exactly where a nonsense `u64` comes from. Allocating
-    // it first would abort the process on a crash-truncated archive - during
-    // daemon recovery, which is the one moment the lenient reader is there to
-    // survive. Rejecting it makes the frame an ordinary error, so recovery
-    // folds back to the last intact record instead.
-    if len > MAX_RECORD_BYTES {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("run-archive frame claims {len} bytes, over the {MAX_RECORD_BYTES} cap"),
-        ));
-    }
-    let mut payload = vec![0u8; len as usize];
-    if !read_exact_or_eof(r, &mut payload)? {
-        return Err(io::Error::new(
-            io::ErrorKind::UnexpectedEof,
-            "truncated run-archive frame",
-        ));
-    }
-    let record = serde_json::from_slice(&payload)
-        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
-    Ok(Some(record))
-}
-
-/// Read the whole archive: validate the preamble, then read every record.
-pub fn read_archive(r: &mut dyn Read) -> io::Result<(u16, Vec<RunRecord>)> {
-    let version = read_archive_start(r)?;
-    let mut records = Vec::new();
-    while let Some(record) = read_record(r)? {
-        records.push(record);
-    }
-    Ok((version, records))
-}
-
-/// Read the archive tolerantly: validate the preamble strictly, then read records
-/// until a clean end-of-stream **or the first unreadable frame**, returning the
-/// records collected so far.
-///
-/// A crash while the persistence lane is appending a record can leave a partial
-/// final frame (a truncated length prefix or payload). The strict [`read_archive`]
-/// would reject the whole file for that torn tail - and once a fallback-resume
-/// appends fresh records *past* the torn bytes, the archive would stay unreadable
-/// forever. This variant instead stops at the torn tail and keeps everything valid
-/// before it, so recovery can still fold the archive to its last intact point. The
-/// preamble is still validated strictly, so a file that isn't a run archive at all
-/// still errors rather than folding to nothing.
-pub fn read_archive_lenient(r: &mut dyn Read) -> io::Result<(u16, Vec<RunRecord>)> {
-    let version = read_archive_start(r)?;
-    let mut records = Vec::new();
-    // A torn/invalid frame ends the read early with whatever preceded it, rather
-    // than propagating the error.
-    while let Ok(Some(record)) = read_record(r) {
-        records.push(record);
-    }
-    Ok((version, records))
-}
+pub use codec::{
+    Frame, RUN_ARCHIVE_MAGIC, RUN_ARCHIVE_VERSION, read_archive, read_archive_lenient,
+    read_archive_start, read_frame, read_record, write_archive_start, write_record,
+};
 
 // ─── fold ───────────────────────────────────────────────────────────────────
 
@@ -1013,14 +887,22 @@ pub fn visit_archive_points(
     visit: &mut dyn FnMut(PointRef<'_>) -> ControlFlow<()>,
 ) -> io::Result<()> {
     read_archive_start(r)?;
-    let mut folder = match read_record(r) {
-        Ok(Some(first)) => match PointFolder::start(&first) {
+    // The first record has to be a Header, and a Header is a kind every build
+    // knows - so an unreadable frame here means this is not a foldable archive.
+    let mut folder = match read_frame(r) {
+        Ok(Some(Frame::Record(first))) => match PointFolder::start(&first) {
             Some(folder) => folder,
             None => return Ok(()),
         },
         _ => return Ok(()),
     };
-    while let Ok(Some(record)) = read_record(r) {
+    // A record kind from a later build is stepped over rather than ending the
+    // walk: it carries no context change this build can apply, and everything
+    // after it still does.
+    while let Ok(Some(frame)) = read_frame(r) {
+        let Frame::Record(record) = frame else {
+            continue;
+        };
         if folder.push(&record, visit).is_break() {
             return Ok(());
         }
@@ -1142,7 +1024,9 @@ pub fn replay_points(records: &[RunRecord]) -> Vec<RunPoint> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Only the tests write through the trait now; the codec moved out.
     use crate::run_meta::RunStatus;
+    use std::io::Write;
 
     fn identity() -> RunIdentity {
         RunIdentity {
@@ -1744,11 +1628,18 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::InvalidData);
     }
 
+    /// The preamble round-trips the version it was written with. Previously
+    /// checked with an arbitrary 7; that now names a framing generation this
+    /// build cannot read, and is refused - see
+    /// `an_archive_from_a_newer_format_is_refused_with_both_versions_named`.
     #[test]
     fn read_archive_start_reports_version() {
         let mut buf = Vec::new();
-        write_archive_start(&mut buf, 7).unwrap();
-        assert_eq!(read_archive_start(&mut buf.as_slice()).unwrap(), 7);
+        write_archive_start(&mut buf, RUN_ARCHIVE_VERSION).unwrap();
+        assert_eq!(
+            read_archive_start(&mut buf.as_slice()).unwrap(),
+            RUN_ARCHIVE_VERSION
+        );
     }
 
     #[test]
@@ -2814,5 +2705,165 @@ mod tests {
             );
             digest = digest_context(next);
         }
+    }
+
+    /// One frame from a later build, written the way a later build would write
+    /// it: correctly framed, with a variant name this one has never heard of.
+    fn trailing_message() -> RunRecord {
+        RunRecord::Message {
+            message: MessageRecord {
+                role: "user".to_string(),
+                content: "after the unknown".to_string(),
+            },
+            at: 9,
+        }
+    }
+
+    /// Returns the archive and the size of the unknown frame's payload, so a
+    /// caller can assert on the exact `Frame` it expects back.
+    fn archive_with_an_unknown_record() -> (Vec<u8>, usize) {
+        let mut buf = Vec::new();
+        write_archive_start(&mut buf, RUN_ARCHIVE_VERSION).unwrap();
+        write_record(&mut buf, &header()).unwrap();
+        let payload =
+            serde_json::to_vec(&serde_json::json!({ "SomethingNew": { "whatever": 1 } })).unwrap();
+        buf.extend_from_slice(&(payload.len() as u64).to_be_bytes());
+        buf.extend_from_slice(&payload);
+        write_record(&mut buf, &trailing_message()).unwrap();
+        (buf, payload.len())
+    }
+
+    /// A record's variant name, read off its serialized form. Avoids a match
+    /// whose unreached arms would be uncovered, and pins the wire spelling.
+    fn record_kind(record: &RunRecord) -> String {
+        serde_json::to_value(record)
+            .expect("a RunRecord always serializes")
+            .as_object()
+            .expect("externally tagged, so an object")
+            .keys()
+            .next()
+            .expect("with exactly one key")
+            .clone()
+    }
+
+    /// The forward-compatibility guarantee, and the reason it is worth having:
+    /// adding a record kind used to truncate the journal for every older
+    /// reader. The lenient reader stopped at the first unknown record and
+    /// returned the prefix, so a build predating `InferenceUsage` would have
+    /// read a 0.3.10 journal as "header, then nothing" - with no error.
+    #[test]
+    fn an_unknown_record_kind_is_stepped_over_not_treated_as_the_end() {
+        let (buf, _) = archive_with_an_unknown_record();
+        let (version, records) = read_archive_lenient(&mut buf.as_slice()).unwrap();
+        assert_eq!(version, RUN_ARCHIVE_VERSION);
+        let kinds: Vec<String> = records.iter().map(record_kind).collect();
+        assert_eq!(
+            kinds,
+            vec!["Header".to_string(), "Message".to_string()],
+            "the header, and the readable record after the gap"
+        );
+        assert_eq!(records[1], trailing_message(), "intact, not just present");
+    }
+
+    /// The streaming reader skips the same way the buffering one does. It has
+    /// its own loop, so "both apply the rule" is a claim that needs checking
+    /// rather than assuming.
+    #[test]
+    fn the_streaming_reader_also_steps_over_an_unknown_record() {
+        // A context record *after* the unknown frame: the only way to reach it
+        // is to step over that frame, so the point count is the proof.
+        let (mut buf, _) = archive_with_an_unknown_record();
+        write_record(
+            &mut buf,
+            &RunRecord::ContextCheckpoint {
+                snapshot: ContextSnapshot {
+                    stage_name: "s".to_string(),
+                    total_tokens: 1,
+                    max_tokens: 10,
+                    regions: vec![],
+                },
+                at: 11,
+            },
+        )
+        .unwrap();
+        let mut points = 0usize;
+        visit_archive_points(&mut buf.as_slice(), &mut |_point| {
+            points += 1;
+            ControlFlow::Continue(())
+        })
+        .expect("a valid preamble");
+        assert_eq!(points, 1, "the walk got past the unknown frame");
+    }
+
+    /// The frame reader distinguishes "cannot parse this" from "cannot find
+    /// the end of this". Only the second is fatal, and the difference is what
+    /// makes stepping over the first safe.
+    #[test]
+    fn a_frame_reports_whether_its_payload_was_readable() {
+        let (buf, unknown_bytes) = archive_with_an_unknown_record();
+        let mut r = buf.as_slice();
+        read_archive_start(&mut r).unwrap();
+
+        let mut frames = Vec::new();
+        while let Some(frame) = read_frame(&mut r).expect("no torn frames here") {
+            frames.push(frame);
+        }
+        assert_eq!(
+            frames,
+            vec![
+                Frame::Record(Box::new(header())),
+                // Stepped over, and it says how far.
+                Frame::Unreadable {
+                    bytes: unknown_bytes
+                },
+                Frame::Record(Box::new(trailing_message())),
+            ],
+            "one frame per record, with the unreadable one accounted for rather than ending the read"
+        );
+    }
+
+    /// A torn tail still ends the read. Skipping is for frames whose bytes are
+    /// all present; a truncated one has no known length to step over.
+    #[test]
+    fn a_torn_frame_still_ends_the_read() {
+        let mut buf = Vec::new();
+        write_archive_start(&mut buf, RUN_ARCHIVE_VERSION).unwrap();
+        write_record(&mut buf, &header()).unwrap();
+        // A length prefix promising more than follows.
+        buf.extend_from_slice(&999u64.to_be_bytes());
+        buf.extend_from_slice(b"not enough");
+
+        let (_, records) = read_archive_lenient(&mut buf.as_slice()).unwrap();
+        assert_eq!(records.len(), 1, "everything intact before the tear");
+    }
+
+    /// An archive from a future framing generation is refused rather than
+    /// misread. Reading it anyway would not fail cleanly - it would take
+    /// whatever the length prefixes happened to say and produce nonsense.
+    #[test]
+    fn an_archive_from_a_newer_format_is_refused_with_both_versions_named() {
+        let mut buf = Vec::new();
+        write_archive_start(&mut buf, RUN_ARCHIVE_VERSION + 1).unwrap();
+        write_record(&mut buf, &header()).unwrap();
+
+        let err = read_archive_lenient(&mut buf.as_slice()).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains(&(RUN_ARCHIVE_VERSION + 1).to_string()),
+            "{message}"
+        );
+        assert!(message.contains("upgrade leviath"), "{message}");
+    }
+
+    /// An older archive is read normally: framing has not changed under it, so
+    /// the only difference is which record kinds it happens to contain.
+    #[test]
+    fn an_archive_from_an_older_format_still_reads() {
+        let mut buf = Vec::new();
+        write_archive_start(&mut buf, 0).unwrap();
+        write_record(&mut buf, &header()).unwrap();
+        let (version, records) = read_archive_lenient(&mut buf.as_slice()).unwrap();
+        assert_eq!(version, 0);
+        assert_eq!(records.len(), 1);
     }
 }

--- a/crates/leviath-core/src/run_archive/codec.rs
+++ b/crates/leviath-core/src/run_archive/codec.rs
@@ -1,0 +1,243 @@
+//! The on-disk shape of `run.lvr`: magic, version, framing, and the reader
+//! that tolerates what it does not understand.
+//!
+//! Separate from the rest of the archive module because it answers a different
+//! question. Everything else decides what a record *means* - how a delta folds,
+//! what a window looks like after it. This decides only where one record ends
+//! and the next begins, which is the part that has to stay stable while the
+//! record set keeps growing.
+
+use std::io::{self, Read, Write};
+
+use super::RunRecord;
+
+/// File magic identifying a leviath run archive (`b"LVR1"`).
+pub const RUN_ARCHIVE_MAGIC: &[u8; 4] = b"LVR1";
+
+/// The archive format version this build writes.
+///
+/// Bump this only for a change to the *framing* - the preamble, the length
+/// prefix, or the payload encoding. Adding a record kind is not that: frames
+/// are length-prefixed and a reader skips a payload it cannot parse, so a new
+/// kind is readable by an older build (it just does not know what it says).
+/// Adding a field to an existing record is not that either, as long as the
+/// field is `#[serde(default)]`.
+///
+/// What a bump means is that an older build cannot find the record boundaries
+/// at all, which is why [`read_archive_start`] refuses a newer archive rather
+/// than trying.
+pub const RUN_ARCHIVE_VERSION: u16 = 1;
+
+// ─── codec ──────────────────────────────────────────────────────────────────
+
+/// Write the archive preamble (magic + version). Call once at file start.
+pub fn write_archive_start(w: &mut dyn Write, version: u16) -> io::Result<()> {
+    w.write_all(RUN_ARCHIVE_MAGIC)?;
+    w.write_all(&version.to_be_bytes())?;
+    Ok(())
+}
+
+/// Read + validate the archive preamble, returning the format version.
+///
+/// A version *newer* than this build understands is refused here rather than
+/// read. The version marks a framing change (see [`RUN_ARCHIVE_VERSION`]), so a
+/// newer archive is one whose record boundaries this build cannot find - and
+/// reading it anyway would not fail cleanly, it would produce nonsense from
+/// whatever the length prefixes happened to say. An older version is read
+/// normally: framing has not changed under it, and unknown record kinds are
+/// skipped rather than fatal.
+pub fn read_archive_start(r: &mut dyn Read) -> io::Result<u16> {
+    let mut magic = [0u8; 4];
+    r.read_exact(&mut magic)?;
+    if &magic != RUN_ARCHIVE_MAGIC {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "not a leviath run archive (bad magic)",
+        ));
+    }
+    let mut version = [0u8; 2];
+    r.read_exact(&mut version)?;
+    let version = u16::from_be_bytes(version);
+    if version > RUN_ARCHIVE_VERSION {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "run archive is format version {version}, but this build reads up to \
+                 {RUN_ARCHIVE_VERSION} - upgrade leviath to read it"
+            ),
+        ));
+    }
+    Ok(version)
+}
+
+/// Append one framed record. The frame length is a `u64` so it can never
+/// overflow the prefix (a `RunRecord` always serializes to JSON).
+pub fn write_record(w: &mut dyn Write, record: &RunRecord) -> io::Result<()> {
+    let payload = serde_json::to_vec(record).expect("a RunRecord always serializes to JSON");
+    let len = payload.len() as u64;
+    w.write_all(&len.to_be_bytes())?;
+    w.write_all(&payload)?;
+    Ok(())
+}
+
+/// Fill `buf` from `r`, returning `false` on a clean end-of-stream (zero bytes
+/// available at the call) and erroring only on a *partial* read (truncation).
+fn read_exact_or_eof(r: &mut dyn Read, buf: &mut [u8]) -> io::Result<bool> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        match r.read(&mut buf[filled..])? {
+            0 => {
+                if filled == 0 {
+                    return Ok(false); // clean EOF at a record boundary
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "truncated run-archive frame",
+                ));
+            }
+            n => filled += n,
+        }
+    }
+    Ok(true)
+}
+
+/// The largest a single archive frame may claim to be.
+///
+/// Generous by design - a record holds one context snapshot, and 256 MiB is far
+/// past anything a real run writes - because this is a sanity bound on a length
+/// prefix, not a size policy. What it rules out is a torn or corrupt prefix
+/// being taken at its word and turned straight into an allocation.
+const MAX_RECORD_BYTES: u64 = 256 * 1024 * 1024;
+
+/// One frame off the wire: a record this build understands, or a complete
+/// payload it does not.
+///
+/// The distinction is the whole point of the length prefix. A frame whose
+/// *content* is unreadable - a record kind added by a later build - is a
+/// well-formed frame whose bytes can be stepped over, and everything after it
+/// is still readable. A frame that is *torn* cannot be stepped over, because
+/// its length is unknown or its payload ran out, and the file ends there.
+///
+/// Conflating the two is what made adding a record kind a breaking change:
+/// `read_archive_lenient` stopped at the first unknown record and returned the
+/// prefix, silently dropping every readable record after it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Frame {
+    /// A record this build knows how to read.
+    Record(Box<RunRecord>),
+    /// A complete frame whose payload this build cannot parse, stepped over.
+    /// Carries its size so a caller can report what it skipped.
+    Unreadable {
+        /// Payload length in bytes.
+        bytes: usize,
+    },
+}
+
+/// Read the next frame, or `None` at a clean end-of-stream.
+///
+/// Errors only on a *torn* frame. An unparseable-but-complete payload comes
+/// back as [`Frame::Unreadable`] with the stream positioned after it, so
+/// reading can continue.
+pub fn read_frame(r: &mut dyn Read) -> io::Result<Option<Frame>> {
+    let Some(payload) = read_framed_payload(r)? else {
+        return Ok(None);
+    };
+    match serde_json::from_slice(&payload) {
+        Ok(record) => Ok(Some(Frame::Record(Box::new(record)))),
+        // Deliberately not an error: the frame was intact and has been
+        // consumed, so the only question is whether the caller wants to know.
+        Err(_) => Ok(Some(Frame::Unreadable {
+            bytes: payload.len(),
+        })),
+    }
+}
+
+/// Read the next framed record, or `None` at a clean end-of-stream.
+///
+/// Strict about content: a payload this build cannot parse is an error. Prefer
+/// [`read_frame`] anywhere an archive written by a *different* build might be
+/// read, which is every path that loads a run from disk.
+pub fn read_record(r: &mut dyn Read) -> io::Result<Option<RunRecord>> {
+    let Some(payload) = read_framed_payload(r)? else {
+        return Ok(None);
+    };
+    let record = serde_json::from_slice(&payload)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(Some(record))
+}
+
+/// Read one length-prefixed payload, or `None` at a clean end-of-stream.
+///
+/// The framing half of a frame read, shared so the strict and skipping readers
+/// cannot disagree about where a record ends.
+fn read_framed_payload(r: &mut dyn Read) -> io::Result<Option<Vec<u8>>> {
+    let mut len_bytes = [0u8; 8];
+    if !read_exact_or_eof(r, &mut len_bytes)? {
+        return Ok(None);
+    }
+    let len = u64::from_be_bytes(len_bytes);
+    // A torn tail is the reason `read_archive_lenient` exists, and a torn
+    // *length prefix* is exactly where a nonsense `u64` comes from. Allocating
+    // it first would abort the process on a crash-truncated archive - during
+    // daemon recovery, which is the one moment the lenient reader is there to
+    // survive. Rejecting it makes the frame an ordinary error, so recovery
+    // folds back to the last intact record instead.
+    if len > MAX_RECORD_BYTES {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("run-archive frame claims {len} bytes, over the {MAX_RECORD_BYTES} cap"),
+        ));
+    }
+    let mut payload = vec![0u8; len as usize];
+    if !read_exact_or_eof(r, &mut payload)? {
+        return Err(io::Error::new(
+            io::ErrorKind::UnexpectedEof,
+            "truncated run-archive frame",
+        ));
+    }
+    Ok(Some(payload))
+}
+
+/// Read the whole archive: validate the preamble, then read every record.
+pub fn read_archive(r: &mut dyn Read) -> io::Result<(u16, Vec<RunRecord>)> {
+    let version = read_archive_start(r)?;
+    let mut records = Vec::new();
+    while let Some(record) = read_record(r)? {
+        records.push(record);
+    }
+    Ok((version, records))
+}
+
+/// Read the archive tolerantly: validate the preamble strictly, then read records
+/// until a clean end-of-stream **or the first unreadable frame**, returning the
+/// records collected so far.
+///
+/// A crash while the persistence lane is appending a record can leave a partial
+/// final frame (a truncated length prefix or payload). The strict [`read_archive`]
+/// would reject the whole file for that torn tail - and once a fallback-resume
+/// appends fresh records *past* the torn bytes, the archive would stay unreadable
+/// forever. This variant instead stops at the torn tail and keeps everything valid
+/// before it, so recovery can still fold the archive to its last intact point. The
+/// preamble is still validated strictly, so a file that isn't a run archive at all
+/// still errors rather than folding to nothing.
+pub fn read_archive_lenient(r: &mut dyn Read) -> io::Result<(u16, Vec<RunRecord>)> {
+    let version = read_archive_start(r)?;
+    let mut records = Vec::new();
+    let mut skipped = 0usize;
+    // A torn frame ends the read with whatever preceded it. A frame this build
+    // simply does not understand is stepped over instead: it was written by a
+    // later version, and everything after it is still ours to read.
+    while let Ok(Some(frame)) = read_frame(r) {
+        match frame {
+            Frame::Record(record) => records.push(*record),
+            Frame::Unreadable { .. } => skipped += 1,
+        }
+    }
+    if skipped > 0 {
+        tracing::debug!(
+            skipped,
+            "run archive holds record kinds this build does not know; skipped them"
+        );
+    }
+    Ok((version, records))
+}

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -719,6 +719,48 @@ Everything persistent sits under the data root, `<home>/.leviath`, which `LEVIAT
 
 The daemon's control socket, its token, its pid file, and a build marker live here too.
 
+### What a run directory holds
+
+Four things, with different jobs:
+
+| File | What it is | Rewritten or appended |
+|---|---|---|
+| `meta.json` | The run's current status, model, token totals, wait reason | Rewritten whole |
+| `context.json` | The context window as it stands right now | Rewritten whole |
+| `stages.json` | Per-stage names and status | Rewritten whole |
+| `run.lvr` | The journal: every step, in order | Append-only |
+
+The first three answer "what is true now" and are cheap to read. `run.lvr` answers "how did it get
+here", and is what [`lev context`](/docs/cli) replays and what a daemon restart folds to recover a
+run.
+
+### The `run.lvr` format
+
+A four-byte magic (`LVR1`), a two-byte format version, then a sequence of records. Each record is
+an eight-byte big-endian length followed by that many bytes of JSON.
+
+```
+LVR1 | u16 version | [ u64 length | JSON payload ] ...
+```
+
+Folding the records in order reconstructs the run. Most are a `Progress` record carrying a diff
+against the previous context, anchored by a full `ContextCheckpoint` whenever the writer has no
+previous state to diff against.
+
+**Adding a record kind is not a breaking change.** Frames carry their length, so a reader that
+meets a record kind it does not know steps over it and keeps going. That is what lets a newer
+Leviath write records an older one can still read around, and it is why the version below does not
+move when a kind is added.
+
+**The version marks a change to the framing** - the preamble, the length prefix, or the payload
+encoding - not to the record set. A build refuses an archive whose version is higher than it
+understands, rather than reading it: at that point it cannot find the record boundaries, so it
+would not fail cleanly, it would produce nonsense. An older version reads normally.
+
+**A torn tail is tolerated.** A crash mid-append leaves a partial final frame, and readers stop
+there and keep everything before it - so an interrupted run still recovers to its last intact
+point.
+
 ## `policy.toml`
 
 Taint-gate policy lives in its own file, not in `config.toml`. It sits in your platform's config


### PR DESCRIPTION
From the run-format audit. Two problems, both confirmed by probe rather than by reading.

## 1. Adding a record kind silently truncated the journal for older readers

Records are length-prefixed and nothing used that. A frame whose *content* a build cannot parse was treated exactly like a frame whose *end* it cannot find, so `read_archive_lenient` stopped at the first one and returned the prefix.

Probed with a well-framed record carrying an unknown variant name, followed by a readable `Message`:

```
lenient read returned 1 records
  Header
strict read = Err("unknown variant `SomethingNew`, expected one of …")
```

The readable record after the gap is **dropped, with no error**.

**This is live.** `InferenceUsage` shipped in 0.3.10 and is written on every provider call, so anything on an older `leviath-core` reads a 0.3.10 journal as "header, then nothing" — which is exactly the shape a harness folding archives meets first.

A frame now reports which kind of failure it is. `Frame::Unreadable` carries a complete payload this build has already stepped over; a torn frame still errors, because its length is unknown and there is nothing to step over. All four readers that load an archive some *other* build may have written skip and continue: the buffering one, the streaming visitor, and both CLI paths.

## 2. The version was read by everyone and checked by nobody

Every caller either discarded it or handed it back; nothing compared it to `RUN_ARCHIVE_VERSION`. A future v2 would have been parsed as v1 and produced nonsense from whatever the length prefixes happened to say.

`read_archive_start` now refuses an archive newer than this build, naming both versions. Older versions read normally.

That also gives the version a contract it did not have. It marks a **framing** change — the preamble, the length prefix, the payload encoding — and not a change to the record set:

- Adding a record kind does not move it, because that is now readable by older builds.
- Adding a `#[serde(default)]` field does not move it either.
- Changing how records are framed or encoded does.

Which is the versioning story the audit was asked for: the common evolution (new record kinds) is now backward compatible by construction, and the version is reserved for the case that genuinely isn't.

## Tests

Six, pinning each guarantee: unknown kind stepped over with the record after it intact, frames distinguishing unparseable from torn, torn tail still ending the read, the streaming reader skipping the same way (it has its own loop, so "both apply the rule" needed checking), newer format refused, older format readable.

## Structure

`run_archive.rs` crossed the 1200-line limit, so the codec moved to `run_archive/codec.rs`. Where a record ends is a different question from what it means, and it is the half that has to stay stable while the record set grows.

## Docs

New "What a run directory holds" and "The `run.lvr` format" sections in `configuration.md`, including the compatibility rules — so the next person adding a record kind knows they do not need a version bump, and the next person changing the framing knows they do.
