### PR TITLE
fix(context): close the remaining cache losses after #477

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ same list.
 
 ## Unreleased
 
+- Fixed: the cacheable prefix no longer stalls for several turns while a cache
+  chunk fills. The chunk size decides how soon a boundary appears that the next
+  request can match, and a budget larger than a typical entry meant the tail
+  kept absorbing entries and changing, so none appeared. Measured over a
+  24-turn run with small entries: the prefix sat pinned at the stable head for
+  six consecutive turns at a stretch, and now sits pinned for two - the first
+  request, and the one straight after a compaction, neither of which has
+  anything to match against yet.
 - Fixed: a compaction no longer destroys the cacheable prefix, and no longer
   does so differently depending on the order regions are declared in. A
   compact-history region gains an entry every time compaction fires, but it was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ same list.
 
 ## Unreleased
 
+- Fixed: a compaction no longer destroys the cacheable prefix, and no longer
+  does so differently depending on the order regions are declared in. A
+  compact-history region gains an entry every time compaction fires, but it was
+  tagged as the most stable kind of content, so it sorted ahead of genuinely
+  immutable pinned instructions and invalidated everything behind it. Declared
+  before the pinned region that cost the whole prefix; declared after, nothing.
+  Measured: 2,502 cacheable tokens against 0, from the same content.
 - Fixed: a growing context region is no longer rewritten into the prompt cache
   on every call. A region became a single system block, and a provider matches a
   cached prefix only at a block boundary - so the one boundary a region offered

--- a/crates/leviath-runtime/src/components/block_cache.rs
+++ b/crates/leviath-runtime/src/components/block_cache.rs
@@ -12,12 +12,26 @@ use super::*;
 
 /// How much text one cache chunk of an append-only region holds, in tokens.
 ///
-/// The chunk is the unit of what can be cached, so it wants to be at least a
-/// provider's minimum cacheable prefix - Anthropic's is 1024 tokens on Sonnet -
-/// and small enough that the uncached tail stays cheap. It also bounds how many
-/// blocks a large region becomes: 200k tokens of history is a hundred blocks,
-/// which is fine to send and costs nothing to skip.
-pub(super) const CACHE_CHUNK_TOKENS: usize = 2048;
+/// Small on purpose, and smaller than it first looks like it should be. The
+/// chunk is not the unit of what gets cached - a breakpoint caches the whole
+/// prefix in front of it, so a provider's minimum cacheable length applies to
+/// that running total and not to any one block. What the chunk size actually
+/// decides is *how soon* a boundary appears that the next request can match.
+///
+/// A budget larger than a typical entry is what makes that slow: the tail chunk
+/// keeps absorbing entries and changing, so no new boundary exists and the
+/// cacheable prefix stalls at whatever froze last. Measured over a 24-turn run
+/// with ~450-token entries: a 2048-token budget left the prefix pinned at the
+/// stable head for six consecutive turns at a stretch, where 64 leaves it
+/// pinned for two - and those two are the turns nothing could help, the first
+/// request and the one straight after a compaction, when there is nothing yet
+/// to have matched.
+///
+/// Anything above this gets a block of its own and so freezes immediately,
+/// which is every real tool result and context write. Below it, entries
+/// coalesce, which keeps a region of thousands of one-line notes from becoming
+/// thousands of blocks.
+pub(super) const CACHE_CHUNK_TOKENS: usize = 64;
 
 /// Split an append-only region's entries into blocks at boundaries that survive
 /// into the next request.
@@ -336,6 +350,34 @@ mod tests {
             assert!(at >= last, "entries came out of order");
             last = at;
         }
