### PR TITLE
feat(dash): graph band in the detail view and blueprint preview on the new-run screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ same list.
   layered layout the explorer already had places the boxes.
 - New: `lev validate --graph` prints the same stage graph as plain text
   (`--width` caps how wide).
+- New: the detail view's stage row is the blueprint's graph on a terminal
+  at least 32 rows tall: one box per stage, edges between them, the stage
+  the run is in lit up, `←`/`→` and `1`-`9` moving through it as they did
+  through the tabs. The flat strip stays on shorter terminals.
+- New: the new-run screen previews the selected blueprint's stage graph
+  above the task, bundled blueprints included before they are installed,
+  and says so when a manifest cannot be read.
 - Fixed: shortcuts that worked but were never hinted or documented. The
   detail view's hint bar names `g` (the graph) and `1-9`; the main list's
   names `m` (MCP servers); the log panel's names PgUp/PgDn, `?` and the

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -116,6 +116,7 @@ impl Dashboard {
             log_scroll: crate::tui::widgets::scroll::ScrollState::default(),
             pane_rects: Vec::new(),
             mouse_capture: None,
+            detail_band: None,
             log_viewport: 0,
             stage_explorer: None,
             context_tree: ContextTreeState::default(),

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -117,6 +117,7 @@ impl Dashboard {
             pane_rects: Vec::new(),
             mouse_capture: None,
             detail_band: None,
+            new_run_preview: None,
             log_viewport: 0,
             stage_explorer: None,
             context_tree: ContextTreeState::default(),

--- a/crates/leviath-cli/src/commands/dashboard/detail_band.rs
+++ b/crates/leviath-cli/src/commands/dashboard/detail_band.rs
@@ -73,6 +73,8 @@ impl Dashboard {
             .max(agent.graph.as_ref().map(|g| g.stage_count()).unwrap_or(0))
             .max(1);
         let selected = self.selected_stage.min(stage_count - 1);
+        // The ledger names the stage when it has one; the blueprint's own
+        // order otherwise (a run that has not written its ledger yet).
         let selected_name = agent
             .stages
             .get(selected)
@@ -82,16 +84,15 @@ impl Dashboard {
                     .graph
                     .as_ref()
                     .and_then(|g| g.ids().nth(selected).map(str::to_string))
-            });
+            })
+            .unwrap_or_default();
 
         let band = self
             .detail_band
             .as_mut()
             .expect("built above when missing or stale");
         band.view.apply_live(&live);
-        if let Some(name) = selected_name {
-            band.view.select_stage(&name);
-        }
+        band.view.select_stage(&selected_name);
         let title = format!(
             " Stages ←/→ to switch  stage {}/{}  ·  [g] graph  ·  drag to pan ",
             selected + 1,
@@ -102,7 +103,7 @@ impl Dashboard {
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(C_BORDER_FOCUS))
             .title(Span::styled(title, Style::default().fg(C_DIM)));
-        let canvas = band.view.render(frame, area, Some(block));
+        let canvas = band.view.render(frame, area, block);
         self.pane_rects.push((PaneId::DetailBand, canvas));
         true
     }
