### PR TITLE
fix(runtime): let a lifecycle region declare that it grows (#490), and unblock Dependabot CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,11 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
+    # Lifted to `env` because the `secrets` context is not available in a step's
+    # `if` - naming it there is a workflow validation error, which fails the run
+    # before a single job starts. `env` is available, and holds the same value.
+    env:
+      DOCS_SSG_TOKEN: ${{ secrets.DOCS_SSG_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
@@ -264,20 +269,20 @@ jobs:
       # site's repo is unreachable from those runs either way, and the push to main after
       # the merge runs this with the secret present.
       - name: Checkout leviath.dev (changelog contract)
-        if: ${{ secrets.DOCS_SSG_TOKEN != '' }}
+        if: env.DOCS_SSG_TOKEN != ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: GEMISIS/leviath.dev
           token: ${{ secrets.DOCS_SSG_TOKEN }}
           path: site
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        if: ${{ secrets.DOCS_SSG_TOKEN != '' }}
+        if: env.DOCS_SSG_TOKEN != ''
         with:
           node-version: 22
       # No npm ci: the checker and its parser import nothing but node:fs, so tsx on its
       # own is the whole dependency.
       - name: Check the changelog the site publishes from
-        if: ${{ secrets.DOCS_SSG_TOKEN != '' }}
+        if: env.DOCS_SSG_TOKEN != ''
         run: npx --yes tsx site/tools/check-changelog.ts CHANGELOG.md
 
   # Coverage runs on all three OSes and enforces a hard 100% on regions, lines,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,18 +256,28 @@ jobs:
       # version it cannot verify. Without this that failure lands on the website, after
       # merging, for somebody who was not editing the website. The checker is the same
       # parser the site uses, so there is one definition of the format rather than two.
+      #
+      # Skipped where the secret is not handed out. A PR opened by Dependabot, or from a
+      # fork, runs without repository secrets, so `token` arrives empty and the checkout
+      # fails the whole Docs job with `Input required and not supplied: token` - after the
+      # actual docs checks above have already passed. Nothing is lost by skipping: the
+      # site's repo is unreachable from those runs either way, and the push to main after
+      # the merge runs this with the secret present.
       - name: Checkout leviath.dev (changelog contract)
+        if: ${{ secrets.DOCS_SSG_TOKEN != '' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           repository: GEMISIS/leviath.dev
           token: ${{ secrets.DOCS_SSG_TOKEN }}
           path: site
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: ${{ secrets.DOCS_SSG_TOKEN != '' }}
         with:
           node-version: 22
       # No npm ci: the checker and its parser import nothing but node:fs, so tsx on its
       # own is the whole dependency.
       - name: Check the changelog the site publishes from
+        if: ${{ secrets.DOCS_SSG_TOKEN != '' }}
         run: npx --yes tsx site/tools/check-changelog.ts CHANGELOG.md
 
   # Coverage runs on all three OSes and enforces a hard 100% on regions, lines,
@@ -443,15 +453,6 @@ jobs:
           BASE: ${{ github.event.pull_request.base.sha }}
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Asked over the API rather than read from
-          # `github.event.pull_request.labels`, because a rerun replays the
-          # event payload it was given the first time. A maintainer who labels
-          # a PR after CI started would rerun this job, watch it report no
-          # labels at all, and have no way to clear the failure short of
-          # pushing a commit. The API answers for the PR as it is right now.
-          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels" --jq '[.[].name] | join(",")')
-          echo "Labels on this PR right now: ${LABELS:-(none)}"
-
           # Three dots, so this asks "what did the PR change" rather than "how
           # do these two trees differ". With two dots the diff also contains
           # everything main gained since the branch point, so any PR would fail
@@ -464,17 +465,33 @@ jobs:
           # added - and naming one path here would have let it through both the
           # measurement and this review gate at once.
           CHANGED=$(git diff --name-only "$BASE...$HEAD" | grep -E '(^|/)main\.rs$' || true)
-          if [ -n "$CHANGED" ]; then
-            case ",$LABELS," in
-              *,allow-main-rs-change,*)
-                echo "main.rs change approved via 'allow-main-rs-change' label: $CHANGED" ;;
-              *)
-                echo "::error::main.rs is the coverage-excluded bin entrypoint; changing it needs maintainer approval. Apply the 'allow-main-rs-change' label to override. Changed: $CHANGED"
-                exit 1 ;;
-            esac
-          else
+          if [ -z "$CHANGED" ]; then
             echo "main.rs unchanged."
+            exit 0
           fi
+
+          # Only asked once the answer can change the outcome. Reading labels
+          # needs a scope the token does not always have - a PR opened by
+          # Dependabot gets a restricted one and the call fails 422 - and a PR
+          # that never touched main.rs has no business failing on a permission
+          # it needed only to confirm it was already passing.
+          #
+          # Asked over the API rather than read from
+          # `github.event.pull_request.labels`, because a rerun replays the
+          # event payload it was given the first time. A maintainer who labels
+          # a PR after CI started would rerun this job, watch it report no
+          # labels at all, and have no way to clear the failure short of
+          # pushing a commit. The API answers for the PR as it is right now.
+          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels" --jq '[.[].name] | join(",")')
+          echo "Labels on this PR right now: ${LABELS:-(none)}"
+
+          case ",$LABELS," in
+            *,allow-main-rs-change,*)
+              echo "main.rs change approved via 'allow-main-rs-change' label: $CHANGED" ;;
+            *)
+              echo "::error::main.rs is the coverage-excluded bin entrypoint; changing it needs maintainer approval. Apply the 'allow-main-rs-change' label to override. Changed: $CHANGED"
+              exit 1 ;;
+          esac
 
   # Merging a version bump to main publishes an alpha within seconds, and a week
   # later that same commit is a permanent `vX.Y.Z` tag and an immutable set of
@@ -504,12 +521,6 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          # Read live rather than from the event payload, for the reason spelled
-          # out in `guard-main-rs`: a rerun replays the payload the run started
-          # with, so a label applied afterwards would be invisible.
-          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels" --jq '[.[].name] | join(",")')
-          echo "Labels on this PR right now: ${LABELS:-(none)}"
-
           # The merge base, not the base branch tip: comparing against the tip
           # would report a bump for every PR opened after someone else's release
           # landed on main.
@@ -524,6 +535,14 @@ jobs:
             echo "Workspace version unchanged at $after."
             exit 0
           fi
+
+          # Only asked once the answer can change the outcome; see
+          # `guard-main-rs` for why that ordering matters to a PR opened by
+          # Dependabot. Read live rather than from the event payload, because a
+          # rerun replays the payload the run started with, so a label applied
+          # afterwards would be invisible.
+          LABELS=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/labels" --jq '[.[].name] | join(",")')
+          echo "Labels on this PR right now: ${LABELS:-(none)}"
 
           case ",$LABELS," in
             *,allow-version-bump,*)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ same list.
 
 ## Unreleased
 
