### PR TITLE
feat(fan-out): 30 workers by default, 0 for unlimited, and the caps on the API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,22 @@ same list.
   ran on `qwen3.5:9b`, a model the user may never have pulled. The user's
   default now leads on its provider, with the blueprint's entries behind it as
   the failover, which is the order the docs already described.
+- Changed: a fan-out stage's `max_workers` defaults to 30 rather than 4, so
+  a split that produces ten work items runs them at once instead of in
+  waves. `max_workers = 0` now means unlimited, where it used to be read
+  as 1, and `max_items = 0` is spelled out as no ceiling. The daemon's
+  inference pool still paces the requests, so a wide fan-out queues at the
+  model rather than at the stage. The bundled `reviewer`, `data-analyst`,
+  `deep-researcher`, `log-analyzer` and `wide-researcher` agents raise both
+  caps to 30. A negative or non-numeric cap is a validation error; before,
+  `max_workers = -1` ran unbounded and `max_items = "twelve"` ran uncapped.
+- New: `GET /api/blueprints/{name}` carries `fan_outs`, one entry per
+  fan-out stage with its worker source, merge stage and both caps resolved
+  as the daemon applies them (`null` for unlimited). Announced as
+  `blueprints.fan_outs` in the `capabilities` list on `GET /api/config`.
+  Until now the only limit a console showed for a fan-out stage was
+  `max_iterations`, so the caps that decide how many workers a stage gets
+  looked like a retry count.
 
 ## 0.4.0 - 2026-08-18
 

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -77,15 +77,18 @@ max_iterations = 4
 max_revisits = 1
 worker_stage = "gather_worker"
 merge_stage = "build"
-max_workers = 4
+# Every slice at once rather than in waves; the daemon's inference pool paces the
+# requests. Set to 0 for no cap at all.
+max_workers = 30
 # Where the workers' rows land, and the budget their shares divide. A region of
 # its own rather than the conversation, which is carrying the message history
 # alongside them.
 results_region = "worker_rows"
-# A ceiling on slices, not just on concurrency. Twelve ways is enough breadth
-# for any subject, and past that each worker's share of the region is too small
-# to carry usable rows.
-max_items = 12
+# A ceiling on slices, not just on concurrency. Thirty ways covers a subject of
+# any breadth while leaving each worker a usable share of the region for its
+# rows; the build stage is told when that share had to be trimmed. Set to 0 for
+# no ceiling.
+max_items = 30
 split_prompt = """
 Split the `subject` into slices that can be gathered independently, one work
 item each. A slice is a country, a company, a year range, a category - whatever

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -88,12 +88,15 @@ max_iterations = 4
 max_revisits = 1
 worker_agent = "researcher"
 merge_stage = "analyze"
-max_workers = 4
+# Every sub-question at once rather than in waves; the daemon's inference
+# pool paces the requests. Set to 0 for no cap at all.
+max_workers = 30
 # Where the workers' findings land, and the budget their shares divide.
 results_region = "sub_findings"
-# A ceiling on sub-questions, not just on concurrency. Past this each worker's
-# share of the region is too small to carry a usable answer.
-max_items = 8
+# A ceiling on sub-questions, not just on concurrency. Thirty leaves each
+# worker a usable share of the region for its answer; the analyze stage is told
+# when that share had to be trimmed. Set to 0 for no ceiling.
+max_items = 30
 on_worker_failure = "continue"
 split_prompt = """
 Split the topic in `query` into sub-questions that can be researched

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -73,7 +73,9 @@ max_iterations = 4
 max_revisits = 1
 worker_stage = "scan_worker"
 merge_stage = "analyze"
-max_workers = 4
+# Every slice at once rather than in waves; the daemon's inference pool paces the
+# requests. Set to 0 for no cap at all.
+max_workers = 30
 # A file that will not parse is a gap in the sweep, not a reason to throw the
 # other workers' findings away. The failure is named in the results and the
 # analyze stage decides what to do about it.
@@ -82,11 +84,11 @@ on_worker_failure = "continue"
 # of its own rather than the conversation, which is carrying the message history
 # alongside them.
 results_region = "worker_findings"
