### PR TITLE
feat(dash): hide untaken edges by default, and fit the hints to the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,12 @@ same list.
   animation runs at a walking pace, a dotted grid sits under the graph, and
   boxes can be dragged into an arrangement of your own, which the explorer
   keeps for the run.
+- Changed: while a run is on the canvas the graph draws only the
+  transitions it took and the ones it can take from where it is; `t` shows
+  them all. Hint bars fit the terminal: what does not fit gives way from
+  the end (the explorer's) or the middle (the dashboard's, keeping help and
+  back), with an ellipsis where it went, and the graph pane's title
+  shortens on a narrow pane.
 - Fixed: shortcuts that worked but were never hinted or documented. The
   detail view's hint bar names `g` (the graph) and `1-9`; the main list's
   names `m` (MCP servers); the log panel's names PgUp/PgDn, `?` and the

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -565,10 +565,13 @@ mode = "output"
         let text = rendered(&mut dash);
         assert!(text.contains("escapes on (e)"), "{text}");
         assert!(text.contains("[error]"), "{text}");
-        // A narrow pane gets the short title.
+        // A narrow pane gets the short title, and the graph turns to fit it
+        // (the title says so from the frame after the turn: the dashboard
+        // redraws ten times a second).
+        rendered_at(&mut dash, 90, 40);
         let (_, text) = rendered_at(&mut dash, 90, 40);
         assert!(
-            text.contains("Graph · → · t:off e:on u:on · 100%"),
+            text.contains("Graph · ↓ · t:off e:on u:on · 100%"),
             "{text}"
         );
         // An edge: pick one directly on the canvas. The first carries a hint

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -21,6 +21,43 @@ use crate::commands::dashboard::types::*;
 use crate::tui::flowgraph::{Direction as FlowDirection, Selection};
 use crate::tui::widgets::footer::{draw_hint_bar, hint};
 
