### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,89 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## 0.4.0 - 2026-08-16
+
+- Breaking: every MCP tool is named `<server>__<tool>`, whether or not anything
+  would have collided. A tool used to be advertised bare and prefixed only on a
+  clash, which made the name a function of registration order: registration
+  follows `config.toml`, so two servers both offering `search` gave the bare
+  name to whichever was listed first. `available_tools = ["search"]` therefore
+  meant a different server's tool depending on the order of a file the blueprint
+  does not control. A blueprint naming a bare MCP tool stops matching, though a
+  name that resolves to exactly one server is now rewritten for you rather than
+  silently dropped. No bundled agent is affected; none of the seven names an MCP
+  tool. The separator is `__` and not the `.` it reads better as, because the
+  advertised name goes to the model provider, which accepts only
+  `[A-Za-z0-9_-]` and rejects the whole request otherwise.
+- Breaking: the run archive's version number marks a change to its *framing* -
+  the preamble, the length prefix, the payload encoding - and an archive newer
+  than the build reading it is refused by name. It was read by every caller and
+  compared by none, so a future format change would have been parsed as the
+  current one and produced nonsense from whatever the length prefixes said.
+- Fixed: a reader steps over a record kind it does not know instead of stopping
+  at it. Records are length-prefixed and nothing used that, so a frame whose
+  contents a build could not parse was treated like a frame whose end it could
+  not find: the read stopped there and returned the prefix. That made adding a
+  record kind a breaking change, and it was already live - `InferenceUsage`
+  shipped in 0.3.10 and is written on every provider call, so an older
+  `leviath-core` read a 0.3.10 journal as "header, then nothing". Adding a
+  record kind no longer moves the version, because older builds can now read
+  past it.
+- Fixed: a provider gets one system message however many blocks were assembled.
+  Leviath models system content as blocks, one per pinned region, and the OpenAI
+  chat shape has no such concept - it has *a* system message. The shared builder
+  emitted one per block, which permissive servers tolerate and strict ones do
+  not: Ollama with a Qwen 3.x template answers `HTTP 500 {"error":"system
+  message must be at the beginning"}`, which is a misleading way to say "at most
+  one". Every multi-region blueprint, which is every real agent, failed on its
+  first inference against those models. Anthropic has its own builder, where
+  block structure earns its keep through per-block `cache_control`, and is
+  unchanged.
+- Fixed: a resumed run is not re-titled. `PendingTitle` was attached on every
+  build with no fresh-versus-reload check, so each pause and resume bought
+  another titling call.
+- Fixed: an unattended run parks rather than failing when the fix is somebody
+  else's. A benchmark round crossed an empty account mid-tier and lost 31 runs
+  across three terminal shapes, none resumable, all one cause. `paused` is
+  visible in `meta.json` and `lev ps --json`, so a harness that can top up an
+  account and `lev resume` gets the work back, and one that cannot cancels the
+  run for the cost of a second. A credits failure on an output stage also used
+  to route through the transition logic and report "never called
+  submit_output", naming the wrong cause to everything downstream.
+- New: a stage can grant a whole MCP server with
+  `available_connectors = ["github"]`, resolved at spawn against what that
+  server actually advertises and merged with `available_tools`. Naming tools one
+  by one meant knowing a list that is not the blueprint author's to know - it is
+  whatever the server advertises today - so a tool added later was never
+  offered, with nothing said.
+- New: `DELETE /api/runs/{id}` removes a finished run's record, and
+  `DELETE /api/runs?before=<unix>` or `?ids=` prunes many at once. Cancelling and
+  deleting are different verbs: `DELETE /api/agents/{id}` stops the work and
+  keeps the record. A console could list runs, read them, cancel them and never
+  get rid of one. A live run is refused with 409, an already-deleted one answers
+  404 so a repeat is readable, and a run whose record will not parse needs
+  `?force=true` - an unreadable record is what a live run looks like to a build
+  whose `RunMeta` has moved on. Announced as `runs.delete` and
+  `runs.delete.bulk`.
+- New: regions that assemble into the system prompt carry their own name above
+  their contents. An agent writes to a region *by name* and the prompt showed it
+  every region's contents with nothing saying which region they came from, so it
+  could read `sources_index`, write to `sources_index`, and have no way to know
+  they were the same place. Three tokens per region, however many entries it
+  holds.
+- New: a region takes a `description`, and `describe_in_prompt = true` shows it
+  to the model as well. On its own it is documentation and costs nothing:
+  `lev dash` prints it under the region, `GET /api/blueprints/{name}` returns it
+  with the region's kind and budget, and `context.json` carries it so no reader
+  has to re-parse the manifest to explain a region it is already showing.
+- New: an Ollama stage can turn off a reasoning model's thinking with
+  `think = false` under `[stages.<name>.model.parameters]`. Ollama puts `think`
+  at the top level of the request while everything in `parameters` is merged
+  into `options`, so setting it there was accepted and ignored. Thinking is
+  billed to the same output budget as the answer: asked for a run title in 64
+  tokens, qwen3.8 returns an empty string, having spent all 64 deciding what a
+  title is.
+
 ## 0.3.10 - 2026-08-14
 
 - Fixed: a run now reports what it was actually billed. A run makes four kinds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ same list.
   first inference against those models. Anthropic has its own builder, where
   block structure earns its keep through per-block `cache_control`, and is
   unchanged.
