### PR TITLE
feat(context): name each region in the prompt, and let it describe itself

### DIFF
--- a/crates/leviath-cli/src/commands/context.rs
+++ b/crates/leviath-cli/src/commands/context.rs
@@ -135,6 +135,7 @@ mod tests {
                             taint: Default::default(),
                         })
                         .collect(),
+                    description: None,
                 }],
             },
             at: 0,

--- a/crates/leviath-cli/src/commands/dashboard/context_tree.rs
+++ b/crates/leviath-cli/src/commands/dashboard/context_tree.rs
@@ -139,6 +139,16 @@ pub(super) fn flatten(
             ),
         ]));
 
+        // What the blueprint says the region is for, under its header. Only
+        // when the region is open: a folded row is a summary, and a sentence
+        // of prose under it would defeat folding.
+        if !folded && let Some(description) = region.description.as_deref() {
+            lines.push(Line::from(Span::styled(
+                format!("    {description}"),
+                Style::default().fg(C_MUTED).add_modifier(Modifier::ITALIC),
+            )));
+        }
+
         if folded {
             if !region.entries.is_empty() {
                 lines.push(Line::from(Span::styled(
@@ -261,6 +271,7 @@ mod tests {
                     current_tokens: 10,
                     max_tokens: 50,
                     entries: vec![entry("first entry line\nmore"), entry("second")],
+                    description: None,
                 },
                 RegionSnapshot {
                     name: "conversation".to_string(),
@@ -268,6 +279,7 @@ mod tests {
                     current_tokens: 20,
                     max_tokens: 50,
                     entries: vec![],
+                    description: None,
                 },
             ],
         }
@@ -292,6 +304,41 @@ mod tests {
 
         // A live search overrides folds so matches stay reachable.
         assert_eq!(rows(&s, &tree, true).len(), 4);
+    }
+
+    /// A region's description belongs where the person is already looking at
+    /// the region, not in the manifest they would otherwise have to go and open.
+    #[test]
+    fn a_region_description_is_shown_under_its_header_while_the_region_is_open() {
+        let mut s = snap();
+        s.regions[0].description = Some("Format: one line per source.".to_string());
+        let mut tree = ContextTreeState::default();
+
+        let text_of = |flat: &FlatTree| -> String {
+            flat.lines
+                .iter()
+                .map(|l| {
+                    l.spans
+                        .iter()
+                        .map(|sp| sp.content.as_ref())
+                        .collect::<String>()
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+
+        let text = text_of(&flatten(&s, &tree, 0, false, 80));
+        assert!(text.contains("Format: one line per source."));
+
+        // Folded, it is gone: a folded row is a summary, and a sentence of
+        // prose under it would defeat the fold.
+        tree.collapsed_regions.insert("system".to_string());
+        let folded = text_of(&flatten(&s, &tree, 0, false, 80));
+        assert!(!folded.contains("Format: one line per source."));
+        assert!(
+            folded.contains("system"),
+            "the region itself is still listed"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -2418,6 +2418,7 @@ mod tests {
                     current_tokens: 10,
                     max_tokens: 50,
                     entries: vec![entry("alpha"), entry("beta")],
+                    description: None,
                 },
                 crate::runstate::RegionSnapshot {
                     name: "conversation".to_string(),
@@ -2425,6 +2426,7 @@ mod tests {
                     current_tokens: 10,
                     max_tokens: 50,
                     entries: vec![entry("gamma")],
+                    description: None,
                 },
             ],
         }));

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -830,6 +830,7 @@ mod tests {
                 current_tokens: total / 2,
                 max_tokens: max / 2,
                 entries: vec![],
+                description: None,
             }],
         }
     }
@@ -918,6 +919,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "history".to_string(),
@@ -925,6 +927,7 @@ mod tests {
                     current_tokens: 3000,
                     max_tokens: 4000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "context".to_string(),
@@ -932,6 +935,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
             ],
         }));
@@ -1790,6 +1794,7 @@ mod tests {
                     key: None,
                     taint: Default::default(),
                 }],
+                description: None,
             }],
         }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
@@ -1815,6 +1820,7 @@ mod tests {
                 current_tokens: 2000,
                 max_tokens: 4000,
                 entries: vec![],
+                description: None,
             }],
         }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
@@ -1964,6 +1970,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "conv".to_string(),
@@ -1971,6 +1978,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "hist".to_string(),
@@ -1978,6 +1986,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "temp".to_string(),
@@ -1985,6 +1994,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "cls".to_string(),
@@ -1992,6 +2002,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "brain".to_string(),
@@ -1999,6 +2010,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "other".to_string(),
@@ -2006,6 +2018,7 @@ mod tests {
                     current_tokens: 1000,
                     max_tokens: 2000,
                     entries: vec![],
+                    description: None,
                 },
             ],
         }));
@@ -2029,6 +2042,7 @@ mod tests {
                 current_tokens: 7500,
                 max_tokens: 8000,
                 entries: vec![],
+                description: None,
             }],
         }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
@@ -2051,6 +2065,7 @@ mod tests {
                 current_tokens: 5800,
                 max_tokens: 8000,
                 entries: vec![],
+                description: None,
             }],
         }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
@@ -2073,6 +2088,7 @@ mod tests {
                 current_tokens: 0,
                 max_tokens: 8000,
                 entries: vec![],
+                description: None,
             }],
         }));
         let (lines, _cursor) = dash.build_context_lines(&agent, 80);
@@ -2110,6 +2126,7 @@ mod tests {
                     key: None,
                     taint: Default::default(),
                 }],
+                description: None,
             }],
         }));
         terminal
@@ -2213,6 +2230,7 @@ mod tests {
                 current_tokens: 4000,
                 max_tokens: 8000,
                 entries,
+                description: None,
             }],
         }));
         terminal
