### PR TITLE
fix(resolve): read a provider-qualified default_model bare, and let it lead on its provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,22 @@ same list.
   the way in. The dashboard docs gained the log panel and MCP screen key
   tables and the keys the detail view, new-run screen and response pane
   were missing.
+- Fixed: `default_model` written as `provider/model` next to the provider it
+  names, such as `default_model = "ollama/qwen3.8:latest"` under
+  `default_provider = "ollama"`, was sent to the provider verbatim, and Ollama
+  answered `model 'ollama/qwen3.8:latest' not found`. The setting is a bare
+  model id, but `--model` and `fallback_order` take the qualified form and an
+  OpenRouter id already has a slash in it, so the qualified form kept getting
+  written. The resolver now drops a leading `<default_provider>/`, config load
+  and `lev doctor` say what the setting was read as, and the docs say which
+  form each setting takes. OpenRouter's own `openrouter/auto`-style ids are
+  left alone.
+- Fixed: `default_model` lost to the blueprint's own entry on the same
+  provider. Every bundled agent lists Ollama as `qwen3.5:9b`, so
+  `default_provider = "ollama"` with `default_model = "qwen3.8:latest"` still
+  ran on `qwen3.5:9b`, a model the user may never have pulled. The user's
+  default now leads on its provider, with the blueprint's entries behind it as
+  the failover, which is the order the docs already described.
 
 ## 0.4.0 - 2026-08-18
 

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -33,7 +33,7 @@ use leviath_core::blueprint::ModelConfig;
 use leviath_providers::{InferenceRequest, Message, Provider};
 use leviath_runtime::ProviderRegistry;
 use leviath_runtime::control_socket::{ControlClient, ControlResponse};
-use leviath_runtime::pipeline::{providers_tried, resolve_stage_model};
+use leviath_runtime::pipeline::{bare_default_model, providers_tried, resolve_stage_model};
 
 use crate::commands::run::session::build_provider_registry_from_config;
 use crate::config::Config;
