### PR TITLE
feat(dash): make more of the stage graph canvas, and let boxes be dragged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ same list.
 - New: the new-run screen previews the selected blueprint's stage graph
   above the task, bundled blueprints included before they are installed,
   and says so when a manifest cannot be read.
+- Changed: the stage graph never shrinks its boxes to fit. The layers run
+  left to right when that fits and top to bottom when only that does (`r`
+  turns it by hand); when neither fits the canvas starts at the entry stage
+  and pans, with a minimap once there is more graph than screen. Boxes keep
+  their frame at every size and cut the name before anything else, the
+  selected one gets a thick bright frame rather than reversed text, edge
+  animation runs at a walking pace, a dotted grid sits under the graph, and
+  boxes can be dragged into an arrangement of your own, which the explorer
+  keeps for the run.
 - Fixed: shortcuts that worked but were never hinted or documented. The
   detail view's hint bar names `g` (the graph) and `1-9`; the main list's
   names `m` (MCP servers); the log panel's names PgUp/PgDn, `?` and the

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -117,6 +117,7 @@ impl Dashboard {
             pane_rects: Vec::new(),
             mouse_capture: None,
             detail_band: None,
+            explorer_cache: None,
             new_run_preview: None,
             log_viewport: 0,
             stage_explorer: None,

--- a/crates/leviath-cli/src/commands/dashboard/detail_band.rs
+++ b/crates/leviath-cli/src/commands/dashboard/detail_band.rs
@@ -209,13 +209,9 @@ condition = "llm_choice"
             assert!(text.contains(&format!(" {stage} ")), "{stage}: {text}");
         }
         // The stage the run is in is drawn in the active colour; the selected
-        // tab is the reversed one; a pending stage is dim.
+        // tab has the bright brackets; a pending stage is dim.
         assert_eq!(style_at_text(&terminal, "implement").fg, Some(C_ACTIVE));