+- Changed: a `temporary` or `clearable` region declared `volatility = "grows"`
+  is now split and cached like any other growing region. Both kinds say when the
+  region is thrown away - one at stage exit, the other on demand - and nothing
+  about whether the contents hold still in between, but both were tagged
+  uncacheable on the strength of that name. Right at the boundary, wrong
+  everywhere else: a stage that reads a corpus into a `temporary` region and
+  then works through it for forty calls re-sent the whole corpus at full rate on
+  every one of them, which measured as 5.36M tokens across 46 calls and the
+  largest single cost line in that run. A region that declares nothing keeps
+  exactly the behaviour it had, so this only reaches a blueprint that asked for
+  it.
+
 - Fixed: the live conversation always ends the request. A custom region is the
   only kind whose `render` hook can emit conversation messages, and it emitted
   them at whatever position its author declared the region - so one declared

--- a/crates/leviath-runtime/src/components/block_cache.rs
+++ b/crates/leviath-runtime/src/components/block_cache.rs
@@ -101,6 +101,63 @@ pub(super) fn push_chunked(
     }
 }
 
+/// Push a region's entries as `[name]:` system blocks, split when the region
+/// declared that it grows.
+///
+/// The bracket label rather than [`super::context_window::labelled`]'s heading,
+/// because that is the shape these regions have always rendered with and the
+/// prompt is not the place to make a cosmetic change.
+pub(super) fn push_bracketed(
+    blocks: &mut Vec<leviath_providers::SystemBlock>,
+    region: &Region,
+    hint: leviath_core::CacheHint,
+) {
+    let entries: Vec<String> = region.content.iter().map(|e| e.content.clone()).collect();
+    let chunks = match region.volatility {
+        leviath_core::Volatility::Grows => append_only_chunks(&entries, CACHE_CHUNK_TOKENS),
+        _ => vec![entries.join("\n\n")],
+    };
+    for (index, chunk) in chunks.iter().enumerate() {
+        let text = match index {
+            0 => format!("[{}]:\n{}", region.name, chunk),
+            _ => format!("[{} continued]:\n{}", region.name, chunk),
+        };
+        blocks.push(leviath_providers::SystemBlock {
+            text,
+            cache_hint: hint,
+            volatility: region.volatility,
+            region: region.name.clone(),
+        });
+    }
+}
+
+/// The cache hint for a region whose kind describes when it is *thrown away*
+/// rather than how it changes.
+///
+/// `temporary` and `clearable` are lifecycle kinds: one is dropped at stage
+/// exit, the other on demand. Both used to be tagged `Never`, which reads that
+/// lifecycle as "this content never holds still" - and for the boundary it is
+/// right, since caching across a wholesale drop would buy nothing. Between
+/// those boundaries it is wrong. A stage that reads a corpus into a `temporary`
+/// region and then works through it for forty calls has an append-mostly region
+/// that changes at the tail, which is the shape chunking exists for; tagging it
+/// `Never` re-sent the whole corpus at full rate on every one of those calls
+/// (issue #490: 5.36M tokens across 46 calls, the largest cost line in the run).
+///
+/// The kind cannot answer this and the author can, so it is read from the
+/// declaration. `Rewritten` is the default, so a region that says nothing keeps
+/// exactly the behaviour it had.
+pub(super) fn lifecycle_cache_hint(
+    volatility: leviath_core::Volatility,
+) -> leviath_core::CacheHint {
+    match volatility {
+        leviath_core::Volatility::Rewritten => leviath_core::CacheHint::Never,
+        leviath_core::Volatility::Stable | leviath_core::Volatility::Grows => {
+            leviath_core::CacheHint::UntilChanged
+        }
+    }
+}
+
 /// A digest of one system block's text, for deciding what held still.
 /// Warn about a region that declared itself `stable` and then moved.
 ///