@@ -314,8 +314,9 @@ fn resolve_check(
             Check::ok(
                 "resolve",
                 format!(
-                    "{provider_name} / {model}{}",
-                    default_provider_note(config, &provider_name, model_override, registry)
+                    "{provider_name} / {model}{}{}",
+                    default_provider_note(config, &provider_name, model_override, registry),
+                    qualified_default_model_note(config, model_override),
                 ),
             ),
             Some(Resolved {
@@ -373,6 +374,34 @@ fn default_provider_note(
     format!(
         "  (note: default_provider is '{named}' but no default_model is set, \
          so it is never chosen - add `default_model` to config.toml)"
+    )
+}
+
+/// The note appended when `default_model` is written as `provider/model`.
+///
+/// `default_model` is a bare model id that pairs with `default_provider`, but
+/// `--model` and `fallback_order` take the qualified form and an OpenRouter id
+/// already contains a slash, so `default_model = "ollama/qwen3.8:latest"` is
+/// an easy thing to write. The resolver drops the redundant prefix, so the run
+/// works; this says what it was read as, so the config can be tidied and so
+/// the line above is not a mystery. Silent under `--model`, when the default
+/// is not in play at all.
+fn qualified_default_model_note(config: &Config, model_override: Option<&str>) -> String {
+    if model_override.is_some() {
+        return String::new();
+    }
+    let Some(written) = config.default_model.as_deref() else {
+        return String::new();
+    };
+    let bare = bare_default_model(&config.default_provider, written);
+    if bare == written {
+        return String::new();
+    }
+    let provider = &config.default_provider;
+    format!(
+        "  (note: default_model is written as '{written}', but it takes a bare model id \
+         and pairs with default_provider - it is read as '{bare}'; drop the '{provider}/' \
+         in config.toml)"
     )
 }
 

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -372,6 +372,37 @@ fn resolve_check_is_quiet_when_the_configured_default_does_win() {
 }
 
 #[test]
+fn resolve_check_reads_a_qualified_default_model_bare_and_says_so() {
+    // `default_model = "ollama/qwen3.8:latest"` next to `default_provider =
+    // "ollama"`: the run goes to `qwen3.8:latest`, and the note says how the
+    // setting was read so the config can be tidied.
+    let config = Config {
+        default_provider: "stub".to_string(),
+        default_model: Some("stub/m-1".to_string()),
+        ..Config::default()
+    };
+    let registry = registry_with("stub", StubProvider::replying("hi"));
+    let (check, resolved) = resolve_check(&config, None, &registry);
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(
+        check.detail.starts_with("stub / m-1  (note:"),
+        "{}",
+        check.detail
+    );
+    assert!(check.detail.contains("'stub/m-1'"), "{}", check.detail);
+    assert!(
+        check.detail.contains("drop the 'stub/'"),
+        "{}",
+        check.detail
+    );
+    assert_eq!(resolved.expect("resolves").model, "m-1");
+
+    // `--model` sidelines the default entirely, note included.
+    let (check, _) = resolve_check(&config, Some("stub/m-2"), &registry);
+    assert_eq!(check.detail, "stub / m-2");
+}
+
+#[test]
 fn resolve_check_does_not_second_guess_an_unregistered_default_provider() {
     // Landing somewhere other than a default provider that has no key is not
     // news - the `config` line already lists what is registered, and this

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -470,6 +470,36 @@ impl Config {
         }
     }
 
+    /// Say so when `default_model` is written as `provider/model`.
+    ///
+    /// The setting is a bare model id that pairs with `default_provider`, but
+    /// `--model` and `[providers] fallback_order` take the qualified form and an
+    /// OpenRouter id already has a slash in it, so `default_model =
+    /// "ollama/qwen3.8:latest"` gets written. The resolver reads it bare, so
+    /// nothing breaks; this names the reading, at the same place the unread-key
+    /// warning appears, so the file can be tidied.
+    fn warn_qualified_default_model(&self) {
+        if let Some((written, bare)) = self.qualified_default_model() {
+            let provider = &self.default_provider;
+            tracing::warn!(
+                default_model = %written,
+                read_as = %bare,
+                "config.toml default_model is written as provider/model; it takes a \
+                 bare model id and pairs with default_provider, so the '{provider}/' \
+                 prefix is dropped. `lev doctor` reports it too, if this scrolls past."
+            );
+        }
+    }
+
+    /// `default_model` when it is written qualified with the default provider's
+    /// own name: the value as written and the bare id it is read as. `None`
+    /// when unset or already bare.
+    pub fn qualified_default_model(&self) -> Option<(&str, &str)> {
+        let written = self.default_model.as_deref()?;
+        let bare = leviath_runtime::pipeline::bare_default_model(&self.default_provider, written);
+        (bare != written).then_some((written, bare))
+    }
+
     /// Keys in the config file at `path` that nothing reads.
     ///
     /// The same answer the start-up warning gives, available to anyone who
@@ -554,6 +584,7 @@ impl Config {
                 .map_err(|e| anyhow::anyhow!("Failed to parse config: {}", e))?;
 
             Self::warn_unknown_config_keys(&content);
+            c.warn_qualified_default_model();
 
             // Catch a malformed MCP server entry here, at load, rather than at
             // the first tool call: a typo that drops a server's tools should
@@ -1874,6 +1905,39 @@ some_custom_thing = \"forwarded to the script\"
         std::fs::write(&path, toml::to_string_pretty(&original).unwrap()).unwrap();
         let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
         assert_eq!(config.default_provider, "openai");
+    }
+
+    /// `default_model = "ollama/qwen3.8:latest"` next to `default_provider =
+    /// "ollama"` is read as `qwen3.8:latest`; the load names the reading, and
+    /// the value in the struct stays as written so `save` does not rewrite a
+    /// file behind the user's back.
+    #[test]
+    fn load_from_path_names_a_default_model_qualified_with_its_provider() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "default_provider = \"ollama\"\ndefault_model = \"ollama/qwen3.8:latest\"\n",
+        )
+        .unwrap();
+        let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
+        assert_eq!(
+            config.default_model.as_deref(),
+            Some("ollama/qwen3.8:latest")
+        );
+        assert_eq!(
+            config.qualified_default_model(),
+            Some(("ollama/qwen3.8:latest", "qwen3.8:latest"))
+        );
+
+        // A bare id, or no default at all, has nothing to say.
+        let bare = Config {
+            default_provider: "ollama".to_string(),
+            default_model: Some("qwen3.8:latest".to_string()),
+            ..Config::default()
+        };
+        assert_eq!(bare.qualified_default_model(), None);
+        assert_eq!(Config::default().qualified_default_model(), None);
     }
 
     #[test]

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -114,10 +114,9 @@ pub fn resolve_stage_candidates(
         }
     }
 