+- Fixed: every request to an OpenAI-dialect server carries a user turn. The task
+  lives in a pinned region, so it assembles into the system prompt and a
+  conversation can legitimately hold no user message: Ollama with a Qwen 3.x
+  template answers `HTTP 500 {"error":"no user query found in messages"}` for
+  any request without one. Most shapes were already covered, by the "Begin."
+  fallback and by the turn ordering fix; the guarantee now holds for the rest.
 - Fixed: a resumed run is not re-titled. `PendingTitle` was attached on every
   build with no fresh-versus-reload check, so each pause and resume bought
   another titling call.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2595,7 +2595,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2609,7 +2609,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "fs4",
  "keyring",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.10"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.10" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.10" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.10" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.10" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.10" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.10" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.10" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.10" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.10" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.10" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.10" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.10" }
+leviath = { path = "crates/leviath", version = "0.4.0" }
+leviath-core = { path = "crates/leviath-core", version = "0.4.0" }
+leviath-net = { path = "crates/leviath-net", version = "0.4.0" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.4.0" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.4.0" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.4.0" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.4.0" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.4.0" }
+leviath-package = { path = "crates/leviath-package", version = "0.4.0" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.4.0" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.4.0" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.4.0" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.10", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.4.0", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -227,7 +227,50 @@ pub fn openai_messages_with(
     for msg in &request.messages {
         messages.extend(message_to_openai_with(&msg.role, &msg.content, tool_args));
     }
-    satisfy_call_turn_order(drop_unpaired_tool_turns(messages))
+    ensure_user_turn(satisfy_call_turn_order(drop_unpaired_tool_turns(messages)))
+}
+
+/// The minimal user turn this layer inserts when a wire format demands one that
+/// the conversation does not have.
+///
+/// Names where the real instruction is, so the addition cannot read as a new
+/// request from the person, and is a fixed string at a fixed position so it
+/// costs nothing in prompt-cache stability.
+fn stand_in_user_turn() -> serde_json::Value {
+    serde_json::json!({
+        "role": "user",
+        "content": "Proceed with the task described in the system instructions.",
+    })
+}
+
+/// Ensure the conversation contains at least one user turn.
+///
+/// Leviath's task lives in a pinned context region, so it assembles into the
+/// system prompt and a request can legitimately carry no user-role message at
+/// all: on the very first inference, when the window holds nothing but assistant
+/// prose, or when the only entries were tool responses whose calls have aged out
+/// and been dropped above.
+///
+/// Anthropic and OpenAI accept that. Ollama with a Qwen 3.x template does not -
+/// it answers `HTTP 500 {"error":"no user query found in messages"}` and the run
+/// dies on a wire-format detail no agent author can see. Measured against
+/// `qwen3.8-32k`: every shape carrying a user turn anywhere is accepted, and
+/// every shape without one is refused, including `[system, assistant]`.
+///
+/// [`satisfy_call_turn_order`] already covers the histories that contain a tool
+/// call, since it puts a user turn ahead of the first one. This covers the rest,
+/// so the guarantee holds for every shape rather than for the common one.
+///
+/// The turn goes directly after the system message, where an opening request
+/// belongs, rather than at the end where it would read as a fresh instruction
+/// arriving after the assistant's last word.
+fn ensure_user_turn(mut messages: Vec<serde_json::Value>) -> Vec<serde_json::Value> {
+    if messages.iter().any(|m| m["role"] == "user") {
+        return messages;
+    }
+    let after_system = usize::from(messages.first().is_some_and(|m| m["role"] == "system"));
+    messages.insert(after_system, stand_in_user_turn());
+    messages
 }
 
 /// Ensure every function-call turn follows a user turn or a function response
@@ -251,10 +294,7 @@ fn satisfy_call_turn_order(messages: Vec<serde_json::Value>) -> Vec<serde_json::
         if is_call_turn {
             let prev_role = out.last().and_then(|m| m["role"].as_str());
             if !matches!(prev_role, Some("user") | Some("tool")) {
-                out.push(serde_json::json!({
-                    "role": "user",
-                    "content": "Proceed with the task described in the system instructions.",
-                }));
+                out.push(stand_in_user_turn());
             }
         }
         out.push(msg);
@@ -871,6 +911,171 @@ mod tests {
         }
     }
 
