### PR TITLE
fix(runtime): stop building two requests every provider rejects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ same list.
 
 ## Unreleased
 
+- Fixed: two provider 400s the runtime built for itself at a tight context
+  window. A prompt that reached the window left a completion budget of zero, and
+  the request went out with it - which OpenAI rejects as
+  `Invalid 'max_completion_tokens': integer below minimum value` and Anthropic
+  likewise. The budget now has a floor of one, and stays capped at what the
+  window has left, because a provider rejects prompt-plus-completion past the
+  window just as readily; a prompt that leaves no room to answer says so in the
+  log rather than only in a 400. Separately, a compaction that returned an empty
+  summary had that blank stored in place of the region it summarized, and it
+  later reached a provider as a zero-length turn, which is
+  `user messages must have non-empty content`. An empty summary now leaves the
+  region as written, and no message with nothing in it is sent at all. Neither
+  400 reads as transient, so both were retried until the run died.
+
 - Changed: a `temporary` or `clearable` region declared `volatility = "grows"`
   is now split and cached like any other growing region. Both kinds say when the
   region is thrown away - one at stage exit, the other on demand - and nothing

--- a/crates/leviath-runtime/src/components/context_window.rs
+++ b/crates/leviath-runtime/src/components/context_window.rs
@@ -1011,6 +1011,22 @@ impl ContextWindow {
             messages[0].cache_breakpoint = true;
         }
 