-        assert!(
-            style_at_text(&terminal, "plan")
-                .add_modifier
-                .contains(ratatui::style::Modifier::REVERSED)
-        );
+        assert_eq!(style_at_text(&terminal, "[ ▶").fg, Some(C_BORDER_FOCUS));
         assert_eq!(style_at_text(&terminal, "done").fg, Some(C_DIM));
         assert!(
             dash.pane_rects
@@ -297,11 +293,15 @@ condition = "llm_choice"
         draw(&mut dash, 160, 40);
         // A second draw of the same run keeps the canvas it built.
         let terminal = draw(&mut dash, 160, 40);
-        assert!(
-            style_at_text(&terminal, "implement")
-                .add_modifier
-                .contains(ratatui::style::Modifier::REVERSED),
-            "the ledger's second stage is the selected one"
+        assert_eq!(
+            style_at_text(&terminal, "[ ▶").fg,
+            Some(C_DIM),
+            "plan is pending, not selected"
+        );
+        assert_eq!(
+            style_at_text(&terminal, "implement ]").fg,
+            Some(C_ACTIVE),
+            "the ledger's second stage is the selected one and the current one"
         );
         let canvas = dash
             .pane_rects

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -30,13 +30,28 @@ impl Dashboard {
         match agent.graph.clone() {
             Some(graph) => {
                 self.ensure_history(&run_id);
-                let view = FlowView::new(graph, NodeStyle::Full, false);
+                // The canvas a previous visit left behind for this run comes
+                // back as it was: viewport, dragged boxes, direction, toggles.
+                let view = match self.explorer_cache.take() {
+                    Some((cached_run, view)) if cached_run == run_id => view,
+                    _ => FlowView::new(graph, NodeStyle::Full, false),
+                };
                 self.stage_explorer = Some(ExplorerState::new(view));
             }
             None => self.toast(
                 "This run's blueprint could not be read, so there is no stage graph to show",
                 ToastLevel::Warning,
             ),
+        }
+    }
+
+    /// Close the explorer, keeping its canvas for the next `g` on the same
+    /// run.
+    pub(super) fn close_stage_explorer(&mut self) {
+        if let Some(explorer) = self.stage_explorer.take()
+            && let Some(run_id) = self.selected_agent().map(|a| a.id.clone())
+        {
+            self.explorer_cache = Some((run_id, explorer.view));
         }
     }
 
@@ -62,7 +77,7 @@ impl Dashboard {
             return;
         };
         match key_code {
-            KeyCode::Esc | KeyCode::Char('g') => self.stage_explorer = None,
+            KeyCode::Esc | KeyCode::Char('g') => self.close_stage_explorer(),
             KeyCode::Tab | KeyCode::BackTab => {
                 explorer.tab = match explorer.tab {
                     ExplorerTab::Graph => ExplorerTab::Timeline,
@@ -97,7 +112,7 @@ impl Dashboard {
                             .and_then(|h| h.visits.get(selected))
                             .map(|v| v.first_point);
                         if let Some(point) = point {
-                            self.stage_explorer = None;
+                            self.close_stage_explorer();
                             self.jump_to_history_point(point);
                         }
                     }
@@ -124,7 +139,7 @@ impl Dashboard {
             self.search_mode = false;
             self.search_query.clear();
             self.search_match_idx = 0;
-            self.stage_explorer = None;
+            self.close_stage_explorer();
         }
     }
 
@@ -508,8 +523,19 @@ condition = "llm_choice"
         assert_eq!(dash.selected_stage, 0);
         assert_eq!(dash.detail_scroll, 0);
 
+        // Reopening the same run brings its canvas back, selection and
+        // toggles included, so Enter opens plan's tab again.
+        dash.handle_key(key(KeyCode::Char('g')));
+        assert_eq!(
+            dash.stage_explorer.as_ref().unwrap().view.selection(),
+            Selection::Node("plan".into())
+        );
+        assert!(!dash.stage_explorer.as_ref().unwrap().view.show_unvisited());
+        dash.handle_key(key(KeyCode::Enter));
+        assert!(dash.stage_explorer.is_none());
         // Enter with nothing selected keeps the explorer open; Enter on an
         // external worker node has no tab to open.
+        dash.explorer_cache = None;
         dash.handle_key(key(KeyCode::Char('g')));
         dash.handle_key(key(KeyCode::Enter));
         assert!(dash.stage_explorer.is_some());

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -36,7 +36,7 @@ impl Dashboard {
                     Some((cached_run, view)) if cached_run == run_id => view,
                     _ => FlowView::new(graph, NodeStyle::Full, false),
                 };
-                self.stage_explorer = Some(ExplorerState::new(view));
+                self.stage_explorer = Some(ExplorerState::new(run_id, view));
             }
             None => self.toast(
                 "This run's blueprint could not be read, so there is no stage graph to show",
@@ -48,10 +48,8 @@ impl Dashboard {
     /// Close the explorer, keeping its canvas for the next `g` on the same
     /// run.
     pub(super) fn close_stage_explorer(&mut self) {
-        if let Some(explorer) = self.stage_explorer.take()
-            && let Some(run_id) = self.selected_agent().map(|a| a.id.clone())
-        {
-            self.explorer_cache = Some((run_id, explorer.view));
+        if let Some(explorer) = self.stage_explorer.take() {
+            self.explorer_cache = Some((explorer.run_id, explorer.view));
         }
     }
 
@@ -510,6 +508,16 @@ condition = "llm_choice"
         assert!(!dash.stage_explorer.as_ref().unwrap().view.show_unvisited());
         dash.handle_key(key(KeyCode::Char('e')));
         assert!(dash.stage_explorer.as_ref().unwrap().view.show_escape());
+        dash.handle_key(key(KeyCode::Char('r')));
+        assert_eq!(
+            dash.stage_explorer.as_ref().unwrap().view.direction(),
+            crate::tui::flowgraph::Direction::TopToBottom
+        );
+        let terminal = draw(&mut dash);
+        assert!(
+            crate::commands::dashboard::test_support::rendered_buffer(&terminal)
+                .contains("top to bottom (r)")
+        );
         dash.handle_key(key(KeyCode::Char('?')));
         assert!(dash.show_help);
         dash.handle_key(key(KeyCode::Esc)); // closes help

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -48,9 +48,13 @@ impl Dashboard {
     /// Close the explorer, keeping its canvas for the next `g` on the same
     /// run.
     pub(super) fn close_stage_explorer(&mut self) {
-        if let Some(explorer) = self.stage_explorer.take() {
-            self.explorer_cache = Some((explorer.run_id, explorer.view));
-        }
+        // Nothing open (never the case for the callers here) keeps whatever
+        // was cached.
+        self.explorer_cache = self
+            .stage_explorer
+            .take()
+            .map(|explorer| (explorer.run_id, explorer.view))
+            .or(self.explorer_cache.take());
     }
 
     /// Advance the edge animation on every open canvas, once per tick.

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -18,7 +18,7 @@ use crate::commands::dashboard::history::{StageVisit, clock};
 use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
 use crate::commands::dashboard::types::*;
-use crate::tui::flowgraph::Selection;
+use crate::tui::flowgraph::{Direction as FlowDirection, Selection};
 use crate::tui::widgets::footer::{draw_hint_bar, hint};
 
 fn duration_label(visit: &StageVisit) -> String {
@@ -106,9 +106,10 @@ impl Dashboard {
                 hint("enter", "open its tab"),
                 hint("+ -", "zoom"),
                 hint("f", "fit"),
+                hint("r", "rotate"),
                 hint("e", "escape edges"),
                 hint("u", "unvisited"),
-                hint("drag/wheel", "pan/zoom"),
+                hint("drag", "move a box or pan"),
                 hint("tab", "timeline"),
                 hint("?", "help"),
                 hint("esc/g", "close"),
@@ -137,7 +138,11 @@ impl Dashboard {
             .constraints([Constraint::Min(3), Constraint::Length(1)])
             .split(area);
         let title = format!(
-            " Graph · {} · zoom {:.0}%{} ",
+            " Graph · {} (r) · {} · zoom {:.0}%{} ",
+            match explorer.view.direction() {
+                FlowDirection::LeftToRight => "left to right",
+                FlowDirection::TopToBottom => "top to bottom",
+            },
             if explorer.view.show_escape() {
                 "escape edges shown"
             } else {

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -379,7 +379,10 @@ mode = "output"
     }
 
     fn explorer() -> ExplorerState {
-        ExplorerState::new(FlowView::new(stage_graph(), NodeStyle::Full, false))
+        ExplorerState::new(
+            "run-1".to_string(),
+            FlowView::new(stage_graph(), NodeStyle::Full, false),
+        )
     }
 
     fn seed(dash: &mut crate::commands::dashboard::state::Dashboard, stages: &[(&str, i64)]) {

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -723,6 +723,7 @@ mod tests {
         dash.update_display_indices();
         dash.detail_view = true;
         dash.stage_explorer = Some(crate::commands::dashboard::types::ExplorerState::new(
+            "run-exp".to_string(),
             crate::tui::flowgraph::FlowView::new(
                 graph,
                 crate::tui::flowgraph::NodeStyle::Full,

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -172,10 +172,12 @@ fn detail_sections() -> Vec<HelpSection> {
                 ),
                 ("+ / - / 0", "zoom in / out / back to 100%"),
                 ("f", "fit the whole graph on screen"),
+                ("r", "turn the graph: left to right / top to bottom"),
                 ("e", "show or hide the escape edges (error, dead_end, ...)"),
                 ("u", "show or hide stages the run never entered"),
                 ("↑ ↓ / k j", "timeline: step through visits"),
-                ("drag / wheel / click", "pan / zoom / select on the canvas"),
+                ("drag", "move a box; on empty canvas, pan"),
+                ("wheel / click", "zoom / select on the canvas"),
                 ("esc / g", "close the explorer"),
                 (
                     "",
@@ -501,7 +503,7 @@ mod tests {
 
     #[test]
     fn draw_help_overlay_detail_view_omits_main_list_section() {
-        let backend = TestBackend::new(120, 50);
+        let backend = TestBackend::new(120, 70);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut dash = make_test_dashboard();
         dash.detail_view = true;

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -51,6 +51,9 @@ pub(crate) struct Dashboard {
     /// The detail view's graph band, kept between frames; rebuilt when the
     /// selected run changes.
     pub(super) detail_band: Option<super::detail_band::DetailBand>,
+    /// The explorer's canvas from its last visit to a run, so reopening
+    /// finds the boxes where they were dragged and the view where it was.
+    pub(super) explorer_cache: Option<(String, crate::tui::flowgraph::FlowView)>,
     /// The new-run screen's blueprint preview, for the selected catalog row.
     pub(super) new_run_preview: Option<super::new_run_preview::BlueprintPreview>,
     /// The log panel's viewport height as of the last draw, so key scrolling

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -102,17 +102,21 @@ pub(super) enum ExplorerTab {
 /// timeline.
 #[derive(Debug)]
 pub(super) struct ExplorerState {
+    /// The run the canvas was built for; the canvas is kept for it after
+    /// the explorer closes.
+    pub(super) run_id: String,
     pub(super) tab: ExplorerTab,
     /// Selected row on the timeline tab.
     pub(super) timeline_selected: usize,
     /// The graph canvas. Owns the toggles (`u` unvisited, `e` escape edges),
-    /// the selection and the viewport.
+    /// the selection, the direction and the viewport.
     pub(super) view: FlowView,
 }
 
 impl ExplorerState {
-    pub(super) fn new(view: FlowView) -> Self {
+    pub(super) fn new(run_id: String, view: FlowView) -> Self {
         Self {
+            run_id,
             tab: ExplorerTab::Graph,
             timeline_selected: 0,
             view,

--- a/crates/leviath-cli/src/tui/flowgraph/content.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/content.rs
@@ -185,27 +185,33 @@ impl StageNodeContent {
         self.workers = None;
     }
 
-    fn title(&self, selected: bool) -> Line<'static> {
+    /// The title: entry marker, status glyph, name, visit count. `budget` is
+    /// how many cells it may take (padding included); the name gives way
+    /// first, with an ellipsis, so the count and the closing bracket or
+    /// border stay in view.
+    fn title(&self, selected: bool, budget: usize) -> Line<'static> {
         let (glyph, colour) = self.status.look(self.tick);
         let mut style = Style::default().fg(colour);
-        if matches!(self.status, NodeStatus::Current { .. }) {
+        if selected || matches!(self.status, NodeStatus::Current { .. }) {
             style = style.add_modifier(Modifier::BOLD);
         }
-        if selected {
-            style = style.add_modifier(Modifier::REVERSED);
-        }
-        let mut text = String::new();
+        let mut prefix = String::new();
         if self.is_entry {
-            text.push_str("▶ ");
+            prefix.push_str("▶ ");
         }
-        text.push_str(glyph);
-        text.push(' ');
-        text.push_str(&self.name);
+        prefix.push_str(glyph);
+        prefix.push(' ');
         let times = self.status.times();
-        if times > 1 {
-            text.push_str(&format!(" ×{times}"));
-        }
-        Line::from(Span::styled(format!(" {text} "), style))
+        let suffix = if times > 1 {
+            format!(" ×{times}")
+        } else {
+            String::new()
+        };
+        // Two cells of padding around the text.
+        let fixed = 2 + prefix.chars().count() + suffix.chars().count();
+        let room = budget.saturating_sub(fixed);
+        let name = fit(&self.name, room);
+        Line::from(Span::styled(format!(" {prefix}{name}{suffix} "), style))
     }
 
     /// The first detail row: what the stage is, and how far the current
@@ -244,33 +250,52 @@ impl StageNodeContent {
     }
 }
 
+/// `text`, cut to `room` cells with an ellipsis when it does not fit.
+fn fit(text: &str, room: usize) -> String {
+    if text.chars().count() <= room {
+        return text.to_string();
+    }
+    let keep = room.saturating_sub(1);
+    let mut cut: String = text.chars().take(keep).collect();
+    if room > 0 {
+        cut.push('…');
+    }
+    cut
+}
+
 impl NodeContent for StageNodeContent {
     fn render(&self, ctx: &NodeRenderContext, buf: &mut Buffer) {
         let area = ctx.area;
         let (_, colour) = self.status.look(self.tick);
-        let border_colour = if ctx.selected { C_BORDER_FOCUS } else { colour };
-        // Zoomed out, or compact: the box would swallow the label, so draw
-        // just the title.
-        if self.style == NodeStyle::Compact || area.height < 3 || area.width < 6 {
-            let mut line = self.title(ctx.selected);
-            if area.width >= 6 {
-                line.spans
-                    .insert(0, Span::styled("[", Style::default().fg(border_colour)));
-                line.spans
-                    .push(Span::styled("]", Style::default().fg(border_colour)));
-            }
+        // Selection is the border's job: a thick focus-coloured frame (or
+        // bright brackets), so the title itself keeps its status colour and
+        // nothing on it flips to reversed video.
+        let border_style = if ctx.selected {
+            Style::default()
+                .fg(C_BORDER_FOCUS)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(colour)
+        };
+        let width = area.width as usize;
+        // Compact, or a box zoomed down to a row: brackets are the bounds.
+        if self.style == NodeStyle::Compact || area.height < 2 {
+            let mut line = self.title(ctx.selected, width.saturating_sub(2));
+            line.spans.insert(0, Span::styled("[", border_style));
+            line.spans.push(Span::styled("]", border_style));
             Paragraph::new(line).render(area, buf);
             return;
         }
+        let border_type = match (ctx.selected, self.is_external) {
+            (true, _) => BorderType::Thick,
+            (false, true) => BorderType::Double,
+            (false, false) => BorderType::Rounded,
+        };
         let block = Block::default()
             .borders(Borders::ALL)
-            .border_type(if self.is_external {
-                BorderType::Double
-            } else {
-                BorderType::Rounded
-            })
-            .border_style(Style::default().fg(border_colour))
-            .title(self.title(ctx.selected));
+            .border_type(border_type)
+            .border_style(border_style)
+            .title(self.title(ctx.selected, width.saturating_sub(2)));
         let inner = block.inner(area);
         block.render(area, buf);
         let rows = [
@@ -494,18 +519,44 @@ mod tests {
     }
 
     #[test]
-    fn a_tiny_area_degrades_to_the_bare_label_and_compact_is_one_row() {
+    fn a_short_area_keeps_its_bounds_and_the_name_gives_way_first() {
         let c = content(NodeStyle::Full);
+        // One row: brackets, always closed.
         let (_, text) = draw(&c, Rect::new(0, 0, 12, 1), false);
         assert!(
             text.contains(&format!("[ {GLYPH_PENDING} plan ]")),
             "{text}"
         );
         assert!(!text.contains('╭'), "{text}");
-        // Narrower than the brackets: just the words.
-        let (_, text) = draw(&c, Rect::new(0, 0, 5, 1), false);
-        assert!(text.starts_with(&format!(" {GLYPH_PENDING} pl")), "{text}");
-        assert!(!text.contains('['), "{text}");
+        // Too narrow for the name: it is cut with an ellipsis, the closing
+        // bracket stays.
+        let (_, text) = draw(&c, Rect::new(0, 0, 9, 1), false);
+        assert_eq!(
+            text.trim_end(),
+            format!("[ {GLYPH_PENDING} pl… ]"),
+            "{text}"
+        );
+        // Two rows: a box with the title in its top border and no body.
+        let (_, text) = draw(&c, Rect::new(0, 0, 14, 2), false);
+        assert!(text.contains(&format!("╭ {GLYPH_PENDING} plan ")), "{text}");
+        assert!(text.contains("╰"), "{text}");
+        assert!(!text.contains("autonomous"), "{text}");
+        // A visit count survives the cut before the name does.
+        let mut counted = content(NodeStyle::Compact);
+        counted.status = NodeStatus::Visited {
+            times: 12,
+            errored: false,
+        };
+        let (_, text) = draw(&counted, Rect::new(0, 0, 13, 1), false);
+        assert_eq!(
+            text.trim_end(),
+            format!("[ {GLYPH_COMPLETE} pl… ×12 ]"),
+            "{text}"
+        );
+        assert_eq!(fit("plan", 4), "plan");
+        assert_eq!(fit("plan", 3), "pl…");
+        assert_eq!(fit("plan", 1), "…");
+        assert_eq!(fit("plan", 0), "");
 
         let compact = content(NodeStyle::Compact);
         let (buf, text) = draw(&compact, Rect::new(0, 0, 14, 1), true);
@@ -513,15 +564,12 @@ mod tests {
             text.contains(&format!("[ {GLYPH_PENDING} plan ]")),
             "{text}"
         );
-        assert!(
-            style_at(&buf, "[").fg == Some(C_BORDER_FOCUS),
-            "selected brackets"
-        );
-        assert!(
-            style_at(&buf, "plan")
-                .add_modifier
-                .contains(Modifier::REVERSED)
-        );
+        let bracket = style_at(&buf, "[");
+        assert_eq!(bracket.fg, Some(C_BORDER_FOCUS), "selected brackets");
+        assert!(bracket.add_modifier.contains(Modifier::BOLD));
+        let title = style_at(&buf, "plan");
+        assert!(title.add_modifier.contains(Modifier::BOLD));
+        assert!(!title.add_modifier.contains(Modifier::REVERSED));
         assert_eq!(NodeStyle::Compact.height(), 1.0);
         assert_eq!(NodeStyle::Full.height(), 4.0);
         assert_eq!(NodeStyle::Compact.width(3), 14.0);
@@ -531,20 +579,25 @@ mod tests {
     }
 
     #[test]
-    fn a_selected_full_node_gets_the_focus_border_and_reversed_title() {
+    fn a_selected_full_node_gets_a_thick_focus_border_and_a_plain_bold_title() {
         let mut c = content(NodeStyle::Full);
         c.status = NodeStatus::Current {
             run: RunPhase::Active,
             times: 1,
         };
-        let (buf, _) = draw(&c, Rect::new(0, 0, 24, 4), true);
-        assert_eq!(style_at(&buf, "╭").fg, Some(C_BORDER_FOCUS));
-        assert!(
-            style_at(&buf, "plan")
-                .add_modifier
-                .contains(Modifier::REVERSED)
+        let (buf, text) = draw(&c, Rect::new(0, 0, 24, 4), true);
+        assert!(text.contains('┏'), "thick frame when selected: {text}");
+        assert_eq!(style_at(&buf, "┏").fg, Some(C_BORDER_FOCUS));
+        let title = style_at(&buf, "plan");
+        assert!(title.add_modifier.contains(Modifier::BOLD));
+        assert!(!title.add_modifier.contains(Modifier::REVERSED));
+        assert_eq!(
+            title.fg,
+            Some(C_ACTIVE),
+            "the title keeps its status colour"
         );
-        let (buf, _) = draw(&c, Rect::new(0, 0, 24, 4), false);
+        let (buf, text) = draw(&c, Rect::new(0, 0, 24, 4), false);
+        assert!(text.contains('╭'), "rounded when not: {text}");
         assert_eq!(style_at(&buf, "╭").fg, Some(C_ACTIVE));
         // A 3-row box has room for one detail row and clips the second.
         let (_, text) = draw(&c, Rect::new(0, 0, 24, 3), false);

--- a/crates/leviath-cli/src/tui/flowgraph/layout.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/layout.rs
@@ -62,30 +62,72 @@ impl GraphLayout {
         nodes
     }
 
-    /// Canvas positions: layers advance along x by `node_w + gap_x`, slots
-    /// along y by `node_h + gap_y`. Layers with fewer nodes are centred on the
-    /// tallest one so a diamond reads as a diamond.
+    /// Canvas positions. Layers advance along the flow axis (x when the graph
+    /// runs left to right, y when it runs top to bottom), slots along the
+    /// other one, each by the box size plus its gap. Layers with fewer nodes
+    /// are centred on the widest one so a diamond reads as a diamond.
     pub(crate) fn positions(
         &self,
+        direction: Direction,
         node_w: f64,
         node_h: f64,
         gap_x: f64,
         gap_y: f64,
     ) -> Vec<(String, (f64, f64))> {
-        let tallest = (0..=self.max_layer)
+        let widest = (0..=self.max_layer)
             .map(|l| self.layer_nodes(l).len())
             .fold(0, usize::max);
         let mut out = Vec::with_capacity(self.nodes.len());
         for l in 0..=self.max_layer {
             let column = self.layer_nodes(l);
-            let offset = (tallest.saturating_sub(column.len())) as f64 / 2.0;
+            let offset = (widest.saturating_sub(column.len())) as f64 / 2.0;
             for node in column {
-                let x = l as f64 * (node_w + gap_x);
-                let y = (node.slot as f64 + offset) * (node_h + gap_y);
+                let along = l as f64;
+                let across = node.slot as f64 + offset;
+                let (x, y) = match direction {
+                    Direction::LeftToRight => (along * (node_w + gap_x), across * (node_h + gap_y)),
+                    Direction::TopToBottom => (across * (node_w + gap_x), along * (node_h + gap_y)),
+                };
                 out.push((node.name.clone(), (x, y)));
             }
         }
         out
+    }
+
+    /// The far corner of the laid-out graph in world units.
+    pub(crate) fn extent(
+        &self,
+        direction: Direction,
+        node_w: f64,
+        node_h: f64,
+        gap_x: f64,
+        gap_y: f64,
+    ) -> (f64, f64) {
+        self.positions(direction, node_w, node_h, gap_x, gap_y)
+            .iter()
+            .fold((0.0_f64, 0.0_f64), |(w, h), (_, (x, y))| {
+                (w.max(x + node_w), h.max(y + node_h))
+            })
+    }
+}
+
+/// Which way the layers run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Direction {
+    /// Layers are columns, left to right: the natural fit for a wide
+    /// terminal.
+    LeftToRight,
+    /// Layers are rows, top to bottom: for a tall one, or a long chain.
+    TopToBottom,
+}
+
+impl Direction {
+    /// The other way round.
+    pub(crate) fn rotated(self) -> Self {
+        match self {
+            Direction::LeftToRight => Direction::TopToBottom,
+            Direction::TopToBottom => Direction::LeftToRight,
+        }
     }
 }
 
@@ -376,7 +418,7 @@ mod tests {
             ],
         );
         let l = layout(&g);
-        let pos = l.positions(10.0, 3.0, 4.0, 1.0);
+        let pos = l.positions(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0);
         assert_eq!(pos.len(), 4);
         let at = |n: &str| pos.iter().find(|(id, _)| id == n).unwrap().1;
         // Layers step along x by node_w + gap_x.
@@ -396,9 +438,26 @@ mod tests {
         seen.sort_unstable();
         seen.dedup();
         assert_eq!(seen.len(), 4, "no two nodes share a cell");
+        assert_eq!(
+            l.extent(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0),
+            (38.0, 7.0)
+        );
+        // Top to bottom swaps the axes: layers are rows.
+        let pos = l.positions(Direction::TopToBottom, 10.0, 3.0, 4.0, 1.0);
+        let at = |n: &str| pos.iter().find(|(id, _)| id == n).unwrap().1;
+        assert_eq!(at("a"), (7.0, 0.0));
+        assert_eq!(at("b"), (0.0, 4.0));
+        assert_eq!(at("c"), (14.0, 4.0));
+        assert_eq!(at("d"), (7.0, 8.0));
+        assert_eq!(
+            l.extent(Direction::TopToBottom, 10.0, 3.0, 4.0, 1.0),
+            (24.0, 11.0)
+        );
+        assert_eq!(Direction::LeftToRight.rotated(), Direction::TopToBottom);
+        assert_eq!(Direction::TopToBottom.rotated(), Direction::LeftToRight);
         assert!(
             GraphLayout::default()
-                .positions(1.0, 1.0, 1.0, 1.0)
+                .positions(Direction::LeftToRight, 1.0, 1.0, 1.0, 1.0)
                 .is_empty()
         );
     }

--- a/crates/leviath-cli/src/tui/flowgraph/mod.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/mod.rs
@@ -21,5 +21,6 @@ pub(crate) mod text;
 pub(crate) mod view;
 
 pub(crate) use content::{NodeStyle, RunPhase, WorkerCounts};
+pub(crate) use layout::Direction;
 pub(crate) use model::StageGraph;
 pub(crate) use view::{FlowView, LiveOverlay, Selection, StageLive};

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -12,7 +12,8 @@ use std::time::Duration;
 
 use crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind};
 use rataflow::{
-    Edge, FitViewOptions, Flow, FlowAction, Handle, HandlePosition, Node, StepEdge, Theme, Viewport,
+    Background, BackgroundVariant, Edge, FitViewOptions, Flow, FlowAction, Handle, HandlePosition,
+    MiniMap, MiniMapPosition, Node, StepEdge, Theme, Viewport,
 };
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -24,7 +25,7 @@ use crate::tui::theme::C_ACCENT;
 use super::content::{
     NodeStatus, NodeStyle, RunPhase, StageNodeContent, WorkerCounts, edge_style, palette,
 };
-use super::layout;
+use super::layout::{self, Direction, GraphLayout};
 use super::model::{EdgeClass, StageEdge, StageGraph};
 
 /// What a run has done to one stage, for the overlay.
@@ -86,21 +87,80 @@ struct EdgeMeta {
 pub(crate) struct FlowView {
     flow: Flow<StageNodeContent, StepEdge>,
     graph: Arc<StageGraph>,
+    layout: GraphLayout,
     edges: Vec<EdgeMeta>,
+    style: NodeStyle,
+    locked: bool,
+    direction: Direction,
+    /// Until the user turns the graph by hand, the first draw picks the
+    /// direction that fits.
+    auto_direction: bool,
     show_escape: bool,
     show_unvisited: bool,
     /// A stage to bring on screen at the next draw.
     reveal: Option<String>,
     last_current: Option<String>,
+    /// The overlay last applied, re-applied after a rebuild.
+    last_live: Option<LiveOverlay>,
     last_area: Rect,
     canvas: Rect,
-    /// The longest lane a visible-by-default edge needs above or below the
-    /// nodes, so fitting the view leaves room for it. Escape lanes are not
-    /// counted: they are hidden until asked for, and a long one would cost
-    /// every fit its width.
+    /// The longest lane a visible-by-default edge needs beside the nodes, so
+    /// fitting the view leaves room for it. Escape lanes are not counted:
+    /// they are hidden until asked for, and a long one would cost every fit
+    /// its width.
     max_stem: f64,
-    /// One-row boxes: the canvas cannot zoom out, so it pans instead.
-    compact: bool,
+}
+
+/// Box size and gaps for a node style: `(node_w, node_h, gap_x, gap_y)`.
+fn metrics(style: NodeStyle, longest_id: usize) -> (f64, f64, f64, f64) {
+    let (gap_x, gap_y) = match style {
+        NodeStyle::Full => (8.0, 1.0),
+        NodeStyle::Compact => (6.0, 1.0),
+    };
+    (style.width(longest_id), style.height(), gap_x, gap_y)
+}
+
+/// Which sides an edge leaves and enters on, and how far it travels before
+/// turning, for a graph flowing in `direction`.
+///
+/// The main flow runs along the layer axis. Edges that go against it (a
+/// loop back to an earlier layer, or out of a stage that only escapes reach)
+/// leave and re-enter on the same side and run along a lane beside the
+/// nodes: below them (right of them, top-to-bottom) for the flow's own
+/// loops, above (left) for the escapes. A lane per layer of distance keeps a
+/// long loop from overwriting a short one's label.
+fn route(
+    direction: Direction,
+    class: EdgeClass,
+    from_layer: usize,
+    to_layer: usize,
+) -> (HandlePosition, HandlePosition, bool, f64) {
+    let loops_back = to_layer <= from_layer;
+    let (forward_out, forward_in, loop_side, escape_side) = match direction {
+        Direction::LeftToRight => (
+            HandlePosition::Right,
+            HandlePosition::Left,
+            HandlePosition::Bottom,
+            HandlePosition::Top,
+        ),
+        Direction::TopToBottom => (
+            HandlePosition::Bottom,
+            HandlePosition::Top,
+            HandlePosition::Right,
+            HandlePosition::Left,
+        ),
+    };
+    let (src, tgt) = match class {
+        EdgeClass::Escape => (escape_side, escape_side),
+        _ if loops_back => (loop_side, loop_side),
+        _ => (forward_out, forward_in),
+    };
+    let stem = if src == tgt {
+        1.0 + from_layer.abs_diff(to_layer) as f64
+    } else {
+        1.0
+    };
+    (src, tgt, loops_back, stem)
 }
 
 impl std::fmt::Debug for FlowView {
@@ -108,6 +168,7 @@ impl std::fmt::Debug for FlowView {
         f.debug_struct("FlowView")
             .field("entry", &self.graph.entry)
             .field("nodes", &self.graph.nodes.len())
+            .field("direction", &self.direction)
             .field("show_escape", &self.show_escape)
             .field("show_unvisited", &self.show_unvisited)
             .finish()
@@ -115,147 +176,207 @@ impl std::fmt::Debug for FlowView {
 }
 
 /// Handles on every side, named by side so an edge can pick where it
-/// attaches. Hidden: the canvas is not an editor, and handle glyphs read as
-/// ports.
-fn handles() -> Vec<Handle> {
+/// attaches. The forward sides (out along the flow, in against it) sit at
+/// the middle of their edge; the lane sides carry the source a little past
+/// the middle and the target a little before it, so a loop leaves and
+/// re-enters at different cells. Hidden: the canvas is not an editor, and
+/// handle glyphs read as ports.
+fn handles(direction: Direction) -> Vec<Handle> {
+    let (out, back, lane_a, lane_b) = match direction {
+        Direction::LeftToRight => (
+            HandlePosition::Right,
+            HandlePosition::Left,
+            HandlePosition::Bottom,
+            HandlePosition::Top,
+        ),
+        Direction::TopToBottom => (
+            HandlePosition::Bottom,
+            HandlePosition::Top,
+            HandlePosition::Right,
+            HandlePosition::Left,
+        ),
+    };
     vec![
-        Handle::source(HandlePosition::Right)
-            .with_id("right")
+        Handle::source(out)
+            .with_id(out.side_name())
             .with_hidden(true),
-        Handle::source(HandlePosition::Bottom)
-            .with_id("bottom")
+        Handle::source(lane_a)
+            .with_id(lane_a.side_name())
             .with_offset(0.7)
             .with_hidden(true),
-        Handle::source(HandlePosition::Top)
-            .with_id("top")
+        Handle::source(lane_b)
+            .with_id(lane_b.side_name())
             .with_offset(0.7)
             .with_hidden(true),
-        Handle::target(HandlePosition::Left)
-            .with_id("left")
+        Handle::target(back)
+            .with_id(back.side_name())
             .with_hidden(true),
-        Handle::target(HandlePosition::Bottom)
-            .with_id("bottom")
+        Handle::target(lane_a)
+            .with_id(lane_a.side_name())
             .with_offset(0.3)
             .with_hidden(true),
-        Handle::target(HandlePosition::Top)
-            .with_id("top")
+        Handle::target(lane_b)
+            .with_id(lane_b.side_name())
             .with_offset(0.3)
             .with_hidden(true),
     ]
 }
 
+/// The canvas for `graph` laid out in `direction`: the nodes, the edges
+/// remembered for live restyling, and the longest lane a visible edge needs.
+fn build(
+    graph: &StageGraph,
+    layout: &GraphLayout,
+    style: NodeStyle,
+    locked: bool,
+    direction: Direction,
+) -> (Flow<StageNodeContent, StepEdge>, Vec<EdgeMeta>, f64) {
+    let longest = graph
+        .nodes
+        .iter()
+        .map(|n| n.id.trim_start_matches("ext:").chars().count())
+        .max()
+        .unwrap_or(0);
+    let (node_w, node_h, gap_x, gap_y) = metrics(style, longest);
+    // A one-row box has no room to shrink: below zoom 1 it is zero rows
+    // tall and gone. Compact canvases stay at 1.0 and pan instead.
+    let min_zoom = match style {
+        NodeStyle::Full => 0.5,
+        NodeStyle::Compact => 1.0,
+    };
+
+    let nodes: Vec<Node<StageNodeContent>> = graph
+        .nodes
+        .iter()
+        .map(|n| {
+            Node::new(
+                n.id.clone(),
+                (0.0, 0.0),
+                (node_w, node_h),
+                StageNodeContent::from_node(n, style),
+            )
+            .with_handles(handles(direction))
+            .with_connectable(false)
+            .with_deletable(false)
+            .with_resizable(false)
+            .with_draggable(!locked)
+        })
+        .collect();
+
+    let mut metas: Vec<EdgeMeta> = Vec::with_capacity(graph.edges.len());
+    let mut max_stem: f64 = 1.0;
+    let edges: Vec<Edge<StepEdge>> = graph
+        .edges
+        .iter()
+        .enumerate()
+        .map(|(i, e)| {
+            let from_layer = layout.layer_of(&e.from).unwrap_or(0);
+            let to_layer = layout.layer_of(&e.to).unwrap_or(0);
+            let (src, tgt, loops_back, stem) = route(direction, e.class, from_layer, to_layer);
+            if e.class != EdgeClass::Escape {
+                max_stem = max_stem.max(stem);
+            }
+            let id = format!("e{i}");
+            metas.push(EdgeMeta {
+                id: id.clone(),
+                edge: e.clone(),
+                loops_back,
+                stem,
+            });
+            let mut edge = Edge::new(id, e.from.clone(), e.to.clone())
+                .with_content(styled_edge(e.class, loops_back, false, stem))
+                .with_source_side(src)
+                .with_target_side(tgt)
+                .with_deletable(false)
+                .with_hidden(e.class == EdgeClass::Escape);
+            let label = e.condition_label();
+            if !label.is_empty() {
+                edge = edge.with_label(format!("[{label}]"));
+            }
+            edge
+        })
+        .collect();
+
+    let mut flow = Flow::with_graph(nodes, edges)
+        .expect("a StageGraph has unique ids, no self-loops and no dangling edges")
+        .with_theme(Theme::Custom(palette()))
+        .with_min_zoom(min_zoom)
+        .with_max_zoom(1.0)
+        // Marching ants at a walking pace; the default is a sprint.
+        .with_animation_speed(220)
+        // A press on empty canvas is how a pan starts; it must not throw
+        // the selection away, or Enter after a pan opens nothing.
+        .with_deselect_on_pane_click(false)
+        .with_locked(locked);
+    flow.set_node_positions(layout.positions(direction, node_w, node_h, gap_x, gap_y));
+    // No fit here: the first `render` settles the viewport for the area it
+    // gets. A fit requested now would land after that and undo it.
+    (flow, metas, max_stem)
+}
+
 impl FlowView {
     /// Build the canvas for `graph`. `locked` makes it a viewer: left-drag
-    /// pans and nothing selects, for the band and the preview.
+    /// pans and nothing selects or moves, for the band and the preview; the
+    /// explorer is unlocked, so boxes can be dragged into a better
+    /// arrangement and clicked to select.
     pub(crate) fn new(graph: Arc<StageGraph>, style: NodeStyle, locked: bool) -> Self {
         let layout = layout::layout(&graph);
-        let longest = graph
-            .nodes
-            .iter()
-            .map(|n| n.id.trim_start_matches("ext:").chars().count())
-            .max()
-            .unwrap_or(0);
-        let node_w = style.width(longest);
-        let node_h = style.height();
-        // A one-row box has no room to shrink: below zoom 1 it is zero rows
-        // tall and gone. Compact canvases stay at 1.0 and pan instead.
-        let (gap_x, gap_y, min_zoom) = match style {
-            NodeStyle::Full => (8.0, 1.0, 0.4),
-            NodeStyle::Compact => (6.0, 1.0, 1.0),
-        };
-
-        let nodes: Vec<Node<StageNodeContent>> = graph
-            .nodes
-            .iter()
-            .map(|n| {
-                Node::new(
-                    n.id.clone(),
-                    (0.0, 0.0),
-                    (node_w, node_h),
-                    StageNodeContent::from_node(n, style),
-                )
-                .with_handles(handles())
-                .with_connectable(false)
-                .with_deletable(false)
-                .with_resizable(false)
-                .with_draggable(false)
-            })
-            .collect();
-
-        let mut metas: Vec<EdgeMeta> = Vec::with_capacity(graph.edges.len());
-        let mut max_stem: f64 = 1.0;
-        let edges: Vec<Edge<StepEdge>> = graph
-            .edges
-            .iter()
-            .enumerate()
-            .map(|(i, e)| {
-                let from_layer = layout.layer_of(&e.from).unwrap_or(0);
-                let to_layer = layout.layer_of(&e.to).unwrap_or(0);
-                let loops_back = to_layer <= from_layer;
-                let (src, tgt) = match e.class {
-                    EdgeClass::Escape => (HandlePosition::Top, HandlePosition::Top),
-                    _ if loops_back => (HandlePosition::Bottom, HandlePosition::Bottom),
-                    _ => (HandlePosition::Right, HandlePosition::Left),
-                };
-                // Edges that leave and re-enter on the same side run along a
-                // lane above or below the nodes; a lane per layer of distance
-                // keeps a long loop from overwriting a short one's label.
-                let stem = if src == tgt {
-                    1.0 + from_layer.abs_diff(to_layer) as f64
-                } else {
-                    1.0
-                };
-                if e.class != EdgeClass::Escape {
-                    max_stem = max_stem.max(stem);
-                }
-                let id = format!("e{i}");
-                metas.push(EdgeMeta {
-                    id: id.clone(),
-                    edge: e.clone(),
-                    loops_back,
-                    stem,
-                });
-                let mut edge = Edge::new(id, e.from.clone(), e.to.clone())
-                    .with_content(styled_edge(e.class, loops_back, false, stem))
-                    .with_source_side(src)
-                    .with_target_side(tgt)
-                    .with_deletable(false)
-                    .with_hidden(e.class == EdgeClass::Escape);
-                let label = e.condition_label();
-                if !label.is_empty() {
-                    edge = edge.with_label(format!("[{label}]"));
-                }
-                edge
-            })
-            .collect();
-
-        let mut flow = Flow::with_graph(nodes, edges)
-            .expect("a StageGraph has unique ids, no self-loops and no dangling edges")
-            .with_theme(Theme::Custom(palette()))
-            .with_min_zoom(min_zoom)
-            .with_max_zoom(1.0)
-            // A press on empty canvas is how a pan starts; it must not throw
-            // the selection away, or Enter after a pan opens nothing.
-            .with_deselect_on_pane_click(false)
-            .with_locked(locked);
-        flow.set_node_positions(layout.positions(node_w, node_h, gap_x, gap_y));
-        // No fit here: the first `render` settles the viewport for the area it
-        // gets (a fit, or the top-left corner for a compact canvas that
-        // overflows). A fit requested now would land after that and undo it.
-
+        let (flow, edges, max_stem) = build(&graph, &layout, style, locked, Direction::LeftToRight);
         Self {
             flow,
             graph,
-            edges: metas,
+            layout,
+            edges,
+            style,
+            locked,
+            direction: Direction::LeftToRight,
+            auto_direction: true,
             show_escape: false,
             show_unvisited: true,
             reveal: None,
             last_current: None,
+            last_live: None,
             last_area: Rect::default(),
             canvas: Rect::default(),
             max_stem,
-            compact: style == NodeStyle::Compact,
         }
+    }
+
+    /// Lay the graph out the other way round. Dragged boxes go back to
+    /// their computed places; the selection, the toggles and the run's
+    /// overlay carry over.
+    pub(crate) fn rotate(&mut self) {
+        self.auto_direction = false;
+        self.rebuild(self.direction.rotated());
+    }
+
+    /// Which way the layers run.
+    pub(crate) fn direction(&self) -> Direction {
+        self.direction
+    }
+
+    fn rebuild(&mut self, direction: Direction) {
+        let selected = self.flow.first_selected_node_id();
+        let (flow, edges, max_stem) = build(
+            &self.graph,
+            &self.layout,
+            self.style,
+            self.locked,
+            direction,
+        );
+        self.flow = flow;
+        self.edges = edges;
+        self.max_stem = max_stem;
+        self.direction = direction;
+        if let Some(live) = self.last_live.take() {
+            self.apply_live(&live);
+        }
+        self.sync_visibility();
+        if let Some(id) = selected {
+            self.flow.select_node(&id);
+        }
+        // Settle again for the current area at the next draw.
+        self.last_area = Rect::default();
     }
 
     /// The longest edge lane, in rows above or below the nodes.
@@ -350,23 +471,38 @@ impl FlowView {
         self.flow.select_node(id);
     }
 
-    /// First look at a canvas of this size: fit the graph when it fits, and
-    /// otherwise, on a canvas that cannot zoom out (compact boxes), start at
-    /// the top-left corner so the entry stage is on screen rather than the
-    /// middle of the picture. A full canvas zooms out to fit instead.
+    /// First look at a canvas of this size. Boxes are never shrunk to make
+    /// the graph fit: a box zoomed down is an unreadable one. Instead the
+    /// layers run the way that fits (left to right first, top to bottom when
+    /// that overflows and the other does not); when neither fits the canvas
+    /// starts at its top-left corner, entry stage on screen, and pans.
     fn settle(&mut self, area: Rect) {
-        // Inside the block's border.
-        let (inner_w, inner_h) = (f64::from(area.width) - 2.0, f64::from(area.height) - 2.0);
-        let (world_w, world_h) = self.world_extent();
-        let overflows = world_w + 2.0 > inner_w || world_h + 2.0 > inner_h;
-        if self.compact && overflows {
+        // Inside the block's border, less a cell of margin each side.
+        let (inner_w, inner_h) = (f64::from(area.width) - 4.0, f64::from(area.height) - 4.0);
+        let fits = |(w, h): (f64, f64)| w <= inner_w && h <= inner_h;
+        let extent = |dir: Direction| {
+            let longest = self
+                .graph
+                .nodes
+                .iter()
+                .map(|n| n.id.trim_start_matches("ext:").chars().count())
+                .max()
+                .unwrap_or(0);
+            let (node_w, node_h, gap_x, gap_y) = metrics(self.style, longest);
+            self.layout.extent(dir, node_w, node_h, gap_x, gap_y)
+        };
+        let other = self.direction.rotated();
+        if self.auto_direction && !fits(extent(self.direction)) && fits(extent(other)) {
+            self.rebuild(other);
+        }
+        if fits(self.world_extent()) {
+            self.fit();
+        } else {
             self.flow.viewport = Viewport {
                 x: 1.0,
                 y: 1.0,
                 zoom: 1.0,
             };
-        } else {
-            self.fit();
         }
     }
 
@@ -413,6 +549,7 @@ impl FlowView {
             KeyCode::Char('-') => self.flow.zoom_out(),
             KeyCode::Char('0') => self.flow.reset_zoom(),
             KeyCode::Char('f') => self.fit(),
+            KeyCode::Char('r') => self.rotate(),
             KeyCode::Char('e') => self.toggle_escape(),
             KeyCode::Char('u') => self.toggle_unvisited(),
             _ => return false,
@@ -441,6 +578,7 @@ impl FlowView {
     /// Paint the run onto the blueprint. Cheap enough to call every draw:
     /// it mutates node content in place and never rebuilds the canvas.
     pub(crate) fn apply_live(&mut self, live: &LiveOverlay) {
+        self.last_live = Some(live.clone());
         let current = live.current.as_deref();
         for (id, content) in self.flow.nodes_content_mut() {
             content.clear_live();
@@ -524,6 +662,7 @@ impl FlowView {
     /// Draw the canvas into `area`, inside `block`. Returns the canvas rect
     /// (the block's inside), which is what mouse routing hit-tests.
     pub(crate) fn render(&mut self, frame: &mut Frame, area: Rect, block: Block<'static>) -> Rect {
+        let inner = block.inner(area);
         self.flow.set_block(Some(block));
         if (area.width, area.height) != (self.last_area.width, self.last_area.height) {
             self.last_area = area;
@@ -532,8 +671,29 @@ impl FlowView {
         if let Some(id) = self.reveal.take() {
             self.flow.ensure_node_visible(&id);
         }
+        // A dotted grid under the graph says "canvas" and moves with a pan,
+        // which is what makes a pan legible.
+        frame.render_widget(
+            Background::new(&self.flow)
+                .variant(BackgroundVariant::Dots)
+                .gap(8, 4),
+            inner,
+        );
         frame.render_widget(&mut self.flow, area);
         self.canvas = self.flow.canvas_area();
+        // A minimap once the graph is bigger than the canvas and the canvas
+        // has room for one.
+        let (world_w, world_h) = self.world_extent();
+        let overflows =
+            world_w > f64::from(self.canvas.width) || world_h > f64::from(self.canvas.height);
+        if overflows && self.canvas.width >= 60 && self.canvas.height >= 16 {
+            frame.render_widget(
+                MiniMap::new(&self.flow)
+                    .position(MiniMapPosition::BottomRight)
+                    .size(20, 6),
+                self.canvas,
+            );
+        }
         self.canvas
     }
 
@@ -578,7 +738,7 @@ fn styled_edge(class: EdgeClass, loops_back: bool, taken: bool, stem: f64) -> St
 fn fit_options(max_stem: f64) -> FitViewOptions {
     FitViewOptions::default()
         .with_padding((max_stem + 1.0).min(5.0))
-        .with_max_zoom(1.0)
+        .with_zoom_range(1.0, 1.0)
 }
 
 #[cfg(test)]
@@ -959,20 +1119,87 @@ merge_stage = "merge"
     }
 
     #[test]
-    fn a_compact_canvas_starts_top_left_when_the_graph_overflows_and_fits_otherwise() {
+    fn a_canvas_the_graph_overflows_starts_top_left_and_boxes_are_never_shrunk() {
         let mut v = FlowView::new(graph(), NodeStyle::Compact, true);
         draw(&mut v, 60, 12);
         assert_eq!(v.pan(), (1.0, 1.0), "the entry stage is on screen");
         assert_eq!(v.node_rect("plan").map(|r| r.0), Some(2));
+        assert_eq!(v.direction(), Direction::LeftToRight);
         // Wide enough: centred like any other fit.
         let mut v = FlowView::new(graph(), NodeStyle::Compact, true);
         draw(&mut v, 200, 20);
         assert_ne!(v.pan(), (1.0, 1.0));
         assert_eq!(v.zoom(), 1.0);
-        // A full canvas that overflows zooms out instead.
+        // A full canvas that overflows both ways keeps its boxes whole and
+        // starts at the corner too, rather than shrinking them to fit.
         let mut v = FlowView::new(graph(), NodeStyle::Full, false);
         draw(&mut v, 60, 20);
-        assert!(v.zoom() < 1.0);
+        assert_eq!(v.zoom(), 1.0);
+        assert_eq!(v.pan(), (1.0, 1.0));
+        assert!(format!("{v:?}").contains("LeftToRight"));
+    }
+
+    #[test]
+    fn a_tall_narrow_canvas_turns_the_graph_top_to_bottom_and_r_turns_it_back() {
+        // Five stages of full boxes: 172 cells wide left to right, 24 rows
+        // top to bottom. A 70x40 canvas fits only the second.
+        let mut v = FlowView::new(graph(), NodeStyle::Full, false);
+        v.select_stage("review");
+        v.toggle_escape();
+        draw(&mut v, 70, 40);
+        assert_eq!(v.direction(), Direction::TopToBottom);
+        assert_eq!(v.zoom(), 1.0);
+        // The turn kept the selection and the toggles.
+        assert_eq!(v.selection(), Selection::Node("review".into()));
+        assert!(v.show_escape());
+        assert!(!v.edge_hidden("implement", "recover"));
+        // Layers are rows now: implement sits under plan, not beside it.
+        let plan = v.node_rect("plan").unwrap();
+        let implement = v.node_rect("implement").unwrap();
+        assert_eq!(plan.0, implement.0);
+        assert!(implement.1 > plan.3);
+        // `r` turns it back by hand, and again.
+        assert!(v.handle_key(KeyCode::Char('r')));
+        assert_eq!(v.direction(), Direction::LeftToRight);
+        draw(&mut v, 70, 40);
+        let plan = v.node_rect("plan").unwrap();
+        let implement = v.node_rect("implement").unwrap();
+        assert_eq!(plan.1, implement.1);
+        assert!(v.handle_key(KeyCode::Char('r')));
+        assert_eq!(v.direction(), Direction::TopToBottom);
+        // The live overlay survives a turn.
+        v.apply_live(&LiveOverlay {
+            current: Some("plan".into()),
+            run: Some(RunPhase::Active),
+            ..LiveOverlay::default()
+        });
+        v.rotate();
+        assert_eq!(
+            v.node_status("plan"),
+            Some(NodeStatus::Current {
+                run: RunPhase::Active,
+                times: 1
+            })
+        );
+        // Boxes can be dragged on an unlocked canvas: press on one, drag,
+        // and it has moved.
+        draw(&mut v, 200, 50);
+        let (x, y, _, _) = v.node_rect("plan").unwrap();
+        let (x, y) = (x as u16 + 2, y as u16 + 1);
+        v.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+        v.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x + 6, y + 3));
+        v.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x + 6, y + 3));
+        draw(&mut v, 200, 50);
+        let moved = v.node_rect("plan").unwrap();
+        assert!(moved.0 > x as i32 - 2 + 3, "{moved:?}");
+        // A minimap appears when the graph is bigger than the canvas.
+        let mut v = FlowView::new(graph(), NodeStyle::Full, false);
+        let (_, text) = draw(&mut v, 90, 24);
+        assert!(text.contains('▄') || text.contains('▀'), "{text}");
+        // And not when everything is on screen already.
+        let mut v = FlowView::new(graph(), NodeStyle::Full, false);
+        let (_, text) = draw(&mut v, 220, 50);
+        assert!(!text.contains('▄') && !text.contains('▀'), "{text}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -1195,11 +1195,14 @@ merge_stage = "merge"
         // A minimap appears when the graph is bigger than the canvas.
         let mut v = FlowView::new(graph(), NodeStyle::Full, false);
         let (_, text) = draw(&mut v, 90, 24);
-        assert!(text.contains('▄') || text.contains('▀'), "{text}");
+        assert!(text.contains('▄'), "{text}");
         // And not when everything is on screen already.
         let mut v = FlowView::new(graph(), NodeStyle::Full, false);
         let (_, text) = draw(&mut v, 220, 50);
-        assert!(!text.contains('▄') && !text.contains('▀'), "{text}");
+        assert!(!text.contains('▄'), "{text}");
+        // Turning a canvas with nothing selected selects nothing after.
+        v.rotate();
+        assert_eq!(v.selection(), Selection::Nothing);
     }
 
     #[test]

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -173,13 +173,17 @@ are on, in which stage, recorded when.
 `g` in the detail view opens the full-screen stage explorer for any run (a linear blueprint is a
 chain; a graph blueprint is a graph):
 
-- **Graph** draws the blueprint on a canvas: stages are boxes laid out left to right on layers,
-  transitions are routed edges. The stage the run is in spins in the run's colour, stages it has
-  been through show a visit count (`×2`) and the time of their last visit, the last transition it
-  took is animated, and revisit loops run along a lane below the boxes. The escape edges
-  (`error`, `dead_end`, `stuck`, `max_iterations`) are hidden until you ask for them, because
-  nearly every stage has one to the same hub. A fan-out stage that is running shows its worker
-  counts. Selecting a stage or an edge describes it on the line under the canvas.
+- **Graph** draws the blueprint on a canvas: stages are boxes on layers, transitions are routed
+  edges. The layers run left to right when that fits the terminal and top to bottom when only that
+  does (`r` turns it by hand); boxes are never shrunk to make a graph fit, the canvas pans instead,
+  with a minimap in the corner when there is more graph than screen. The stage the run is in
+  spins in the run's colour, stages it has been through show a visit count (`×2`) and the time of
+  their last visit, the last transition it took is animated, and revisit loops run along a lane
+  beside the boxes. The escape edges (`error`, `dead_end`, `stuck`, `max_iterations`) are hidden
+  until you ask for them, because nearly every stage has one to the same hub. A fan-out stage that
+  is running shows its worker counts. Selecting a stage or an edge describes it on the line under
+  the canvas. Boxes can be dragged into an arrangement you prefer; the explorer remembers it, and
+  the view, for as long as the dashboard is open.
 - **Timeline** lists each actual visit in order, with when it started, how long it lasted, and how
   many iterations it ran. `Enter` on a visit opens the context window exactly as it was at that
   point.
@@ -191,14 +195,15 @@ chain; a graph blueprint is a graph):
 | `Enter` | Graph: open the selected stage's tab. Timeline: open the visit's context |
 | `+` / `-` , `0` | Zoom in / out, back to 100% |
 | `f` | Fit the whole graph on screen |
+| `r` | Turn the graph: left to right or top to bottom |
 | `e` | Show or hide the escape edges |
 | `u` | Show or hide stages the run has never entered |
 | `Tab` / `Shift-Tab` | Switch between Graph and Timeline |
 | `?` / `F1` | Help |
 | `Esc` / `g` | Close the explorer |
 
-The mouse works on the canvas: drag to pan, wheel to zoom at the cursor, click a stage to select
-it. While the explorer is open the detail view's keys are off, so `e`, `c`, `l`, `o` and `b` mean
+The mouse works on the canvas: drag a box to move it, drag empty canvas to pan, wheel to zoom at
+the cursor, click a stage to select it. While the explorer is open the detail view's keys are off, so `e`, `c`, `l`, `o` and `b` mean
 what the table above says rather than what they mean underneath.
 
 `lev validate --graph <agent>` prints the same picture as plain text.


### PR DESCRIPTION
## What

Follow-up to #499/#500 from watching the explorer on a wide, short terminal: a fit-to-screen zoom shrank the boxes to a row, cut the names with no closing bracket, left the picture a thin strip across an empty canvas, and showed the selected stage by flipping its title to reversed video. This PR:

- **Never shrinks boxes to fit.** The layers run left to right when that fits and top to bottom when only that does (`r` turns it by hand and the choice sticks); when neither fits, the canvas starts at the entry stage and pans, with a **minimap** in the corner once there is more graph than screen. Zooming out by hand still works, and a box keeps its frame at every size: bordered down to two rows, bracketed at one, and it is the name that gives way (with an ellipsis), never the closing bracket or the visit count.
- **Selection** is a thick frame in the focus colour with a bold title in the stage's own status colour; nothing flips to reversed video.
- **Animation** runs at a walking pace (edge marching ants at 220ms), and a **dotted grid** sits under the graph so a pan reads as a pan.
- **Boxes can be dragged** on the explorer's canvas into an arrangement of your own; the explorer keeps that canvas (viewport, direction, toggles, positions) for the run until the dashboard closes. The detail band and the new-run preview stay viewers.

Live, in a pty at 200x50, the explorer turned top-to-bottom with `r` (loops on the right lane), and after dragging the `plan` box down-left (thick frame = selected, edge re-routed):

```
╭ Graph · top to bottom (r) · escape edges hidden (e) · zoom 100% ─────
│   ·       ·       ·       ·       ·      ╭ ▶ ✓ plan ────────────────╮
│                                          │ autonomous               │
│                                          │ 16:11:23                 │
│                                          ╰──────────────────────────╯
│                                                        ▼
│                                          ╭ ✓ implement ×2 ──────────╮
│   ·       ·       ·       ·       ·      │ autonomous               │◀··
│                                          │ 16:11:36                 │  ·
│                                          ╰──────────────────────────╯  ·
│                                                        ▼               ·
│   ·       ·       ·       ·       ·      ╭ ✓ review ×2 ─────────────╮ [llm_choice]
```

```
│                                                │        ▲                                              ·
│   ·       ·       ·       ·       ·       ·    │  ·     ··················[llm_choice]··················
│                                                ╰─────────────╮
│                                 ┏ ▶ ✓ plan ━━━━━━━━━━━━━━━━┓ │
│   ·       ·       ·       ·     ┃ autonomous               ┃ │
│                                 ┃ 16:11:23                 ┃─╯
```

## How

- `tui/flowgraph/layout.rs`: `Direction::{LeftToRight, TopToBottom}`, `positions(direction, ..)`, `extent(direction, ..)`.
- `tui/flowgraph/view.rs`: `build(graph, layout, style, locked, direction)` with per-direction handles and routing (`route`: forward edges out/in at the middle of their sides, loops on the lane side, escapes on the other), `rebuild`/`rotate` keeping selection, toggles and the last overlay, `settle` picking a direction on the first draw and never fitting below zoom 1, `Background::Dots` + `MiniMap` in `render`, `with_draggable(!locked)`, `with_animation_speed(220)`.
- `tui/flowgraph/content.rs`: `fit()` cuts the name to the box's budget; two-row boxes keep a border, one-row ones brackets; selected = `BorderType::Thick` + focus colour + bold.
- `dashboard/explorer.rs`: `Dashboard.explorer_cache: Option<(run_id, FlowView)>` filled by `close_stage_explorer`, reused by `open_stage_explorer` for the same run; `r` in the hint bar, overlay and docs.

## Checks

- `cargo xtask coverage --package leviath-cli` 100%.
- Live pty run as above: fit stays at 100%, `r` turns and turns back, dragging moves a box and its edges follow, the escape lanes sit left/above per direction, the minimap appears on an overflowing canvas.
