### PR TITLE
docs(changelog): backfill the entries between 0.3.10 and the cache work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,86 @@ same list.
 
 ## Unreleased
 
+- Breaking: every MCP tool is named `<server>__<tool>`, whether or not anything
+  would have collided. A tool used to be advertised bare and prefixed only on a
+  clash, which made the name a function of registration order: registration
+  follows `config.toml`, so two servers both offering `search` gave the bare
+  name to whichever was listed first. `available_tools = ["search"]` therefore
+  meant a different server's tool depending on the order of a file the blueprint
+  does not control. A blueprint naming a bare MCP tool stops matching, though a
+  name that resolves to exactly one server is now rewritten for you rather than
+  silently dropped. No bundled agent is affected; none of the seven names an MCP
+  tool. The separator is `__` and not the `.` it reads better as, because the
+  advertised name goes to the model provider, which accepts only
+  `[A-Za-z0-9_-]` and rejects the whole request otherwise.
+- Breaking: the run archive's version number marks a change to its *framing* -
+  the preamble, the length prefix, the payload encoding - and an archive newer
+  than the build reading it is refused by name. It was read by every caller and
+  compared by none, so a future format change would have been parsed as the
+  current one and produced nonsense from whatever the length prefixes said.
+- Fixed: a reader steps over a record kind it does not know instead of stopping
+  at it. Records are length-prefixed and nothing used that, so a frame whose
+  contents a build could not parse was treated like a frame whose end it could
+  not find: the read stopped there and returned the prefix. That made adding a
+  record kind a breaking change, and it was already live - `InferenceUsage`
+  shipped in 0.3.10 and is written on every provider call, so an older
+  `leviath-core` read a 0.3.10 journal as "header, then nothing". Adding a
+  record kind no longer moves the version, because older builds can now read
+  past it.
+- Fixed: a provider gets one system message however many blocks were assembled.
+  Leviath models system content as blocks, one per pinned region, and the OpenAI
+  chat shape has no such concept - it has *a* system message. The shared builder
+  emitted one per block, which permissive servers tolerate and strict ones do
+  not: Ollama with a Qwen 3.x template answers `HTTP 500 {"error":"system
+  message must be at the beginning"}`, which is a misleading way to say "at most
+  one". Every multi-region blueprint, which is every real agent, failed on its
+  first inference against those models. Anthropic has its own builder, where
+  block structure earns its keep through per-block `cache_control`, and is
+  unchanged.
+- Fixed: a resumed run is not re-titled. `PendingTitle` was attached on every
+  build with no fresh-versus-reload check, so each pause and resume bought
+  another titling call.
+- Fixed: an unattended run parks rather than failing when the fix is somebody
+  else's. A benchmark round crossed an empty account mid-tier and lost 31 runs
+  across three terminal shapes, none resumable, all one cause. `paused` is
+  visible in `meta.json` and `lev ps --json`, so a harness that can top up an
+  account and `lev resume` gets the work back, and one that cannot cancels the
+  run for the cost of a second. A credits failure on an output stage also used
+  to route through the transition logic and report "never called
+  submit_output", naming the wrong cause to everything downstream.
+- New: a stage can grant a whole MCP server with
+  `available_connectors = ["github"]`, resolved at spawn against what that
+  server actually advertises and merged with `available_tools`. Naming tools one
+  by one meant knowing a list that is not the blueprint author's to know - it is
+  whatever the server advertises today - so a tool added later was never
+  offered, with nothing said.
+- New: `DELETE /api/runs/{id}` removes a finished run's record, and
+  `DELETE /api/runs?before=<unix>` or `?ids=` prunes many at once. Cancelling and
+  deleting are different verbs: `DELETE /api/agents/{id}` stops the work and
+  keeps the record. A console could list runs, read them, cancel them and never
+  get rid of one. A live run is refused with 409, an already-deleted one answers
+  404 so a repeat is readable, and a run whose record will not parse needs
+  `?force=true` - an unreadable record is what a live run looks like to a build
+  whose `RunMeta` has moved on. Announced as `runs.delete` and
+  `runs.delete.bulk`.
+- New: regions that assemble into the system prompt carry their own name above
+  their contents. An agent writes to a region *by name* and the prompt showed it
+  every region's contents with nothing saying which region they came from, so it
+  could read `sources_index`, write to `sources_index`, and have no way to know
+  they were the same place. Three tokens per region, however many entries it
+  holds.
+- New: a region takes a `description`, and `describe_in_prompt = true` shows it
+  to the model as well. On its own it is documentation and costs nothing:
+  `lev dash` prints it under the region, `GET /api/blueprints/{name}` returns it
+  with the region's kind and budget, and `context.json` carries it so no reader
+  has to re-parse the manifest to explain a region it is already showing.
+- New: an Ollama stage can turn off a reasoning model's thinking with
+  `think = false` under `[stages.<name>.model.parameters]`. Ollama puts `think`
+  at the top level of the request while everything in `parameters` is merged
+  into `options`, so setting it there was accepted and ignored. Thinking is
+  billed to the same output budget as the answer: asked for a run title in 64
+  tokens, qwen3.8 returns an empty string, having spent all 64 deciding what a
+  title is.
 - Changed: the bundled agents declare how much each of their regions moves, so
   the prompt-cache ordering applies to them rather than shipping switched off.
   43 regions across the seven: a task, a query or a seeded convention file is

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -332,10 +332,15 @@ planning stage only reads what it collected - every chunk is already frozen and 
 caches. Measured on that shape: 99% of the prompt cacheable in the planning stage, with only the
 plan itself, rewritten each turn, outside it.
 