+        // ── Drop any message with nothing in it ─────────────────────────
+        //
+        // Every provider rejects a zero-length turn (`messages.0: user messages
+        // must have non-empty content`), so one reaching the wire is a 400 the
+        // runtime built for itself - and a 400 does not retry away.
+        //
+        // Here rather than at each writer because there are many writers and
+        // one request. A block-shaped message that emptied out is already
+        // dropped by the tool-pair sanitizer above; this catches the text-shaped
+        // ones, and it runs before the two guards below so that a conversation
+        // left empty by the drop still gets its fallback turn (issue #495).
+        messages.retain(|m| match &m.content {
+            leviath_providers::MessageContent::Text(text) => !text.trim().is_empty(),
+            leviath_providers::MessageContent::Blocks(blocks) => !blocks.is_empty(),
+        });
+
         // Ensure there's at least one user message
         if !messages.iter().any(|m| m.role == "user") {
             messages.push(leviath_providers::Message {

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -2493,6 +2493,82 @@ mod tests {
         assert_eq!(assembled.messages[3].content.as_text(), "Now fix the bug");
     }
 
+    // ─── no zero-length turn reaches the wire (issue #495) ───────────────
+
+    /// Every provider rejects an empty turn (`messages.0: user messages must
+    /// have non-empty content`), and a 400 does not retry away - so a blank
+    /// entry that reached the request killed the run. One writer produced it
+    /// (an empty compaction summary), but the guard belongs at the request,
+    /// because there are many writers and one wire.
+    #[test]
+    fn an_empty_entry_never_becomes_a_message() {
+        let mut window = ContextWindow::new(100_000);
+        let mut conversation = Region::new(
+            "conversation".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 50,
+                eviction_strategy: Default::default(),
+            },
+            50_000,
+        );
+        conversation
+            .add_typed_entry(
+                "find the conflicts".to_string(),
+                10,
+                leviath_core::EntryKind::UserMessage,
+            )
+            .unwrap();
+        conversation
+            .add_typed_entry(String::new(), 0, leviath_core::EntryKind::UserMessage)
+            .unwrap();
+        conversation
+            .add_typed_entry(
+                "   \n  ".to_string(),
+                0,
+                leviath_core::EntryKind::UserMessage,
+            )
+            .unwrap();
+        window.add_region(conversation);
+
+        let assembled = window.assemble();
+
+        let texts: Vec<String> = assembled
+            .messages
+            .iter()
+            .map(|m| m.content.as_text())
+            .collect();
+        assert_eq!(
+            texts,
+            vec!["find the conflicts".to_string()],
+            "the real turn survives and no empty one is sent"
+        );
+    }
+
+    /// Dropping the blanks must not strand the conversation without a user
+    /// turn - the fallback that guarantees one runs after the drop.
+    #[test]
+    fn a_conversation_of_nothing_but_blanks_still_gets_a_user_turn() {
+        let mut window = ContextWindow::new(100_000);
+        let mut conversation = Region::new(
+            "conversation".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 50,
+                eviction_strategy: Default::default(),
+            },
+            50_000,
+        );
+        conversation
+            .add_typed_entry(String::new(), 0, leviath_core::EntryKind::UserMessage)
+            .unwrap();
+        window.add_region(conversation);
+
+        let assembled = window.assemble();
+
+        assert_eq!(assembled.messages.len(), 1);
+        assert_eq!(assembled.messages[0].role, "user");
+        assert_eq!(assembled.messages[0].content.as_text(), "Begin.");
+    }
+
     // ─── the conversation ends the request (issue #486) ──────────────────
 
     /// A custom region is the only kind that can render into the conversation,

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -225,6 +225,23 @@ pub fn collect_compaction(
         }
         if let Ok(summaries) = outcome.result {
             for (region_name, summary) in summaries {
+                // A summary with nothing in it is a compaction that failed, not
+                // one that found nothing worth keeping - and writing it would
+                // trade the region's real contents for a blank. Measured on a
+                // 32k window, where the transcript being summarized was small
+                // enough that the model returned an empty string; the blank was
+                // stored and later reached a provider as a zero-length turn,
+                // which is a 400 (issue #495). Leave the region as written and
+                // say so: eviction has other phases, and losing the content is
+                // worse than staying over budget for another tick.
+                if summary.trim().is_empty() {
+                    tracing::warn!(
+                        region = %region_name,
+                        "compaction returned an empty summary; keeping the region \
+                         as written rather than replacing it with nothing"
+                    );
+                    continue;
+                }
                 let summary_tokens = leviath_core::estimate_tokens(&summary);
                 let history = window
                     .regions

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -75,6 +75,25 @@ pub(crate) fn hint_blocks(
     blocks
 }
 
+/// The smallest completion budget a request may carry.
+///
+/// Providers reject a request whose completion budget is below one - OpenAI
+/// with `Invalid 'max_completion_tokens': integer below minimum value`,
+/// Anthropic likewise - and the runtime derived that budget by subtracting the
+/// prompt from the window with no floor under it. On a tight pinned window a
+/// prompt that reached the ceiling drove it to zero and the request went out
+/// anyway. A 400 does not read as transient, so the retry loop resent the same
+/// doomed request until the run died (issue #495).
+///
+/// Deliberately one, and not something roomier. The budget is also capped at
+/// what the window has left, because a provider rejects `prompt + completion`
+/// past the context window just as readily - so clamping *up* to a comfortable
+/// figure would trade one 400 for another. One token is the smallest request
+/// the API accepts, which is the only property this constant exists to
+/// guarantee; whether the reply is *useful* at that size is a budget problem,
+/// and the warning beside it says so.
+const MIN_OUTPUT_TOKENS: usize = 1;
+
 /// What earlier calls in this run taught us, carried into the next request.
 ///
 /// Three pieces of evidence with one thing in common: none of them can be
@@ -135,7 +154,19 @@ pub(crate) fn build_request(
     let output_cap = config
         .and_then(|c| c.max_output_tokens)
         .unwrap_or(caps.max_output_tokens);
-    let max_tokens = remaining.min(output_cap);
+    let max_tokens = remaining.min(output_cap).max(MIN_OUTPUT_TOKENS);
+    if remaining < MIN_OUTPUT_TOKENS {
+        // The prompt has filled the window and left nothing to answer with.
+        // Said out loud because the request still goes out, and a reply capped
+        // this short is going to be empty or truncated - which reads as a model
+        // problem rather than a budget one unless somebody says so here.
+        tracing::warn!(
+            window_tokens = window.max_tokens,
+            prompt_tokens = spent,
+            "the assembled prompt leaves no room for a reply; raise the stage's \
+             window or lower the region budgets that fill it"
+        );
+    }
 
     let filtered_tools = match stage.tool_filter.as_deref() {
         Some(filter) if !filter.is_empty() => stage

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1447,6 +1447,77 @@ fn collect_inference_buffers_output_token_line_and_stage_tokens() {
     assert_eq!(led.0[1].cached_tokens, 2);
 }
 
+// ─── requests the runtime must never build (issue #495) ──────────────
+
+/// A prompt that reaches the window leaves nothing to answer with, and the
+/// derived completion budget went to zero. Providers reject that outright
+/// (`Invalid 'max_completion_tokens': integer below minimum value`), and a 400
+/// is not transient, so the retry loop resent the same doomed request until the
+/// run died.
+#[tokio::test]
+async fn a_full_window_still_asks_for_at_least_one_output_token() {
+    let (mut world, _rx) = build_world(InferencePools::new(InferencePoolConfig::new()));
+    // A window whose regions have consumed every token it has.
+    let mut w = window();
+    w.current_tokens = w.max_tokens;
+    let e = world
+        .spawn((agent_state(), w, stage("m", vec![], None), ReadyToInfer))
+        .id();
+
+    run(&mut world);
+
+    // The request reached the lane rather than being rejected by the provider.
+    assert!(world.get::<AwaitingInference>(e).is_some());
+}
+
+/// The same arithmetic, read straight off the built request so the number the
+/// provider would see is the one under test.
+#[test]
+fn the_completion_budget_never_falls_below_the_provider_minimum() {
+    let mut w = window();
+    w.current_tokens = w.max_tokens; // nothing left over
+    let si = stage("model-x", vec![], None);
+
+    let req = build_request(
+        &w,
+        None,
+        &si,
+        &provider(true, 500),
+        "implement",
+        1,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+
+    assert!(
+        req.max_tokens >= 1,
+        "a zero budget is a 400 every provider rejects: {}",
+        req.max_tokens
+    );
+}
+
+/// And the clamp must not overshoot: a provider rejects `prompt + completion`
+/// past the window just as readily, so the budget stays inside what is left.
+#[test]
+fn the_completion_budget_stays_inside_what_the_window_has_left() {
+    let mut w = window();
+    w.current_tokens = w.max_tokens - 10;
+    let si = stage("model-x", vec![], None);
+
+    let req = build_request(
+        &w,
+        None,
+        &si,
+        &provider(true, 500),
+        "implement",
+        1,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+
+    assert_eq!(req.max_tokens, 10, "10 left means 10 asked for");
+}
+
 // ─── estimator calibration (issue #485) ───
 //
 // The arithmetic is unit-tested in `pipeline::calibration`. What these cover is
@@ -9930,6 +10001,48 @@ fn collect_compaction_stores_summary_and_clears_source() {
     assert!(w.get_region("history").unwrap().current_tokens > 0); // summary stored
     assert!(world.get::<ReadyToInfer>(e).is_some());
     assert!(world.get::<AwaitingCompaction>(e).is_none());
+}
+
+/// A summary with nothing in it is a compaction that failed, not one that found
+/// nothing worth keeping. Storing it traded the region's real contents for a
+/// blank, and the blank later reached a provider as a zero-length turn - which
+/// is a 400 no retry clears (issue #495).
+#[test]
+fn collect_compaction_keeps_the_region_when_the_summary_is_empty() {
+    for summary in ["", "   \n\t "] {
+        let (mut world, tx) = world_with_compaction_results();
+        let e = world.spawn((compacting_window(), AwaitingCompaction)).id();
+        let before = world
+            .get::<ContextWindow>(e)
+            .unwrap()
+            .get_region("conv")
+            .unwrap()
+            .current_tokens;
+        tx.send(CompactionOutcome {
+            entity: e,
+            usage: Vec::new(),
+            provider_name: "p".to_string(),
+            model: "m".to_string(),
+            result: Ok(vec![("conv".to_string(), summary.to_string())]),
+        })
+        .unwrap();
+
+        run_collect_compaction(&mut world);
+
+        let w = world.get::<ContextWindow>(e).unwrap();
+        assert_eq!(
+            w.get_region("conv").unwrap().current_tokens,
+            before,
+            "the source keeps what the summary failed to capture"
+        );
+        assert_eq!(
+            w.get_region("history").unwrap().current_tokens,
+            0,
+            "and nothing blank is stored in its place"
+        );
+        // Still handed back to inference: compaction is best-effort.
+        assert!(world.get::<ReadyToInfer>(e).is_some());
+    }
 }
 
 /// Compaction is the largest uncounted cost a run had: a summarize call sees


### PR DESCRIPTION
Both shapes fixed. Both were the runtime's own arithmetic, and both retried into
the same 400 until the run died — a 400 does not read as transient by its
wording, so the retry loop resent the identical doomed request.

## Shape 1: completion budget of zero

The budget is `window - prompt`, and that subtraction had no floor. A prompt
reaching the ceiling drove it to zero and the request went out anyway.

Now floored at one. **Deliberately one, and not something roomier** — the budget
is also capped at what the window has left, because a provider rejects
`prompt + completion` past the context window just as readily. Clamping *up* to
a comfortable figure would trade one 400 for another, which is the trap worth
naming here.

You asked for evict-first as well. The eviction trigger already fires at 0.9 of
the window and, since #485, measures that against the corrected prompt size — so
reaching a zero budget means eviction ran and **could not free anything**
(pinned and sliding regions are never reduced). No trigger change helps that
case, so instead a prompt that leaves no room to answer now warns with the two
numbers, because a reply capped that short otherwise reads as a model problem
rather than a budget one.

## Shape 2: zero-length turn

An empty compaction summary was stored *in place of* the region it summarized,
and later reached a provider as an empty message.

Two changes, because they answer different halves:

- **An empty summary is a compaction that failed**, not one that found nothing
  worth keeping. The region now keeps what it had rather than trading it for a
  blank, and warns. Losing the content is worse than staying over budget for
  another tick, and eviction has other phases.
- **No empty message is assembled into a request at all.** That guard sits at
  the request rather than at the writer, because there are many writers and one
  wire. It runs before the fallback that guarantees a user turn, so a
  conversation left empty by the drop still gets one — there is a test for
  exactly that, since it is the obvious way this fix could have introduced a
  second 400.

## Verified

Full suite, `leviath-runtime` coverage at 100%, clippy `--all-targets
--all-features -D warnings`, structure and docs all clean.

Six tests, each written to fail without its fix: a full window still asks for
≥1 output token (both through `dispatch_inference` and read off the built
request), the budget stays inside what the window has left, empty and
whitespace-only entries never become messages, an all-blank conversation still
gets its `Begin.` turn, and an empty summary leaves the region intact.

## One thing I did not do

When the window genuinely has no room, a one-token request is valid but
unproductive — the run grinds rather than 400s. Parking it with a named reason
would be better than grinding, but that needs a new `StallReason` **and** a new
serialized `SetupBlocker` variant in `run_meta`, which is a wider change than
this bug warrants and touches the archive format. Flagged for a separate call.

Closes #495
