### PR TITLE
feat(api): delete a run's record

### DIFF
--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -62,6 +62,12 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     "logs.stream",
     "context.history.page",
     "runs.waiting_on",
+    // `DELETE /api/runs/{id}` and the bulk `DELETE /api/runs`. Announced
+    // because a console that cannot tell whether the route exists has to find
+    // out by sending a real delete, and that probe is destructive when it
+    // works. `max_ids` bounds the bulk form.
+    "runs.delete",
+    "runs.delete.bulk",
     // The same vocabulary on the websocket, not just on the run. Worth
     // announcing separately: a client that has it can render a parked run's
     // reason straight from the event stream, and one that doesn't has to

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -83,7 +83,8 @@ fn api_router() -> Router<AppState> {
         )
         // Runs - the paginated, searchable listing. Supersedes the GET half of
         // /api/agents, which stays as it is for existing clients.
-        .route("/api/runs", get(runs::list_runs))
+        .route("/api/runs", get(runs::list_runs).delete(runs::delete_runs))
+        .route("/api/runs/{id}", delete(runs::delete_run))
         // Agents
         .route(
             "/api/agents",

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -816,6 +816,13 @@ pub(super) struct DeleteRunsResp {
     pub(super) skipped: Vec<SkippedRun>,
 }
 
+/// Query for `DELETE /api/runs/{id}`.
+#[derive(Debug, Deserialize)]
+pub(super) struct DeleteRunQuery {
+    /// Delete a run whose record cannot be read, which is otherwise a 409.
+    pub(super) force: Option<bool>,
+}
+
 /// Query for `DELETE /api/runs`.
 #[derive(Debug, Deserialize)]
 pub(super) struct DeleteRunsQuery {
@@ -829,25 +836,43 @@ pub(super) struct DeleteRunsQuery {
 ///
 /// One definition for the single and bulk routes, so a run that 409s on its own
 /// cannot be silently deleted as part of a sweep.
-fn deletable(id: &str) -> Result<(), (StatusCode, String)> {
+///
+/// `force` covers only the last case below, and only the single-run route ever
+/// passes it.
+fn deletable(id: &str, force: bool) -> Result<(), (StatusCode, String)> {
     let dir = runstate::run_dir(id);
     if !dir.exists() {
         return Err((StatusCode::NOT_FOUND, format!("Run '{id}' not found")));
     }
     // Judged from the run's own record, not by asking the daemon: a daemon that
-    // is down must not make every run undeletable. A directory whose `meta.json`
-    // is unreadable is deletable - such a run is skipped by `list_runs`, so
-    // refusing here would make the unreadable ones permanent, which is exactly
-    // the corner an operator most wants to clear.
+    // is down must not make every run undeletable.
     match runstate::read_meta(id) {
-        Ok(meta) if !runstate::is_terminal_status(&meta.status) => Err((
+        Ok(meta) if runstate::is_terminal_status(&meta.status) => Ok(()),
+        Ok(meta) => Err((
             StatusCode::CONFLICT,
             format!(
                 "Run '{id}' is {}; cancel it before deleting it",
                 meta.status
             ),
         )),
-        _ => Ok(()),
+        // A run whose `meta.json` will not parse says nothing about whether it
+        // is finished, and "cannot read it" must not quietly read as "finished".
+        // An unparseable record is what a *live* run looks like to a binary
+        // whose `RunMeta` has moved on, and the failure mode there is deleting a
+        // running agent's directory and answering 204 - which is precisely what
+        // this route refuses to do for a run it *can* see is live.
+        //
+        // Such a run is still skipped by `list_runs`, which would leave it both
+        // invisible and permanent, so the escape hatch stays - as something the
+        // caller types rather than something that happens to them.
+        Err(_) if force => Ok(()),
+        Err(e) => Err((
+            StatusCode::CONFLICT,
+            format!(
+                "Run '{id}' has no readable record ({e}), so it cannot be shown \
+                 to be finished; pass force=true to delete it anyway"
+            ),
+        )),
     }
 }
 
@@ -877,12 +902,15 @@ fn remove_run(id: &str) -> Result<(), (StatusCode, String)> {
 /// is a different and much larger feature, and refusing is the honest answer.
 /// **404** on a run that is already gone, so a client that lost the response to
 /// its own delete can repeat it rather than treat a missing run as a failure.
+/// **409** too on a run whose record will not parse, which `force=true`
+/// overrides; see [`deletable`] for why that one is not automatic.
 pub(super) async fn delete_run(
     AxumPath(id): AxumPath<String>,
+    Query(query): Query<DeleteRunQuery>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
     // `run_dir` maps an unsafe id to a path that cannot exist, so a traversal
     // attempt arrives here as an ordinary miss rather than a removed directory.
-    deletable(&id).map_err(|(code, msg)| err(code, msg))?;
+    deletable(&id, query.force.unwrap_or(false)).map_err(|(code, msg)| err(code, msg))?;
     remove_run(&id).map_err(|(code, msg)| err(code, msg))?;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -935,7 +963,10 @@ pub(super) async fn delete_runs(
     let mut deleted = Vec::new();
     let mut skipped = Vec::new();
     for id in targets {
-        match deletable(&id).and_then(|()| remove_run(&id)) {
+        // Never forced. A sweep names runs by a predicate rather than one at a
+        // time, so an unreadable record inside it is far likelier to be
+        // collateral than the thing the operator meant to clear.
+        match deletable(&id, false).and_then(|()| remove_run(&id)) {
             Ok(()) => deleted.push(id),
             Err((_, reason)) => skipped.push(SkippedRun { id, reason }),
         }

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -12,15 +12,18 @@
 //! **What it does not fix.** Every listing here still walks the runs directory
 //! and parses every `meta.json`, because that is the only index there is.
 //! Pagination bounds what crosses the wire and what the browser holds; it does
-//! not bound the server's work, and runs are never pruned. The guard that does
-//! bound the damage is [`MAX_SEARCH_SCAN`], on the filesystem-reading half of
-//! search.
+//! not bound the server's work. The guard that does bound the damage is
+//! [`MAX_SEARCH_SCAN`], on the filesystem-reading half of search.
+//!
+//! Pruning is [`delete_run`] and [`delete_runs`], which is the other half of
+//! that story: the listing can now be made smaller, not only paged over.
 
 use std::collections::HashSet;
 
-use axum::extract::Query;
+use axum::extract::{Path as AxumPath, Query};
 use axum::http::StatusCode;
 use axum::response::Json;
+use serde::{Deserialize, Serialize};
 
 use super::cursor::{self, Cursor, CursorKey};
 use super::search;
@@ -788,3 +791,154 @@ fn build_item(meta: &RunMeta, resolved: &Resolved, highlights: Option<Vec<Highli
 #[cfg(test)]
 #[path = "runs_tests.rs"]
 mod tests;
+
+/// Why a run named in a bulk delete was left alone.
+#[derive(Debug, Serialize)]
+pub(super) struct SkippedRun {
+    /// The run that was not deleted.
+    pub(super) id: String,
+    /// A sentence saying why, for a console to show verbatim.
+    pub(super) reason: String,
+}
+
+/// What a bulk delete did.
+///
+/// Reports per-run outcomes rather than a count, because the interesting result
+/// of "clear everything older than a month" is which runs survived it: a live
+/// run and a run that was already gone are both non-deletions and a caller that
+/// only got `deleted: 12` cannot tell them apart, or tell the user why the list
+/// did not empty.
+#[derive(Debug, Serialize)]
+pub(super) struct DeleteRunsResp {
+    /// Ids whose directories are gone.
+    pub(super) deleted: Vec<String>,
+    /// Ids that were left, each with a reason.
+    pub(super) skipped: Vec<SkippedRun>,
+}
+
+/// Query for `DELETE /api/runs`.
+#[derive(Debug, Deserialize)]
+pub(super) struct DeleteRunsQuery {
+    /// Delete every finished run last updated strictly before this unix time.
+    pub(super) before: Option<i64>,
+    /// Delete exactly these runs, comma-separated.
+    pub(super) ids: Option<String>,
+}
+
+/// Whether a run may be removed, or the reason it may not.
+///
+/// One definition for the single and bulk routes, so a run that 409s on its own
+/// cannot be silently deleted as part of a sweep.
+fn deletable(id: &str) -> Result<(), (StatusCode, String)> {
+    let dir = runstate::run_dir(id);
+    if !dir.exists() {
+        return Err((StatusCode::NOT_FOUND, format!("Run '{id}' not found")));
+    }
+    // Judged from the run's own record, not by asking the daemon: a daemon that
+    // is down must not make every run undeletable. A directory whose `meta.json`
+    // is unreadable is deletable - such a run is skipped by `list_runs`, so
+    // refusing here would make the unreadable ones permanent, which is exactly
+    // the corner an operator most wants to clear.
+    match runstate::read_meta(id) {
+        Ok(meta) if !runstate::is_terminal_status(&meta.status) => Err((
+            StatusCode::CONFLICT,
+            format!(
+                "Run '{id}' is {}; cancel it before deleting it",
+                meta.status
+            ),
+        )),
+        _ => Ok(()),
+    }
+}
+
+/// Remove a run's directory, having already decided it may go.
+fn remove_run(id: &str) -> Result<(), (StatusCode, String)> {
+    std::fs::remove_dir_all(runstate::run_dir(id)).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to delete run '{id}': {e}"),
+        )
+    })
+}
+
+/// `DELETE /api/runs/{id}`: remove a finished run's record from disk.
+///
+/// Separate from `DELETE /api/agents/{id}`, which cancels. The two verbs mean
+/// genuinely different things - one stops the work, the other forgets it
+/// happened - and answering 204 to both would leave a client unable to say
+/// which it got (issue #463).
+///
+/// The deletion is real: the directory and everything in it, including the
+/// transcript. That is the point of the route. A console that offered a
+/// "Delete" which only hid the run locally would tell somebody clearing a
+/// sensitive transcript that it was gone when it was not.
+///
+/// **409** on a live run - removing a directory out from under a running agent
+/// is a different and much larger feature, and refusing is the honest answer.
+/// **404** on a run that is already gone, so a client that lost the response to
+/// its own delete can repeat it rather than treat a missing run as a failure.
+pub(super) async fn delete_run(
+    AxumPath(id): AxumPath<String>,
+) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+    // `run_dir` maps an unsafe id to a path that cannot exist, so a traversal
+    // attempt arrives here as an ordinary miss rather than a removed directory.
+    deletable(&id).map_err(|(code, msg)| err(code, msg))?;
+    remove_run(&id).map_err(|(code, msg)| err(code, msg))?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /api/runs?before=<unix>` or `?ids=a,b`: prune many runs at once.
+///
+/// The realistic use is "clear everything older than a month", and one request
+/// per run over a few hundred runs is its own problem.
+///
+/// Partial success is the normal outcome, not an error: a sweep that meets one
+/// live run has still correctly deleted the rest, so this answers 200 with the
+/// per-run verdicts rather than failing the whole request. The single-run route
+/// is the one that reports a status per outcome.
+///
+/// Neither parameter is a **400** rather than "every run": a bulk delete with no
+/// predicate is much more likely to be a client that failed to build its query
+/// than an operator asking to erase the machine's entire history.
+pub(super) async fn delete_runs(
+    Query(query): Query<DeleteRunsQuery>,
+) -> Result<Json<DeleteRunsResp>, (StatusCode, Json<ErrorResponse>)> {
+    let targets: Vec<String> = match (&query.ids, query.before) {
+        (Some(ids), _) => {
+            let ids = comma_list(ids);
+            if ids.len() > MAX_IDS {
+                return Err(err(
+                    StatusCode::BAD_REQUEST,
+                    format!(
+                        "`ids` names {} runs; at most {MAX_IDS} may be deleted at once",
+                        ids.len()
+                    ),
+                ));
+            }
+            ids
+        }
+        // Scoped to terminal runs at selection time as well as in `deletable`,
+        // so a sweep does not report every live run on the machine as skipped.
+        (None, Some(before)) => runstate::list_runs()
+            .into_iter()
+            .filter(|m| runstate::is_terminal_status(&m.status) && m.updated_at < before)
+            .map(|m| m.run_id)
+            .collect(),
+        (None, None) => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                "a bulk delete needs `before` or `ids`; refusing to delete every run".to_string(),
+            ));
+        }
+    };
+
+    let mut deleted = Vec::new();
+    let mut skipped = Vec::new();
+    for id in targets {
+        match deletable(&id).and_then(|()| remove_run(&id)) {
+            Ok(()) => deleted.push(id),
+            Err((_, reason)) => skipped.push(SkippedRun { id, reason }),
+        }
+    }
+    Ok(Json(DeleteRunsResp { deleted, skipped }))
+}

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -1231,6 +1231,14 @@ fn delete_query(pairs: &[(&str, &str)]) -> DeleteRunsQuery {
         .0
 }
 
+/// The single-route query, through the extractor for the same reason as above.
+fn force(on: bool) -> Query<DeleteRunQuery> {
+    let uri: axum::http::Uri = format!("http://test/api/runs/x?force={on}")
+        .parse()
+        .expect("uri parses");
+    Query::<DeleteRunQuery>::try_from_uri(&uri).expect("query parses")
+}
+
 fn finished(id: &str, updated_at: i64) -> RunMeta {
     let mut meta = meta_at(id, updated_at);
     meta.status = RunStatus::Complete;
@@ -1244,7 +1252,7 @@ async fn deleting_a_finished_run_removes_it_from_disk() {
         create_run(&finished("run-done", 1)).unwrap();
         assert!(crate::runstate::run_dir("run-done").exists());
 
-        let code = delete_run(AxumPath("run-done".to_string()))
+        let code = delete_run(AxumPath("run-done".to_string()), force(false))
             .await
             .expect("the delete succeeds");
 
@@ -1263,7 +1271,7 @@ async fn deleting_a_live_run_is_refused_rather_than_done_behind_the_agent() {
     crate::runstate::with_isolated_runs_dir_async("runs-delete-live", |_d| async move {
         create_run(&meta_at("run-live", 1)).unwrap();
 
-        let (code, body) = delete_run(AxumPath("run-live".to_string()))
+        let (code, body) = delete_run(AxumPath("run-live".to_string()), force(false))
             .await
             .expect_err("a live run is refused");
 
@@ -1280,7 +1288,7 @@ async fn deleting_a_live_run_is_refused_rather_than_done_behind_the_agent() {
 #[tokio::test]
 async fn deleting_a_run_that_is_already_gone_is_a_404() {
     crate::runstate::with_isolated_runs_dir_async("runs-delete-missing", |_d| async move {
-        let (code, _) = delete_run(AxumPath("run-never".to_string()))
+        let (code, _) = delete_run(AxumPath("run-never".to_string()), force(false))
             .await
             .expect_err("a missing run is a 404");
         assert_eq!(code, StatusCode::NOT_FOUND);
@@ -1297,7 +1305,7 @@ async fn a_traversing_run_id_deletes_nothing() {
         let victim = dir.join("keep-me");
         std::fs::create_dir_all(&victim).unwrap();
 
-        let (code, _) = delete_run(AxumPath("../keep-me".to_string()))
+        let (code, _) = delete_run(AxumPath("../keep-me".to_string()), force(false))
             .await
             .expect_err("a traversing id finds nothing");
 
@@ -1307,10 +1315,15 @@ async fn a_traversing_run_id_deletes_nothing() {
     .await;
 }
 
-/// A run whose `meta.json` cannot be read is skipped by `list_runs`, so
-/// refusing to delete it would make it both invisible and permanent.
+/// A record that will not parse says nothing about whether the run is finished,
+/// and "cannot read it" must not quietly read as "finished" - that is what a
+/// *live* run looks like to a binary whose `RunMeta` has moved on, and deleting
+/// one is exactly what this route refuses to do for a run it can see is live.
+///
+/// It is still deletable on request, because `list_runs` skips it and refusing
+/// outright would leave it both invisible and permanent.
 #[tokio::test]
-async fn a_run_with_unreadable_metadata_can_still_be_deleted() {
+async fn a_run_with_unreadable_metadata_is_refused_until_the_caller_forces_it() {
     crate::runstate::with_isolated_runs_dir_async("runs-delete-corrupt", |_d| async move {
         create_run(&finished("run-corrupt", 1)).unwrap();
         std::fs::write(
@@ -1319,12 +1332,41 @@ async fn a_run_with_unreadable_metadata_can_still_be_deleted() {
         )
         .unwrap();
 
-        let code = delete_run(AxumPath("run-corrupt".to_string()))
+        let (code, body) = delete_run(AxumPath("run-corrupt".to_string()), force(false))
             .await
-            .expect("a corrupt run is still deletable");
+            .expect_err("an unreadable record is not proof the run finished");
+        assert_eq!(code, StatusCode::CONFLICT);
+        assert!(body.0.error.contains("force=true"), "{}", body.0.error);
+        assert!(crate::runstate::run_dir("run-corrupt").exists());
 
+        let code = delete_run(AxumPath("run-corrupt".to_string()), force(true))
+            .await
+            .expect("forcing it works");
         assert_eq!(code, StatusCode::NO_CONTENT);
         assert!(!crate::runstate::run_dir("run-corrupt").exists());
+    })
+    .await;
+}
+
+/// `force` is not offered on the bulk route at all, and a sweep must not pick up
+/// an unreadable run as collateral.
+#[tokio::test]
+async fn a_bulk_sweep_never_forces_an_unreadable_run() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-bulk-corrupt", |_d| async move {
+        create_run(&finished("run-corrupt", 1)).unwrap();
+        std::fs::write(
+            crate::runstate::run_dir("run-corrupt").join("meta.json"),
+            "{ not json",
+        )
+        .unwrap();
+
+        let resp = delete_runs(Query(delete_query(&[("ids", "run-corrupt")])))
+            .await
+            .expect("the sweep runs");
+
+        assert!(resp.deleted.is_empty());
+        assert!(resp.skipped[0].reason.contains("force=true"));
+        assert!(crate::runstate::run_dir("run-corrupt").exists());
     })
     .await;
 }
@@ -1432,7 +1474,7 @@ async fn a_run_that_cannot_be_removed_reports_the_failure() {
         perms.set_mode(0o500);
         std::fs::set_permissions(&dir, perms).unwrap();
 
-        let outcome = delete_run(AxumPath("run-stuck".to_string())).await;
+        let outcome = delete_run(AxumPath("run-stuck".to_string()), force(false)).await;
 
         // Restored before asserting, so a failed assert cannot leave an
         // undeletable directory behind for the next run of the suite.
@@ -1457,7 +1499,7 @@ async fn a_run_that_cannot_be_removed_reports_the_failure() {
         let held =
             std::fs::File::open(crate::runstate::run_dir("run-stuck").join("meta.json")).unwrap();
 
-        let outcome = delete_run(AxumPath("run-stuck".to_string())).await;
+        let outcome = delete_run(AxumPath("run-stuck".to_string()), force(false)).await;
         drop(held);
 
         let (code, body) = outcome.expect_err("the removal fails");

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -1212,3 +1212,257 @@ async fn a_bad_request_is_reported_rather_than_served() {
     })
     .await;
 }
+
+// ─── delete ─────────────────────────────────────────────────────────────────
+
+/// Build a `DeleteRunsQuery` through axum's extractor, for the same reason
+/// `query` above does: a struct shape the wire never produces is not a test.
+fn delete_query(pairs: &[(&str, &str)]) -> DeleteRunsQuery {
+    let encoded = pairs
+        .iter()
+        .map(|(k, v)| format!("{k}={}", urlencode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    let uri: axum::http::Uri = format!("http://test/api/runs?{encoded}")
+        .parse()
+        .expect("uri parses");
+    Query::<DeleteRunsQuery>::try_from_uri(&uri)
+        .expect("query parses")
+        .0
+}
+
+fn finished(id: &str, updated_at: i64) -> RunMeta {
+    let mut meta = meta_at(id, updated_at);
+    meta.status = RunStatus::Complete;
+    meta.updated_at = updated_at;
+    meta
+}
+
+#[tokio::test]
+async fn deleting_a_finished_run_removes_it_from_disk() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-one", |_d| async move {
+        create_run(&finished("run-done", 1)).unwrap();
+        assert!(crate::runstate::run_dir("run-done").exists());
+
+        let code = delete_run(AxumPath("run-done".to_string()))
+            .await
+            .expect("the delete succeeds");
+
+        assert_eq!(code, StatusCode::NO_CONTENT);
+        // The directory, not just the listing entry: a delete that left the
+        // transcript behind would be the "hides it locally" bug with extra
+        // steps.
+        assert!(!crate::runstate::run_dir("run-done").exists());
+        assert!(crate::runstate::list_runs().is_empty());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn deleting_a_live_run_is_refused_rather_than_done_behind_the_agent() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-live", |_d| async move {
+        create_run(&meta_at("run-live", 1)).unwrap();
+
+        let (code, body) = delete_run(AxumPath("run-live".to_string()))
+            .await
+            .expect_err("a live run is refused");
+
+        assert_eq!(code, StatusCode::CONFLICT);
+        // Says what to do about it, not just that it failed.
+        assert!(body.0.error.contains("cancel it"));
+        assert!(crate::runstate::run_dir("run-live").exists());
+    })
+    .await;
+}
+
+/// A repeat of a delete whose response was lost has to be readable as "already
+/// gone" rather than as a failure.
+#[tokio::test]
+async fn deleting_a_run_that_is_already_gone_is_a_404() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-missing", |_d| async move {
+        let (code, _) = delete_run(AxumPath("run-never".to_string()))
+            .await
+            .expect_err("a missing run is a 404");
+        assert_eq!(code, StatusCode::NOT_FOUND);
+    })
+    .await;
+}
+
+/// `run_dir` maps an unsafe id onto a path that cannot exist, so a traversal
+/// arrives as an ordinary miss. Asserted here because this is the one route
+/// where being wrong removes a directory.
+#[tokio::test]
+async fn a_traversing_run_id_deletes_nothing() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-traversal", |dir| async move {
+        let victim = dir.join("keep-me");
+        std::fs::create_dir_all(&victim).unwrap();
+
+        let (code, _) = delete_run(AxumPath("../keep-me".to_string()))
+            .await
+            .expect_err("a traversing id finds nothing");
+
+        assert_eq!(code, StatusCode::NOT_FOUND);
+        assert!(victim.exists());
+    })
+    .await;
+}
+
+/// A run whose `meta.json` cannot be read is skipped by `list_runs`, so
+/// refusing to delete it would make it both invisible and permanent.
+#[tokio::test]
+async fn a_run_with_unreadable_metadata_can_still_be_deleted() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-corrupt", |_d| async move {
+        create_run(&finished("run-corrupt", 1)).unwrap();
+        std::fs::write(
+            crate::runstate::run_dir("run-corrupt").join("meta.json"),
+            "{ not json",
+        )
+        .unwrap();
+
+        let code = delete_run(AxumPath("run-corrupt".to_string()))
+            .await
+            .expect("a corrupt run is still deletable");
+
+        assert_eq!(code, StatusCode::NO_CONTENT);
+        assert!(!crate::runstate::run_dir("run-corrupt").exists());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn a_bulk_delete_by_age_takes_the_old_finished_runs_and_leaves_the_rest() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-before", |_d| async move {
+        create_run(&finished("run-ancient", 100)).unwrap();
+        create_run(&finished("run-recent", 300)).unwrap();
+        let mut live = meta_at("run-live", 100);
+        live.status = RunStatus::Running;
+        create_run(&live).unwrap();
+
+        let resp = delete_runs(Query(delete_query(&[("before", "200")])))
+            .await
+            .expect("the sweep runs");
+
+        assert_eq!(resp.deleted, vec!["run-ancient".to_string()]);
+        // The live run is old enough by the clock and is still not swept: it is
+        // filtered out at selection, so it is not reported as a skip either.
+        assert!(resp.skipped.is_empty());
+        assert!(crate::runstate::run_dir("run-live").exists());
+        assert!(crate::runstate::run_dir("run-recent").exists());
+    })
+    .await;
+}
+
+/// Partial success is the normal outcome, and the caller has to be able to tell
+/// the two kinds of non-deletion apart.
+#[tokio::test]
+async fn a_bulk_delete_by_id_reports_a_verdict_for_every_run_it_was_given() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-ids", |_d| async move {
+        create_run(&finished("run-done", 1)).unwrap();
+        create_run(&meta_at("run-live", 2)).unwrap();
+
+        let resp = delete_runs(Query(delete_query(&[(
+            "ids",
+            "run-done,run-live,run-gone",
+        )])))
+        .await
+        .expect("the sweep runs");
+
+        assert_eq!(resp.deleted, vec!["run-done".to_string()]);
+        let reasons: Vec<(&str, &str)> = resp
+            .skipped
+            .iter()
+            .map(|s| (s.id.as_str(), s.reason.as_str()))
+            .collect();
+        assert_eq!(reasons.len(), 2);
+        assert_eq!(reasons[0].0, "run-live");
+        assert!(reasons[0].1.contains("cancel it"));
+        assert_eq!(reasons[1].0, "run-gone");
+        assert!(reasons[1].1.contains("not found"));
+    })
+    .await;
+}
+
+/// Far likelier to be a client that failed to build its query than an operator
+/// asking to erase the machine's history.
+#[tokio::test]
+async fn a_bulk_delete_with_no_predicate_is_refused() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-nothing", |_d| async move {
+        create_run(&finished("run-done", 1)).unwrap();
+
+        let (code, body) = delete_runs(Query(delete_query(&[])))
+            .await
+            .expect_err("a predicate is required");
+
+        assert_eq!(code, StatusCode::BAD_REQUEST);
+        assert!(body.0.error.contains("before"));
+        assert!(crate::runstate::run_dir("run-done").exists());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn a_bulk_delete_naming_more_runs_than_the_cap_is_refused() {
+    let many = (0..MAX_IDS + 1)
+        .map(|i| format!("run-{i}"))
+        .collect::<Vec<_>>()
+        .join(",");
+
+    let (code, body) = delete_runs(Query(delete_query(&[("ids", &many)])))
+        .await
+        .expect_err("over the cap");
+
+    assert_eq!(code, StatusCode::BAD_REQUEST);
+    assert!(body.0.error.contains("at most"));
+}
+
+/// The failing arm of `remove_run`. Reached with a run directory that exists
+/// and is terminal but cannot be removed, which on unix means a parent that is
+/// read-only.
+#[cfg(unix)]
+#[tokio::test]
+async fn a_run_that_cannot_be_removed_reports_the_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-locked", |_d| async move {
+        create_run(&finished("run-stuck", 1)).unwrap();
+        // The runs dir itself, not the temp root above it: removing a directory
+        // needs write permission on its own parent.
+        let dir = crate::runstate::runs_dir();
+        let mut perms = std::fs::metadata(&dir).unwrap().permissions();
+        perms.set_mode(0o500);
+        std::fs::set_permissions(&dir, perms).unwrap();
+
+        let outcome = delete_run(AxumPath("run-stuck".to_string())).await;
+
+        // Restored before asserting, so a failed assert cannot leave an
+        // undeletable directory behind for the next run of the suite.
+        let mut perms = std::fs::metadata(&dir).unwrap().permissions();
+        perms.set_mode(0o700);
+        std::fs::set_permissions(&dir, perms).unwrap();
+
+        let (code, body) = outcome.expect_err("the removal fails");
+        assert_eq!(code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body.0.error.contains("Failed to delete"));
+    })
+    .await;
+}
+
+/// The Windows twin: no permission trick, so the unremovable directory is made
+/// by holding a file in it open, which Windows refuses to delete under.
+#[cfg(windows)]
+#[tokio::test]
+async fn a_run_that_cannot_be_removed_reports_the_failure() {
+    crate::runstate::with_isolated_runs_dir_async("runs-delete-locked", |_d| async move {
+        create_run(&finished("run-stuck", 1)).unwrap();
+        let held =
+            std::fs::File::open(crate::runstate::run_dir("run-stuck").join("meta.json")).unwrap();
+
+        let outcome = delete_run(AxumPath("run-stuck".to_string())).await;
+        drop(held);
+
+        let (code, body) = outcome.expect_err("the removal fails");
+        assert_eq!(code, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body.0.error.contains("Failed to delete"));
+    })
+    .await;
+}

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -1489,15 +1489,36 @@ async fn a_run_that_cannot_be_removed_reports_the_failure() {
     .await;
 }
 
-/// The Windows twin: no permission trick, so the unremovable directory is made
-/// by holding a file in it open, which Windows refuses to delete under.
+/// The Windows twin.
+///
+/// Windows has no equivalent of the Unix "write permission on the parent
+/// directory governs unlinking", and marking a file inside read-only does not
+/// help either: `remove_dir_all` clears that attribute and deletes anyway. A
+/// *sharing violation* does block it - but only from a handle opened with no
+/// share mode. A plain `File::open` shares delete access, so holding one lets
+/// the removal succeed, which is how the first version of this test passed
+/// locally and answered 204 on CI.
+///
+/// The file is also created through that exclusive handle rather than written
+/// and reopened. Reopening leaves a window in which Defender or the indexer has
+/// the just-written file open, and then it is *our* exclusive open that takes
+/// the sharing violation - a known flake here, documented on
+/// `delete_blueprint_removal_failure_returns_500_windows`.
 #[cfg(windows)]
 #[tokio::test]
 async fn a_run_that_cannot_be_removed_reports_the_failure() {
+    use std::fs::OpenOptions;
+    use std::os::windows::fs::OpenOptionsExt;
+
     crate::runstate::with_isolated_runs_dir_async("runs-delete-locked", |_d| async move {
         create_run(&finished("run-stuck", 1)).unwrap();
-        let held =
-            std::fs::File::open(crate::runstate::run_dir("run-stuck").join("meta.json")).unwrap();
+        let held = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .share_mode(0)
+            .open(crate::runstate::run_dir("run-stuck").join("held.bin"))
+            .unwrap();
 
         let outcome = delete_run(AxumPath("run-stuck".to_string()), force(false)).await;
         drop(held);

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -158,9 +158,10 @@ Base path `/api`; all JSON unless noted.
 
 | Method · Path | Purpose |
 |---|---|
-| `GET /api/runs` | List runs: paginated, sortable, searchable. See [below](#listing-and-searching-runs) |
+| `GET /api/runs` · `DELETE /api/runs` | List runs: paginated, sortable, searchable · prune many at once. See [below](#listing-and-searching-runs) |
+| `DELETE /api/runs/{id}` | Delete one finished run's record. Not the same as cancelling it. See [below](#deleting-runs) |
 | `GET /api/agents` · `POST /api/agents` | List runs *(deprecated, use `/api/runs`)* · spawn an agent. Reads the persisted records, so finished runs stay listed |
-| `GET /api/agents/{id}` · `DELETE …` | Get one · cancel |
+| `GET /api/agents/{id}` · `DELETE …` | Get one · cancel. Cancelling stops the work and **keeps** the record; see [deleting runs](#deleting-runs) for removing it |
 | `GET /api/agents/{id}/result` · `/context` | The run's answer and log tail · current context window |
 | `GET /api/agents/{id}/logs?stage=&stream=&tail=` | A run's logs. `stage`, `stream` and `tail` pick which stage, which stream, and how much |
 | `GET /api/agents/{id}/context/history` | How the context window changed over the run, paginated |
@@ -244,6 +245,56 @@ done in the browser, because The Lair never holds a run's transcript.
 
 One honest limit: the deep sources match the raw JSON on disk, so a query containing a quote,
 a backslash or a newline may not match text that does contain it.
+
+## Deleting runs
+
+Cancelling and deleting are different verbs on purpose. `DELETE /api/agents/{id}` stops the run and
+leaves everything it wrote; `DELETE /api/runs/{id}` removes the record. One stops the work, the
+other forgets it happened.
+
+Deletion is real and irreversible. The run's directory goes, transcript included. That is the point
+of the route: a "Delete" button that only hid the run in one browser would tell somebody clearing a
+sensitive transcript that it was gone when it was not.
+
+```
+DELETE /api/runs/deep-researcher-1786839472-d908ad2d9455
+→ 204
+```
+
+- **409** if the run is still going. Removing a directory out from under a running agent is a much
+  larger feature than this, so cancel it first and delete it after.
+- **404** if it is already gone, so a client that lost the response to its own delete can just send
+  it again instead of treating a missing run as a failure.
+
+A run whose `meta.json` is unreadable *can* be deleted. Such a run is skipped by the listing, so
+refusing would leave it both invisible and permanent.
+
+### Clearing out old runs
+
+One request per run is its own problem once there are a few hundred, so there is a bulk form. It
+takes either an age or an explicit list:
+
+```
+DELETE /api/runs?before=1785869070
+DELETE /api/runs?ids=run-a,run-b,run-c
+```
+
+`before` is a unix timestamp and matches `updated_at`; only finished runs are considered. `ids` is
+capped at `max_ids` from `GET /api/config`, the same cap as the batch fetch. Sending neither is a
+400 rather than "every run" -- a bulk delete with no predicate is far more likely to be a client
+that failed to build its query than somebody asking to erase the machine's history.
+
+Partial success is the normal outcome, not an error. A sweep that runs into one live run has still
+correctly deleted the rest, so the response is a 200 with a verdict per run:
+
+```json
+{ "deleted": ["run-a", "run-c"],
+  "skipped": [{ "id": "run-b", "reason": "Run 'run-b' is Running; cancel it before deleting it" }] }
+```
+
+Read `skipped` when the list does not empty. A run that is still going and a run that was already
+gone are both non-deletions, and only the reason tells them apart. Use the single-run route when you
+want a status code per outcome instead.
 
 ## Where a run's cost went
 
@@ -384,6 +435,10 @@ those instead of calling a route and treating a 404 as "unsupported": a 404 also
 run", and it costs a round trip per feature. The limits matter as much as the capability names: they
 are where the page cap, file cap and listing cap actually live, so a client never has to hardcode
 one.
+
+`runs.delete` and `runs.delete.bulk` are the ones worth checking before drawing a button rather than
+after clicking it. Finding out whether the other routes exist costs a wasted request; finding out
+this way costs a deleted run.
 
 ## Live updates over WebSocket
 

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -266,8 +266,17 @@ DELETE /api/runs/deep-researcher-1786839472-d908ad2d9455
 - **404** if it is already gone, so a client that lost the response to its own delete can just send
   it again instead of treating a missing run as a failure.
 
-A run whose `meta.json` is unreadable *can* be deleted. Such a run is skipped by the listing, so
-refusing would leave it both invisible and permanent.
+A run whose `meta.json` will not parse is a **409** too, overridden with `?force=true`:
+
+```
+DELETE /api/runs/{id}?force=true
+```
+
+A record that cannot be read says nothing about whether the run finished, and "cannot read it" must
+not quietly read as "finished" -- that is exactly what a live run looks like to a binary whose
+`RunMeta` has moved on. Such a run is also skipped by the listing, which would leave it both
+invisible and permanent, so the escape hatch stays; it is just something you type rather than
+something that happens to you. The bulk route never forces.
 
 ### Clearing out old runs
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -367,6 +367,78 @@
             "$ref": "#/components/responses/Error"
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Delete many runs at once",
+        "description": "Prunes finished runs. The realistic use is \"clear everything older than a month\", which one request per run over a few hundred runs does badly.\n\nNeeds `before` or `ids`. Neither is a 400 rather than \"every run\": a bulk delete with no predicate is far more likely to be a client that failed to build its query than an operator asking to erase the machine's history.\n\nPartial success is the normal outcome, not a failure. A sweep that meets a live run has still correctly deleted the rest, so this answers 200 with a verdict per run rather than failing the whole request. Read `skipped` to find out why the list did not empty. Use DELETE /api/runs/{id} when you want a status code per outcome.\n\nDeletion is real and irreversible: the run directory and its transcript go.",
+        "parameters": [
+          {
+            "name": "before",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            },
+            "description": "Delete every finished run whose updated_at is strictly before this unix timestamp. Ignored when ids is given."
+          },
+          {
+            "name": "ids",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated run ids to delete. At most max_ids (see GET /api/config) per request."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The sweep ran. Every named run is in exactly one of the two lists.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteRunsResp"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/api/runs/{id}": {
+      "delete": {
+        "tags": [
+          "runs"
+        ],
+        "summary": "Delete one run's record",
+        "description": "Removes a finished run's directory from disk. Distinct from DELETE /api/agents/{id}, which cancels the run and leaves the record: one stops the work, the other forgets it happened.\n\nDeletion is real and irreversible - the directory and everything in it, including the transcript. A console offering a \"Delete\" that only hid the run locally would tell somebody clearing a sensitive transcript that it was gone when it was not.\n\n409 on a live run: removing a directory out from under a running agent is a different and much larger feature, so cancel it first. 404 on a run that is already gone, so a client that lost the response to its own delete can repeat it rather than treat a missing run as a failure.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The run id."
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted. No body."
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "409": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
       }
     },
     "/api/agents": {
@@ -1698,6 +1770,46 @@
               "null"
             ],
             "description": "Unix seconds; null until the stage is left."
+          }
+        }
+      },
+      "SkippedRun": {
+        "type": "object",
+        "required": [
+          "id",
+          "reason"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The run that was not deleted."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why, as a sentence a console can show verbatim."
+          }
+        }
+      },
+      "DeleteRunsResp": {
+        "type": "object",
+        "required": [
+          "deleted",
+          "skipped"
+        ],
+        "properties": {
+          "deleted": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Ids whose directories are gone."
+          },
+          "skipped": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SkippedRun"
+            },
+            "description": "Ids that were left alone, each with a reason. A live run and a run that was already gone are both non-deletions, and a caller needs to tell them apart."
           }
         }
       }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -416,7 +416,7 @@
           "runs"
         ],
         "summary": "Delete one run's record",
-        "description": "Removes a finished run's directory from disk. Distinct from DELETE /api/agents/{id}, which cancels the run and leaves the record: one stops the work, the other forgets it happened.\n\nDeletion is real and irreversible - the directory and everything in it, including the transcript. A console offering a \"Delete\" that only hid the run locally would tell somebody clearing a sensitive transcript that it was gone when it was not.\n\n409 on a live run: removing a directory out from under a running agent is a different and much larger feature, so cancel it first. 404 on a run that is already gone, so a client that lost the response to its own delete can repeat it rather than treat a missing run as a failure.",
+        "description": "Removes a finished run's directory from disk. Distinct from DELETE /api/agents/{id}, which cancels the run and leaves the record: one stops the work, the other forgets it happened.\n\nDeletion is real and irreversible - the directory and everything in it, including the transcript. A console offering a \"Delete\" that only hid the run locally would tell somebody clearing a sensitive transcript that it was gone when it was not.\n\n409 on a live run: removing a directory out from under a running agent is a different and much larger feature, so cancel it first. 404 on a run that is already gone, so a client that lost the response to its own delete can repeat it rather than treat a missing run as a failure. 409 as well on a run whose record will not parse, which force=true overrides.",
         "parameters": [
           {
             "name": "id",
@@ -426,6 +426,15 @@
               "type": "string"
             },
             "description": "The run id."
+          },
+          {
+            "name": "force",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "description": "Delete a run whose meta.json will not parse, which is otherwise a 409. A record that cannot be read is not proof the run finished - that is what a live run looks like to a binary whose RunMeta has moved on - so this is something the caller types rather than the default. The bulk route never forces."
           }
         ],
         "responses": {


### PR DESCRIPTION
Closes #463.

A console could list runs, read them, cancel them, and never get rid of one. A machine
that has been running agents for a few weeks accumulated a run list nobody could prune
without going into `~/.leviath` by hand.

```
DELETE /api/runs/{id}
```

A separate route from `DELETE /api/agents/{id}`, which cancels, rather than a
`?purge=true` on it. The two verbs mean genuinely different things -- one stops the work,
the other forgets it happened -- and 204 for both leaves a client unable to say which it
got.

| Case | Answer |
|---|---|
| Finished run | 204, directory gone |
| Still live | 409, "cancel it before deleting it" |
| Already gone | 404, so a repeat of a lost delete is readable |
| `meta.json` unreadable | 409, overridden with `?force=true` -- see below |
| Traversing id | 404; `run_dir` maps an unsafe id onto a path that cannot exist |

Liveness is judged from the run's own record rather than by asking the daemon, so a
daemon that is down does not make every run undeletable.

### The unreadable case, found live

The first version of this treated a run whose `meta.json` would not parse as deletable:
such a run is skipped by the listing, so refusing outright leaves it both invisible and
permanent.

Driving the routes against a real `lev serve` killed that. With a fixture whose meta was
missing required fields, a run whose status was `running` deleted with a **204** -- the
exact thing the route refuses to do for a run it can see is live. The fixture was wrong,
but the behaviour it exposed is not fixture-shaped: an unparseable record is what a live
run looks like to a binary whose `RunMeta` has moved on, so that turns a schema skew into
a deleted running agent.

It is now a 409 with an explicit override:

```
DELETE /api/runs/{id}?force=true
```

`force` covers only that case -- a run the server can *see* is running is still a 409
with it -- and the bulk route never forces, because a sweep names runs by a predicate and
an unreadable record inside one is far likelier to be collateral than the target.

### Bulk

The realistic use is "clear everything older than a month", and one request per run over
a few hundred runs is its own problem:

```
DELETE /api/runs?before=<unix>
DELETE /api/runs?ids=a,b,c
```

Partial success is the normal outcome rather than an error -- a sweep that meets one live
run has still correctly deleted the rest -- so it answers 200 with a verdict per run:

```json
{ "deleted": ["run-a", "run-c"],
  "skipped": [{ "id": "run-b", "reason": "Run 'run-b' is Running; cancel it before deleting it" }] }
```

`skipped` carries a reason each, because a run that is still going and a run that was
already gone are both non-deletions and only the reason tells them apart. Neither
parameter is a 400 rather than "every run": a bulk delete with no predicate is far more
likely to be a client that failed to build its query than somebody asking to erase the
machine's history. `ids` is capped at the same `max_ids` as the batch fetch.

### Discovery

Announced as `runs.delete` and `runs.delete.bulk` in `GET /api/config`. Finding out
whether the other routes exist costs a wasted request; finding out about this one by
trying it costs a deleted run.

### Notes

The deletion is real -- the directory and the transcript. That is the point of the route:
leviath.dev can only hide a run locally today and has to say so in as many words, because
a "Delete" that quietly meant "hide from this browser" would tell somebody clearing a
sensitive transcript that they had removed it when they had not.

`lev dash` keeps its own cancel-then-delete policy on the selected run: there a person
picked the run in front of them, where a programmatic client has not.

Documented in `docs/content/api.md` and `docs/schema/openapi.json`, which the router
conformance test holds to the real route table. Ten unit tests plus a live harness of
**29 checks** against a real server -- both routes, the capability flags, 409/404/204 per
case, the force override, traversal, and that the listing agrees with the filesystem
afterwards. All four coverage gates green.

Incidental finding from the live run, recorded because it looks like a bug and is not: a
`running` run written to disk *before* the daemon boots is reclaimed to `error` by the
stuck-run recovery within a couple of seconds, and then deletes like any finished run.

Was stacked on #466, now merged; rebased onto it.