-    if let Some((provider, model)) =
-        user_default_model(model_cfg, override_model.as_deref(), defaults, registry)
-    {
-        push(provider, model);
+    let user_default = user_default_model(model_cfg, override_model.as_deref(), defaults, registry);
+    if let Some((provider, model)) = &user_default {
+        push(provider.clone(), model.clone());
     }
 
     // The host-wide chain last: it is the safety net for a blueprint that names
@@ -136,13 +135,20 @@ pub fn resolve_stage_candidates(
     // dispatched every stage at a localhost server that was not running.
     //
     // Registered candidates on the user's default provider therefore move to
-    // the front, keeping their relative order. A blueprint that must pin its
-    // own provider already has the way to say so - `allow_user_default =
-    // false` - and that suppresses this too.
+    // the front, the user's own `default_model` first among them and the rest
+    // in blueprint order. The default model leads because it is the one the
+    // user named: every bundled blueprint lists Ollama as `qwen3.5:9b`, and
+    // someone who set `default_model = "qwen3.8:latest"` was still sent to the
+    // blueprint's model, which they may never have pulled. A blueprint that
+    // must pin its own provider already has the way to say so -
+    // `allow_user_default = false` - and that suppresses this too.
     if model_cfg.allow_user_default && registry.has(&defaults.provider) {
-        let (preferred, rest): (Vec<ModelEntry>, Vec<ModelEntry>) = candidates
+        let (mut preferred, rest): (Vec<ModelEntry>, Vec<ModelEntry>) = candidates
             .into_iter()
             .partition(|c| c.provider == defaults.provider);
+        // Stable, so the blueprint's order survives behind the default.
+        let default_model = user_default.as_ref().map(|(_, m)| m.as_str());
+        preferred.sort_by_key(|c| Some(c.model.as_str()) != default_model);
         candidates = preferred.into_iter().chain(rest).collect();
     }
 
@@ -189,9 +195,43 @@ fn user_default_model(
     if let Some(default_model) = &defaults.model
         && registry.has(&defaults.provider)
     {
-        return Some((defaults.provider.clone(), default_model.clone()));
+        let model = bare_default_model(&defaults.provider, default_model);
+        return Some((defaults.provider.clone(), model.to_string()));
     }
     None
+}
+
+/// The model id a `default_model` setting actually names, with a leading
+/// `<default_provider>/` taken off.
+///
+/// `default_model` is a bare model id that pairs with `default_provider`, but
+/// it is easy to write qualified: `--model` and `[providers] fallback_order`
+/// both take `provider/model`, an OpenRouter id such as
+/// `deepseek/deepseek-v4-flash` already looks qualified, and a console that
+/// lists models as `provider/id` hands the pair back in one string. Sent
+/// verbatim, `default_provider = "ollama"` with `default_model =
+/// "ollama/qwen3.8:latest"` reached Ollama as a request for a model called
+/// `ollama/qwen3.8:latest`, which it does not have. The prefix names the
+/// provider the setting already names, so dropping it loses nothing.
+///
+/// The one catalog that can legitimately start an id with its own name is
+/// OpenRouter's (`openrouter/auto` is its router). Those ids have no further
+/// `/`, while a mistakenly qualified OpenRouter model always does
+/// (`openrouter/deepseek/deepseek-v4-flash`), which is how the two are told
+/// apart. Anything that does not begin with the provider's name is returned as
+/// written.
+pub fn bare_default_model<'a>(provider: &str, model: &'a str) -> &'a str {
+    let Some(rest) = model
+        .strip_prefix(provider)
+        .and_then(|rest| rest.strip_prefix('/'))
+        .filter(|rest| !rest.is_empty())
+    else {
+        return model;
+    };
+    if provider == "openrouter" && !rest.contains('/') {
+        return model;
+    }
+    rest
 }
 
 /// Which MCP server advertises each tool: advertised name -> server name.