@@ -282,10 +283,26 @@ condition = "llm_choice"
     #[test]
     fn the_band_takes_the_mouse_and_ticks() {
         let mut dash = make_test_dashboard();
-        dash.agents.push(agent("run-1"));
+        let mut run = agent("run-1");
+        // A ledger names the stages: the selection follows it rather than
+        // the blueprint's order.
+        run.stages = vec![
+            leviath_core::run_meta::StageRecord::new("plan".to_string(), 0),
+            leviath_core::run_meta::StageRecord::new("implement".to_string(), 1),
+        ];
+        dash.agents.push(run);
         dash.update_display_indices();
         dash.detail_view = true;
+        dash.selected_stage = 1;
         draw(&mut dash, 160, 40);
+        // A second draw of the same run keeps the canvas it built.
+        let terminal = draw(&mut dash, 160, 40);
+        assert!(
+            style_at_text(&terminal, "implement")
+                .add_modifier
+                .contains(ratatui::style::Modifier::REVERSED),
+            "the ledger's second stage is the selected one"
+        );
         let canvas = dash
             .pane_rects
             .iter()

--- a/crates/leviath-cli/src/commands/dashboard/detail_band.rs
+++ b/crates/leviath-cli/src/commands/dashboard/detail_band.rs
@@ -1,0 +1,307 @@
+//! The detail view's graph band: the blueprint's stage graph, one row per
+//! stage box, in the rows the flat tab strip used to have.
+//!
+//! The strip said "3 of 7" and which stage was selected; the band says the
+//! same and also where the run has been, where it is, and how the stages
+//! connect. It is a viewer, not a second explorer: `←`/`→` and `1-9` still
+//! move the selection, `g` opens the full-screen graph, and the mouse only
+//! pans. On a terminal too short to give it its rows the strip stays.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::Span;
+use ratatui::widgets::{Block, BorderType, Borders};
+
+use super::state::Dashboard;
+use super::theme::*;
+use super::types::*;
+use crate::tui::flowgraph::{FlowView, NodeStyle};
+
+/// Rows the band takes: a border, up to three stacked stage boxes with a
+/// gap between them, and one lane under them for a revisit loop.
+pub(super) const BAND_HEIGHT: u16 = 8;
+
+/// The detail area must be at least this tall for the band to replace the
+/// three-row strip; below it every other pane needs the rows more.
+pub(super) const BAND_MIN_AREA_HEIGHT: u16 = 32;
+
+/// The band's canvas, kept between frames so the viewport survives a
+/// redraw. Rebuilt when the selected run changes.
+#[derive(Debug)]
+pub(super) struct DetailBand {
+    pub(super) run_id: String,
+    pub(super) view: FlowView,
+}
+
+impl Dashboard {
+    /// How tall the stage row of the detail view is: the band when the area
+    /// is tall enough and the run has a graph, the flat strip otherwise.
+    pub(super) fn stage_row_height(area_height: u16, agent: &DashboardAgent) -> u16 {
+        if area_height >= BAND_MIN_AREA_HEIGHT && agent.graph.is_some() {
+            BAND_HEIGHT
+        } else {
+            3
+        }
+    }
+
+    /// Draw the band into `area`. Returns `false` when the run has no graph
+    /// to draw, so the caller can fall back to the strip.
+    pub(super) fn draw_stage_band(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+        agent: &DashboardAgent,
+    ) -> bool {
+        let stale = self
+            .detail_band
+            .as_ref()
+            .is_none_or(|b| b.run_id != agent.id);
+        if stale {
+            let Some(graph) = agent.graph.clone() else {
+                return false;
+            };
+            self.detail_band = Some(DetailBand {
+                run_id: agent.id.clone(),
+                view: FlowView::new(graph, NodeStyle::Compact, true),
+            });
+        }
+        let live = self.live_overlay_for(agent);
+        let stage_count = agent
+            .stages
+            .len()
+            .max(agent.graph.as_ref().map(|g| g.stage_count()).unwrap_or(0))
+            .max(1);
+        let selected = self.selected_stage.min(stage_count - 1);
+        let selected_name = agent
+            .stages
+            .get(selected)
+            .map(|s| s.name.clone())
+            .or_else(|| {
+                agent
+                    .graph
+                    .as_ref()
+                    .and_then(|g| g.ids().nth(selected).map(str::to_string))
+            });
+
+        let band = self
+            .detail_band
+            .as_mut()
+            .expect("built above when missing or stale");
+        band.view.apply_live(&live);
+        if let Some(name) = selected_name {
+            band.view.select_stage(&name);
+        }
+        let title = format!(
+            " Stages ←/→ to switch  stage {}/{}  ·  [g] graph  ·  drag to pan ",
+            selected + 1,
+            stage_count
+        );
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(C_BORDER_FOCUS))
+            .title(Span::styled(title, Style::default().fg(C_DIM)));
+        let canvas = band.view.render(frame, area, Some(block));
+        self.pane_rects.push((PaneId::DetailBand, canvas));
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::commands::dashboard::test_support::{
+        make_test_dashboard, rendered_buffer, style_at_text,
+    };
+    use crate::tui::flowgraph::StageGraph;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    use leviath_core::manifest::parse_manifest;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn stage_graph() -> Arc<StageGraph> {
+        Arc::new(StageGraph::from_blueprint(
+            &parse_manifest(
+                r#"
+[agent]
+name = "grapher"
+[stages.plan]
+[stages.plan.transitions.implement]
+[stages.implement]
+[stages.implement.transitions.review]
+[stages.review]
+[stages.review.transitions.implement]
+condition = "llm_choice"
+[stages.review.transitions.done]
+[stages.done]
+[stages.done.transitions]
+"#,
+            )
+            .unwrap(),
+        ))
+    }
+
+    fn agent(id: &str) -> DashboardAgent {
+        DashboardAgent {
+            id: id.to_string(),
+            blueprint_name: "grapher".to_string(),
+            stage: "implement".to_string(),
+            stage_index: 1,
+            num_stages: 4,
+            status: AgentDisplayStatus::Active,
+            tokens_in: 0,
+            tokens_out: 0,
+            cached_tokens: 0,
+            iteration: 2,
+            waiting_prompt: None,
+            wait_reason: None,
+            pending_request: None,
+            last_answered_request_id: None,
+            context_snapshot: None,
+            stages: vec![],
+            workdir: "/tmp".to_string(),
+            task: "t".to_string(),
+            title: None,
+            model: None,
+            parent_id: None,
+            depth: 0,
+            started_at: 1000,
+            last_progress_at: None,
+            active_until: None,
+            waiting_secs: 0,
+            graph: Some(stage_graph()),
+            accepts_messages: true,
+            taint_summary: vec![],
+        }
+    }
+
+    fn draw(dash: &mut Dashboard, w: u16, h: u16) -> Terminal<TestBackend> {
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        terminal
+    }
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::NONE,
+        }
+    }
+
+    #[test]
+    fn a_tall_detail_view_draws_the_band_with_the_current_stage_lit_and_the_tab_selected() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(agent("run-1"));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.selected_stage = 0;
+        let terminal = draw(&mut dash, 160, 40);
+        let text = rendered_buffer(&terminal);
+        assert!(text.contains("stage 1/4"), "{text}");
+        assert!(text.contains("drag to pan"), "{text}");
+        for stage in ["plan", "implement", "review", "done"] {
+            assert!(text.contains(&format!(" {stage} ")), "{stage}: {text}");
+        }
+        // The stage the run is in is drawn in the active colour; the selected
+        // tab is the reversed one; a pending stage is dim.
+        assert_eq!(style_at_text(&terminal, "implement").fg, Some(C_ACTIVE));
+        assert!(
+            style_at_text(&terminal, "plan")
+                .add_modifier
+                .contains(ratatui::style::Modifier::REVERSED)
+        );
+        assert_eq!(style_at_text(&terminal, "done").fg, Some(C_DIM));
+        assert!(
+            dash.pane_rects
+                .iter()
+                .any(|(id, _)| *id == PaneId::DetailBand)
+        );
+        // The strip's own chrome is gone.
+        assert!(!text.contains("←/→ to switch  stage 1/4 ·  [g]"), "{text}");
+    }
+
+    #[test]
+    fn a_short_detail_view_keeps_the_flat_strip() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(agent("run-1"));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        let terminal = draw(&mut dash, 160, 24);
+        let text = rendered_buffer(&terminal);
+        assert!(text.contains("stage 1/4"), "{text}");
+        assert!(!text.contains("drag to pan"), "{text}");
+        assert!(dash.detail_band.is_none());
+        assert_eq!(Dashboard::stage_row_height(24, &agent("run-1")), 3);
+        assert_eq!(
+            Dashboard::stage_row_height(40, &agent("run-1")),
+            BAND_HEIGHT
+        );
+        let mut no_graph = agent("run-2");
+        no_graph.graph = None;
+        assert_eq!(Dashboard::stage_row_height(40, &no_graph), 3);
+    }
+
+    #[test]
+    fn the_band_rebuilds_when_the_selected_run_changes_and_declines_without_a_graph() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(agent("run-1"));
+        let mut other = agent("run-2");
+        other.stage = "review".to_string();
+        dash.agents.push(other);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        draw(&mut dash, 160, 40);
+        assert_eq!(dash.detail_band.as_ref().unwrap().run_id, "run-1");
+        dash.selected = 1;
+        draw(&mut dash, 160, 40);
+        assert_eq!(dash.detail_band.as_ref().unwrap().run_id, "run-2");
+
+        // Called for a run without a graph, the band declines and the caller
+        // is told so.
+        let mut bare = agent("run-3");
+        bare.graph = None;
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        let mut drew = true;
+        terminal
+            .draw(|f| drew = dash.draw_stage_band(f, f.area(), &bare))
+            .unwrap();
+        assert!(!drew);
+        assert!(rendered_buffer(&terminal).trim().is_empty());
+        // The selected stage is clamped to what the run has.
+        dash.selected = 0;
+        dash.selected_stage = 40;
+        let terminal = draw(&mut dash, 160, 40);
+        assert!(rendered_buffer(&terminal).contains("stage 4/4"));
+    }
+
+    #[test]
+    fn the_band_takes_the_mouse_and_ticks() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(agent("run-1"));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        draw(&mut dash, 160, 40);
+        let canvas = dash
+            .pane_rects
+            .iter()
+            .find(|(id, _)| *id == PaneId::DetailBand)
+            .map(|(_, r)| *r)
+            .expect("the band registered its canvas");
+        let pan = dash.detail_band.as_ref().unwrap().view.pan();
+        let (x, y) = (canvas.x + canvas.width - 3, canvas.y + 1);
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+        assert!(
+            dash.selection.is_none(),
+            "a press on the band is not a text selection"
+        );
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x - 10, y));
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x - 10, y));
+        assert_ne!(dash.detail_band.as_ref().unwrap().view.pan(), pan);
+        dash.tick_graphs(std::time::Duration::from_millis(100));
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -45,6 +45,9 @@ impl Dashboard {
         if let Some(explorer) = self.stage_explorer.as_mut() {
             explorer.view.tick(elapsed);
         }
+        if let Some(band) = self.detail_band.as_mut() {
+            band.view.tick(elapsed);
+        }
     }
 
     /// Keys while the full-screen stage explorer is open. The explorer owns