+    }
+
+    /// The property the budget exists to buy: an entry worth caching gets a
+    /// boundary of its own straight away, rather than waiting for a chunk to
+    /// fill.
+    ///
+    /// When the budget was larger than a typical entry the tail chunk kept
+    /// absorbing and changing, so no new boundary appeared and the cacheable
+    /// prefix stalled for turns at a time. This asserts each realistic entry
+    /// lands in its own chunk.
+    #[test]
+    fn an_entry_worth_caching_freezes_a_boundary_immediately() {
+        let entry = "word ".repeat(200); // ~250 tokens, a small tool result
+        for count in 1..6 {
+            let chunks = append_only_chunks(&entries(count, &entry), CACHE_CHUNK_TOKENS);
+            // Bare, with no format arguments: anything in an assert's message
+            // is a region only the failing path reaches, which the 100% gate
+            // then reports as uncovered.
+            assert_eq!(chunks.len(), count);
+        }
+    }
+
+    /// And the coalescing still bounds the block count for trivia.
+    #[test]
+    fn entries_too_small_to_cache_are_coalesced() {
+        let tiny: Vec<String> = (0..40).map(|i| format!("note {i}")).collect();
+        let chunks = append_only_chunks(&tiny, CACHE_CHUNK_TOKENS);
+        assert!(chunks.len() < tiny.len());
     }
 
     // ─── eligibility ────────────────────────────────────────────────────────

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -655,7 +655,22 @@ impl ContextWindow {
                         .iter()
                         .map(|e| e.content.clone())
                         .collect::<Vec<_>>();
-                    push_chunked(&mut system_blocks, region, &body, CacheHint::Always);
+                    // Not `Always`, though nothing ever evicts from here.
+                    // `Always` is the most-stable tier and sorts ahead of
+                    // everything else, and this region gains an entry every
+                    // time compaction fires - so tagging it stable put a
+                    // *changing* block in front of genuinely immutable content
+                    // and invalidated the whole prefix behind it. Which content
+                    // survived depended on the order the regions happened to be
+                    // declared in: measured with the history region declared
+                    // first, one compaction took the cacheable prefix from
+                    // 2,502 tokens to zero, pinned instructions included, and
+                    // declared second it kept them (issue #474).
+                    //
+                    // `UntilChanged` says what is true of it - held still until
+                    // compaction moves it - and sorts it behind the pinned
+                    // content it must not poison.
+                    push_chunked(&mut system_blocks, region, &body, CacheHint::UntilChanged);
                 }
 
                 // Messages region → Vec<Message> with proper typed entries.