@@ -642,6 +682,69 @@ mod tests {
         assert_eq!((p.as_str(), m.as_str()), ("anthropic", "claude-default"));
     }
 
+    /// The case that reached Ollama as a request for `ollama/qwen3.8:latest`: a
+    /// `default_model` written as `provider/model` next to the provider it
+    /// names. The prefix is dropped on the way to the resolver.
+    #[test]
+    fn a_default_model_qualified_with_its_own_provider_is_sent_bare() {
+        let defaults = ModelDefaults {
+            provider: "ollama".to_string(),
+            model: Some("ollama/qwen3.8:latest".to_string()),
+            fallback_order: Vec::new(),
+        };
+        let (p, m) = resolve_stage_model(
+            &model_cfg(vec![("ghost", "g")]),
+            None,
+            &defaults,
+            &registry_with(&["ollama"]),
+        );
+        assert_eq!((p.as_str(), m.as_str()), ("ollama", "qwen3.8:latest"));
+    }
+
+    #[test]
+    fn bare_default_model_strips_only_the_named_providers_prefix() {
+        // The provider's own name, and nothing else, comes off.
+        assert_eq!(
+            bare_default_model("ollama", "ollama/qwen3.8:latest"),
+            "qwen3.8:latest"
+        );
+        assert_eq!(
+            bare_default_model("anthropic", "anthropic/claude-sonnet-5"),
+            "claude-sonnet-5"
+        );
+        // Another provider's name is part of the model id, as far as this
+        // provider is concerned.
+        assert_eq!(bare_default_model("ollama", "openai/gpt-5"), "openai/gpt-5");
+        // A bare id is untouched, as is one that merely starts with the same
+        // letters or has nothing after the slash.
+        assert_eq!(
+            bare_default_model("ollama", "qwen3.8:latest"),
+            "qwen3.8:latest"
+        );
+        assert_eq!(bare_default_model("ollama", "ollamafoo/x"), "ollamafoo/x");
+        assert_eq!(bare_default_model("ollama", "ollama/"), "ollama/");
+        assert_eq!(bare_default_model("ollama", "ollama"), "ollama");
+    }
+
+    #[test]
+    fn bare_default_model_keeps_openrouters_own_catalog_ids() {
+        // `openrouter/auto` is a real OpenRouter model, not a qualified one.
+        assert_eq!(
+            bare_default_model("openrouter", "openrouter/auto"),
+            "openrouter/auto"
+        );
+        // A qualified OpenRouter model still carries the vendor segment, so
+        // there is a second slash and the prefix comes off.
+        assert_eq!(
+            bare_default_model("openrouter", "openrouter/deepseek/deepseek-v4-flash"),
+            "deepseek/deepseek-v4-flash"
+        );
+        assert_eq!(
+            bare_default_model("openrouter", "deepseek/deepseek-v4-flash"),
+            "deepseek/deepseek-v4-flash"
+        );
+    }
+
     #[test]
     fn resolve_user_default_with_model_override() {
         let defaults = ModelDefaults {
@@ -959,6 +1062,54 @@ mod tests {
                 ("openrouter", "deepseek"),
                 ("openai", "gpt"),
             ]
+        );
+    }
+
+    /// Every bundled blueprint lists Ollama as `qwen3.5:9b`. A user who set
+    /// `default_model = "qwen3.8:latest"` next to `default_provider = "ollama"`
+    /// was still sent to the blueprint's model, because the preference only
+    /// moved the *provider* forward and left the blueprint's entry ahead of
+    /// the user's. The named default leads; the blueprint's entry stays behind
+    /// it as the fallback.
+    #[test]
+    fn the_users_default_model_leads_the_blueprints_entry_on_the_same_provider() {
+        let cfg = model_cfg(vec![
+            ("anthropic", "claude-sonnet-5"),
+            ("ollama", "qwen3.5:9b"),
+            ("ollama", "qwen3.6:27b"),
+        ]);
+        let defaults = ModelDefaults {
+            provider: "ollama".to_string(),
+            model: Some("qwen3.8:latest".to_string()),
+            ..Default::default()
+        };
+        let registry = registry_with(&["anthropic", "ollama"]);
+        let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![
+                ("ollama", "qwen3.8:latest"),
+                ("ollama", "qwen3.5:9b"),
+                ("ollama", "qwen3.6:27b"),
+                ("anthropic", "claude-sonnet-5"),
+            ],
+        );
+
+        // A default that repeats the blueprint's own entry changes nothing but
+        // the head, and is listed once.
+        let repeated = ModelDefaults {
+            provider: "ollama".to_string(),
+            model: Some("qwen3.6:27b".to_string()),
+            ..Default::default()
+        };
+        let got = resolve_stage_candidates(&cfg, None, &repeated, &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![
+                ("ollama", "qwen3.6:27b"),
+                ("ollama", "qwen3.5:9b"),
+                ("anthropic", "claude-sonnet-5"),
+            ],
         );
     }
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -25,7 +25,7 @@ where you look up the exact name, type, and default. The same contract ships mac
 
 ```toml
 default_provider     = "anthropic"   # provider used when a blueprint names none
-default_model        = "claude-sonnet-4-5"   # optional model override
+default_model        = "claude-sonnet-4-5"   # bare model id on default_provider, no "anthropic/" prefix
 agent_paths          = ["~/projects/my-agents"]   # extra directories scanned for blueprints
 openrouter_api_key   = "sk-or-..."   # env fallback: OPENROUTER_API_KEY
 ollama_base_url      = "http://localhost:11434"   # env fallback: OLLAMA_HOST
@@ -38,7 +38,7 @@ shell_hint           = true          # global master switch, see below
 | Key | Type | Default | Notes |
 |---|---|---|---|
 | `default_provider` | string | `"anthropic"` | |
-| `default_model` | string | unset | |
+| `default_model` | string | unset | A bare model id on `default_provider`, not `provider/model`. A leading `<default_provider>/` is dropped and named at load, so `"ollama/qwen3.8:latest"` under `default_provider = "ollama"` still works. See [which entry a stage starts on](/docs/providers#which-entry-a-stage-starts-on) |
 | `agent_paths` | array of paths | `[]` | Searched in addition to `~/.leviath/agents` |
 | `openrouter_api_key` | string | unset | Falls back to `OPENROUTER_API_KEY` |
 | `ollama_base_url` | string | unset | Falls back to `OLLAMA_HOST`, then `http://localhost:11434` |

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -156,7 +156,10 @@ In order:
 1. `lev run --model <provider>/<model>`, which overrides everything and skips the check entirely. A
    bare `--model <model>` replaces only the model name and keeps the provider resolved below.
 2. Your `default_provider` / `default_model` from `config.toml`, when `default_model` is set, the
