### PR TITLE
chore(release): 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
+## 0.4.0 - 2026-08-18
 
 - New: a provider can be reached through a gateway, with
   `[providers] <provider>_base_url` for `anthropic`, `openai`, `google` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2375,7 +2375,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2400,7 +2400,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2408,7 +2408,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2468,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2488,7 +2488,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2515,7 +2515,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2525,7 +2525,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2545,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2571,7 +2571,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2610,7 +2610,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "fs4",
  "keyring",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2641,7 +2641,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "csv",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.10"
+version = "0.4.0"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.3.10" }
-leviath-core = { path = "crates/leviath-core", version = "0.3.10" }
-leviath-net = { path = "crates/leviath-net", version = "0.3.10" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.3.10" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.3.10" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.3.10" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.3.10" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.3.10" }
-leviath-package = { path = "crates/leviath-package", version = "0.3.10" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.3.10" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.3.10" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.3.10" }
+leviath = { path = "crates/leviath", version = "0.4.0" }
+leviath-core = { path = "crates/leviath-core", version = "0.4.0" }
+leviath-net = { path = "crates/leviath-net", version = "0.4.0" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.4.0" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.4.0" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.4.0" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.4.0" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.4.0" }
+leviath-package = { path = "crates/leviath-package", version = "0.4.0" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.4.0" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.4.0" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.4.0" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.3.10", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.4.0", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }


### PR DESCRIPTION
Cuts 0.4.0. Merging this publishes the alpha; beta and prod follow by dispatch.

`cargo xtask version 0.4.0` bumped the workspace and renamed `## Unreleased` to
`## 0.4.0 - 2026-08-18`. Nothing else in the diff.

## What is in it

27 entries: **2 breaking**, 7 new, 3 changed, 15 fixed.

**Breaking**

- Every MCP tool is named `<server>__<tool>`, whether or not anything would have
  collided. The bare name used to be a function of registration order, so
  `available_tools = ["search"]` meant a different server's tool depending on
  the order of a file the blueprint does not control. A blueprint naming a bare
  MCP tool stops matching, though a name resolving to exactly one server is
  rewritten rather than dropped. No bundled agent is affected.
- The run archive's version number now marks a change to its *framing* only, and
  an archive newer than the build reading it is refused by name.

**The through-line of the rest** is prompt-cache correctness, most of it driven
by an external reporter's production workload rather than by synthetic
reproductions:

- Cache markers anchored to a fixed stride from the start of the conversation,
  after their measurement showed Anthropic's lookup only scans a bounded run of
  blocks back from a marker. Verified on their cell: hit rate 11.6% to 69.2%,
  cost $4.62 to $1.70, task score unchanged.
- Regions declare how much they move (`volatility`), and the prompt is ordered
  by it. `temporary`/`clearable` become chunk-cacheable when declared `grows`.
- The token estimate corrects itself against what the provider reports charging,
  in tokens rather than as a ratio.
- The live conversation always ends the request.
- Two provider 400s the runtime built for itself at a tight window.
- A provider can be reached through an enterprise gateway.

## Release notes

The changelog section is the release notes, and it is written for someone
deciding whether to upgrade rather than as a commit log. Worth a read before the
prod promotion, since that is the one the public docs channel follows.