-# A ceiling on slices, not just on concurrency. Eight is enough breadth for any
-# log set - a rotation with more files than that wants time windows, not one
-# worker each - and past it every worker's share of the region is too small to
-# carry the counts that make a finding evidence.
-max_items = 8
+# A ceiling on slices, not just on concurrency. Thirty covers a large rotation
+# one file each while leaving every worker a usable share of the region for the
+# counts that make a finding evidence; the analyze stage is told when that
+# share had to be trimmed. Set to 0 for no ceiling.
+max_items = 30
 split_prompt = """
 Split the sweep into slices that can be read independently, one work item each.
 A slice is one log file, one service's files, or one time window of a single

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -117,19 +117,22 @@ max_iterations = 4
 max_revisits = 1
 worker_stage = "review_worker"
 merge_stage = "deep_review"
-max_workers = 4
+# Every area at once rather than in waves; the daemon's inference pool paces the
+# requests. Set to 0 for no cap at all.
+max_workers = 30
 # An area nobody could review is a gap in the report, not a reason to throw the
-# other nine away. The failed worker is named in the results, and the deep review
+# others away. The failed worker is named in the results, and the deep review
 # is told to cover its area itself.
 on_worker_failure = "continue"
 # Where the workers' findings land, and the budget their shares divide. A region
 # of its own rather than the conversation, which is carrying the message history
 # alongside them.
 results_region = "worker_findings"
-# A ceiling on areas, not just on concurrency. Ten areas is enough breadth for
-# any one change, and past that each worker's share of the region is too small
-# to carry a usable finding list.
-max_items = 10
+# A ceiling on areas, not just on concurrency. Thirty areas covers a change of
+# any size while leaving each worker a usable share of the region for its
+# finding list; the merge is told when that share had to be trimmed. Set to 0
+# for no ceiling.
+max_items = 30
 split_prompt = """
 Split this review into areas that can be scrutinized independently, one work
 item each. An area is a file, a module, a subsystem, or one coherent group of

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -82,12 +82,15 @@ max_iterations = 4
 max_revisits = 1
 worker_agent = "researcher"
 merge_stage = "compare"
-max_workers = 4
+# Every thread at once rather than in waves; the daemon's inference pool paces the
+# requests. Set to 0 for no cap at all.
+max_workers = 30
 # Where the workers' findings land, and the budget their shares divide.
 results_region = "thread_findings"
