### PR TITLE
fix(runtime): token-estimate calibration (#485) and conversation ordering (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ same list.
 
 ## Unreleased
 
+- Fixed: the live conversation always ends the request. A custom region is the
+  only kind whose `render` hook can emit conversation messages, and it emitted
+  them at whatever position its author declared the region - so one declared
+  after the conversation put its contents *behind* the last user turn. A model
+  reads the end of its input as "now", and for an agent that is the dialogue it
+  is having; with a document corpus in that region, what sat in the position the
+  model weighs most heavily was a wall of reference material and the agent
+  stopped behaving like it was in a conversation. Emitted messages now render in
+  front of the conversation wherever the region sits, which leaves a blueprint
+  that already declared it earlier completely unchanged.
+
 - Fixed: the context window corrects its own token estimate against what the
   provider reports charging, so a run on a hard context window evicts in time
   instead of overflowing it. Everything is sized with bytes-over-four, which on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ same list.
 
 ## Unreleased
 
+- Fixed: the context window corrects its own token estimate against what the
+  provider reports charging, so a run on a hard context window evicts in time
+  instead of overflowing it. Everything is sized with bytes-over-four, which on
+  dense ASCII - code, mostly - reads about 10% light. A 27B model pinned to
+  `num_ctx 32768` therefore assembled 32,497 real tokens while believing it was
+  inside its budgets: the 0.9 eviction trigger was meant to leave 3,277 tokens
+  of margin and was really leaving 269, less than one tool result, so the next
+  read overflowed the window. Every response already reports `prompt_tokens`
+  from the server's own tokenizer, and the runtime now compares that against
+  what it believed the same request would cost. The correction only ever
+  tightens and only on measured evidence: a provider that charges less than
+  estimated, which is every provider on text with any non-ASCII in it, changes
+  nothing, and nothing is held back from a workload not seen drifting.
+- Fixed: Ollama's `no user query found in messages` is reported as the size
+  error it is, when the request that provoked it did carry a user turn. Ollama
+  does not refuse an oversized request, it truncates from the front, and when
+  the last user turn is what falls off it then reports the conversation's shape
+  rather than its size - which sent two separate investigations after
+  message-shape bugs. Since a `500` reads as transient it was also retried on
+  backoff, and every attempt sent the same oversized conversation.
+
 - Breaking: every MCP tool is named `<server>__<tool>`, whether or not anything
   would have collided. A tool used to be advertised bare and prefixed only on a
   clash, which made the name a function of registration order: registration

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -82,6 +82,54 @@ fn next_tool_call_id() -> String {
 /// Ollama does not report anywhere. `None` leaves the compiled table in charge
 /// rather than recording a guess that would outrank it - the same rule the
 /// OpenRouter provider follows for a model its `/models` says nothing about.
+/// Whether an error is Ollama saying the conversation reached it with no user
+/// turn in it.
+///
+/// Matched on the fragment rather than the whole sentence: the surrounding text
+/// is an HTTP status and a JSON envelope that the shared send path formats, and
+/// the phrase itself is what Ollama writes.
+fn mentions_dropped_user_turn(message: &str) -> bool {
+    message.to_ascii_lowercase().contains("no user query found")
+}
+
+/// Roughly what the request would have cost, for the size error's sake.
+///
+/// The same byte estimate the rest of the runtime budgets with, which is the
+/// point: this number is meant to be compared against the window the operator
+/// configured, and against what the run's own accounting reported. An exact
+/// count would need the server's tokenizer, and the server has just refused to
+/// talk to us.
+fn estimated_request_tokens(request: &InferenceRequest) -> usize {
+    let blocks = request
+        .system
+        .iter()
+        .map(|b| leviath_core::estimate_tokens(&b.text));
+    let messages = request.messages.iter().map(|m| match &m.content {
+        crate::MessageContent::Text(text) => leviath_core::estimate_tokens(text),
+        crate::MessageContent::Blocks(blocks) => blocks.iter().map(estimated_block_tokens).sum(),
+    });
+    // Tool schemas travel with every request and are charged for every time,
+    // which is easy to forget precisely because nothing in the window holds
+    // them.
+    let tools = request.tools.iter().map(|t| {
+        leviath_core::estimate_tokens(&t.name)
+            + leviath_core::estimate_tokens(&t.description)
+            + leviath_core::estimate_tokens(&t.parameters.to_string())
+    });
+    blocks.chain(messages).chain(tools).sum()
+}
+
+/// One content block's share of [`estimated_request_tokens`].
+fn estimated_block_tokens(block: &crate::ContentBlock) -> usize {
+    match block {
+        crate::ContentBlock::Text { text } => leviath_core::estimate_tokens(text),
+        crate::ContentBlock::ToolUse { name, input, .. } => {
+            leviath_core::estimate_tokens(name) + leviath_core::estimate_tokens(&input.to_string())
+        }
+        crate::ContentBlock::ToolResult { content, .. } => leviath_core::estimate_tokens(content),
+    }
+}
+
 fn effective_window(show: &serde_json::Value) -> Option<usize> {
     let parameters = show.get("parameters")?.as_str()?;
     parameters.lines().find_map(|line| {
@@ -182,6 +230,40 @@ impl OllamaProvider {
              Set the real window with [model_capabilities.\"{model}\"] \
              max_context_tokens = <n>",
         );
+    }
+
+    /// Rewrite Ollama's answer to an overflowed request as the size error it is.
+    ///
+    /// A request past `num_ctx` is not refused. The server truncates it from the
+    /// front until it fits, and when what falls off the front is the last user
+    /// turn it then reports `no user query found in messages` - a message about
+    /// the shape of the conversation, describing a failure of its size. That
+    /// sent two separate investigations after message-shape bugs before a wire
+    /// capture settled it (issues #469, #475, #485).
+    ///
+    /// The test is exact rather than a threshold: if this request carried a user
+    /// message and the server says it received none, the server dropped it, and
+    /// front-truncation is the only thing that drops it. A request that really
+    /// carries no user turn keeps the original error, because then the message
+    /// is telling the truth.
+    ///
+    /// Rewriting also stops the retry loop. `500` reads as transient, so the
+    /// unrewritten error is retried on backoff - and every attempt sends the
+    /// same oversized conversation and is truncated the same way.
+    fn explain_truncation(
+        &self,
+        error: ProviderError,
+        request: &InferenceRequest,
+    ) -> ProviderError {
+        if !mentions_dropped_user_turn(&error.to_string())
+            || !request.messages.iter().any(|m| m.role == "user")
+        {
+            return error;
+        }
+        ProviderError::TokenLimitExceeded {
+            used: estimated_request_tokens(request),
+            max: self.max_context_tokens(&request.model),
+        }
     }
 
     /// Ask the server for every installed model's effective window.
@@ -476,7 +558,8 @@ impl Provider for OllamaProvider {
             None,
             request.request_timeout_secs,
         )
-        .await?;
+        .await
+        .map_err(|e| self.explain_truncation(e, request))?;
 
         let response_body: serde_json::Value = response
             .json()
@@ -505,7 +588,8 @@ impl Provider for OllamaProvider {
             None,
             request.request_timeout_secs,
         )
-        .await?;
+        .await
+        .map_err(|e| self.explain_truncation(e, request))?;
 
         let byte_stream = response.bytes_stream();
         let stream = OllamaNdjsonStream::new(byte_stream);
@@ -2229,6 +2313,154 @@ mod tests {
             extra: serde_json::Value::Null,
             request_timeout_secs: None,
         }
+    }
+
+    // ─── the overflow that reports itself as a message-shape problem ───────
+
+    /// The whole point of the rewrite: a request that carried a user turn, and
+    /// a server that says it received none, is a request that was truncated.
+    #[tokio::test]
+    async fn an_overflowed_request_is_reported_as_a_size_error() {
+        let url = spawn_mock_server(
+            500,
+            "Internal Server Error",
+            br#"{"error":"no user query found in messages"}"#,
+        )
+        .await;
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
+
+        let shown = provider
+            .infer(&mock_request())
+            .await
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            shown.starts_with("Token limit exceeded:"),
+            "the size is what the operator can act on, not the shape: {shown}"
+        );
+        assert!(
+            !shown.contains("no user query"),
+            "and Ollama's own wording is what sent two investigations wrong: {shown}"
+        );
+    }
+
+    /// Retrying an oversized conversation sends the same oversized conversation.
+    /// The unrewritten `500` reads as transient and would be retried on backoff.
+    #[test]
+    fn a_size_error_is_not_retried() {
+        assert!(
+            !ProviderError::TokenLimitExceeded {
+                used: 33_000,
+                max: 32_768
+            }
+            .is_transient(),
+            "no backoff makes an oversized request fit"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_overflowed_stream_request_is_reported_as_a_size_error() {
+        let url = spawn_mock_server(
+            500,
+            "Internal Server Error",
+            br#"{"error":"no user query found in messages"}"#,
+        )
+        .await;
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
+
+        let shown = provider
+            .infer_stream(&mock_request())
+            .await
+            .err()
+            .map_or(String::new(), |e| e.to_string());
+
+        assert!(
+            shown.starts_with("Token limit exceeded:"),
+            "streaming overflows the same way and should report it the same: {shown}"
+        );
+    }
+
+    /// When the conversation really carries no user turn, Ollama is describing
+    /// what it received and there is nothing to reinterpret.
+    #[test]
+    fn a_conversation_with_no_user_turn_keeps_ollamas_own_words() {
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
+        let mut request = mock_request();
+        request.messages[0].role = "assistant".to_string();
+        let original = ProviderError::ApiError("HTTP 500: no user query found in messages".into());
+
+        let kept = provider.explain_truncation(original, &request).to_string();
+
+        assert!(
+            kept.contains("no user query found"),
+            "the message is accurate here, so it survives: {kept}"
+        );
+    }
+
+    /// Every part of the request is charged for, including the two that no
+    /// region holds: the tool schemas and the tool results.
+    #[test]
+    fn the_size_estimate_counts_everything_the_request_carries() {
+        let mut request = mock_request();
+        request.system = vec![crate::provider::SystemBlock {
+            text: "s".repeat(400),
+            cache_hint: leviath_core::CacheHint::Never,
+            region: String::new(),
+            volatility: leviath_core::Volatility::default(),
+        }];
+        request.messages = vec![crate::provider::Message {
+            role: "user".to_string(),
+            content: crate::MessageContent::Blocks(vec![
+                crate::ContentBlock::Text {
+                    text: "t".repeat(400),
+                },
+                crate::ContentBlock::ToolUse {
+                    id: "1".to_string(),
+                    name: "read_files".to_string(),
+                    input: serde_json::json!({"path": "x"}),
+                    thought_signature: None,
+                },
+                crate::ContentBlock::ToolResult {
+                    tool_use_id: "1".to_string(),
+                    content: "r".repeat(400),
+                    is_error: false,
+                },
+            ]),
+            cache_breakpoint: false,
+        }];
+        request.tools = vec![crate::provider::Tool {
+            name: "read_files".to_string(),
+            description: "d".repeat(400),
+            parameters: serde_json::json!({"type": "object"}),
+        }];
+
+        let counted = estimated_request_tokens(&request);
+
+        // 400 bytes at four bytes a token is 100 each, from four separate parts
+        // of the request; the ids and schemas add the rest.
+        assert!(
+            counted > 400,
+            "the system block, the text, the result and the schema all count: {counted}"
+        );
+    }
+
+    /// A plain-text message is the other content shape, and it is what every
+    /// short conversation is made of.
+    #[test]
+    fn the_size_estimate_reads_plain_text_messages_too() {
+        let mut request = mock_request();
+        request.messages[0].content = crate::MessageContent::Text("x".repeat(400));
+
+        assert!(estimated_request_tokens(&request) >= 100);
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -609,6 +609,9 @@ impl ContextWindow {
 
         let mut system_blocks = Vec::new();
         let mut messages: Vec<leviath_providers::Message> = Vec::new();
+        // Messages a custom region rendered. Held apart from the conversation
+        // and spliced in front of it after the loop (issue #486).
+        let mut preamble: Vec<leviath_providers::Message> = Vec::new();
         // One entry per `UntilChanged` system block, in assembly order, holding
         // the newest entry timestamp of the region that produced it. Feeds the
         // cache-breakpoint split after the sort.
@@ -849,7 +852,10 @@ impl ContextWindow {
                         },
                         crate::custom_region::RenderSink {
                             system_blocks: &mut system_blocks,
-                            messages: &mut messages,
+                            // Not into the conversation directly: wherever this
+                            // region sits in the manifest, what it renders comes
+                            // before the dialogue. See the splice below.
+                            messages: &mut preamble,
                         },
                     );
                 }
@@ -892,6 +898,29 @@ impl ContextWindow {
                     volatile_recency.push(newest);
                 }
             }
+        }
+
+        // ── The conversation ends the request ────────────────────────────
+        //
+        // A model treats the end of its input as "now", and for an agent the
+        // thing that is now is the dialogue it is having. Every other region is
+        // reference material, however recently it was written.
+        //
+        // Only a custom region can render into the conversation at all, and it
+        // rendered wherever its author happened to declare it - so a region
+        // declared after the conversation put its contents *behind* the last
+        // user turn. On a small region that is untidy; on one holding a document
+        // corpus it replaces the dialogue in the position the model weighs most
+        // heavily, and the agent stops behaving like it is in a conversation
+        // (issue #486).
+        //
+        // Splicing rather than sorting: a region declared before the
+        // conversation already rendered in front of it and stays exactly where
+        // it was, so this changes nothing for a blueprint that was already
+        // ordered sensibly.
+        if !preamble.is_empty() {
+            let conversation = std::mem::replace(&mut messages, preamble);
+            messages.extend(conversation);
         }
 
         // ── Sort system blocks for optimal prefix caching ────────────────

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -2493,6 +2493,135 @@ mod tests {
         assert_eq!(assembled.messages[3].content.as_text(), "Now fix the bug");
     }
 
+    // ─── the conversation ends the request (issue #486) ──────────────────
+
+    /// A custom region is the only kind that can render into the conversation,
+    /// and it used to render at whatever position its author declared it - so
+    /// one declared after the conversation put its contents behind the last
+    /// user turn. With a document corpus in that region, the thing sitting in
+    /// the position the model weighs most heavily stopped being the dialogue.
+    #[test]
+    fn a_custom_region_declared_after_the_conversation_still_renders_before_it() {
+        let mut window = ContextWindow::new(100_000);
+
+        let mut conversation = Region::new(
+            "conversation".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 50,
+                eviction_strategy: Default::default(),
+            },
+            50_000,
+        );
+        conversation
+            .add_typed_entry(
+                "find the conflicts".to_string(),
+                10,
+                leviath_core::EntryKind::UserMessage,
+            )
+            .unwrap();
+        conversation
+            .add_typed_entry(
+                "keep going".to_string(),
+                10,
+                leviath_core::EntryKind::UserMessage,
+            )
+            .unwrap();
+        window.add_region(conversation);
+
+        let mut corpus = Region::new(
+            "corpus".to_string(),
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent: false,
+            },
+            10_000,
+        );
+        corpus.add_entry("x".to_string(), 1).unwrap();
+        window.add_region(corpus);
+        window.region_scripts.insert(
+            "s.rhai".to_string(),
+            std::sync::Arc::new(
+                leviath_scripting::region_hook::compile(
+                    "s.rhai",
+                    r#"fn render(ctx) {
+                        #{ messages: [ #{ role: "user", content: "REFERENCE" } ] }
+                    }"#,
+                )
+                .unwrap(),
+            ),
+        );
+
+        let assembled = window.assemble();
+
+        let texts: Vec<String> = assembled
+            .messages
+            .iter()
+            .map(|m| m.content.as_text())
+            .collect();
+        assert_eq!(
+            texts,
+            vec!["REFERENCE", "find the conflicts", "keep going"],
+            "reference material renders in front of the dialogue, never behind it"
+        );
+    }
+
+    /// The same splice must not disturb a blueprint that was already ordered
+    /// sensibly - a custom region declared *before* the conversation was
+    /// already rendering in front of it and stays exactly where it was.
+    #[test]
+    fn a_custom_region_declared_before_the_conversation_does_not_move() {
+        let mut window = ContextWindow::new(100_000);
+
+        let mut corpus = Region::new(
+            "corpus".to_string(),
+            RegionKind::Custom {
+                script: "s.rhai".to_string(),
+                persistent: false,
+            },
+            10_000,
+        );
+        corpus.add_entry("x".to_string(), 1).unwrap();
+        window.add_region(corpus);
+        window.region_scripts.insert(
+            "s.rhai".to_string(),
+            std::sync::Arc::new(
+                leviath_scripting::region_hook::compile(
+                    "s.rhai",
+                    r#"fn render(ctx) {
+                        #{ messages: [ #{ role: "user", content: "REFERENCE" } ] }
+                    }"#,
+                )
+                .unwrap(),
+            ),
+        );
+
+        let mut conversation = Region::new(
+            "conversation".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 50,
+                eviction_strategy: Default::default(),
+            },
+            50_000,
+        );
+        conversation
+            .add_typed_entry(
+                "find the conflicts".to_string(),
+                10,
+                leviath_core::EntryKind::UserMessage,
+            )
+            .unwrap();
+        window.add_region(conversation);
+
+        let assembled = window.assemble();
+
+        let texts: Vec<String> = assembled
+            .messages
+            .iter()
+            .map(|m| m.content.as_text())
+            .collect();
+        assert_eq!(texts, vec!["REFERENCE", "find the conflicts"]);
+    }
+
     // ─── assemble() "Begin." fallback ─────────────────────────────────────
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/calibration.rs
+++ b/crates/leviath-runtime/src/pipeline/calibration.rs
@@ -1,0 +1,286 @@
+//! Correcting the window's estimate against what the provider actually charged.
+//!
+//! The context window sizes everything it holds with
+//! [`leviath_core::estimate_tokens`], which is bytes divided by four. That is a
+//! guess, and it is a guess in a place where being wrong is expensive: region
+//! budgets, the eviction trigger and the output cap are all decided against it,
+//! and on a provider whose window is a hard ceiling the arithmetic being a few
+//! percent light is the difference between a run that finishes and a run that
+//! dies.
+//!
+//! The guess is also correctable, because every response says what the request
+//! really cost. `prompt_tokens` comes back from the server's own tokenizer on
+//! every call and is already journaled. Comparing it against what the window
+//! believed the same request would cost gives the drift directly, so the
+//! runtime does not have to guess better - it only has to listen.
+//!
+//! What is measured here is deliberately end-to-end rather than a pure
+//! tokenizer ratio: the reported figure covers the tool schemas and the hint
+//! blocks as well as the regions, and those are just as real. One number that
+//! maps "what the window thinks it holds" onto "what the provider will charge"
+//! is what the eviction trigger needs, and it is what this produces.
+//!
+//! Two properties keep this from being a trade:
+//!
+//! * It only ever tightens. A provider that charges less than the estimate -
+//!   which is the common case, since `len()` counts bytes and any non-ASCII
+//!   text inflates the estimate - leaves the factor at one and changes nothing
+//!   at all. Nobody's usable context shrinks unless their provider was measured
+//!   charging more than the runtime believed.
+//! * It only engages on measured evidence. There is no margin here, no
+//!   guessed percentage held back from every workload on the chance that some
+//!   of them drift. Until a call is observed drifting, the arithmetic is exactly
+//!   what it was.
+//!
+//! Issue #485: a 27B model pinned to `num_ctx 32768` assembled 32,497 real
+//! tokens on a Python-heavy corpus while the estimator believed it was inside
+//! the region budgets. The next call appended three more read results, crossed
+//! the window, and Ollama front-truncated from the start - taking the last user
+//! turn with it and answering `no user query found in messages`, which names
+//! neither the size nor the truncation.
+
+use bevy_ecs::prelude::Component;
+
+/// The largest correction that will be applied, as a multiple of the estimate.
+///
+/// A tokenizer that disagrees with bytes-over-four by more than this is not
+/// drifting, it is measuring something else - an image part, or a schema the
+/// request carries but the window never saw - and shrinking the usable window
+/// to a quarter on the strength of one such call would be its own outage. The
+/// cap keeps a single anomalous response from collapsing a run that is
+/// otherwise fine.
+const MAX_CALIBRATION: f64 = 4.0;
+
+/// What the window believed the request just dispatched would cost.
+///
+/// Written at dispatch and read when the response lands, which is the only
+/// place both halves of the comparison exist at once. Kept as its own component
+/// rather than folded into [`PromptCalibration`] because dispatch overwrites it
+/// wholesale on every call while the calibration accumulates across them.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct PromptEstimate(pub usize);
+
+/// How far this agent's estimate falls short of what its provider charges.
+///
+/// One factor per agent rather than per model: an agent's stages can name
+/// different models, but they share a window, and it is the window's arithmetic
+/// being corrected. A stage that moves to a model with a friendlier tokenizer
+/// keeps the tighter factor, which costs it some headroom and cannot cost it a
+/// run.
+#[derive(Component, Debug, Clone, Copy)]
+pub struct PromptCalibration {
+    /// Reported over estimated, at the highest yet observed, never below one.
+    factor: f64,
+}
+
+impl Default for PromptCalibration {
+    fn default() -> Self {
+        Self { factor: 1.0 }
+    }
+}
+
+impl PromptCalibration {
+    /// The correction to apply to an estimate, as a multiplier of at least one.
+    pub fn factor(&self) -> f64 {
+        self.factor
+    }
+
+    /// Fold in one call's reported cost against what was estimated for it.
+    ///
+    /// The high-water mark rather than an average or a decay. The failure being
+    /// prevented is absorbing - a run that overflows a hard window dies, and
+    /// dies again on every retry, because the content that overflowed is still
+    /// in the window. The failure being risked by holding the maximum is that
+    /// eviction fires earlier than it strictly had to, which is a mechanism
+    /// that already runs on every long run and drops the regions marked
+    /// droppable first. Those are not the same size of mistake.
+    pub fn observe(&mut self, estimated: usize, reported: usize) {
+        // A call with nothing to compare says nothing. Zero estimated would
+        // divide by zero; zero reported is a provider that did not report usage
+        // at all, and reading that as "this request was free" would drive the
+        // factor down - except that it cannot, because the factor only rises.
+        if estimated == 0 || reported == 0 {
+            return;
+        }
+        let observed = reported as f64 / estimated as f64;
+        if observed > self.factor {
+            self.factor = observed.min(MAX_CALIBRATION);
+        }
+    }
+}
+
+/// The factor to apply, for an agent that may not have been calibrated yet.
+///
+/// Absent means an agent spawned before this existed, or one in a test that
+/// builds its components by hand. Both should behave exactly as they did.
+pub(crate) fn factor_of(calibration: Option<&PromptCalibration>) -> f64 {
+    calibration.map_or(1.0, PromptCalibration::factor)
+}
+
+/// What `estimated` tokens are really expected to cost.
+///
+/// Rounded up, so the correction is never rounded away on a small region.
+pub(crate) fn calibrated_tokens(
+    estimated: usize,
+    calibration: Option<&PromptCalibration>,
+) -> usize {
+    let factor = factor_of(calibration);
+    if factor <= 1.0 {
+        return estimated;
+    }
+    // f64 carries every usize a context window can hold without loss, and the
+    // factor is bounded by MAX_CALIBRATION, so the product cannot leave range.
+    (estimated as f64 * factor).ceil() as usize
+}
+
+/// The fill threshold that means the same thing in real tokens as `base` did in
+/// estimated ones.
+///
+/// Scaling the trigger rather than the window's `max_tokens`: the region
+/// budgets were resolved against `max_tokens` at spawn, and moving it under a
+/// live window would leave regions retroactively over budget. The threshold is
+/// read fresh on every tick and belongs to nothing else.
+pub(crate) fn calibrated_threshold(base: f32, calibration: Option<&PromptCalibration>) -> f32 {
+    let factor = factor_of(calibration);
+    if factor <= 1.0 {
+        return base;
+    }
+    base / factor as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_uncalibrated_agent_changes_nothing() {
+        assert_eq!(factor_of(None), 1.0);
+        assert_eq!(calibrated_tokens(1000, None), 1000);
+        assert_eq!(calibrated_threshold(0.9, None), 0.9);
+    }
+
+    #[test]
+    fn a_fresh_calibration_changes_nothing_either() {
+        let cal = PromptCalibration::default();
+        assert_eq!(cal.factor(), 1.0);
+        assert_eq!(calibrated_tokens(1000, Some(&cal)), 1000);
+        assert_eq!(calibrated_threshold(0.9, Some(&cal)), 0.9);
+    }
+
+    /// The reporter's numbers: a window that believed it held 29,491 and was
+    /// charged 32,497 for it.
+    #[test]
+    fn a_provider_that_charges_more_than_estimated_tightens_the_window() {
+        let mut cal = PromptCalibration::default();
+        cal.observe(29_491, 32_497);
+
+        assert!(cal.factor() > 1.10, "measured drift is about 10%");
+        assert!(cal.factor() < 1.11);
+        // Eviction has to start early enough that the freed space arrives
+        // before the real window does.
+        let threshold = calibrated_threshold(0.9, Some(&cal));
+        assert!(threshold < 0.82, "0.9 of a window 10% larger than believed");
+        assert_eq!(calibrated_tokens(10_000, Some(&cal)), 11_020);
+    }
+
+    /// The common case. `estimate_tokens` counts bytes, so any non-ASCII text
+    /// reads as larger than it is charged - and nothing about that needs fixing.
+    #[test]
+    fn a_provider_that_charges_less_than_estimated_is_left_alone() {
+        let mut cal = PromptCalibration::default();
+        cal.observe(10_000, 6_000);
+
+        assert_eq!(cal.factor(), 1.0);
+        assert_eq!(calibrated_tokens(10_000, Some(&cal)), 10_000);
+        assert_eq!(calibrated_threshold(0.9, Some(&cal)), 0.9);
+    }
+
+    #[test]
+    fn the_correction_holds_its_high_water_mark() {
+        let mut cal = PromptCalibration::default();
+        cal.observe(1_000, 1_300);
+        cal.observe(1_000, 1_050);
+
+        let factor = cal.factor();
+        assert!(
+            (factor - 1.3).abs() < 1e-9,
+            "a friendlier call does not forget the drift: {factor}"
+        );
+    }
+
+    #[test]
+    fn one_anomalous_call_cannot_collapse_the_window() {
+        let mut cal = PromptCalibration::default();
+        cal.observe(1_000, 100_000);
+
+        assert_eq!(cal.factor(), MAX_CALIBRATION);
+    }
+
+    #[test]
+    fn a_call_with_nothing_to_compare_is_ignored() {
+        let mut cal = PromptCalibration::default();
+        cal.observe(0, 5_000);
+        cal.observe(5_000, 0);
+
+        assert_eq!(cal.factor(), 1.0);
+    }
+
+    #[test]
+    fn the_estimate_component_carries_what_was_believed() {
+        let estimate = PromptEstimate(4_096);
+        assert_eq!(estimate.0, 4_096);
+        assert_eq!(format!("{estimate:?}"), "PromptEstimate(4096)");
+    }
+
+    /// The end the whole thing exists for, on the reporter's own numbers: a
+    /// 32,768 window and an estimator running about 10% light.
+    ///
+    /// The eviction threshold exists to leave a margin between "nearly full"
+    /// and "over the window", and 0.9 of 32,768 is meant to be 3,277 tokens of
+    /// it. Measured against the real tokenizer that margin is 269 - less than a
+    /// single tool result, so the very next append crosses the window whatever
+    /// eviction does. The threshold had not stopped working; it was being
+    /// applied to a number that was not the one that mattered.
+    ///
+    /// The 32,499 this computes is the same figure the reporter's journal
+    /// recorded for the last call that succeeded, which is the corroboration
+    /// that the drift is what it looks like.
+    #[test]
+    fn eviction_leaves_room_to_evict_into_rather_than_a_sliver() {
+        const WINDOW: usize = 32_768;
+        const DRIFT: f64 = 1.102;
+        /// A read result landing in the window, which is what the run appended
+        /// next.
+        const ONE_TOOL_RESULT: usize = 1_000;
+
+        let real = |estimated: usize| (estimated as f64 * DRIFT) as usize;
+        let headroom_at = |threshold: f32| {
+            let trip = (WINDOW as f32 * threshold) as usize;
+            WINDOW.saturating_sub(real(trip))
+        };
+
+        let uncalibrated = headroom_at(0.9);
+        assert!(
+            uncalibrated < ONE_TOOL_RESULT,
+            "the bug: {uncalibrated} real tokens of margin, and the next append is larger"
+        );
+
+        let mut cal = PromptCalibration::default();
+        let believed = WINDOW / 2;
+        cal.observe(believed, real(believed));
+        let calibrated = headroom_at(calibrated_threshold(0.9, Some(&cal)));
+        assert!(
+            calibrated > ONE_TOOL_RESULT * 3,
+            "the fix: {calibrated} real tokens of margin, which eviction can work with"
+        );
+    }
+
+    #[test]
+    fn a_calibration_is_inspectable() {
+        let mut cal = PromptCalibration::default();
+        cal.observe(1_000, 1_500);
+        let shown = format!("{cal:?}");
+        assert!(shown.contains("1.5"), "the factor is legible: {shown}");
+        assert_eq!(cal.factor(), PromptCalibration::clone(&cal).factor());
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -68,6 +68,7 @@ type CompactionQuery = (
     &'static AgentState,
     &'static mut ContextWindow,
     &'static CompactionSettings,
+    Option<&'static crate::pipeline::PromptCalibration>,
 );
 
 /// Compaction-dispatch system: for each `ReadyToInfer` agent with
@@ -86,12 +87,17 @@ pub fn dispatch_compaction(
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
-    for (entity, state, mut window, settings) in agents.iter_mut() {
+    for (entity, state, mut window, settings, calibration) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         if state.status != AgentStatus::Active {
             continue; // paused / waiting / cancelled - don't start new work
         }
-        if !window.needs_eviction(EVICTION_THRESHOLD) {
+        // Against the corrected estimate, not the raw one. The threshold is
+        // there to leave room between "nearly full" and "over the window", and
+        // an estimate measured running light spends that room without ever
+        // reporting it (issue #485).
+        let threshold = crate::pipeline::calibrated_threshold(EVICTION_THRESHOLD, calibration);
+        if !window.needs_eviction(threshold) {
             continue; // under threshold - nothing to do
         }
         let target_free = window.max_tokens / 10;

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -75,18 +75,24 @@ pub(crate) fn hint_blocks(
     blocks
 }
 
-/// What the previous request's system prefix looked like.
+/// What earlier calls in this run taught us, carried into the next request.
 ///
-/// The whole-prefix digest and the per-block digests answer different
-/// questions ("did anything move", and "how far did it hold still"), and they
-/// are only ever read together, so they travel together rather than as two
-/// adjacent parameters of different shapes that a caller could transpose.
+/// Three pieces of evidence with one thing in common: none of them can be
+/// derived from the window as it stands, they exist only because a previous
+/// request was sent and answered. The whole-prefix digest and the per-block
+/// digests answer different questions ("did anything move", and "how far did it
+/// hold still"); the calibration answers a third ("what did the last one really
+/// cost"). They are only ever read together, so they travel together rather
+/// than as adjacent parameters of similar shapes a caller could transpose.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct PriorPrefix {
+pub(crate) struct PriorCalls {
     /// Digest of the whole prefix, or `None` before the first request.
     pub(crate) system_hash: Option<u64>,
     /// Per-block digests, empty before the first request.
     pub(crate) block_hashes: Vec<u64>,
+    /// How far the estimate ran under what the provider charged, or `None`
+    /// before anything was measured (issue #485).
+    pub(crate) calibration: Option<crate::pipeline::PromptCalibration>,
 }
 
 /// Build the [`InferenceRequest`] for an agent from its context window + stage
@@ -103,11 +109,12 @@ pub(crate) fn build_request(
     provider: &Arc<dyn Provider>,
     stage_name: &str,
     stage_iterations: usize,
-    prior: PriorPrefix,
+    prior: PriorCalls,
 ) -> (InferenceRequest, u64, Vec<u64>) {
-    let PriorPrefix {
+    let PriorCalls {
         system_hash: previous_system_hash,
         block_hashes: previous_block_hashes,
+        calibration,
     } = prior;
     let assembled = window.assemble_with_meta(&crate::custom_region::AssembleMeta {
         stage_name: stage_name.to_string(),
@@ -118,7 +125,12 @@ pub(crate) fn build_request(
     });
     let system_hash = assembled.system_hash;
     let block_hashes = assembled.block_hashes.clone();
-    let remaining = window.max_tokens.saturating_sub(window.current_tokens);
+    // What the input really costs, not what the byte estimate said it would.
+    // On a provider whose window is a hard ceiling the two share it, so an
+    // output cap sized against an optimistic input is how a request that fit
+    // when it was assembled stops fitting halfway through the answer.
+    let spent = crate::pipeline::calibrated_tokens(window.current_tokens, calibration.as_ref());
+    let remaining = window.max_tokens.saturating_sub(spent);
     let caps = provider.capabilities(&stage.model);
     let output_cap = config
         .and_then(|c| c.max_output_tokens)
@@ -251,6 +263,7 @@ type InferenceQuery = (
     Option<&'static DispatchStall>,
     Option<&'static SystemPrefixHash>,
     Option<&'static SystemBlockHashes>,
+    Option<&'static crate::pipeline::PromptCalibration>,
 );
 
 /// The system prefix the last request sent, as a digest.
@@ -312,6 +325,7 @@ pub fn dispatch_inference(
             stalled,
             prefix,
             block_prefix,
+            calibration,
         )| {
             crate::tick_scope::run_agent_parallel(entity, &par_commands, &mut || {
                 if state.status != AgentStatus::Active {
@@ -367,9 +381,10 @@ pub fn dispatch_inference(
                     &provider,
                     &state.current_stage,
                     progress.map(|p| p.iterations).unwrap_or(0),
-                    PriorPrefix {
+                    PriorCalls {
                         system_hash: prefix.map(|p| p.0),
                         block_hashes: block_prefix.map(|b| b.0.clone()).unwrap_or_default(),
+                        calibration: calibration.copied(),
                     },
                 );
                 // Remembered for the next request, which is the only way the
@@ -381,6 +396,13 @@ pub fn dispatch_inference(
                     commands
                         .entity(entity)
                         .insert(SystemBlockHashes(block_hashes.clone()));
+                    // What the window believes this call will cost. The response
+                    // says what it really cost, and the two together are the
+                    // only measurement of the estimator's drift the runtime
+                    // gets (issue #485).
+                    commands
+                        .entity(entity)
+                        .insert(crate::pipeline::PromptEstimate(window.current_tokens));
                 });
                 let job = InferenceJob {
                     entity,

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -70,6 +70,8 @@ mod wedge;
 pub use wedge::*;
 mod circuit;
 pub use circuit::*;
+mod calibration;
+pub use calibration::*;
 
 // ─── Phase marker components (an agent is in exactly one) ────────────────────
 //

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -48,6 +48,8 @@ type InferenceQuery = (
     Option<&'static mut StageIoBuffer>,
     Option<&'static mut StageInference>,
     Option<&'static mut crate::telemetry::StageActivity>,
+    Option<&'static crate::pipeline::PromptEstimate>,
+    Option<&'static mut crate::pipeline::PromptCalibration>,
 );
 
 /// Inference-collect system: drain completed inferences and apply them. A
@@ -77,6 +79,8 @@ pub fn collect_inference(
             buffer,
             mut inference,
             activity,
+            estimate,
+            mut calibration,
         )) = agents.get_mut(outcome.entity)
         else {
             continue; // stale: agent cancelled/despawned since dispatch
@@ -184,6 +188,18 @@ pub fn collect_inference(
                     }
                     warn_if_context_is_running_away(rec, response.tokens_used.prompt_tokens);
                 }
+                // The provider just said what this request really cost. Against
+                // what the window believed it would cost, that is the only
+                // measurement of the estimator's drift there is - and on a
+                // provider whose window is a hard ceiling, drift is what
+                // decides whether the run finishes (issue #485).
+                calibrate(
+                    &mut commands,
+                    outcome.entity,
+                    calibration.as_deref_mut(),
+                    estimate,
+                    response.tokens_used.prompt_tokens,
+                );
                 // Buffer the readable output + a token line for the stage's logs.
                 if let Some(mut buffer) = buffer {
                     if !response.content.trim().is_empty() {
@@ -368,6 +384,34 @@ pub(crate) fn warn_if_context_is_running_away(
          re-sent on every call; check whether a region is accumulating without a cap \
          (`lev stages <run-id>` shows the per-region sizes)"
     );
+}
+
+/// Fold one call's real cost into the agent's estimator correction, creating
+/// the correction if this is its first measured call.
+///
+/// Split out because the insert-if-absent has to reach `Commands` while the
+/// update does not, and the collect loop is long enough already. An agent with
+/// no [`PromptEstimate`] never dispatched through the inference lane - a
+/// compaction reply, or a test driving the outcome channel directly - and there
+/// is nothing to compare, so it is left alone.
+pub(crate) fn calibrate(
+    commands: &mut Commands,
+    entity: Entity,
+    calibration: Option<&mut crate::pipeline::PromptCalibration>,
+    estimate: Option<&crate::pipeline::PromptEstimate>,
+    reported: usize,
+) {
+    let Some(estimate) = estimate else {
+        return;
+    };
+    match calibration {
+        Some(calibration) => calibration.observe(estimate.0, reported),
+        None => {
+            let mut fresh = crate::pipeline::PromptCalibration::default();
+            fresh.observe(estimate.0, reported);
+            commands.entity(entity).insert(fresh);
+        }
+    }
 }
 
 /// Per-stage progress counters, reset when an agent enters a stage.

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1447,6 +1447,119 @@ fn collect_inference_buffers_output_token_line_and_stage_tokens() {
     assert_eq!(led.0[1].cached_tokens, 2);
 }
 
+// ─── estimator calibration (issue #485) ───
+//
+// The arithmetic is unit-tested in `pipeline::calibration`. What these cover is
+// the wiring, which is the half that can silently do nothing: whether dispatch
+// really records what it believed, whether collect really compares it against
+// what came back, and whether the compaction gate really reads the result.
+
+#[tokio::test]
+async fn dispatch_records_what_it_believed_the_request_would_cost() {
+    let (mut world, _rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
+    let e = world
+        .spawn((
+            agent_state(),
+            window(),
+            stage("m", vec![], None),
+            ReadyToInfer,
+        ))
+        .id();
+    let believed = world
+        .get::<ContextWindow>(e)
+        .expect("a window")
+        .current_tokens;
+
+    run(&mut world);
+
+    let recorded = world.get::<PromptEstimate>(e).map(|p| p.0);
+    assert_eq!(
+        recorded,
+        Some(believed),
+        "without this the response has nothing to be compared against"
+    );
+}
+
+#[test]
+fn collect_learns_the_drift_between_what_was_believed_and_what_was_charged() {
+    let (mut world, tx) = world_with_results();
+    let e = world
+        .spawn((agent_state(), AwaitingInference, PromptEstimate(1_000)))
+        .id();
+    let mut response = resp("done");
+    response.tokens_used.prompt_tokens = 1_200;
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Ok(response),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    let factor = world
+        .get::<PromptCalibration>(e)
+        .map_or(0.0, PromptCalibration::factor);
+    assert!(
+        (factor - 1.2).abs() < 1e-9,
+        "20% under, measured off the wire rather than guessed: {factor}"
+    );
+}
+
+#[test]
+fn collect_folds_a_worse_call_into_an_existing_calibration() {
+    let (mut world, tx) = world_with_results();
+    let mut existing = PromptCalibration::default();
+    existing.observe(1_000, 1_100);
+    let e = world
+        .spawn((
+            agent_state(),
+            AwaitingInference,
+            PromptEstimate(1_000),
+            existing,
+        ))
+        .id();
+    let mut response = resp("done");
+    response.tokens_used.prompt_tokens = 1_400;
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Ok(response),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    let factor = world
+        .get::<PromptCalibration>(e)
+        .map_or(0.0, PromptCalibration::factor);
+    assert!(
+        (factor - 1.4).abs() < 1e-9,
+        "the agent keeps one factor rather than a fresh one per call: {factor}"
+    );
+}
+
+/// An agent that never dispatched through the inference lane - a test driving
+/// the outcome channel directly, or a run predating this - has nothing to
+/// compare and must be left exactly as it was.
+#[test]
+fn collect_calibrates_nothing_when_there_was_no_estimate() {
+    let (mut world, tx) = world_with_results();
+    let e = world.spawn((agent_state(), AwaitingInference)).id();
+    let mut response = resp("done");
+    response.tokens_used.prompt_tokens = 9_999;
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Ok(response),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert!(world.get::<PromptCalibration>(e).is_none());
+}
+
 // ─── abort_terminal_work ───
 
 fn run_abort(world: &mut World) {

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -116,7 +116,7 @@ fn build_request_threads_stage_meta_into_custom_region_render() {
         &provider(true, 500),
         "implement",
         4,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert!(
@@ -148,7 +148,7 @@ fn build_request_filters_tools_and_uses_config_overrides() {
         &provider(true, 9999),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert_eq!(req.tools.len(), 1); // filtered to "keep"
@@ -175,7 +175,7 @@ fn build_request_threads_per_stage_timeout() {
         &provider(true, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert_eq!(req.request_timeout_secs, Some(120));
@@ -187,7 +187,7 @@ fn build_request_threads_per_stage_timeout() {
         &provider(true, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert_eq!(req_none.request_timeout_secs, None);
@@ -213,7 +213,7 @@ fn build_request_passes_through_extra_params() {
         &provider(true, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert_eq!(req.extra, serde_json::json!({ "top_p": 0.9 }));
@@ -247,7 +247,7 @@ fn build_request_prepends_batch_hint_when_enabled() {
         &provider(true, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     // The hint is prepended ahead of the stage's own system block(s).
@@ -283,7 +283,7 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
         &provider(true, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert!(!req.system.is_empty());
@@ -296,7 +296,7 @@ fn build_request_omits_batch_hint_when_disabled_or_absent() {
         &provider(true, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert!(!req_none.system.is_empty());
@@ -386,7 +386,7 @@ fn build_request_puts_the_hints_ahead_of_the_stage_context() {
         &provider(true, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     let hints = hint_blocks(Some(&cfg), &si.tools, std::env::consts::OS);
@@ -411,7 +411,7 @@ fn build_request_all_tools_default_temperature_no_config() {
         &provider(true, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert_eq!(req.tools.len(), 2);
@@ -429,7 +429,7 @@ fn build_request_empty_filter_is_all_and_no_temperature_when_unsupported() {
         &provider(false, 500),
         "test-stage",
         0,
-        crate::pipeline::inference::PriorPrefix::default(),
+        crate::pipeline::inference::PriorCalls::default(),
     )
     .0;
     assert_eq!(req.tools.len(), 1);

--- a/docs/content/rhai-regions.md
+++ b/docs/content/rhai-regions.md
@@ -93,6 +93,11 @@ Providers reject a request where a tool call has no matching result, or the othe
 strips any unpaired tool block before sending, so a script with a bug in it cannot produce a request
 the provider will refuse.
 
+Emitted messages render **in front of the live conversation**, wherever the region is declared. A
+model reads the end of its input as "now", and for an agent that is the dialogue it is having, so
+the conversation always ends the request. Declaring a region after the conversation to append a
+trailing reminder does not work; use a [nudge](/docs/stages) for that.
+
 `on_write(ctx)` is **optional**. It sees each entry headed into the region, with
 `ctx = { region, entry: { content, kind, tokens } }`. Return a string to replace the content (tokens
 re-estimated, kind preserved), `true` or `()` to accept unchanged, or `false` to drop the entry.


### PR DESCRIPTION
## The arithmetic

The context window sizes everything it holds with `estimate_tokens`, which is
bytes over four. Every decision the window makes is made against that number:
region budgets, the eviction trigger, the output cap.

On dense ASCII it reads about ten percent light. On a frontier model with a
262k window that is invisible. On a model pinned to `num_ctx 32768` it is fatal,
because there is no slack to absorb it and the failure is a silent front-
truncation rather than a 4xx.

The reporter's numbers make the mechanism exact. The last successful call was
charged 32,497 tokens on a 32,768 window. The 0.9 eviction threshold exists to
leave 3,277 tokens between "nearly full" and "over the window". Measured against
the real tokenizer it was leaving **269** - less than one tool result. The
threshold had not stopped working; it was being applied to a number that was not
the one that mattered.

Recomputing that from the drift figure alone lands on 32,499 against their
recorded 32,497, which is the corroboration that the drift is what it looks
like.

## The fix

The estimate does not have to get better. It has to be checked.

Every response already reports `prompt_tokens` from the server's own tokenizer.
The runtime now records what it believed a request would cost when it dispatches
one (`PromptEstimate`, written beside the existing prefix-hash bookkeeping) and
compares the two when the answer lands. The measured ratio scales the eviction
trigger and the output cap.

It is deliberately end-to-end rather than a pure tokenizer ratio. The reported
figure covers the tool schemas and the hint blocks as well as the regions, and
those are just as real - the tool schemas especially, since nothing in the
window holds them. One number mapping "what the window thinks it holds" onto
"what the provider will charge" is what the trigger actually needs.

**This does not shrink anyone's context on a guess.** Two properties:

* *It only ever tightens.* A provider charging less than estimated - which is
  every provider on text with any non-ASCII in it, since `len()` counts bytes -
  leaves the factor at one and changes nothing at all.
* *It only engages on measured evidence.* There is no safety margin here. The
  issue suggested holding back 5-10% on providers with hard windows; that would
  cost every workload some context against the chance that some of them drift.
  Until a call is observed drifting, the arithmetic is exactly what it was.

The correction is the high-water mark rather than an average. The failure being
prevented is absorbing - a run that overflows a hard window dies, and dies again
on retry, because the content that overflowed is still in the window. The
failure being risked is that eviction fires earlier than it strictly had to,
which is a mechanism that already runs on every long run. Those are not the same
size of mistake. It is capped at 4x so one anomalous response cannot collapse a
window on its own.

Scaling the *trigger* rather than the window's `max_tokens`: the region budgets
were resolved against `max_tokens` at spawn, and moving it under a live window
would leave regions retroactively over budget.

## The second layer

Ollama does not refuse an oversized request. It truncates from the front until
it fits, and when the last user turn is what falls off it answers `no user query
found in messages` - a message about the shape of the conversation, describing a
failure of its size. That sent two separate investigations after message-shape
bugs (#469, #475) before a wire capture settled it.

The rewrite's test is exact rather than a threshold: **if this request carried a
user message and the server says it received none, the server dropped it**, and
front-truncation is the only thing that drops it. A request that genuinely
carries no user turn keeps the original error, because then Ollama is telling
the truth.

Rewriting it also stops the retry loop. `500` reads as transient, so the
unrewritten error was retried on backoff - every attempt sending the same
oversized conversation to be truncated the same way. `TokenLimitExceeded` is
not transient.

## Coverage

Both touched crates back at 100%. The end-to-end test is the reporter's own
numbers: uncalibrated headroom at the trigger is smaller than one tool result,
calibrated headroom is more than three.

Closes #485