@@ -2311,6 +2329,7 @@ mod tests {
                     current_tokens: 500,
                     max_tokens: 1000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "s2".to_string(),
@@ -2318,6 +2337,7 @@ mod tests {
                     current_tokens: 500,
                     max_tokens: 1000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "s3".to_string(),
@@ -2325,6 +2345,7 @@ mod tests {
                     current_tokens: 500,
                     max_tokens: 1000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "s4".to_string(),
@@ -2332,6 +2353,7 @@ mod tests {
                     current_tokens: 500,
                     max_tokens: 1000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "s5".to_string(),
@@ -2339,6 +2361,7 @@ mod tests {
                     current_tokens: 500,
                     max_tokens: 1000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "s6".to_string(),
@@ -2346,6 +2369,7 @@ mod tests {
                     current_tokens: 500,
                     max_tokens: 1000,
                     entries: vec![],
+                    description: None,
                 },
                 runstate::RegionSnapshot {
                     name: "s7".to_string(),
@@ -2353,6 +2377,7 @@ mod tests {
                     current_tokens: 500,
                     max_tokens: 1000,
                     entries: vec![],
+                    description: None,
                 },
             ],
         }));
@@ -2531,6 +2556,7 @@ mod tests {
                     current_tokens: 42,
                     max_tokens: 100,
                     entries: vec![],
+                    description: None,
                 }],
             }),
         );

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -299,7 +299,28 @@ pub(super) async fn get_blueprint(
     // Taken out of the info rather than read again: discovery already read
     // this file to build everything else in the response.
     let manifest = std::mem::take(&mut info.manifest);
-    Ok(Json(BlueprintDetail { info, manifest }))
+    // Parsed from the text already in hand rather than re-read: the same
+    // reason the manifest itself is carried through from discovery.
+    let regions = parse_manifest(&manifest)
+        .map(|bp| {
+            bp.context_layout
+                .regions
+                .iter()
+                .map(|r| RegionInfo {
+                    name: r.name.clone(),
+                    kind: leviath_runtime::persistence::region_kind_str(&r.kind).to_string(),
+                    description: r.description.clone(),
+                    describe_in_prompt: r.describe_in_prompt,
+                    max_tokens: r.max_tokens,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(Json(BlueprintDetail {
+        info,
+        regions,
+        manifest,
+    }))
 }
 
 pub(super) async fn create_blueprint(
@@ -887,6 +908,66 @@ system_prompt = "Plan the work"
         // local draft or a copy bundled at build time - neither of which is
         // the file the daemon runs.
         assert_eq!(bp["manifest"].as_str().unwrap(), test_manifest());
+    }
+
+    /// A console showed a blueprint's stages and nothing about its memory, so a
+    /// person editing an agent could see what it *does* and not what it
+    /// *keeps* - which is the half that decides whether it can do the job on a
+    /// small window.
+    #[tokio::test]
+    async fn the_detail_route_reports_the_blueprints_context_regions() {
+        let manifest = r#"
+[agent]
+name = "curator"
+
+[context.regions]
+sources = { kind = "pinned", max_tokens = 400, describe_in_prompt = true, description = "One line per source." }
+chat = { kind = "sliding_window", max_tokens = 900 }
+
+[stages.plan]
+system_prompt = "Plan the work"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join("curator");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("agent.leviath"), manifest).unwrap();
+
+        let state = test_state_with_path(dir.path().to_path_buf());
+        let app = Router::new()
+            .route("/api/blueprints/{name}", get(get_blueprint))
+            .with_state(state);
+        let req = Request::builder()
+            .uri("/api/blueprints/curator")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let bp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        // Compared whole, so a field that stops being serialized fails here
+        // rather than passing a check that only looks at the fields it knows.
+        assert_eq!(
+            bp["regions"],
+            serde_json::json!([
+                {
+                    "name": "sources",
+                    "kind": "pinned",
+                    "description": "One line per source.",
+                    "describe_in_prompt": true,
+                    "max_tokens": 400,
+                },
+                {
+                    "name": "chat",
+                    // The same spelling a context snapshot uses. Two spellings
+                    // of one kind is a trap for a console reading both.
+                    "kind": "sliding",
+                    "describe_in_prompt": false,
+                    "max_tokens": 900,
+                },
+            ])
+        );
     }
 
     /// The listing must not carry manifests: it answers "what agents are

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -686,6 +686,7 @@ fn plant_journal(run_id: &str, content: &str, secret: Option<&str>) {
                         key: None,
                         taint: leviath_core::taint::TaintLevel::default(),
                     }],
+                    description: None,
                 }],
             },
             at: 2,
@@ -770,6 +771,7 @@ fn plant_rich_journal(run_id: &str) {
             current_tokens: 1,
             max_tokens: 100,
             entries: vec![entry(content)],
+            description: None,
         }
     }
     fn snapshot(regions: Vec<RegionSnapshot>) -> ContextSnapshot {
@@ -990,6 +992,7 @@ async fn a_context_search_names_the_region_that_matched() {
                         key: None,
                         taint: leviath_core::taint::TaintLevel::default(),
                     }],
+                    description: None,
                 }],
             },
         )
@@ -1159,6 +1162,7 @@ async fn deep_sources_that_read_files_and_find_nothing_are_quiet() {
                         key: None,
                         taint: leviath_core::taint::TaintLevel::default(),
                     }],
+                    description: None,
                 }],
             },
         )

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -474,6 +474,28 @@ pub(super) struct BlueprintInfo {
     pub(super) manifest: String,
 }
 
+/// One context region of a blueprint, as the API reports it.
+///
+/// The console showed a blueprint's stages and nothing about its memory, so a
+/// person editing an agent could see what it *does* and not what it *keeps* -
+/// which is the half that decides whether it can do the job on a small window.
+#[derive(Debug, Serialize)]
+pub(super) struct RegionInfo {
+    /// The region's name - the one an agent passes to `context_write`.
+    pub(super) name: String,
+    /// Its kind, as written in the manifest (`pinned`, `sliding_window`, …).
+    pub(super) kind: String,
+    /// What it is for, when the blueprint says.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) description: Option<String>,
+    /// Whether the description is also shown to the model, rather than only
+    /// being documentation. A console offering an editor needs this to render
+    /// the toggle honestly.
+    pub(super) describe_in_prompt: bool,
+    /// Its token ceiling, resolved as far as the manifest alone allows.
+    pub(super) max_tokens: usize,
+}
+
 /// One blueprint, with the manifest text behind it.
 ///
 /// The detail route only. A listing that carried one of these per blueprint
@@ -487,6 +509,12 @@ pub(super) struct BlueprintInfo {
 pub(super) struct BlueprintDetail {
     #[serde(flatten)]
     pub(super) info: BlueprintInfo,
+    /// The blueprint's context regions.
+    ///
+    /// On the detail route rather than the listing, for the same reason the
+    /// manifest is: answering "what agents are there" should not cost every
+    /// region of every agent on the machine.
+    pub(super) regions: Vec<RegionInfo>,
     /// The manifest exactly as it is on disk.
     ///
     /// Without this a console has no way to read what it is editing: naming

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -956,6 +956,7 @@ mod tests {
                     key: None,
                     taint: Default::default(),
                 }],
+                description: None,
             }],
         };
         write_run(
@@ -1353,6 +1354,7 @@ mod tests {
                         taint: Default::default(),
                     },
                 ],
+                description: None,
             }],
         };
         write_run_archive(runs.path(), "run-applied", mpath, 0, 9, 99, &ctx);

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -1433,6 +1433,7 @@ mod tests {
                 key: None,
                 taint: Default::default(),
             }],