-# A ceiling on threads, not just on concurrency. Past this each worker's share
-# of the region is too small to carry a usable answer.
-max_items = 8
+# A ceiling on threads, not just on concurrency. Thirty leaves each worker a
+# usable share of the region for its answer; the compare stage is told when
+# that share had to be trimmed. Set to 0 for no ceiling.
+max_items = 30
 on_worker_failure = "continue"
 split_prompt = """
 Split the landscape in `landscape` into threads that can be researched

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -301,7 +301,9 @@ pub(super) async fn get_blueprint(
     let manifest = std::mem::take(&mut info.manifest);
     // Parsed from the text already in hand rather than re-read: the same
     // reason the manifest itself is carried through from discovery.
-    let regions = parse_manifest(&manifest)
+    let parsed = parse_manifest(&manifest).ok();
+    let regions = parsed
+        .as_ref()
         .map(|bp| {
             bp.context_layout
                 .regions
@@ -316,11 +318,45 @@ pub(super) async fn get_blueprint(
                 .collect()
         })
         .unwrap_or_default();
+    let fan_outs = parsed.as_ref().map(fan_out_infos).unwrap_or_default();
     Ok(Json(BlueprintDetail {
         info,
         regions,
+        fan_outs,
         manifest,
     }))
+}
+
+/// The fan-out stages of a blueprint, with their limits resolved.
+///
+/// The manifest text is on the same response, so a client *could* work these
+/// out itself, but only by re-implementing the parser's defaults and its
+/// reading of `0`. A console that got the default wrong would show a stage
+/// as capped at four workers when the daemon runs thirty; one that missed the
+/// zero rule would show "0 workers" for a stage that is unlimited. Resolving
+/// the numbers here means what the API says is what the run does.
+fn fan_out_infos(bp: &leviath_core::blueprint::Blueprint) -> Vec<FanOutInfo> {
+    bp.stages
+        .iter()
+        .filter_map(|stage| match &stage.mode {
+            leviath_core::blueprint::StageMode::FanOut { config } => Some(FanOutInfo {
+                stage: stage.name.clone(),
+                worker_agent: config.worker_agent.clone(),
+                worker_stage: config.worker_stage.clone(),
+                worker_query: config.worker_query.clone(),
+                merge_stage: config.merge_stage.clone(),
+                max_workers: config.worker_cap(),
+                max_items: config.max_items,
+                on_worker_failure: match config.on_worker_failure {
+                    leviath_core::blueprint::WorkerFailurePolicy::Continue => "continue",
+                    leviath_core::blueprint::WorkerFailurePolicy::FailAll => "fail_all",
+                }
+                .to_string(),
+                results_region: config.results_region.clone(),
+            }),
+            _ => None,
+        })
+        .collect()
 }
 
 pub(super) async fn create_blueprint(
@@ -968,6 +1004,113 @@ system_prompt = "Plan the work"
                 },
             ])
         );
+    }
+
+    /// The detail route resolves each fan-out stage's limits the way the
+    /// daemon does: the default filled in for a stage that names none, `null`
+    /// for a cap that is not there (`0` in the manifest, or no `max_items`),
+    /// and the number itself otherwise. Stages that do not fan out are not
+    /// listed, and a blueprint with no fan-out has an empty list rather than
+    /// no key.
+    #[tokio::test]
+    async fn the_detail_route_reports_the_blueprints_fan_out_limits() {
+        let manifest = r#"
+[agent]
+name = "spreader"
+
+[stages.plan]
+system_prompt = "Plan the work"
+
+[stages.spread]
+mode = "fan_out"
+worker_stage = "worker"
+merge_stage = "gather"
+split_prompt = "split it"
+results_region = "findings"
+on_worker_failure = "fail_all"
+max_workers = 0
+max_items = 12
+
+[stages.wide]
+mode = "fan_out"
+worker_agent = "researcher"
+split_prompt = "split it"
+
+[stages.worker]
+system_prompt = "Do one part"
+allow_as_worker = true
+
+[stages.gather]
+system_prompt = "Gather"
+
+[context.regions]
+findings = { kind = "clearable", max_tokens = 4000 }
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join("spreader");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("agent.leviath"), manifest).unwrap();
+
+        let state = test_state_with_path(dir.path().to_path_buf());
+        let app = Router::new()
+            .route("/api/blueprints/{name}", get(get_blueprint))
+            .with_state(state);
+        let req = Request::builder()
+            .uri("/api/blueprints/spreader")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let bp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(
+            bp["fan_outs"],
+            serde_json::json!([
+                {
+                    "stage": "spread",
+                    "worker_stage": "worker",
+                    "merge_stage": "gather",
+                    "max_workers": null,
+                    "max_items": 12,
+                    "on_worker_failure": "fail_all",
+                    "results_region": "findings",
+                },
+                {
+                    "stage": "wide",
+                    "worker_agent": "researcher",
+                    "max_workers": leviath_core::blueprint::DEFAULT_MAX_WORKERS,
+                    "max_items": null,
+                    "on_worker_failure": "continue",
+                },
+            ])
+        );
+    }
+
+    /// A blueprint that never fans out reports an empty list, so a client can
+    /// tell "no fan-out here" from a daemon too old to say.
+    #[tokio::test]
+    async fn a_blueprint_without_fan_out_reports_an_empty_fan_outs_list() {
+        let dir = tempfile::tempdir().unwrap();
+        let agent_dir = dir.path().join("test-bp");
+        std::fs::create_dir_all(&agent_dir).unwrap();
+        std::fs::write(agent_dir.join("agent.leviath"), test_manifest()).unwrap();
+
+        let state = test_state_with_path(dir.path().to_path_buf());
+        let app = Router::new()
+            .route("/api/blueprints/{name}", get(get_blueprint))
+            .with_state(state);
+        let req = Request::builder()
+            .uri("/api/blueprints/test-bp")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let bp: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(bp["fan_outs"], serde_json::json!([]));
     }
 
     /// The listing must not carry manifests: it answers "what agents are

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -361,6 +361,7 @@ mod tests {
             "runs.search",
             "runs.files.listing",
             "blueprints.envelope",
+            "blueprints.fan_outs",
             "context.history.page",
         ] {
             assert!(

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -77,6 +77,12 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     "blueprints.query",
     "blueprints.manifest",
     "blueprints.validate.name",
+    // `fan_outs` on the blueprint detail route: each fan-out stage's limits as
+    // the daemon resolves them (`null` for unlimited, the default filled in),
+    // and the manifest's `0` spelling for "no cap" on `max_workers` and
+    // `max_items`. A console that has this can show and edit the caps without
+    // re-implementing the parser's defaults.
+    "blueprints.fan_outs",
     "tools.list",
     "scripts.read",
     // Announced whether or not `--allow-admin` was passed, which is a narrower

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -496,6 +496,46 @@ pub(super) struct RegionInfo {
     pub(super) max_tokens: usize,
 }
 
+/// One fan-out stage of a blueprint, as the API reports it.
+///
+/// A console editing a fan-out stage showed `max_iterations` and nothing else,
+/// so the only limit in sight read as a retry count and the two that decide
+/// how many workers a stage gets, `max_workers` and `max_items`, were
+/// invisible unless you read the TOML. This is the same block resolved the
+/// way the daemon resolves it: defaults filled in, and `null` for a cap that
+/// is not there.
+#[derive(Debug, Serialize)]
+pub(super) struct FanOutInfo {
+    /// The stage's name.
+    pub(super) stage: String,
+    /// A separate installed blueprint the workers run as, when that is how the
+    /// stage picks its worker.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) worker_agent: Option<String>,
+    /// A stage of this blueprint the workers run as, when that is how.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) worker_stage: Option<String>,
+    /// A discovery query matched against installed agents, when that is how.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) worker_query: Option<String>,
+    /// The stage that reconciles the workers' results, when there is one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) merge_stage: Option<String>,
+    /// How many workers run at once. `null` is unlimited (`max_workers = 0` in
+    /// the manifest); a stage that names no cap gets the default, and that
+    /// default is what appears here.
+    pub(super) max_workers: Option<usize>,
+    /// How many work items the split may produce at all. `null` is unlimited
+    /// (`max_items = 0`, or no key).
+    pub(super) max_items: Option<usize>,
+    /// `continue` or `fail_all`, as the manifest spells them.
+    pub(super) on_worker_failure: String,
+    /// The region the consolidated worker report is written to, when the
+    /// stage names one; `null` means the conversation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) results_region: Option<String>,
+}
+
 /// One blueprint, with the manifest text behind it.
 ///
 /// The detail route only. A listing that carried one of these per blueprint
@@ -515,6 +555,9 @@ pub(super) struct BlueprintDetail {
     /// manifest is: answering "what agents are there" should not cost every
     /// region of every agent on the machine.
     pub(super) regions: Vec<RegionInfo>,
+    /// The blueprint's fan-out stages, with their limits as the daemon will
+    /// apply them. Empty for a blueprint that never fans out.
+    pub(super) fan_outs: Vec<FanOutInfo>,
     /// The manifest exactly as it is on disk.
     ///
     /// Without this a console has no way to read what it is editing: naming

--- a/crates/leviath-cli/src/tui/flowgraph/model.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/model.rs
@@ -726,7 +726,7 @@ worker_query = "anything that reads logs"
             NodeKind::Stage(StageKind::FanOut {
                 worker: WorkerRef::Query("anything that reads logs".to_string()),
                 merge: None,
-                max_workers: 4,
+                max_workers: leviath_core::blueprint::DEFAULT_MAX_WORKERS,
             })
         );
         // External nodes come after every stage, and are not stages.

--- a/crates/leviath-core/src/blueprint/mod.rs
+++ b/crates/leviath-core/src/blueprint/mod.rs
@@ -1972,7 +1972,16 @@ on_worker_failure = "fail_all"
 "#;
         let cfg: FanOutConfig = toml::from_str(toml).unwrap();
         assert_eq!(cfg.worker_agent.as_deref(), Some("fixer"));
-        assert_eq!(cfg.max_workers, 4); // default
+        assert_eq!(cfg.max_workers, DEFAULT_MAX_WORKERS);
+        assert_eq!(cfg.worker_cap(), Some(DEFAULT_MAX_WORKERS));
+        assert_eq!(
+            FanOutConfig {
+                max_workers: 0,
+                ..fanout_config()
+            }
+            .worker_cap(),
+            None
+        );
         assert_eq!(cfg.on_worker_failure, WorkerFailurePolicy::FailAll);
         // JSON round-trip preserves everything.
         let json = serde_json::to_string(&fanout_config()).unwrap();

--- a/crates/leviath-core/src/blueprint/stage.rs
+++ b/crates/leviath-core/src/blueprint/stage.rs
@@ -172,7 +172,12 @@ pub struct FanOutConfig {
     /// Optional stage that reconciles worker results before transitioning.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub merge_stage: Option<String>,
-    /// Maximum number of workers running concurrently.
+    /// Most workers running at once. Defaults to [`DEFAULT_MAX_WORKERS`].
+    ///
+    /// `0` means unlimited: every work item starts as soon as the split has
+    /// produced it, and the daemon's inference pool (`[limits]
+    /// max_concurrent_inferences`) is what paces the requests. Read it through
+    /// [`Self::worker_cap`] rather than comparing against zero by hand.
     #[serde(default = "default_max_workers")]
     pub max_workers: usize,
     /// How to handle worker failures.
@@ -194,7 +199,8 @@ pub struct FanOutConfig {
     pub results_region: Option<String>,
 
     /// Most work items the split may produce. `None` means however many it
-    /// produces.
+    /// produces (a manifest spells that `max_items = 0`, or leaves the key
+    /// out).
     ///
     /// Distinct from `max_workers`, which caps how many run *at once*. This
     /// caps how many there are at all, which is what bounds both the run's cost
@@ -204,9 +210,30 @@ pub struct FanOutConfig {
     pub max_items: Option<usize>,
 }
 
+impl FanOutConfig {
+    /// The concurrency cap as an option: `Some(n)` for `max_workers = n`,
+    /// `None` when the stage is unlimited (`max_workers = 0`).
+    ///
+    /// The runtime and the API both want the question answered this way, and
+    /// answering it in one place keeps "zero is unlimited" from being restated
+    /// wherever the number is read.
+    pub fn worker_cap(&self) -> Option<usize> {
+        (self.max_workers > 0).then_some(self.max_workers)
+    }
+}
+
+/// `max_workers` when a fan-out stage does not set one.
+///
+/// Thirty rather than the four this started at. Four made a fan-out that split
+/// ten ways run in three waves, and the wait for the last wave was the wait a
+/// person saw. The inference pool caps concurrent model requests either way, so
+/// a wide fan-out over a narrow pool queues at the provider rather than at the
+/// stage.
+pub const DEFAULT_MAX_WORKERS: usize = 30;
+
 /// Default `max_workers` when unspecified.
 fn default_max_workers() -> usize {
-    4
+    DEFAULT_MAX_WORKERS
 }
 
 /// Style of interaction at an interaction point.

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -641,6 +641,32 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
     }
 }
 
+/// Read one of a fan-out stage's two caps, `max_workers` or `max_items`.
+///
+/// `Ok(None)` when the key is absent, so the caller picks the default;
+/// `Ok(Some(n))` for a non-negative integer, where `0` is the manifest's word
+/// for "unlimited" on both keys. Anything else is an error rather than a
+/// silent fallback: `max_workers = -1` used to wrap to the largest `usize` and
+/// so run unbounded, while `max_items = "twelve"` was read as no cap at all.
+/// Either mistake shows up as an unexpectedly wide fan-out, which is the wrong
+/// place to first hear about a typo.
+fn fan_out_cap(stage_value: &toml::Value, stage_name: &str, key: &str) -> Result<Option<usize>> {
+    let Some(value) = stage_value.get(key) else {
+        return Ok(None);
+    };
+    let n = value.as_integer().ok_or_else(|| {
+        Error::Other(format!(
+            "stage '{stage_name}': {key} must be a whole number (0 means unlimited)"
+        ))
+    })?;
+    let n = usize::try_from(n).map_err(|_| {
+        Error::Other(format!(
+            "stage '{stage_name}': {key} must not be negative (got {n}; 0 means unlimited)"
+        ))
+    })?;
+    Ok(Some(n))
+}
+
 /// Apply `[stages.<name>] mode`, along with the sub-tables a given mode reads
 /// (`interaction_points` for `interactive_points`, the fan-out block for
 /// `fan_out`). A stage that names no mode keeps the constructor's default.
@@ -807,19 +833,12 @@ pub(super) fn apply_stage_mode(
                 worker_stage: str_field("worker_stage"),
                 worker_query: str_field("worker_query"),
                 merge_stage: str_field("merge_stage"),
-                max_workers: stage_value
-                    .get("max_workers")
-                    .and_then(|v| v.as_integer())
-                    .map(|n| n as usize)
-                    .unwrap_or(4),
+                max_workers: fan_out_cap(stage_value, stage_name, "max_workers")?
+                    .unwrap_or(crate::blueprint::DEFAULT_MAX_WORKERS),
                 on_worker_failure,
                 split_prompt: str_field("split_prompt").unwrap_or_default(),
                 results_region: str_field("results_region"),
-                max_items: stage_value
-                    .get("max_items")
-                    .and_then(|v| v.as_integer())
-                    .filter(|n| *n > 0)
-                    .map(|n| n as usize),
+                max_items: fan_out_cap(stage_value, stage_name, "max_items")?.filter(|n| *n > 0),
             };
             stage.with_mode(StageMode::FanOut { config })
         }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -2172,7 +2172,7 @@ split_prompt = "go"
             worker_stage: None,
             worker_query: None,
             merge_stage: None,
-            max_workers: 4, // default
+            max_workers: crate::blueprint::DEFAULT_MAX_WORKERS,
             on_worker_failure: crate::blueprint::WorkerFailurePolicy::Continue,
             split_prompt: "go".to_string(),
             results_region: None,
@@ -2208,7 +2208,7 @@ max_items = 12
             worker_stage: None,
             worker_query: None,
             merge_stage: None,
-            max_workers: 4,
+            max_workers: crate::blueprint::DEFAULT_MAX_WORKERS,
             on_worker_failure: crate::blueprint::WorkerFailurePolicy::Continue,
             split_prompt: "go".to_string(),
             results_region: Some("worker_rows".to_string()),
@@ -2218,12 +2218,57 @@ max_items = 12
     assert_eq!(bp.find_stage("parallel").unwrap().mode, expected);
 }
 
-/// A cap of zero or below would mean "no work items at all", which is not
-/// something anyone writes on purpose. Reading it as "no cap" matches an
-/// absent key rather than producing a fan-out that can never run.
+/// `0` is the manifest's word for "unlimited" on both caps: `max_items = 0`
+/// reads as no ceiling on how many items the split may produce (the same as
+/// leaving the key out), and `max_workers = 0` keeps the zero so the runtime
+/// starts every item at once. Neither is a fan-out that can never run.
 #[test]
-fn parse_manifest_fan_out_rejects_a_non_positive_max_items() {
-    for value in ["0", "-3", "\"twelve\""] {
+fn parse_manifest_fan_out_zero_caps_mean_unlimited() {
+    let toml = r#"
+[agent]
+name = "fanout-cap"
+
+[stages.parallel]
+mode = "fan_out"
+worker_agent = "w"
+split_prompt = "go"
+max_items = 0
+max_workers = 0
+"#;
+    let bp = parse_manifest(toml).unwrap();
+    let expected = crate::blueprint::StageMode::FanOut {
+        config: crate::blueprint::FanOutConfig {
+            worker_agent: Some("w".to_string()),
+            worker_stage: None,
+            worker_query: None,
+            merge_stage: None,
+            max_workers: 0,
+            on_worker_failure: crate::blueprint::WorkerFailurePolicy::Continue,
+            split_prompt: "go".to_string(),
+            results_region: None,
+            max_items: None,
+        },
+    };
+    let stage = bp.find_stage("parallel").unwrap();
+    assert_eq!(stage.mode, expected);
+    let crate::blueprint::StageMode::FanOut { config } = &stage.mode else {
+        unreachable!("asserted equal to a fan-out above");
+    };
+    assert_eq!(config.worker_cap(), None);
+}
+
+/// A negative or non-numeric cap is a mistake the author should hear about at
+/// parse time. `max_workers = -1` used to wrap to the largest `usize` and run
+/// unbounded, and `max_items = "twelve"` was read as no cap at all; both showed
+/// up only as a fan-out wider than the manifest appeared to allow.
+#[test]
+fn parse_manifest_fan_out_rejects_a_negative_or_non_numeric_cap() {
+    for (key, value, wants) in [
+        ("max_items", "-3", "must not be negative"),
+        ("max_items", "\"twelve\"", "must be a whole number"),
+        ("max_workers", "-1", "must not be negative"),
+        ("max_workers", "\"lots\"", "must be a whole number"),
+    ] {
         let toml = format!(
             r#"
 [agent]
@@ -2233,28 +2278,15 @@ name = "fanout-cap"
 mode = "fan_out"
 worker_agent = "w"
 split_prompt = "go"
-max_items = {value}
+{key} = {value}
 "#
         );
-        let bp = parse_manifest(&toml).unwrap();
-        let expected = crate::blueprint::StageMode::FanOut {
-            config: crate::blueprint::FanOutConfig {
-                worker_agent: Some("w".to_string()),
-                worker_stage: None,
-                worker_query: None,
-                merge_stage: None,
-                max_workers: 4,
-                on_worker_failure: crate::blueprint::WorkerFailurePolicy::Continue,
-                split_prompt: "go".to_string(),
-                results_region: None,
-                max_items: None,
-            },
-        };
-        assert_eq!(
-            bp.find_stage("parallel").unwrap().mode,
-            expected,
-            "max_items = {value}"
+        let err = parse_manifest(&toml).unwrap_err().to_string();
+        assert!(
+            err.contains(&format!("stage 'parallel': {key} {wants}")),
+            "{key} = {value}: {err}"
         );
+        assert!(err.contains("0 means unlimited"), "{key} = {value}: {err}");
     }
 }
 

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -164,7 +164,7 @@ pub struct FanOutWaiting {
 pub struct FanOutState {
     /// The fan-out configuration.
     pub config: FanOutConfig,
-    /// The concurrency cap.
+    /// The concurrency cap; `usize::MAX` for a stage with `max_workers = 0`.
     pub max_workers: usize,
     /// Work items not yet started.
     pub pending: Vec<WorkItem>,
@@ -269,7 +269,11 @@ pub fn fan_out_split(world: &mut World) {
             .remove::<InferenceResult>();
         match parse_work_items(&response) {
             Ok(items) => {
-                let max_workers = config.max_workers.max(1);
+                // Unlimited (`max_workers = 0`) is the largest cap there is,
+                // rather than a separate flag: the start loop below compares
+                // against it and nothing else, and the persisted state keeps
+                // the one number it always kept.
+                let max_workers = config.worker_cap().unwrap_or(usize::MAX);
                 // A split decides its own item count, so without a cap a model
                 // that returns five hundred items spawns five hundred runs. The
                 // cap also fixes each worker's share of the results region: past
@@ -1449,6 +1453,29 @@ mod tests {
         fan_out_collect(&mut world);
         assert!(world.get::<FanOutWaiting>(e).is_none());
         assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+    }
+
+    /// `max_workers = 0` is unlimited: every item starts on the first collect
+    /// pass, and the persisted state carries the cap as the largest number
+    /// there is, which round-trips through JSON like any other.
+    #[test]
+    fn collect_with_max_workers_zero_starts_every_item_at_once() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(Some("merge"), 0, WorkerFailurePolicy::Continue)),
+            r#"[{"id":"a"},{"id":"b"},{"id":"c"},{"id":"d"},{"id":"e"}]"#,
+        );
+        fan_out_split(&mut world);
+        fan_out_collect(&mut world);
+        assert_eq!(world.get::<SubAgentChildren>(e).unwrap().children.len(), 5);
+        let state = world.get::<FanOutWaiting>(e).unwrap().to_state();
+        assert_eq!(state.max_workers, usize::MAX);
+        assert!(state.pending.is_empty());
+        let json = serde_json::to_string(&state).unwrap();
+        let back: FanOutState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.max_workers, usize::MAX);
     }
 
     #[test]

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -171,7 +171,7 @@ Base path `/api`; all JSON unless noted.
 | `POST /api/agents/{id}/pause` · `/resume` | Pause a run · resume it |
 | `POST /api/agents/{id}/message` | Steer a running agent |
 | `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question |
-| `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q` |
+| `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q`; the detail carries the manifest, the regions and the [fan-out limits](#fan-out-limits) |
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
 | `GET /api/models` | Enumerate models |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
@@ -395,6 +395,45 @@ in the response says where the window actually began. That is what keeps the pie
 offset past the end of the file returns 416 rather than an empty window, so a loop cannot spin.
 
 A whole-file read serializes exactly as it always has. `offset` is omitted when it is zero.
+
+## Fan-out limits
+
+A [fan-out stage](/docs/sub-agents#fan-out) has two caps, and neither is the stage's
+`max_iterations`. `max_workers` is how many workers run at once and `max_items` is how many work
+items the split may produce at all. `GET /api/blueprints/{name}` reports both for every fan-out
+stage, resolved the way the daemon will apply them:
+
+```json
+{
+  "name": "reviewer",
+  "fan_outs": [
+    {
+      "stage": "split_review",
+      "worker_stage": "review_worker",
+      "merge_stage": "deep_review",
+      "max_workers": 30,
+      "max_items": 30,
+      "on_worker_failure": "continue",
+      "results_region": "worker_findings"
+    }
+  ],
+  "regions": ["…"],
+  "manifest": "…"
+}
+```
+
+`max_workers` is the default (30) when the manifest names none, and `null` when the stage is
+unlimited. `max_items` is `null` when there is no ceiling. Whichever of `worker_agent`,
+`worker_stage` or `worker_query` the stage uses is the one present. A blueprint that never fans out
+has an empty list. `blueprints.fan_outs` in the `capabilities` list on `GET /api/config` says the
+daemon reports this.
+
+Changing a cap is a manifest write: `PUT /api/blueprints/{name}` with the manifest text, the stage's
+`max_workers` or `max_items` set to the number you want, or to `0` for no cap at all. `POST
+/api/blueprints/validate` will tell you first if the value is not a whole number or is negative,
+which are errors rather than quiet fallbacks. The workers still share the daemon's inference pool
+(`[limits] max_concurrent_inferences`, 8 by default), so an unlimited fan-out queues at the model
+rather than running away.
 
 ## Tools and scripts
 

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -44,7 +44,7 @@ mode         = "fan_out"
 worker_stage = "fix_one"    # which worker to run, see below
 split_prompt = "..."        # prompt that produces the JSON array of work items
 merge_stage  = "verify"     # stage the parent resumes at once workers finish
-max_workers  = 8            # how many run at once, default 4
+max_workers  = 8            # how many run at once, default 30; 0 is unlimited
 on_worker_failure = "continue"
 ```
 
@@ -57,8 +57,8 @@ Those keys sit directly on the stage next to `mode = "fan_out"`, not in a sub-ta
 | `worker_query` | unset | A hint matched against installed agent types |
 | `merge_stage` | unset | Stage that reconciles worker results before the parent moves on |
 | `results_region` | `conversation` | Where the consolidated worker report lands |
-| `max_items` | unset | Most work items the split may produce |
-| `max_workers` | `4` | How many workers run at once |
+| `max_items` | unset | Most work items the split may produce. `0` or unset means however many it produces |
+| `max_workers` | `30` | How many workers run at once. `0` means unlimited |
 | `on_worker_failure` | `"continue"` | `continue` merges what succeeded. `fail_all` fails the whole fan-out if any worker fails |
 | `split_prompt` | `""` | Added to the stage's system prompt. Its reply is parsed as the list of work items |
 
@@ -75,7 +75,7 @@ installed agent instead, which is worth doing when one already does the job:
 mode = "fan_out"
 worker_agent = "researcher"    # every item is a full researcher run
 merge_stage = "analyze"
-max_workers = 4
+max_workers = 30
 ```
 
 That is what the bundled `deep-researcher` and `wide-researcher` do. The difference is not only who
@@ -154,6 +154,11 @@ Split a hundred ways and every worker gets a hundredth of the space. Past some p
 too small to be worth reading, and `max_items` is how you stop the split getting there. Without it,
 whatever the split produces is what runs.
 
+Both caps take `0` to mean no cap. `max_workers = 0` starts every work item the moment the split
+has produced it; `max_items = 0` is the same as leaving the key out. A negative value, or a value
+that is not a whole number, is a validation error rather than a quiet fallback, so a typo shows up
+in `lev validate` and not as a fan-out wider than the manifest appeared to allow.
+
 ## `max_workers` is not the knob you might think
 
 Three different settings limit concurrency, and they are easy to confuse. All three apply at once:
@@ -164,9 +169,13 @@ Three different settings limit concurrency, and they are easy to confuse. All th
 | `[limits] max_concurrent_inferences` | Model requests in flight | Per model, daemon-wide |
 | `[rate_limits.<provider>]` | Requests per minute | Per provider |
 
-So `max_workers = 8` starts eight sub-agents, but if the model pool only allows four requests at
-once, four of them wait. That is fine and costs nothing. See
+So `max_workers = 30` (the default) starts up to thirty sub-agents, but if the model pool only allows
+eight requests at once (also the default), the rest wait for a slot. That is fine and costs nothing;
+it is also why an unlimited fan-out is safe to run. See
 [inference pools](/docs/engine#inference-pools).
+
+Both caps can be read and changed over the [HTTP API](/docs/api#fan-out-limits): the blueprint
+detail route reports them resolved, and writing the manifest back is how they change.
 
 ## Any sub-agent can ask you a question
 

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -281,7 +281,12 @@
           "items": { "$ref": "#/$defs/interactionPoint" }
         },
         "on_worker_failure": { "enum": ["continue", "fail_all"] },
-        "max_workers": { "type": "integer", "minimum": 1 },
+        "max_workers": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 30,
+          "description": "How many workers run at once. 0 means unlimited: every work item starts as soon as the split has produced it, and the daemon's inference pool paces the requests."
+        },
         "worker_agent": { "type": "string" },
         "worker_stage": { "type": "string" },
         "worker_query": { "type": "string" },
@@ -293,8 +298,8 @@
         },
         "max_items": {
           "type": "integer",
-          "minimum": 1,
-          "description": "Most work items the split may produce. Distinct from max_workers, which caps how many run at once. This caps how many exist at all, bounding both the run's cost and each worker's share of the results region."
+          "minimum": 0,
+          "description": "Most work items the split may produce. 0 (or no key) means however many it produces. Distinct from max_workers, which caps how many run at once. This caps how many exist at all, bounding both the run's cost and each worker's share of the results region."
         }
       }
     },

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -226,6 +226,7 @@
           "blueprints"
         ],
         "summary": "Fetch one blueprint",
+        "description": "The catalog entry plus the manifest text, the context regions, and fan_outs: one entry per fan-out stage with its worker source, merge stage and both caps (max_workers, max_items) resolved as the daemon applies them, null meaning unlimited.",
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"


### PR DESCRIPTION
## What

A fan-out stage's two caps, opened up and put on the API.

- `max_workers` defaults to **30** rather than 4, so a split that produces ten work items runs them at once instead of in waves. `leviath_core::blueprint::DEFAULT_MAX_WORKERS` is the one place the number lives.
- **`max_workers = 0` means unlimited.** It used to be coerced to 1. `max_items = 0` is spelled out as no ceiling (it already parsed that way). `FanOutConfig::worker_cap()` answers the question as an `Option`; the runtime stores `usize::MAX` in `FanOutState`, which round-trips through `fanout.json` like any other number.
- A negative or non-numeric cap is a validation error. Before, `max_workers = -1` wrapped to the largest `usize` and ran unbounded, and `max_items = "twelve"` was read as no cap. Both surfaced only as a fan-out wider than the manifest appeared to allow.
- `GET /api/blueprints/{name}` carries **`fan_outs`**: one entry per fan-out stage with its worker source, `merge_stage`, `on_worker_failure`, `results_region` and both caps resolved as the daemon applies them (`null` for unlimited, the default filled in). Announced as `blueprints.fan_outs` on `GET /api/config`. Writing is still `PUT` with the manifest, which already worked; the read side is what a console had to re-derive from TOML.
- The five bundled fan-out agents (`reviewer`, `data-analyst`, `deep-researcher`, `log-analyzer`, `wide-researcher`) set both `max_workers` and `max_items` to 30. The old `max_items` of 8 to 12 were justified in their comments by each worker's share of the results region; at thirty the shares are still a few hundred tokens and the merge is told when one had to be trimmed. If a merge stage suffers, lower `max_items` on that agent alone.

## Why

The Lair's blueprint editor shows only "Max tries" (`max_iterations`) for a fan-out stage, so the only visible limit read as a retry count and there was no way, short of editing TOML, to see or raise the caps that decide how many workers a stage gets. GEMISIS/leviath.dev#65 asks the editor to use `fan_outs`.

`[limits] max_concurrent_inferences` (8 by default) still paces every worker at the model, so a wide or unlimited fan-out queues at the provider rather than running away.

## Verified

- Unit: parser accepts `0` on both keys, rejects negatives and strings with a message naming `0 means unlimited`; runtime starts every item on the first collect pass at `max_workers = 0` and the state survives JSON; the detail route reports resolved caps, `null`s, worker sources and an empty list for a blueprint that never fans out; bundled agents still validate against `blueprint.schema.json`.
- Live, against `lev serve` in an isolated `LEVIATH_HOME`: `GET /api/config` lists `blueprints.fan_outs`; `GET /api/blueprints/{name}` shows `null`/`null` for a `0`/`0` stage and `30`/`30` for the bundled reviewer; `PUT` with `max_workers = 12` is reflected on the next `GET`; `POST /validate` and `PUT` both refuse `max_workers = -4` with the parser's message and the file on disk is untouched.
- `lev validate` and `lev validate --graph` on the same manifests.
- `cargo xtask docs`, clippy `-D warnings`, and the coverage gate for `leviath-core`, `leviath-runtime` and `leviath-cli`.