-Re-declaring such a region `stable` for the later stage buys nothing and costs a little.
-`stable` content is one block rather than several, so the region goes from two cache markers to
-one: the same total cached, with fewer fallbacks if something does change. `grows` is the
-better answer for anything ever appended to, and it optimises itself when the appending stops.
+Re-declaring such a region `stable` for the later stage changes nothing worth having. The same
+bytes are cached either way; `stable` renders as one block where `grows` renders as several, so
+there are fewer places to put a marker and one fewer *fallback* - and a fallback only pays if the
+region turns out to change, which in that stage it does not. Declare a region by what it does
+across the run and leave it alone.
+
+Caching is also per model, so a stage that switches model starts cold whatever the blocks look
+like. The benefit concentrates inside a stage rather than across a model change, and no layout
+avoids that.
 
 A stage can still override the layout, volatility included, with
 `[stages.<name>.context.regions]` - see [per-stage layouts](/docs/agents#context-regions). That is


### PR DESCRIPTION
Main's `## Unreleased` had eight bullets, all from the prompt-cache work, which wrote its entries as it went. Everything merged before that was undocumented — eleven entries, including **both breaking changes**:

- every MCP tool is now `<server>__<tool>`, so a blueprint naming a bare one stops matching
- the run archive's version marks a framing change, and an archive newer than the reader is refused

Those two are why the next release is a minor rather than a patch. A changelog that omits them is worse than none: someone reads the section, sees only cache tuning, and upgrades expecting a quiet release.

The rest is the delete routes, MCP connectors, region names and descriptions in the prompt, the unattended-run parking fix, the one-system-message fix, and the Ollama `think` knob. They go in front of the cache entries so the section reads oldest-first, as the released sections do.

Twenty bullets under `## Unreleased` now, two of them breaking.

Also corrects a claim in the context guide. It said re-declaring a settled region `stable` "costs a little", which overstates it — the same bytes cache either way, and the only difference is one fewer *fallback* marker, which pays only if the region unexpectedly changes. It now says that instead, and adds the constraint that actually shapes a staged agent's caching: entries are per model, so a stage that switches model starts cold whatever the layout.