@@ -258,6 +261,7 @@ impl Dashboard {
                 .as_mut()
                 .filter(|e| e.tab == ExplorerTab::Graph)
                 .map(|e| &mut e.view),
+            PaneId::DetailBand => self.detail_band.as_mut().map(|b| &mut b.view),
             PaneId::RunTable | PaneId::LogPanel => None,
         }
     }

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -48,6 +48,9 @@ impl Dashboard {
         if let Some(band) = self.detail_band.as_mut() {
             band.view.tick(elapsed);
         }
+        if let Some(Ok(view)) = self.new_run_preview.as_mut().map(|p| p.view.as_mut()) {
+            view.tick(elapsed);
+        }
     }
 
     /// Keys while the full-screen stage explorer is open. The explorer owns
@@ -254,7 +257,7 @@ impl Dashboard {
     }
 
     /// The canvas behind a graph pane, if it is showing.
-    fn graph_view_mut(&mut self, id: PaneId) -> Option<&mut FlowView> {
+    pub(super) fn graph_view_mut(&mut self, id: PaneId) -> Option<&mut FlowView> {
         match id {
             PaneId::ExplorerGraph => self
                 .stage_explorer
@@ -262,6 +265,13 @@ impl Dashboard {
                 .filter(|e| e.tab == ExplorerTab::Graph)
                 .map(|e| &mut e.view),
             PaneId::DetailBand => self.detail_band.as_mut().map(|b| &mut b.view),
+            PaneId::NewRunPreview => {
+                let open = self.new_run_screen;
+                self.new_run_preview
+                    .as_mut()
+                    .filter(|_| open)
+                    .and_then(|p| p.view.as_mut().ok())
+            }
             PaneId::RunTable | PaneId::LogPanel => None,
         }
     }

--- a/crates/leviath-cli/src/commands/dashboard/graph.rs
+++ b/crates/leviath-cli/src/commands/dashboard/graph.rs
@@ -20,6 +20,25 @@ pub(super) fn load_stage_graph(agent_path: &str) -> Option<Arc<StageGraph>> {
     Some(Arc::new(StageGraph::from_blueprint(&blueprint)))
 }
 
+/// The stage graph of a blueprint shipped inside the binary, by name, so
+/// the new-run screen can preview one that `lev setup` has not installed.
+pub(super) fn bundled_stage_graph(name: &str) -> Option<Arc<StageGraph>> {
+    let agent = crate::bundled::BUNDLED_AGENTS
+        .iter()
+        .find(|a| a.name == name)?;
+    // Every bundled agent has a manifest and it parses (the bundle tests
+    // say so), hence no fallible arms of our own past this point.
+    let content = agent
+        .files
+        .iter()
+        .find(|(path, _)| *path == "agent.leviath")
+        .map(|(_, content)| *content)
+        .unwrap_or_default();
+    leviath_core::manifest::parse_manifest(content)
+        .ok()
+        .map(|blueprint| Arc::new(StageGraph::from_blueprint(&blueprint)))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -51,5 +70,16 @@ name = "linear"
         assert!(!via_dir.is_branching, "a linear agent is a graph too");
         assert_eq!(via_dir.entry, "first");
         assert_eq!(via_dir.edges.len(), 1);
+    }
+
+    #[test]
+    fn a_bundled_blueprint_loads_by_name_and_an_unknown_name_does_not() {
+        let name = crate::bundled::BUNDLED_AGENTS
+            .first()
+            .expect("the binary bundles agents")
+            .name;
+        let graph = bundled_stage_graph(name).expect("bundled parses");
+        assert!(graph.nodes.len() > 1);
+        assert!(bundled_stage_graph("no-such-blueprint").is_none());
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -2,6 +2,7 @@
 
 mod construct;
 mod context_tree;
+mod detail_band;
 mod explorer;
 mod graph;
 mod helpers;

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -10,6 +10,7 @@ mod history;
 mod input;
 mod mcp;
 mod new_run;
+mod new_run_preview;
 mod render;
 mod selection;
 mod state;

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -64,6 +64,7 @@ impl Dashboard {
     /// Close the screen, discarding whatever was typed.
     pub(super) fn close_new_run_screen(&mut self) {
         self.new_run_screen = false;
+        self.new_run_preview = None;
         self.close_file_ref();
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/new_run_preview.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run_preview.rs
@@ -1,0 +1,326 @@
+//! The new-run screen's blueprint preview: the selected agent's stage graph,
+//! drawn above the task editor while you pick.
+//!
+//! The picker row says a name and a description; the preview says what the
+//! agent will do: how many stages, in what order, where it loops. It is a
+//! viewer (drag pans, nothing selects) and it follows the picker: moving the
+//! selection swaps the graph, and a blueprint whose manifest cannot be read
+//! says so here, before `lev run` would have refused it.
+
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
+
+use super::graph::{bundled_stage_graph, load_stage_graph};
+use super::state::Dashboard;
+use super::theme::*;
+use super::types::*;
+use crate::tui::flowgraph::{FlowView, NodeStyle};
+
+/// The rows the task editor keeps for itself; the preview only appears
+/// when the pane has this many left over for it.
+pub(super) const TASK_MIN_HEIGHT: u16 = 8;
+/// The preview's smallest useful height (a border, two rows of boxes, a lane).
+pub(super) const PREVIEW_MIN_HEIGHT: u16 = 8;
+/// And its largest: more rows than this only show empty canvas.
+pub(super) const PREVIEW_MAX_HEIGHT: u16 = 14;
+
+/// The preview canvas for one catalog row, kept between frames.
+#[derive(Debug)]
+pub(super) struct BlueprintPreview {
+    /// The row it was built for: `NewRunAgent::path`.
+    pub(super) key: String,
+    /// The graph, or why there is none.
+    pub(super) view: Result<FlowView, String>,
+}
+
+/// How many rows the preview takes out of a right pane `height` rows tall:
+/// none when the task editor would drop below its minimum.
+pub(super) fn preview_height(pane_height: u16) -> u16 {
+    if pane_height < TASK_MIN_HEIGHT + PREVIEW_MIN_HEIGHT {
+        return 0;
+    }
+    (pane_height * 2 / 5).clamp(PREVIEW_MIN_HEIGHT, PREVIEW_MAX_HEIGHT)
+}
+
+impl Dashboard {
+    /// Make the preview match the picker's selection: build it when the
+    /// selected row changed, keep it otherwise. Parsing a manifest per frame
+    /// would be wasteful; per selection change it is nothing.
+    pub(super) fn sync_new_run_preview(&mut self) {
+        let Some(agent) = self.new_run_selected_agent() else {
+            self.new_run_preview = None;
+            return;
+        };
+        if self
+            .new_run_preview
+            .as_ref()
+            .is_some_and(|p| p.key == agent.path)
+        {
+            return;
+        }
+        let key = agent.path.clone();
+        let graph = if agent.source == "bundled" {
+            bundled_stage_graph(&agent.name)
+        } else {
+            load_stage_graph(&agent.path)
+        };
+        let view = match graph {
+            Some(graph) => Ok(FlowView::new(graph, NodeStyle::Compact, true)),
+            None => Err(format!(
+                "no preview: could not read a blueprint at {}",
+                agent.path
+            )),
+        };
+        self.new_run_preview = Some(BlueprintPreview { key, view });
+    }
+
+    /// Draw the preview into `area`.
+    pub(super) fn draw_new_run_preview(&mut self, frame: &mut Frame, area: Rect) {
+        self.sync_new_run_preview();
+        let Some(preview) = self.new_run_preview.as_mut() else {
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    " Pick an agent blueprint to see its stages.",
+                    Style::default().fg(C_DIM),
+                )))
+                .block(preview_block(" Blueprint ".to_string())),
+                area,
+            );
+            return;
+        };
+        match &mut preview.view {
+            Ok(view) => {
+                let graph = view.graph().clone();
+                // The key is a directory for a discovered blueprint and the
+                // bare name for a bundled one; either way the last component
+                // is the name.
+                let name = std::path::Path::new(&preview.key)
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or(preview.key.clone());
+                let title = format!(
+                    " {name} · {} stage{} · entry {} · drag to pan ",
+                    graph.stage_count(),
+                    if graph.stage_count() == 1 { "" } else { "s" },
+                    graph.entry
+                );
+                let canvas = view.render(frame, area, Some(preview_block(title)));
+                self.pane_rects.push((PaneId::NewRunPreview, canvas));
+            }
+            Err(why) => {
+                frame.render_widget(
+                    Paragraph::new(Line::from(Span::styled(
+                        format!(" {why}"),
+                        Style::default().fg(C_WARN),
+                    )))
+                    .block(preview_block(" Blueprint ".to_string())),
+                    area,
+                );
+            }
+        }
+    }
+}
+
+fn preview_block(title: String) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(C_BORDER))
+        .title(Span::styled(title, Style::default().fg(C_DIM)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
+    use crate::test_support::write_test_agent;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use std::path::Path;
+
+    /// A dashboard whose new-run catalog is read from `dir`, with the screen
+    /// open.
+    fn dash_at(dir: &Path) -> Dashboard {
+        let mut dash = make_test_dashboard();
+        dash.new_run_ctx = NewRunContext {
+            agents_dir: dir.join("agents"),
+            config_path: dir.join("config.toml"),
+            workdir: dir.to_path_buf(),
+        };
+        dash.open_new_run_screen();
+        dash
+    }
+
+    fn write_agent(dir: &Path, name: &str, body: &str) {
+        let agent_dir = dir.join("agents").join(name);
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        write_test_agent(
+            &agent_dir,
+            format!("[agent]\nname = \"{name}\"\ndescription = \"d\"\n{body}"),
+        );
+    }
+
+    fn draw(dash: &mut Dashboard, w: u16, h: u16) -> Terminal<TestBackend> {
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        terminal
+    }
+
+    fn select(dash: &mut Dashboard, name: &str) {
+        let index = dash
+            .filtered_new_run_agents()
+            .into_iter()
+            .position(|i| dash.new_run_agents[i].name == name)
+            .expect("the agent is in the catalog");
+        dash.new_run_selected = index;
+    }
+
+    #[test]
+    fn preview_height_leaves_the_task_editor_its_rows() {
+        assert_eq!(preview_height(10), 0);
+        assert_eq!(
+            preview_height(TASK_MIN_HEIGHT + PREVIEW_MIN_HEIGHT),
+            PREVIEW_MIN_HEIGHT
+        );
+        assert_eq!(preview_height(30), 12);
+        assert_eq!(preview_height(80), PREVIEW_MAX_HEIGHT);
+    }
+
+    #[test]
+    fn the_preview_follows_the_selected_agent_and_says_why_when_it_cannot_draw() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "alpha",
+            "[stages.gather]\n[stages.gather.transitions.write]\n[stages.write]\n[stages.write.transitions]\n",
+        );
+        let mut dash = dash_at(dir.path());
+        select(&mut dash, "alpha");
+        let terminal = draw(&mut dash, 160, 40);
+        let text = rendered_buffer(&terminal);
+        assert!(text.contains("alpha · 2 stages · entry gather"), "{text}");
+        assert!(
+            text.contains(" gather ") && text.contains(" write "),
+            "{text}"
+        );
+        assert!(
+            dash.pane_rects
+                .iter()
+                .any(|(id, _)| *id == PaneId::NewRunPreview)
+        );
+        // Drawing again with the same selection keeps the same canvas.
+        let key = dash.new_run_preview.as_ref().unwrap().key.clone();
+        draw(&mut dash, 160, 40);
+        assert_eq!(dash.new_run_preview.as_ref().unwrap().key, key);
+
+        // A row whose manifest cannot be read (the catalog lists what parsed
+        // when it was built; a file can go away after) says so instead of
+        // drawing.
+        dash.new_run_agents.push(NewRunAgent {
+            name: "broken".to_string(),
+            source: "local".to_string(),
+            description: String::new(),
+            path: dir
+                .path()
+                .join("agents/gone")
+                .to_string_lossy()
+                .into_owned(),
+        });
+        select(&mut dash, "broken");
+        let text = rendered_buffer(&draw(&mut dash, 160, 40));
+        assert!(text.contains("no preview"), "{text}");
+        assert!(text.contains("could not read a blueprint"), "{text}");
+        assert!(dash.new_run_preview.as_ref().unwrap().view.is_err());
+
+        // A bundled blueprint that is not installed previews from the binary.
+        let bundled = dash
+            .new_run_agents
+            .iter()
+            .position(|a| a.source == "bundled")
+            .expect("the catalog lists the bundled blueprints");
+        dash.new_run_filter.clear();
+        dash.new_run_selected = bundled;
+        let text = rendered_buffer(&draw(&mut dash, 200, 50));
+        assert!(text.contains("stages · entry"), "{text}");
+        assert!(dash.new_run_preview.as_ref().unwrap().view.is_ok());
+
+        // Filtering everything out empties the preview.
+        dash.new_run_filter = "zzz-nothing".to_string();
+        let text = rendered_buffer(&draw(&mut dash, 160, 40));
+        assert!(text.contains("Pick an agent blueprint"), "{text}");
+        assert!(dash.new_run_preview.is_none());
+    }
+
+    #[test]
+    fn a_short_screen_skips_the_preview_and_the_popup_still_anchors_to_the_task_pane() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(dir.path(), "alpha", "[stages.only]\n");
+        std::fs::write(dir.path().join("notes.md"), "x").unwrap();
+        let mut dash = dash_at(dir.path());
+        select(&mut dash, "alpha");
+        let text = rendered_buffer(&draw(&mut dash, 100, 12));
+        assert!(!text.contains("entry only"), "{text}");
+        assert!(text.contains("Task for alpha"), "{text}");
+        // The `@` completion floats at the bottom of the task pane, whether or
+        // not the preview is above it.
+        dash.new_run_focus = NewRunPane::Task;
+        dash.new_run_file_ref = true;
+        dash.new_run_file_query.clear();
+        let text = rendered_buffer(&draw(&mut dash, 100, 12));
+        assert!(text.contains(" files "), "{text}");
+        let text = rendered_buffer(&draw(&mut dash, 160, 40));
+        assert!(
+            text.contains(" files ") && text.contains("entry only"),
+            "{text}"
+        );
+    }
+
+    #[test]
+    fn the_preview_takes_the_mouse_and_ticks() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(
+            dir.path(),
+            "alpha",
+            "[stages.a]\n[stages.a.transitions.b]\n[stages.b]\n[stages.b.transitions.a]\n[stages.b.transitions.c]\n[stages.c]\n[stages.c.transitions]\n",
+        );
+        let mut dash = dash_at(dir.path());
+        select(&mut dash, "alpha");
+        draw(&mut dash, 160, 40);
+        let canvas = dash
+            .pane_rects
+            .iter()
+            .find(|(id, _)| *id == PaneId::NewRunPreview)
+            .map(|(_, r)| *r)
+            .expect("the preview registered its canvas");
+        let view = |d: &Dashboard| {
+            d.new_run_preview
+                .as_ref()
+                .unwrap()
+                .view
+                .as_ref()
+                .ok()
+                .unwrap()
+                .pan()
+        };
+        let pan = view(&dash);
+        let (x, y) = (canvas.x + canvas.width - 3, canvas.y + 1);
+        let mouse = |kind, x, y| MouseEvent {
+            kind,
+            column: x,
+            row: y,
+            modifiers: KeyModifiers::NONE,
+        };
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x - 10, y));
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x - 10, y));
+        assert_ne!(view(&dash), pan);
+        dash.tick_graphs(std::time::Duration::from_millis(100));
+        // With the screen closed the preview canvas is not a mouse target.
+        dash.close_new_run_screen();
+        assert!(dash.graph_view_mut(PaneId::NewRunPreview).is_none());
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/new_run_preview.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run_preview.rs
@@ -107,7 +107,7 @@ impl Dashboard {
                     if graph.stage_count() == 1 { "" } else { "s" },
                     graph.entry
                 );
