### PR TITLE
fix(runtime): park an unattended run whose fix is somebody else's, too

### DIFF
--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -137,6 +137,14 @@ pub async fn persistence_worker(
         std::collections::HashMap::new();
     let mut last_context: std::collections::HashMap<String, run_archive::ContextDigest> =
         std::collections::HashMap::new();
+    // The status last written into the archive, so a change of status can be
+    // recorded as the event it is. `Progress` carries the whole `RunMeta` and
+    // therefore the status too, but only as a value that happens to differ
+    // from the previous record's - a post-mortem asking "when did this die,
+    // and to what" had to diff its way there, and a run whose last act was to
+    // go terminal might have no `Progress` after it at all.
+    let mut last_status: std::collections::HashMap<String, leviath_core::run_meta::RunStatus> =
+        std::collections::HashMap::new();
     while let Some(first) = jobs.recv().await {
         // Drain whatever else is already queued and process it as one batch,
         // keeping only the NEWEST snapshot per run: each snapshot carries the
@@ -166,9 +174,17 @@ pub async fn persistence_worker(
                     // Record what the write actually put on disk, not what this
                     // job hoped to - deriving the watermark from the job rather
                     // than the write is the shape of the bug being fixed.
-                    let outcome =
-                        write_snapshot(&runs_dir, &job, &machine_id, &world_id, prev, written)
-                            .await;
+                    let status_before = last_status.get(&job.run_id);
+                    let outcome = write_snapshot(
+                        &runs_dir,
+                        &job,
+                        &machine_id,
+                        &world_id,
+                        prev,
+                        written,
+                        status_before,
+                    )
+                    .await;
                     if let Some(key) = outcome.output {
                         last_output.insert(job.run_id.clone(), key);
                     }
@@ -176,9 +192,13 @@ pub async fn persistence_worker(
                     // written again), so the map stays bounded by the set of
                     // *live* runs rather than every run the daemon has ever
                     // seen.
+                    if outcome.archived {
+                        last_status.insert(job.run_id.clone(), job.meta.status.clone());
+                    }
                     if is_terminal_run(&job.meta.status) {
                         last_context.remove(&job.run_id);
                         last_output.remove(&job.run_id);
+                        last_status.remove(&job.run_id);
                     } else if outcome.archived {
                         // Only for a record that reached the file. If the append
                         // failed, the digest stays at the last state a reader
@@ -297,7 +317,7 @@ fn is_terminal_run(status: &leviath_core::run_meta::RunStatus) -> bool {
     use leviath_core::run_meta::RunStatus;
     matches!(
         status,
-        RunStatus::Complete | RunStatus::Error | RunStatus::Cancelled
+        leviath_core::run_meta::RunStatus::Complete | RunStatus::Error | RunStatus::Cancelled
     )
 }
 
@@ -361,13 +381,15 @@ async fn write_snapshot(
     world_id: &str,
     prev_context: Option<&run_archive::ContextDigest>,
     written_output: Option<(i64, usize)>,
+    status_before: Option<&leviath_core::run_meta::RunStatus>,
 ) -> WriteOutcome {
     let dir = runs_dir.join(&job.run_id);
     if let Err(e) = create_private_dir(&dir).await {
         tracing::warn!(run_id = %job.run_id, error = %e, "persistence: create run dir failed");
         return WriteOutcome::default();
     }
-    let archived = append_run_archive(&dir, job, machine_id, world_id, prev_context).await;
+    let archived =
+        append_run_archive(&dir, job, machine_id, world_id, prev_context, status_before).await;
     let meta_json = serde_json::to_string_pretty(&job.meta).expect("RunMeta always serializes");
     write_bytes_atomic(&dir.join("meta.json"), meta_json.into_bytes(), &job.run_id).await;
     // Compact, not pretty: the context is the largest file the lane writes and
@@ -486,6 +508,7 @@ async fn append_run_archive(
     machine_id: &str,
     world_id: &str,
     prev_context: Option<&run_archive::ContextDigest>,
+    status_before: Option<&leviath_core::run_meta::RunStatus>,
 ) -> bool {
     use leviath_core::run_archive::{RunIdentity, RunRecord};
 
@@ -537,6 +560,20 @@ async fn append_run_archive(
             };
             run_archive::write_record(&mut buf, &checkpoint).expect("writing to a Vec never fails");
         }
+    }
+
+    // Beside whatever else this write records: a *change* of status is an
+    // event in its own right, and the one a post-mortem looks for first.
+    //
+    // Only a change. The first write has no previous status to differ from,
+    // and the `Header` it goes out with already carries the run's opening
+    // state - a `StatusChanged` there would say the same thing twice.
+    if status_before.is_some_and(|before| before != &job.meta.status) {
+        let changed = RunRecord::StatusChanged {
+            status: job.meta.status.clone(),
+            at,
+        };
+        run_archive::write_record(&mut buf, &changed).expect("writing to a Vec never fails");
     }
 
     // Open and write share one outcome, because they share one meaning: either
@@ -788,7 +825,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let mut j = job("run-perms");
         j.final_output = Some("the answer".to_string());
-        write_snapshot(dir.path(), &j, "m", "w", None, None).await;
+        write_snapshot(dir.path(), &j, "m", "w", None, None, None).await;
 
         let run_dir = dir.path().join("run-perms");
         for name in ["meta.json", "context.json", leviath_core::FINAL_OUTPUT_FILE] {
@@ -814,7 +851,7 @@ mod tests {
         let dir = tempfile::tempdir().expect("temp dir");
         let mut j = job("run-answer");
         j.final_output = Some("metric,value\nrows,2\n".to_string());
-        write_snapshot(dir.path(), &j, "m", "w", None, None).await;
+        write_snapshot(dir.path(), &j, "m", "w", None, None, None).await;
 
         let written = std::fs::read_to_string(
             dir.path()
@@ -850,7 +887,7 @@ mod tests {
 
         // `None` is what the lane knows after the job that would have written
         // the bytes was coalesced away: nothing has been written for this run.
-        write_snapshot(dir.path(), &j, "m", "w", None, None).await;
+        write_snapshot(dir.path(), &j, "m", "w", None, None, None).await;
 
         let sidecar = dir
             .path()
@@ -891,7 +928,7 @@ mod tests {
             .join("run-heartbeat")
             .join(leviath_core::FINAL_OUTPUT_FILE);
 
-        write_snapshot(dir.path(), &j, "m", "w", None, None).await;
+        write_snapshot(dir.path(), &j, "m", "w", None, None, None).await;
         assert!(sidecar.exists(), "first write lands");
         // Replace it with a marker: if the skip does not hold, the marker is
         // overwritten, which is a difference a mere "file exists" cannot see.
@@ -904,6 +941,7 @@ mod tests {
             "w",
             None,
             Some((100, "the answer".len())),
+            None,
         )
         .await;
         assert_eq!(
@@ -925,6 +963,7 @@ mod tests {
             "w",
             None,
             Some((100, "the answer".len())),
+            None,
         )
         .await;
         assert_eq!(
@@ -939,7 +978,7 @@ mod tests {
     #[tokio::test]
     async fn no_answer_writes_no_sidecar() {
         let dir = tempfile::tempdir().expect("temp dir");
-        write_snapshot(dir.path(), &job("run-silent"), "m", "w", None, None).await;
+        write_snapshot(dir.path(), &job("run-silent"), "m", "w", None, None, None).await;
         assert!(
             !dir.path()
                 .join("run-silent")
@@ -962,7 +1001,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let run = dir.path().join("run-perms");
 
-        write_snapshot(dir.path(), &job("run-perms"), "m", "w", None, None).await;
+        write_snapshot(dir.path(), &job("run-perms"), "m", "w", None, None, None).await;
         append_stage_line(&run, 0, "output.log", "a line of agent output", "run-perms").await;
         append_stage_line(&run, 0, "logs.log", "a line of tool activity", "run-perms").await;
         append_record(
@@ -1051,6 +1090,7 @@ mod tests {
             "world-y",
             None,
             None,
+            None,
         )
         .await;
 
@@ -1082,13 +1122,14 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let first = job_with_context("run-1", 1);
         let second = job_with_context("run-1", 3); // grew by 2 entries
-        write_snapshot(dir.path(), &first, "m", "w", None, None).await;
+        write_snapshot(dir.path(), &first, "m", "w", None, None, None).await;
         write_snapshot(
             dir.path(),
             &second,
             "m",
             "w",
             Some(&run_archive::digest_context(&first.context)),
+            None,
             None,
         )
         .await;
@@ -1118,10 +1159,10 @@ mod tests {
         use leviath_core::run_archive::{RunRecord, read_archive};
         let dir = tempfile::tempdir().unwrap();
         // First process writes the archive.
-        write_snapshot(dir.path(), &job("run-1"), "m1", "w1", None, None).await;
+        write_snapshot(dir.path(), &job("run-1"), "m1", "w1", None, None, None).await;
         // A "restarted" worker (no prior context) writes to the existing archive:
         // it records an ownership handoff + a fresh context re-anchor, not a Header.
-        write_snapshot(dir.path(), &job("run-1"), "m2", "w2", None, None).await;
+        write_snapshot(dir.path(), &job("run-1"), "m2", "w2", None, None, None).await;
 
         let bytes = std::fs::read(dir.path().join("run-1").join("run.lvr")).unwrap();
         let (_v, records) = read_archive(&mut bytes.as_slice()).unwrap();
@@ -1150,11 +1191,17 @@ mod tests {
     #[test]
     fn is_terminal_run_classifies_statuses() {
         use leviath_core::run_meta::RunStatus;
-        assert!(is_terminal_run(&RunStatus::Complete));
+        assert!(is_terminal_run(
+            &leviath_core::run_meta::RunStatus::Complete
+        ));
         assert!(is_terminal_run(&RunStatus::Error));
         assert!(is_terminal_run(&RunStatus::Cancelled));
-        assert!(!is_terminal_run(&RunStatus::Running));
-        assert!(!is_terminal_run(&RunStatus::CompleteInteractive));
+        assert!(!is_terminal_run(
+            &leviath_core::run_meta::RunStatus::Running
+        ));
+        assert!(!is_terminal_run(
+            &leviath_core::run_meta::RunStatus::CompleteInteractive
+        ));
     }
 
     /// Snapshots queued behind a slow write are coalesced latest-wins per run:
@@ -1285,7 +1332,7 @@ mod tests {
         // A job carrying fan-out state writes fanout.json.
         let mut fo_job = job("run-1");
         fo_job.fanout = Some(r#"{"resume":"me"}"#.to_string());
-        write_snapshot(dir.path(), &fo_job, "m", "w", None, None).await;
+        write_snapshot(dir.path(), &fo_job, "m", "w", None, None, None).await;
         assert!(path.exists());
         // A later job without fan-out state removes the now-stale file.
         write_snapshot(
@@ -1294,6 +1341,7 @@ mod tests {
             "m",
             "w",
             Some(&run_archive::digest_context(&fo_job.context)),
+            None,
             None,
         )
         .await;
@@ -1307,7 +1355,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let run_dir = dir.path().join("run-1");
         std::fs::create_dir_all(run_dir.join("run.lvr")).unwrap();
-        write_snapshot(dir.path(), &job("run-1"), "m", "w", None, None).await;
+        write_snapshot(dir.path(), &job("run-1"), "m", "w", None, None, None).await;
         // meta.json still written despite the archive failure.
         assert!(run_dir.join("meta.json").exists());
     }
@@ -1447,6 +1495,7 @@ mod tests {
             "world-test",
             None,
             None,
+            None,
         )
         .await;
 
@@ -1482,6 +1531,7 @@ mod tests {
             "world-test",
             None,
             None,
+            None,
         )
         .await;
         let audit =
@@ -1505,6 +1555,7 @@ mod tests {
             "world-test",
             None,
             None,
+            None,
         )
         .await;
         let written = std::fs::read_to_string(&path).unwrap();
@@ -1516,6 +1567,7 @@ mod tests {
             &job("r"),
             "machine-test",
             "world-test",
+            None,
             None,
             None,
         )
@@ -1542,6 +1594,7 @@ mod tests {
             },
             "machine-test",
             "world-test",
+            None,
             None,
             None,
         )
@@ -1584,6 +1637,7 @@ mod tests {
             "world-test",
             None,
             None,
+            None,
         )
         .await;
     }
@@ -1613,6 +1667,7 @@ mod tests {
             },
             "machine-test",
             "world-test",
+            None,
             None,
             None,
         )
@@ -1650,6 +1705,7 @@ mod tests {
             "world-test",
             None,
             None,
+            None,
         )
         .await;
 
@@ -1672,14 +1728,14 @@ mod tests {
         let j = job_with_context("run-torn", 3);
 
         // Nothing in the way: the record lands and the write says so.
-        let ok = write_snapshot(dir.path(), &j, "m", "w", None, None).await;
+        let ok = write_snapshot(dir.path(), &j, "m", "w", None, None, None).await;
         assert!(ok.archived, "an unobstructed append lands");
 
         // Now make `run.lvr` unopenable and try again.
         let blocked = tempfile::tempdir().expect("temp dir");
         let run_dir = blocked.path().join(&j.run_id);
         std::fs::create_dir_all(run_dir.join("run.lvr")).expect("occupy the archive path");
-        let failed = write_snapshot(blocked.path(), &j, "m", "w", None, None).await;
+        let failed = write_snapshot(blocked.path(), &j, "m", "w", None, None, None).await;
         assert!(
             !failed.archived,
             "an append that could not open its file must not report success"
@@ -1747,6 +1803,54 @@ mod tests {
             folded.context.regions[0].entries.len(),
             5,
             "folds to what the run actually held"
+        );
+    }
+
+    /// A run's terminal transition is recorded as an event, not left to be
+    /// inferred by diffing metadata between records.
+    ///
+    /// Issue #456 asked for this from the post-mortem side: the journals of 31
+    /// runs that died on an empty account carried no statement of when or to
+    /// what, so working it out meant correlating daemon logs that a harness
+    /// had sent to /dev/null.
+    #[tokio::test]
+    async fn a_change_of_status_is_journalled_as_its_own_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut running = job("run-status");
+        running.meta.status = leviath_core::run_meta::RunStatus::Running;
+        let mut done = job("run-status");
+        done.meta.status = leviath_core::run_meta::RunStatus::Complete;
+
+        // Two batches through *one* worker: the lane remembers the last status
+        // it archived for the life of the worker, which is how a long-running
+        // daemon sees the transition. Sending both at once would coalesce them
+        // to the newest and there would be no transition to see.
+        let (tx, rx) = mpsc::unbounded_channel();
+        let runs_dir = dir.path().to_path_buf();
+        let worker = tokio::spawn(async move { persistence_worker(Some(runs_dir), rx).await });
+        tx.send(PersistMsg::Snapshot(Box::new(running))).unwrap();
+        tokio::task::yield_now().await;
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tx.send(PersistMsg::Snapshot(Box::new(done))).unwrap();
+        drop(tx);
+        worker
+            .await
+            .expect("the worker exits when the channel closes");
+
+        let bytes = std::fs::read(dir.path().join("run-status").join("run.lvr")).unwrap();
+        let (_, records) =
+            leviath_core::run_archive::read_archive_lenient(&mut bytes.as_slice()).unwrap();
+        let changes: Vec<&leviath_core::run_meta::RunStatus> = records
+            .iter()
+            .filter_map(|r| match r {
+                leviath_core::run_archive::RunRecord::StatusChanged { status, .. } => Some(status),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            changes,
+            vec![&leviath_core::run_meta::RunStatus::Complete],
+            "the transition, and not the opening status the Header already carries"
         );
     }
 }

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -261,10 +261,13 @@ pub fn collect_inference(
                 // watching for a terminal status and would wait for ever for
                 // one that never comes, so for those a failure is the honest
                 // answer.
-                let attended = !md.is_some_and(|m| m.unattended);
-                if attended
-                    && err.unavailable_reason()
-                        == Some(leviath_providers::UnavailableReason::CreditsExhausted)
+                // Unattended included. A run that hit an empty account has
+                // done real work and needs one edit elsewhere to continue, so
+                // ending it throws that away to punish somebody for a billing
+                // lapse. A harness that cannot rescue it cancels instead
+                // (issue #456).
+                if err.unavailable_reason()
+                    == Some(leviath_providers::UnavailableReason::CreditsExhausted)
                 {
                     let message = format!(
                         "out of credits ({err}): top up the account, then \

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -298,35 +298,19 @@ pub fn fail_stalled_dispatch(
             ),
             _ => stall.reason.give_up_message(&si.provider_name),
         };
-        // Unless nobody is there to read it. An unattended run was launched by
-        // a scheduler or a harness, which is watching for a terminal status
-        // and will wait for ever for one that never comes - so for those,
-        // failing is the honest answer and stays what it was.
-        let unattended = md.is_some_and(|m| m.unattended);
-        if unattended {
-            tracing::error!(
-                provider = %si.provider_name,
-                reason = stall.reason.label(),
-                stalled_secs = now.saturating_sub(stall.since),
-                "failing an unattended run: nobody is there to fix it"
-            );
-            // No `lev resume` here: this run is ending, and pointing somebody
-            // at a command that will not work is worse than saying nothing.
-            let message = format!("{remedy}; this run has ended and cannot be resumed");
-            if let Some(mut buffer) = buffer {
-                buffer.logs.push((0, format!("[stalled] {message}")));
-            }
-            state.status = AgentStatus::Error { message };
-            commands
-                .entity(entity)
-                .remove::<ReadyToInfer>()
-                .remove::<DispatchStall>();
-            continue;
-        }
+        // Every run parks, unattended included. This used to fail an
+        // unattended one on the reasoning that a scheduler watches for a
+        // terminal status and would wait for ever for one that never comes.
+        // That undersold harnesses: `paused` is visible in `meta.json` and
+        // `lev ps --json`, and one that can top up an account and `lev resume`
+        // gets its work back. One that cannot is no worse off than before -
+        // it cancels the run, which is a decision it can make in a second,
+        // where a failed run's work is gone for good (issue #456).
         tracing::warn!(
             provider = %si.provider_name,
             reason = stall.reason.label(),
             stalled_secs = now.saturating_sub(stall.since),
+            unattended = md.is_some_and(|m| m.unattended),
             "pausing a run until the machine is fixed"
         );
         // Paused, so resume is the truthful next step and is worth naming.
@@ -484,29 +468,31 @@ mod tests {
         );
     }
 
-    /// Unless nobody is watching. A scheduler polling for a terminal status
-    /// would wait for ever for one that never came, so an unattended run still
-    /// fails - the one case where an error is the more useful answer.
+    /// Nobody watching is not a reason to throw the work away.
+    ///
+    /// This used to fail, on the reasoning that a scheduler polls for a
+    /// terminal status and would wait for ever for one that never came. A
+    /// benchmark round lost 31 runs and a tier to that (issue #456): the
+    /// account needed topping up, which is one edit elsewhere, and every one
+    /// of those runs had already done real work. A harness that can rescue a
+    /// paused run now gets to; one that cannot cancels it, which costs a
+    /// second, where a failed run's work is gone.
     #[test]
-    fn an_unattended_run_still_fails_because_nobody_will_fix_it() {
+    fn an_unattended_run_parks_like_any_other_rather_than_losing_its_work() {
         let mut world = World::new();
         world.insert_resource(StallTimeout(60));
         let e = spawn_stalled_unattended(&mut world, StallReason::ProviderMissing, 61);
 
         run(&mut world);
 
-        let status = &world.get::<AgentState>(e).unwrap().status;
-        assert!(
-            matches!(status, AgentStatus::Error { message }
-                if message.contains("ghost") && message.contains("not configured")),
-            "got: {status:?}"
-        );
-        assert!(world.get::<ReadyToInfer>(e).is_none());
-        assert!(world.get::<PausedForSetup>(e).is_none());
+        assert_paused_for_setup(&world, e, "not configured");
+        // The staged retry survives, so a resume re-dispatches rather than
+        // rebuilding - the whole point of parking instead of failing.
+        assert!(world.get::<ReadyToInfer>(e).is_some());
         let logs = &world.get::<StageIoBuffer>(e).unwrap().logs;
         assert!(
-            logs.iter().any(|(_, line)| line.starts_with("[stalled]")),
-            "expected a [stalled] log line, got: {logs:?}"
+            logs.iter().any(|(_, line)| line.starts_with("[paused]")),
+            "expected a [paused] log line, got: {logs:?}"
         );
     }
 
@@ -866,7 +852,7 @@ mod tests {
     /// `StageIoBuffer` is optional on the query, so the unattended failure has
     /// to land even when there is no stage log to explain it in.
     #[test]
-    fn an_unattended_failure_copes_without_a_stage_log_buffer() {
+    fn an_unattended_park_copes_without_a_stage_log_buffer() {
         let mut world = World::new();
         world.insert_resource(StallTimeout(60));
         let e = world
@@ -882,7 +868,7 @@ mod tests {
         run(&mut world);
 
         let status = format!("{:?}", world.get::<AgentState>(e).unwrap().status);
-        assert!(status.contains("Error"), "{status}");
+        assert!(status.contains("Paused"), "{status}");
     }
 
     /// A provider that was never configured is a different fix again, and the

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -972,8 +972,15 @@ fn an_exhausted_fallback_list_pauses_on_credits_instead_of_dying() {
 /// a scheduler or a benchmark, which is watching for a terminal status and
 /// would wait for ever for one that never arrives - so the one case where an
 /// error is more useful than patience keeps getting one.
+/// An empty account parks an unattended run too.
+///
+/// It used to fail, and that cost a benchmark round 31 runs (issue #456). The
+/// error also arrived as three different terminal shapes depending on where it
+/// landed - the worst being a run that died on its output stage and recorded
+/// "never called submit_output", which names the wrong cause entirely. Parking
+/// at the point of failure collapses all three into one answer.
 #[test]
-fn an_unattended_run_out_of_credits_fails_rather_than_waiting_for_nobody() {
+fn an_unattended_run_out_of_credits_parks_instead_of_losing_its_work() {
     let (mut world, tx) = world_with_results();
     let mut si = stage_with_fallback();
     si.fallbacks.clear();
@@ -990,9 +997,21 @@ fn an_unattended_run_out_of_credits_fails_rather_than_waiting_for_nobody() {
     run_collect(&mut world);
 
     let status = format!("{:?}", world.get::<AgentState>(e).unwrap().status);
-    assert!(status.contains("Error"), "{status}");
-    assert!(world.get::<crate::pipeline::PausedForSetup>(e).is_none());
-    assert!(world.get::<ResolveTransition>(e).is_some());
+    assert!(status.contains("Paused"), "{status}");
+    let parked = world
+        .get::<crate::pipeline::PausedForSetup>(e)
+        .expect("parked, with the reason a client can read");
+    assert_eq!(
+        parked.blocker,
+        leviath_core::run_meta::SetupBlocker::CreditsExhausted
+    );
+    // Not routed into the transition logic, which is what let a credits
+    // failure on an output stage be recorded as a missing answer.
+    assert!(world.get::<ResolveTransition>(e).is_none());
+    assert!(
+        world.get::<ReadyToInfer>(e).is_some(),
+        "the retry is staged"
+    );
 }
 
 /// The attended run says what to do, in a form a client can read rather than


### PR DESCRIPTION
Closes #456. Always pause, no config knob, per @GEMISIS's call — a harness that cannot rescue a run can cancel it, which costs a second, where a failed run's work is gone.

## Three shapes, one cause

The issue reported an empty account killing 31 runs in three distinct terminal shapes. Tracing them, they are the same event failing in three places, and the common factor is the unattended-equals-fail decision — which was mine, in #438.

- **Shape 1** — the stall watchdog failing an unattended run after the breaker opened.
- **Shape 2** — mid-inference credits exhaustion falling through to the generic error arm, because the pause was guarded on `attended`.
- **Shape 3** — the same credits error landing on an output stage, routing into the transition logic, and the required-output machinery reporting first. The run recorded *"never called submit_output"*, which names the wrong cause to every consumer there is.

Parking at the point of failure fixes all three, and shape 3 falls out for free: the pause path returns before anything reaches `ResolveTransition`.

## Correcting one part of ask 1

The credits *classification* was already right, and this is worth recording so nobody re-fixes it. `UnavailableReason::classify` has matched Anthropic's HTTP 400 low-balance body since #201 — there's an explicit `"credit balance is too low"` case with a comment about that exact scenario. The message quoted in the issue as evidence of a raw API error (*"out of credits: top up the account, or lower max_tokens…"*) **is that classification's own remedy text**. It was recognised as credits and failed anyway, for being unattended.

So matching harder on the error type would have changed nothing. The classification was fine; the decision it fed into was not.

## Ask 5: `StatusChanged`

Now journalled on a transition. The variant has existed, been folded, and been handled by the serve filter since the archive was written — and nothing has ever produced one. (That's the third variant in this enum in that state; `InferenceUsage` was the same until #445.)

Only on a *change*: the first write's `Header` already carries the opening status, so emitting one there would say the same thing twice.

This is the piece the reporter needs most for post-mortems, since their harness had daemon stderr going to `/dev/null` and the terminal cause was only reconstructable from those logs.

## Ask 4: message truthfulness

Moot as a separate fix now — there is no failing branch to write an untruthful message for. The remedy and the "then `lev resume`" promise are still split, so the paused message names resume and the remedy stands alone.

## Ask 3: the cascade

Partly addressed and worth being precise about what isn't. Once the breaker opens on credits, runs that reach it now park with the credits classification rather than each dying on their own discovery — so no work is lost across the fleet. What this does **not** do is shortcut the stall timeout: a run still waits out the watchdog before parking. That's latency, not lost work, so I've left it rather than adding a second mechanism speculatively.

## Tests

Three rewritten to the new contract (they were pinning the old decision, which is a fair signal for how visible this is), plus a new one asserting the status transition reaches the journal. That one drives two batches through a *single* worker, because the lane's memory of the last archived status lives for the worker's lifetime — restarting it between sends, as the obvious version of the test does, silently tests nothing.

Full suite green; `leviath-runtime` back at 100%.