-   provider is configured, and the stage did not set `allow_user_default = false`.
+   provider is configured, and the stage did not set `allow_user_default = false`. It leads even
+   when the blueprint lists that same provider with a different model: `default_provider = "ollama"`
+   with `default_model = "qwen3.8:latest"` runs on `qwen3.8:latest`, and the blueprint's own
+   `qwen3.5:9b` becomes the failover.
 3. The first entry in `models` whose provider is configured.
 4. The host-wide `fallback_order`, for the stages that got past everything above with nothing left.
 5. The first entry in the list, whether or not its provider exists. If it does not, the run fails at
@@ -169,6 +172,13 @@ your default still has the blueprint's own entries to fall back to.
 > `default_provider` on its own buys nothing. The resolver needs a model to send and has none, so it
 > falls through to whatever the blueprint listed. Set `default_model` alongside it. `lev doctor`
 > says so when you have not.
+
+`default_model` is a bare model id: `qwen3.8:latest`, not `ollama/qwen3.8:latest`. The provider is
+`default_provider`. That differs from `--model` and `[providers] fallback_order`, which take
+`provider/model` in one string, so a leading `<default_provider>/` is dropped rather than sent
+(`lev doctor` names the reading when it happens). The slash in an OpenRouter id such as
+`deepseek/deepseek-v4-flash` is part of the model id itself, and OpenRouter's own
+`openrouter/auto`-style ids are left as written.
 
 ### Running the bundled agents on your provider
 

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -166,6 +166,13 @@ Model strings are passed to the provider exactly as written and are never checke
 typo, a missing OpenRouter `vendor/` prefix, or an identifier the provider has retired all show up
 the same way: an API error on the first call, not a `lev validate` failure.
 