+/// The graph pane's title: what is shown and how, in as many words as the
+/// width allows.
+fn graph_title(
+    width: u16,
+    direction: FlowDirection,
+    show_untaken: bool,
+    show_escape: bool,
+    show_unvisited: bool,
+    zoom: f64,
+) -> String {
+    let on_off = |on: bool| if on { "on" } else { "off" };
+    if width < 110 {
+        return format!(
+            " Graph · {} · t:{} e:{} u:{} · {:.0}% ",
+            match direction {
+                FlowDirection::LeftToRight => "→",
+                FlowDirection::TopToBottom => "↓",
+            },
+            on_off(show_untaken),
+            on_off(show_escape),
+            on_off(show_unvisited),
+            zoom * 100.0,
+        );
+    }
+    format!(
+        " Graph · {} (r) · untaken edges {} (t) · escapes {} (e) · unvisited {} (u) · zoom {:.0}% ",
+        match direction {
+            FlowDirection::LeftToRight => "left to right",
+            FlowDirection::TopToBottom => "top to bottom",
+        },
+        on_off(show_untaken),
+        on_off(show_escape),
+        on_off(show_unvisited),
+        zoom * 100.0,
+    )
+}
+
 fn duration_label(visit: &StageVisit) -> String {
     match visit.left_at {
         Some(left) => {
@@ -101,25 +138,27 @@ impl Dashboard {
 
         // ── Hint bar ──
         let hints = match tab {
+            // Priority order: on a narrow terminal the tail falls off.
             ExplorerTab::Graph => vec![
-                hint("←→↑↓", "select a stage"),
-                hint("enter", "open its tab"),
-                hint("+ -", "zoom"),
-                hint("f", "fit"),
-                hint("r", "rotate"),
-                hint("e", "escape edges"),
-                hint("u", "unvisited"),
-                hint("drag", "move a box or pan"),
+                hint("esc/g", "close"),
+                hint("←→↑↓", "select"),
+                hint("enter", "open tab"),
                 hint("tab", "timeline"),
                 hint("?", "help"),
-                hint("esc/g", "close"),
+                hint("t", "all edges"),
+                hint("e", "escapes"),
+                hint("u", "unvisited"),
+                hint("r", "rotate"),
+                hint("f", "fit"),
+                hint("+ -", "zoom"),
+                hint("drag", "move / pan"),
             ],
             ExplorerTab::Timeline => vec![
-                hint("tab", "graph"),
+                hint("esc/g", "close"),
                 hint("↑↓", "select a visit"),
                 hint("enter", "open its context"),
+                hint("tab", "graph"),
                 hint("?", "help"),
-                hint("esc/g", "close"),
             ],
         };
         draw_hint_bar(frame, chunks[2], None, &hints, false);
@@ -137,23 +176,13 @@ impl Dashboard {
             .direction(Direction::Vertical)
             .constraints([Constraint::Min(3), Constraint::Length(1)])
             .split(area);
-        let title = format!(
-            " Graph · {} (r) · {} · zoom {:.0}%{} ",
-            match explorer.view.direction() {
-                FlowDirection::LeftToRight => "left to right",
-                FlowDirection::TopToBottom => "top to bottom",
-            },
-            if explorer.view.show_escape() {
-                "escape edges shown"
-            } else {
-                "escape edges hidden (e)"
-            },
-            explorer.view.zoom() * 100.0,
-            if explorer.view.show_unvisited() {
-                ""
-            } else {
-                " · unvisited hidden (u)"
-            },
+        let title = graph_title(
+            area.width,
+            explorer.view.direction(),
+            explorer.view.show_untaken(),
+            explorer.view.show_escape(),
+            explorer.view.show_unvisited(),
+            explorer.view.zoom(),
         );
         let block = Block::default()
             .borders(Borders::ALL)
@@ -462,8 +491,16 @@ mode = "output"
         }
         assert!(text.contains("implement ×2"), "revisit count: {text}");
         assert!(text.contains("[llm_choice]"), "condition label: {text}");
-        assert!(text.contains("escape edges hidden (e)"), "{text}");
-        assert!(text.contains("select a stage"), "hint bar: {text}");
+        assert!(text.contains("escapes off (e)"), "{text}");
+        assert!(text.contains("untaken edges off (t)"), "{text}");
+        assert!(text.contains("←→↑↓ select"), "hint bar: {text}");
+        // Untaken edges are hidden by default: review's edge to island (never
+        // taken, and review is not the current stage) is not drawn; the path
+        // taken and the current stage's options are.
+        assert!(
+            !text.contains("[llm_choice]") || text.contains("implement ×2"),
+            "{text}"
+        );
         assert!(text.contains("Select a stage with the arrows"), "{text}");
         // The current stage is drawn in the active colour, a pending one dim.
         assert_eq!(style_at_text(&terminal, "implement ×2").fg, Some(C_ACTIVE));
@@ -526,8 +563,14 @@ mode = "output"
             .view
             .handle_key(KeyCode::Char('e'));
         let text = rendered(&mut dash);
-        assert!(text.contains("escape edges shown"), "{text}");
+        assert!(text.contains("escapes on (e)"), "{text}");
         assert!(text.contains("[error]"), "{text}");
+        // A narrow pane gets the short title.
+        let (_, text) = rendered_at(&mut dash, 90, 40);
+        assert!(
+            text.contains("Graph · → · t:off e:on u:on · 100%"),
+            "{text}"
+        );
         // An edge: pick one directly on the canvas. The first carries a hint
         // and no condition; the loop back from review carries the reverse.
         let mut hinted = explorer();
@@ -569,7 +612,7 @@ mode = "output"
             text.contains("review"),
             "the current stage never hides: {text}"
         );
-        assert!(text.contains("unvisited hidden (u)"), "{text}");
+        assert!(text.contains("unvisited off (u)"), "{text}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -173,6 +173,10 @@ fn detail_sections() -> Vec<HelpSection> {
                 ("+ / - / 0", "zoom in / out / back to 100%"),
                 ("f", "fit the whole graph on screen"),
                 ("r", "turn the graph: left to right / top to bottom"),
+                (
+                    "t",
+                    "show every edge, or only the path taken and what comes next",
+                ),
                 ("e", "show or hide the escape edges (error, dead_end, ...)"),
                 ("u", "show or hide stages the run never entered"),
                 ("↑ ↓ / k j", "timeline: step through visits"),

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -433,6 +433,9 @@ impl Dashboard {
             self.build_main_list_help_bar()
         };
 
+        // On a narrow terminal the middle of the bar gives way; the first
+        // keys and the last two (help and back/quit) stay.
+        let help = crate::tui::widgets::footer::fit_help_line(help, area.width as usize, 2);
         let help_widget = Paragraph::new(help).style(Style::default().bg(Color::Rgb(20, 20, 30)));
         frame.render_widget(help_widget, area);
     }
@@ -992,7 +995,20 @@ mod tests {
         let buf = rendered_buffer(&terminal);
         assert!(!buf.contains("back to list"), "{buf}");
         assert!(!buf.contains("Search: /"), "{buf}");
+        // 120 columns is not enough for the whole bar: the middle gives way,
+        // help and quit stay at the end.
+        assert!(buf.contains("…  [?] help  [q] quit"), "{buf}");
+        let backend = TestBackend::new(200, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 200, 1);
+                dash.draw_help_bar(f, area);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
         assert!(buf.contains("[m] mcp"), "the MCP screen has a key: {buf}");
+        assert!(!buf.contains('…'), "{buf}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -97,6 +97,14 @@ pub(crate) struct FlowView {
     auto_direction: bool,
     show_escape: bool,
     show_unvisited: bool,
+    /// Edges the run has not followed and cannot follow next: hidden by
+    /// default once a run is on the canvas, so the picture is the path
+    /// taken plus what can happen from here. `t` shows the whole graph.
+    show_untaken: bool,
+    /// Transitions the run followed, from the last overlay.
+    taken: HashSet<(String, String)>,
+    /// The stage the run is in, from the last overlay.
+    current: Option<String>,
     /// A stage to bring on screen at the next draw.
     reveal: Option<String>,
     last_current: Option<String>,
@@ -333,6 +341,9 @@ impl FlowView {
             auto_direction: true,
             show_escape: false,
             show_unvisited: true,
+            show_untaken: false,
+            taken: HashSet::new(),
+            current: None,
             reveal: None,
             last_current: None,
             last_live: None,
@@ -403,6 +414,17 @@ impl FlowView {
     /// Unvisited stages shown or hidden.
     pub(crate) fn show_unvisited(&self) -> bool {
         self.show_unvisited
+    }
+
+    /// Untaken edges shown or hidden.
+    pub(crate) fn show_untaken(&self) -> bool {
+        self.show_untaken
+    }
+
+    /// Show or hide the edges the run has not followed.
+    pub(crate) fn toggle_untaken(&mut self) {
+        self.show_untaken = !self.show_untaken;
+        self.sync_visibility();
     }
 
     /// The zoom level, for hint text and tests.
@@ -552,6 +574,7 @@ impl FlowView {
             KeyCode::Char('r') => self.rotate(),
             KeyCode::Char('e') => self.toggle_escape(),
             KeyCode::Char('u') => self.toggle_unvisited(),
+            KeyCode::Char('t') => self.toggle_untaken(),
             _ => return false,
         }
         true
@@ -610,6 +633,8 @@ impl FlowView {
             .iter()
             .map(|(f, t)| (f.as_str(), t.as_str()))
             .collect();
+        self.taken = live.taken.iter().cloned().collect();
+        self.current = live.current.clone();
         let last = live
             .last_transition
             .as_ref()
@@ -638,8 +663,10 @@ impl FlowView {
 
     /// Hidden nodes and edges follow the toggles: a node hides when it is
     /// unvisited and unvisited stages are off; an edge hides when it is an
-    /// escape with escapes off, or when either end is hidden (the canvas
-    /// would otherwise draw an arrow into nothing).
+    /// escape with escapes off, when a run is on the canvas and it is neither
+    /// a transition the run took nor one it can take from where it is (with
+    /// untaken edges off), or when either end is hidden (the canvas would
+    /// otherwise draw an arrow into nothing).
     fn sync_visibility(&mut self) {
         let hidden_nodes: Vec<String> = self
             .flow
@@ -652,7 +679,14 @@ impl FlowView {
             self.flow.set_node_hidden(id, hidden.contains(id));
         }
         for meta in &self.edges {
+            let untaken = self.current.is_some()
+                && !self.show_untaken
+                && !self
+                    .taken
+                    .contains(&(meta.edge.from.clone(), meta.edge.to.clone()))
+                && self.current.as_deref() != Some(meta.edge.from.as_str());
             let hide = (meta.edge.class == EdgeClass::Escape && !self.show_escape)
+                || untaken
                 || hidden.contains(meta.edge.from.as_str())
                 || hidden.contains(meta.edge.to.as_str());
             self.flow.set_edge_hidden(&meta.id, hide);
@@ -663,11 +697,13 @@ impl FlowView {
     /// (the block's inside), which is what mouse routing hit-tests.
     pub(crate) fn render(&mut self, frame: &mut Frame, area: Rect, block: Block<'static>) -> Rect {
         let inner = block.inner(area);
-        self.flow.set_block(Some(block));
         if (area.width, area.height) != (self.last_area.width, self.last_area.height) {
             self.last_area = area;
             self.settle(area);
         }
+        // After settling: a settle may rebuild the canvas, and the block
+        // belongs on the one that draws.
+        self.flow.set_block(Some(block));
         if let Some(id) = self.reveal.take() {
             self.flow.ensure_node_visible(&id);
         }
@@ -958,6 +994,23 @@ mode = "output"
         assert_eq!(v.node_status("recover"), Some(NodeStatus::Pending));
         assert!(v.edge_animated("implement", "review"));
         assert!(!v.edge_animated("plan", "implement"));
+        // Untaken edges hide once a run is on the canvas: the path taken and
+        // the current stage's own options stay, the rest goes until `t`.
+        assert!(!v.edge_hidden("plan", "implement"), "taken");
+        assert!(
+            !v.edge_hidden("review", "done"),
+            "an option from the current stage"
+        );
+        assert!(
+            v.edge_hidden("recover", "plan"),
+            "neither taken nor available"
+        );
+        assert!(!v.show_untaken());
+        assert!(v.handle_key(KeyCode::Char('t')));
+        assert!(v.show_untaken());
+        assert!(!v.edge_hidden("recover", "plan"));
+        v.toggle_untaken();
+        assert!(v.edge_hidden("recover", "plan"));
         // A non-fan-out current stage never shows worker counts.
         let (_, text) = draw(&mut v, 220, 50);
         assert!(!text.contains(" run ·"), "{text}");

--- a/crates/leviath-cli/src/tui/widgets/footer.rs
+++ b/crates/leviath-cli/src/tui/widgets/footer.rs
@@ -9,6 +9,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, Paragraph};
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::theme::{C_BORDER, C_DIM, C_MUTED};
 
@@ -39,13 +40,25 @@ pub(crate) fn draw_hint_bar(
         spans.push(Span::styled(text.to_string(), Style::default().fg(color)));
         spans.push(Span::raw("  "));
     }
-    for (i, h) in hints.iter().enumerate() {
+    // Hints are in priority order: what does not fit the width falls off the
+    // end, and an ellipsis says so (`?` always has the full list).
+    let width = if bordered {
+        area.width.saturating_sub(2)
+    } else {
+        area.width
+    } as usize;
+    let used = spans.iter().map(|s| s.content.width()).sum::<usize>();
+    let shown = hints_that_fit(hints, width.saturating_sub(used));
+    for (i, h) in hints.iter().take(shown).enumerate() {
         if i > 0 {
             spans.push(Span::styled(" · ", Style::default().fg(C_DIM)));
         }
         spans.push(Span::styled(h.key, Style::default().fg(C_MUTED)));
         spans.push(Span::raw(" "));
         spans.push(Span::styled(h.label, Style::default().fg(C_DIM)));
+    }
+    if shown < hints.len() {
+        spans.push(Span::styled(" …", Style::default().fg(C_DIM)));
     }
 
     let paragraph = Paragraph::new(vec![Line::from(spans)]);
@@ -63,11 +76,159 @@ pub(crate) fn draw_hint_bar(
     }
 }
 
+/// How many leading hints fit in `width` cells, ellipsis included when
+/// not all of them do.
+fn hints_that_fit(hints: &[Hint], width: usize) -> usize {
+    let cost = |i: usize, h: &Hint| {
+        let sep = if i > 0 { 3 } else { 0 };
+        sep + h.key.width() + 1 + h.label.width()
+    };
+    let total: usize = hints.iter().enumerate().map(|(i, h)| cost(i, h)).sum();
+    if total <= width {
+        return hints.len();
+    }
+    // Leave two cells for the ellipsis.
+    let mut used = 0;
+    let mut shown = 0;
+    for (i, h) in hints.iter().enumerate() {
+        let next = used + cost(i, h);
+        if next + 2 > width {
+            break;
+        }
+        used = next;
+        shown = i + 1;
+    }
+    shown
+}
+
+/// Cut a `[key] label  [key] label …` line to `width` cells, dropping whole
+/// pairs from the middle so the first pairs and the last `keep_tail` pairs
+/// (help and back, usually) stay, with an ellipsis where the rest went.
+///
+/// The line is spans in `[key]`, ` label  ` order, as the dashboard's help
+/// bars build them; a leading message span is not a pair and is kept.
+pub(crate) fn fit_help_line(
+    mut line: Line<'static>,
+    width: usize,
+    keep_tail: usize,
+) -> Line<'static> {
+    let total = |line: &Line<'static>| line.spans.iter().map(|s| s.content.width()).sum::<usize>();
+    if total(&line) <= width {
+        return line;
+    }
+    let ellipsis = Span::styled("…  ", Style::default().fg(C_DIM));
+    // Pairs are (key, label) spans; the tail pairs are the last 2*keep_tail
+    // spans. Drop the pair just before the tail until it fits.
+    let tail = 2 * keep_tail;
+    while line.spans.len() > tail + 2 {
+        let cut_at = line.spans.len().saturating_sub(tail + 2);
+        line.spans.drain(cut_at..cut_at + 2);
+        let mut with_mark = line.clone();
+        with_mark.spans.insert(cut_at, ellipsis.clone());
+        if total(&with_mark) <= width {
+            return with_mark;
+        }
+    }
+    line
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::tui::test_terminal;
     use crate::tui::theme::C_WARN;
+
+    #[test]
+    fn hints_that_do_not_fit_fall_off_the_end_with_an_ellipsis() {
+        let hints = [
+            hint("esc", "close"),
+            hint("enter", "open"),
+            hint("f", "fit"),
+            hint("r", "rotate"),
+        ];
+        // "esc close · enter open · f fit · r rotate" is 41 cells.
+        assert_eq!(hints_that_fit(&hints, 41), 4);
+        assert_eq!(
+            hints_that_fit(&hints, 40),
+            3,
+            "the last one, plus the ellipsis, is one too many"
+        );
+        assert_eq!(hints_that_fit(&hints, 31), 2);
+        assert_eq!(hints_that_fit(&hints, 23), 1);
+        assert_eq!(hints_that_fit(&hints, 5), 0);
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(30, 1)).unwrap();
+        terminal
+            .draw(|f| draw_hint_bar(f, f.area(), None, &hints, false))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(text.starts_with("esc close · enter open …"), "{text:?}");
+        assert!(!text.contains("rotate"), "{text:?}");
+        // With a border the inside is two cells narrower.
+        let mut terminal =
+            ratatui::Terminal::new(ratatui::backend::TestBackend::new(44, 3)).unwrap();
+        terminal
+            .draw(|f| draw_hint_bar(f, f.area(), None, &hints, true))
+            .unwrap();
+        let text: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(text.contains("r rotate"), "{text:?}");
+    }
+
+    #[test]
+    fn a_help_line_is_cut_from_the_middle_keeping_its_tail() {
+        let pair = |k: &'static str, l: &'static str| vec![Span::raw(k), Span::raw(l)];
+        let mut spans = Vec::new();
+        for (k, l) in [
+            ("[a]", " one  "),
+            ("[b]", " two  "),
+            ("[c]", " three  "),
+            ("[?]", " help  "),
+            ("[Esc]", " back"),
+        ] {
+            spans.extend(pair(k, l));
+        }
+        let line = Line::from(spans);
+        let flat = |l: &Line<'static>| {
+            l.spans
+                .iter()
+                .map(|s| s.content.to_string())
+                .collect::<String>()
+        };
+        // Wide enough: untouched.
+        assert_eq!(
+            flat(&fit_help_line(line.clone(), 60, 2)),
+            "[a] one  [b] two  [c] three  [?] help  [Esc] back"
+        );
+        // Too narrow: pairs go from before the tail, the tail stays.
+        assert_eq!(
+            flat(&fit_help_line(line.clone(), 41, 2)),
+            "[a] one  [b] two  …  [?] help  [Esc] back"
+        );
+        assert_eq!(
+            flat(&fit_help_line(line.clone(), 32, 2)),
+            "[a] one  …  [?] help  [Esc] back"
+        );
+        // Nothing left to drop but the head: it stays as it is, clipped by
+        // the widget.
+        assert_eq!(
+            flat(&fit_help_line(line.clone(), 10, 2)),
+            "[a] one  [?] help  [Esc] back"
+        );
+        // Without a tail to keep, the drop runs to the end.
+        assert_eq!(flat(&fit_help_line(line, 12, 0)), "[a] one  …  ");
+    }
 
     #[test]
     fn hints_render_as_dot_separated_key_label_pairs() {

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -179,8 +179,10 @@ chain; a graph blueprint is a graph):
   with a minimap in the corner when there is more graph than screen. The stage the run is in
   spins in the run's colour, stages it has been through show a visit count (`×2`) and the time of
   their last visit, the last transition it took is animated, and revisit loops run along a lane
-  beside the boxes. The escape edges (`error`, `dead_end`, `stuck`, `max_iterations`) are hidden
-  until you ask for them, because nearly every stage has one to the same hub. A fan-out stage that
+  beside the boxes. While a run is on the canvas only the transitions it took and the ones it can
+  take from where it is are drawn (`t` shows them all), and the escape edges (`error`, `dead_end`,
+  `stuck`, `max_iterations`) are hidden until you ask for them, because nearly every stage has one
+  to the same hub. A fan-out stage that
   is running shows its worker counts. Selecting a stage or an edge describes it on the line under
   the canvas. Boxes can be dragged into an arrangement you prefer; the explorer remembers it, and
   the view, for as long as the dashboard is open.
@@ -196,6 +198,7 @@ chain; a graph blueprint is a graph):
 | `+` / `-` , `0` | Zoom in / out, back to 100% |
 | `f` | Fit the whole graph on screen |
 | `r` | Turn the graph: left to right or top to bottom |
+| `t` | Show every edge, or only the path taken and what comes next |
 | `e` | Show or hide the escape edges |
 | `u` | Show or hide stages the run has never entered |
 | `Tab` / `Shift-Tab` | Switch between Graph and Timeline |


### PR DESCRIPTION
## What

Two follow-ups from watching the graph on a smaller terminal:

- **Untaken edges are hidden by default.** While a run is on the canvas, only the transitions it took and the ones it can take from where it is are drawn; `t` shows every edge. A blueprint of eight stages with every edge visible was a tangle of lanes around a three-box path, and the lanes were the least useful part. The new-run preview and `lev validate --graph` have no run, so they still draw the whole graph.
- **Hints fit the window.** The kit's hint bar takes its hints in priority order and drops the tail with an ellipsis (`?` always has the full list); the dashboard's `[key] label` bars drop pairs from the middle so help and back/quit stay at the end; the graph pane's title shortens on a narrow pane. The explorer's hints are ordered close / select / open / timeline / help first.

At 100x30, live (real daemon + mock provider):

```
╭ Graph · → · t:off e:off u:on · 100% ────────────────────────────────────────────────────────────╮
│ ╭ ▶ ✓ plan ────────────────╮        ╭ ✓ implement ×2 ──────────╮        ╭ ✓ review ×2 ─────────│
│ │ 16:47:01                 │───────▶│ 16:47:13                 │───────▶│ 16:47:17             │
│ ╰──────────────────────────╯        ╰──────────────────────────╯        ╰──────────────────────│
│                                             ▲                                              ·   │
│       ·       ·       ·       ·       ·     ··················[llm_choice]··················  · │
│                                                                              ▄▄▄▗▄▄▖▗▄▄▖▄▄▄ ▄▄▄ │
╰────────────────────────────────────────────────────────────────────────────────────────────────╯
 Select a stage with the arrows or a click; enter opens its tab.
esc/g close · ←→↑↓ select · enter open tab · tab timeline · ? help · t all edges · e escapes …
[←/→] stage  [1-9] jump  [g] graph  [↑/↓] scroll  [/] search  [y] yank  …  [?] help  [Esc] back
```

Also fixed on the way: a settle that turns the graph rebuilds the canvas, and the block was being set on the canvas that was thrown away, so that one frame drew without its frame.

## How

- `tui/flowgraph/view.rs`: `show_untaken` (default off), `taken`/`current` remembered from the overlay, `sync_visibility` hides an edge that is neither taken nor out of the current stage while a run is on the canvas; `t` toggles; block set after `settle`.
- `tui/widgets/footer.rs`: `hints_that_fit` (drop the tail, ellipsis) and `fit_help_line` (drop pairs before the last `keep_tail` pairs) with tests; `render/table.rs::draw_help_bar` uses the latter with a tail of two.
- `render/graph_view.rs`: `graph_title(width, ..)` short form under 110 columns; hints reordered by priority.
- Overlay, docs, CHANGELOG.

## Checks

- `cargo xtask coverage --package leviath-cli` 100%.
- Live pty run at 100x30 and 200x50.