+            description: None,
         };
         let json = serde_json::to_string(&snap).unwrap();
         let back: RegionSnapshot = serde_json::from_str(&json).unwrap();
@@ -1449,6 +1450,7 @@ mod tests {
             current_tokens: 0,
             max_tokens: 100,
             entries: vec![],
+            description: None,
         };
         let json = serde_json::to_value(&snap).unwrap();
         assert!(json.get("entries").is_none());
@@ -1466,6 +1468,7 @@ mod tests {
                 current_tokens: 300,
                 max_tokens: 2000,
                 entries: vec![],
+                description: None,
             }],
         };
         let json = serde_json::to_string(&snap).unwrap();
@@ -2586,6 +2589,7 @@ mod tests {
                             taint: Default::default(),
                         },
                     ],
+                    description: None,
                 },
                 RegionSnapshot {
                     name: "conversation".into(),
@@ -2593,6 +2597,7 @@ mod tests {
                     current_tokens: 900,
                     max_tokens: 6000,
                     entries: vec![],
+                    description: None,
                 },
             ],
         };

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -499,6 +499,11 @@ pub struct RegionDefinition {
     /// Human-readable description of this region's purpose
     pub description: Option<String>,
 
+    /// Whether `description` is also shown to the model, under the region's
+    /// name. Off by default - see [`crate::region::Region::describe_in_prompt`].
+    #[serde(default)]
+    pub describe_in_prompt: bool,
+
     /// When true, this region must be non-empty before a stage that can write
     /// to it is allowed to complete. Guards against an agent skipping a
     /// context-population step (e.g. never writing the `plan` region). Enforced
@@ -557,6 +562,7 @@ impl RegionDefinition {
             compact_at: None,
             schema: None,
             description: None,
+            describe_in_prompt: false,
             required: false,
             required_message: None,
             summarizable: true,

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -223,6 +223,15 @@ pub(super) fn parse_region_layout(
             }
         };
 
+        // One line on what the region is for, shown to the model above its
+        // contents. Optional: most regions are named well enough that a
+        // sentence would only cost tokens.
+        let description = region_value
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
         let seed = parse_region_seed(region_name, region_value.get("seed"));
 
         // Percentage regions contribute their (unknown) size at resolution, so
@@ -236,6 +245,7 @@ pub(super) fn parse_region_layout(
             .with_required(required, required_message);
         def.summarizable = summarizable;
         def.admission = admission;
+        def.description = description;
         if let Some(f) = compact_at_field {
             def = def.with_compact_at(f);
         }

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -232,6 +232,13 @@ pub(super) fn parse_region_layout(
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
+        // Spending the description on the model is opt-in: a person reading a
+        // blueprint wants a sentence per region, a model re-reads it every turn.
+        let describe_in_prompt = region_value
+            .get("describe_in_prompt")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+
         let seed = parse_region_seed(region_name, region_value.get("seed"));
 
         // Percentage regions contribute their (unknown) size at resolution, so
@@ -246,6 +253,7 @@ pub(super) fn parse_region_layout(
         def.summarizable = summarizable;
         def.admission = admission;
         def.description = description;
+        def.describe_in_prompt = describe_in_prompt;
         if let Some(f) = compact_at_field {
             def = def.with_compact_at(f);
         }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -4763,6 +4763,42 @@ notes = { kind = "sliding_window", max_items = 20 }
     assert!(region("notes").summarizable, "and defaults to on");
 }
 
+/// A region's `description` parses, and its absence stays absent.
+///
+/// Optional on purpose: it is rendered above the region's contents on every
+/// turn, so a region that is named well enough to explain itself should not be
+/// charged for a sentence saying so.
+#[test]
+fn parse_manifest_reads_a_region_description() {
+    let toml = r#"
+[agent]
+name = "curator"
+
+[context.regions]
+sources_index = { kind = "pinned", max_tokens = 100, description = "One bibliography line per source actually used." }
+task = { kind = "pinned", max_tokens = 100 }
+blank = { kind = "pinned", max_tokens = 100, description = "   " }
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let region = |name: &str| {
+        bp.context_layout
+            .regions
+            .iter()
+            .find(|r| r.name == name)
+            .unwrap_or_else(|| panic!("{name} declared"))
+    };
+    assert_eq!(
+        region("sources_index").description.as_deref(),
+        Some("One bibliography line per source actually used.")
+    );
+    assert_eq!(region("task").description, None);
+    assert_eq!(
+        region("blank").description,
+        None,
+        "whitespace is not a description, and would render as a blank line"
+    );
+}
+
 /// `admission` parses, defaults to evicting, and refuses a value it does not
 /// know rather than falling back.
 ///

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -4765,9 +4765,8 @@ notes = { kind = "sliding_window", max_items = 20 }
 
 /// A region's `description` parses, and its absence stays absent.
 ///
-/// Optional on purpose: it is rendered above the region's contents on every
-/// turn, so a region that is named well enough to explain itself should not be
-/// charged for a sentence saying so.
+/// Documentation on its own: it reaches `lev dash` and the blueprint API, and
+/// only reaches the model when the region also sets `describe_in_prompt`.
 #[test]
 fn parse_manifest_reads_a_region_description() {
     let toml = r#"
@@ -4796,6 +4795,43 @@ blank = { kind = "pinned", max_tokens = 100, description = "   " }
         region("blank").description,
         None,
         "whitespace is not a description, and would render as a blank line"
+    );
+}
+
+/// `describe_in_prompt` decides whether the description is spent on the model.
+///
+/// Off by default, so describing every region for the people who maintain a
+/// blueprint cannot quietly add a sentence per region to every turn. A
+/// non-boolean value falls back to the default rather than failing the load:
+/// the cost of guessing wrong is a sentence, and refusing to load an agent over
+/// it would be the larger harm.
+#[test]
+fn parse_manifest_reads_the_describe_in_prompt_flag() {
+    let toml = r#"
+[agent]
+name = "curator"
+
+[context.regions]
+shown = { kind = "pinned", max_tokens = 100, description = "Format: one line per source.", describe_in_prompt = true }
+quiet = { kind = "pinned", max_tokens = 100, description = "For whoever edits this." }
+odd = { kind = "pinned", max_tokens = 100, describe_in_prompt = "yes" }
+"#;
+    let bp = parse_manifest(toml).expect("parses");
+    let region = |name: &str| {
+        bp.context_layout
+            .regions
+            .iter()
+            .find(|r| r.name == name)
+            .unwrap_or_else(|| panic!("{name} declared"))
+    };
+    assert!(region("shown").describe_in_prompt, "the flag is read");
+    assert!(
+        !region("quiet").describe_in_prompt,
+        "a description alone does not reach the model"
+    );
+    assert!(
+        !region("odd").describe_in_prompt,
+        "a non-boolean falls back to the default rather than failing the load"
     );
 }
 

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -460,6 +460,17 @@ pub struct Region {
     /// What this region does when a write does not fit. See [`Admission`].
     #[serde(default)]
     pub admission: Admission,
+
+    /// One line on what this region is for, shown to the model above its
+    /// contents.
+    ///
+    /// The name alone already tells an agent which region a `context_write`
+    /// should name. This is for the ones whose contents do not explain
+    /// themselves - a bibliography, a scratch area with a convention - where a
+    /// sentence buys more than it costs. Absent by default, so a region that
+    /// needs no explanation is charged nothing for one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// What a region does when a write does not fit.
@@ -509,6 +520,7 @@ impl Region {
             needs_message_compaction: false,
             summarizable: true,
             admission: Admission::default(),
+            description: None,
         }
     }
 

--- a/crates/leviath-core/src/region.rs
+++ b/crates/leviath-core/src/region.rs
@@ -461,16 +461,26 @@ pub struct Region {
     #[serde(default)]
     pub admission: Admission,
 
-    /// One line on what this region is for, shown to the model above its
-    /// contents.
+    /// One line on what this region is for.
     ///
-    /// The name alone already tells an agent which region a `context_write`
-    /// should name. This is for the ones whose contents do not explain
-    /// themselves - a bibliography, a scratch area with a convention - where a
-    /// sentence buys more than it costs. Absent by default, so a region that
-    /// needs no explanation is charged nothing for one.
+    /// Documentation first: it is what `GET /api/blueprints/{name}` reports and
+    /// what the dashboard shows beside the region, and in that role it costs
+    /// nothing at inference time. Set [`describe_in_prompt`](Self::describe_in_prompt)
+    /// to also spend it on the model.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Whether [`description`](Self::description) is also shown to the model,
+    /// under the region's name.
+    ///
+    /// Off by default, because the two audiences want different things. A
+    /// person reading a blueprint benefits from a sentence on every region; a
+    /// model re-reads that sentence on every turn, and most region names are
+    /// already the explanation. Turn it on for the ones with a convention the
+    /// agent has to follow rather than a purpose it can infer - a bibliography
+    /// with a required citation format, a scratch area with a protocol.
+    #[serde(default)]
+    pub describe_in_prompt: bool,
 }
 
 /// What a region does when a write does not fit.
@@ -521,6 +531,7 @@ impl Region {
             summarizable: true,
             admission: Admission::default(),
             description: None,
+            describe_in_prompt: false,
         }
     }
 

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -1098,6 +1098,7 @@ mod tests {
             current_tokens: current,
             max_tokens: 1000,
             entries,
+            description: None,
         }
     }
 