+If the name in the error carries a provider prefix, as in Ollama's
+`model 'ollama/qwen3.8:latest' not found`, the model was written as `provider/model` where a bare
+id was expected. `default_model` in `config.toml` and a `model` in a blueprint's `models` list
+pair with a provider that is named separately, so they take `qwen3.8:latest`; only `--model` and
+`[providers] fallback_order` take `ollama/qwen3.8:latest`. A `default_model` prefixed with its own
+`default_provider` is read bare and `lev doctor` says so; a blueprint entry is sent as written.
+
 Check the spelling against `lev models list --provider <name> --remote`, which asks the provider
 rather than Leviath's built-in table. Note that a valid dated identifier such as
 `deepseek/deepseek-v4-flash-0731` may be absent from the offline table while still working, so


### PR DESCRIPTION
## What

`default_model = "ollama/qwen3.8:latest"` next to `default_provider = "ollama"` was sent to Ollama verbatim, and Ollama answered `model 'ollama/qwen3.8:latest' not found`.

`default_model` is a bare model id that pairs with `default_provider`, but `--model` and `[providers] fallback_order` take `provider/model`, an OpenRouter id already has a slash in it, and the Lair's Settings view lists models as `provider/id` and writes that string straight into `default_model` (filed against leviath.dev separately). So the qualified form kept getting written, and nothing said anything about it.

Two changes in the resolver, plus the surfaces that report on it:

1. **A leading `<default_provider>/` is dropped from `default_model`.** OpenRouter's own `openrouter/auto`-style ids have no second slash and are left alone; a mistakenly qualified OpenRouter model (`openrouter/deepseek/deepseek-v4-flash`) always does, and loses its prefix. Config load warns at the same place the unread-key warning appears, and `lev doctor` appends what the setting was read as to its `resolve` line.
2. **The user's default model now leads on its provider.** Every bundled agent lists Ollama as `qwen3.5:9b`, so `default_provider = "ollama"` with `default_model = "qwen3.8:latest"` still ran on `qwen3.5:9b`, a model the user may never have pulled: the preference only moved the *provider* forward and left the blueprint's entry ahead of the user's. The named default heads its provider's partition and the blueprint's entries follow as the failover, which is the order `docs/content/providers.md` already described.

Docs: `configuration.md` and `providers.md` say which form each setting takes; `troubleshooting.md`'s "the provider says my model doesn't exist" names the prefixed error.

## Verified

- `cargo test --workspace --all-features`: 7756 passed.
- `cargo xtask coverage --package leviath-runtime` and `--package leviath-cli`: both at 100%.
- `cargo xtask docs`, clippy `-D warnings`, fmt: clean.
- Live, against a fake Ollama that logs the model it receives, daemon built from this branch, `default_provider = "ollama"` + `default_model = "ollama/qwen3.8:latest"`:
  - `lev doctor` → `resolve OK ollama / qwen3.8:latest (note: default_model is written as 'ollama/qwen3.8:latest' ... read as 'qwen3.8:latest'; drop the 'ollama/' in config.toml)`
  - `McQueen` (no ollama entry) → `POST /api/chat model='qwen3.8:latest'` (before: `ollama/qwen3.8:latest`, 404)
  - `deep-researcher` (lists `qwen3.5:9b`) → `POST /api/chat model='qwen3.8:latest'` (before: `qwen3.5:9b`)
- Also confirmed on the current release that `lev run --model ollama/qwen3.8:latest` and the Lair launch path (`POST /api/agents` with `model: "ollama/qwen3.8:latest"`) were already correct; only the config default was affected.