-                let canvas = view.render(frame, area, Some(preview_block(title)));
+                let canvas = view.render(frame, area, preview_block(title));
                 self.pane_rects.push((PaneId::NewRunPreview, canvas));
             }
             Err(why) => {

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -155,7 +155,7 @@ impl Dashboard {
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(C_BORDER_FOCUS))
             .title(Span::styled(title, Style::default().fg(C_ACCENT)));
-        let canvas = explorer.view.render(frame, rows[0], Some(block));
+        let canvas = explorer.view.render(frame, rows[0], block);
         self.pane_rects.push((PaneId::ExplorerGraph, canvas));
 
         let line = match explorer.view.selection() {

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -156,10 +156,9 @@ impl Dashboard {
 
         let header_h: u16 = 1; // compact breadcrumb line
         let info_h: u16 = 4; // task + workdir/stats strip (2 content + 2 border lines)
-        // Graph agents get the same 3-row tab strip as linear ones; the real
-        // graph lives in the full-screen explorer (`g`), which no longer
-        // costs every other pane four rows.
-        let tabs_h: u16 = 3;
+        // The stage row: the graph band on a tall terminal, the three-row
+        // strip otherwise (the band would cost every other pane its rows).
+        let tabs_h: u16 = Self::stage_row_height(area.height, &agent);
         let context_h: u16 = if agent.context_snapshot.is_some() || !agent.stages.is_empty() {
             5
         } else {

--- a/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
@@ -29,9 +29,22 @@ impl Dashboard {
             .split(rows[0]);
 
         self.draw_new_run_agents(frame, panes[0]);
-        self.draw_new_run_task(frame, panes[1]);
+        // The selected blueprint's stage graph sits above the task editor,
+        // when the pane has the rows for both; the editor keeps its minimum.
+        let preview_h = super::super::new_run_preview::preview_height(panes[1].height);
+        let task_area = if preview_h > 0 {
+            let right = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([Constraint::Length(preview_h), Constraint::Min(1)])
+                .split(panes[1]);
+            self.draw_new_run_preview(frame, right[0]);
+            right[1]
+        } else {
+            panes[1]
+        };
+        self.draw_new_run_task(frame, task_area);
         // The completion floats over the task pane, so it is drawn after it.
-        self.draw_file_ref_popup(frame, panes[1]);
+        self.draw_file_ref_popup(frame, task_area);
         self.draw_new_run_help_bar(frame, rows[1]);
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -14,15 +14,21 @@ use crate::runstate::StageRunStatus;
 
 impl Dashboard {
     pub(in crate::commands::dashboard) fn render_stage_tabs(
-        &self,
+        &mut self,
         frame: &mut Frame,
         tabs_area: Rect,
         agent: &DashboardAgent,
     ) {
-        // Both agent shapes use the same compact tab strip; a graph agent's
-        // real DAG (with revisit counts and the visit timeline) lives in the
-        // full-screen explorer on `g`, instead of a 7-row strip that could
-        // only draw arrows between list-neighbors.
+        // Given the rows for it (`stage_row_height`), the stage row is the
+        // graph band: the same "N of M" and selection, plus where the run
+        // has been and how the stages connect. The flat strip is the
+        // fallback for short terminals and runs without a readable
+        // blueprint; the full-screen explorer stays on `g`.
+        if tabs_area.height >= super::super::detail_band::BAND_HEIGHT
+            && self.draw_stage_band(frame, tabs_area, agent)
+        {
+            return;
+        }
         self.draw_linear_tabs(frame, tabs_area, agent);
     }
 
@@ -293,7 +299,7 @@ mod tests {
     fn render_stage_tabs_linear_empty_stages() {
         let backend = TestBackend::new(120, 10);
         let mut terminal = Terminal::new(backend).unwrap();
-        let dash = make_test_dashboard();
+        let mut dash = make_test_dashboard();
         let agent = make_test_agent("run-s", AgentDisplayStatus::Active);
         terminal
             .draw(|f| {
@@ -309,7 +315,7 @@ mod tests {
     fn render_stage_tabs_linear_with_records() {
         let backend = TestBackend::new(120, 10);
         let mut terminal = Terminal::new(backend).unwrap();
-        let dash = make_test_dashboard();
+        let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-sr", AgentDisplayStatus::Active);
         agent.stages = vec![
             make_stage_record("plan", StageRunStatus::Complete),
@@ -363,7 +369,7 @@ mod tests {
     fn render_stage_tabs_graph_mode() {
         let backend = TestBackend::new(120, 10);
         let mut terminal = Terminal::new(backend).unwrap();
-        let dash = make_test_dashboard();
+        let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-g", AgentDisplayStatus::Active);
         agent.stages = vec![
             make_stage_record("plan", StageRunStatus::Complete),
@@ -396,7 +402,7 @@ mod tests {
         // branch for the earlier, already-passed stages.
         let backend = TestBackend::new(120, 10);
         let mut terminal = Terminal::new(backend).unwrap();
-        let dash = make_test_dashboard();
+        let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-fallback-idx", AgentDisplayStatus::Active);
         agent.stages = vec![];
         agent.num_stages = 3;

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -48,6 +48,9 @@ pub(crate) struct Dashboard {
     /// The graph pane holding the mouse between a left press and its
     /// release, so a pan that leaves the canvas keeps panning.
     pub(super) mouse_capture: Option<PaneId>,
+    /// The detail view's graph band, kept between frames; rebuilt when the
+    /// selected run changes.
+    pub(super) detail_band: Option<super::detail_band::DetailBand>,
     /// The log panel's viewport height as of the last draw, so key scrolling
     /// pages by what is actually visible.
     pub(super) log_viewport: usize,

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -51,6 +51,8 @@ pub(crate) struct Dashboard {
     /// The detail view's graph band, kept between frames; rebuilt when the
     /// selected run changes.
     pub(super) detail_band: Option<super::detail_band::DetailBand>,
+    /// The new-run screen's blueprint preview, for the selected catalog row.
+    pub(super) new_run_preview: Option<super::new_run_preview::BlueprintPreview>,
     /// The log panel's viewport height as of the last draw, so key scrolling
     /// pages by what is actually visible.
     pub(super) log_viewport: usize,

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -73,13 +73,15 @@ pub(super) enum PaneId {
     LogPanel,
     /// The stage explorer's graph canvas: the wheel zooms, a drag pans.
     ExplorerGraph,
+    /// The detail view's graph band: a drag pans.
+    DetailBand,
 }
 
 impl PaneId {
     /// Whether the pane is a graph canvas, which takes the mouse before the
     /// text-selection machinery sees it.
     pub(super) fn is_graph(self) -> bool {
-        matches!(self, PaneId::ExplorerGraph)
+        matches!(self, PaneId::ExplorerGraph | PaneId::DetailBand)
     }
 }
 

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -75,13 +75,18 @@ pub(super) enum PaneId {
     ExplorerGraph,
     /// The detail view's graph band: a drag pans.
     DetailBand,
+    /// The new-run screen's blueprint preview: a drag pans.
+    NewRunPreview,
 }
 
 impl PaneId {
     /// Whether the pane is a graph canvas, which takes the mouse before the
     /// text-selection machinery sees it.
     pub(super) fn is_graph(self) -> bool {
-        matches!(self, PaneId::ExplorerGraph | PaneId::DetailBand)
+        matches!(
+            self,
+            PaneId::ExplorerGraph | PaneId::DetailBand | PaneId::NewRunPreview
+        )
     }
 }
 

--- a/crates/leviath-cli/src/tui/flowgraph/model.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/model.rs
@@ -383,6 +383,15 @@ impl StageGraph {
         self.nodes.iter().find(|n| n.id == id)
     }
 
+    /// How many stages the blueprint has (external worker blueprints are
+    /// nodes, not stages).
+    pub(crate) fn stage_count(&self) -> usize {
+        self.nodes
+            .iter()
+            .filter(|n| n.kind != NodeKind::ExternalBlueprint)
+            .count()
+    }
+
     /// Position of the stage `id` in the blueprint's stage list: `None` for
     /// an external worker blueprint, which is a node but not a stage.
     pub(crate) fn stage_index(&self, id: &str) -> Option<usize> {
@@ -451,6 +460,7 @@ allow_complete = true
         assert!(c.is_terminal && c.allow_complete);
         assert_eq!(g.stage_index("c"), Some(2));
         assert_eq!(g.stage_index("nope"), None);
+        assert_eq!(g.stage_count(), 3);
         assert_eq!(g.ids().collect::<Vec<_>>(), vec!["a", "b", "c"]);
     }
 
@@ -722,6 +732,7 @@ worker_query = "anything that reads logs"
         // External nodes come after every stage, and are not stages.
         assert_eq!(g.ids().last(), Some("ext:researcher"));
         assert_eq!(g.stage_index("ext:researcher"), None);
+        assert_eq!(g.stage_count(), 3, "the external node is not a stage");
         assert_eq!(g.node("ext:researcher").unwrap().kind_label(), "blueprint");
     }
 

--- a/crates/leviath-cli/src/tui/flowgraph/text.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/text.rs
@@ -4,7 +4,6 @@
 
 use std::sync::Arc;
 
-use rataflow::Position;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::widgets::Widget;
@@ -18,6 +17,7 @@ use super::view::FlowView;
 pub(crate) fn render_to_text(graph: &StageGraph, width: u16) -> String {
     let mut view = FlowView::new(Arc::new(graph.clone()), NodeStyle::Full, true);
     view.toggle_escape();
+    view.fit();
     let (world_w, world_h) = view.world_extent();
     // Room for the edge lanes above and below the nodes and a cell of margin
     // each side; the fit-view keeps zoom at 1.0 when everything fits and
@@ -43,20 +43,6 @@ pub(crate) fn render_to_text(graph: &StageGraph, width: u16) -> String {
 }
 
 impl FlowView {
-    /// The far corner of the laid-out graph in world units.
-    pub(crate) fn world_extent(&self) -> (f64, f64) {
-        self.flow()
-            .nodes()
-            .map(|n| n.bounds())
-            .fold((0.0_f64, 0.0_f64), |(w, h), b| {
-                let Position { x, y } = b.position;
-                (
-                    w.max(x + b.dimensions.width),
-                    h.max(y + b.dimensions.height),
-                )
-            })
-    }
-
     /// Draw straight into a buffer, for the text render.
     pub(crate) fn render_into(&mut self, area: Rect, buf: &mut Buffer) {
         self.flow_mut().render(area, buf);

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -155,9 +155,11 @@ impl FlowView {
             .unwrap_or(0);
         let node_w = style.width(longest);
         let node_h = style.height();
-        let (gap_x, gap_y) = match style {
-            NodeStyle::Full => (8.0, 1.0),
-            NodeStyle::Compact => (6.0, 1.0),
+        // A one-row box has no room to shrink: below zoom 1 it is zero rows
+        // tall and gone. Compact canvases stay at 1.0 and pan instead.
+        let (gap_x, gap_y, min_zoom) = match style {
+            NodeStyle::Full => (8.0, 1.0, 0.4),
+            NodeStyle::Compact => (6.0, 1.0, 1.0),
         };
 
         let nodes: Vec<Node<StageNodeContent>> = graph
@@ -228,7 +230,7 @@ impl FlowView {
         let mut flow = Flow::with_graph(nodes, edges)
             .expect("a StageGraph has unique ids, no self-loops and no dangling edges")
             .with_theme(Theme::Custom(palette()))
-            .with_min_zoom(0.4)
+            .with_min_zoom(min_zoom)
             .with_max_zoom(1.0)
             // A press on empty canvas is how a pan starts; it must not throw
             // the selection away, or Enter after a pan opens nothing.
@@ -337,9 +339,8 @@ impl FlowView {
         Selection::Nothing
     }
 
-    /// Select a stage by name (the detail band will follow the stage tabs
-    /// this way; the tests use it to pick a node without a mouse).
-    #[cfg(test)]
+    /// Select a stage by name: the detail band follows the stage tabs this
+    /// way, and it works on a locked canvas.
     pub(crate) fn select_stage(&mut self, id: &str) {
         self.flow.select_node(id);
     }
@@ -910,13 +911,21 @@ merge_stage = "merge"
                 Selection::Node("plan".into()),
                 "a pan keeps the selection (locked={locked})"
             );
-            let zoom = v.zoom();
+            // A compact canvas cannot zoom out: its boxes are one row tall.
             v.handle_mouse(mouse(MouseEventKind::ScrollDown, x, y));
-            assert!(v.zoom() < zoom, "locked={locked}");
-            v.handle_mouse(mouse(MouseEventKind::ScrollUp, x, y));
-            assert!(v.zoom() > zoom * 0.9, "locked={locked}");
+            assert_eq!(v.zoom(), 1.0, "locked={locked}");
             v.tick(Duration::from_millis(100));
         }
+        // A full canvas zooms at the wheel.
+        let mut v = view();
+        draw(&mut v, 220, 50);
+        let c = v.canvas();
+        let (x, y) = (c.x + c.width - 2, c.y + c.height - 2);
+        let zoom = v.zoom();
+        v.handle_mouse(mouse(MouseEventKind::ScrollDown, x, y));
+        assert!(v.zoom() < zoom);
+        v.handle_mouse(mouse(MouseEventKind::ScrollUp, x, y));
+        assert!(v.zoom() > zoom * 0.9);
     }
 
     #[test]

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -354,12 +354,9 @@ impl FlowView {
     /// otherwise, on a canvas that cannot zoom out (compact boxes), start at
     /// the top-left corner so the entry stage is on screen rather than the
     /// middle of the picture. A full canvas zooms out to fit instead.
-    fn settle(&mut self, area: Rect, bordered: bool) {
-        let border = if bordered { 2.0 } else { 0.0 };
-        let (inner_w, inner_h) = (
-            f64::from(area.width) - border,
-            f64::from(area.height) - border,
-        );
+    fn settle(&mut self, area: Rect) {
+        // Inside the block's border.
+        let (inner_w, inner_h) = (f64::from(area.width) - 2.0, f64::from(area.height) - 2.0);
         let (world_w, world_h) = self.world_extent();
         let overflows = world_w + 2.0 > inner_w || world_h + 2.0 > inner_h;
         if self.compact && overflows {
@@ -524,19 +521,13 @@ impl FlowView {
         }
     }
 
-    /// Draw the canvas into `area`, inside `block` when given. Returns the
-    /// canvas rect (the block's inside), which is what mouse routing hit-tests.
-    pub(crate) fn render(
-        &mut self,
-        frame: &mut Frame,
-        area: Rect,
-        block: Option<Block<'static>>,
-    ) -> Rect {
-        let bordered = block.is_some();
-        self.flow.set_block(block);
+    /// Draw the canvas into `area`, inside `block`. Returns the canvas rect
+    /// (the block's inside), which is what mouse routing hit-tests.
+    pub(crate) fn render(&mut self, frame: &mut Frame, area: Rect, block: Block<'static>) -> Rect {
+        self.flow.set_block(Some(block));
         if (area.width, area.height) != (self.last_area.width, self.last_area.height) {
             self.last_area = area;
-            self.settle(area, bordered);
+            self.settle(area);
         }
         if let Some(id) = self.reveal.take() {
             self.flow.ensure_node_visible(&id);
@@ -633,7 +624,7 @@ mode = "output"
         let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
         terminal
             .draw(|f| {
-                view.render(f, f.area(), Some(Block::bordered()));
+                view.render(f, f.area(), Block::bordered());
             })
             .unwrap();
         let text: String = terminal

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind};
 use rataflow::{
-    Edge, FitViewOptions, Flow, FlowAction, Handle, HandlePosition, Node, StepEdge, Theme,
+    Edge, FitViewOptions, Flow, FlowAction, Handle, HandlePosition, Node, StepEdge, Theme, Viewport,
 };
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -99,6 +99,8 @@ pub(crate) struct FlowView {
     /// counted: they are hidden until asked for, and a long one would cost
     /// every fit its width.
     max_stem: f64,
+    /// One-row boxes: the canvas cannot zoom out, so it pans instead.
+    compact: bool,
 }
 
 impl std::fmt::Debug for FlowView {
@@ -237,7 +239,9 @@ impl FlowView {
             .with_deselect_on_pane_click(false)
             .with_locked(locked);
         flow.set_node_positions(layout.positions(node_w, node_h, gap_x, gap_y));
-        flow.request_fit_view_with_options(fit_options(max_stem));
+        // No fit here: the first `render` settles the viewport for the area it
+        // gets (a fit, or the top-left corner for a compact canvas that
+        // overflows). A fit requested now would land after that and undo it.
 
         Self {
             flow,
@@ -250,6 +254,7 @@ impl FlowView {
             last_area: Rect::default(),
             canvas: Rect::default(),
             max_stem,
+            compact: style == NodeStyle::Compact,
         }
     }
 
@@ -343,6 +348,29 @@ impl FlowView {
     /// way, and it works on a locked canvas.
     pub(crate) fn select_stage(&mut self, id: &str) {
         self.flow.select_node(id);
+    }
+
+    /// First look at a canvas of this size: fit the graph when it fits, and
+    /// otherwise, on a canvas that cannot zoom out (compact boxes), start at
+    /// the top-left corner so the entry stage is on screen rather than the
+    /// middle of the picture. A full canvas zooms out to fit instead.
+    fn settle(&mut self, area: Rect, bordered: bool) {
+        let border = if bordered { 2.0 } else { 0.0 };
+        let (inner_w, inner_h) = (
+            f64::from(area.width) - border,
+            f64::from(area.height) - border,
+        );
+        let (world_w, world_h) = self.world_extent();
+        let overflows = world_w + 2.0 > inner_w || world_h + 2.0 > inner_h;
+        if self.compact && overflows {
+            self.flow.viewport = Viewport {
+                x: 1.0,
+                y: 1.0,
+                zoom: 1.0,
+            };
+        } else {
+            self.fit();
+        }
     }
 
     /// Bring the whole graph on screen at the next draw.
@@ -504,10 +532,11 @@ impl FlowView {
         area: Rect,
         block: Option<Block<'static>>,
     ) -> Rect {
+        let bordered = block.is_some();
         self.flow.set_block(block);
         if (area.width, area.height) != (self.last_area.width, self.last_area.height) {
             self.last_area = area;
-            self.fit();
+            self.settle(area, bordered);
         }
         if let Some(id) = self.reveal.take() {
             self.flow.ensure_node_visible(&id);
@@ -525,9 +554,17 @@ impl FlowView {
         self.flow.select_edge(&format!("e{index}"));
     }
 
-    /// The canvas itself, for the text render.
-    pub(super) fn flow(&self) -> &Flow<StageNodeContent, StepEdge> {
-        &self.flow
+    /// The far corner of the laid-out graph in world units.
+    pub(crate) fn world_extent(&self) -> (f64, f64) {
+        self.flow
+            .nodes()
+            .map(|n| n.bounds())
+            .fold((0.0_f64, 0.0_f64), |(w, h), b| {
+                (
+                    w.max(b.position.x + b.dimensions.width),
+                    h.max(b.position.y + b.dimensions.height),
+                )
+            })
     }
 
     /// The canvas itself, mutably, for the text render.
@@ -899,12 +936,14 @@ merge_stage = "merge"
             draw(&mut v, 60, 12);
             v.select_stage("plan");
             let pan = v.pan();
-            // Press on empty canvas (far corner), drag, release.
+            // Press on empty canvas (the top-right corner: a compact canvas
+            // starts at its top-left, so the boxes run along row 2 and the
+            // loop lanes below them), drag, release.
             let c = v.canvas();
-            let (x, y) = (c.x + c.width - 2, c.y + c.height - 2);
+            let (x, y) = (c.x + c.width - 2, c.y);
             v.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
-            v.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x - 5, y - 2));
-            v.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x - 5, y - 2));
+            v.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x - 5, y + 2));
+            v.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x - 5, y + 2));
             assert_ne!(v.pan(), pan, "locked={locked}");
             assert_eq!(
                 v.selection(),
@@ -926,6 +965,23 @@ merge_stage = "merge"
         assert!(v.zoom() < zoom);
         v.handle_mouse(mouse(MouseEventKind::ScrollUp, x, y));
         assert!(v.zoom() > zoom * 0.9);
+    }
+
+    #[test]
+    fn a_compact_canvas_starts_top_left_when_the_graph_overflows_and_fits_otherwise() {
+        let mut v = FlowView::new(graph(), NodeStyle::Compact, true);
+        draw(&mut v, 60, 12);
+        assert_eq!(v.pan(), (1.0, 1.0), "the entry stage is on screen");
+        assert_eq!(v.node_rect("plan").map(|r| r.0), Some(2));
+        // Wide enough: centred like any other fit.
+        let mut v = FlowView::new(graph(), NodeStyle::Compact, true);
+        draw(&mut v, 200, 20);
+        assert_ne!(v.pan(), (1.0, 1.0));
+        assert_eq!(v.zoom(), 1.0);
+        // A full canvas that overflows zooms out instead.
+        let mut v = FlowView::new(graph(), NodeStyle::Full, false);
+        draw(&mut v, 60, 20);
+        assert!(v.zoom() < 1.0);
     }
 
     #[test]

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -36,9 +36,9 @@ panel and answer. `lev respond` does the same from the shell.
 - **Agent run table**: title and run id, blueprint, stage, status, tokens, and start time, with
   sub-agents nested under their parent. Titles are auto-generated per run. The model, iteration,
   and context-window occupancy live in the detail view.
-- **Detail view**: per-stage tabs, a context-window visualization, and content panes for
-  **Output**, **Logs**, and **Context** (JSON). Markdown is rendered. `g` opens the stage graph:
-  the blueprint drawn as boxes and routed edges, with the stage the run is in lit up.
+- **Detail view**: the blueprint's stage graph as a band under the header (the flat stage tabs
+  on a short terminal), a context-window visualization, and content panes for **Output**,
+  **Logs**, and **Context** (JSON). Markdown is rendered. `g` opens the graph full screen.
 - **Interactions**: answer an agent's question (free-text, edit, multiple-choice, tool-approval, or
   confirm) or send it a mid-run message.
 - **Mouse support**: wheel scroll, click-drag select with copy-on-release, OSC52 copy over SSH,
@@ -98,8 +98,13 @@ skips marked runs that have already finished.
 
 ### Starting a run (`n`)
 
-Agent blueprints on the left, the task on the right. Once it starts, the dashboard opens that run's page, and
-`Esc` from there goes back to the list rather than back into the form.
+Agent blueprints on the left, the task on the right, and above the task the selected blueprint's
+stage graph, so you can see what an agent will do before you give it a task: how many stages, in
+what order, where it loops back. It follows the selection, previews bundled blueprints that are not
+installed yet from the copy inside the binary, and says so when a manifest cannot be read. Drag to
+pan it; on a screen too short to fit both, the task keeps its rows and the preview is skipped. Once
+the run starts, the dashboard opens that run's page, and `Esc` from there goes back to the list
+rather than back into the form.
 
 | Key | Action |
 |---|---|
@@ -119,6 +124,12 @@ the blueprint asks a person for. Those still stop, and one nobody answers ends t
 interaction timeout expires. The setting is off again every time the screen opens.
 
 ### Detail view
+
+On a terminal at least 32 rows tall the stage row is the blueprint's graph: one box per stage,
+transitions as edges, the stage the run is in in the run's colour, visited stages with their
+visit count, the selected stage reversed. `←` / `→` and `1`-`9` move through it exactly as they
+did through the tabs, and dragging pans it. On a shorter terminal, and for a run whose blueprint
+could not be read, the flat tab strip stays.
 
 | Key | Action |
 |---|---|


### PR DESCRIPTION
## What

The two remaining surfaces from the stage-graph plan (#499 shipped the kit and the explorer):

- **A graph band in the detail view.** On a detail area at least 32 rows tall the stage row is the blueprint's graph, one-row boxes on the layered layout in place of the flat tab strip: the same "stage N of M" and the same selection (`←`/`→` and `1-9` move it, the selected stage is reversed, `g` opens the full explorer), plus where the run has been, where it is (the run's colour, spinning), and how the stages connect. It is a viewer: the mouse pans, nothing selects by click. On shorter terminals, and for a run whose blueprint could not be read, the three-row strip stays as it was.
- **A blueprint preview on the new-run screen.** Above the task editor, the selected blueprint's stage graph, so what an agent will do is on screen before it is given a task. It follows the picker (one parse per selection change), previews bundled blueprints that are not installed yet from the copy inside the binary, says why when a manifest cannot be read, and pans under the mouse. On a right pane too short for both, the task editor keeps its rows and the preview is skipped; the `@` completion still anchors to the task pane.

Live, in a pty at 200x50 (mock provider, real daemon), the new-run screen with `coder` selected:

```
╭ Agent Blueprints (8) ──────────────────────────────────╮╭ coder · 8 stages · entry discover · drag to pan ────────────────────────────────────────────╮
│  Blueprint         Source     Description              ││                                                                                            │
│› coder             bundled    v0.1.0 - install with …  ││ [ ▶ ○ discover ]       ─────▶[ ○ plan ]             ─────▶[ ○ prototype ]        ─────▶[ ○ im│
│  data-analyst      bundled    v0.0.2 - install with …  ││                                    ▲                                      ·                  │
│  deep-researcher   bundled    v0.1.1 - install with …  ││                                    ·                                      ·                  │
│  log-analyzer      bundled    v0.1.1 - install with …  ││                                    ········································                  │
```

and the band under a running `looper`'s header, one arrow-right after opening it:

```
╭ Stages ←/→ to switch  stage 3/5  ·  [g] graph  ·  drag to pan ────────────────────────────────────────╮
│                                                                                                        │
│[ ▶ ✓ plan ]      ─────▶[ ✓ implement ]   ─────▶[ ⠹ review ]      ─────▶[ ○ done ]         [ ○ recover ]│
│                             ▲                              ·                ▲                          │
│                             ·                              ·                ·                          │
│                             ··········[llm_choice]··········                ·························  │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## How

- `dashboard/detail_band.rs`: `Dashboard.detail_band: Option<DetailBand{run_id, view}>`, rebuilt when the selected run changes; `stage_row_height` picks 8 rows or 3; `render_stage_tabs` draws the band when it has the rows and falls back to `draw_linear_tabs` otherwise. `PaneId::DetailBand` for the mouse.
- `dashboard/new_run_preview.rs`: `Dashboard.new_run_preview: Option<BlueprintPreview{key: NewRunAgent::path, view: Result<FlowView, String>}>`, `sync_new_run_preview` on draw, `preview_height` splits the right pane only when the task editor keeps 8 rows; `graph.rs::bundled_stage_graph` parses `BUNDLED_AGENTS[..].files["agent.leviath"]`. `PaneId::NewRunPreview`, active only while the screen is open.
- Kit: `NodeStyle::Compact` canvases have `min_zoom = 1.0` (a one-row box zoomed out is zero rows and gone), and when the graph overflows such a canvas the first draw settles at the top-left corner so the entry stage is on screen rather than the middle of the picture; the constructor no longer requests its own fit (found live: the coder preview opened on "prototype" with `discover` off the left edge). `select_stage` is production now (the band follows the tabs with it).
- Docs (`dashboard.md` detail view + starting a run) and CHANGELOG.

## Checks

- `cargo xtask coverage --package leviath-cli` 100%.
- Live pty run as above: preview follows the picker (bundled `coder` → `data-analyst` with its fan-out `═══╣` hand-offs), band shows the run advancing and `→` moving the reversed selection, explorer unchanged.

Stacked on #499 (merged); rebased onto main.
