### PR TITLE
fix(providers): send one system message, however many blocks assembled

### DIFF
--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -218,6 +218,12 @@ struct RunRecordParts {
     output_validators:
         HashMap<String, std::sync::Arc<leviath_scripting::output_validator::OutputValidator>>,
     outcome_flags: leviath_runtime::persistence::RunOutcomeFlags,
+    /// Whether this run should be marked for one-shot title generation.
+    ///
+    /// Decided by the caller rather than here, because the answer turns on
+    /// whether this is a fresh spawn or a run being paged back in - which is
+    /// the caller's distinction, not a property of the record.
+    wants_title: bool,
     compaction: Option<leviath_core::CompactionConfig>,
     tool_sensitivities: Option<HashMap<String, leviath_core::TaintLevel>>,
     security: leviath_core::taint::SecurityConfig,
@@ -271,7 +277,8 @@ fn attach_run_record(
         // searches). Root runs only: sub-agents inherit their parent's context
         // in the run list, and titling every fan-out worker would multiply
         // cheap-but-nonzero LLM calls for no UX gain.
-        (deps.config.title.enabled && !args.task.is_empty() && args.parent_run_id.is_none())
+        parts
+            .wants_title
             .then_some(leviath_runtime::title::PendingTitle)
             .into_iter()
             .for_each(|marker| {
@@ -704,6 +711,15 @@ fn build_agent_inner(
             read_path_counts,
             output_validators,
             outcome_flags,
+            // `enforce_seeds` is false on the recovery path, which is also the
+            // resume path - and a run being paged back in has already had its
+            // one shot at a title. Without this, every pause/resume cycle buys
+            // another titling call for a run that either has a title or has
+            // already failed to get one.
+            wants_title: enforce_seeds
+                && deps.config.title.enabled
+                && !args.task.is_empty()
+                && args.parent_run_id.is_none(),
             compaction,
             tool_sensitivities,
             security: security.clone(),

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -200,8 +200,29 @@ pub fn openai_messages_with(
     tool_args: ToolArgsFormat,
 ) -> Vec<serde_json::Value> {
     let mut messages: Vec<serde_json::Value> = Vec::new();
-    for block in &request.system {
-        messages.push(serde_json::json!({ "role": "system", "content": block.text }));
+    // One system message, however many blocks the context assembled into.
+    //
+    // A block per pinned region is how Leviath thinks about system content, and
+    // Anthropic takes it that way natively. The OpenAI chat shape has no such
+    // concept: it has *a* system message, and emitting several is at best
+    // unusual. Some Ollama chat templates reject the second one outright -
+    // qwen3.8 answers `HTTP 500 {"error":"system message must be at the
+    // beginning"}`, which is a misleading way to say "at most one". An agent
+    // with several pinned regions could not take a single turn against it.
+    //
+    // Empty blocks are dropped rather than joined, or a region that happens to
+    // be empty this turn contributes a blank paragraph to the prompt.
+    let system: Vec<&str> = request
+        .system
+        .iter()
+        .map(|block| block.text.trim())
+        .filter(|text| !text.is_empty())
+        .collect();
+    if !system.is_empty() {
+        messages.push(serde_json::json!({
+            "role": "system",
+            "content": system.join("\n\n"),
+        }));
     }
     for msg in &request.messages {
         messages.extend(message_to_openai_with(&msg.role, &msg.content, tool_args));
@@ -2145,14 +2166,114 @@ mod tests {
         };
         let body = build_openai_request_body(&req);
         let messages = body["messages"].as_array().unwrap();
-        // 2 system blocks + 1 user message
-        assert_eq!(messages.len(), 3);
+        // Both blocks, joined into the one system message the chat shape has.
+        assert_eq!(messages.len(), 2);
         assert_eq!(messages[0]["role"], "system");
-        assert_eq!(messages[0]["content"], "You are helpful.");
-        assert_eq!(messages[1]["role"], "system");
-        assert_eq!(messages[1]["content"], "Be concise.");
-        assert_eq!(messages[2]["role"], "user");
-        assert_eq!(messages[2]["content"], "Hi");
+        assert_eq!(messages[0]["content"], "You are helpful.\n\nBe concise.");
+        assert_eq!(messages[1]["role"], "user");
+        assert_eq!(messages[1]["content"], "Hi");
+    }
+
+    /// However many blocks the context assembles into, exactly one system
+    /// message goes out.
+    ///
+    /// Some Ollama chat templates reject the second one - qwen3.8 answers
+    /// `HTTP 500 {"error":"system message must be at the beginning"}`, which is
+    /// a misleading way to say "at most one". An agent with several pinned
+    /// regions (deep-researcher has eight) could not take a single turn against
+    /// it, and every stage failed on its first call.
+    #[test]
+    fn many_system_blocks_become_exactly_one_system_message() {
+        let req = InferenceRequest {
+            system: (0..8)
+                .map(|i| SystemBlock {
+                    text: format!("block {i}"),
+                    cache_hint: leviath_core::CacheHint::Always,
+                })
+                .collect(),
+            messages: vec![Message {
+                role: "user".into(),
+                content: "Hi".into(),
+                cache_breakpoint: false,
+            }],
+            model: "qwen3.8".into(),
+            max_tokens: 100,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::json!({}),
+            request_timeout_secs: None,
+        };
+        let messages = openai_messages_with(&req, ToolArgsFormat::Object);
+        let systems = messages.iter().filter(|m| m["role"] == "system").count();
+        assert_eq!(systems, 1, "{messages:#?}");
+        let joined = (0..8)
+            .map(|i| format!("block {i}"))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        assert_eq!(
+            messages[0]["content"], joined,
+            "every block survives the join"
+        );
+    }
+
+    /// A pinned region that happens to be empty this turn contributes nothing,
+    /// rather than a blank paragraph in the middle of the prompt.
+    #[test]
+    fn empty_system_blocks_are_dropped_rather_than_joined() {
+        let req = InferenceRequest {
+            system: vec![
+                SystemBlock {
+                    text: "real".into(),
+                    cache_hint: leviath_core::CacheHint::Always,
+                },
+                SystemBlock {
+                    text: "   ".into(),
+                    cache_hint: leviath_core::CacheHint::Always,
+                },
+                SystemBlock {
+                    text: "also real".into(),
+                    cache_hint: leviath_core::CacheHint::Always,
+                },
+            ],
+            messages: vec![Message {
+                role: "user".into(),
+                content: "Hi".into(),
+                cache_breakpoint: false,
+            }],
+            model: "m".into(),
+            max_tokens: 100,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::json!({}),
+            request_timeout_secs: None,
+        };
+        let messages = openai_messages_with(&req, ToolArgsFormat::Object);
+        assert_eq!(messages[0]["content"], "real\n\nalso real");
+    }
+
+    /// A request with no system content at all sends no system message, rather
+    /// than an empty one.
+    #[test]
+    fn no_system_blocks_means_no_system_message() {
+        let req = InferenceRequest {
+            system: vec![],
+            messages: vec![Message {
+                role: "user".into(),
+                content: "Hi".into(),
+                cache_breakpoint: false,
+            }],
+            model: "m".into(),
+            max_tokens: 100,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::json!({}),
+            request_timeout_secs: None,
+        };
+        let messages = openai_messages_with(&req, ToolArgsFormat::Object);
+        assert!(
+            messages.iter().all(|m| m["role"] != "system"),
+            "{messages:#?}"
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -1439,4 +1439,30 @@ mod tests {
         let total = system + message;
         assert!(total <= 4, "total breakpoints: {total}");
     }
+
+    /// A blueprint declares its pinned regions up front and most are empty for
+    /// most of a run - deep-researcher has eight, of which four were empty at
+    /// the point it failed against ollama. They contribute no system block,
+    /// which is worth pinning: it bounds how many system messages a provider
+    /// that counts them actually receives.
+    #[test]
+    fn an_empty_pinned_region_assembles_into_no_system_block() {
+        let mut window = ContextWindow::new(10_000);
+        let mut filled = Region::new("task".to_string(), RegionKind::Pinned, 1000);
+        filled
+            .add_entry("do the thing".to_string(), 5)
+            .expect("fits");
+        window.add_region(filled);
+        // Declared, never written to - the common case mid-run.
+        window.add_region(Region::new("scope".to_string(), RegionKind::Pinned, 1000));
+        window.add_region(Region::new("notes".to_string(), RegionKind::Pinned, 1000));
+
+        let assembled = window.assemble();
+        let texts: Vec<&str> = assembled
+            .system_blocks
+            .iter()
+            .map(|b| b.text.as_str())
+            .collect();
+        assert_eq!(texts, vec!["do the thing"], "only the region with content");
+    }
 }


### PR DESCRIPTION
Closes #464. Also the cause of the pause/resume run @GEMISIS reported — which turned out not to be pause/resume at all.

## The bug

Leviath models system content as blocks, one per pinned region. The OpenAI chat shape has no such concept — it has *a* system message — and the shared builder emitted one message per block.

Ollama with a Qwen 3.x template rejects that. Probed directly rather than inferred:

| request | result |
|---|---|
| 1 system message | ✅ |
| 2 system messages, both leading | ❌ `system message must be at the beginning` |
| system after a user turn | ❌ same |

The error text is misleading — the actual rule is **at most one**. Confirmed on `qwen3.8` and `qwen3.8-32k`.

So every multi-region blueprint — every real agent — failed on its first inference. The reported run died 7s in, before the pause, and again in `error_recovery`. Its 104 prompt tokens were two title calls; **no stage inference ever succeeded**.

## Why this is safe for providers that worked

One leading system message is the canonical shape, so any server that accepted several accepts one. This can only move requests from rejected-by-strict-servers to accepted-everywhere.

Checked rather than assumed:

- **Anthropic is untouched** — it has its own builder with a native system array and per-block `cache_control`, and does not use this path. That is the one provider where block structure earns its keep.
- **No cache behaviour lost** — the shared builder never read `cache_hint`; only `block.text`.
- **Shared by** ollama, OpenAI, OpenRouter and Gemini. All get identical text, same order, one message.

## Also: resume no longer re-titles

`PendingTitle` was attached on every build with no fresh-versus-reload check, so each pause/resume cycle bought another titling call. Visible in the reported journal as two title calls around the resume.

## Verified live

Same agent, same model, same pause/resume sequence:

```
status=running stage=gather iter=1
prompt_tokens=1179 completion_tokens=260   error=None
title calls: 1   stage calls: 1
```

Previously: 104 tokens, zero stage calls, dead.

## A correction worth recording

I first added a guard skipping empty pinned regions, on the belief that four of deep-researcher's eight emitted empty blocks. The coverage gate rejected it as unreachable — `assemble()` already skips empty regions before the match. The real count was four blocks, not eight. Guard removed; a test now pins that empty regions contribute nothing.

Follow-ups requested and not in this PR: whether Ollama exposes any way to detect the single-system constraint, and carrying region name/description into the system prompt.