@@ -2659,8 +2660,10 @@ mod tests {
                         taint: crate::taint::TaintLevel::Public,
                     })
                     .collect(),
+                description: None,
             }
         }
+
         fn snap(entries: &[(&str, usize)]) -> ContextSnapshot {
             let r = region("logs", entries);
             ContextSnapshot {

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -665,6 +665,14 @@ pub struct RegionSnapshot {
     /// Actual content entries stored in this region (empty for zero-token regions).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub entries: Vec<RegionEntrySnapshot>,
+    /// What the blueprint says this region is for, when it says.
+    ///
+    /// Carried on the snapshot so every reader of `context.json` can show it -
+    /// the dashboard, the history API, a console - rather than each having to
+    /// find and re-parse the manifest to explain a region it is already
+    /// displaying.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Snapshot of the full context window, written to `context.json` alongside `meta.json`.
@@ -1270,6 +1278,7 @@ mod tests {
                     key: Some("k".to_string()),
                     taint: Default::default(),
                 }],
+                description: None,
             }],
         };
         let json = serde_json::to_string(&snap).unwrap();
@@ -1289,6 +1298,7 @@ mod tests {
             current_tokens: 0,
             max_tokens: 0,
             entries: vec![],
+            description: None,
         };
         let json = serde_json::to_string(&snap).unwrap();
         assert!(!json.contains("entries"));

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -200,13 +200,30 @@ impl OllamaProvider {
             body["tools"] = serde_json::Value::Array(tools);
         }
 
-        // Pass through extra model parameters (top_p, top_k, stop, seed, …).
-        // Ollama's sampling knobs live under `options`, so merge there.
+        // `think` is Ollama's own switch for a reasoning model, and it sits at
+        // the top level rather than under `options` - so it is lifted out
+        // before the rest of `extra` is merged, or it would arrive as a
+        // sampling knob Ollama ignores.
+        //
+        // Worth having as a knob at all because a thinking model spends real
+        // budget before it says anything: qwen3.8 asked for a run title in 64
+        // tokens returns an empty string, having used all of them reasoning
+        // about what a title is. `think = false` on that stage returns the
+        // title. Only sent when a blueprint asks for it, since a model with no
+        // thinking to switch off rejects the field.
+        let think = request.extra.get("think").cloned();
+        if let Some(think) = think {
+            body["think"] = think;
+        }
+        let mut sampling = request.extra.clone();
+        if let Some(params) = sampling.as_object_mut() {
+            params.remove("think");
+        }
         crate::openai_compat::merge_extra_params(
             body.get_mut("options")
                 .and_then(|v| v.as_object_mut())
                 .expect("ollama request body always has an `options` object"),
-            &request.extra,
+            &sampling,
         );
         body
     }
@@ -891,6 +908,24 @@ mod tests {
         let response = provider.parse_response(&body).unwrap();
         assert_eq!(response.tokens_used.prompt_tokens, 0);
         assert_eq!(response.tokens_used.completion_tokens, 0);
+    }
+
+    /// A minimal request for the body-shape tests.
+    fn base_request() -> InferenceRequest {
+        InferenceRequest {
+            system: vec![],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "Hello".into(),
+                cache_breakpoint: false,
+            }],
+            model: "qwen3.8".to_string(),
+            max_tokens: 64,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::json!({}),
+            request_timeout_secs: None,
+        }
     }
 
     #[test]
@@ -2236,5 +2271,41 @@ mod tests {
             assert_eq!(chunks.len(), 1);
             assert_eq!(chunks[0].as_ref().unwrap().delta, "ok");
         });
