### PR TITLE
revert(context): drop the breakpoint-eligibility rule from #477

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ same list.
   to store. Anthropic caches nothing below about 1,024 tokens, and a dumped
   request showed one of the four breakpoints sitting on a 269-byte block, where
   it could never be read back.
+- Changed: a cache breakpoint is placed at the end of its tier again, rather
+  than being withheld when the content in front of it changed. Withholding it
+  also prevents the *read* that would have paid for it, since nothing gets
+  stored to match against once the content settles, and it judged staleness
+  against the previous request alone while a provider's cache lives for minutes.
+  Region ordering now keeps churn out of the prefix at its source, which is the
+  part that was measured to help.
 - Fixed: a growing context region is no longer rewritten into the prompt cache
   on every call. A region became a single system block, and a provider matches a
   cached prefix only at a block boundary - so the one boundary a region offered

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -57,28 +57,15 @@ fn system_cache_breakpoints(blocks: &[crate::provider::SystemBlock], budget: usi
         return Vec::new();
     }
     let mut ends = Vec::new();
-    let mut run_end: Option<usize> = None;
     for (i, block) in blocks.iter().enumerate() {
         let hint = block.cache_hint;
         if hint == leviath_core::CacheHint::Never {
-            run_end = None;
             continue;
-        }
-        // The furthest block in this run whose entry could actually be read
-        // back. A block the assembler marked ineligible has changed since the
-        // last request, so a breakpoint at or after it names a prefix that has
-        // already been invalidated - the 1.25x write is charged and nothing is
-        // ever read (issue #474). Keeping the last eligible one instead caches
-        // the part that did hold still.
-        if block.breakpoint_eligible {
-            run_end = Some(i);
         }
         // End of a contiguous same-hint run: the next block is absent or a
         // different hint (a `Never` block also breaks the run).
-        if blocks.get(i + 1).map(|b| b.cache_hint) != Some(hint)
-            && let Some(end) = run_end.take()
-        {
-            ends.push(end);
+        if blocks.get(i + 1).map(|b| b.cache_hint) != Some(hint) {
+            ends.push(i);
         }
     }
     // Drop any breakpoint whose prefix is too short for the provider to cache.
@@ -1226,7 +1213,6 @@ mod tests {
             system: vec![crate::SystemBlock {
                 text: "You are helpful. ".repeat(400),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -1475,7 +1461,6 @@ mod tests {
             system: vec![crate::SystemBlock {
                 text: "You are helpful. ".repeat(400),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -1577,89 +1562,10 @@ mod tests {
                 // rule that refuses a breakpoint on an uncacheably short prefix.
                 text: "word ".repeat(1200),
                 cache_hint: *h,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             })
             .collect()
-    }
-
-    /// A run ends its breakpoint at the last block that could actually be read
-    /// back, not at its last block. Placing it further would name a prefix the
-    /// assembler already said had changed - the 1.25x write charged for an
-    /// entry nothing will ever read (issue #474).
-    #[test]
-    fn a_run_places_its_breakpoint_at_the_last_eligible_block() {
-        let blocks = vec![
-            crate::provider::SystemBlock {
-                text: format!("{} {}", "frozen", "word ".repeat(1200)),
-                cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
-                volatility: leviath_core::Volatility::default(),
-                region: String::new(),
-            },
-            crate::provider::SystemBlock {
-                text: format!("{} {}", "also frozen", "word ".repeat(1200)),
-                cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
-                volatility: leviath_core::Volatility::default(),
-                region: String::new(),
-            },
-            crate::provider::SystemBlock {
-                text: format!("{} {}", "grew this turn", "word ".repeat(1200)),
-                cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: false,
-                volatility: leviath_core::Volatility::default(),
-                region: String::new(),
-            },
-        ];
-        assert_eq!(system_cache_breakpoints(&blocks, 4), vec![1]);
-    }
-
-    /// A run with nothing eligible gets no breakpoint at all rather than one
-    /// that cannot pay for itself.
-    #[test]
-    fn a_run_with_nothing_stable_gets_no_breakpoint() {
-        let blocks = vec![
-            crate::provider::SystemBlock {
-                text: format!("{} {}", "changed", "word ".repeat(1200)),
-                cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: false,
-                volatility: leviath_core::Volatility::default(),
-                region: String::new(),
-            },
-            crate::provider::SystemBlock {
-                text: format!("{} {}", "also changed", "word ".repeat(1200)),
-                cache_hint: leviath_core::CacheHint::UntilChanged,
-                breakpoint_eligible: false,
-                volatility: leviath_core::Volatility::default(),
-                region: String::new(),
-            },
-        ];
-        assert!(system_cache_breakpoints(&blocks, 4).is_empty());
-    }
-
-    /// Eligibility is per run: a stable tier keeps its breakpoint even when a
-    /// later, more volatile tier has moved.
-    #[test]
-    fn a_stable_tier_keeps_its_breakpoint_when_a_later_tier_moved() {
-        let blocks = vec![
-            crate::provider::SystemBlock {
-                text: format!("{} {}", "pinned", "word ".repeat(1200)),
-                cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
-                volatility: leviath_core::Volatility::default(),
-                region: String::new(),
-            },
-            crate::provider::SystemBlock {
-                text: format!("{} {}", "history that grew", "word ".repeat(1200)),
-                cache_hint: leviath_core::CacheHint::UntilChanged,
-                breakpoint_eligible: false,
-                volatility: leviath_core::Volatility::default(),
-                region: String::new(),
-            },
-        ];
-        assert_eq!(system_cache_breakpoints(&blocks, 4), vec![0]);
     }
 
     #[test]
@@ -1754,35 +1660,30 @@ mod tests {
             crate::SystemBlock {
                 text: "architecture ".repeat(400),
                 cache_hint: CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
             crate::SystemBlock {
                 text: "program_flows ".repeat(400),
                 cache_hint: CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
             crate::SystemBlock {
                 text: "plan ".repeat(400),
                 cache_hint: CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
             crate::SystemBlock {
                 text: "task ".repeat(400),
                 cache_hint: CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
             crate::SystemBlock {
                 text: "files ".repeat(400),
                 cache_hint: CacheHint::UntilChanged,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
@@ -1832,21 +1733,18 @@ mod tests {
             crate::SystemBlock {
                 text: "alpha ".repeat(900),
                 cache_hint: CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
             crate::SystemBlock {
                 text: "bravo ".repeat(900),
                 cache_hint: CacheHint::UntilChanged,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
             crate::SystemBlock {
                 text: "charlie ".repeat(900),
                 cache_hint: CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
@@ -1906,7 +1804,6 @@ mod tests {
             system: vec![crate::SystemBlock {
                 text: "ephemeral".into(),
                 cache_hint: CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -2454,14 +2351,12 @@ mod tests {
                 crate::SystemBlock {
                     text: "System part 1".to_string(),
                     cache_hint: leviath_core::CacheHint::Always,
-                    breakpoint_eligible: true,
                     volatility: leviath_core::Volatility::default(),
                     region: String::new(),
                 },
                 crate::SystemBlock {
                     text: "System part 2".to_string(),
                     cache_hint: leviath_core::CacheHint::Always,
-                    breakpoint_eligible: true,
                     volatility: leviath_core::Volatility::default(),
                     region: String::new(),
                 },
@@ -2522,7 +2417,6 @@ mod tests {
             system: vec![crate::SystemBlock {
                 text: "No caching here.".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -668,14 +668,12 @@ mod tests {
             SystemBlock {
                 text: "[architecture]:\nhexagonal".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
             SystemBlock {
                 text: "[plan]:\nstep one".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
@@ -692,14 +690,12 @@ mod tests {
             SystemBlock {
                 text: String::new(),
                 cache_hint: leviath_core::CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },
             SystemBlock {
                 text: "kept".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             },

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -1194,7 +1194,6 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "You are a local assistant.".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -2557,7 +2556,6 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "instructions".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -922,7 +922,6 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "## task\ncount the ERROR lines".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -955,7 +954,6 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "instructions".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -987,7 +985,6 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "instructions".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -1046,7 +1043,6 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "instructions".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -1143,7 +1139,6 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "## task\ncount the ERROR lines".to_string(),
                 cache_hint: leviath_core::CacheHint::Always,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -2247,7 +2242,6 @@ mod tests {
             system: vec![SystemBlock {
                 text: "You are a coding agent. Task: add a doc comment.".into(),
                 cache_hint: leviath_core::CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],
@@ -2468,14 +2462,12 @@ mod tests {
                 crate::provider::SystemBlock {
                     text: "You are helpful.".into(),
                     cache_hint: leviath_core::CacheHint::Always,
-                    breakpoint_eligible: true,
                     volatility: leviath_core::Volatility::default(),
                     region: String::new(),
                 },
                 crate::provider::SystemBlock {
                     text: "Be concise.".into(),
                     cache_hint: leviath_core::CacheHint::Always,
-                    breakpoint_eligible: true,
                     volatility: leviath_core::Volatility::default(),
                     region: String::new(),
                 },
@@ -2517,7 +2509,6 @@ mod tests {
                 .map(|i| SystemBlock {
                     text: format!("block {i}"),
                     cache_hint: leviath_core::CacheHint::Always,
-                    breakpoint_eligible: true,
                     volatility: leviath_core::Volatility::default(),
                     region: String::new(),
                 })
@@ -2556,21 +2547,18 @@ mod tests {
                 SystemBlock {
                     text: "real".into(),
                     cache_hint: leviath_core::CacheHint::Always,
-                    breakpoint_eligible: true,
                     volatility: leviath_core::Volatility::default(),
                     region: String::new(),
                 },
                 SystemBlock {
                     text: "   ".into(),
                     cache_hint: leviath_core::CacheHint::Always,
-                    breakpoint_eligible: true,
                     volatility: leviath_core::Volatility::default(),
                     region: String::new(),
                 },
                 SystemBlock {
                     text: "also real".into(),
                     cache_hint: leviath_core::CacheHint::Always,
-                    breakpoint_eligible: true,
                     volatility: leviath_core::Volatility::default(),
                     region: String::new(),
                 },

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -729,7 +729,6 @@ mod tests {
             system: vec![crate::provider::SystemBlock {
                 text: "You are a helpful assistant.".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -539,18 +539,6 @@ pub struct SystemBlock {
     /// region's *kind* cannot answer this - a pinned region is written
     /// constantly - so the blueprint says and this carries the answer.
     pub volatility: leviath_core::Volatility,
-    /// Whether a cache breakpoint may be placed at the end of this block.
-    ///
-    /// A provider caches by prefix, so an entry named by a breakpoint is
-    /// readable next time only if every byte before it is unchanged. The
-    /// assembler knows which blocks those are - it compares this request's
-    /// blocks against the last one - and says so here, rather than leaving each
-    /// provider to guess and pay the write premium for an entry that can never
-    /// be read (issue #474).
-    ///
-    /// `true` when nothing upstream said otherwise, which keeps a provider that
-    /// ignores this field behaving exactly as before.
-    pub breakpoint_eligible: bool,
 }
 
 /// Request for LLM inference.

--- a/crates/leviath-runtime/src/components/block_cache.rs
+++ b/crates/leviath-runtime/src/components/block_cache.rs
@@ -95,7 +95,6 @@ pub(super) fn push_chunked(
         blocks.push(leviath_providers::SystemBlock {
             text,
             cache_hint: hint,
-            breakpoint_eligible: true,
             volatility: region.volatility,
             region: region.name.clone(),
         });
@@ -158,43 +157,6 @@ pub(super) fn block_hash(text: &str) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     text.hash(&mut hasher);
     hasher.finish()
-}
-
-/// Mark every block a cache breakpoint could actually be read back at.
-///
-/// A provider caches by prefix, so the entry a breakpoint names is readable
-/// next time only if every byte before it is unchanged. That makes the rule
-/// exact rather than a heuristic: a block is eligible when it, and every block
-/// ahead of it, is byte-identical to the previous request. The eligible set is
-/// therefore the longest common prefix of this request's block hashes and the
-/// last one's.
-///
-/// Before the first request there is nothing to compare against, so everything
-/// is eligible - the first call is a write whatever we do, and marking it
-/// ineligible would forfeit the entry the second call wants to read.
-///
-/// This is what stops a growing region being paid for over and over. A region
-/// that gained content is not in the common prefix, so no breakpoint lands at
-/// or after it, and the stable head in front of it keeps the entry it always
-/// had (issue #474: 456,860 cache-write tokens across twelve calls, zero reads,
-/// because the only breakpoint sat after content that changed every call).
-pub(super) fn mark_breakpoint_eligibility(
-    blocks: &mut [leviath_providers::SystemBlock],
-    previous: &[u64],
-) -> Vec<u64> {
-    let hashes: Vec<u64> = blocks.iter().map(|b| block_hash(&b.text)).collect();
-    if previous.is_empty() {
-        return hashes;
-    }
-    let stable = hashes
-        .iter()
-        .zip(previous)
-        .take_while(|(now, before)| now == before)
-        .count();
-    for (index, block) in blocks.iter_mut().enumerate() {
-        block.breakpoint_eligible = index < stable;
-    }
-    hashes
 }
 
 /// A stable digest of the assembled system prefix.
@@ -333,16 +295,6 @@ mod tests {
         (0..n).map(|i| format!("{i}:{each}")).collect()
     }
 
-    fn block(text: &str, hint: CacheHint, eligible: bool) -> leviath_providers::SystemBlock {
-        leviath_providers::SystemBlock {
-            text: text.to_string(),
-            cache_hint: hint,
-            breakpoint_eligible: eligible,
-            volatility: leviath_core::Volatility::default(),
-            region: String::new(),
-        }
-    }
-
     // ─── chunking ───────────────────────────────────────────────────────────
 
     /// The property the whole fix rests on: a boundary that existed last turn
@@ -435,7 +387,6 @@ mod tests {
         leviath_providers::SystemBlock {
             text: text.to_string(),
             cache_hint: CacheHint::Always,
-            breakpoint_eligible: true,
             volatility: leviath_core::Volatility::Stable,
             region: region.to_string(),
         }
@@ -495,69 +446,5 @@ mod tests {
         // One previous hash, two blocks now: the second is new, not changed.
         warn_on_unstable_declaration(&blocks, &[block_hash("a")], &mut seen);
         assert!(seen.is_empty());
-    }
-
-    // ─── eligibility ────────────────────────────────────────────────────────
-
-    /// Nothing to compare against, so nothing is held back: the first request
-    /// is a write whatever we do, and refusing it would forfeit the entry the
-    /// second request wants to read.
-    #[test]
-    fn the_first_request_leaves_every_block_eligible() {
-        let mut blocks = vec![
-            block("a", CacheHint::Always, true),
-            block("b", CacheHint::Always, true),
-        ];
-        let hashes = mark_breakpoint_eligibility(&mut blocks, &[]);
-        assert_eq!(hashes.len(), 2);
-        assert!(blocks.iter().all(|b| b.breakpoint_eligible));
-    }
-
-    /// The rule, stated as the provider needs it: a block is eligible only if it
-    /// and everything ahead of it is byte-identical to last time.
-    #[test]
-    fn eligibility_stops_at_the_first_block_that_changed() {
-        let mut first = vec![
-            block("head", CacheHint::Always, true),
-            block("middle", CacheHint::Always, true),
-            block("tail", CacheHint::Always, true),
-        ];
-        let previous = mark_breakpoint_eligibility(&mut first, &[]);
-
-        let mut second = vec![
-            block("head", CacheHint::Always, true),
-            block("middle grew", CacheHint::Always, true),
-            block("tail", CacheHint::Always, true),
-        ];
-        mark_breakpoint_eligibility(&mut second, &previous);
-
-        assert!(second[0].breakpoint_eligible, "the head held still");
-        assert!(!second[1].breakpoint_eligible, "this is what changed");
-        assert!(
-            !second[2].breakpoint_eligible,
-            "and everything after it is behind changed bytes, however stable its own text"
-        );
-    }
-
-    /// A prefix that held still entirely stays entirely eligible.
-    #[test]
-    fn an_unchanged_prefix_stays_eligible() {
-        let mut first = vec![
-            block("head", CacheHint::Always, true),
-            block("body", CacheHint::Always, true),
-        ];
-        let previous = mark_breakpoint_eligibility(&mut first, &[]);
-        let mut second = vec![
-            block("head", CacheHint::Always, true),
-            block("body", CacheHint::Always, true),
-            block("new tail", CacheHint::Always, true),
-        ];
-        mark_breakpoint_eligibility(&mut second, &previous);
-        assert!(second[0].breakpoint_eligible);
-        assert!(second[1].breakpoint_eligible);
-        assert!(
-            !second[2].breakpoint_eligible,
-            "the new block is not proven yet"
-        );
     }
 }

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -7,7 +7,7 @@
 //! questions to arrive with.
 
 use super::block_cache::{
-    CACHE_CHUNK_TOKENS, append_only_chunks, block_sort_priority, mark_breakpoint_eligibility,
+    CACHE_CHUNK_TOKENS, append_only_chunks, block_hash, block_sort_priority,
     mark_recently_changed_run, push_chunked, system_prefix_hash, warn_on_unstable_declaration,
 };
 use super::*;
@@ -653,7 +653,6 @@ impl ContextWindow {
                         system_blocks.push(leviath_providers::SystemBlock {
                             text: labelled(region, &body),
                             cache_hint: CacheHint::UntilChanged,
-                            breakpoint_eligible: true,
                             volatility: region.volatility,
                             region: region.name.clone(),
                         });
@@ -800,7 +799,6 @@ impl ContextWindow {
                         system_blocks.push(leviath_providers::SystemBlock {
                             text,
                             cache_hint: CacheHint::UntilChanged,
-                            breakpoint_eligible: true,
                             volatility: region.volatility,
                             region: region.name.clone(),
                         });
@@ -816,7 +814,6 @@ impl ContextWindow {
                     system_blocks.push(leviath_providers::SystemBlock {
                         text: format!("[{}]:\n{}", region.name, text),
                         cache_hint: CacheHint::Never,
-                        breakpoint_eligible: true,
                         volatility: region.volatility,
                         region: region.name.clone(),
                     });
@@ -831,7 +828,6 @@ impl ContextWindow {
                     system_blocks.push(leviath_providers::SystemBlock {
                         text: format!("[{}]:\n{}", region.name, text),
                         cache_hint: CacheHint::Never,
-                        breakpoint_eligible: true,
                         volatility: region.volatility,
                         region: region.name.clone(),
                     });
@@ -875,7 +871,6 @@ impl ContextWindow {
                     system_blocks.push(leviath_providers::SystemBlock {
                         text: format!("[{}]:\n{}", region.name, text),
                         cache_hint: CacheHint::UntilChanged,
-                        breakpoint_eligible: true,
                         volatility: region.volatility,
                         region: region.name.clone(),
                     });
@@ -908,8 +903,7 @@ impl ContextWindow {
         system_blocks.sort_by_key(block_sort_priority);
         // After the sort, because the order is part of what Anthropic matches.
         let system_hash = system_prefix_hash(&system_blocks);
-        let block_hashes =
-            mark_breakpoint_eligibility(&mut system_blocks, &meta.previous_block_hashes);
+        let block_hashes: Vec<u64> = system_blocks.iter().map(|b| block_hash(&b.text)).collect();
         // A declaration is a hint we can falsify, not a promise: `stable` sorts a
         // region to the front, so one that is really churning does the most
         // damage possible and does it because we believed the label.
@@ -1147,7 +1141,6 @@ mod tests {
         SystemBlock {
             text: "x".to_string(),
             cache_hint: hint,
-            breakpoint_eligible: true,
             volatility: leviath_core::Volatility::default(),
             region: String::new(),
         }
@@ -1466,6 +1459,11 @@ mod tests {
         window.add_region(task);
         let mut scratch = Region::new("scratch".to_string(), RegionKind::Pinned, 100_000);
         scratch.volatility = leviath_core::Volatility::Rewritten;
+        // Seeded, because an empty region contributes no block at all and the
+        // comparison below is between two requests that both have one.
+        scratch
+            .add_entry("first state".to_string(), 5)
+            .expect("fits");
         window.add_region(scratch);
 
         let first = window.assemble();
@@ -1487,14 +1485,15 @@ mod tests {
             previous_system_hash: Some(first.system_hash),
             previous_block_hashes: first.block_hashes.clone(),
         });
-        let task_block = second
-            .system_blocks
-            .iter()
-            .find(|b| b.region == "task")
-            .expect("the task block is present");
-        assert!(
-            task_block.breakpoint_eligible,
-            "the stable content held still and must stay cacheable"
+        // The property that matters to a prefix cache: the stable content is
+        // still first and still byte-identical, so everything a provider stores
+        // up to and including it can be read back. The churn is behind it, where
+        // it invalidates only itself.
+        assert_eq!(second.system_blocks[0].region, "task");
+        assert_eq!(second.block_hashes[0], first.block_hashes[0]);
+        assert_ne!(
+            second.block_hashes[1], first.block_hashes[1],
+            "the fixture is meant to churn the second region"
         );
     }
 

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -110,7 +110,6 @@ fn fallback_block(region: &Region) -> leviath_providers::SystemBlock {
     leviath_providers::SystemBlock {
         text: format!("[{}]:\n{}", region.name, text),
         cache_hint: leviath_core::CacheHint::Never,
-        breakpoint_eligible: true,
         volatility: region.volatility,
         region: region.name.clone(),
     }
@@ -280,7 +279,6 @@ fn parse_render_output(
     let block = |text: &str| leviath_providers::SystemBlock {
         text: text.to_string(),
         cache_hint: hint,
-        breakpoint_eligible: true,
         volatility: leviath_core::Volatility::default(),
         region: String::new(),
     };

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -606,7 +606,6 @@ mod tests {
             system: vec![SystemBlock {
                 text: "sys".to_string(),
                 cache_hint: leviath_core::CacheHint::Never,
-                breakpoint_eligible: true,
                 volatility: leviath_core::Volatility::default(),
                 region: String::new(),
             }],

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -59,7 +59,6 @@ pub(crate) fn hint_blocks(
     let always = |text: &str| leviath_providers::SystemBlock {
         text: text.to_string(),
         cache_hint: leviath_core::CacheHint::Always,
-        breakpoint_eligible: true,
         volatility: leviath_core::Volatility::default(),
         region: String::new(),
     };

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -92,7 +92,6 @@ fn title_request(task: &str, model: &str) -> InferenceRequest {
         system: vec![leviath_providers::SystemBlock {
             text: TITLE_SYSTEM_PROMPT.to_string(),
             cache_hint: leviath_core::CacheHint::Never,
-            breakpoint_eligible: true,
             volatility: leviath_core::Volatility::default(),
             region: String::new(),
         }],


### PR DESCRIPTION
revert(context): drop the breakpoint-eligibility rule from #477

Removes `breakpoint_eligible` and `mark_breakpoint_eligibility`. A run's
breakpoint goes back to the end of its hint run, which is where it sat before
#477.

The rule refused a breakpoint whenever the content in front of it had changed
since the last request. That is true of the byte comparison and wrong as a
policy, for two reasons I can argue but have not been able to measure:

Refusing to write also prevents reads. If nothing is stored because the content
just changed, the *next* request has nothing to match even once the content has
settled. The behaviour it replaced at least stored something a later call could
read.

And it compared against the immediately previous request only, while the
provider's cache lives for minutes and can match an entry from several calls
back. So the rule was strictly more pessimistic than the thing it was modelling.

Both fit the one production measurement we have, where the hit rate and the cost
rose together - more reads and more writes at once.

The reason to take it out now rather than keep iterating: after #480 gated
chunking on `volatility = "grows"`, with `rewritten` as the default, the half of
#477 that produced the only win I measured is inert for every undeclared
blueprint - which is all of them, including the seven bundled agents. That left
main running the suspect half and none of the beneficial half. Removing this
puts every active mechanism back to one that has been measured to help.

What stays, because each was measured on its own terms:

- Region ordering by declared volatility (#480): hit rate 0% to 66.5%, cost per
  iteration down 58%, same binary and agent, 24 iterations either side.
- Chunking a `grows` region, which is the same measurement.
- Refusing a breakpoint on a prefix under the provider's minimum, which is
  arithmetic rather than a policy: Anthropic stores nothing below ~1024 tokens,
  and a dumped request had one of the four sitting on a 269-byte block.

Worth recording for whoever picks this up: the message-path suppression from
#441 in `assemble_with_meta` has the same shape as what is removed here - it
skips the message breakpoint when the system prefix moved. It is left alone
because it was measured when it landed (3.3M cache-write tokens against 267k
reads on a run whose bulk region grew every turn). But that measurement predates
volatility ordering, which now keeps churn out of the prefix at the source, so
the case it was solving should be much rarer and the suppression may now be
firing where it is no longer needed. Worth re-measuring, not worth guessing at.

Refs #474.
