### PR TITLE
fix(context): stop rewriting a growing region into the cache every call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ same list.
 
 ## Unreleased
 
+- Fixed: a growing context region is no longer rewritten into the prompt cache
+  on every call. A region became a single system block, and a provider matches a
+  cached prefix only at a block boundary - so the one boundary a region offered
+  sat after its newest content, and the moment the region grew the entry named
+  there could never be read again. Measured against Sonnet on a twelve-call run:
+  456,860 cache-write tokens and zero reads. Regions whose entries append are
+  now split into chunks at boundaries that survive into the next request, and a
+  breakpoint is only placed where every byte ahead of it is unchanged, so the
+  settled history caches and only the tail is re-sent. The same run now writes
+  74,256 and reads 300,588, with the per-call write flat rather than ratcheting.
+  Runs whose history already lived in the messages are unaffected, to the token.
 - Fixed: an Ollama model's context window is read from the server rather than
   guessed from its name. The compiled table matches on a family substring, so
   `qwen3.8-32k` took the `qwen3` arm and was handed 131072 against the 32768 it

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -412,6 +412,7 @@ async fn run_test_case(
         model: model_name.to_string(),
         // One assembly, so there is no previous request to compare against.
         previous_system_hash: None,
+        previous_block_hashes: Vec::new(),
     });
     let caps = provider.capabilities(model_name);
     let remaining = window.max_tokens.saturating_sub(window.current_tokens);

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -40,19 +40,33 @@ fn maybe_dump_request(body: &serde_json::Value) {
 /// budget, the last `budget` are kept - the final run always ends on the last
 /// cacheable block, so its breakpoint spans the full cacheable prefix and
 /// nothing cacheable is left entirely uncached.
-fn system_cache_breakpoints(hints: &[leviath_core::CacheHint], budget: usize) -> Vec<usize> {
+fn system_cache_breakpoints(blocks: &[crate::provider::SystemBlock], budget: usize) -> Vec<usize> {
     if budget == 0 {
         return Vec::new();
     }
     let mut ends = Vec::new();
-    for (i, hint) in hints.iter().enumerate() {
-        if *hint == leviath_core::CacheHint::Never {
+    let mut run_end: Option<usize> = None;
+    for (i, block) in blocks.iter().enumerate() {
+        let hint = block.cache_hint;
+        if hint == leviath_core::CacheHint::Never {
+            run_end = None;
             continue;
+        }
+        // The furthest block in this run whose entry could actually be read
+        // back. A block the assembler marked ineligible has changed since the
+        // last request, so a breakpoint at or after it names a prefix that has
+        // already been invalidated - the 1.25x write is charged and nothing is
+        // ever read (issue #474). Keeping the last eligible one instead caches
+        // the part that did hold still.
+        if block.breakpoint_eligible {
+            run_end = Some(i);
         }
         // End of a contiguous same-hint run: the next block is absent or a
         // different hint (a `Never` block also breaks the run).
-        if hints.get(i + 1) != Some(hint) {
-            ends.push(i);
+        if blocks.get(i + 1).map(|b| b.cache_hint) != Some(hint)
+            && let Some(end) = run_end.take()
+        {
+            ends.push(end);
         }
     }
     if ends.len() > budget {
@@ -371,10 +385,8 @@ impl AnthropicProvider {
         // pinned/cached regions stays within the limit (issue #12): one
         // `cache_control` per contiguous run of same-hint cacheable blocks,
         // capped at the total budget.
-        let system_hints: Vec<leviath_core::CacheHint> =
-            request.system.iter().map(|b| b.cache_hint).collect();
         let system_breakpoints: std::collections::HashSet<usize> =
-            system_cache_breakpoints(&system_hints, MAX_BREAKPOINTS)
+            system_cache_breakpoints(&request.system, MAX_BREAKPOINTS)
                 .into_iter()
                 .collect();
 
@@ -1182,6 +1194,7 @@ mod tests {
             system: vec![crate::SystemBlock {
                 text: "You are helpful.".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             }],
             messages: vec![crate::provider::Message {
                 role: "user".to_string(),
@@ -1428,6 +1441,7 @@ mod tests {
             system: vec![crate::SystemBlock {
                 text: "You are helpful.".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             }],
             messages: vec![
                 crate::provider::Message {
@@ -1516,12 +1530,89 @@ mod tests {
 
     // ── issue #12: system-block cache_control budget ──────────────────────────
 
+    /// Blocks carrying only the hints under test, all eligible - these tests
+    /// are about how runs are grouped, not about what held still.
+    fn blocks_of(hints: &[leviath_core::CacheHint]) -> Vec<crate::provider::SystemBlock> {
+        hints
+            .iter()
+            .map(|h| crate::provider::SystemBlock {
+                text: "x".to_string(),
+                cache_hint: *h,
+                breakpoint_eligible: true,
+            })
+            .collect()
+    }
+
+    /// A run ends its breakpoint at the last block that could actually be read
+    /// back, not at its last block. Placing it further would name a prefix the
+    /// assembler already said had changed - the 1.25x write charged for an
+    /// entry nothing will ever read (issue #474).
+    #[test]
+    fn a_run_places_its_breakpoint_at_the_last_eligible_block() {
+        let blocks = vec![
+            crate::provider::SystemBlock {
+                text: "frozen".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
+            },
+            crate::provider::SystemBlock {
+                text: "also frozen".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
+            },
+            crate::provider::SystemBlock {
+                text: "grew this turn".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: false,
+            },
+        ];
+        assert_eq!(system_cache_breakpoints(&blocks, 4), vec![1]);
+    }
+
+    /// A run with nothing eligible gets no breakpoint at all rather than one
+    /// that cannot pay for itself.
+    #[test]
+    fn a_run_with_nothing_stable_gets_no_breakpoint() {
+        let blocks = vec![
+            crate::provider::SystemBlock {
+                text: "changed".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: false,
+            },
+            crate::provider::SystemBlock {
+                text: "also changed".to_string(),
+                cache_hint: leviath_core::CacheHint::UntilChanged,
+                breakpoint_eligible: false,
+            },
+        ];
+        assert!(system_cache_breakpoints(&blocks, 4).is_empty());
+    }
+
+    /// Eligibility is per run: a stable tier keeps its breakpoint even when a
+    /// later, more volatile tier has moved.
+    #[test]
+    fn a_stable_tier_keeps_its_breakpoint_when_a_later_tier_moved() {
+        let blocks = vec![
+            crate::provider::SystemBlock {
+                text: "pinned".to_string(),
+                cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
+            },
+            crate::provider::SystemBlock {
+                text: "history that grew".to_string(),
+                cache_hint: leviath_core::CacheHint::UntilChanged,
+                breakpoint_eligible: false,
+            },
+        ];
+        assert_eq!(system_cache_breakpoints(&blocks, 4), vec![0]);
+    }
+
     #[test]
     fn system_cache_breakpoints_collapses_same_hint_run_to_one() {
         use leviath_core::CacheHint;
         // 5 consecutive pinned (Always) blocks → a single breakpoint, on the last.
         assert_eq!(
-            system_cache_breakpoints(&[CacheHint::Always; 5], 4),
+            system_cache_breakpoints(&blocks_of(&[CacheHint::Always; 5]), 4),
             vec![4]
         );
     }
@@ -1533,7 +1624,7 @@ mod tests {
         // end of the Always run (idx 3) and end of the UntilChanged run (idx 4).
         let mut hints = vec![CacheHint::Always; 4];
         hints.push(CacheHint::UntilChanged);
-        assert_eq!(system_cache_breakpoints(&hints, 4), vec![3, 4]);
+        assert_eq!(system_cache_breakpoints(&blocks_of(&hints), 4), vec![3, 4]);
     }
 
     #[test]
@@ -1542,13 +1633,13 @@ mod tests {
         // A `Never` block is uncacheable AND breaks the contiguous run, so the
         // two `Always` blocks are separate runs → two breakpoints.
         let hints = [CacheHint::Always, CacheHint::Never, CacheHint::Always];
-        assert_eq!(system_cache_breakpoints(&hints, 4), vec![0, 2]);
+        assert_eq!(system_cache_breakpoints(&blocks_of(&hints), 4), vec![0, 2]);
     }
 
     #[test]
     fn system_cache_breakpoints_all_never_is_empty() {
         use leviath_core::CacheHint;
-        assert!(system_cache_breakpoints(&[CacheHint::Never; 3], 4).is_empty());
+        assert!(system_cache_breakpoints(&blocks_of(&[CacheHint::Never; 3]), 4).is_empty());
     }
 
     #[test]
@@ -1562,13 +1653,13 @@ mod tests {
             CacheHint::Always,
             CacheHint::UntilChanged,
         ];
-        assert_eq!(system_cache_breakpoints(&hints, 2), vec![2, 3]);
+        assert_eq!(system_cache_breakpoints(&blocks_of(&hints), 2), vec![2, 3]);
     }
 
     #[test]
     fn system_cache_breakpoints_zero_budget_is_empty() {
         use leviath_core::CacheHint;
-        assert!(system_cache_breakpoints(&[CacheHint::Always], 0).is_empty());
+        assert!(system_cache_breakpoints(&blocks_of(&[CacheHint::Always]), 0).is_empty());
     }
 
     /// Total `cache_control` annotations across system blocks + message content.
@@ -1608,22 +1699,27 @@ mod tests {
             crate::SystemBlock {
                 text: "architecture".into(),
                 cache_hint: CacheHint::Always,
+                breakpoint_eligible: true,
             },
             crate::SystemBlock {
                 text: "program_flows".into(),
                 cache_hint: CacheHint::Always,
+                breakpoint_eligible: true,
             },
             crate::SystemBlock {
                 text: "plan".into(),
                 cache_hint: CacheHint::Always,
+                breakpoint_eligible: true,
             },
             crate::SystemBlock {
                 text: "task".into(),
                 cache_hint: CacheHint::Always,
+                breakpoint_eligible: true,
             },
             crate::SystemBlock {
                 text: "files".into(),
                 cache_hint: CacheHint::UntilChanged,
+                breakpoint_eligible: true,
             },
         ];
         let request = InferenceRequest {
@@ -1671,14 +1767,17 @@ mod tests {
             crate::SystemBlock {
                 text: "a".into(),
                 cache_hint: CacheHint::Always,
+                breakpoint_eligible: true,
             },
             crate::SystemBlock {
                 text: "b".into(),
                 cache_hint: CacheHint::UntilChanged,
+                breakpoint_eligible: true,
             },
             crate::SystemBlock {
                 text: "c".into(),
                 cache_hint: CacheHint::Always,
+                breakpoint_eligible: true,
             },
         ];
         let messages: Vec<crate::provider::Message> = (0..3)
@@ -1736,6 +1835,7 @@ mod tests {
             system: vec![crate::SystemBlock {
                 text: "ephemeral".into(),
                 cache_hint: CacheHint::Never,
+                breakpoint_eligible: true,
             }],
             messages: vec![crate::provider::Message {
                 role: "user".to_string(),
@@ -2281,10 +2381,12 @@ mod tests {
                 crate::SystemBlock {
                     text: "System part 1".to_string(),
                     cache_hint: leviath_core::CacheHint::Always,
+                    breakpoint_eligible: true,
                 },
                 crate::SystemBlock {
                     text: "System part 2".to_string(),
                     cache_hint: leviath_core::CacheHint::Always,
+                    breakpoint_eligible: true,
                 },
             ],
             messages: vec![crate::provider::Message {
@@ -2343,6 +2445,7 @@ mod tests {
             system: vec![crate::SystemBlock {
                 text: "No caching here.".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
+                breakpoint_eligible: true,
             }],
             messages: vec![crate::provider::Message {
                 role: "user".to_string(),

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -668,10 +668,12 @@ mod tests {
             SystemBlock {
                 text: "[architecture]:\nhexagonal".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             },
             SystemBlock {
                 text: "[plan]:\nstep one".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
+                breakpoint_eligible: true,
             },
         ];
         let prompt = ClaudeCodeProvider::build_system_prompt(&req);
@@ -686,10 +688,12 @@ mod tests {
             SystemBlock {
                 text: String::new(),
                 cache_hint: leviath_core::CacheHint::Never,
+                breakpoint_eligible: true,
             },
             SystemBlock {
                 text: "kept".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
+                breakpoint_eligible: true,
             },
         ];
         assert_eq!(ClaudeCodeProvider::build_system_prompt(&req), "kept");

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -1194,6 +1194,7 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "You are a local assistant.".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
+                breakpoint_eligible: true,
             }],
             messages: vec![crate::provider::Message {
                 role: "user".to_string(),
@@ -2554,6 +2555,7 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "instructions".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             }],
             messages: vec![
                 // The stranded response, its own call long since evicted.

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -922,6 +922,7 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "## task\ncount the ERROR lines".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             }],
             messages: vec![],
             model: "qwen3.8".to_string(),
@@ -952,6 +953,7 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "instructions".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             }],
             messages: vec![crate::provider::Message {
                 role: "assistant".to_string(),
@@ -981,6 +983,7 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "instructions".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             }],
             messages: vec![crate::provider::Message {
                 role: "user".to_string(),
@@ -1037,6 +1040,7 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "instructions".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             }],
             messages: vec![call.clone(), result.clone(), call, result],
             model: "qwen3.8".to_string(),
@@ -1131,6 +1135,7 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "## task\ncount the ERROR lines".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
+                breakpoint_eligible: true,
             }],
             messages: vec![stranded, call, answer],
             model: "qwen3.8-32k".to_string(),
@@ -2232,6 +2237,7 @@ mod tests {
             system: vec![SystemBlock {
                 text: "You are a coding agent. Task: add a doc comment.".into(),
                 cache_hint: leviath_core::CacheHint::Never,
+                breakpoint_eligible: true,
             }],
             messages: vec![Message {
                 role: "assistant".into(),
@@ -2450,10 +2456,12 @@ mod tests {
                 crate::provider::SystemBlock {
                     text: "You are helpful.".into(),
                     cache_hint: leviath_core::CacheHint::Always,
+                    breakpoint_eligible: true,
                 },
                 crate::provider::SystemBlock {
                     text: "Be concise.".into(),
                     cache_hint: leviath_core::CacheHint::Always,
+                    breakpoint_eligible: true,
                 },
             ],
             messages: vec![Message {
@@ -2493,6 +2501,7 @@ mod tests {
                 .map(|i| SystemBlock {
                     text: format!("block {i}"),
                     cache_hint: leviath_core::CacheHint::Always,
+                    breakpoint_eligible: true,
                 })
                 .collect(),
             messages: vec![Message {
@@ -2529,14 +2538,17 @@ mod tests {
                 SystemBlock {
                     text: "real".into(),
                     cache_hint: leviath_core::CacheHint::Always,
+                    breakpoint_eligible: true,
                 },
                 SystemBlock {
                     text: "   ".into(),
                     cache_hint: leviath_core::CacheHint::Always,
+                    breakpoint_eligible: true,
                 },
                 SystemBlock {
                     text: "also real".into(),
                     cache_hint: leviath_core::CacheHint::Always,
+                    breakpoint_eligible: true,
                 },
             ],
             messages: vec![Message {

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -729,6 +729,7 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "You are a helpful assistant.".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
+                breakpoint_eligible: true,
             }],
             messages: vec![crate::provider::Message {
                 role: "user".to_string(),

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -526,6 +526,18 @@ pub struct SystemBlock {
     pub text: String,
     /// Cache hint for this system block.
     pub cache_hint: leviath_core::CacheHint,
+    /// Whether a cache breakpoint may be placed at the end of this block.
+    ///
+    /// A provider caches by prefix, so an entry named by a breakpoint is
+    /// readable next time only if every byte before it is unchanged. The
+    /// assembler knows which blocks those are - it compares this request's
+    /// blocks against the last one - and says so here, rather than leaving each
+    /// provider to guess and pay the write premium for an entry that can never
+    /// be read (issue #474).
+    ///
+    /// `true` when nothing upstream said otherwise, which keeps a provider that
+    /// ignores this field behaving exactly as before.
+    pub breakpoint_eligible: bool,
 }
 
 /// Request for LLM inference.

--- a/crates/leviath-runtime/src/components/block_cache.rs
+++ b/crates/leviath-runtime/src/components/block_cache.rs
@@ -1,0 +1,404 @@
+//! How assembled system blocks are made cacheable.
+//!
+//! Split out of `context_window` because "what an agent remembers" and "which
+//! of those bytes a provider can read back" are different questions, and this
+//! is the half that has to hold still while the region kinds grow.
+//!
+//! A provider caches by prefix and matches only at a block boundary. Everything
+//! here exists to make sure the boundaries offered are ones that survive into
+//! the next request, and that a breakpoint is only ever placed at one of them.
+
+use super::*;
+
+/// How much text one cache chunk of an append-only region holds, in tokens.
+///
+/// The chunk is the unit of what can be cached, so it wants to be at least a
+/// provider's minimum cacheable prefix - Anthropic's is 1024 tokens on Sonnet -
+/// and small enough that the uncached tail stays cheap. It also bounds how many
+/// blocks a large region becomes: 200k tokens of history is a hundred blocks,
+/// which is fine to send and costs nothing to skip.
+pub(super) const CACHE_CHUNK_TOKENS: usize = 2048;
+
+/// Split an append-only region's entries into blocks at boundaries that survive
+/// into the next request.
+///
+/// A provider matches a cached prefix only at a *block boundary*. A region
+/// rendered as one block therefore offers exactly one boundary, and it sits
+/// after the region's newest content - so the moment the region grows, the entry
+/// named there is unreadable and every call rewrites the lot at the write
+/// premium. Measured before this: 456,860 cache-write tokens across twelve
+/// calls with zero reads (issue #474).
+///
+/// Chunking gives the region interior boundaries. Entries are packed greedily
+/// and a full chunk is never repacked, so a boundary that existed last turn
+/// exists this turn with the same bytes in front of it - which is precisely the
+/// condition [`mark_breakpoint_eligibility`] looks for. The frozen head of the
+/// region then caches and only the tail is re-sent, which is how the message
+/// path has always behaved.
+///
+/// Only for kinds whose entries append. A region that rewrites entries in place
+/// has no stable interior boundary to offer, and gets its protection from
+/// eligibility alone.
+pub(super) fn append_only_chunks(entries: &[String], budget: usize) -> Vec<String> {
+    let mut chunks = Vec::new();
+    let mut current: Vec<&str> = Vec::new();
+    let mut tokens = 0usize;
+    for entry in entries {
+        current.push(entry.as_str());
+        tokens = tokens.saturating_add(leviath_core::estimate_tokens(entry));
+        if tokens >= budget {
+            chunks.push(current.join("\n\n"));
+            current.clear();
+            tokens = 0;
+        }
+    }
+    if !current.is_empty() {
+        chunks.push(current.join("\n\n"));
+    }
+    chunks
+}
+
+/// Push a region's entries as chunked system blocks.
+///
+/// Every chunk after the first says it continues the same region. Splitting for
+/// the cache's benefit must not cost the model what the heading buys it:
+/// without this the second half of a region arrives as unlabelled prose and
+/// reads as content from nowhere, which is the confusion naming regions was
+/// meant to remove. The continuation line is a constant, so a frozen chunk
+/// stays frozen and the split still caches.
+pub(super) fn push_chunked(
+    blocks: &mut Vec<leviath_providers::SystemBlock>,
+    region: &Region,
+    entries: &[String],
+    hint: leviath_core::CacheHint,
+) {
+    let chunks = append_only_chunks(entries, CACHE_CHUNK_TOKENS);
+    for (index, chunk) in chunks.iter().enumerate() {
+        let text = match index {
+            0 => super::context_window::labelled(region, chunk),
+            _ => format!("## {} (continued)\n{}", region.name, chunk),
+        };
+        blocks.push(leviath_providers::SystemBlock {
+            text,
+            cache_hint: hint,
+            breakpoint_eligible: true,
+        });
+    }
+}
+
+/// A digest of one system block's text, for deciding what held still.
+pub(super) fn block_hash(text: &str) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    text.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Mark every block a cache breakpoint could actually be read back at.
+///
+/// A provider caches by prefix, so the entry a breakpoint names is readable
+/// next time only if every byte before it is unchanged. That makes the rule
+/// exact rather than a heuristic: a block is eligible when it, and every block
+/// ahead of it, is byte-identical to the previous request. The eligible set is
+/// therefore the longest common prefix of this request's block hashes and the
+/// last one's.
+///
+/// Before the first request there is nothing to compare against, so everything
+/// is eligible - the first call is a write whatever we do, and marking it
+/// ineligible would forfeit the entry the second call wants to read.
+///
+/// This is what stops a growing region being paid for over and over. A region
+/// that gained content is not in the common prefix, so no breakpoint lands at
+/// or after it, and the stable head in front of it keeps the entry it always
+/// had (issue #474: 456,860 cache-write tokens across twelve calls, zero reads,
+/// because the only breakpoint sat after content that changed every call).
+pub(super) fn mark_breakpoint_eligibility(
+    blocks: &mut [leviath_providers::SystemBlock],
+    previous: &[u64],
+) -> Vec<u64> {
+    let hashes: Vec<u64> = blocks.iter().map(|b| block_hash(&b.text)).collect();
+    if previous.is_empty() {
+        return hashes;
+    }
+    let stable = hashes
+        .iter()
+        .zip(previous)
+        .take_while(|(now, before)| now == before)
+        .count();
+    for (index, block) in blocks.iter_mut().enumerate() {
+        block.breakpoint_eligible = index < stable;
+    }
+    hashes
+}
+
+/// A stable digest of the assembled system prefix.
+///
+/// Over the block texts in final order, which is exactly the byte sequence
+/// Anthropic prefix-matches against. Hints are excluded deliberately: they
+/// decide ordering, and ordering is already reflected in the sequence.
+pub(super) fn system_prefix_hash(blocks: &[leviath_providers::SystemBlock]) -> u64 {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    for block in blocks {
+        block.text.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Sort priority for a system block's cache hint.
+///
+/// Anthropic caches system content by prefix matching, so the most stable
+/// blocks must sort first to form the cacheable prefix. Lower value = earlier.
+pub(super) fn cache_hint_sort_priority(hint: leviath_core::CacheHint) -> u8 {
+    use leviath_core::CacheHint;
+    match hint {
+        CacheHint::Always => 0,               // Pinned, CompactHistory - most stable
+        CacheHint::SlidingPrefix { .. } => 1, // Partially stable
+        CacheHint::UntilChanged => 2,         // Compacting - changes on compaction
+        // Same tier as UntilChanged on purpose: the hint marks where a cache
+        // breakpoint belongs, never where a block belongs in the prompt.
+        CacheHint::RecentlyChanged => 2,
+        CacheHint::Never => 3, // Temporary, Clearable - changes every iteration
+    }
+}
+
+/// The most cache breakpoints assembly will let the system blocks claim.
+///
+/// Anthropic allows four `cache_control` blocks across the whole request and
+/// the provider hands the system blocks first claim on that budget, so leaving
+/// one run unclaimed is what keeps a breakpoint available for the messages.
+pub(super) const MAX_SYSTEM_CACHE_RUNS: usize = 3;
+
+/// Split the volatile tier of the system prompt at its most recently changed
+/// block, by retagging that block and every block after it as
+/// [`leviath_core::CacheHint::RecentlyChanged`].
+///
+/// Providers place one cache breakpoint per run of same-hint blocks, so with a
+/// single `UntilChanged` run the only breakpoint sits at the end of the tier.
+/// A block mutating in the middle of that run therefore invalidates the whole
+/// run, and every block after the mutation is re-sent as a cache write. Adding
+/// a boundary just before the changed block gives the unchanged head of the
+/// tier a cache entry of its own. Only the breakpoint metadata moves: block
+/// order and block text are both left exactly as the sort left them, and this
+/// runs after the sort so it cannot influence ordering at all. The effect on
+/// cache-write volume is not measurable inside this repository.
+///
+/// `recency` carries the newest entry timestamp of the region behind each
+/// `UntilChanged` block, in the order those blocks were assembled. The sort is
+/// stable and every block in the tier shares one sort priority, so that order
+/// is also the order the blocks appear in now.
+///
+/// Nothing is retagged when the newest block is already the first one (there is
+/// no stable head to protect), or when the blocks already fill the run budget.
+pub(super) fn mark_recently_changed_run(
+    blocks: &mut [leviath_providers::SystemBlock],
+    recency: &[i64],
+) {
+    use leviath_core::CacheHint;
+
+    let mut volatile: Vec<usize> = Vec::new();
+    for (index, block) in blocks.iter().enumerate() {
+        if block.cache_hint == CacheHint::UntilChanged {
+            volatile.push(index);
+        }
+    }
+
+    // The first block carrying the newest timestamp. Ties resolve to the
+    // earliest block, which is the conservative choice: when two regions were
+    // written in the same second, both of them changed, and the boundary
+    // belongs ahead of the earlier one.
+    let mut boundary = 0usize;
+    let mut newest = i64::MIN;
+    for (position, &stamp) in recency.iter().enumerate() {
+        if stamp > newest {
+            newest = stamp;
+            boundary = position;
+        }
+    }
+    if boundary == 0 {
+        return;
+    }
+
+    // Count the breakpoints the provider would place today. Splitting the
+    // volatile tier adds exactly one, so refusing at the limit is what keeps
+    // the messages breakpoint from being squeezed out.
+    let mut runs = 0usize;
+    for index in 0..blocks.len() {
+        let hint = blocks[index].cache_hint;
+        if hint != CacheHint::Never && blocks.get(index + 1).map(|b| b.cache_hint) != Some(hint) {
+            runs += 1;
+        }
+    }
+    if runs >= MAX_SYSTEM_CACHE_RUNS {
+        return;
+    }
+
+    for &index in volatile.iter().skip(boundary) {
+        blocks[index].cache_hint = CacheHint::RecentlyChanged;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::{CacheHint, Region, RegionKind};
+
+    fn entries(n: usize, each: &str) -> Vec<String> {
+        (0..n).map(|i| format!("{i}:{each}")).collect()
+    }
+
+    fn block(text: &str, hint: CacheHint, eligible: bool) -> leviath_providers::SystemBlock {
+        leviath_providers::SystemBlock {
+            text: text.to_string(),
+            cache_hint: hint,
+            breakpoint_eligible: eligible,
+        }
+    }
+
+    // ─── chunking ───────────────────────────────────────────────────────────
+
+    /// The property the whole fix rests on: a boundary that existed last turn
+    /// exists this turn, with the same bytes in front of it. Without it there is
+    /// nothing a provider can match.
+    #[test]
+    fn appending_never_repacks_an_earlier_chunk() {
+        let big = "word ".repeat(400);
+        let mut before: Vec<String> = Vec::new();
+        for turn in 1..12 {
+            let now = append_only_chunks(&entries(turn, &big), 2048);
+            // Every *full* chunk the previous turn had, this turn still has,
+            // verbatim. The last chunk is the live tail and is meant to grow -
+            // it is the only part a provider has to re-send.
+            let frozen = before.len().saturating_sub(1);
+            for (old, new) in before.iter().take(frozen).zip(&now) {
+                assert_eq!(old, new, "a frozen chunk was repacked at turn {turn}");
+            }
+            assert!(now.len() >= before.len(), "chunks never merge back");
+            before = now;
+        }
+    }
+
+    /// Nothing is lost or reordered by splitting: the chunks rejoin into exactly
+    /// the text a single block used to carry.
+    #[test]
+    fn chunking_preserves_the_content_exactly() {
+        let all = entries(25, &"word ".repeat(120));
+        let rejoined = append_only_chunks(&all, 2048).join("\n\n");
+        assert_eq!(rejoined, all.join("\n\n"));
+    }
+
+    #[test]
+    fn a_region_with_nothing_in_it_produces_no_chunks() {
+        assert!(append_only_chunks(&[], 2048).is_empty());
+    }
+
+    /// One entry larger than the budget is still one chunk: the entry is the
+    /// smallest thing there is to split on.
+    #[test]
+    fn an_entry_larger_than_the_budget_is_its_own_chunk() {
+        let huge = "word ".repeat(5000);
+        let chunks = append_only_chunks(std::slice::from_ref(&huge), 2048);
+        assert_eq!(chunks, vec![huge.clone()]);
+    }
+
+    /// Splitting for the cache must not cost the model the heading. Every chunk
+    /// after the first says which region it continues.
+    #[test]
+    fn every_chunk_after_the_first_names_the_region_it_continues() {
+        let mut region = Region::new("sources".to_string(), RegionKind::Pinned, 1_000_000);
+        for entry in entries(20, &"word ".repeat(200)) {
+            region.add_entry(entry, 250).expect("fits");
+        }
+        let contents: Vec<String> = region.content.iter().map(|e| e.content.clone()).collect();
+
+        let mut blocks = Vec::new();
+        push_chunked(&mut blocks, &region, &contents, CacheHint::Always);
+
+        assert!(blocks.len() > 1, "the fixture is meant to span chunks");
+        assert!(blocks[0].text.starts_with("## sources"));
+        for block in &blocks[1..] {
+            assert!(
+                block.text.starts_with("## sources (continued)"),
+                "a continuation arrived unlabelled: {:.40}",
+                block.text
+            );
+        }
+        // And every entry is still present, in order.
+        let whole = blocks
+            .iter()
+            .map(|b| b.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        let mut last = 0;
+        for (i, _) in contents.iter().enumerate() {
+            let needle = format!("{i}:");
+            let at = whole.find(&needle).expect("entry present");
+            assert!(at >= last, "entries came out of order");
+            last = at;
+        }
+    }
+
+    // ─── eligibility ────────────────────────────────────────────────────────
+
+    /// Nothing to compare against, so nothing is held back: the first request
+    /// is a write whatever we do, and refusing it would forfeit the entry the
+    /// second request wants to read.
+    #[test]
+    fn the_first_request_leaves_every_block_eligible() {
+        let mut blocks = vec![
+            block("a", CacheHint::Always, true),
+            block("b", CacheHint::Always, true),
+        ];
+        let hashes = mark_breakpoint_eligibility(&mut blocks, &[]);
+        assert_eq!(hashes.len(), 2);
+        assert!(blocks.iter().all(|b| b.breakpoint_eligible));
+    }
+
+    /// The rule, stated as the provider needs it: a block is eligible only if it
+    /// and everything ahead of it is byte-identical to last time.
+    #[test]
+    fn eligibility_stops_at_the_first_block_that_changed() {
+        let mut first = vec![
+            block("head", CacheHint::Always, true),
+            block("middle", CacheHint::Always, true),
+            block("tail", CacheHint::Always, true),
+        ];
+        let previous = mark_breakpoint_eligibility(&mut first, &[]);
+
+        let mut second = vec![
+            block("head", CacheHint::Always, true),
+            block("middle grew", CacheHint::Always, true),
+            block("tail", CacheHint::Always, true),
+        ];
+        mark_breakpoint_eligibility(&mut second, &previous);
+
+        assert!(second[0].breakpoint_eligible, "the head held still");
+        assert!(!second[1].breakpoint_eligible, "this is what changed");
+        assert!(
+            !second[2].breakpoint_eligible,
+            "and everything after it is behind changed bytes, however stable its own text"
+        );
+    }
+
+    /// A prefix that held still entirely stays entirely eligible.
+    #[test]
+    fn an_unchanged_prefix_stays_eligible() {
+        let mut first = vec![
+            block("head", CacheHint::Always, true),
+            block("body", CacheHint::Always, true),
+        ];
+        let previous = mark_breakpoint_eligibility(&mut first, &[]);
+        let mut second = vec![
+            block("head", CacheHint::Always, true),
+            block("body", CacheHint::Always, true),
+            block("new tail", CacheHint::Always, true),
+        ];
+        mark_breakpoint_eligibility(&mut second, &previous);
+        assert!(second[0].breakpoint_eligible);
+        assert!(second[1].breakpoint_eligible);
+        assert!(
+            !second[2].breakpoint_eligible,
+            "the new block is not proven yet"
+        );
+    }
+}

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -6,6 +6,10 @@
 //! because "what an agent *is*" and "what an agent *remembers*" are different
 //! questions to arrive with.
 
+use super::block_cache::{
+    CACHE_CHUNK_TOKENS, append_only_chunks, cache_hint_sort_priority, mark_breakpoint_eligibility,
+    mark_recently_changed_run, push_chunked, system_prefix_hash,
+};
 use super::*;
 
 /// Result of an eviction attempt, including tokens freed and regions needing LLM compaction.
@@ -72,6 +76,13 @@ pub struct AssembledContext {
     pub system_blocks: Vec<leviath_providers::SystemBlock>,
     /// Conversation messages with proper role typing.
     pub messages: Vec<leviath_providers::Message>,
+    /// Per-block digests of the system prefix this assembly produced.
+    ///
+    /// Handed back so the caller can pass them as
+    /// [`crate::custom_region::AssembleMeta::previous_block_hashes`] next time,
+    /// which is what lets the breakpoint decision name only blocks that held
+    /// still.
+    pub block_hashes: Vec<u64>,
     /// Hash of the system prefix this assembly produced.
     ///
     /// Handed back so the caller can pass it as
@@ -79,110 +90,6 @@ pub struct AssembledContext {
     /// and let the breakpoint decision below be made on evidence rather than
     /// hope.
     pub system_hash: u64,
-}
-
-/// A stable digest of the assembled system prefix.
-///
-/// Over the block texts in final order, which is exactly the byte sequence
-/// Anthropic prefix-matches against. Hints are excluded deliberately: they
-/// decide ordering, and ordering is already reflected in the sequence.
-fn system_prefix_hash(blocks: &[leviath_providers::SystemBlock]) -> u64 {
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    for block in blocks {
-        block.text.hash(&mut hasher);
-    }
-    hasher.finish()
-}
-
-/// Sort priority for a system block's cache hint.
-///
-/// Anthropic caches system content by prefix matching, so the most stable
-/// blocks must sort first to form the cacheable prefix. Lower value = earlier.
-pub(super) fn cache_hint_sort_priority(hint: leviath_core::CacheHint) -> u8 {
-    use leviath_core::CacheHint;
-    match hint {
-        CacheHint::Always => 0,               // Pinned, CompactHistory - most stable
-        CacheHint::SlidingPrefix { .. } => 1, // Partially stable
-        CacheHint::UntilChanged => 2,         // Compacting - changes on compaction
-        // Same tier as UntilChanged on purpose: the hint marks where a cache
-        // breakpoint belongs, never where a block belongs in the prompt.
-        CacheHint::RecentlyChanged => 2,
-        CacheHint::Never => 3, // Temporary, Clearable - changes every iteration
-    }
-}
-
-/// The most cache breakpoints assembly will let the system blocks claim.
-///
-/// Anthropic allows four `cache_control` blocks across the whole request and
-/// the provider hands the system blocks first claim on that budget, so leaving
-/// one run unclaimed is what keeps a breakpoint available for the messages.
-const MAX_SYSTEM_CACHE_RUNS: usize = 3;
-
-/// Split the volatile tier of the system prompt at its most recently changed
-/// block, by retagging that block and every block after it as
-/// [`leviath_core::CacheHint::RecentlyChanged`].
-///
-/// Providers place one cache breakpoint per run of same-hint blocks, so with a
-/// single `UntilChanged` run the only breakpoint sits at the end of the tier.
-/// A block mutating in the middle of that run therefore invalidates the whole
-/// run, and every block after the mutation is re-sent as a cache write. Adding
-/// a boundary just before the changed block gives the unchanged head of the
-/// tier a cache entry of its own. Only the breakpoint metadata moves: block
-/// order and block text are both left exactly as the sort left them, and this
-/// runs after the sort so it cannot influence ordering at all. The effect on
-/// cache-write volume is not measurable inside this repository.
-///
-/// `recency` carries the newest entry timestamp of the region behind each
-/// `UntilChanged` block, in the order those blocks were assembled. The sort is
-/// stable and every block in the tier shares one sort priority, so that order
-/// is also the order the blocks appear in now.
-///
-/// Nothing is retagged when the newest block is already the first one (there is
-/// no stable head to protect), or when the blocks already fill the run budget.
-fn mark_recently_changed_run(blocks: &mut [leviath_providers::SystemBlock], recency: &[i64]) {
-    use leviath_core::CacheHint;
-
-    let mut volatile: Vec<usize> = Vec::new();
-    for (index, block) in blocks.iter().enumerate() {
-        if block.cache_hint == CacheHint::UntilChanged {
-            volatile.push(index);
-        }
-    }
-
-    // The first block carrying the newest timestamp. Ties resolve to the
-    // earliest block, which is the conservative choice: when two regions were
-    // written in the same second, both of them changed, and the boundary
-    // belongs ahead of the earlier one.
-    let mut boundary = 0usize;
-    let mut newest = i64::MIN;
-    for (position, &stamp) in recency.iter().enumerate() {
-        if stamp > newest {
-            newest = stamp;
-            boundary = position;
-        }
-    }
-    if boundary == 0 {
-        return;
-    }
-
-    // Count the breakpoints the provider would place today. Splitting the
-    // volatile tier adds exactly one, so refusing at the limit is what keeps
-    // the messages breakpoint from being squeezed out.
-    let mut runs = 0usize;
-    for index in 0..blocks.len() {
-        let hint = blocks[index].cache_hint;
-        if hint != CacheHint::Never && blocks.get(index + 1).map(|b| b.cache_hint) != Some(hint) {
-            runs += 1;
-        }
-    }
-    if runs >= MAX_SYSTEM_CACHE_RUNS {
-        return;
-    }
-
-    for &index in volatile.iter().skip(boundary) {
-        blocks[index].cache_hint = CacheHint::RecentlyChanged;
-    }
 }
 
 /// Context window component storing the agent's memory regions.
@@ -237,7 +144,7 @@ pub struct ContextWindow {
 /// well enough that a sentence would only cost tokens. It is for the ones whose
 /// contents do not explain themselves - a bibliography with a required format,
 /// a scratch area with a convention.
-fn labelled(region: &Region, body: &str) -> String {
+pub(super) fn labelled(region: &Region, body: &str) -> String {
     match region
         .description
         .as_deref()
@@ -723,13 +630,9 @@ impl ContextWindow {
                     let body = region
                         .content
                         .iter()
-                        .map(|e| e.content.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n\n");
-                    system_blocks.push(leviath_providers::SystemBlock {
-                        text: labelled(region, &body),
-                        cache_hint: CacheHint::Always,
-                    });
+                        .map(|e| e.content.clone())
+                        .collect::<Vec<_>>();
+                    push_chunked(&mut system_blocks, region, &body, CacheHint::Always);
                 }
                 // A checklist renders as instruction rather than history: one
                 // stable block, open items first, so what is left to do is at
@@ -742,6 +645,7 @@ impl ContextWindow {
                         system_blocks.push(leviath_providers::SystemBlock {
                             text: labelled(region, &body),
                             cache_hint: CacheHint::UntilChanged,
+                            breakpoint_eligible: true,
                         });
                     }
                 }
@@ -749,13 +653,9 @@ impl ContextWindow {
                     let body = region
                         .content
                         .iter()
-                        .map(|e| e.content.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n\n");
-                    system_blocks.push(leviath_providers::SystemBlock {
-                        text: labelled(region, &body),
-                        cache_hint: CacheHint::Always,
-                    });
+                        .map(|e| e.content.clone())
+                        .collect::<Vec<_>>();
+                    push_chunked(&mut system_blocks, region, &body, CacheHint::Always);
                 }
 
                 // Messages region → Vec<Message> with proper typed entries.
@@ -869,16 +769,23 @@ impl ContextWindow {
 
                 // Compacting / Temporary / Clearable → system blocks
                 leviath_core::RegionKind::Compacting { .. } => {
-                    let text = region
+                    let entries = region
                         .content
                         .iter()
-                        .map(|e| e.content.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n\n");
-                    system_blocks.push(leviath_providers::SystemBlock {
-                        text: format!("[{}]:\n{}", region.name, text),
-                        cache_hint: CacheHint::UntilChanged,
-                    });
+                        .map(|e| e.content.clone())
+                        .collect::<Vec<_>>();
+                    let chunks = append_only_chunks(&entries, CACHE_CHUNK_TOKENS);
+                    for (index, chunk) in chunks.iter().enumerate() {
+                        let text = match index {
+                            0 => format!("[{}]:\n{}", region.name, chunk),
+                            _ => format!("[{} continued]:\n{}", region.name, chunk),
+                        };
+                        system_blocks.push(leviath_providers::SystemBlock {
+                            text,
+                            cache_hint: CacheHint::UntilChanged,
+                            breakpoint_eligible: true,
+                        });
+                    }
                 }
                 leviath_core::RegionKind::Temporary => {
                     let text = region
@@ -890,6 +797,7 @@ impl ContextWindow {
                     system_blocks.push(leviath_providers::SystemBlock {
                         text: format!("[{}]:\n{}", region.name, text),
                         cache_hint: CacheHint::Never,
+                        breakpoint_eligible: true,
                     });
                 }
                 leviath_core::RegionKind::Clearable => {
@@ -902,6 +810,7 @@ impl ContextWindow {
                     system_blocks.push(leviath_providers::SystemBlock {
                         text: format!("[{}]:\n{}", region.name, text),
                         cache_hint: CacheHint::Never,
+                        breakpoint_eligible: true,
                     });
                 }
 
@@ -943,6 +852,7 @@ impl ContextWindow {
                     system_blocks.push(leviath_providers::SystemBlock {
                         text: format!("[{}]:\n{}", region.name, text),
                         cache_hint: CacheHint::UntilChanged,
+                        breakpoint_eligible: true,
                     });
                 }
             }
@@ -973,6 +883,8 @@ impl ContextWindow {
         system_blocks.sort_by_key(|block| cache_hint_sort_priority(block.cache_hint));
         // After the sort, because the order is part of what Anthropic matches.
         let system_hash = system_prefix_hash(&system_blocks);
+        let block_hashes =
+            mark_breakpoint_eligibility(&mut system_blocks, &meta.previous_block_hashes);
 
         // ── Spend a cache breakpoint on the volatile boundary ────────────
         //
@@ -1112,6 +1024,7 @@ impl ContextWindow {
         }
 
         AssembledContext {
+            block_hashes,
             system_blocks,
             messages,
             system_hash,
@@ -1201,6 +1114,7 @@ mod tests {
         SystemBlock {
             text: "x".to_string(),
             cache_hint: hint,
+            breakpoint_eligible: true,
         }
     }
 
@@ -1459,15 +1373,53 @@ mod tests {
             .filter(|m| m.cache_breakpoint)
             .count();
 
-        assert!(system <= MAX_SYSTEM_CACHE_RUNS, "system runs: {system}");
+        assert!(
+            system <= super::block_cache::MAX_SYSTEM_CACHE_RUNS,
+            "system runs: {system}"
+        );
         assert_eq!(message, 1);
         let total = system + message;
         assert!(total <= 4, "total breakpoints: {total}");
     }
 
-    /// The name is the part that earns its tokens: an agent writes to a region
-    /// *by name*, and until this the prompt showed it every region's contents
-    /// with nothing saying which was which.
+    /// A compacting region large enough to span chunks says which region each
+    /// continuation belongs to, and keeps every entry.
+    #[test]
+    fn a_compacting_region_labels_its_continuations() {
+        let mut window = ContextWindow::new(2_000_000);
+        window.add_region(Region::new(
+            "history".to_string(),
+            RegionKind::Compacting {
+                threshold_tokens: usize::MAX,
+            },
+            1_000_000,
+        ));
+        for i in 0..20 {
+            window
+                .add_to_region("history", format!("{i}:{}", "word ".repeat(200)), 250)
+                .expect("fits");
+        }
+
+        let blocks = window.assemble().system_blocks;
+        assert!(blocks.len() > 1, "the fixture is meant to span chunks");
+        assert!(blocks[0].text.starts_with("[history]:"));
+        for block in &blocks[1..] {
+            assert!(
+                block.text.starts_with("[history continued]:"),
+                "{:.40}",
+                block.text
+            );
+        }
+        let whole = blocks
+            .iter()
+            .map(|b| b.text.as_str())
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        for i in 0..20 {
+            assert!(whole.contains(&format!("{i}:")), "entry {i} went missing");
+        }
+    }
+
     #[test]
     fn a_pinned_region_is_labelled_with_its_own_name() {
         let mut window = ContextWindow::new(10_000);

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -186,6 +186,7 @@ pub use leviath_core::run_meta::WaitReason;
 
 // The context window, which was two thirds of this file. Glob re-exported so
 // every existing `components::ContextWindow` path keeps working.
+mod block_cache;
 mod context_window;
 pub use context_window::*;
 
@@ -2007,6 +2008,7 @@ mod tests {
             stage_iterations: 7,
             model: "m".to_string(),
             previous_system_hash: None,
+            previous_block_hashes: Vec::new(),
         });
         assert_eq!(assembled.system_blocks[0].text, "<brain iter=7>");
     }
@@ -2939,19 +2941,22 @@ mod tests {
     fn cache_hint_sort_priority_orders_by_stability() {
         use leviath_core::CacheHint;
         // Most stable first (lowest priority), volatile last.
-        assert_eq!(cache_hint_sort_priority(CacheHint::Always), 0);
+        assert_eq!(block_cache::cache_hint_sort_priority(CacheHint::Always), 0);
         assert_eq!(
-            cache_hint_sort_priority(CacheHint::SlidingPrefix {
+            block_cache::cache_hint_sort_priority(CacheHint::SlidingPrefix {
                 stable_fraction: 0.75
             }),
             1
         );
-        assert_eq!(cache_hint_sort_priority(CacheHint::UntilChanged), 2);
-        assert_eq!(cache_hint_sort_priority(CacheHint::Never), 3);
+        assert_eq!(
+            block_cache::cache_hint_sort_priority(CacheHint::UntilChanged),
+            2
+        );
+        assert_eq!(block_cache::cache_hint_sort_priority(CacheHint::Never), 3);
         // The four priorities are strictly increasing by volatility.
         assert!(
-            cache_hint_sort_priority(CacheHint::Always)
-                < cache_hint_sort_priority(CacheHint::SlidingPrefix {
+            block_cache::cache_hint_sort_priority(CacheHint::Always)
+                < block_cache::cache_hint_sort_priority(CacheHint::SlidingPrefix {
                     stable_fraction: 0.5
                 })
         );

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -35,6 +35,10 @@ pub struct AssembleMeta {
     /// first request, or a caller with no state to keep), and the breakpoint is
     /// placed as it always was.
     pub previous_system_hash: Option<u64>,
+    /// Per-block digests of the previous request's system prefix, so assembly
+    /// can tell which blocks held still and place cache breakpoints only where
+    /// the entry could actually be read back. Empty on the first request.
+    pub previous_block_hashes: Vec<u64>,
 }
 
 /// What `on_write` decided about an incoming entry.
@@ -106,6 +110,7 @@ fn fallback_block(region: &Region) -> leviath_providers::SystemBlock {
     leviath_providers::SystemBlock {
         text: format!("[{}]:\n{}", region.name, text),
         cache_hint: leviath_core::CacheHint::Never,
+        breakpoint_eligible: true,
     }
 }
 
@@ -273,6 +278,7 @@ fn parse_render_output(
     let block = |text: &str| leviath_providers::SystemBlock {
         text: text.to_string(),
         cache_hint: hint,
+        breakpoint_eligible: true,
     };
 
     match value {
@@ -603,6 +609,7 @@ mod tests {
                         stage_iterations: 2,
                         model: "m1".to_string(),
                         previous_system_hash: None,
+                        previous_block_hashes: Vec::new(),
                     },
                     window_current: 50,
                     window_max: 2000,

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -606,6 +606,7 @@ mod tests {
             system: vec![SystemBlock {
                 text: "sys".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
+                breakpoint_eligible: true,
             }],
             messages: vec![leviath_providers::Message {
                 role: "user".to_string(),

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -59,6 +59,7 @@ pub(crate) fn hint_blocks(
     let always = |text: &str| leviath_providers::SystemBlock {
         text: text.to_string(),
         cache_hint: leviath_core::CacheHint::Always,
+        breakpoint_eligible: true,
     };
     let mut blocks = Vec::new();
     if config.map(|c| c.batch_tool_hint).unwrap_or(false) {
@@ -71,6 +72,20 @@ pub(crate) fn hint_blocks(
         blocks.push(always(text));
     }
     blocks
+}
+
+/// What the previous request's system prefix looked like.
+///
+/// The whole-prefix digest and the per-block digests answer different
+/// questions ("did anything move", and "how far did it hold still"), and they
+/// are only ever read together, so they travel together rather than as two
+/// adjacent parameters of different shapes that a caller could transpose.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PriorPrefix {
+    /// Digest of the whole prefix, or `None` before the first request.
+    pub(crate) system_hash: Option<u64>,
+    /// Per-block digests, empty before the first request.
+    pub(crate) block_hashes: Vec<u64>,
 }
 
 /// Build the [`InferenceRequest`] for an agent from its context window + stage
@@ -87,15 +102,21 @@ pub(crate) fn build_request(
     provider: &Arc<dyn Provider>,
     stage_name: &str,
     stage_iterations: usize,
-    previous_system_hash: Option<u64>,
-) -> (InferenceRequest, u64) {
+    prior: PriorPrefix,
+) -> (InferenceRequest, u64, Vec<u64>) {
+    let PriorPrefix {
+        system_hash: previous_system_hash,
+        block_hashes: previous_block_hashes,
+    } = prior;
     let assembled = window.assemble_with_meta(&crate::custom_region::AssembleMeta {
         stage_name: stage_name.to_string(),
         stage_iterations,
         model: stage.model.clone(),
         previous_system_hash,
+        previous_block_hashes,
     });
     let system_hash = assembled.system_hash;
+    let block_hashes = assembled.block_hashes.clone();
     let remaining = window.max_tokens.saturating_sub(window.current_tokens);
     let caps = provider.capabilities(&stage.model);
     let output_cap = config
@@ -139,7 +160,7 @@ pub(crate) fn build_request(
         extra,
         request_timeout_secs: config.and_then(|c| c.request_timeout_secs),
     };
-    (request, system_hash)
+    (request, system_hash, block_hashes)
 }
 
 /// Build the [`RetryPolicy`] for a job from the operator's `[limits]` retry
@@ -228,6 +249,7 @@ type InferenceQuery = (
     Option<&'static StageProgress>,
     Option<&'static DispatchStall>,
     Option<&'static SystemPrefixHash>,
+    Option<&'static SystemBlockHashes>,
 );
 
 /// The system prefix the last request sent, as a digest.
@@ -237,6 +259,12 @@ type InferenceQuery = (
 /// which is exactly when there is nothing to invalidate.
 #[derive(bevy_ecs::component::Component, Debug, Clone, Copy)]
 pub struct SystemPrefixHash(pub u64);
+
+/// The previous request's per-block system digests, kept on the agent so the
+/// next assembly can tell which blocks held still and place cache breakpoints
+/// only where the entry is readable back (issue #474).
+#[derive(Component, Debug, Clone, Default)]
+pub struct SystemBlockHashes(pub Vec<u64>);
 
 /// Inference-dispatch system: for every `ReadyToInfer` agent, resolve its
 /// provider and, **if a per-model permit is free**, build the request, spawn the
@@ -272,7 +300,18 @@ pub fn dispatch_inference(
     let retry_tuning = retry.map(|r| *r).unwrap_or_default();
     let circuits = circuits.as_deref();
     agents.par_iter().for_each(
-        |(entity, state, window, config, si, in_flight, progress, stalled, prefix)| {
+        |(
+            entity,
+            state,
+            window,
+            config,
+            si,
+            in_flight,
+            progress,
+            stalled,
+            prefix,
+            block_prefix,
+        )| {
             crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
                 if state.status != AgentStatus::Active {
                     return; // paused / waiting / cancelled - don't start new work
@@ -320,14 +359,17 @@ pub fn dispatch_inference(
                     stall(StallReason::PoolFull);
                     return;
                 };
-                let (request, system_hash) = build_request(
+                let (request, system_hash, block_hashes) = build_request(
                     window,
                     config,
                     si,
                     &provider,
                     &state.current_stage,
                     progress.map(|p| p.iterations).unwrap_or(0),
-                    prefix.map(|p| p.0),
+                    PriorPrefix {
+                        system_hash: prefix.map(|p| p.0),
+                        block_hashes: block_prefix.map(|b| b.0.clone()).unwrap_or_default(),
+                    },
                 );
                 // Remembered for the next request, which is the only way the
                 // breakpoint decision can be made on evidence.
@@ -335,6 +377,9 @@ pub fn dispatch_inference(
                     commands
                         .entity(entity)
                         .insert(SystemPrefixHash(system_hash));
+                    commands
+                        .entity(entity)
+                        .insert(SystemBlockHashes(block_hashes.clone()));
                 });
                 let job = InferenceJob {
                     entity,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -109,7 +109,16 @@ fn build_request_threads_stage_meta_into_custom_region_render() {
         ),
     );
     let si = stage("model-x", vec![], None);
-    let req = build_request(&w, None, &si, &provider(true, 500), "implement", 4, None).0;
+    let req = build_request(
+        &w,
+        None,
+        &si,
+        &provider(true, 500),
+        "implement",
+        4,
+        crate::pipeline::inference::PriorPrefix::default(),
+    )
+    .0;
     assert!(
         req.system.iter().any(|b| b.text == "implement#4@model-x"),
         "system blocks: {:?}",
@@ -139,7 +148,7 @@ fn build_request_filters_tools_and_uses_config_overrides() {
         &provider(true, 9999),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     assert_eq!(req.tools.len(), 1); // filtered to "keep"
@@ -166,7 +175,7 @@ fn build_request_threads_per_stage_timeout() {
         &provider(true, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     assert_eq!(req.request_timeout_secs, Some(120));
@@ -178,7 +187,7 @@ fn build_request_threads_per_stage_timeout() {
         &provider(true, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     assert_eq!(req_none.request_timeout_secs, None);
@@ -204,7 +213,7 @@ fn build_request_passes_through_extra_params() {
         &provider(true, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     assert_eq!(req.extra, serde_json::json!({ "top_p": 0.9 }));
@@ -238,7 +247,7 @@ fn build_request_prepends_batch_hint_when_enabled() {
         &provider(true, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     // The hint is prepended ahead of the stage's own system block(s).
@@ -274,7 +283,7 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
         &provider(true, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     assert!(!req.system.is_empty());
@@ -287,7 +296,7 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
         &provider(true, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     assert!(!req_none.system.is_empty());
@@ -377,7 +386,7 @@ fn build_request_puts_the_hints_ahead_of_the_stage_context() {
         &provider(true, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     let hints = hint_blocks(Some(&cfg), &si.tools, std::env::consts::OS);
@@ -402,7 +411,7 @@ fn build_request_all_tools_default_temperature_no_config() {
         &provider(true, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     assert_eq!(req.tools.len(), 2);
@@ -420,7 +429,7 @@ fn build_request_empty_filter_is_all_and_no_temperature_when_unsupported() {
         &provider(false, 500),
         "test-stage",
         0,
-        None,
+        crate::pipeline::inference::PriorPrefix::default(),
     )
     .0;
     assert_eq!(req.tools.len(), 1);
@@ -14181,6 +14190,7 @@ fn assembled_with_prev(
         stage_iterations: 0,
         model: "m".to_string(),
         previous_system_hash: previous,
+        previous_block_hashes: Vec::new(),
     })
 }
 

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -92,6 +92,7 @@ fn title_request(task: &str, model: &str) -> InferenceRequest {
         system: vec![leviath_providers::SystemBlock {
             text: TITLE_SYSTEM_PROMPT.to_string(),
             cache_hint: leviath_core::CacheHint::Never,
+            breakpoint_eligible: true,
         }],
         messages: vec![leviath_providers::Message {
             role: "user".to_string(),


### PR DESCRIPTION
Closes #474. Root-caused against the real API, and both halves measured.

## The bug

A region became **one system block**. A provider matches a cached prefix only at a *block
boundary*, so the single boundary a region offered sat after its newest content — and the
moment the region grew, the entry named there could never be read back. Every call rewrote
the whole history at the 1.25x write premium and read none of it.

Proven at the byte level with `LEVIATH_DUMP_REQUEST_DIR`:

```
call 3  blk0:380B ad2a7140 | blk1:44B 4758719d | blk2:335B e25a36e4CC | blk3: 27015B 6aa40dd9CC
call 6  blk0:380B ad2a7140 | blk1:44B 4758719d | blk2:335B e25a36e4CC | blk3:107241B 1639f496CC
call 9  blk0:380B ad2a7140 | blk1:44B 4758719d | blk2:335B e25a36e4CC | blk3:187577B bb175bd0CC
        vs previous: stable blocks [0, 1, 2], changed [3]
```

It is not confined to `compacting`. Every cacheable kind is one monolithic block — pinned,
compact-history, compacting, checklist, hashmap, custom — and a **pinned** region an agent
writes to is the worst case, because it invalidates the `Always` run, the most valuable
prefix there is.

## The fix, in two halves

**Breakpoints go only where the entry is readable.** A cached entry can be read next time
only if every byte ahead of it is unchanged, so eligibility is exactly the longest common
prefix of this request's per-block digests and the last one's. That is a fact the assembler
has and the provider does not, so it is computed once and carried on `SystemBlock`; a run
then ends its breakpoint at its last *eligible* block rather than its last block. Measured
across every kind — the breakpoint retreats to the stable head instead of sitting on changed
content:

```
pinned          t1: eligible=[0] bp=[0]   (was bp=[1], invalidated every turn)
compacting      t1: eligible=[0] bp=[0]
compact_history t1: eligible=[0] bp=[0]
hashmap         t1: eligible=[0] bp=[0]
```

**Append-only regions are chunked**, so there are boundaries *inside* them worth caching.
Entries pack greedily into 2048-token chunks and a full chunk is never repacked, so a
boundary that existed last turn exists this turn with the same bytes in front of it. The
settled head caches; only the tail is re-sent — which is how the message path has always
behaved.

## Measured, live, same workload

Twelve calls against Sonnet, history in a compacting region:

| | before | after |
|---|---|---|
| cache reads (cum) | **0** | **300,588** |
| cache writes (cum) | **456,860** | **74,256** |
| write per call | 9k → 82k, ratcheting | **flat ~8,149** |

Writes down 84%. In Sonnet pricing (write 1.25x, read 0.1x) that is roughly a **79%
reduction** on the cached portion, and it improves as history grows, since the uncached tail
is bounded by one chunk.

## Quality is unchanged, which was the constraint

- Every chunk after the first says which region it continues. Splitting for the cache's
  benefit must not hand the model a wall of unlabelled prose — the confusion that naming
  regions was meant to remove.
- Tests assert the chunks rejoin to **exactly** the text the single block carried, in order,
  with nothing dropped, and that every entry ever written is still in the prompt.
- A run whose history already lived in the messages is unaffected **to the token**:
  1,924,472 reads and 181,937 writes across 26 calls, before and after.
- The entire existing suite passes untouched, which is the strongest statement that assembled
  prompt content did not move.

## Notes

The cacheability machinery moves to `components/block_cache.rs` — "what an agent remembers"
and "which of those bytes a provider can read back" are different questions, and the file
was over the structural limit with both in it.

`build_request` reached the argument limit, so the two prefix digests travel as one
`PriorPrefix` rather than two adjacent parameters a caller could transpose.

Full suite green, clippy clean under `-D warnings`, all four coverage gates at 100%.