+    }
+
+    /// `think` is Ollama's top-level switch for a reasoning model, not a
+    /// sampling knob - buried under `options` it would be silently ignored,
+    /// and the model would keep spending its budget reasoning.
+    #[test]
+    fn think_is_lifted_out_of_extra_to_the_top_level() {
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
+        let mut request = base_request();
+        request.extra = serde_json::json!({ "think": false, "top_k": 20 });
+
+        let body = provider.build_request_body(&request);
+        assert_eq!(body["think"], serde_json::json!(false));
+        assert_eq!(
+            body["options"]["top_k"],
+            serde_json::json!(20),
+            "the rest of extra still lands as sampling"
+        );
+        assert!(
+            body["options"].get("think").is_none(),
+            "and think is not left behind in options"
+        );
+    }
+
+    /// Absent unless asked for. A model with no thinking to switch off rejects
+    /// the field, so sending it by default would break every non-reasoning
+    /// model to help the ones that reason.
+    #[test]
+    fn no_think_field_is_sent_when_the_blueprint_does_not_ask() {
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
+        let body = provider.build_request_body(&base_request());
+        assert!(body.get("think").is_none(), "{body}");
     }
 }

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -238,7 +238,11 @@ pub struct ContextWindow {
 /// contents do not explain themselves - a bibliography with a required format,
 /// a scratch area with a convention.
 fn labelled(region: &Region, body: &str) -> String {
-    match &region.description {
+    match region
+        .description
+        .as_deref()
+        .filter(|_| region.describe_in_prompt)
+    {
         Some(description) => format!("## {}\n{}\n\n{}", region.name, description, body),
         None => format!("## {}\n{}", region.name, body),
     }
@@ -1484,12 +1488,22 @@ mod tests {
     /// Most regions are named well enough that a sentence would only spend
     /// tokens.
     #[test]
-    fn a_description_is_rendered_only_when_declared() {
+    fn a_description_reaches_the_model_only_when_the_blueprint_opts_in() {
         let mut window = ContextWindow::new(10_000);
-        let mut described = Region::new("scratch".to_string(), RegionKind::Pinned, 1000);
-        described.description = Some("Working notes; cleared between stages.".to_string());
-        described.add_entry("half an idea".to_string(), 5).unwrap();
-        window.add_region(described);
+
+        let mut shown = Region::new("scratch".to_string(), RegionKind::Pinned, 1000);
+        shown.description = Some("Working notes; cleared between stages.".to_string());
+        shown.describe_in_prompt = true;
+        shown.add_entry("half an idea".to_string(), 5).unwrap();
+        window.add_region(shown);
+
+        // Described for whoever maintains the blueprint, not for the model. The
+        // sentence is still on the region - `lev dash` and the blueprint API
+        // read it - and it costs nothing per turn.
+        let mut documented = Region::new("sources".to_string(), RegionKind::Pinned, 1000);
+        documented.description = Some("One line per source actually used.".to_string());
+        documented.add_entry("[1] RFC 9110".to_string(), 5).unwrap();
+        window.add_region(documented);
 
         let mut plain = Region::new("task".to_string(), RegionKind::Pinned, 1000);
         plain.add_entry("do the thing".to_string(), 5).unwrap();
@@ -1505,8 +1519,26 @@ mod tests {
             texts,
             vec![
                 "## scratch\nWorking notes; cleared between stages.\n\nhalf an idea",
+                "## sources\n[1] RFC 9110",
                 "## task\ndo the thing",
             ]
+        );
+    }
+
+    /// The opt-in with nothing to show is the same as no opt-in: a region that
+    /// asks for its description in the prompt and has none must not render a
+    /// blank line where the sentence would go.
+    #[test]
+    fn opting_in_with_no_description_changes_nothing() {
+        let mut window = ContextWindow::new(10_000);
+        let mut region = Region::new("task".to_string(), RegionKind::Pinned, 1000);
+        region.describe_in_prompt = true;
+        region.add_entry("do the thing".to_string(), 5).unwrap();
+        window.add_region(region);
+
+        assert_eq!(
+            window.assemble().system_blocks[0].text,
+            "## task\ndo the thing"
         );
     }
 

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -223,6 +223,27 @@ pub struct ContextWindow {
     pub hidden: std::collections::HashSet<String>,
 }
 
+/// Put a region's own name above its contents, and its description under that
+/// when it has one.
+///
+/// The name is the part that earns its tokens. An agent writes to a region *by
+/// name* - `context_write { region: "sources_index", .. }` - but until now the
+/// prompt showed it the contents of every region with nothing saying which was
+/// which. It could read `sources_index` and it could write to `sources_index`,
+/// and it had no way to know they were the same place. Three tokens of heading
+/// closes that.
+///
+/// The description is opt-in and usually absent, because most regions are named
+/// well enough that a sentence would only cost tokens. It is for the ones whose
+/// contents do not explain themselves - a bibliography with a required format,
+/// a scratch area with a convention.
+fn labelled(region: &Region, body: &str) -> String {
+    match &region.description {
+        Some(description) => format!("## {}\n{}\n\n{}", region.name, description, body),
+        None => format!("## {}\n{}", region.name, body),
+    }
+}
+
 impl ContextWindow {
     /// Create a new context window with the specified budget.
     pub fn new(max_tokens: usize) -> Self {
@@ -695,14 +716,14 @@ impl ContextWindow {
             match &region.kind {
                 // System-level content → system blocks
                 leviath_core::RegionKind::Pinned => {
-                    let text = region
+                    let body = region
                         .content
                         .iter()
                         .map(|e| e.content.as_str())
                         .collect::<Vec<_>>()
                         .join("\n\n");
                     system_blocks.push(leviath_providers::SystemBlock {
-                        text,
+                        text: labelled(region, &body),
                         cache_hint: CacheHint::Always,
                     });
                 }
@@ -712,23 +733,23 @@ impl ContextWindow {
                 // of the state being real is that this block is derived from
                 // it rather than from whatever prose the model last wrote.
                 leviath_core::RegionKind::Checklist => {
-                    let text = region.render_checklist();
-                    if !text.is_empty() {
+                    let body = region.render_checklist();
+                    if !body.is_empty() {
                         system_blocks.push(leviath_providers::SystemBlock {
-                            text,
+                            text: labelled(region, &body),
                             cache_hint: CacheHint::UntilChanged,
                         });
                     }
                 }
                 leviath_core::RegionKind::CompactHistory { .. } => {
-                    let text = region
+                    let body = region
                         .content
                         .iter()
                         .map(|e| e.content.as_str())
                         .collect::<Vec<_>>()
                         .join("\n\n");
                     system_blocks.push(leviath_providers::SystemBlock {
-                        text,
+                        text: labelled(region, &body),
                         cache_hint: CacheHint::Always,
                     });
                 }
@@ -1440,11 +1461,86 @@ mod tests {
         assert!(total <= 4, "total breakpoints: {total}");
     }
 
+    /// The name is the part that earns its tokens: an agent writes to a region
+    /// *by name*, and until this the prompt showed it every region's contents
+    /// with nothing saying which was which.
+    #[test]
+    fn a_pinned_region_is_labelled_with_its_own_name() {
+        let mut window = ContextWindow::new(10_000);
+        let mut region = Region::new("sources_index".to_string(), RegionKind::Pinned, 1000);
+        region
+            .add_entry("[1] RFC 9110 - https://example".to_string(), 10)
+            .expect("fits");
+        window.add_region(region);
+
+        let assembled = window.assemble();
+        assert_eq!(
+            assembled.system_blocks[0].text, "## sources_index\n[1] RFC 9110 - https://example",
+            "the name the agent would pass to context_write"
+        );
+    }
+
+    /// A description is opt-in, and absent costs nothing - which is the point.
+    /// Most regions are named well enough that a sentence would only spend
+    /// tokens.
+    #[test]
+    fn a_description_is_rendered_only_when_declared() {
+        let mut window = ContextWindow::new(10_000);
+        let mut described = Region::new("scratch".to_string(), RegionKind::Pinned, 1000);
+        described.description = Some("Working notes; cleared between stages.".to_string());
+        described.add_entry("half an idea".to_string(), 5).unwrap();
+        window.add_region(described);
+
+        let mut plain = Region::new("task".to_string(), RegionKind::Pinned, 1000);
+        plain.add_entry("do the thing".to_string(), 5).unwrap();
+        window.add_region(plain);
+
+        let assembled = window.assemble();
+        let texts: Vec<&str> = assembled
+            .system_blocks
+            .iter()
+            .map(|b| b.text.as_str())
+            .collect();
+        assert_eq!(
+            texts,
+            vec![
+                "## scratch\nWorking notes; cleared between stages.\n\nhalf an idea",
+                "## task\ndo the thing",
+            ]
+        );
+    }
+
+    /// What the labelling actually costs, held to a number rather than a
+    /// feeling: a heading is a handful of tokens against a region's contents,
+    /// and it is charged once per region rather than per entry.
+    #[test]
+    fn labelling_costs_a_few_tokens_per_region_not_per_entry() {
+        let mut window = ContextWindow::new(100_000);
+        let mut region = Region::new("findings".to_string(), RegionKind::Pinned, 50_000);
+        for i in 0..20 {
+            region
+                .add_entry(format!("finding number {i}, with some substance to it"), 12)
+                .expect("fits");
+        }
+        window.add_region(region);
+
+        let assembled = window.assemble();
+        let text = &assembled.system_blocks[0].text;
+        let header = "## findings\n";
+        assert!(text.starts_with(header), "{text:.60}");
+        assert_eq!(
+            leviath_core::estimate_tokens(header),
+            3,
+            "one short heading for the whole region, however many entries it holds"
+        );
+    }
+
     /// A blueprint declares its pinned regions up front and most are empty for
     /// most of a run - deep-researcher has eight, of which four were empty at
     /// the point it failed against ollama. They contribute no system block,
     /// which is worth pinning: it bounds how many system messages a provider
-    /// that counts them actually receives.
+    /// that counts them actually receives, and how many headings the labelled
+    /// prompt carries.
     #[test]
     fn an_empty_pinned_region_assembles_into_no_system_block() {
         let mut window = ContextWindow::new(10_000);
@@ -1463,6 +1559,10 @@ mod tests {
             .iter()
             .map(|b| b.text.as_str())
             .collect();
-        assert_eq!(texts, vec!["do the thing"], "only the region with content");
+        assert_eq!(
+            texts,
+            vec!["## task\ndo the thing"],
+            "only the region with content, and it names itself"
+        );
     }
 }

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -1515,9 +1515,11 @@ mod tests {
         let assembled = window.assemble();
 
         assert_eq!(assembled.system_blocks.len(), 1);
+        // Named, so the model can tell a wall of summary prose from the region
+        // it summarizes.
         assert_eq!(
             assembled.system_blocks[0].text,
-            "summary of earlier conversation"
+            "## history\nsummary of earlier conversation"
         );
         assert_eq!(
             assembled.system_blocks[0].cache_hint,

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -32,6 +32,7 @@ pub fn init_window_seeded(
         );
         region.summarizable = region_def.summarizable;
         region.admission = region_def.admission;
+        region.description = region_def.description.clone();
         window.add_region(region);
     }
 
@@ -164,6 +165,7 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
         );
         new_region.summarizable = region_def.summarizable;
         new_region.admission = region_def.admission;
+        new_region.description = region_def.description.clone();
 
         if let Some(existing) = window.get_region(&region_def.name) {
             // Carry entries verbatim - kind, metadata, key, timestamp survive
@@ -222,6 +224,7 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
         );
         carried.summarizable = existing.summarizable;
         carried.admission = existing.admission;
+        carried.description = existing.description.clone();
         // Verbatim, exactly as above: these are the regions whose typed turns
         // a rebuild would flatten.
         for entry in &existing.content {

--- a/crates/leviath-runtime/src/context_setup.rs
+++ b/crates/leviath-runtime/src/context_setup.rs
@@ -33,6 +33,7 @@ pub fn init_window_seeded(
         region.summarizable = region_def.summarizable;
         region.admission = region_def.admission;
         region.description = region_def.description.clone();
+        region.describe_in_prompt = region_def.describe_in_prompt;
         window.add_region(region);
     }
 
@@ -166,6 +167,7 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
         new_region.summarizable = region_def.summarizable;
         new_region.admission = region_def.admission;
         new_region.description = region_def.description.clone();
+        new_region.describe_in_prompt = region_def.describe_in_prompt;
 
         if let Some(existing) = window.get_region(&region_def.name) {
             // Carry entries verbatim - kind, metadata, key, timestamp survive
@@ -225,6 +227,7 @@ pub fn apply_layout(window: &mut ContextWindow, layout: &ContextLayout) {
         carried.summarizable = existing.summarizable;
         carried.admission = existing.admission;
         carried.description = existing.description.clone();
+        carried.describe_in_prompt = existing.describe_in_prompt;
         // Verbatim, exactly as above: these are the regions whose typed turns
         // a rebuild would flatten.
         for entry in &existing.content {

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -211,7 +211,11 @@ pub fn stage_status_from(status: &AgentStatus) -> StageRunStatus {
 }
 
 /// The stringified region kind used in snapshots (matches the dashboard reader).
-fn region_kind_str(kind: &RegionKind) -> &'static str {
+///
+/// Public because the blueprint API reports region kinds too, and two spellings
+/// of the same kind - `sliding` from a context snapshot, `sliding_window` from
+/// a blueprint - is a trap for any console reading both.
+pub fn region_kind_str(kind: &RegionKind) -> &'static str {
     match kind {
         RegionKind::Pinned => "pinned",
         RegionKind::Temporary => "temporary",
@@ -234,6 +238,7 @@ pub fn build_context_snapshot(window: &ContextWindow, stage_name: &str) -> Conte
         .map(|r| RegionSnapshot {
             name: r.name.clone(),
             kind: region_kind_str(&r.kind).to_string(),
+            description: r.description.clone(),
             current_tokens: r.current_tokens,
             max_tokens: r.max_tokens,
             entries: r
@@ -1043,6 +1048,12 @@ mod tests {
             100,
         ));
         w.add_region(Region::new("todos".to_string(), RegionKind::Checklist, 100));
+        // Carried onto the snapshot so every reader of context.json can explain
+        // a region it is already displaying, rather than each one having to
+        // find and re-parse the manifest.
+        let mut described = Region::new("sources".to_string(), RegionKind::Pinned, 100);
+        described.description = Some("One line per source.".to_string());
+        w.add_region(described);
         let _ = w.add_to_region("pin", "hello".to_string(), 3);
         w.current_tokens = w.calculate_tokens();
 
@@ -1061,9 +1072,17 @@ mod tests {
                 "history",
                 "hashmap",
                 "custom",
-                "checklist"
+                "checklist",
+                "pinned"
             ]
         );
+        let described = snap.regions.iter().find(|r| r.name == "sources").unwrap();
+        assert_eq!(
+            described.description.as_deref(),
+            Some("One line per source.")
+        );
+        let pin_desc = snap.regions.iter().find(|r| r.name == "pin").unwrap();
+        assert_eq!(pin_desc.description, None);
         // The pinned region's entry is captured.
         let pin = snap.regions.iter().find(|r| r.name == "pin").unwrap();
         assert_eq!(pin.entries.len(), 1);

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -801,6 +801,7 @@ mod tests {
                         taint: Default::default(),
                     })
                     .collect(),
+                description: None,
             }],
         };
         PersistJob {

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -422,6 +422,7 @@ mod tests {
                             taint: Default::default(),
                         },
                     ],
+                    description: None,
                 },
                 // A region that no longer exists in the window - skipped.
                 RegionSnapshot {
@@ -437,6 +438,7 @@ mod tests {
                         key: None,
                         taint: Default::default(),
                     }],
+                    description: None,
                 },
             ],
         }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -2586,6 +2586,7 @@ mod tests {
                     key: None,
                     taint: Default::default(),
                 }],
+                description: None,
             }],
         };
         crate::restore::restore_agent(

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -160,6 +160,7 @@ and pass on the first attempt, which looks exactly like a stage that finished it
 | `seed` | unset | What the region starts with. See below |
 | `required` | `false` | The stage re-runs rather than moving on while this region is empty |
 | `summarizable` | `true` | Set false to keep an edge `transform = "compact"` from paraphrasing this region. See [transforms](/docs/stages#carrying-context-across-an-edge) |
+| `description` | unset | One line on what the region is for, shown to the model above its contents. See [what the model sees](#what-the-model-sees) |
 | `admission` | `"evict"` | What happens when a write does not fit. `"reject"` refuses it instead of dropping something. See [letting the agent decide what to forget](#letting-the-agent-decide-what-to-forget) |
 | `required_message` | generated | What the model is told when a required region is empty. Supports `{region}` |
 
@@ -236,6 +237,50 @@ be judged before it is expanded.
 Scripts are stricter and have no `[read_paths]` escape: a stage hook, a custom-region script and an
 output validator must all live inside the blueprint's own directory. A script is code the agent
 ships, and there is no such thing as loading your logic from somewhere else on purpose.
+
+## What the model sees
+
+Regions that assemble into the system prompt are labelled with their own name:
+
+```
+## task
+research what meta's most recent earnings call was about
+
+## sources_index
+[1] RFC 9110 - https://example - 2022 - credibility: high
+```
+
+The name is the part that earns its tokens. An agent writes to a region *by
+name* - `context_write { region: "sources_index", … }` - and without the heading
+it reads a region's contents with nothing saying which region they came from. It
+could read `sources_index` and write to `sources_index` and have no way to know
+they were the same place. A heading costs three tokens, once per region, however
+many entries the region holds.
+
+Add a `description` where the contents do not explain themselves:
+
+```toml
+[context.regions]
+sources_index = { kind = "pinned", budget = "4%", description = "One bibliography line per source actually used." }
+```
+
+which renders as:
+
+```
+## sources_index
+One bibliography line per source actually used.
+
+[1] RFC 9110 - …
+```
+
+It is optional and usually worth leaving out. Most region names are already the
+explanation, and a sentence repeated on every turn is a real cost against a
+small window. Reach for it when the region has a convention the agent has to
+follow rather than a purpose it can infer.
+
+Empty regions contribute nothing - no heading, no blank block - so a blueprint
+can declare the regions it might need without paying for the ones it has not
+filled yet.
 
 ## Where a stage's own instructions live
 

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -160,7 +160,8 @@ and pass on the first attempt, which looks exactly like a stage that finished it
 | `seed` | unset | What the region starts with. See below |
 | `required` | `false` | The stage re-runs rather than moving on while this region is empty |
 | `summarizable` | `true` | Set false to keep an edge `transform = "compact"` from paraphrasing this region. See [transforms](/docs/stages#carrying-context-across-an-edge) |
-| `description` | unset | One line on what the region is for, shown to the model above its contents. See [what the model sees](#what-the-model-sees) |
+| `description` | unset | One line on what the region is for. Documentation by default: it reaches `lev dash` and the API, not the model |
+| `describe_in_prompt` | `false` | Also show the `description` to the model, above the region's contents. See [what the model sees](#what-the-model-sees) |
 | `admission` | `"evict"` | What happens when a write does not fit. `"reject"` refuses it instead of dropping something. See [letting the agent decide what to forget](#letting-the-agent-decide-what-to-forget) |
 | `required_message` | generated | What the model is told when a required region is empty. Supports `{region}` |
 
@@ -257,11 +258,15 @@ could read `sources_index` and write to `sources_index` and have no way to know
 they were the same place. A heading costs three tokens, once per region, however
 many entries the region holds.
 
-Add a `description` where the contents do not explain themselves:
+A `description` says what the region is for. On its own it is documentation:
+`lev dash` shows it under the region, `GET /api/blueprints/{name}` returns it,
+and the model never sees it. Add `describe_in_prompt` to spend the tokens and
+put it in front of the model too:
 
 ```toml
 [context.regions]
-sources_index = { kind = "pinned", budget = "4%", description = "One bibliography line per source actually used." }
+sources_index = { kind = "pinned", budget = "4%", describe_in_prompt = true,
+                  description = "One bibliography line per source actually used." }
 ```
 
 which renders as:
@@ -273,10 +278,11 @@ One bibliography line per source actually used.
 [1] RFC 9110 - …
 ```
 
-It is optional and usually worth leaving out. Most region names are already the
-explanation, and a sentence repeated on every turn is a real cost against a
-small window. Reach for it when the region has a convention the agent has to
-follow rather than a purpose it can infer.
+The split is deliberate. Describing every region for the people who maintain the
+blueprint should not quietly cost tokens on every turn, and most region names
+are already the explanation. Turn it on where the region has a convention the
+agent has to follow - a format, an ordering, a rule about what belongs - rather
+than a purpose it can infer from the name.
 
 Empty regions contribute nothing - no heading, no blank block - so a blueprint
 can declare the regions it might need without paying for the ones it has not

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -207,6 +207,30 @@ model = { models = [
 > `http://localhost:11434`. The run moves on to its next candidate rather than dying there, but
 > it still spends four attempts finding out.
 
+### Turning off an Ollama model's thinking
+
+Reasoning models served by Ollama think by default, and the thinking is billed to the same output
+budget as the answer. On a local model that mostly shows up as latency: a stage that wanted two
+sentences waits through several hundred tokens of deliberation first.
+
+`think` is a top-level field on Ollama's API rather than a sampling parameter, and Leviath lifts it
+out of the stage's parameters for you:
+
+```toml
+[stages.classify.model.parameters]
+think = false
+```
+
+Left unset, nothing is sent and the model does whatever it does by default. Set it per stage, not
+globally: the stage that picks a label off a list has nothing to think about, and the one that
+plans the work does.
+
+> [!NOTE]
+> Ollama also accepts at most one system message, so Leviath merges a blueprint's context regions
+> into a single system block for every OpenAI-compatible provider, Ollama included. The region
+> headings survive the merge, which is what keeps a multi-region agent coherent there. See
+> [what the model sees](/docs/context#what-the-model-sees).
+
 ## Where credentials live
 
 Keys live in `~/.leviath/config.toml` by default, or (to keep them out of a plaintext file) in

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -380,6 +380,7 @@
         "min_tokens": { "type": "integer", "minimum": 0 },
         "required": { "type": "boolean", "default": false },
           "summarizable": { "type": "boolean", "default": true, "description": "Set false to keep an edge transform = \"compact\" from handing this region to the summarizer. Protects the region wherever it is used, and wins over an explicit compact list." },
+        "description": { "type": "string", "description": "One line on what this region is for, shown to the model above the region's contents on every turn. Optional - most regions are named well enough that a sentence would only cost tokens; use it where the contents do not explain themselves." },
         "admission": { "enum": ["evict", "reject"], "default": "evict", "description": "What the region does when a write does not fit. \"evict\" makes room by dropping the oldest entry; \"reject\" refuses the write and tells the agent to release something first, so nothing is discarded without the agent knowing." },
         "required_message": {
           "type": "string",


### PR DESCRIPTION
#465 (the merge fix this needs) is merged; rebased onto it.

## The gap

An agent writes to a region **by name** — `context_write { region: "sources_index", … }` — and the prompt showed it every region's contents with nothing saying which region they came from. It could read `sources_index` and write to `sources_index` and have no way to know they were the same place.

Now:

```
## task
research what meta's most recent earnings call was about

## sources_index
[1] RFC 9110 - https://example - 2022 - credibility: high
```

**Three tokens, once per region**, however many entries it holds. Measured, not estimated — there's a test pinning the number, so a future change to the heading format has to justify its cost.

## Descriptions, and who pays for them

A first pass rendered `description` above the region's contents on every turn. That is right for some regions and a quiet tax on the rest: describing every region for the people who maintain a blueprint should not add a sentence per region to every request the agent ever makes.

So the two uses are split. `description` is documentation and costs nothing. `describe_in_prompt = true` spends it on the model as well:

```toml
sources = { kind = "pinned", budget = "4%", describe_in_prompt = true,
            description = "One line per source actually used." }
```

Turn it on where the region has a *convention* the agent has to follow — a format, an ordering, a rule about what belongs. Leave it off where the name is already the explanation, which is most of them.

The field already existed on `RegionDefinition`, with a builder — parsed from nothing, read by nothing. **Fourth** instance of that pattern I've hit in this codebase (after `Inference`, `InferenceUsage`, `StatusChanged`).

## Documentation nobody can see isn't worth writing

So the description now reaches the places somebody is already looking at the region:

| Surface | What it gets |
|---|---|
| `context.json` | `RegionSnapshot.description`, so no reader has to find and re-parse the manifest to explain a region it is already showing |
| `lev dash` | Printed under the region header while the region is open. Folded it is hidden — a folded row is a summary, and a sentence under it would defeat the fold |
| `GET /api/blueprints/{name}` | A `regions` array: name, kind, description, `describe_in_prompt`, `max_tokens` |

The API half is the one worth arguing for. A console could show a blueprint's stages and nothing about its memory, so a person editing an agent could see what it *does* and not what it *keeps* — which is the half that decides whether it can do the job on a small window. On the detail route rather than the listing, for the same reason the manifest is.

`region_kind_str` is now shared between the snapshot and the blueprint API rather than each spelling the kinds itself. Two spellings of one kind — `sliding` from a snapshot, `sliding_window` from a blueprint — is a trap for a console reading both, and there was one.

## Ollama's thinking, while I was here

Reasoning models on Ollama think by default and it comes out of the same output budget as the answer. Asked for a run title in 64 tokens, qwen3.8 returns an empty string, having spent all 64 reasoning about what a title is.

`think` looked reachable — `[stages.x.model.parameters]` passes anything through — but Ollama puts `think` at the *top level* of the request and everything in `parameters` was merged into `options`, where it is a sampling knob Ollama ignores. The knob existed and did nothing. It is now lifted onto the body, and only sent when a blueprint asks: a model with no thinking to switch off rejects the field.

## Scope

Labelling applies to the three kinds that become system blocks: pinned, compact-history, checklist. Compact-history needs it most — a wall of summary prose with nothing saying what it summarizes.

Empty regions still contribute nothing, which bounds both the heading count and, on a strict provider, the system-message count.

## Verified live

deep-researcher on qwen3.8 via ollama, paused and resumed mid-run: 3819 prompt tokens, iteration 2, no error. Separately, a stage with `think = false` answered in 75 completion tokens and finished complete, where the same stage without it spent the budget thinking and returned nothing.

Suite green; `leviath-core`, `leviath-runtime`, `leviath-cli` and `leviath-providers` all at 100%.

#467 (delete a run's record, closing #463) is stacked on this.