@@ -293,6 +350,119 @@ mod tests {
 
     fn entries(n: usize, each: &str) -> Vec<String> {
         (0..n).map(|i| format!("{i}:{each}")).collect()
+    }
+
+    // ─── lifecycle kinds (issue #490) ───────────────────────────────────────
+
+    fn lifecycle_region(
+        kind: RegionKind,
+        volatility: leviath_core::Volatility,
+        entry_count: usize,
+    ) -> Region {
+        let mut region = Region::new("corpus".to_string(), kind, 1_000_000);
+        region.volatility = volatility;
+        for i in 0..entry_count {
+            let body = format!("excerpt {i} {}", "word ".repeat(600));
+            region.add_entry(body, 750).unwrap();
+        }
+        region
+    }
+
+    /// A region that says nothing about how it moves keeps exactly the
+    /// behaviour it had: one block, uncacheable. This is what makes the change
+    /// safe to ship on by default - nobody who has not opted in is affected.
+    #[test]
+    fn an_undeclared_lifecycle_region_is_unchanged() {
+        for kind in [RegionKind::Temporary, RegionKind::Clearable] {
+            let region = lifecycle_region(kind, leviath_core::Volatility::Rewritten, 8);
+            let mut blocks = Vec::new();
+            push_bracketed(
+                &mut blocks,
+                &region,
+                lifecycle_cache_hint(region.volatility),
+            );
+
+            assert_eq!(blocks.len(), 1, "one block, as before");
+            assert_eq!(blocks[0].cache_hint, CacheHint::Never);
+            assert!(blocks[0].text.starts_with("[corpus]:\n"));
+        }
+    }
+
+    /// The fix. A corpus the author says accumulates gets interior boundaries
+    /// and a hint a marker can land on, so the settled head caches and only the
+    /// tail is re-sent.
+    #[test]
+    fn a_lifecycle_region_declared_grows_is_chunk_cacheable() {
+        let region = lifecycle_region(RegionKind::Temporary, leviath_core::Volatility::Grows, 12);
+        let mut blocks = Vec::new();
+        push_bracketed(
+            &mut blocks,
+            &region,
+            lifecycle_cache_hint(region.volatility),
+        );
+
+        let count = blocks.len();
+        assert!(
+            count > 1,
+            "a 12-entry corpus past the chunk budget splits: {count} blocks"
+        );
+        assert!(
+            blocks
+                .iter()
+                .all(|b| b.cache_hint == CacheHint::UntilChanged)
+        );
+        assert!(blocks[0].text.starts_with("[corpus]:\n"));
+        assert!(
+            blocks[1].text.starts_with("[corpus continued]:\n"),
+            "a split region still says which region it is"
+        );
+    }
+
+    /// Chunking must not change a single byte of what the model reads, headings
+    /// aside - the whole point is a cheaper way to send the same corpus.
+    #[test]
+    fn chunking_a_lifecycle_region_preserves_its_content() {
+        let grows = lifecycle_region(RegionKind::Temporary, leviath_core::Volatility::Grows, 9);
+        let whole = lifecycle_region(
+            RegionKind::Temporary,
+            leviath_core::Volatility::Rewritten,
+            9,
+        );
+        let mut split = Vec::new();
+        push_bracketed(&mut split, &grows, CacheHint::UntilChanged);
+        let mut one = Vec::new();
+        push_bracketed(&mut one, &whole, CacheHint::Never);
+
+        let strip = |text: &str| {
+            text.replace("[corpus continued]:\n", "")
+                .replace("[corpus]:\n", "")
+        };
+        let rejoined: String = split
+            .iter()
+            .map(|b| strip(&b.text))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        assert_eq!(rejoined, strip(&one[0].text));
+    }
+
+    /// The declaration is what decides, because the kind cannot: `temporary`
+    /// says when the region is thrown away, not whether it holds still between
+    /// those moments.
+    #[test]
+    fn the_hint_follows_the_declaration_not_the_kind() {
+        use leviath_core::Volatility;
+        assert_eq!(
+            lifecycle_cache_hint(Volatility::Rewritten),
+            CacheHint::Never
+        );
+        assert_eq!(
+            lifecycle_cache_hint(Volatility::Grows),
+            CacheHint::UntilChanged
+        );
+        assert_eq!(
+            lifecycle_cache_hint(Volatility::Stable),
+            CacheHint::UntilChanged
+        );
     }
 
     // ─── chunking ───────────────────────────────────────────────────────────

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -7,8 +7,8 @@
 //! questions to arrive with.
 
 use super::block_cache::{
-    CACHE_CHUNK_TOKENS, append_only_chunks, block_hash, block_sort_priority,
-    mark_recently_changed_run, push_chunked, system_prefix_hash, warn_on_unstable_declaration,
+    block_hash, block_sort_priority, lifecycle_cache_hint, mark_recently_changed_run,
+    push_bracketed, push_chunked, system_prefix_hash, warn_on_unstable_declaration,
 };
 use super::*;
 
@@ -781,59 +781,14 @@ impl ContextWindow {
 
                 // Compacting / Temporary / Clearable → system blocks
                 leviath_core::RegionKind::Compacting { .. } => {
-                    let entries = region
-                        .content
-                        .iter()
-                        .map(|e| e.content.clone())
-                        .collect::<Vec<_>>();
-                    // Split only when the region declared that it grows; see
-                    // `push_chunked` for why the kind cannot answer that.
-                    let chunks = match region.volatility {
-                        leviath_core::Volatility::Grows => {
-                            append_only_chunks(&entries, CACHE_CHUNK_TOKENS)
-                        }
-                        _ => vec![entries.join("\n\n")],
-                    };
-                    for (index, chunk) in chunks.iter().enumerate() {
-                        let text = match index {
-                            0 => format!("[{}]:\n{}", region.name, chunk),
-                            _ => format!("[{} continued]:\n{}", region.name, chunk),
-                        };
-                        system_blocks.push(leviath_providers::SystemBlock {
-                            text,
-                            cache_hint: CacheHint::UntilChanged,
-                            volatility: region.volatility,
-                            region: region.name.clone(),
-                        });
-                    }
+                    push_bracketed(&mut system_blocks, region, CacheHint::UntilChanged);
                 }
-                leviath_core::RegionKind::Temporary => {
-                    let text = region
-                        .content
-                        .iter()
-                        .map(|e| e.content.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n\n");
-                    system_blocks.push(leviath_providers::SystemBlock {
-                        text: format!("[{}]:\n{}", region.name, text),
-                        cache_hint: CacheHint::Never,
-                        volatility: region.volatility,
-                        region: region.name.clone(),
-                    });
-                }
-                leviath_core::RegionKind::Clearable => {
-                    let text = region
-                        .content
-                        .iter()
-                        .map(|e| e.content.as_str())
-                        .collect::<Vec<_>>()
-                        .join("\n\n");
-                    system_blocks.push(leviath_providers::SystemBlock {
-                        text: format!("[{}]:\n{}", region.name, text),
-                        cache_hint: CacheHint::Never,
-                        volatility: region.volatility,
-                        region: region.name.clone(),
-                    });
+                // Both say when the region is thrown away, not how it moves
+                // in between, so the hint comes from the declaration - see
+                // `lifecycle_cache_hint` (issue #490).
+                leviath_core::RegionKind::Temporary | leviath_core::RegionKind::Clearable => {
+                    let hint = lifecycle_cache_hint(region.volatility);
+                    push_bracketed(&mut system_blocks, region, hint);
                 }
 
                 // Custom (script-backed) regions render through their Rhai

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -321,6 +321,15 @@ is what makes it faster.
 > is an ordinary move, and [tool routing](#routing-tool-output) sends read results straight
 > into one. Only the blueprint knows which of yours is which.
 
+`temporary` and `clearable` are worth declaring for the same reason, and the payoff is larger.
+Both names describe when the region is *thrown away* - one at stage exit, the other on demand -
+and say nothing about whether the contents hold still in between. Undeclared they are treated as
+uncacheable, which is right at the boundary and wrong everywhere else: a stage that reads a corpus
+into a `temporary` region and then works through it for forty calls re-sends the whole corpus at
+full rate on every one of them. Measured on one such stage: 5.36M tokens across 46 calls, the
+largest single cost line in the run. Declaring it `grows` splits it the same way any other growing
+region is split, so the part already read caches and only the newest excerpt is re-sent.
+
 If a region declares `stable` and then keeps changing, Leviath says so in the log rather than
 silently paying for it: the declaration is a hint it checks, not a promise it trusts.
 


### PR DESCRIPTION
Two changes: the #490 cache fix, and the CI failures blocking the Dependabot PRs.

## `temporary` was uncacheable for the wrong reason (#490)

`temporary` and `clearable` name when a region is **thrown away** — one at stage
exit, the other on demand — and say nothing about whether its contents hold
still in between. Both were tagged `CacheHint::Never` on the strength of that
name.

That is right at the boundary: caching across a wholesale drop buys nothing. It
is wrong everywhere else. A stage that reads a corpus into a `temporary` region
and works through it for forty calls has an append-mostly region that changes
only at the tail, which is precisely what chunking exists for — and it re-sent
the whole corpus at full rate on every call instead. The reporter measured
**5.36M tokens across 46 calls, the largest single cost line in the run.**

The kind cannot answer this and the blueprint can, so the hint now follows the
declaration, the same way ordering and chunking already do:

| declared | hint | rendered |
|---|---|---|
| *(nothing)* → `rewritten` | `Never` | one block, exactly as before |
| `grows` | `UntilChanged` | chunked, settled head cacheable |
| `stable` | `UntilChanged` | one block, cacheable |

**`rewritten` is the default, so a region that declares nothing renders
byte-identically to before.** This only reaches a blueprint that asked for it —
which is the same property that made the volatility work safe to ship on by
default, and the reason I am comfortable landing it without a quality
measurement.

Tests are a discriminating pair: an undeclared region is asserted unchanged
(one block, `Never`, same label), a declared one is asserted to split with
continuation labels — plus a round-trip proving chunking changes not one byte of
what the model reads, headings aside.

Also folds the three bracket-labelled kinds through one helper. `Compacting`
already had this exact chunking loop open-coded and the other two had a second
copy of its unchunked half.

## CI: three jobs failing every Dependabot PR

None of them for a reason to do with the change under review.

**`Docs`** runs its own checks, passes them, then checks out the private
leviath.dev repo to validate the changelog against the parser the site publishes
with. A PR from Dependabot — or from a fork — runs without repository secrets,
so `token` arrives empty and the checkout kills the job with `Input required and
not supplied: token`, *after* every real check has gone green. Those steps now
skip when the secret is absent. Nothing is lost: the site's repo is unreachable
from those runs either way, and the push to main after the merge runs them with
the secret present.

**Both guard jobs** read the PR's labels over the API *before* deciding whether
the guard applies. That call needs a scope a Dependabot token does not get and
fails 422 — so a PR touching neither main.rs nor the workspace version failed on
a permission it needed only to confirm it was already passing. The read now
happens after the check that decides the outcome, which is where it was always
wanted: the guards are unreachable for a PR that does not trip them. The live
read and its rationale are kept — a rerun replays the payload it started with,
so a label applied afterwards would otherwise be invisible.

The `Test` and toolchain failures on those PRs were a separate, transient thing
(429s from codeload during this morning's GitHub outage) and cleared on a rerun.

Closes #490