@@ -1380,6 +1395,71 @@ mod tests {
         assert_eq!(message, 1);
         let total = system + message;
         assert!(total <= 4, "total breakpoints: {total}");
+    }
+
+    /// Whether a compaction destroys the cacheable prefix must not depend on
+    /// the order regions happen to be declared in.
+    ///
+    /// A compact-history region gains an entry every time compaction fires. It
+    /// used to be tagged `Always` - the most-stable tier - so it sorted ahead of
+    /// genuinely immutable pinned content, and a compaction invalidated
+    /// everything behind it. Declared before the pinned region that cost the
+    /// whole prefix; declared after, it cost nothing. Same content, same run.
+    #[test]
+    fn a_compaction_does_not_depend_on_region_declaration_order() {
+        fn cacheable_after_a_compaction(history_first: bool) -> usize {
+            let mut window = ContextWindow::new(1_000_000);
+            let history = || {
+                Region::new(
+                    "notes_history".to_string(),
+                    RegionKind::CompactHistory {
+                        source_region: "notes".to_string(),
+                    },
+                    100_000,
+                )
+            };
+            if history_first {
+                window.add_region(history());
+            }
+            let mut task = Region::new("task".to_string(), RegionKind::Pinned, 40_000);
+            task.add_entry("stable instructions ".repeat(300), 1500)
+                .expect("fits");
+            window.add_region(task);
+            if !history_first {
+                window.add_region(history());
+            }
+
+            // One settled request, then a compaction: the history gains a
+            // summary, which is what moves the prefix.
+            let first = window.assemble();
+            window
+                .add_to_region("notes_history", "a summary".to_string(), 5)
+                .expect("fits");
+            let second = window.assemble_with_meta(&crate::custom_region::AssembleMeta {
+                stage_name: "work".to_string(),
+                stage_iterations: 1,
+                model: "m".to_string(),
+                previous_system_hash: Some(first.system_hash),
+                previous_block_hashes: first.block_hashes.clone(),
+            });
+            second
+                .system_blocks
+                .iter()
+                .filter(|b| b.breakpoint_eligible)
+                .map(|b| leviath_core::estimate_tokens(&b.text))
+                .sum()
+        }
+
+        let declared_first = cacheable_after_a_compaction(true);
+        let declared_second = cacheable_after_a_compaction(false);
+        assert_eq!(
+            declared_first, declared_second,
+            "declaration order changed what survives a compaction"
+        );
+        assert!(
+            declared_first > 1000,
+            "the pinned instructions should survive a compaction, got {declared_first}"
+        );
     }
 
     /// A compacting region large enough to span chunks says which region each

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -1464,6 +1464,7 @@ mod tests {
 
     /// A compacting region large enough to span chunks says which region each
     /// continuation belongs to, and keeps every entry.
+
     #[test]
     fn a_compacting_region_labels_its_continuations() {
         let mut window = ContextWindow::new(2_000_000);

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -1522,9 +1522,15 @@ mod tests {
             assembled.system_blocks[0].text,
             "## history\nsummary of earlier conversation"
         );
+        // Deliberately not `Always`, though nothing evicts from here. `Always`
+        // is the most-stable tier and sorts ahead of everything, and this region
+        // gains an entry every time compaction fires - so tagging it stable put
+        // a changing block in front of immutable pinned content and invalidated
+        // the prefix behind it, with which content survived depending on the
+        // order regions were declared in (issue #474).
         assert_eq!(
             assembled.system_blocks[0].cache_hint,
-            leviath_core::CacheHint::Always
+            leviath_core::CacheHint::UntilChanged
         );
     }
 
@@ -2911,7 +2917,8 @@ mod tests {
 
     #[test]
     fn test_assemble_compact_history_with_sliding_prefix_sorting() {
-        // CompactHistory should sort before Compacting/Temporary in system blocks
+        // CompactHistory sorts before the volatile `Never` tier, and behind
+        // pinned content - it holds still between compactions but does move.
         use leviath_core::CacheHint;
 
         let mut window = ContextWindow::new(100_000);
@@ -2932,8 +2939,11 @@ mod tests {
 
         let assembled = window.assemble();
         assert_eq!(assembled.system_blocks.len(), 2);
-        // CompactHistory (Always) should come before Temporary (Never)
-        assert_eq!(assembled.system_blocks[0].cache_hint, CacheHint::Always);
+        // CompactHistory (UntilChanged) still comes before Temporary (Never).
+        assert_eq!(
+            assembled.system_blocks[0].cache_hint,
+            CacheHint::UntilChanged
+        );
         assert_eq!(assembled.system_blocks[1].cache_hint, CacheHint::Never);
     }
 


### PR DESCRIPTION
Follow-up to #477. Two further cache losses, both measured, both from the report on #474
that #477 improved but did not close.

## 1. A compact-history region poisoned the stable prefix

It was tagged `CacheHint::Always` — the most-stable tier, which sorts ahead of everything —
but it **gains an entry every time compaction fires**. So a changing block sat in front of
immutable pinned content and every compaction invalidated the whole prefix behind it.

Which content survived depended on nothing but the order the regions were declared in.
Identical content, one compaction:

```
history declared first    cacheable prefix  2,502 -> 0
history declared second   cacheable prefix  2,502 -> 2,502
```

That is the report's *"load-order-sensitive, not a fixed threshold"*. It isn't a threshold —
it's which block sorted first. `UntilChanged` says what is true of the region and sorts it
behind the pinned content it must not poison. Both orders now keep 2,502 cacheable.

## 2. The prefix stalled for turns at a time while a chunk filled

The 2048-token chunk budget in #477 was chosen on the reasoning that a chunk should be at
least a provider's minimum cacheable prefix. **That reasoning was wrong** — a breakpoint
caches the whole prefix in front of it, so the minimum applies to the running total, not to
any one block.

What the chunk size actually decides is how soon a boundary appears that the next request
can match. A budget bigger than a typical entry means the tail keeps absorbing and changing,
so none appears. Measured over 24 turns with ~450-token entries and periodic compaction:

| budget | longest stall |
|---|---|
| 2048 | 6 turns |
| 512 | 3 turns |
| **64** | **2 turns** |
| 1 | 2 turns |

64 reaches the same floor as one-block-per-entry while still coalescing entries too small to
be worth a boundary, so a region of a thousand one-line notes stays a handful of blocks.

The remaining two turns are the ones nothing can help: the first request, and the one
straight after a compaction, when there is nothing yet to have matched.

This is the collapse window the reporter saw recovering later, and it explains why recovery
landed on *"the first small step after a run of large ones"* — that was a chunk finally
crossing the budget.

## Honesty about what is verified

Measured deterministically at the assembly layer, over full simulated runs including
compaction. I did **not** reproduce the reporter's eight-call window live — my agents kept
finishing early, so the longest live run I drove was 12 iterations, where caching recovers in
one to two calls.

Both fixes are real and measured; whether they fully close that run needs their re-run to
say. Request bodies from a failing run (`LEVIATH_DUMP_REQUEST_DIR`) would settle it in one
look — usage counters cannot show which block moved.

Full suite green, clippy clean under `-D warnings`, coverage gates at 100%.