+    // ─── ensure_user_turn ───────────────────────────────────────────────────
+
+    /// A request with a system prompt and nothing else, which is exactly the
+    /// first inference of any run: the task lives in a pinned region, so there
+    /// is no user message until the assistant has said something to answer.
+    #[test]
+    fn a_conversation_with_no_messages_still_carries_a_user_turn() {
+        let request = InferenceRequest {
+            system: vec![crate::provider::SystemBlock {
+                text: "## task\ncount the ERROR lines".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+            }],
+            messages: vec![],
+            model: "qwen3.8".to_string(),
+            max_tokens: 64,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let messages = openai_messages(&request);
+        let roles: Vec<&str> = messages.iter().filter_map(|m| m["role"].as_str()).collect();
+        assert_eq!(roles, vec!["system", "user"]);
+        // The stand-in points at where the real task is, so it cannot read as
+        // a fresh request from the person.
+        assert_eq!(
+            messages[1]["content"],
+            serde_json::json!("Proceed with the task described in the system instructions.")
+        );
+    }
+
+    /// The window holding nothing but the assistant's own prose. No tool call,
+    /// so `satisfy_call_turn_order` does not fire and this is the shape that
+    /// reached Ollama without a user turn (issue #469).
+    #[test]
+    fn a_conversation_of_only_assistant_prose_gains_a_user_turn() {
+        let request = InferenceRequest {
+            system: vec![crate::provider::SystemBlock {
+                text: "instructions".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+            }],
+            messages: vec![crate::provider::Message {
+                role: "assistant".to_string(),
+                content: crate::provider::MessageContent::Text("still working".to_string()),
+                cache_breakpoint: false,
+            }],
+            model: "qwen3.8".to_string(),
+            max_tokens: 64,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let messages = openai_messages(&request);
+        let roles: Vec<&str> = messages.iter().filter_map(|m| m["role"].as_str()).collect();
+        // Ahead of the assistant, where an opening request belongs, rather than
+        // after its last word where it would read as a new instruction.
+        assert_eq!(roles, vec!["system", "user", "assistant"]);
+    }
+
+    /// Tool responses whose calls have aged out are dropped, which can empty a
+    /// conversation that looked non-empty on the way in.
+    #[test]
+    fn a_conversation_emptied_by_dropping_orphans_gains_a_user_turn() {
+        let request = InferenceRequest {
+            system: vec![crate::provider::SystemBlock {
+                text: "instructions".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+            }],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: crate::provider::MessageContent::Blocks(vec![
+                    crate::provider::ContentBlock::ToolResult {
+                        tool_use_id: "gone".to_string(),
+                        content: "a.log".to_string(),
+                        is_error: false,
+                    },
+                ]),
+                cache_breakpoint: false,
+            }],
+            model: "qwen3.8".to_string(),
+            max_tokens: 64,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let messages = openai_messages(&request);
+        let roles: Vec<&str> = messages.iter().filter_map(|m| m["role"].as_str()).collect();
+        assert_eq!(roles, vec!["system", "user"]);
+    }
+
+    /// The histories `satisfy_call_turn_order` already covers must not gain a
+    /// second stand-in: one user turn is the requirement, not one per request.
+    #[test]
+    fn a_conversation_that_already_has_a_user_turn_is_left_alone() {
+        let call = crate::provider::Message {
+            role: "assistant".to_string(),
+            content: crate::provider::MessageContent::Blocks(vec![
+                crate::provider::ContentBlock::ToolUse {
+                    id: "c1".to_string(),
+                    name: "list_dir".to_string(),
+                    input: serde_json::json!({"path": "logs/"}),
+                    thought_signature: None,
+                },
+            ]),
+            cache_breakpoint: false,
+        };
+        let result = crate::provider::Message {
+            role: "user".to_string(),
+            content: crate::provider::MessageContent::Blocks(vec![
+                crate::provider::ContentBlock::ToolResult {
+                    tool_use_id: "c1".to_string(),
+                    content: "a.log".to_string(),
+                    is_error: false,
+                },
+            ]),
+            cache_breakpoint: false,
+        };
+        let request = InferenceRequest {
+            system: vec![crate::provider::SystemBlock {
+                text: "instructions".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+            }],
+            messages: vec![call.clone(), result.clone(), call, result],
+            model: "qwen3.8".to_string(),
+            max_tokens: 64,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let messages = openai_messages(&request);
+        let users = messages.iter().filter(|m| m["role"] == "user").count();
+        assert_eq!(users, 1, "the turn-order pass already supplied one");
+    }
+
+    /// With no system message there is nothing to insert after, and index 0 has
+    /// to stay in range.
+    #[test]
+    fn a_conversation_with_no_system_message_gains_a_leading_user_turn() {
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![crate::provider::Message {
+                role: "assistant".to_string(),
+                content: crate::provider::MessageContent::Text("still working".to_string()),
+                cache_breakpoint: false,
+            }],
+            model: "qwen3.8".to_string(),
+            max_tokens: 64,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let messages = openai_messages(&request);
+        let roles: Vec<&str> = messages.iter().filter_map(|m| m["role"].as_str()).collect();
+        assert_eq!(roles, vec!["user", "assistant"]);
+    }
+
     // ─── merge_extra_params ─────────────────────────────────────────────────
 
     #[test]
@@ -1400,6 +1605,11 @@ mod tests {
 
     // ── Additional coverage tests ──────────────────────────────────────────
 
+    /// A request carrying nothing at all still goes out with a user turn.
+    ///
+    /// Every chat API rejects an empty message list, so there is no shape this
+    /// makes worse, and guaranteeing the turn unconditionally keeps one rule
+    /// rather than one rule and an exception nobody would think to test.
     #[test]
     fn build_request_body_empty_messages() {
         let req = InferenceRequest {
@@ -1413,7 +1623,9 @@ mod tests {
             request_timeout_secs: None,
         };
         let body = build_openai_request_body(&req);
-        assert_eq!(body["messages"].as_array().unwrap().len(), 0);
+        let messages = body["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "user");
     }
 
     #[test]


### PR DESCRIPTION
Cuts **0.4.0** to alpha. Beta and prod are not dispatched.

## Why a minor bump

Two breaking changes since 0.3.10:

**MCP tool names are always `<server>__<tool>`.** The bare name used to be a function of
registration order - registration follows `config.toml`, so two servers both offering
`search` gave the bare name to whichever was listed first, and reordering that file
silently re-pointed the grant. A blueprint naming a bare MCP tool stops matching, though a
name resolving to exactly one server is rewritten for you rather than silently dropped. No
bundled agent is affected; none of the seven names an MCP tool.

**The run archive's version marks a framing change**, and an archive newer than the build
reading it is refused by name. It was read by every caller and compared by none, so a
future format change would have been parsed as the current one.

## Not bumped

`api_version` stays at `0.3.0`. It marks breaking changes to the HTTP contract - the spec's
own text reads "Breaking change in 0.3.0" - and 0.3.x has added routes and capabilities
repeatedly without moving it. The delete routes and the blueprint `regions` array are
additive and discoverable through `capabilities`.

## Also in this release

- Readers step over an unknown record kind instead of stopping at it. This was already
  live: `InferenceUsage` shipped in 0.3.10 and an older `leviath-core` read those journals
  as "header, then nothing".
- One system message per request, however many blocks were assembled. Every multi-region
  blueprint failed on its first inference against Ollama with a Qwen 3.x template.
- Unattended runs park instead of failing when the fix is somebody else's. A benchmark
  round lost 31 runs across three terminal shapes, all one cause.
- A resumed run is not re-titled.
- `available_connectors` grants a whole MCP server.
- `DELETE /api/runs/{id}` and the bulk sweep (#463).
- Region names in the prompt; `description` / `describe_in_prompt`.
- `think = false` reaches Ollama.

## Checks

Full suite, docs, structure and fmt green locally; all four per-crate coverage gates at
100%. The version bump needs the `allow-version-bump` label, applied below.
