### PR TITLE
fix(control): ride out a daemon restart, and tell an update from one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ same list.
 
 ## Unreleased
 
+- Fixed: `lev serve`, `lev dash`, and `lev agent-client` ride out a daemon
+  restart instead of breaking. A request that lands while the daemon is down
+  (a `lev daemon restart`, a supervisor relaunch, or the restart that follows
+  `lev update`) waits up to ten seconds for it to come back and is served by
+  the new daemon, where before `lev serve` answered 503 and the ACP bridge
+  refused the turn, for a daemon that was back a second later. The wait is per
+  outage, not per request: a daemon that is really gone costs one caller the
+  ten seconds and every caller after that fails fast until it returns. Only
+  requests that cannot double an effect are retried after they were sent; a
+  spawn or a message that got no reply is reported rather than sent twice. The
+  ACP bridge follows a run onto the new daemon mid-turn instead of ending the
+  turn with a truncated reply. One-shot commands (`lev ps`, `lev cancel`) are
+  unchanged: a daemon that is not running is still reported at once.
+- New: the daemon says who it is (version, build, pid) in the control
+  handshake, and each front-end uses that to tell a restart from an update.
+  `lev serve` logs the reconnect, tells WebSocket subscribers with a
+  `daemon_link` event (connected or not, which daemon, whether it restarted),
+  and when the daemon came back on a different build than the server, says so
+  in the log, in the event, and in a `daemon_link` greeting to every new
+  WebSocket subscriber, with the remedy: restart `lev serve`. Requests keep
+  working while the two still understand each other; one that fails because
+  they no longer do answers 502 with the same text instead of a 503 that a
+  daemon restart cannot fix. `lev dash` says the same in its log and a toast,
+  and wears a chip on the run list while the daemon is unreachable or
+  updated. The ACP bridge tells the editor in the conversation.
 - New: `lev dash` draws a run's blueprint as a stage graph. The stage
   explorer (`g` in the detail view) is a canvas now: stages are boxes on
   layers, transitions are routed edges, the stage the run is in spins in

--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -44,7 +44,9 @@ use leviath_agent_client::{
 };
 use leviath_core::interaction::{ApprovalScope, InteractionRequest, InteractionResponse};
 use leviath_core::run_meta::RunStatus;
-use leviath_runtime::control_socket::{ControlClient, ControlRequest, ControlResponse};
+use leviath_runtime::control_socket::{
+    ControlClient, ControlRequest, ControlResponse, WorldEventStream,
+};
 use leviath_runtime::host::WorldEvent;
 use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -54,6 +56,17 @@ use self::translate::{StageTail, split_chunks};
 
 /// How often, absent a daemon event, the loop flushes newly-written run output.
 const OUTPUT_POLL: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// How many times in a row the daemon may drop the event stream without
+/// delivering an event before the turn gives up following the run. Every
+/// event resets the count, so a run that lives through several restarts is
+/// followed through all of them; only a daemon that comes back and drops the
+/// stream again at once, repeatedly, ends the turn.
+const MAX_SILENT_DROPS: u32 = 3;
+
+/// The pause before re-subscribing after a drop, so a daemon that keeps
+/// dropping the stream is not hammered in a tight loop.
+const RESUBSCRIBE_PAUSE: std::time::Duration = std::time::Duration::from_millis(200);
 
 /// Arguments for `lev agent-client`.
 #[derive(Args, Debug, Clone, Default)]
@@ -415,16 +428,42 @@ impl Server {
         };
 
         let mut tail = StageTail::new();
+        // Consecutive stream drops with no event in between - see the `None`
+        // arm below.
+        let mut silent_drops = 0u32;
         while self.io_alive {
             tokio::select! {
                 biased;
                 event = stream.next() => {
                     let Some(event) = event else {
-                        // The daemon closed the stream (restart); end the turn
-                        // with whatever output we have.
+                        // The daemon closed the stream: it is restarting, or it
+                        // is gone. Flush what the run wrote so far, then follow
+                        // the run onto the new daemon - which reloads it - by
+                        // subscribing again; the control client waits a restart
+                        // out. This used to end the turn on the spot, so a
+                        // `lev daemon restart` mid-answer handed the editor a
+                        // truncated reply while the run finished unwatched.
+                        // The turn ends only when no daemon comes back, or when
+                        // one keeps coming back and dropping the stream without
+                        // a single event - a daemon in that state is not going
+                        // to deliver the run, and following it forever would
+                        // hold the editor's turn open forever.
                         self.flush_output(&session_id, &mut tail, &run_id).await;
-                        return StopReason::EndTurn;
+                        silent_drops += 1;
+                        if silent_drops > MAX_SILENT_DROPS {
+                            return StopReason::EndTurn;
+                        }
+                        match self.resubscribe(&session_id).await {
+                            Some(fresh) => stream = fresh,
+                            None => return StopReason::EndTurn,
+                        }
+                        // The run may have finished while the stream was down.
+                        if let Some(reason) = self.run_finished(&run_id) {
+                            return reason;
+                        }
+                        continue;
                     };
+                    silent_drops = 0;
                     if event.run_id() != run_id {
                         continue; // another run in the shared world
                     }
@@ -477,6 +516,24 @@ impl Server {
         }
         // The output stream broke mid-turn; the client is gone.
         StopReason::EndTurn
+    }
+
+    /// Reopen the daemon's event stream after it dropped mid-turn.
+    ///
+    /// `None` when no daemon came back within the control client's grace, and
+    /// the turn has to end. When one did, and it runs different code than
+    /// this bridge - the daemon was updated under a running editor session -
+    /// the editor is told so in the conversation, since a bridge that stays
+    /// on the older code will eventually stop understanding the daemon and
+    /// the fix (restart the session) is on the editor's side.
+    async fn resubscribe(&mut self, session_id: &str) -> Option<WorldEventStream> {
+        tokio::time::sleep(RESUBSCRIBE_PAUSE).await;
+        let stream = self.control.subscribe().await.ok()?;
+        if let Some(mismatch) = self.control.code_mismatch() {
+            let notice = format!("\n[leviath: {mismatch}]\n");
+            self.emit_chunk(session_id, &notice).await;
+        }
+        Some(stream)
     }
 
     /// Whether the run has reached a state that should end the current turn,

--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -1393,6 +1393,198 @@ async fn a_closed_event_stream_ends_the_turn() {
     h.close_input().await;
 }
 
+// ─── the daemon restarts mid-turn ────────────────────────────────────────────
+
+/// A fake daemon that drops the *first* event stream after `first` and serves
+/// every later `Subscribe` with `then`, held open - the shape of a daemon that
+/// restarted under a turn. With an `identity` it speaks the handshake, so a
+/// tokened client learns who it reached; without one it is tokenless.
+fn restarting_daemon(
+    identity: Option<leviath_runtime::control_socket::DaemonIdentity>,
+    first: Vec<WorldEvent>,
+    then: Vec<WorldEvent>,
+) -> ScriptedDaemon {
+    use leviath_runtime::control_socket::{ControlRequest, ControlResponse, ControlToken};
+    let dir = tempfile::tempdir().unwrap();
+    let id = control_id(dir.path());
+    let mut listener = bind_control_listener(&id).unwrap();
+    let client = match &identity {
+        Some(_) => {
+            let _token = ControlToken::create(dir.path()).unwrap();
+            ControlClient::for_home(id, dir.path()).with_build("this-build")
+        }
+        None => ControlClient::new(id),
+    };
+    let subscribes = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let (first, then) = (Arc::new(first), Arc::new(then));
+    let accept = tokio::spawn(async move {
+        loop {
+            let Ok(Some(stream)) = listener.accept().await else {
+                break;
+            };
+            let identity = identity.clone();
+            let subscribes = subscribes.clone();
+            let (first, then) = (first.clone(), then.clone());
+            tokio::spawn(async move {
+                let (read_half, mut write_half) = tokio::io::split(stream);
+                let mut lines = BufReader::new(read_half).lines();
+                let say = |resp: ControlResponse| {
+                    let mut out = serde_json::to_string(&resp).unwrap();
+                    out.push('\n');
+                    out
+                };
+                if let Some(daemon) = identity {
+                    let _hello = lines.next_line().await.unwrap();
+                    let welcome = say(ControlResponse::Welcome { daemon });
+                    let _ = write_half.write_all(welcome.as_bytes()).await;
+                }
+                let line = lines.next_line().await.unwrap().unwrap();
+                match serde_json::from_str::<ControlRequest>(&line).unwrap() {
+                    ControlRequest::Subscribe => {
+                        let nth = subscribes.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                        let events = if nth == 0 { first } else { then };
+                        for ev in events.iter() {
+                            let mut out = serde_json::to_string(ev).unwrap();
+                            out.push('\n');
+                            let _ = write_half.write_all(out.as_bytes()).await;
+                        }
+                        if nth > 0 {
+                            std::future::pending::<()>().await;
+                        }
+                        // The first stream ends here: "the daemon restarted".
+                    }
+                    ControlRequest::Spawn { .. } => {
+                        let out = say(ControlResponse::Spawned {
+                            run_id: RUN_ID.to_string(),
+                        });
+                        let _ = write_half.write_all(out.as_bytes()).await;
+                    }
+                    _ => {
+                        let out = say(ControlResponse::Ok { ok: true });
+                        let _ = write_half.write_all(out.as_bytes()).await;
+                    }
+                }
+            });
+        }
+    });
+    ScriptedDaemon {
+        client,
+        _dir: dir,
+        _accept: AbortOnDrop(accept),
+    }
+}
+
+/// The daemon restarts mid-turn: the event stream drops, and the turn used to
+/// end right there with a truncated reply while the run finished unwatched.
+/// Now the bridge follows the run onto the new daemon and the turn ends when
+/// the run does.
+#[tokio::test]
+async fn a_dropped_event_stream_is_followed_onto_the_new_daemon() {
+    let daemon = restarting_daemon(None, vec![status_event()], vec![completed("complete")]);
+    let (mut h, _bp) = opened_session(daemon, false).await;
+    h.send(r#"{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"prompt":[{"type":"text","text":"go"}]}}"#)
+        .await;
+    let result = h.recv_until(is_result).await;
+    assert_eq!(result.result.unwrap()["stopReason"], "end_turn");
+    h.close_input().await;
+}
+
+/// A run that finished while the stream was down is noticed as soon as the
+/// stream is back, without waiting for an event that will never come.
+#[tokio::test]
+async fn a_run_that_finished_during_the_drop_ends_the_turn_on_reconnect() {
+    let daemon = restarting_daemon(None, vec![], vec![]);
+    let (mut h, _bp) = opened_session(daemon, false).await;
+    // The daemon's persistence lane recorded the finish before the stream came back.
+    h.write_meta_status("complete");
+    h.send(r#"{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"prompt":[{"type":"text","text":"go"}]}}"#)
+        .await;
+    let result = h.recv_until(is_result).await;
+    assert_eq!(result.result.unwrap()["stopReason"], "end_turn");
+    h.close_input().await;
+}
+
+/// When no daemon comes back at all, the turn ends with what the run wrote so
+/// far - which is what it always did, now after having tried.
+#[tokio::test]
+async fn a_daemon_that_never_comes_back_ends_the_turn() {
+    use leviath_runtime::control_socket::{ControlRequest, ControlResponse};
+    let dir = tempfile::tempdir().unwrap();
+    let id = control_id(dir.path());
+    let mut listener = bind_control_listener(&id).unwrap();
+    let accept = tokio::spawn(async move {
+        loop {
+            let Ok(Some(stream)) = listener.accept().await else {
+                break;
+            };
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let line = lines.next_line().await.unwrap().unwrap();
+            match serde_json::from_str::<ControlRequest>(&line).unwrap() {
+                // The turn subscribes first, then spawns. The subscribe is
+                // dropped unanswered; the spawn is honoured, and then the
+                // daemon is gone for good: nothing listens after this.
+                ControlRequest::Subscribe => continue,
+                _ => {
+                    let mut out = serde_json::to_string(&ControlResponse::Spawned {
+                        run_id: RUN_ID.to_string(),
+                    })
+                    .unwrap();
+                    out.push('\n');
+                    let _ = write_half.write_all(out.as_bytes()).await;
+                    break;
+                }
+            }
+        }
+    });
+    let daemon = ScriptedDaemon {
+        client: ControlClient::new(control_id(dir.path())),
+        _dir: dir,
+        _accept: AbortOnDrop(accept),
+    };
+    let (mut h, _bp) = opened_session(daemon, false).await;
+    h.send(r#"{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"prompt":[{"type":"text","text":"go"}]}}"#)
+        .await;
+    assert_eq!(
+        h.recv_until(is_result).await.result.unwrap()["stopReason"],
+        "end_turn"
+    );
+    h.close_input().await;
+}
+
+/// The daemon that comes back runs different code than this bridge - it was
+/// updated under a running editor session. The turn continues, and the editor
+/// is told in the conversation, since the fix (restart the session) is on its
+/// side.
+#[tokio::test]
+async fn a_daemon_back_on_other_code_is_named_in_the_conversation() {
+    let mut updated = leviath_runtime::control_socket::DaemonIdentity::this_process("this-build");
+    updated.build = "newer-build".to_string();
+    let daemon = restarting_daemon(Some(updated), vec![], vec![completed("complete")]);
+    let (mut h, _bp) = opened_session(daemon, false).await;
+    h.send(r#"{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"prompt":[{"type":"text","text":"go"}]}}"#)
+        .await;
+    let notice = h
+        .recv_until(|m| {
+            m.method.as_deref() == Some("session/update")
+                && m.params.as_ref().is_some_and(|p| {
+                    p["update"]["content"]["text"]
+                        .as_str()
+                        .is_some_and(|t| t.contains("[leviath:"))
+                })
+        })
+        .await;
+    let text = notice.params.unwrap()["update"]["content"]["text"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(text.contains("newer-build"), "{text}");
+    assert!(text.contains("restart this process"), "{text}");
+    let result = h.recv_until(is_result).await;
+    assert_eq!(result.result.unwrap()["stopReason"], "end_turn");
+    h.close_input().await;
+}
+
 // ─── pure helpers: run-status → stop reason ──────────────────────────────────
 
 mod run_status_helpers {

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -174,6 +174,7 @@ impl Dashboard {
             daemon_outcome_rx,
             daemon_outcome_tx: Some(daemon_outcome_tx),
             daemon_run_ids: None,
+            daemon_link: Default::default(),
             clock: system_now_secs,
         }
     }

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -171,6 +171,9 @@ async fn run_dashboard_loop<B: ratatui::backend::Backend>(
         // driving can be shown as stale rather than ACTIVE.
         dashboard.sync_daemon_runs(control).await;
 
+        // …and whether those polls reached a daemon at all, and which one.
+        dashboard.sync_daemon_link(control);
+
         // Sync background runs from on-disk run-state dir (the daemon persists
         // meta/context/stages there).
         dashboard.sync_from_run_state();
@@ -307,7 +310,13 @@ pub async fn execute_with<S: TerminalSetup, E: EventSource>(
     yank_fn: fn(&str) -> bool,
 ) -> anyhow::Result<()> {
     let mut dashboard = init_dashboard(control.clone(), yank_fn);
-    execute_core(&mut dashboard, &control, setup, events).await
+    // The render loop's own polls must fail fast: they run inline at ten a
+    // second, and a poll that waited a restart out would freeze the screen for
+    // as long as the daemon was down. The background loops keep the patient
+    // client, so a cancel or a spawn asked for mid-restart lands once the
+    // daemon is back instead of failing.
+    let poll = control.with_reconnect_grace(std::time::Duration::ZERO);
+    execute_core(&mut dashboard, &poll, setup, events).await
 }
 
 #[cfg(test)]

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -170,7 +170,7 @@ impl Dashboard {
         // Register for wheel hit-testing and show which pane holds focus.
         self.pane_rects.push((PaneId::RunTable, area));
         let focused = self.main_focus == MainPane::RunList;
-        let block = Block::default()
+        let mut block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(if focused { C_BORDER_FOCUS } else { C_BORDER }))
@@ -185,6 +185,17 @@ impl Dashboard {
                 ))
                 .right_aligned(),
             );
+        // The daemon link's chip, while there is something to say about it:
+        // beside the sort chip, in the colour of how wrong things are.
+        if let Some((chip, colour)) = self.daemon_link.chip() {
+            block = block.title_top(
+                Line::from(Span::styled(
+                    chip,
+                    Style::default().fg(colour).add_modifier(Modifier::BOLD),
+                ))
+                .right_aligned(),
+            );
+        }
 
         if let Some(msg) = empty_state_msg {
             let widget = Paragraph::new(Line::from(Span::styled(msg, Style::default().fg(C_DIM))))
@@ -600,7 +611,7 @@ impl Dashboard {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::test_support::{make_test_dashboard, style_at_text};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
@@ -636,6 +647,37 @@ mod tests {
             accepts_messages: true,
             taint_summary: vec![],
         }
+    }
+
+    /// While the daemon is unreachable the run list says so beside the sort
+    /// chip, in the warning colour; a healthy link draws no chip at all.
+    #[test]
+    fn the_run_list_wears_the_daemon_chip_while_something_is_wrong() {
+        let backend = TestBackend::new(140, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        terminal
+            .draw(|f| dash.draw_agent_table(f, f.area()))
+            .unwrap();
+        assert!(
+            !rendered_buffer(&terminal).contains("daemon"),
+            "healthy: no chip"
+        );
+
+        dash.daemon_link.unreachable = true;
+        terminal
+            .draw(|f| dash.draw_agent_table(f, f.area()))
+            .unwrap();
+        let text = rendered_buffer(&terminal);
+        assert!(text.contains("daemon unreachable, reconnecting"), "{text}");
+        assert!(
+            text.contains("sort:"),
+            "the sort chip is still there: {text}"
+        );
+        assert_eq!(
+            style_at_text(&terminal, "daemon unreachable").fg,
+            Some(crate::tui::theme::C_WARN)
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -224,6 +224,10 @@ pub(crate) struct Dashboard {
     /// the daemon did not answer - the disk view is then taken at face value
     /// rather than declaring every run stale.
     pub(super) daemon_run_ids: Option<std::collections::HashSet<String>>,
+    /// What the dashboard last knew about its link to the daemon, kept so a
+    /// change is announced once (see [`Self::sync_daemon_link`]) and the run
+    /// list can wear a chip while something is wrong.
+    pub(super) daemon_link: DaemonLinkView,
     /// Wall-clock source, injected so staleness is testable without sleeping.
     pub(super) clock: fn() -> i64,
     /// The background loop's ends of the MCP channels. `init_dashboard` takes
@@ -876,6 +880,61 @@ impl Dashboard {
             }
             _ => None,
         };
+    }
+
+    /// Notice what this tick's polls learned about the daemon itself, and say
+    /// it once: the daemon stopped answering, it is back (and whether it is
+    /// the same daemon or a restarted one), or it came back on a different
+    /// build than this dashboard.
+    ///
+    /// The polls above already ride out a restart on their own - they fail
+    /// fast, and the next tick simply succeeds - so nothing here reconnects.
+    /// It only announces, because a run list that silently went stale for two
+    /// seconds and silently recovered leaves the user guessing what happened,
+    /// and a daemon that came back updated is the one case where the fix is
+    /// on the user's side of the socket.
+    pub(super) fn sync_daemon_link(&mut self, control: &ControlClient) {
+        use crate::commands::dashboard::types::ToastLevel;
+        let link = control.link();
+        let mismatch = control.code_mismatch().map(|m| m.to_string());
+
+        match (self.daemon_link.unreachable, link.reachable) {
+            (false, false) => {
+                self.daemon_link.unreachable = true;
+                self.add_log("The daemon stopped answering; reconnecting.".to_string());
+                self.toast("daemon unreachable, reconnecting", ToastLevel::Warning);
+            }
+            (true, true) => {
+                self.daemon_link.unreachable = false;
+                let daemon = link
+                    .daemon
+                    .as_ref()
+                    .map(|d| format!(", now {d}"))
+                    .unwrap_or_default();
+                let what = match link.restarts != self.daemon_link.restarts {
+                    true => format!("The daemon restarted{daemon}; reconnected."),
+                    false => format!("Reconnected to the daemon{daemon}."),
+                };
+                self.add_log(what);
+                self.toast("reconnected to the daemon", ToastLevel::Info);
+            }
+            _ => {}
+        }
+        // A restart the polls never missed (fast enough that no tick failed)
+        // still moves the count; note it so the next reconnect is not
+        // misreported as one.
+        self.daemon_link.restarts = link.restarts;
+
+        if mismatch != self.daemon_link.mismatch {
+            if let Some(text) = &mismatch {
+                self.add_log(text.clone());
+                self.toast(
+                    "the daemon was updated; restart lev dash",
+                    ToastLevel::Error,
+                );
+            }
+            self.daemon_link.mismatch = mismatch;
+        }
     }
 
     /// Cycle the run-list sort mode and say so in the log.
@@ -2551,6 +2610,152 @@ mod tests {
         )))
         .await;
         assert_eq!(dash.daemon_run_ids, None);
+    }
+
+    /// The messages the log pane holds, newest last.
+    fn log_messages(dash: &Dashboard) -> Vec<String> {
+        dash.log.iter().map(|e| e.message.clone()).collect()
+    }
+
+    /// The daemon stops answering, then answers again: each said once, in the
+    /// log and as a toast, and the run list wears the chip in between. Polls
+    /// that keep failing, or keep succeeding, add nothing.
+    #[tokio::test]
+    async fn the_link_announces_an_outage_and_the_return_once_each() {
+        use crate::test_support::{TEST_BUILD, identified_daemon_in, same_code_daemon};
+        use leviath_runtime::control_socket::{ControlResponse, ControlToken, control_id};
+        {
+            {
+                let dir = tempfile::tempdir().unwrap();
+                let _token = ControlToken::create(dir.path()).unwrap();
+                let poll = ControlClient::for_home(control_id(dir.path()), dir.path())
+                    .with_build(TEST_BUILD)
+                    .with_reconnect_grace(std::time::Duration::ZERO);
+                let mut dash = make_test_dashboard();
+                dash.log.clear();
+                dash.toasts.clear();
+                assert!(dash.daemon_link.chip().is_none(), "healthy at first");
+
+                // Two failed polls: one announcement.
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                assert_eq!(
+                    log_messages(&dash),
+                    vec!["The daemon stopped answering; reconnecting.".to_string()]
+                );
+                assert_eq!(dash.toasts.len(), 1);
+                assert!(dash.daemon_link.unreachable);
+                let (chip, _) = dash.daemon_link.chip().expect("the chip is up");
+                assert!(chip.contains("daemon unreachable"), "{chip}");
+
+                // The daemon appears (the first one this dashboard has met, so
+                // not a restart) and two polls succeed: one announcement.
+                let (_c, _events, server) =
+                    identified_daemon_in(dir.path(), same_code_daemon(4), 2, |_| {
+                        ControlResponse::List {
+                            runs: vec![],
+                            finished: vec![],
+                            health: Default::default(),
+                        }
+                    });
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                server.await.unwrap();
+                let messages = log_messages(&dash);
+                assert_eq!(messages.len(), 2, "{messages:?}");
+                assert!(
+                    messages[1].starts_with("Reconnected to the daemon, now"),
+                    "{messages:?}"
+                );
+                assert!(messages[1].contains("pid 4"), "{messages:?}");
+                assert_eq!(dash.toasts.len(), 2);
+                assert!(!dash.daemon_link.unreachable);
+                assert!(dash.daemon_link.chip().is_none(), "the chip is down");
+                assert_eq!(dash.daemon_link.restarts, 0);
+            }
+        }
+    }
+
+    /// A different daemon behind the socket is announced as a restart, and
+    /// one on different code from this dashboard says so - once - and keeps
+    /// the chip up, since that restart is the dashboard's to make.
+    #[tokio::test]
+    async fn the_link_names_a_restart_and_an_update() {
+        use crate::test_support::{TEST_BUILD, identified_daemon_in, same_code_daemon};
+        use leviath_runtime::control_socket::{ControlResponse, ControlToken, control_id};
+        {
+            {
+                let dir = tempfile::tempdir().unwrap();
+                let _token = ControlToken::create(dir.path()).unwrap();
+                let poll = ControlClient::for_home(control_id(dir.path()), dir.path())
+                    .with_build(TEST_BUILD)
+                    .with_reconnect_grace(std::time::Duration::ZERO);
+                let empty = |_| ControlResponse::List {
+                    runs: vec![],
+                    finished: vec![],
+                    health: Default::default(),
+                };
+                let mut dash = make_test_dashboard();
+                dash.log.clear();
+                dash.toasts.clear();
+
+                // The first daemon, met and lost.
+                let (_c, _e, server) =
+                    identified_daemon_in(dir.path(), same_code_daemon(1), 1, empty);
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                server.await.unwrap();
+                assert!(
+                    log_messages(&dash).is_empty(),
+                    "meeting the daemon is not news"
+                );
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                assert_eq!(log_messages(&dash).len(), 1, "gone");
+
+                // Back as a different process on newer code.
+                let mut newer = same_code_daemon(2);
+                newer.build = "newer-build".to_string();
+                let (_c, _e, server) = identified_daemon_in(dir.path(), newer, 2, empty);
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                let messages = log_messages(&dash);
+                assert_eq!(messages.len(), 3, "{messages:?}");
+                assert!(
+                    messages[1].starts_with("The daemon restarted, now"),
+                    "{messages:?}"
+                );
+                assert!(messages[1].contains("pid 2"), "{messages:?}");
+                assert!(messages[2].contains("newer-build"), "{messages:?}");
+                assert!(messages[2].contains("restart this process"), "{messages:?}");
+                assert_eq!(dash.daemon_link.restarts, 1);
+                let (chip, _) = dash.daemon_link.chip().expect("the chip stays up");
+                assert!(chip.contains("restart lev dash"), "{chip}");
+                assert_eq!(dash.toasts.len(), 3);
+
+                // Said once: another successful poll adds nothing.
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                server.await.unwrap();
+                assert_eq!(log_messages(&dash).len(), 3);
+                assert_eq!(dash.toasts.len(), 3);
+
+                // And a daemon back on this dashboard's own code clears it:
+                // the chip comes down without a word.
+                let (_c, _e, server) =
+                    identified_daemon_in(dir.path(), same_code_daemon(3), 1, empty);
+                dash.sync_daemon_runs(&poll).await;
+                dash.sync_daemon_link(&poll);
+                server.await.unwrap();
+                assert!(dash.daemon_link.chip().is_none(), "the chip is down");
+                assert_eq!(dash.daemon_link.mismatch, None);
+                assert_eq!(log_messages(&dash).len(), 3, "nothing to say");
+            }
+        }
     }
 
     /// A stale run sorts above the finished ones: it is unfinished business the

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -353,6 +353,39 @@ pub(super) struct DaemonOutcome {
     pub(super) ok: bool,
 }
 
+/// The dashboard's view of its link to the daemon, refreshed each tick from
+/// the control client's own bookkeeping.
+///
+/// The dashboard polls the daemon ten times a second, so it notices a restart
+/// within a tick and needs no reconnect of its own; what it needs is to *say*
+/// so, once, and to say when the daemon that came back runs different code
+/// than this dashboard, since that is the one restart the dashboard should
+/// follow. Both are edge-triggered off this record.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(super) struct DaemonLinkView {
+    /// Whether the last poll went unanswered. Starts `false`: the daemon was
+    /// ensured before the dashboard opened.
+    pub(super) unreachable: bool,
+    /// The restart count last seen, so a return to a *different* daemon is
+    /// announced as a restart rather than a blip.
+    pub(super) restarts: u64,
+    /// The mismatch last announced, so the warning fires once per daemon and
+    /// the chip stays up until it is resolved.
+    pub(super) mismatch: Option<String>,
+}
+
+impl DaemonLinkView {
+    /// The chip the run list wears while something is wrong, and its colour;
+    /// `None` when the link is healthy and nothing needs saying.
+    pub(super) fn chip(&self) -> Option<(&'static str, Color)> {
+        match (self.unreachable, &self.mismatch) {
+            (true, _) => Some((" ⟳ daemon unreachable, reconnecting ", C_WARN)),
+            (false, Some(_)) => Some((" ⚠ daemon updated: restart lev dash ", C_ERROR)),
+            (false, None) => None,
+        }
+    }
+}
+
 /// A long-running MCP action dispatched from the (sync) MCP screen to the async
 /// background task, so browser login and connect-and-list never block the UI.
 #[derive(Debug, PartialEq)]

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -129,10 +129,7 @@ pub(super) async fn spawn_agent(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Unexpected daemon response: {other:?}"),
         )),
-        Err(e) => Err(err(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Daemon not reachable: {e}"),
-        )),
+        Err(e) => Err(daemon_error(e)),
     }
 }
 
@@ -769,10 +766,7 @@ pub(super) async fn kill_agent(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Unexpected daemon response: {other:?}"),
         )),
-        Err(e) => Err(err(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Daemon not reachable: {e}"),
-        )),
+        Err(e) => Err(daemon_error(e)),
     }
 }
 
@@ -797,10 +791,7 @@ pub(super) async fn pause_agent(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Unexpected daemon response: {other:?}"),
         )),
-        Err(e) => Err(err(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Daemon not reachable: {e}"),
-        )),
+        Err(e) => Err(daemon_error(e)),
     }
 }
 
@@ -823,10 +814,7 @@ pub(super) async fn resume_agent(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Unexpected daemon response: {other:?}"),
         )),
-        Err(e) => Err(err(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Daemon not reachable: {e}"),
-        )),
+        Err(e) => Err(daemon_error(e)),
     }
 }
 

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -37,10 +37,7 @@ pub(super) async fn get_interaction(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Unexpected daemon response: {other:?}"),
         )),
-        Err(e) => Err(err(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Daemon not reachable: {e}"),
-        )),
+        Err(e) => Err(daemon_error(e)),
     }
 }
 
@@ -87,10 +84,7 @@ pub(super) async fn submit_interaction(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Unexpected daemon response: {other:?}"),
         )),
-        Err(e) => Err(err(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Daemon not reachable: {e}"),
-        )),
+        Err(e) => Err(daemon_error(e)),
     }
 }
 
@@ -118,10 +112,7 @@ pub(super) async fn send_message(
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("Unexpected daemon response: {other:?}"),
         )),
-        Err(e) => Err(err(
-            StatusCode::SERVICE_UNAVAILABLE,
-            format!("Daemon not reachable: {e}"),
-        )),
+        Err(e) => Err(daemon_error(e)),
     }
 }
 
@@ -175,6 +166,56 @@ mod tests {
         ControlClient::new(leviath_runtime::control_socket::control_id(
             std::path::Path::new("/no/such/daemon"),
         ))
+    }
+
+    /// A daemon updated under a running server, answering with something this
+    /// server cannot read: not a 503 (retrying, or restarting the daemon,
+    /// cannot help) but a 502 naming the process that needs restarting.
+    #[tokio::test]
+    async fn a_daemon_on_other_code_that_cannot_be_read_is_a_502_naming_the_fix() {
+        use leviath_runtime::control_socket::{
+            ControlToken, DaemonIdentity, bind_control_listener, control_id,
+        };
+        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+        let dir = tempfile::tempdir().unwrap();
+        let id = control_id(dir.path());
+        let mut listener = bind_control_listener(&id).unwrap();
+        let _token = ControlToken::create(dir.path()).unwrap();
+        let mut updated = DaemonIdentity::this_process("this-build");
+        updated.build = "newer-build".to_string();
+        let server = tokio::spawn(async move {
+            let stream = listener
+                .accept()
+                .await
+                .expect("accept succeeds")
+                .expect("our own connection is admitted");
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _hello = lines.next_line().await.unwrap();
+            let mut welcome =
+                serde_json::to_string(&ControlResponse::Welcome { daemon: updated }).unwrap();
+            welcome.push('\n');
+            let _ = write_half.write_all(welcome.as_bytes()).await;
+            let _request = lines.next_line().await.unwrap();
+            let _ = write_half
+                .write_all(b"{\"result\":\"from_the_future\"}\n")
+                .await;
+        });
+        let control = ControlClient::for_home(id, dir.path()).with_build("this-build");
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/agents/a1/interaction")
+            .body(Body::empty())
+            .unwrap();
+        let response = app_with(control).oneshot(req).await.unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("This server needs a restart"), "{text}");
+        assert!(text.contains("newer-build"), "{text}");
+        server.await.unwrap();
     }
 
     // ─── get_interaction ─────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -34,23 +34,95 @@ pub(super) async fn event_loop(state: AppState, backoff: Duration) {
         leviath_net::ClientTimeouts::default(),
         state.limits.allow_local_network,
     );
+    let mut link = LinkWatch::new(&state);
     loop {
-        consume_once(&state, &client).await;
+        consume_once(&state, &client, &mut link).await;
         // The stream ended (daemon closed / restarted) or was unreachable; back
         // off briefly, then re-subscribe.
         tokio::time::sleep(backoff).await;
     }
 }
 
+/// The event loop's memory of its link to the daemon, so that a drop and a
+/// return are each announced once - to the log, and to WebSocket subscribers as
+/// a [`ServerEvent::DaemonLink`] - rather than on every failed re-subscribe.
+///
+/// A daemon restart is the interesting case. The gateway rides it out on its
+/// own (the control client waits the restart out and re-reads the token), so
+/// nothing a WebSocket client did needs redoing; but a run's events stopped
+/// for a moment, and if the daemon came back on a *different build*, this
+/// server is now the older half of the pair and should be restarted too. Both
+/// facts ride on the same event, and the second is also logged as a warning so
+/// the operator sees it without a browser.
+struct LinkWatch {
+    /// Whether the stream was up the last time this was consulted. Starts
+    /// `true`: the daemon was ensured before the server started, so the first
+    /// successful subscribe is not news and the first failure is.
+    connected: bool,
+    /// The restart count last announced, to tell a reconnect to the same
+    /// daemon from one to its replacement.
+    restarts: u64,
+}
+
+impl LinkWatch {
+    fn new(state: &AppState) -> Self {
+        Self {
+            connected: true,
+            restarts: state.control.link().restarts,
+        }
+    }
+
+    /// The stream is up. Announces it when it was down, or when the daemon
+    /// behind it changed while it was up (a restart fast enough that no
+    /// subscribe attempt failed in between).
+    fn up(&mut self, state: &AppState) {
+        let restarts = state.control.link().restarts;
+        let restarted = restarts != self.restarts;
+        if self.connected && !restarted {
+            return;
+        }
+        self.connected = true;
+        self.restarts = restarts;
+        match state.control.link().daemon {
+            Some(daemon) if restarted => {
+                tracing::info!(%daemon, "reconnected to the daemon after it restarted")
+            }
+            Some(daemon) => tracing::info!(%daemon, "reconnected to the daemon"),
+            None => tracing::info!("reconnected to the daemon"),
+        }
+        if let Some(mismatch) = state.control.code_mismatch() {
+            tracing::warn!("{mismatch}");
+        }
+        let _ = state
+            .event_tx
+            .send(ServerEvent::daemon_link(&state.control, true, restarted));
+    }
+
+    /// The stream is down. Announced once per outage.
+    fn down(&mut self, state: &AppState) {
+        if !self.connected {
+            return;
+        }
+        self.connected = false;
+        tracing::warn!("lost the daemon's event stream; reconnecting");
+        let _ = state
+            .event_tx
+            .send(ServerEvent::daemon_link(&state.control, false, false));
+    }
+}
+
 /// One subscribe-and-consume pass: forward events until the stream ends. Returns
 /// immediately if the daemon can't be reached.
-async fn consume_once(state: &AppState, client: &reqwest::Client) {
+async fn consume_once(state: &AppState, client: &reqwest::Client, link: &mut LinkWatch) {
     let Ok(mut stream) = state.control.subscribe().await else {
+        link.down(state);
         return;
     };
+    link.up(state);
     while let Some(event) = stream.next().await {
         handle_event(state, client, event);
     }
+    link.down(state);
 }
 
 /// Broadcast one world event to WebSocket subscribers, firing a completion
@@ -944,7 +1016,7 @@ mod tests {
         );
         let (state, mut rx) = state_with(control);
         let client = reqwest::Client::new();
-        consume_once(&state, &client).await; // returns when the stream closes
+        consume_once(&state, &client, &mut LinkWatch::new(&state)).await; // returns when the stream closes
         server.await.unwrap();
         assert_eq!(tag(&rx.try_recv().unwrap()), "agent_status");
     }
@@ -953,7 +1025,7 @@ mod tests {
     async fn consume_once_returns_when_daemon_absent() {
         let (state, _rx) = state_with(no_daemon_client());
         let client = reqwest::Client::new();
-        consume_once(&state, &client).await; // subscribe fails → returns immediately
+        consume_once(&state, &client, &mut LinkWatch::new(&state)).await; // subscribe fails → returns immediately
     }
 
     /// A fake daemon that accepts `passes` subscribe connections, streaming one
@@ -1000,14 +1072,135 @@ mod tests {
         // through consume_once → backoff → re-subscribe (its loop-back edge). A
         // zero backoff keeps it prompt, but the `recv().await`s - not scheduler
         // timing - are what gate the assertions, so this is platform-stable.
+        //
+        // The drop and the return are each announced to subscribers between
+        // the two run events: `daemon_link` down, then `daemon_link` up. The
+        // first subscribe announces nothing - the daemon was ensured before the
+        // server started, so a stream that simply comes up is not news.
         let dir = tempfile::tempdir().unwrap();
         let (control, server) = reconnecting_daemon(dir.path(), 2);
         let (state, mut rx) = state_with(control);
         let handle = tokio::spawn(event_loop(state, Duration::ZERO));
         assert_eq!(tag(&rx.recv().await.unwrap()), "agent_status");
+        let down = serde_json::to_value(rx.recv().await.unwrap()).unwrap();
+        assert_eq!(down["type"], "daemon_link");
+        assert_eq!(down["connected"], false);
+        let up = serde_json::to_value(rx.recv().await.unwrap()).unwrap();
+        assert_eq!(up["type"], "daemon_link");
+        assert_eq!(up["connected"], true);
+        // A tokenless test daemon never introduces itself, so this reconnect
+        // is to a daemon of unknown identity: not a restart, and no advice.
+        assert_eq!(up["restarted"], false);
+        assert!(up.get("daemon").is_none(), "{up}");
+        assert!(up.get("restart_advised").is_none(), "{up}");
         assert_eq!(tag(&rx.recv().await.unwrap()), "agent_status");
         handle.abort();
         server.await.unwrap();
+    }
+
+    /// A second failed pass announces nothing new: the drop was said once.
+    #[tokio::test]
+    async fn an_outage_is_announced_once_however_many_passes_fail() {
+        let (state, mut rx) = state_with(no_daemon_client());
+        let client = reqwest::Client::new();
+        let mut link = LinkWatch::new(&state);
+        consume_once(&state, &client, &mut link).await;
+        consume_once(&state, &client, &mut link).await;
+        let down = serde_json::to_value(rx.try_recv().unwrap()).unwrap();
+        assert_eq!(down["type"], "daemon_link");
+        assert_eq!(down["connected"], false);
+        assert!(rx.try_recv().is_err(), "the second failure is not news");
+    }
+
+    /// The daemon says who it is, so a reconnect can say whether it is to
+    /// the same daemon or a new one, and whether the new one runs the same
+    /// code as this server. Three passes: no daemon (an outage), a daemon
+    /// (back), then a different daemon on newer code (restarted, and updated).
+    #[tokio::test]
+    async fn a_reconnect_reports_the_daemon_it_reached() {
+        use crate::test_support::{TEST_BUILD, identified_daemon_in, same_code_daemon};
+        use leviath_runtime::control_socket::{ControlResponse, ControlToken};
+        let ok = |_| ControlResponse::Ok { ok: true };
+        let dir = tempfile::tempdir().unwrap();
+        // A client with a token in hand (so it handshakes) and no patience
+        // (so the absent-daemon pass returns at once).
+        let _token = ControlToken::create(dir.path()).unwrap();
+        let control = ControlClient::for_home(control_id(dir.path()), dir.path())
+            .with_build(TEST_BUILD)
+            .with_reconnect_grace(Duration::ZERO);
+        let (state, mut rx) = state_with(control);
+        let client = reqwest::Client::new();
+        let mut link = LinkWatch::new(&state);
+        let next = |rx: &mut broadcast::Receiver<ServerEvent>| {
+            serde_json::to_value(rx.try_recv().expect("an announcement")).unwrap()
+        };
+
+        // Pass 1: nothing listening.
+        consume_once(&state, &client, &mut link).await;
+        let down = next(&mut rx);
+        assert_eq!(down["connected"], false);
+
+        // Pass 2: a daemon appears (and answers a request, so the handshake
+        // is a real one); its stream carries one event, then ends when its
+        // sender drops.
+        let (_a, events, server_a) = identified_daemon_in(dir.path(), same_code_daemon(1), 2, ok);
+        state
+            .control
+            .request(&leviath_runtime::control_socket::ControlRequest::List)
+            .await
+            .expect("served");
+        let ender = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = events.send(WorldEvent::Status {
+                run_id: "r".into(),
+                agent_id: "a".into(),
+                status: "active".into(),
+                stage: "s".into(),
+                iteration: 0,
+                tool_calls: 0,
+                accepts_messages: true,
+                wait_reason: None,
+            });
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            drop(events);
+        });
+        consume_once(&state, &client, &mut link).await;
+        ender.await.unwrap();
+        server_a.await.unwrap();
+        let up = next(&mut rx);
+        assert_eq!(up["connected"], true);
+        assert_eq!(
+            up["restarted"], false,
+            "the first daemon seen is not a restart"
+        );
+        assert_eq!(up["daemon"]["pid"], 1);
+        assert!(up.get("restart_advised").is_none(), "{up}");
+        assert_eq!(next(&mut rx)["type"], "agent_status");
+        let down = next(&mut rx);
+        assert_eq!(down["connected"], false);
+
+        // Pass 3: a different daemon, on newer code, behind the same socket.
+        let mut newer = same_code_daemon(2);
+        newer.build = "newer-build".to_string();
+        let (_b, events, server_b) = identified_daemon_in(dir.path(), newer, 1, ok);
+        let ender = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            drop(events);
+        });
+        consume_once(&state, &client, &mut link).await;
+        ender.await.unwrap();
+        server_b.await.unwrap();
+        let up = next(&mut rx);
+        assert_eq!(up["connected"], true);
+        assert_eq!(up["restarted"], true);
+        assert_eq!(up["daemon"]["pid"], 2);
+        assert!(
+            up["restart_advised"]
+                .as_str()
+                .unwrap()
+                .contains("newer-build"),
+            "{up}"
+        );
     }
 
     fn payload_meta() -> leviath_core::run_meta::RunMeta {

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -208,6 +208,30 @@ pub enum ServerEvent {
         /// The runtime's own serde-tagged event JSON, forwarded as-is.
         event: serde_json::Value,
     },
+    /// This server's own link to the daemon changed.
+    ///
+    /// Sent when the daemon's event stream drops and when it is back, and once
+    /// on connect so a subscriber that arrives mid-outage learns what it is
+    /// looking at. It is about no run in particular, so every subscription
+    /// receives it, per-run ones included: a run's events simply stop while
+    /// the daemon is down, and this is what says why.
+    DaemonLink {
+        /// Whether the server is receiving the daemon's events right now.
+        connected: bool,
+        /// The daemon on the other end, once it has said who it is.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        daemon: Option<leviath_runtime::control_socket::DaemonIdentity>,
+        /// Whether the daemon behind the link is a different process than the
+        /// one before it - a restart this server lived through and its clients
+        /// need not.
+        restarted: bool,
+        /// Present when the daemon and this server run different code, with
+        /// the remedy: restart `lev serve` to match. Requests keep working
+        /// while the two still understand each other; one that fails for this
+        /// reason answers 502 with the same text.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        restart_advised: Option<String>,
+    },
 }
 
 impl ServerEvent {
@@ -227,6 +251,29 @@ impl ServerEvent {
                 .get("run_id")
                 .and_then(|v| v.as_str())
                 .unwrap_or_default(),
+            ServerEvent::DaemonLink { .. } => "",
+        }
+    }
+
+    /// Whether a subscription filtered to `run_id` should receive this event:
+    /// its own run's events, and the ones about no run at all.
+    pub fn is_for_run(&self, run_id: &str) -> bool {
+        matches!(self, ServerEvent::DaemonLink { .. }) || self.run_id() == run_id
+    }
+
+    /// The [`DaemonLink`](Self::DaemonLink) event for what `control` currently
+    /// knows, given whether the event stream is up and whether the daemon
+    /// behind it just changed.
+    pub(super) fn daemon_link(
+        control: &leviath_runtime::control_socket::ControlClient,
+        connected: bool,
+        restarted: bool,
+    ) -> Self {
+        ServerEvent::DaemonLink {
+            connected,
+            daemon: control.link().daemon,
+            restarted,
+            restart_advised: control.code_mismatch().map(|m| m.to_string()),
         }
     }
 }
@@ -353,6 +400,33 @@ pub(super) fn err(
     message: String,
 ) -> (axum::http::StatusCode, axum::response::Json<ErrorResponse>) {
     (code, axum::response::Json(ErrorResponse { error: message }))
+}
+
+/// The response for a control request the daemon did not answer.
+///
+/// Two different failures, told apart by the error's kind, because they have
+/// different remedies:
+///
+/// - **503 Service Unavailable**: the daemon is not reachable right now. It
+///   may be restarting (the client already waited a grace period for that),
+///   stopped, or wedged. Retrying later, or `lev daemon restart`, is the fix.
+/// - **502 Bad Gateway**: the daemon answered, but this server could not
+///   understand it - the daemon was updated under a running `lev serve`, and
+///   the two no longer speak the same protocol. Retrying cannot help; the
+///   message says what does, which is restarting `lev serve`.
+pub(super) fn daemon_error(
+    e: std::io::Error,
+) -> (axum::http::StatusCode, axum::response::Json<ErrorResponse>) {
+    match e.kind() {
+        std::io::ErrorKind::Unsupported => err(
+            axum::http::StatusCode::BAD_GATEWAY,
+            format!("This server needs a restart: {e}"),
+        ),
+        _ => err(
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            format!("Daemon not reachable: {e}"),
+        ),
+    }
 }
 
 // ─── Pagination ─────────────────────────────────────────────────────────────
@@ -1159,6 +1233,55 @@ mod status_matches_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A daemon that is not there is a 503 (try later, or restart it); a
+    /// daemon that answered in a way this server cannot read is a 502 with the
+    /// remedy in the message, because no daemon restart fixes that.
+    #[test]
+    fn daemon_errors_are_503_unless_the_two_ends_no_longer_understand_each_other() {
+        let (code, body) = daemon_error(std::io::Error::new(
+            std::io::ErrorKind::ConnectionRefused,
+            "no socket",
+        ));
+        assert_eq!(code, axum::http::StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(body.error, "Daemon not reachable: no socket");
+
+        let (code, body) = daemon_error(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "the daemon is now version 9; restart this process",
+        ));
+        assert_eq!(code, axum::http::StatusCode::BAD_GATEWAY);
+        assert_eq!(
+            body.error,
+            "This server needs a restart: the daemon is now version 9; restart this process"
+        );
+    }
+
+    /// The link event is about no run: it filters as the empty run id, and a
+    /// per-run subscription still receives it.
+    #[test]
+    fn a_daemon_link_event_is_for_every_subscription() {
+        let link = ServerEvent::DaemonLink {
+            connected: false,
+            daemon: None,
+            restarted: false,
+            restart_advised: None,
+        };
+        assert_eq!(link.run_id(), "");
+        assert!(link.is_for_run("run-1"));
+        let log = ServerEvent::Log {
+            agent_id: "a".to_string(),
+            run_id: "run-1".to_string(),
+            line: "x".to_string(),
+        };
+        assert!(log.is_for_run("run-1"));
+        assert!(!log.is_for_run("run-2"));
+        // Absent fields stay absent on the wire.
+        let json = serde_json::to_value(&link).unwrap();
+        assert_eq!(json["type"], "daemon_link");
+        assert!(json.get("daemon").is_none());
+        assert!(json.get("restart_advised").is_none());
+    }
 
     #[test]
     fn server_event_agent_status_serialization() {

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -34,8 +34,9 @@ pub(super) async fn ws_global(
     // channel becomes Closed and rx.recv() returns Err(Closed) immediately,
     // making that match arm reachable in tests.
     let rx = state.event_tx.subscribe();
+    let greeting = link_greeting(&state);
     ws.max_write_buffer_size(WS_MAX_WRITE_BUFFER)
-        .on_upgrade(move |socket| handle_ws(socket, rx, None))
+        .on_upgrade(move |socket| handle_ws(socket, rx, None, greeting))
 }
 
 pub(super) async fn ws_agent(
@@ -44,16 +45,47 @@ pub(super) async fn ws_agent(
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
     let rx = state.event_tx.subscribe();
+    let greeting = link_greeting(&state);
     ws.max_write_buffer_size(WS_MAX_WRITE_BUFFER)
-        .on_upgrade(move |socket| handle_ws(socket, rx, Some(id)))
+        .on_upgrade(move |socket| handle_ws(socket, rx, Some(id), greeting))
+}
+
+/// What a subscriber that connects right now is told first about the daemon:
+/// a [`ServerEvent::DaemonLink`] when there is news - the daemon is not
+/// answering, or it runs different code from this server - and nothing when
+/// all is well, so a healthy stream looks exactly as it always has.
+///
+/// The event loop's re-subscribe attempts keep the client's view of
+/// reachability current while the daemon is down (see `polling::event_loop`),
+/// which is what makes it safe to read here rather than only at a transition.
+fn link_greeting(state: &AppState) -> Option<ServerEvent> {
+    let link = state.control.link();
+    let greeting = ServerEvent::daemon_link(&state.control, link.reachable, false);
+    match &greeting {
+        ServerEvent::DaemonLink {
+            connected: true,
+            restart_advised: None,
+            ..
+        } => None,
+        _ => Some(greeting),
+    }
 }
 
 async fn handle_ws(
     socket: WebSocket,
     rx: broadcast::Receiver<ServerEvent>,
     filter_run_id: Option<String>,
+    greeting: Option<ServerEvent>,
 ) {
-    handle_ws_with(socket, rx, filter_run_id, WS_PING_INTERVAL, WS_SEND_TIMEOUT).await
+    handle_ws_with(
+        socket,
+        rx,
+        filter_run_id,
+        WS_PING_INTERVAL,
+        WS_SEND_TIMEOUT,
+        greeting,
+    )
+    .await
 }
 
 /// Core of the WS relay, with the ping cadence and send deadline injected so
@@ -69,7 +101,16 @@ async fn handle_ws_with(
     filter_run_id: Option<String>,
     ping_every: std::time::Duration,
     send_timeout: std::time::Duration,
+    greeting: Option<ServerEvent>,
 ) {
+    // Something worth saying about the daemon before any run event: said
+    // first. A peer that cannot take even that is a dead peer, and the ping
+    // cadence below catches it the same as any other; nothing to do here.
+    if let Some(greeting) = greeting {
+        let json =
+            serde_json::to_string(&greeting).expect("ServerEvent serialization must not fail");
+        let _ = send_within(&mut socket, send_timeout, Message::Text(json.into())).await;
+    }
     // First ping only after a full interval - a fresh connection is known
     // live, and pinging in the handshake's shadow confuses simple clients.
     let mut ping = tokio::time::interval_at(tokio::time::Instant::now() + ping_every, ping_every);
@@ -89,8 +130,9 @@ async fn handle_ws_with(
                 match event {
                     Ok(ev) => {
                         // If filtering by run_id, skip non-matching events
+                        // (a `DaemonLink` is for every subscriber).
                         if let Some(ref filter) = filter_run_id
-                            && ev.run_id() != filter
+                            && !ev.is_for_run(filter)
                         {
                             continue;
                         }
@@ -362,8 +404,9 @@ mod tests {
                 get(
                     move |State(state): State<AppState>, ws: WebSocketUpgrade| async move {
                         let rx = state.event_tx.subscribe();
+                        let greeting = link_greeting(&state);
                         ws.on_upgrade(move |socket| {
-                            handle_ws_with(socket, rx, None, ping_every, send_timeout)
+                            handle_ws_with(socket, rx, None, ping_every, send_timeout, greeting)
                         })
                     },
                 ),
@@ -613,6 +656,73 @@ mod tests {
         // Close so the server-side handle_ws task terminates instead of
         // idling forever on rx.recv() for the rest of the process lifetime.
         client.send_close().await;
+    }
+
+    /// A subscriber that connects while the daemon is down is told so first,
+    /// on a per-run subscription as much as on the global one: its run's
+    /// events have stopped, and this is what says why. The link event is
+    /// about no run, so the run filter lets it through.
+    #[tokio::test]
+    async fn a_subscriber_arriving_mid_outage_is_greeted_with_the_link_state() {
+        let state = test_state();
+        // The event loop's re-subscribe attempts are what mark an outage; one
+        // failed request stands in for them here.
+        assert!(state.control.list().await.is_err());
+        assert!(!state.control.link().reachable);
+        let addr = spawn_test_server(state).await;
+
+        let mut client = WsTestClient::connect(addr, "/ws/agents/run-match").await;
+        let (opcode, payload) =
+            tokio::time::timeout(std::time::Duration::from_secs(5), client.recv_frame())
+                .await
+                .expect("timed out waiting for the greeting");
+        assert_text_frame(opcode);
+        let greeting: serde_json::Value = serde_json::from_slice(&payload).unwrap();
+        assert_eq!(greeting["type"], "daemon_link");
+        assert_eq!(greeting["connected"], false);
+        assert_eq!(greeting["restarted"], false);
+        client.send_close().await;
+    }
+
+    /// A healthy link says nothing on connect (the stream looks exactly as it
+    /// always has), and a link to a daemon on other code says so.
+    #[test]
+    fn the_greeting_speaks_only_when_there_is_news() {
+        let state = test_state();
+        assert!(
+            link_greeting(&state).is_none(),
+            "nothing to say about a healthy link"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_greeting_advises_a_restart_when_the_daemon_is_on_other_code() {
+        let mut updated = crate::test_support::same_code_daemon(77);
+        updated.build = "newer-build".to_string();
+        let daemon = crate::test_support::identified_daemon(updated, 1, |_| {
+            leviath_runtime::control_socket::ControlResponse::Ok { ok: true }
+        });
+        daemon.client.list().await.expect("served, and introduced");
+        let (tx, _) = broadcast::channel(64);
+        let state = AppState {
+            config: Arc::new(Config::default()),
+            event_tx: tx,
+            control: daemon.client.clone(),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Default::default(),
+        };
+        let greeting = serde_json::to_value(link_greeting(&state).expect("news")).unwrap();
+        assert_eq!(greeting["type"], "daemon_link");
+        assert_eq!(greeting["connected"], true);
+        assert_eq!(greeting["daemon"]["build"], "newer-build");
+        assert!(
+            greeting["restart_advised"]
+                .as_str()
+                .unwrap()
+                .contains("restart this process"),
+            "{greeting}"
+        );
+        daemon.server.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -145,7 +145,7 @@ impl RiskyExecutors for RealExecutors {
         // The HTTP API is a gateway to the shared-world daemon: ensure it's
         // running, then serve, routing agent actions through its control socket.
         ensure_daemon_running().await?;
-        commands::serve::execute(args, control_client()?).await
+        commands::serve::execute(args, long_lived_control_client()?).await
     }
 
     async fn agent_client(
@@ -166,7 +166,7 @@ impl RiskyExecutors for RealExecutors {
         commands::agent_client::serve_over(
             tokio::io::BufReader::new(tokio::io::stdin()),
             tokio::io::stdout(),
-            control_client()?,
+            long_lived_control_client()?,
             args,
             leviath_cli::runstate::runs_dir(),
             default_cwd,
@@ -616,7 +616,7 @@ fn remove_legacy_services() -> Vec<std::path::PathBuf> {
 async fn real_daemon(args: commands::daemon::DaemonArgs) -> anyhow::Result<()> {
     use leviath_cli::daemon::setup::{control_address, setup_daemon_host};
     use leviath_runtime::control_socket::{
-        bind_control_listener, control_id_from_str, handle_connection,
+        DaemonIdentity, bind_control_listener, control_id_from_str, handle_connection_as,
     };
 
     // Refuse to start on a config that exists but doesn't parse. The old
@@ -660,6 +660,10 @@ async fn real_daemon(args: commands::daemon::DaemonArgs) -> anyhow::Result<()> {
     // connections stream world events from the host's event sender.
     let (op_tx, op_rx) = tokio::sync::mpsc::unbounded_channel();
     let events = host.event_sender();
+    // Who this daemon is, told to every client that asks in its handshake. A
+    // long-lived client (`lev serve`, `lev dash`, the ACP bridge) compares it
+    // against its own build to tell a restart from an update.
+    let identity = DaemonIdentity::this_process(leviath_cli::daemon::setup::CURRENT_BUILD);
     tokio::spawn(async move {
         // `Ok(None)` means someone connected but is not this user: the listener
         // has already closed that connection and logged it. Skip and keep
@@ -669,8 +673,9 @@ async fn real_daemon(args: commands::daemon::DaemonArgs) -> anyhow::Result<()> {
             let op_tx = op_tx.clone();
             let events = events.clone();
             let token = token.clone();
+            let identity = identity.clone();
             tokio::spawn(async move {
-                let _ = handle_connection(stream, op_tx, events, Some(token)).await;
+                let _ = handle_connection_as(stream, op_tx, events, Some(token), identity).await;
             });
         }
     });
@@ -689,14 +694,27 @@ async fn real_daemon(args: commands::daemon::DaemonArgs) -> anyhow::Result<()> {
 }
 
 /// Build a control client pointed at the daemon's control socket.
+///
+/// For one-shot commands: an absent daemon is reported at once, with the
+/// advice to start it. The build id lets the client tell a daemon that
+/// restarted from one that was updated under it.
 fn control_client() -> anyhow::Result<leviath_runtime::control_socket::ControlClient> {
     let id = leviath_cli::daemon::setup::control_address()
         .ok_or_else(|| anyhow::anyhow!("cannot resolve a home directory for the control socket"))?;
     let dir = leviath_cli::daemon::setup::control_dir()
         .ok_or_else(|| anyhow::anyhow!("cannot resolve a home directory for the control token"))?;
-    Ok(leviath_runtime::control_socket::ControlClient::for_home(
-        id, &dir,
-    ))
+    Ok(
+        leviath_runtime::control_socket::ControlClient::for_home(id, &dir)
+            .with_build(leviath_cli::daemon::setup::CURRENT_BUILD),
+    )
+}
+
+/// [`control_client`] for the front-ends that outlive a daemon: `lev serve`,
+/// `lev dash`, `lev agent-client`. These wait a restart out instead of
+/// failing the request that landed in it - see
+/// [`RESTART_GRACE`](leviath_runtime::control_socket::RESTART_GRACE).
+fn long_lived_control_client() -> anyhow::Result<leviath_runtime::control_socket::ControlClient> {
+    Ok(control_client()?.with_reconnect_grace(leviath_runtime::control_socket::RESTART_GRACE))
 }
 
 /// Real `lev dash`: supplies the real crossterm terminal backend and event
@@ -707,7 +725,7 @@ async fn real_dashboard(_args: DashboardArgs) -> anyhow::Result<()> {
     // The dashboard is a client of the shared-world daemon: ensure it's running,
     // then observe/control it over the control socket.
     ensure_daemon_running().await?;
-    let control = control_client()?;
+    let control = long_lived_control_client()?;
     let mut setup = CrosstermSetup {
         viewport: Viewport::Fullscreen,
         mouse_capture: true,

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -222,6 +222,10 @@ pub(crate) fn identified_daemon_in(
     let respond = std::sync::Arc::new(respond);
     let server_events = events.clone();
     let server = tokio::spawn(async move {
+        // Joined before the task ends: a test that "restarts" the daemon
+        // rebinds the same id, and on Windows a pipe instance still held by
+        // a connection task makes that bind fail with `AddrInUse`.
+        let mut served = Vec::new();
         for _ in 0..connections {
             let stream = listener
                 .accept()
@@ -231,7 +235,7 @@ pub(crate) fn identified_daemon_in(
             let identity = identity.clone();
             let respond = respond.clone();
             let mut rx = server_events.subscribe();
-            tokio::spawn(async move {
+            served.push(tokio::spawn(async move {
                 let (read_half, mut write_half) = tokio::io::split(stream);
                 let mut lines = BufReader::new(read_half).lines();
                 let _hello = lines.next_line().await.unwrap().unwrap();
@@ -256,7 +260,15 @@ pub(crate) fn identified_daemon_in(
                     out.push('\n');
                     let _ = write_half.write_all(out.as_bytes()).await;
                 }
-            });
+            }));
+        }
+        // The listener goes now, and so does this task's hold on the event
+        // sender: a subscribed connection ends only when every sender is gone,
+        // and the test's own clone is the one that should decide that.
+        drop(listener);
+        drop(server_events);
+        for connection in served {
+            connection.await.unwrap();
         }
     });
     let client = ControlClient::for_home(id, dir).with_build(TEST_BUILD);

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -140,6 +140,138 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
     .to_string()
 }
 
+/// A fake daemon that speaks the real control handshake - a token, and the
+/// identity it introduces itself with - and answers every request `respond`
+/// gives it, for as long as `connections` says. Subscribers get the events
+/// sent through the returned broadcast sender, until it is dropped.
+///
+/// The token is created in `dir` (where `ControlClient::for_home` reads it),
+/// so `for_home(id, dir)` reaches it. Tests that need the daemon to *say who
+/// it is* - the reconnect and update surfaces in `serve`, `dash`, and the ACP
+/// bridge - use this; tests that only need answers use the tokenless
+/// hand-rolled fakes beside them, which never handshake.
+///
+/// Deliberately trusting: the first line on every connection is taken to be
+/// the handshake and answered with `Welcome` unread, and every later line is
+/// taken to be a well-formed request. Only clients this crate builds talk to
+/// it, and the runtime's own tests cover a daemon that refuses.
+pub(crate) struct IdentifiedDaemon {
+    /// A client that reaches it (with the token, and this process's build).
+    pub(crate) client: leviath_runtime::control_socket::ControlClient,
+    /// The accept loop, done once `connections` have been served.
+    pub(crate) server: tokio::task::JoinHandle<()>,
+    /// The socket's directory, kept alive as long as the daemon. Tests that
+    /// need to feed subscribers events, or restart the daemon in the same
+    /// directory, use [`identified_daemon_in`] directly.
+    _dir: tempfile::TempDir,
+}
+
+/// The build a test daemon on "the same code" as the test's clients reports.
+pub(crate) const TEST_BUILD: &str = "test-build";
+
+/// Start an [`IdentifiedDaemon`] introducing itself as `identity`, in a fresh
+/// temp dir. See [`identified_daemon_in`] to reuse a dir across restarts.
+pub(crate) fn identified_daemon(
+    identity: leviath_runtime::control_socket::DaemonIdentity,
+    connections: usize,
+    respond: impl Fn(
+        leviath_runtime::control_socket::ControlRequest,
+    ) -> leviath_runtime::control_socket::ControlResponse
+    + Send
+    + Sync
+    + 'static,
+) -> IdentifiedDaemon {
+    let dir = tempfile::tempdir().unwrap();
+    let (client, _events, server) =
+        identified_daemon_in(dir.path(), identity, connections, respond);
+    IdentifiedDaemon {
+        client,
+        server,
+        _dir: dir,
+    }
+}
+
+/// Start an identity-speaking fake daemon on the socket under `dir`, minting a
+/// fresh token there (as a real daemon does on every start). Returns a client
+/// pointed at it, the event sender, and the accept task.
+pub(crate) fn identified_daemon_in(
+    dir: &std::path::Path,
+    identity: leviath_runtime::control_socket::DaemonIdentity,
+    connections: usize,
+    respond: impl Fn(
+        leviath_runtime::control_socket::ControlRequest,
+    ) -> leviath_runtime::control_socket::ControlResponse
+    + Send
+    + Sync
+    + 'static,
+) -> (
+    leviath_runtime::control_socket::ControlClient,
+    tokio::sync::broadcast::Sender<leviath_runtime::host::WorldEvent>,
+    tokio::task::JoinHandle<()>,
+) {
+    use leviath_runtime::control_socket::{
+        ControlClient, ControlRequest, ControlResponse, ControlToken, bind_control_listener,
+        control_id,
+    };
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+    let id = control_id(dir);
+    let mut listener = bind_control_listener(&id).unwrap();
+    let _token = ControlToken::create(dir).unwrap();
+    let (events, _keep) = tokio::sync::broadcast::channel(64);
+    let respond = std::sync::Arc::new(respond);
+    let server_events = events.clone();
+    let server = tokio::spawn(async move {
+        for _ in 0..connections {
+            let stream = listener
+                .accept()
+                .await
+                .expect("accept succeeds")
+                .expect("our own connection is admitted");
+            let identity = identity.clone();
+            let respond = respond.clone();
+            let mut rx = server_events.subscribe();
+            tokio::spawn(async move {
+                let (read_half, mut write_half) = tokio::io::split(stream);
+                let mut lines = BufReader::new(read_half).lines();
+                let _hello = lines.next_line().await.unwrap().unwrap();
+                let mut out =
+                    serde_json::to_string(&ControlResponse::Welcome { daemon: identity }).unwrap();
+                out.push('\n');
+                let _ = write_half.write_all(out.as_bytes()).await;
+                // Then requests, until the client hangs up.
+                while let Ok(Some(line)) = lines.next_line().await {
+                    let req = serde_json::from_str::<ControlRequest>(&line).unwrap();
+                    if let ControlRequest::Subscribe = req {
+                        // Until the sender is dropped, which is how a test
+                        // "stops" this daemon.
+                        while let Ok(event) = rx.recv().await {
+                            let mut out = serde_json::to_string(&event).unwrap();
+                            out.push('\n');
+                            let _ = write_half.write_all(out.as_bytes()).await;
+                        }
+                        return;
+                    }
+                    let mut out = serde_json::to_string(&respond(req)).unwrap();
+                    out.push('\n');
+                    let _ = write_half.write_all(out.as_bytes()).await;
+                }
+            });
+        }
+    });
+    let client = ControlClient::for_home(id, dir).with_build(TEST_BUILD);
+    (client, events, server)
+}
+
+/// The identity of a fake daemon on the same code as the test's clients, at
+/// `pid`. Change `build` or `version` to make it "an update".
+pub(crate) fn same_code_daemon(pid: u32) -> leviath_runtime::control_socket::DaemonIdentity {
+    leviath_runtime::control_socket::DaemonIdentity {
+        pid,
+        ..leviath_runtime::control_socket::DaemonIdentity::this_process(TEST_BUILD)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/leviath-runtime/src/control_socket/client.rs
+++ b/crates/leviath-runtime/src/control_socket/client.rs
@@ -1,0 +1,745 @@
+//! The client half of the control transport: [`ControlClient`], which dials the
+//! daemon's socket once per request, and what it remembers between requests so
+//! that a long-lived client rides out a daemon restart.
+//!
+//! The daemon half - [`handle_connection`](super::handle_connection) and its
+//! dispatch - lives in the parent module, alongside the wire types both halves
+//! share.
+
+use std::path::{Path, PathBuf};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use super::{
+    AUTH_REQUIRED, ClientStream, ControlId, ControlRequest, ControlResponse, ControlToken,
+    DaemonIdentity, INVALID_REQUEST, SHUTTING_DOWN, connect,
+};
+use crate::host::{SpawnArgs, WorldEvent};
+
+/// How long a control request waits for the daemon before giving up, when
+/// `LEVIATH_CONTROL_TIMEOUT_SECS` is unset.
+///
+/// Generous enough to cover a busy daemon's control loop, short enough that a
+/// wedged one is reported rather than waited on indefinitely.
+pub const DEFAULT_CONTROL_TIMEOUT_SECS: u64 = 30;
+
+/// Floor on the deadline for a `Spawn`, which does more work than the other ops:
+/// the daemon connects the blueprint's MCP servers before spawning, and each of
+/// those has its own 30s connect timeout, so a blueprint declaring several
+/// servers can legitimately outlast the ordinary deadline. Without this floor a
+/// slow-but-succeeding spawn would be reported to the user as a timeout.
+pub const SPAWN_CONTROL_TIMEOUT_SECS: u64 = 300;
+
+/// The deadline for one control request. `LEVIATH_CONTROL_TIMEOUT_SECS`
+/// overrides it; `0` disables the deadline (for debugging a daemon that is
+/// legitimately slow). An unparseable value falls back to the default.
+pub fn request_timeout() -> std::time::Duration {
+    let secs = std::env::var("LEVIATH_CONTROL_TIMEOUT_SECS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .unwrap_or(DEFAULT_CONTROL_TIMEOUT_SECS);
+    match secs {
+        0 => std::time::Duration::MAX,
+        secs => std::time::Duration::from_secs(secs),
+    }
+}
+
+/// The deadline for `req`: [`request_timeout`], raised to at least
+/// [`SPAWN_CONTROL_TIMEOUT_SECS`] for a `Spawn`. An explicitly disabled deadline
+/// (`0`) stays disabled.
+pub(super) fn timeout_for(req: &ControlRequest) -> std::time::Duration {
+    let base = request_timeout();
+    match req {
+        ControlRequest::Spawn { .. } if base != std::time::Duration::MAX => {
+            base.max(std::time::Duration::from_secs(SPAWN_CONTROL_TIMEOUT_SECS))
+        }
+        _ => base,
+    }
+}
+
+/// How long a long-lived client keeps trying to reach a daemon that has just
+/// stopped answering before it reports the daemon unreachable. Opted into with
+/// [`ControlClient::with_reconnect_grace`]; a client has none by default.
+///
+/// A daemon restart - `lev daemon restart`, a supervisor relaunch after a
+/// crash, or `ensure_daemon_running` replacing a stale build after an update -
+/// takes well under a second on a warm machine and a few seconds on a slow one,
+/// and during that window the socket simply is not there. Before this, every
+/// request that landed in the window failed outright: `lev serve` answered 503
+/// and the ACP bridge refused the turn, for a daemon that was back a second
+/// later. Now a request waits out the window and is served by the new daemon.
+///
+/// The clock starts at the *first* failure after the daemon was last reached
+/// (see [`ControlClient::link`]), not at each request. So a daemon that is
+/// genuinely gone costs one caller the grace period, and every caller after
+/// that fails fast until it comes back - a long outage never turns into a queue
+/// of callers each waiting ten seconds.
+///
+/// One-shot commands (`lev ps`, `lev cancel`) keep no grace: a daemon that is
+/// not running is a fact to report at once, with the advice to start it, and
+/// ten seconds of silence before that advice would help nobody.
+pub const RESTART_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// The first pause between reconnect attempts inside [`RESTART_GRACE`]. Doubles
+/// per attempt up to [`RECONNECT_BACKOFF_CAP`], so a fast restart is noticed
+/// fast and a slow one is not polled hundreds of times.
+const RECONNECT_BACKOFF_START: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// The longest pause between reconnect attempts.
+const RECONNECT_BACKOFF_CAP: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Everything one client and all its clones share about the daemon on the
+/// other end. One lock, held only for the reads and writes below and never
+/// across an `.await`.
+///
+/// Shared across clones on purpose: `lev serve` hands a clone of one client to
+/// every request handler and to its event loop, and a token refresh, an
+/// identity, or an outage that one of them observes is true for all of them.
+#[derive(Default)]
+struct Link {
+    /// The token to present. Refreshed from disk on a refusal, because the
+    /// daemon mints a fresh one on every start.
+    token: Option<ControlToken>,
+    /// Who was on the other end the last time a handshake completed. `None`
+    /// until a daemon has introduced itself, which a daemon that predates the
+    /// handshake, or a tokenless test daemon, never does.
+    daemon: Option<DaemonIdentity>,
+    /// How many times `daemon` has been seen to change. A different process,
+    /// or a different build, behind the same socket is a restart.
+    restarts: u64,
+    /// When the daemon was first found missing, after last being reached.
+    /// `None` while it is answering.
+    outage_since: Option<std::time::Instant>,
+}
+
+/// A snapshot of what a client currently knows about its daemon - see
+/// [`ControlClient::link`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinkStatus {
+    /// The daemon last reached, once one has introduced itself.
+    pub daemon: Option<DaemonIdentity>,
+    /// How many times a different daemon has appeared behind the socket since
+    /// this client was created. A change here is a restart the client lived
+    /// through.
+    pub restarts: u64,
+    /// Whether the last transport attempt reached a daemon at all. `false`
+    /// from the first connect failure until the next success; a refusal or a
+    /// timeout is not an outage, since something answered.
+    pub reachable: bool,
+}
+
+/// The daemon and this process no longer run the same code.
+///
+/// Reported by [`ControlClient::code_mismatch`], and folded into the error a
+/// request returns when the two ends have actually stopped understanding each
+/// other. The two identities are public so a front-end can render them its own
+/// way; [`Display`](std::fmt::Display) says it in one sentence with the remedy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodeMismatch {
+    /// What the daemon reported.
+    pub daemon: DaemonIdentity,
+    /// What this process is.
+    pub client: DaemonIdentity,
+}
+
+impl std::fmt::Display for CodeMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "the daemon is now version {} (build {}, pid {}), but this process was built from \
+             version {} (build {}); restart this process so both ends run the same code",
+            self.daemon.version,
+            self.daemon.build,
+            self.daemon.pid,
+            self.client.version,
+            self.client.build,
+        )
+    }
+}
+
+/// Where an attempt to make a request failed. Decides whether a retry is safe:
+/// a failure before the request was written cannot have had any effect, while
+/// one after it may have - the daemon may have spawned the run and died before
+/// saying so.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stage {
+    /// Connecting or authenticating: nothing of the request has left this
+    /// process.
+    Connect,
+    /// The request was written; the failure was in getting a reply.
+    Sent,
+}
+
+/// One failed attempt: the error and where it happened.
+struct AttemptError {
+    stage: Stage,
+    error: std::io::Error,
+}
+
+impl AttemptError {
+    fn at(stage: Stage) -> impl FnOnce(std::io::Error) -> Self {
+        move |error| Self { stage, error }
+    }
+}
+
+/// Whether `e` says "no daemon answered", as opposed to "a daemon answered and
+/// said no". Only the first kind is worth waiting out.
+pub(super) fn is_transient(e: &std::io::Error) -> bool {
+    use std::io::ErrorKind::*;
+    matches!(
+        e.kind(),
+        // The socket file or pipe is not there: between one daemon unlinking
+        // it and the next binding it.
+        NotFound
+        // A stale socket file nothing listens on: the daemon died without
+        // unlinking, and its successor has not bound yet.
+        | ConnectionRefused
+        // The daemon went away mid-connection.
+        | ConnectionReset
+        | ConnectionAborted
+        | BrokenPipe
+        | UnexpectedEof
+    ) || pipe_busy(e)
+}
+
+/// `ERROR_PIPE_BUSY`: a Windows named pipe whose server has no free instance
+/// right now, which is what a client sees between the daemon accepting one
+/// connection and creating the next listener instance. Retryable by definition;
+/// `std` gives it no `ErrorKind` of its own.
+#[cfg(windows)]
+fn pipe_busy(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(231)
+}
+
+/// No Unix errno means "try again in a moment" the way `ERROR_PIPE_BUSY` does.
+#[cfg(not(windows))]
+fn pipe_busy(_: &std::io::Error) -> bool {
+    false
+}
+
+/// The client half of the control transport: connects to the daemon's control
+/// socket (resolved from a [`ControlId`]), sends one [`ControlRequest`], and
+/// reads back its [`ControlResponse`]. A fresh connection per request keeps it
+/// simple and stateless.
+///
+/// What it remembers between requests is about the *daemon*, not the
+/// connection: the token, who answered last, and whether it is answering at all
+/// (see [`Self::link`]). That is what lets a long-lived client - `lev serve`, `lev
+/// dash`, the ACP bridge - ride out a daemon restart: a request that lands
+/// while the daemon is down waits [`RESTART_GRACE`] for it to come back, a
+/// refusal after a restart re-reads the token, and a daemon that comes back
+/// on a different build is reported as such.
+#[derive(Clone)]
+pub struct ControlClient {
+    id: ControlId,
+    /// Shared across clones - see [`Link`].
+    link: std::sync::Arc<std::sync::Mutex<Link>>,
+    /// Where the token was looked for, so a refusal can name the file - and so
+    /// a refusal can re-read it: the daemon mints a fresh token on every start,
+    /// which is exactly when a long-lived client's cached copy goes stale.
+    token_dir: Option<PathBuf>,
+    /// How long to keep trying when the daemon is not answering. Zero means a
+    /// failed connect is reported at once.
+    grace: std::time::Duration,
+    /// Who this process is, for comparing against the daemon's answer.
+    own: DaemonIdentity,
+}
+
+impl ControlClient {
+    /// A client for the control socket identified by `id`, with no token and
+    /// no patience: an unreachable daemon is reported at once.
+    ///
+    /// Only reaches a daemon that runs without a token, which in practice means
+    /// a test driving the protocol directly. Real callers use
+    /// [`for_home`](Self::for_home) - see [`ControlToken`].
+    pub fn new(id: impl Into<ControlId>) -> Self {
+        Self {
+            id: id.into(),
+            link: Default::default(),
+            token_dir: None,
+            grace: std::time::Duration::ZERO,
+            own: DaemonIdentity::this_process(DaemonIdentity::unknown_build()),
+        }
+    }
+
+    /// Present `token` on every connection this client opens.
+    pub fn with_token(self, token: ControlToken) -> Self {
+        leviath_core::sync::lock(&self.link).token = Some(token);
+        self
+    }
+
+    /// Wait up to `grace` for a daemon that has just stopped answering,
+    /// instead of reporting it unreachable at once. Zero disables the wait.
+    ///
+    /// Per clone, not shared: `lev dash` polls the daemon ten times a second
+    /// on its render loop and wants that clone to fail fast, while the clone
+    /// its cancel/pause keypresses go through should wait a restart out.
+    pub fn with_reconnect_grace(mut self, grace: std::time::Duration) -> Self {
+        self.grace = grace;
+        self
+    }
+
+    /// Record this process's build id, so a daemon on a different build can be
+    /// told from one that merely restarted. Without it only the version is
+    /// compared - see [`DaemonIdentity::same_code_as`].
+    pub fn with_build(mut self, build: impl Into<String>) -> Self {
+        self.own.build = build.into();
+        self
+    }
+
+    /// A client that reads the daemon's token out of `dir`. Like
+    /// [`new`](Self::new) it has no patience for an absent daemon; a
+    /// long-lived caller adds [`with_reconnect_grace`](Self::with_reconnect_grace).
+    ///
+    /// A missing token file is **not** an error here. It has two very different
+    /// causes - no daemon is running, or one is running that predates tokens -
+    /// and the client cannot tell them apart, while the daemon can. Refusing to
+    /// even construct a client would make the second case unrecoverable: an
+    /// upgraded CLI could not ask the still-running pre-token daemon to shut
+    /// down, so it could neither stop it nor start a replacement, and the error
+    /// it printed ("Is the daemon running? Start it with `lev daemon start`")
+    /// would be advice the user was already following.
+    ///
+    /// The daemon is the enforcer. A client with no token connects, is refused
+    /// if the daemon requires one, and reports *that* - which is accurate.
+    pub fn for_home(id: impl Into<ControlId>, dir: &Path) -> Self {
+        Self {
+            id: id.into(),
+            link: std::sync::Arc::new(std::sync::Mutex::new(Link {
+                token: ControlToken::load(dir).ok(),
+                ..Default::default()
+            })),
+            token_dir: Some(dir.to_path_buf()),
+            grace: std::time::Duration::ZERO,
+            own: DaemonIdentity::this_process(DaemonIdentity::unknown_build()),
+        }
+    }
+
+    /// What this client currently knows about the daemon behind its socket.
+    ///
+    /// Updated by every request and subscription the client (or any clone of
+    /// it) makes, so a front-end that already talks to the daemon regularly
+    /// can render this without asking again. A front-end that has been idle
+    /// sees whatever its last request saw.
+    pub fn link(&self) -> LinkStatus {
+        let link = leviath_core::sync::lock(&self.link);
+        LinkStatus {
+            daemon: link.daemon.clone(),
+            restarts: link.restarts,
+            reachable: link.outage_since.is_none(),
+        }
+    }
+
+    /// The daemon last reached runs different code from this process, when it
+    /// does and has said who it is. `None` while the two match, or while no
+    /// daemon has introduced itself yet.
+    ///
+    /// This is advisory: the two ends may well still understand each other,
+    /// and requests keep flowing. It becomes an error only when they stop -
+    /// see [`Self::request`].
+    pub fn code_mismatch(&self) -> Option<CodeMismatch> {
+        let daemon = leviath_core::sync::lock(&self.link).daemon.clone()?;
+        (!daemon.same_code_as(&self.own)).then(|| CodeMismatch {
+            daemon,
+            client: self.own.clone(),
+        })
+    }
+
+    /// The token to present right now, if any.
+    fn current_token(&self) -> Option<ControlToken> {
+        leviath_core::sync::lock(&self.link).token.clone()
+    }
+
+    /// Re-read the token file after a refusal. Returns `true` when the file
+    /// held a *different* token than the cached one - the daemon restarted and
+    /// minted afresh, so a retry with the new token can succeed. `false` (file
+    /// missing, unreadable, or unchanged) means a retry would be refused the
+    /// same way.
+    ///
+    /// This is what lets a long-lived client (`lev serve`, `lev dash`, the ACP
+    /// bridge) survive a daemon restart: tokens are per-daemon-start by design,
+    /// and before this the only recovery was restarting the client too.
+    fn refresh_token(&self) -> bool {
+        let Some(dir) = &self.token_dir else {
+            return false;
+        };
+        let Ok(fresh) = ControlToken::load(dir) else {
+            return false;
+        };
+        let mut link = leviath_core::sync::lock(&self.link);
+        let changed = link
+            .token
+            .as_ref()
+            .is_none_or(|t| !t.matches(fresh.expose()));
+        if changed {
+            link.token = Some(fresh);
+        }
+        changed
+    }
+
+    /// Note that a daemon answered: the outage, if one was being timed, is
+    /// over.
+    fn reached(&self) {
+        leviath_core::sync::lock(&self.link).outage_since = None;
+    }
+
+    /// Note that no daemon answered, and say whether it is still worth waiting
+    /// for one: `true` while the outage is younger than this clone's grace.
+    /// The outage clock starts at the first failure and is shared by every
+    /// clone, so the wait is per outage, not per caller.
+    fn worth_waiting(&self) -> bool {
+        let mut link = leviath_core::sync::lock(&self.link);
+        let since = *link
+            .outage_since
+            .get_or_insert_with(std::time::Instant::now);
+        !self.grace.is_zero() && since.elapsed() < self.grace
+    }
+
+    /// Record who answered a handshake. A daemon that differs from the last
+    /// one seen - a new pid, or a new build behind the same socket - is a
+    /// restart, and counts as one.
+    fn observe(&self, daemon: DaemonIdentity) {
+        let mut link = leviath_core::sync::lock(&self.link);
+        match &link.daemon {
+            Some(known) if known == &daemon => {}
+            Some(_) => {
+                link.restarts += 1;
+                link.daemon = Some(daemon);
+            }
+            None => link.daemon = Some(daemon),
+        }
+    }
+
+    /// Why the daemon refused us, said in terms of what the user can do.
+    pub(super) fn refused(&self) -> std::io::Error {
+        let detail = match (self.current_token(), &self.token_dir) {
+            (None, Some(dir)) => format!(
+                "no control token was found at {}. If a daemon is running, it was \
+                 started by a different user or before this file existed - restart \
+                 it with `lev daemon restart`.",
+                ControlToken::path(dir).display()
+            ),
+            _ => "the daemon refused this client's control token. Restart it with \
+                  `lev daemon restart` to issue a fresh one."
+                .to_string(),
+        };
+        std::io::Error::new(std::io::ErrorKind::PermissionDenied, detail)
+    }
+
+    /// An error the daemon and this process could not avoid because they no
+    /// longer speak the same protocol, when that is what `e` is. A reply that
+    /// does not parse, or a request the daemon could not read, is a bug when
+    /// both ends run the same code and an *update* when they do not - and the
+    /// second one has a remedy the user can act on, so it is named.
+    fn explained(&self, e: std::io::Error) -> std::io::Error {
+        match (e.kind(), self.code_mismatch()) {
+            (std::io::ErrorKind::InvalidData, Some(mismatch)) => std::io::Error::new(
+                std::io::ErrorKind::Unsupported,
+                format!("{mismatch} (its reply could not be read: {e})"),
+            ),
+            _ => e,
+        }
+    }
+
+    /// Send one request and await its response. Errors if the daemon can't be
+    /// reached, does not answer within [`request_timeout`], the connection closes
+    /// before a reply, or the reply doesn't parse.
+    ///
+    /// A daemon that is not there is waited for, when this client was given a
+    /// grace to wait (see [`RESTART_GRACE`]), and one that refuses a stale
+    /// token is retried with a fresh one. A daemon
+    /// that answers but cannot be understood, when it and this process run
+    /// different code, is reported as [`ErrorKind::Unsupported`](std::io::ErrorKind::Unsupported)
+    /// with the remedy in the message; that is the one failure a restart of
+    /// the daemon does not fix, because the process that needs restarting is
+    /// this one.
+    pub async fn request(&self, req: &ControlRequest) -> std::io::Result<ControlResponse> {
+        // The daemon services control ops from a single loop, so one op that
+        // takes a long time (or a wedged world) delays every other client. With
+        // no deadline, `lev cancel` and the dashboard simply hung - no output, no
+        // error, nothing to act on. A timeout turns that into a failure the
+        // caller can fall back from.
+        let deadline = timeout_for(req);
+        tokio::time::timeout(deadline, self.request_with_recovery(req))
+            .await
+            .unwrap_or_else(|_| {
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::TimedOut,
+                    format!("the daemon did not respond within {}s", deadline.as_secs()),
+                ))
+            })
+    }
+
+    /// [`Self::attempt`], repeated across the two recoverable failures.
+    ///
+    /// **A refused token** is retried once with a re-read one. The daemon mints
+    /// a fresh token every start, so a refusal is most often not an intruder
+    /// but a restart this long-lived client slept through - `lev serve` held
+    /// one client for its whole life, and a single daemon restart (a crash,
+    /// `lev daemon restart`, or `ensure_daemon_running` replacing a stale
+    /// build) bricked every control op it made from then on until someone
+    /// restarted serve too. Once, not in a loop: a token that is wrong after a
+    /// re-read is wrong.
+    ///
+    /// **No daemon answering** is retried with backoff for as long as the
+    /// outage is younger than this clone's grace, but only when a retry cannot
+    /// double an effect: a failure before the request was written, or after it
+    /// for a request that only reads. A spawn or a message that got no reply
+    /// may or may not have happened, and asking again is how a run gets started
+    /// twice; that failure is reported instead. The one exception is a reply
+    /// saying the daemon was already shutting down, which means the request was
+    /// dropped unprocessed - safe to repeat against its successor.
+    async fn request_with_recovery(
+        &self,
+        req: &ControlRequest,
+    ) -> std::io::Result<ControlResponse> {
+        let mut refreshed = false;
+        let mut backoff = RECONNECT_BACKOFF_START;
+        loop {
+            match self.attempt(req).await {
+                Ok(ControlResponse::Error { message })
+                    if message == SHUTTING_DOWN && self.worth_waiting() =>
+                {
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(RECONNECT_BACKOFF_CAP);
+                }
+                // The daemon could not read what this process sent. Between two
+                // ends on the same code that is a bug; between an updated
+                // daemon and a client that predates it, it is the client's cue
+                // to restart, and the error says so.
+                Ok(ControlResponse::Error { message }) if message.starts_with(INVALID_REQUEST) => {
+                    self.reached();
+                    return match self.code_mismatch() {
+                        Some(mismatch) => Err(std::io::Error::new(
+                            std::io::ErrorKind::Unsupported,
+                            format!("{mismatch} (it could not read this request: {message})"),
+                        )),
+                        None => Ok(ControlResponse::Error { message }),
+                    };
+                }
+                Ok(response) => {
+                    self.reached();
+                    return Ok(response);
+                }
+                Err(AttemptError { error, .. })
+                    if error.kind() == std::io::ErrorKind::PermissionDenied
+                        && !refreshed
+                        && self.refresh_token() =>
+                {
+                    refreshed = true;
+                }
+                Err(AttemptError { stage, error })
+                    if is_transient(&error)
+                        && (stage == Stage::Connect || req.is_read_only())
+                        && self.worth_waiting() =>
+                {
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(RECONNECT_BACKOFF_CAP);
+                }
+                Err(AttemptError { error, .. }) => return Err(self.explained(error)),
+            }
+        }
+    }
+
+    /// One connection, one request, one reply.
+    async fn attempt(&self, req: &ControlRequest) -> Result<ControlResponse, AttemptError> {
+        let stream = connect(&self.id)
+            .await
+            .map_err(AttemptError::at(Stage::Connect))?;
+        let (read_half, mut write_half) = tokio::io::split(stream);
+        let mut lines = BufReader::new(read_half).lines();
+        self.authenticate(&mut write_half, &mut lines)
+            .await
+            .map_err(AttemptError::at(Stage::Connect))?;
+
+        let mut line = serde_json::to_string(req).expect("ControlRequest serializes");
+        line.push('\n');
+        // A failed write means the peer is already gone; the read below then sees
+        // EOF and returns the error, so the write needs no separate propagation.
+        let _ = write_half.write_all(line.as_bytes()).await;
+
+        match lines
+            .next_line()
+            .await
+            .map_err(AttemptError::at(Stage::Sent))?
+        {
+            Some(resp_line) => {
+                let parsed: ControlResponse = serde_json::from_str(&resp_line)
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+                    .map_err(AttemptError::at(Stage::Sent))?;
+                // A daemon that refused us: report what to do about it, not the
+                // wire message. Reached when this client had no token to send
+                // and so never ran the handshake - nothing was served, so this
+                // is a connect-stage failure for retry purposes.
+                match &parsed {
+                    ControlResponse::Error { message } if message.starts_with(AUTH_REQUIRED) => {
+                        Err(AttemptError {
+                            stage: Stage::Connect,
+                            error: self.refused(),
+                        })
+                    }
+                    _ => Ok(parsed),
+                }
+            }
+            None => Err(AttemptError {
+                stage: Stage::Sent,
+                error: std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "control connection closed before a response",
+                ),
+            }),
+        }
+    }
+
+    /// Authenticate a fresh connection: send the token (when there is one) and
+    /// read the daemon's verdict. On every connection, because the client opens
+    /// a fresh one per request, so there is no session to carry the proof
+    /// across. With no token nothing is sent - a daemon that predates tokens
+    /// serves the request, and one that requires them refuses it, which is the
+    /// outcome to report either way.
+    ///
+    /// The handshake asks the daemon who it is, and what it says is recorded
+    /// (see [`Self::observe`]). A daemon that predates the question answers a
+    /// bare `Ok`, which is accepted and records nothing.
+    async fn authenticate(
+        &self,
+        write_half: &mut tokio::io::WriteHalf<ClientStream>,
+        lines: &mut tokio::io::Lines<BufReader<tokio::io::ReadHalf<ClientStream>>>,
+    ) -> std::io::Result<()> {
+        let Some(token) = self.current_token() else {
+            return Ok(());
+        };
+        let hello = ControlRequest::Authenticate {
+            token: token.expose().to_string(),
+            hello: true,
+        };
+        let mut line = serde_json::to_string(&hello).expect("ControlRequest serializes");
+        line.push('\n');
+        let _ = write_half.write_all(line.as_bytes()).await;
+
+        // `.ok().flatten()`: a read error and a clean EOF are the same fact
+        // here - the daemon did not answer the handshake - and giving the
+        // error its own `?` arm leaves a branch no test can drive.
+        match lines.next_line().await.ok().flatten() {
+            Some(resp) => match serde_json::from_str::<ControlResponse>(&resp) {
+                Ok(ControlResponse::Ok { ok: true }) => Ok(()),
+                Ok(ControlResponse::Welcome { daemon }) => {
+                    self.observe(daemon);
+                    Ok(())
+                }
+                _ => Err(self.refused()),
+            },
+            None => Err(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "control connection closed during authentication",
+            )),
+        }
+    }
+
+    /// Spawn a new agent.
+    pub async fn spawn(&self, args: SpawnArgs) -> std::io::Result<ControlResponse> {
+        self.request(&ControlRequest::Spawn {
+            args: Box::new(args),
+        })
+        .await
+    }
+
+    /// Query a run's status.
+    pub async fn status(&self, run_id: &str) -> std::io::Result<ControlResponse> {
+        self.request(&ControlRequest::Status {
+            run_id: run_id.to_string(),
+        })
+        .await
+    }
+
+    /// List every known live run.
+    pub async fn list(&self) -> std::io::Result<ControlResponse> {
+        self.request(&ControlRequest::List).await
+    }
+
+    /// Ask the daemon to shut down.
+    pub async fn shutdown(&self) -> std::io::Result<ControlResponse> {
+        self.request(&ControlRequest::Shutdown).await
+    }
+
+    /// Open a pushed event stream: connect, authenticate, send `Subscribe`, and
+    /// return a reader that yields [`WorldEvent`]s until the daemon closes the
+    /// connection. The HTTP/WS gateway uses this instead of polling.
+    ///
+    /// Authenticated like every other request - it was not, which meant a
+    /// production daemon (they all require a token) refused every subscription
+    /// before it began: the serve gateway's event loop read the refusal as a
+    /// closed stream and silently re-subscribed twice a second forever, and no
+    /// live event ever reached a WebSocket. Only tokenless test daemons ever
+    /// saw the stream work. Recovers the same way [`Self::request`] does: a
+    /// stale token is re-read once, and a daemon that is not there is waited
+    /// for. Subscribing has no effect to double, so a retry is always safe.
+    pub async fn subscribe(&self) -> std::io::Result<WorldEventStream> {
+        let mut refreshed = false;
+        let mut backoff = RECONNECT_BACKOFF_START;
+        loop {
+            match self.subscribe_once().await {
+                Ok(stream) => {
+                    self.reached();
+                    return Ok(stream);
+                }
+                Err(e)
+                    if e.kind() == std::io::ErrorKind::PermissionDenied
+                        && !refreshed
+                        && self.refresh_token() =>
+                {
+                    refreshed = true;
+                }
+                Err(e) if is_transient(&e) && self.worth_waiting() => {
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(RECONNECT_BACKOFF_CAP);
+                }
+                Err(e) => return Err(e),
+            }
+        }
+    }
+
+    /// One subscribe attempt with the currently-cached token.
+    async fn subscribe_once(&self) -> std::io::Result<WorldEventStream> {
+        let stream = connect(&self.id).await?;
+        let (read_half, mut write_half) = tokio::io::split(stream);
+        let mut lines = BufReader::new(read_half).lines();
+        self.authenticate(&mut write_half, &mut lines).await?;
+        let mut line =
+            serde_json::to_string(&ControlRequest::Subscribe).expect("ControlRequest serializes");
+        line.push('\n');
+        // A failed write means the peer is already gone; the read side then sees
+        // EOF and `next` returns `None`, so the write needs no separate handling.
+        let _ = write_half.write_all(line.as_bytes()).await;
+        Ok(WorldEventStream {
+            lines,
+            _write: write_half,
+        })
+    }
+}
+
+/// A reader over a `Subscribe` connection, yielding [`WorldEvent`]s the daemon
+/// pushes.
+pub struct WorldEventStream {
+    lines: tokio::io::Lines<BufReader<tokio::io::ReadHalf<ClientStream>>>,
+    // Held open so the connection (and thus the subscription) stays alive.
+    _write: tokio::io::WriteHalf<ClientStream>,
+}
+
+impl WorldEventStream {
+    /// The next event, or `None` once the connection closes.
+    ///
+    /// A line that does not parse as a [`WorldEvent`] is skipped, not treated
+    /// as end-of-stream: the daemon may be a newer build whose event enum grew
+    /// a variant this client does not know, and ending the stream on the first
+    /// such event would put the consumer into a reconnect loop that tears the
+    /// subscription down once per unknown event.
+    pub async fn next(&mut self) -> Option<WorldEvent> {
+        loop {
+            let line = self.lines.next_line().await.ok().flatten()?;
+            if let Ok(event) = serde_json::from_str(&line) {
+                return Some(event);
+            }
+        }
+    }
+}

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -2115,6 +2115,11 @@ mod tests {
     /// A daemon at `id` with `token`, introducing itself as `identity`, that
     /// serves `connections` connections through the real handshake and then
     /// stops accepting. The fake host behind it answers every op.
+    ///
+    /// The returned task ends only once every connection it served has been
+    /// closed, not merely accepted. A test that "restarts" the daemon rebinds
+    /// the same id, and on Windows a pipe instance still held by a
+    /// connection task makes that bind fail with `AddrInUse`.
     fn identified_daemon(
         mut listener: ControlListener,
         token: ControlToken,
@@ -2126,16 +2131,25 @@ mod tests {
         spawn_fake_host(op_rx);
         let server_events = events.clone();
         let handle = tokio::spawn(async move {
+            let mut served = Vec::new();
             for _ in 0..connections {
                 let stream = listener.accept().await.unwrap().unwrap();
                 let op_tx = op_tx.clone();
                 let events = server_events.clone();
                 let token = token.clone();
                 let identity = identity.clone();
-                tokio::spawn(async move {
+                served.push(tokio::spawn(async move {
                     let _ =
                         handle_connection_as(stream, op_tx, events, Some(token), identity).await;
-                });
+                }));
+            }
+            // The listener goes now, and so does this task's hold on the event
+            // sender: a subscribed connection ends only when every sender is gone,
+            // and the test's own clone is the one that should decide that.
+            drop(listener);
+            drop(server_events);
+            for connection in served {
+                connection.await.unwrap();
             }
         });
         (events, handle)

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -28,6 +28,14 @@ use crate::components::AgentStatus;
 use crate::host::{ControlOp, DaemonHealth, RunListEntry, SpawnArgs, WorldEvent};
 use leviath_core::interaction::{InteractionRequest, InteractionResponse};
 
+mod client;
+pub use client::{
+    CodeMismatch, ControlClient, DEFAULT_CONTROL_TIMEOUT_SECS, LinkStatus, RESTART_GRACE,
+    SPAWN_CONTROL_TIMEOUT_SECS, WorldEventStream, request_timeout,
+};
+#[cfg(test)]
+use client::{is_transient, timeout_for};
+
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
@@ -49,7 +57,17 @@ pub use windows::{
 /// Shared by both sides rather than matched as prose: the client turns it back
 /// into an actionable error naming the token file, and a message the two ends
 /// spelled differently would silently stop being recognised.
-const AUTH_REQUIRED: &str = "authentication";
+pub(super) const AUTH_REQUIRED: &str = "authentication";
+
+/// Prefix on the daemon's reply to a request line it could not parse. Shared
+/// with the client so it can recognise it and, when the two ends run different
+/// code, name that as the cause.
+pub(super) const INVALID_REQUEST: &str = "invalid request";
+
+/// The daemon's reply when a request reached it while its serve loop was
+/// already gone. Shared with the client so it can recognise it: the request was
+/// dropped unprocessed, which makes a retry safe even for a spawn.
+pub(super) const SHUTTING_DOWN: &str = "daemon is shutting down";
 
 /// The most one connection may send before the stream is cut.
 ///
@@ -177,6 +195,12 @@ pub enum ControlRequest {
     Authenticate {
         /// The token read from `<leviath-home>/control.token`.
         token: String,
+        /// Ask the daemon to say who it is in reply ([`ControlResponse::Welcome`]
+        /// rather than a bare `Ok`). Defaulted so a daemon that predates the
+        /// field reads the request exactly as before, and a client that
+        /// predates it keeps getting the `Ok` it expects.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        hello: bool,
     },
     /// Spawn a new agent.
     Spawn {
@@ -235,6 +259,28 @@ pub enum ControlRequest {
     Subscribe,
 }
 
+impl ControlRequest {
+    /// Whether repeating this request can never do more than the first send
+    /// did. Decides what a client may retry after a request was written and
+    /// the daemon vanished before replying: a `List` asked twice is a `List`,
+    /// while a `Spawn` asked twice may be two runs.
+    ///
+    /// The mutating ops that *are* idempotent in effect - a second `Cancel`
+    /// of the same run does nothing - are still excluded, because their
+    /// second reply says `ok: false`, and the caller would report a cancel
+    /// that worked as "no such run".
+    pub fn is_read_only(&self) -> bool {
+        matches!(
+            self,
+            Self::Authenticate { .. }
+                | Self::Status { .. }
+                | Self::List
+                | Self::ListInteractions
+                | Self::Subscribe
+        )
+    }
+}
+
 /// A control response over the wire.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "result", rename_all = "snake_case")]
@@ -280,6 +326,80 @@ pub enum ControlResponse {
         /// A human-readable message.
         message: String,
     },
+    /// The answer to an `authenticate` that asked `hello`: who this daemon is.
+    ///
+    /// Sent instead of `Ok`, and only when asked for, so a client that does not
+    /// know this variant never receives it.
+    Welcome {
+        /// The daemon's identity.
+        daemon: DaemonIdentity,
+    },
+}
+
+/// Which process a control connection reached.
+///
+/// A daemon reports this in the authentication handshake, and a long-lived
+/// client keeps the last one it saw. That is how the client tells three
+/// situations apart that all begin with "the connection dropped": the same
+/// daemon is back (`pid` and `build` unchanged), the daemon restarted (`pid`
+/// moved, `build` did not), or the daemon was *updated* (`build` or `version`
+/// moved) - the one case where the client itself may need restarting, because
+/// the two ends no longer run the same code.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DaemonIdentity {
+    /// The Leviath version the daemon was built from (`0.4.0`).
+    pub version: String,
+    /// The build id, as `lev daemon` records it in `daemon.build`. `unknown`
+    /// when the process did not say (an embedder driving the runtime directly).
+    #[serde(default = "DaemonIdentity::unknown_build")]
+    pub build: String,
+    /// The daemon's process id.
+    pub pid: u32,
+}
+
+impl DaemonIdentity {
+    /// The identity of *this* process, given its build id.
+    ///
+    /// The version is this crate's, which is the workspace's: the daemon and
+    /// every client of it are built from the same tree, so comparing versions
+    /// across the wire compares releases. The build id lives with the binary
+    /// (it hashes the working tree), so the binary passes it in.
+    pub fn this_process(build: impl Into<String>) -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            build: build.into(),
+            pid: std::process::id(),
+        }
+    }
+
+    /// The build to record when a process does not say. Named rather than a
+    /// literal because [`same_code_as`](Self::same_code_as) must recognise it:
+    /// an unknown build is compared as "could be the same", never as the word.
+    pub fn unknown_build() -> String {
+        "unknown".to_string()
+    }
+
+    /// Whether the two ends run the same code, as far as they can tell.
+    ///
+    /// Versions must match. Builds must match too when both are known; a side
+    /// that does not know its build cannot contradict the other, so it does
+    /// not.
+    pub fn same_code_as(&self, other: &Self) -> bool {
+        let unknown = Self::unknown_build();
+        self.version == other.version
+            && (self.build == unknown || other.build == unknown || self.build == other.build)
+    }
+}
+
+impl std::fmt::Display for DaemonIdentity {
+    /// `0.4.0 (build 3ba95219, pid 4242)`: what a log line or a toast says.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} (build {}, pid {})",
+            self.version, self.build, self.pid
+        )
+    }
 }
 
 /// Translate a parsed request into a [`ControlOp`], forward it to the host, and
@@ -297,7 +417,7 @@ async fn dispatch(req: ControlRequest, op_tx: &UnboundedSender<ControlOp>) -> Co
                 Ok(Ok(run_id)) => ControlResponse::Spawned { run_id },
                 Ok(Err(message)) => ControlResponse::Error { message },
                 Err(_) => ControlResponse::Error {
-                    message: "daemon is shutting down".to_string(),
+                    message: SHUTTING_DOWN.to_string(),
                 },
             }
         }
@@ -450,10 +570,44 @@ pub async fn handle_connection<S>(
 where
     S: AsyncRead + AsyncWrite + Unpin,
 {
-    handle_connection_capped(stream, op_tx, events, token, MAX_REQUEST_BYTES).await
+    handle_connection_as(
+        stream,
+        op_tx,
+        events,
+        token,
+        DaemonIdentity::this_process(DaemonIdentity::unknown_build()),
+    )
+    .await
 }
 
-/// [`handle_connection`] with the per-request cap injected.
+/// [`handle_connection`], introducing the daemon as `identity` to a client that
+/// asks. The `lev daemon` binary passes its build id here; the plain form is
+/// for embedders and tests, which have no build id to give.
+pub async fn handle_connection_as<S>(
+    stream: S,
+    op_tx: UnboundedSender<ControlOp>,
+    events: broadcast::Sender<WorldEvent>,
+    token: Option<ControlToken>,
+    identity: DaemonIdentity,
+) -> std::io::Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    handle_connection_capped(stream, op_tx, events, token, identity, MAX_REQUEST_BYTES).await
+}
+
+/// The reply to a successful `authenticate`: `Welcome` when the client asked
+/// who it reached, the historical bare `Ok` when it did not.
+fn authenticated_reply(hello: bool, identity: &DaemonIdentity) -> ControlResponse {
+    match hello {
+        true => ControlResponse::Welcome {
+            daemon: identity.clone(),
+        },
+        false => ControlResponse::Ok { ok: true },
+    }
+}
+
+/// [`handle_connection_as`] with the per-request cap injected.
 ///
 /// The cap is a parameter purely so a test can cross it without pushing 8 MiB
 /// through a duplex - and crossing it is the only way to tell a per-request
@@ -463,6 +617,7 @@ async fn handle_connection_capped<S>(
     op_tx: UnboundedSender<ControlOp>,
     events: broadcast::Sender<WorldEvent>,
     token: Option<ControlToken>,
+    identity: DaemonIdentity,
     max_request_bytes: u64,
 ) -> std::io::Result<()>
 where
@@ -500,16 +655,17 @@ where
         // peer cannot sit probing the protocol.
         if !authenticated {
             let refused = match serde_json::from_str::<ControlRequest>(&line) {
-                Ok(ControlRequest::Authenticate { token: presented }) => {
-                    match token.as_ref().is_some_and(|t| t.matches(&presented)) {
-                        true => {
-                            authenticated = true;
-                            write_line(&mut write_half, &ControlResponse::Ok { ok: true }).await;
-                            continue;
-                        }
-                        false => "authentication failed",
+                Ok(ControlRequest::Authenticate {
+                    token: presented,
+                    hello,
+                }) => match token.as_ref().is_some_and(|t| t.matches(&presented)) {
+                    true => {
+                        authenticated = true;
+                        write_line(&mut write_half, &authenticated_reply(hello, &identity)).await;
+                        continue;
                     }
-                }
+                    false => "authentication failed",
+                },
                 _ => "authentication required: send an `authenticate` request first",
             };
             write_line(
@@ -532,11 +688,13 @@ where
                 drop(events);
                 return stream_events(&mut lines, &mut write_half, rx).await;
             }
-            // Already authenticated: a repeat is harmless, not an error.
-            Ok(ControlRequest::Authenticate { .. }) => ControlResponse::Ok { ok: true },
+            // Already authenticated: a repeat is harmless, not an error. On a
+            // tokenless daemon this is also the only way a client's `hello`
+            // gets answered, since no handshake gate ran.
+            Ok(ControlRequest::Authenticate { hello, .. }) => authenticated_reply(hello, &identity),
             Ok(req) => dispatch(req, &op_tx).await,
             Err(e) => ControlResponse::Error {
-                message: format!("invalid request: {e}"),
+                message: format!("{INVALID_REQUEST}: {e}"),
             },
         };
         write_line(&mut write_half, &response).await;
@@ -556,347 +714,6 @@ where
     let mut out = serde_json::to_string(response).expect("ControlResponse serializes");
     out.push('\n');
     let _ = write_half.write_all(out.as_bytes()).await;
-}
-
-/// How long a control request waits for the daemon before giving up, when
-/// `LEVIATH_CONTROL_TIMEOUT_SECS` is unset.
-///
-/// Generous enough to cover a busy daemon's control loop, short enough that a
-/// wedged one is reported rather than waited on indefinitely.
-pub const DEFAULT_CONTROL_TIMEOUT_SECS: u64 = 30;
-
-/// Floor on the deadline for a `Spawn`, which does more work than the other ops:
-/// the daemon connects the blueprint's MCP servers before spawning, and each of
-/// those has its own 30s connect timeout, so a blueprint declaring several
-/// servers can legitimately outlast the ordinary deadline. Without this floor a
-/// slow-but-succeeding spawn would be reported to the user as a timeout.
-pub const SPAWN_CONTROL_TIMEOUT_SECS: u64 = 300;
-
-/// The deadline for one control request. `LEVIATH_CONTROL_TIMEOUT_SECS`
-/// overrides it; `0` disables the deadline (for debugging a daemon that is
-/// legitimately slow). An unparseable value falls back to the default.
-pub fn request_timeout() -> std::time::Duration {
-    let secs = std::env::var("LEVIATH_CONTROL_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.trim().parse::<u64>().ok())
-        .unwrap_or(DEFAULT_CONTROL_TIMEOUT_SECS);
-    match secs {
-        0 => std::time::Duration::MAX,
-        secs => std::time::Duration::from_secs(secs),
-    }
-}
-
-/// The deadline for `req`: [`request_timeout`], raised to at least
-/// [`SPAWN_CONTROL_TIMEOUT_SECS`] for a `Spawn`. An explicitly disabled deadline
-/// (`0`) stays disabled.
-fn timeout_for(req: &ControlRequest) -> std::time::Duration {
-    let base = request_timeout();
-    match req {
-        ControlRequest::Spawn { .. } if base != std::time::Duration::MAX => {
-            base.max(std::time::Duration::from_secs(SPAWN_CONTROL_TIMEOUT_SECS))
-        }
-        _ => base,
-    }
-}
-
-/// The client half of the control transport: connects to the daemon's control
-/// socket (resolved from a [`ControlId`]), sends one [`ControlRequest`], and
-/// reads back its [`ControlResponse`]. A fresh connection per request keeps it
-/// simple and stateless.
-#[derive(Clone)]
-pub struct ControlClient {
-    id: ControlId,
-    /// The token to present, shared across clones so a refresh (see
-    /// [`Self::refresh_token`]) reaches every handler holding a clone. A `std`
-    /// mutex held only for reads/writes of the option, never across `.await`.
-    token: std::sync::Arc<std::sync::Mutex<Option<ControlToken>>>,
-    /// Where the token was looked for, so a refusal can name the file - and so
-    /// a refusal can re-read it: the daemon mints a fresh token on every start,
-    /// which is exactly when a long-lived client's cached copy goes stale.
-    token_dir: Option<PathBuf>,
-}
-
-impl ControlClient {
-    /// A client for the control socket identified by `id`, with no token.
-    ///
-    /// Only reaches a daemon that runs without one, which in practice means a
-    /// test driving the protocol directly. Real callers use
-    /// [`with_token`](Self::with_token) - see [`ControlToken`].
-    pub fn new(id: impl Into<ControlId>) -> Self {
-        Self {
-            id: id.into(),
-            token: std::sync::Arc::new(std::sync::Mutex::new(None)),
-            token_dir: None,
-        }
-    }
-
-    /// Present `token` on every connection this client opens.
-    pub fn with_token(self, token: ControlToken) -> Self {
-        *leviath_core::sync::lock(&self.token) = Some(token);
-        self
-    }
-
-    /// A client that reads the daemon's token out of `dir`.
-    ///
-    /// A missing token file is **not** an error here. It has two very different
-    /// causes - no daemon is running, or one is running that predates tokens -
-    /// and the client cannot tell them apart, while the daemon can. Refusing to
-    /// even construct a client would make the second case unrecoverable: an
-    /// upgraded CLI could not ask the still-running pre-token daemon to shut
-    /// down, so it could neither stop it nor start a replacement, and the error
-    /// it printed ("Is the daemon running? Start it with `lev daemon start`")
-    /// would be advice the user was already following.
-    ///
-    /// The daemon is the enforcer. A client with no token connects, is refused
-    /// if the daemon requires one, and reports *that* - which is accurate.
-    pub fn for_home(id: impl Into<ControlId>, dir: &Path) -> Self {
-        Self {
-            id: id.into(),
-            token: std::sync::Arc::new(std::sync::Mutex::new(ControlToken::load(dir).ok())),
-            token_dir: Some(dir.to_path_buf()),
-        }
-    }
-
-    /// The token to present right now, if any.
-    fn current_token(&self) -> Option<ControlToken> {
-        leviath_core::sync::lock(&self.token).clone()
-    }
-
-    /// Re-read the token file after a refusal. Returns `true` when the file
-    /// held a *different* token than the cached one - the daemon restarted and
-    /// minted afresh, so a retry with the new token can succeed. `false` (file
-    /// missing, unreadable, or unchanged) means a retry would be refused the
-    /// same way.
-    ///
-    /// This is what lets a long-lived client (`lev serve`, `lev dash`, the ACP
-    /// bridge) survive a daemon restart: tokens are per-daemon-start by design,
-    /// and before this the only recovery was restarting the client too.
-    fn refresh_token(&self) -> bool {
-        let Some(dir) = &self.token_dir else {
-            return false;
-        };
-        let Ok(fresh) = ControlToken::load(dir) else {
-            return false;
-        };
-        let mut cached = leviath_core::sync::lock(&self.token);
-        let changed = cached.as_ref().is_none_or(|t| !t.matches(fresh.expose()));
-        if changed {
-            *cached = Some(fresh);
-        }
-        changed
-    }
-
-    /// Why the daemon refused us, said in terms of what the user can do.
-    fn refused(&self) -> std::io::Error {
-        let detail = match (self.current_token(), &self.token_dir) {
-            (None, Some(dir)) => format!(
-                "no control token was found at {}. If a daemon is running, it was \
-                 started by a different user or before this file existed - restart \
-                 it with `lev daemon restart`.",
-                ControlToken::path(dir).display()
-            ),
-            _ => "the daemon refused this client's control token. Restart it with \
-                  `lev daemon restart` to issue a fresh one."
-                .to_string(),
-        };
-        std::io::Error::new(std::io::ErrorKind::PermissionDenied, detail)
-    }
-
-    /// Send one request and await its response. Errors if the daemon can't be
-    /// reached, does not answer within [`request_timeout`], the connection closes
-    /// before a reply, or the reply doesn't parse.
-    pub async fn request(&self, req: &ControlRequest) -> std::io::Result<ControlResponse> {
-        // The daemon services control ops from a single loop, so one op that
-        // takes a long time (or a wedged world) delays every other client. With
-        // no deadline, `lev cancel` and the dashboard simply hung - no output, no
-        // error, nothing to act on. A timeout turns that into a failure the
-        // caller can fall back from.
-        let deadline = timeout_for(req);
-        tokio::time::timeout(deadline, self.request_with_refresh(req))
-            .await
-            .unwrap_or_else(|_| {
-                Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    format!("the daemon did not respond within {}s", deadline.as_secs()),
-                ))
-            })
-    }
-
-    /// [`Self::request_uncapped`], retried once with a re-read token when the
-    /// daemon refuses the cached one. The daemon mints a fresh token every
-    /// start, so a refusal is most often not an intruder but a restart this
-    /// long-lived client slept through - `lev serve` held one client for its
-    /// whole life, and a single daemon restart (a crash, `lev daemon restart`,
-    /// or `ensure_daemon_running` replacing a stale build) bricked every
-    /// control op it made from then on until someone restarted serve too.
-    async fn request_with_refresh(&self, req: &ControlRequest) -> std::io::Result<ControlResponse> {
-        match self.request_uncapped(req).await {
-            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied && self.refresh_token() => {
-                self.request_uncapped(req).await
-            }
-            other => other,
-        }
-    }
-
-    /// [`Self::request`] without the deadline.
-    async fn request_uncapped(&self, req: &ControlRequest) -> std::io::Result<ControlResponse> {
-        let stream = connect(&self.id).await?;
-        let (read_half, mut write_half) = tokio::io::split(stream);
-        let mut lines = BufReader::new(read_half).lines();
-        self.authenticate(&mut write_half, &mut lines).await?;
-
-        let mut line = serde_json::to_string(req).expect("ControlRequest serializes");
-        line.push('\n');
-        // A failed write means the peer is already gone; the read below then sees
-        // EOF and returns the error, so the write needs no separate propagation.
-        let _ = write_half.write_all(line.as_bytes()).await;
-
-        match lines.next_line().await? {
-            Some(resp_line) => {
-                let parsed: ControlResponse = serde_json::from_str(&resp_line)
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-                // A daemon that refused us: report what to do about it, not the
-                // wire message. Reached when this client had no token to send
-                // and so never ran the handshake.
-                match &parsed {
-                    ControlResponse::Error { message } if message.starts_with(AUTH_REQUIRED) => {
-                        Err(self.refused())
-                    }
-                    _ => Ok(parsed),
-                }
-            }
-            None => Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "control connection closed before a response",
-            )),
-        }
-    }
-
-    /// Authenticate a fresh connection: send the token (when there is one) and
-    /// read the daemon's verdict. On every connection, because the client opens
-    /// a fresh one per request, so there is no session to carry the proof
-    /// across. With no token nothing is sent - a daemon that predates tokens
-    /// serves the request, and one that requires them refuses it, which is the
-    /// outcome to report either way.
-    async fn authenticate(
-        &self,
-        write_half: &mut tokio::io::WriteHalf<ClientStream>,
-        lines: &mut tokio::io::Lines<BufReader<tokio::io::ReadHalf<ClientStream>>>,
-    ) -> std::io::Result<()> {
-        let Some(token) = self.current_token() else {
-            return Ok(());
-        };
-        let hello = ControlRequest::Authenticate {
-            token: token.expose().to_string(),
-        };
-        let mut line = serde_json::to_string(&hello).expect("ControlRequest serializes");
-        line.push('\n');
-        let _ = write_half.write_all(line.as_bytes()).await;
-
-        // `.ok().flatten()`: a read error and a clean EOF are the same fact
-        // here - the daemon did not answer the handshake - and giving the
-        // error its own `?` arm leaves a branch no test can drive.
-        match lines.next_line().await.ok().flatten() {
-            Some(resp) => match serde_json::from_str::<ControlResponse>(&resp) {
-                Ok(ControlResponse::Ok { ok: true }) => Ok(()),
-                _ => Err(self.refused()),
-            },
-            None => Err(std::io::Error::new(
-                std::io::ErrorKind::UnexpectedEof,
-                "control connection closed during authentication",
-            )),
-        }
-    }
-
-    /// Spawn a new agent.
-    pub async fn spawn(&self, args: SpawnArgs) -> std::io::Result<ControlResponse> {
-        self.request(&ControlRequest::Spawn {
-            args: Box::new(args),
-        })
-        .await
-    }
-
-    /// Query a run's status.
-    pub async fn status(&self, run_id: &str) -> std::io::Result<ControlResponse> {
-        self.request(&ControlRequest::Status {
-            run_id: run_id.to_string(),
-        })
-        .await
-    }
-
-    /// List every known live run.
-    pub async fn list(&self) -> std::io::Result<ControlResponse> {
-        self.request(&ControlRequest::List).await
-    }
-
-    /// Ask the daemon to shut down.
-    pub async fn shutdown(&self) -> std::io::Result<ControlResponse> {
-        self.request(&ControlRequest::Shutdown).await
-    }
-
-    /// Open a pushed event stream: connect, authenticate, send `Subscribe`, and
-    /// return a reader that yields [`WorldEvent`]s until the daemon closes the
-    /// connection. The HTTP/WS gateway uses this instead of polling.
-    ///
-    /// Authenticated like every other request - it was not, which meant a
-    /// production daemon (they all require a token) refused every subscription
-    /// before it began: the serve gateway's event loop read the refusal as a
-    /// closed stream and silently re-subscribed twice a second forever, and no
-    /// live event ever reached a WebSocket. Only tokenless test daemons ever
-    /// saw the stream work. Retried once with a re-read token on refusal, same
-    /// as [`Self::request`].
-    pub async fn subscribe(&self) -> std::io::Result<WorldEventStream> {
-        match self.subscribe_uncapped().await {
-            Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied && self.refresh_token() => {
-                self.subscribe_uncapped().await
-            }
-            other => other,
-        }
-    }
-
-    /// One subscribe attempt with the currently-cached token.
-    async fn subscribe_uncapped(&self) -> std::io::Result<WorldEventStream> {
-        let stream = connect(&self.id).await?;
-        let (read_half, mut write_half) = tokio::io::split(stream);
-        let mut lines = BufReader::new(read_half).lines();
-        self.authenticate(&mut write_half, &mut lines).await?;
-        let mut line =
-            serde_json::to_string(&ControlRequest::Subscribe).expect("ControlRequest serializes");
-        line.push('\n');
-        // A failed write means the peer is already gone; the read side then sees
-        // EOF and `next` returns `None`, so the write needs no separate handling.
-        let _ = write_half.write_all(line.as_bytes()).await;
-        Ok(WorldEventStream {
-            lines,
-            _write: write_half,
-        })
-    }
-}
-
-/// A reader over a `Subscribe` connection, yielding [`WorldEvent`]s the daemon
-/// pushes.
-pub struct WorldEventStream {
-    lines: tokio::io::Lines<BufReader<tokio::io::ReadHalf<ClientStream>>>,
-    // Held open so the connection (and thus the subscription) stays alive.
-    _write: tokio::io::WriteHalf<ClientStream>,
-}
-
-impl WorldEventStream {
-    /// The next event, or `None` once the connection closes.
-    ///
-    /// A line that does not parse as a [`WorldEvent`] is skipped, not treated
-    /// as end-of-stream: the daemon may be a newer build whose event enum grew
-    /// a variant this client does not know, and ending the stream on the first
-    /// such event would put the consumer into a reconnect loop that tears the
-    /// subscription down once per unknown event.
-    pub async fn next(&mut self) -> Option<WorldEvent> {
-        loop {
-            let line = self.lines.next_line().await.ok().flatten()?;
-            if let Ok(event) = serde_json::from_str(&line) {
-                return Some(event);
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -1156,7 +973,15 @@ mod tests {
                 .expect("our own connection is admitted");
             // A cap just over one request's length: three requests cross it,
             // so a budget that never refills cuts the connection partway.
-            handle_connection_capped(stream, op_tx, no_events(), None, 40).await
+            handle_connection_capped(
+                stream,
+                op_tx,
+                no_events(),
+                None,
+                DaemonIdentity::this_process("test"),
+                40,
+            )
+            .await
         });
 
         let stream = connect(&id).await.unwrap();
@@ -1518,6 +1343,7 @@ mod tests {
         let response = dispatch(
             ControlRequest::Authenticate {
                 token: "irrelevant".to_string(),
+                hello: false,
             },
             &op_tx,
         )
@@ -1546,6 +1372,7 @@ mod tests {
         let mut lines = BufReader::new(read_half).lines();
         let hello = serde_json::to_string(&ControlRequest::Authenticate {
             token: token.expose().to_string(),
+            hello: false,
         })
         .unwrap();
         for _ in 0..2 {
@@ -2281,5 +2108,606 @@ mod tests {
                 message: String::new()
             })
         );
+    }
+
+    // ── Riding out a daemon restart ─────────────────────────────────────────
+
+    /// A daemon at `id` with `token`, introducing itself as `identity`, that
+    /// serves `connections` connections through the real handshake and then
+    /// stops accepting. The fake host behind it answers every op.
+    fn identified_daemon(
+        mut listener: ControlListener,
+        token: ControlToken,
+        identity: DaemonIdentity,
+        connections: usize,
+    ) -> (broadcast::Sender<WorldEvent>, tokio::task::JoinHandle<()>) {
+        let (events, _r) = broadcast::channel::<WorldEvent>(16);
+        let (op_tx, op_rx) = mpsc::unbounded_channel();
+        spawn_fake_host(op_rx);
+        let server_events = events.clone();
+        let handle = tokio::spawn(async move {
+            for _ in 0..connections {
+                let stream = listener.accept().await.unwrap().unwrap();
+                let op_tx = op_tx.clone();
+                let events = server_events.clone();
+                let token = token.clone();
+                let identity = identity.clone();
+                tokio::spawn(async move {
+                    let _ =
+                        handle_connection_as(stream, op_tx, events, Some(token), identity).await;
+                });
+            }
+        });
+        (events, handle)
+    }
+
+    /// An identity for a daemon on the same code as this process, at `pid`.
+    fn same_code(pid: u32) -> DaemonIdentity {
+        DaemonIdentity {
+            pid,
+            ..DaemonIdentity::this_process("build-a")
+        }
+    }
+
+    #[test]
+    fn this_process_identity_carries_the_crate_version_and_the_given_build() {
+        let me = DaemonIdentity::this_process("abc123");
+        assert_eq!(me.version, env!("CARGO_PKG_VERSION"));
+        assert_eq!(me.build, "abc123");
+        assert_eq!(me.pid, std::process::id());
+        assert_eq!(
+            me.to_string(),
+            format!(
+                "{} (build abc123, pid {})",
+                env!("CARGO_PKG_VERSION"),
+                std::process::id()
+            )
+        );
+    }
+
+    /// Versions must match; builds must match when both are known; a side that
+    /// does not know its build cannot contradict the other.
+    #[test]
+    fn same_code_compares_versions_and_known_builds() {
+        let a = same_code(1);
+        let mut b = same_code(2);
+        assert!(a.same_code_as(&b), "a different pid is the same code");
+        b.build = "build-b".to_string();
+        assert!(!a.same_code_as(&b), "a different build is different code");
+        b.build = DaemonIdentity::unknown_build();
+        assert!(a.same_code_as(&b), "an unknown build cannot contradict");
+        assert!(b.same_code_as(&a), "in either direction");
+        let mut c = same_code(3);
+        c.version = "0.0.1".to_string();
+        assert!(!a.same_code_as(&c), "a different version is different code");
+    }
+
+    /// The identity's build is optional on the wire (an older daemon never
+    /// sends one), and `hello: false` is left off the request entirely so a
+    /// daemon that predates the field sees exactly the request it always saw.
+    #[test]
+    fn the_handshake_additions_are_backward_compatible_on_the_wire() {
+        let plain = serde_json::to_value(ControlRequest::Authenticate {
+            token: "t".to_string(),
+            hello: false,
+        })
+        .unwrap();
+        assert_eq!(
+            plain,
+            serde_json::json!({"op": "authenticate", "token": "t"})
+        );
+        let asking = serde_json::to_value(ControlRequest::Authenticate {
+            token: "t".to_string(),
+            hello: true,
+        })
+        .unwrap();
+        assert_eq!(asking["hello"], true);
+        let parsed: ControlRequest =
+            serde_json::from_value(serde_json::json!({"op": "authenticate", "token": "t"}))
+                .unwrap();
+        assert_eq!(
+            parsed,
+            ControlRequest::Authenticate {
+                token: "t".to_string(),
+                hello: false
+            }
+        );
+        let identity: DaemonIdentity =
+            serde_json::from_value(serde_json::json!({"version": "0.4.0", "pid": 7})).unwrap();
+        assert_eq!(identity.build, DaemonIdentity::unknown_build());
+    }
+
+    #[test]
+    fn only_the_reading_requests_are_read_only() {
+        let run = || "r".to_string();
+        let read_only = [
+            ControlRequest::Authenticate {
+                token: run(),
+                hello: true,
+            },
+            ControlRequest::Status { run_id: run() },
+            ControlRequest::List,
+            ControlRequest::ListInteractions,
+            ControlRequest::Subscribe,
+        ];
+        let mutating = [
+            ControlRequest::Spawn {
+                args: Box::new(SpawnArgs::default()),
+            },
+            ControlRequest::Pause { run_id: run() },
+            ControlRequest::Resume { run_id: run() },
+            ControlRequest::Cancel { run_id: run() },
+            ControlRequest::Message {
+                agent_id: run(),
+                content: run(),
+                target_region: None,
+            },
+            ControlRequest::AnswerInteraction {
+                response: InteractionResponse {
+                    request_id: run(),
+                    value: None,
+                    choice_index: None,
+                    approved: None,
+                    scope: None,
+                },
+            },
+            ControlRequest::CancelInteraction { request_id: run() },
+            ControlRequest::Shutdown,
+        ];
+        assert!(read_only.iter().all(ControlRequest::is_read_only));
+        assert!(!mutating.iter().any(ControlRequest::is_read_only));
+    }
+
+    /// The reasons a connect can fail that mean "no daemon answered", versus
+    /// the ones where something did.
+    #[test]
+    fn transient_errors_are_the_absent_daemon_ones() {
+        use std::io::ErrorKind::*;
+        for kind in [
+            NotFound,
+            ConnectionRefused,
+            ConnectionReset,
+            ConnectionAborted,
+            BrokenPipe,
+            UnexpectedEof,
+        ] {
+            assert!(is_transient(&std::io::Error::new(kind, "x")), "{kind:?}");
+        }
+        for kind in [PermissionDenied, InvalidData, TimedOut, Unsupported, Other] {
+            assert!(!is_transient(&std::io::Error::new(kind, "x")), "{kind:?}");
+        }
+    }
+
+    /// `ERROR_PIPE_BUSY` has no `ErrorKind` of its own and is retryable by
+    /// definition.
+    #[cfg(windows)]
+    #[test]
+    fn a_busy_named_pipe_is_transient() {
+        assert!(is_transient(&std::io::Error::from_raw_os_error(231)));
+    }
+
+    /// The daemon introduces itself in the handshake, the client records it,
+    /// and a client whose build matches sees no mismatch. Before any handshake
+    /// the client knows nothing and says so.
+    #[tokio::test]
+    async fn the_client_learns_who_it_reached_from_the_handshake() {
+        let (listener, id, dir) = test_listener();
+        let token = ControlToken::create(dir.path()).unwrap();
+        let (_events, server) = identified_daemon(listener, token, same_code(41), 1);
+        let client = ControlClient::for_home(id, dir.path()).with_build("build-a");
+        assert_eq!(
+            client.link(),
+            LinkStatus {
+                daemon: None,
+                restarts: 0,
+                reachable: true,
+            }
+        );
+        client.list().await.expect("served");
+        assert_eq!(client.link().daemon, Some(same_code(41)));
+        assert_eq!(
+            client.link().restarts,
+            0,
+            "learning who it is is not a restart"
+        );
+        assert!(client.link().reachable);
+        assert_eq!(client.code_mismatch(), None);
+        server.await.unwrap();
+    }
+
+    /// A daemon that predates the question answers the handshake with the
+    /// bare `Ok` it always did. That is accepted, and the client simply keeps
+    /// not knowing who it reached.
+    #[tokio::test]
+    async fn a_daemon_that_predates_the_handshake_is_served_without_an_identity() {
+        let (mut listener, id, dir) = test_listener();
+        let _token = ControlToken::create(dir.path()).unwrap();
+        let client = ControlClient::for_home(id, dir.path()).with_build("build-a");
+        let server = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap().unwrap();
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _hello = lines.next_line().await.unwrap();
+            write_line(&mut write_half, &ControlResponse::Ok { ok: true }).await;
+            let _request = lines.next_line().await.unwrap();
+            write_line(&mut write_half, &ControlResponse::Ok { ok: true }).await;
+        });
+        client.shutdown().await.expect("served");
+        assert_eq!(client.link().daemon, None);
+        assert_eq!(client.code_mismatch(), None);
+        server.await.unwrap();
+    }
+
+    /// The plain `handle_connection` (embedders, tests) introduces the daemon
+    /// with an unknown build, which a client with a known build accepts as
+    /// possibly-the-same code.
+    #[tokio::test]
+    async fn a_daemon_that_does_not_know_its_build_is_not_a_mismatch() {
+        let (listener, id, dir) = test_listener();
+        let token = ControlToken::create(dir.path()).unwrap();
+        let (_events, server) = tokened_daemon(listener, token, 1);
+        let client = ControlClient::for_home(id, dir.path()).with_build("build-a");
+        client.list().await.expect("served");
+        let daemon = client.link().daemon.expect("introduced itself");
+        assert_eq!(daemon.build, DaemonIdentity::unknown_build());
+        assert_eq!(client.code_mismatch(), None);
+        server.await.unwrap();
+    }
+
+    /// A different daemon behind the same socket - a new pid - counts as a
+    /// restart, once per change; the same daemon answering again does not.
+    #[tokio::test]
+    async fn a_new_daemon_behind_the_socket_counts_as_a_restart() {
+        let (listener, id, dir) = test_listener();
+        let token = ControlToken::create(dir.path()).unwrap();
+        let (_events, first) = identified_daemon(listener, token.clone(), same_code(1), 2);
+        let client = ControlClient::for_home(id.clone(), dir.path()).with_build("build-a");
+        client.list().await.expect("served by the first daemon");
+        client.list().await.expect("and again");
+        assert_eq!(client.link().restarts, 0, "the same daemon twice");
+        first.await.unwrap();
+
+        // "Restart": a new listener on the same id, a new pid in the greeting.
+        let listener = bind_control_listener(&id).unwrap();
+        let (_events, second) = identified_daemon(listener, token, same_code(2), 1);
+        client.list().await.expect("served by the second daemon");
+        assert_eq!(client.link().restarts, 1);
+        assert_eq!(client.link().daemon.map(|d| d.pid), Some(2));
+        second.await.unwrap();
+    }
+
+    /// A request that lands while no daemon is listening waits for one, and
+    /// is served by the daemon that binds a moment later. This is the restart
+    /// window: `lev serve` answered 503 across it, `lev ps` printed "Daemon
+    /// not reachable", and the ACP bridge refused the turn.
+    #[tokio::test]
+    async fn a_request_during_the_restart_window_waits_for_the_new_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = control_id(dir.path());
+        let token = ControlToken::create(dir.path()).unwrap();
+        let client = ControlClient::for_home(id.clone(), dir.path())
+            .with_reconnect_grace(std::time::Duration::from_secs(5));
+        assert!(!is_daemon_running(&id), "nothing listening yet");
+
+        // The daemon comes back a little after the request goes out.
+        let late = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+            let listener = bind_control_listener(&id).unwrap();
+            let (_events, server) = identified_daemon(listener, token, same_code(9), 1);
+            server.await.unwrap();
+        });
+        let response = client.list().await.expect("waited out the window");
+        assert!(format!("{response:?}").starts_with("List"));
+        assert!(client.link().reachable, "the outage is over");
+        late.await.unwrap();
+    }
+
+    /// The wait is per outage, not per request. Once the daemon has been gone
+    /// longer than the grace, callers fail fast instead of each waiting the
+    /// whole grace again - and the link reads as unreachable meanwhile.
+    #[tokio::test]
+    async fn an_outage_older_than_the_grace_fails_fast() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = control_id(dir.path());
+        let client = ControlClient::for_home(id, dir.path())
+            .with_reconnect_grace(std::time::Duration::from_millis(30));
+        // The first caller pays the grace (a backoff sleep or two)...
+        let started = std::time::Instant::now();
+        assert!(client.list().await.is_err());
+        assert!(started.elapsed() >= std::time::Duration::from_millis(30));
+        assert!(!client.link().reachable);
+        // ...and every caller after it fails at once.
+        let started = std::time::Instant::now();
+        assert!(client.list().await.is_err());
+        assert!(started.elapsed() < std::time::Duration::from_millis(30));
+    }
+
+    /// A clone can opt out of the wait: `lev dash` polls on its render loop
+    /// and must not freeze the screen for the length of an outage.
+    #[tokio::test]
+    async fn a_zero_grace_clone_reports_an_absent_daemon_at_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = control_id(dir.path());
+        let patient = ControlClient::for_home(id, dir.path()).with_reconnect_grace(RESTART_GRACE);
+        let hasty = patient
+            .clone()
+            .with_reconnect_grace(std::time::Duration::ZERO);
+        let started = std::time::Instant::now();
+        assert!(hasty.list().await.is_err());
+        assert!(started.elapsed() < std::time::Duration::from_secs(1));
+        // The clones share what they learn: the patient one now knows too.
+        assert!(!patient.link().reachable);
+    }
+
+    /// The daemon can vanish *after* the request was written. A request that
+    /// only reads is simply asked again of the daemon that comes back...
+    #[tokio::test]
+    async fn a_read_only_request_cut_off_before_its_reply_is_asked_again() {
+        let (mut listener, id, dir) = test_listener();
+        let token = ControlToken::create(dir.path()).unwrap();
+        let client = ControlClient::for_home(id.clone(), dir.path())
+            .with_reconnect_grace(std::time::Duration::from_secs(5));
+        // First connection: handshake, read the request, then hang up.
+        let dying = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap().unwrap();
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _hello = lines.next_line().await.unwrap();
+            write_line(&mut write_half, &authenticated_reply(true, &same_code(1))).await;
+            let _request = lines.next_line().await.unwrap();
+            drop(listener);
+            // Dropping the stream: EOF before any reply.
+        });
+        // The replacement binds a moment after the first daemon is gone and
+        // answers properly.
+        let late = tokio::spawn(async move {
+            dying.await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+            let listener = bind_control_listener(&id).unwrap();
+            let (_events, server) = identified_daemon(listener, token, same_code(2), 1);
+            server.await.unwrap();
+        });
+        let response = client.list().await.expect("asked again of the new daemon");
+        assert!(format!("{response:?}").starts_with("List"));
+        late.await.unwrap();
+    }
+
+    /// ...while one that mutates is not, because it may already have happened
+    /// - the daemon may have spawned the run and died before saying so, and
+    /// asking again is how a run gets started twice.
+    #[tokio::test]
+    async fn a_mutating_request_cut_off_before_its_reply_is_not_repeated() {
+        let (mut listener, id, dir) = test_listener();
+        let _token = ControlToken::create(dir.path()).unwrap();
+        let client = ControlClient::for_home(id, dir.path())
+            .with_reconnect_grace(std::time::Duration::from_secs(5));
+        let dying = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap().unwrap();
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _hello = lines.next_line().await.unwrap();
+            write_line(&mut write_half, &authenticated_reply(true, &same_code(1))).await;
+            let _request = lines.next_line().await.unwrap();
+        });
+        let started = std::time::Instant::now();
+        let err = client
+            .spawn(SpawnArgs::default())
+            .await
+            .expect_err("a spawn that got no reply is reported, not repeated");
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+        assert!(
+            started.elapsed() < std::time::Duration::from_secs(4),
+            "no wait"
+        );
+        dying.await.unwrap();
+    }
+
+    /// The one mutating reply that *is* safe to repeat: the daemon saying it
+    /// was already shutting down, which means the request was dropped
+    /// unprocessed. The spawn goes to the daemon that replaces it.
+    #[tokio::test]
+    async fn a_spawn_the_dying_daemon_dropped_goes_to_its_replacement() {
+        let (mut listener, id, dir) = test_listener();
+        let token = ControlToken::create(dir.path()).unwrap();
+        let client = ControlClient::for_home(id.clone(), dir.path())
+            .with_reconnect_grace(std::time::Duration::from_secs(5));
+        // A daemon whose host is already gone: `dispatch` cannot deliver the
+        // op, and says so.
+        let draining_token = token.clone();
+        let draining = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap().unwrap();
+            let (op_tx, op_rx) = mpsc::unbounded_channel();
+            drop(op_rx);
+            let _ = handle_connection_as(
+                stream,
+                op_tx,
+                no_events(),
+                Some(draining_token),
+                same_code(1),
+            )
+            .await;
+            drop(listener);
+        });
+        // Its replacement, a moment later, with a live host.
+        let late = tokio::spawn(async move {
+            draining.await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+            let listener = bind_control_listener(&id).unwrap();
+            let (_events, server) = identified_daemon(listener, token, same_code(2), 1);
+            server.await.unwrap();
+        });
+        let args = SpawnArgs {
+            run_id: "run-x".to_string(),
+            ..Default::default()
+        };
+        let response = client
+            .spawn(args)
+            .await
+            .expect("spawned by the replacement");
+        assert_eq!(
+            response,
+            ControlResponse::Spawned {
+                run_id: "run-x".to_string()
+            }
+        );
+        late.await.unwrap();
+    }
+
+    /// Without the wait, the same reply is handed back as it always was.
+    #[tokio::test]
+    async fn a_shutting_down_reply_is_returned_when_there_is_no_grace() {
+        let (mut listener, id, dir) = test_listener();
+        let token = ControlToken::create(dir.path()).unwrap();
+        let client =
+            ControlClient::for_home(id, dir.path()).with_reconnect_grace(std::time::Duration::ZERO);
+        let draining = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap().unwrap();
+            let (op_tx, op_rx) = mpsc::unbounded_channel();
+            drop(op_rx);
+            let _ = handle_connection(stream, op_tx, no_events(), Some(token)).await;
+        });
+        let response = client.spawn(SpawnArgs::default()).await.unwrap();
+        assert_eq!(
+            response,
+            ControlResponse::Error {
+                message: SHUTTING_DOWN.to_string()
+            }
+        );
+        draining.await.unwrap();
+    }
+
+    /// The event stream is subscribed with the same patience: a subscribe
+    /// during the restart window attaches to the daemon that comes back.
+    #[tokio::test]
+    async fn a_subscribe_during_the_restart_window_attaches_to_the_new_daemon() {
+        let dir = tempfile::tempdir().unwrap();
+        let id = control_id(dir.path());
+        let token = ControlToken::create(dir.path()).unwrap();
+        let client = ControlClient::for_home(id.clone(), dir.path())
+            .with_reconnect_grace(std::time::Duration::from_secs(5));
+        let (events_tx, events_rx) = tokio::sync::oneshot::channel();
+        let late = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+            let listener = bind_control_listener(&id).unwrap();
+            let (events, server) = identified_daemon(listener, token, same_code(3), 1);
+            let _ = events_tx.send(events.clone());
+            server.await.unwrap();
+        });
+        let mut stream = client.subscribe().await.expect("attached after the wait");
+        let events = events_rx.await.unwrap();
+        let event = loop {
+            let _ = events.send(completed("late-run"));
+            tokio::select! {
+                e = stream.next() => break e,
+                _ = tokio::time::sleep(std::time::Duration::from_millis(5)) => {}
+            }
+        };
+        assert!(format!("{:?}", event.expect("the event arrives")).contains("late-run"));
+        drop(stream);
+        drop(events);
+        late.await.unwrap();
+    }
+
+    /// A daemon on different code that answers with something this client
+    /// cannot read: not "not reachable", and not a daemon-side bug, but the
+    /// one failure a restart of the daemon does not fix. The error says which
+    /// process to restart.
+    #[tokio::test]
+    async fn an_unreadable_reply_from_a_daemon_on_other_code_names_the_mismatch() {
+        let (mut listener, id, dir) = test_listener();
+        let _token = ControlToken::create(dir.path()).unwrap();
+        let client = ControlClient::for_home(id, dir.path()).with_build("build-a");
+        let mut other = same_code(5);
+        other.build = "build-b".to_string();
+        let server = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap().unwrap();
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _hello = lines.next_line().await.unwrap();
+            write_line(&mut write_half, &authenticated_reply(true, &other)).await;
+            let _request = lines.next_line().await.unwrap();
+            let _ = write_half
+                .write_all(b"{\"result\":\"from_the_future\"}\n")
+                .await;
+        });
+        let err = client.list().await.expect_err("could not read the reply");
+        assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+        let text = err.to_string();
+        assert!(text.contains("build build-b"), "{text}");
+        assert!(text.contains("built from version"), "{text}");
+        assert!(text.contains("restart this process"), "{text}");
+        assert!(text.contains("could not be read"), "{text}");
+        let mismatch = client.code_mismatch().expect("recorded");
+        assert_eq!(mismatch.daemon.build, "build-b");
+        assert_eq!(mismatch.client.build, "build-a");
+        server.await.unwrap();
+    }
+
+    /// The same unreadable reply from a daemon on the *same* code is the plain
+    /// parse error it always was: there is no update to blame.
+    #[tokio::test]
+    async fn an_unreadable_reply_from_the_same_code_is_a_plain_parse_error() {
+        let (mut listener, id, dir) = test_listener();
+        let _token = ControlToken::create(dir.path()).unwrap();
+        let client = ControlClient::for_home(id, dir.path()).with_build("build-a");
+        let server = tokio::spawn(async move {
+            let stream = listener.accept().await.unwrap().unwrap();
+            let (read_half, mut write_half) = tokio::io::split(stream);
+            let mut lines = BufReader::new(read_half).lines();
+            let _hello = lines.next_line().await.unwrap();
+            write_line(&mut write_half, &authenticated_reply(true, &same_code(5))).await;
+            let _request = lines.next_line().await.unwrap();
+            let _ = write_half.write_all(b"not json\n").await;
+        });
+        let err = client.list().await.expect_err("could not read the reply");
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        server.await.unwrap();
+    }
+
+    /// And the mirror image: a request the daemon could not read. Named as a
+    /// mismatch when the two run different code, passed through as the
+    /// daemon's own error when they do not.
+    #[tokio::test]
+    async fn a_request_the_daemon_cannot_read_is_a_mismatch_only_across_code() {
+        for (build, expect_mismatch) in [("build-b", true), ("build-a", false)] {
+            let (mut listener, id, dir) = test_listener();
+            let _token = ControlToken::create(dir.path()).unwrap();
+            let client = ControlClient::for_home(id, dir.path()).with_build("build-a");
+            let mut daemon = same_code(5);
+            daemon.build = build.to_string();
+            let server = tokio::spawn(async move {
+                let stream = listener.accept().await.unwrap().unwrap();
+                let (read_half, mut write_half) = tokio::io::split(stream);
+                let mut lines = BufReader::new(read_half).lines();
+                let _hello = lines.next_line().await.unwrap();
+                write_line(&mut write_half, &authenticated_reply(true, &daemon)).await;
+                let _request = lines.next_line().await.unwrap();
+                write_line(
+                    &mut write_half,
+                    &ControlResponse::Error {
+                        message: format!("{INVALID_REQUEST}: unknown variant `list`"),
+                    },
+                )
+                .await;
+            });
+            let result = client.list().await;
+            match expect_mismatch {
+                true => {
+                    let err = result.expect_err("named as a mismatch");
+                    assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+                    assert!(err.to_string().contains("could not read this request"));
+                }
+                false => {
+                    let response = result.expect("the daemon's own error, passed through");
+                    assert_eq!(
+                        response,
+                        ControlResponse::Error {
+                            message: format!("{INVALID_REQUEST}: unknown variant `list`"),
+                        }
+                    );
+                }
+            }
+            server.await.unwrap();
+        }
     }
 }

--- a/docs/content/agent-client-protocol.md
+++ b/docs/content/agent-client-protocol.md
@@ -111,3 +111,15 @@ adjusting.
 > Editor integration is a thin front end over the daemon, exactly like `lev run` and `lev serve`. It
 > owns no agent world of its own. See the [daemon](/docs/daemon) for what actually hosts the run, and
 > the [CLI reference](/docs/cli) for the rest of the `lev` commands.
+
+## If the daemon restarts mid-turn
+
+A `lev daemon restart` while a prompt is streaming does not end the turn. The bridge waits for the
+daemon to come back (up to ten seconds), subscribes again, and follows the run, which the new
+daemon reloads from disk. The editor sees the output pause and resume. The turn ends only when no
+daemon returns, with whatever the run had written by then.
+
+If the daemon comes back on a different build than the bridge, which is what a `lev update` looks
+like from a session that was already open, the bridge says so in the conversation and carries on.
+The remedy is on the editor's side: start a new session, so the bridge and the daemon run the same
+code.

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -507,6 +507,32 @@ sequenceDiagram
   Serve-->>Browser: {done}
 ```
 
+### When the daemon restarts
+
+The stream stays open across a [daemon](/docs/daemon) restart. `lev serve` reconnects to the daemon
+on its own, so your socket never has to. What you see is one `daemon_link` frame when the daemon's
+events stop, and one when they resume:
+
+```json
+{"type":"daemon_link","connected":false,"daemon":{"version":"0.4.0","build":"3ba95219","pid":4242},"restarted":false}
+{"type":"daemon_link","connected":true,"daemon":{"version":"0.4.0","build":"3ba95219","pid":4301},"restarted":true}
+```
+
+`restarted` says whether the daemon that came back is a different process from the one before.
+`daemon` is absent until the daemon has introduced itself, which every current daemon does on
+connect.
+
+If the daemon came back on a different build than the running `lev serve` (the usual cause is a
+`lev update` with the server left running), the frame also carries `restart_advised`, a sentence
+that names both builds and says to restart `lev serve`. Every subscriber that connects while that
+is true, or while the daemon is unreachable, gets a `daemon_link` frame first thing. A healthy
+stream sends none, so a client that ignores the type sees exactly what it always saw.
+
+Requests keep working across a version gap as long as the two ends still understand each other. A
+request that fails because they no longer do answers **502** with the same sentence, where a
+daemon that is simply not answering is a **503**. Retrying helps the second; only restarting
+`lev serve` helps the first.
+
 ## Asking for a shape
 
 Add `output_format` to ask for the answer in a particular shape. Any label works, because nothing

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -87,6 +87,37 @@ stateDiagram-v2
   Stopped --> [*]
 ```
 
+## What the front-ends do while it restarts
+
+A daemon restart used to break whatever was talking to it. `lev serve` answered 503 for the
+second the socket was gone, and the ACP bridge ended its turn with half an answer. Now the
+long-lived front-ends ride the restart out: `lev serve`, `lev dash`, and `lev agent-client`.
+
+A request that arrives while the daemon is down waits up to ten seconds for it to come back. The
+new daemon serves it. The wait is per outage, not per request: a daemon that is really gone costs
+one caller the ten seconds, and every caller after that fails at once until it returns. Requests
+that could double an effect, a spawn or a message that got no reply, are reported rather than
+sent twice. One-shot commands such as `lev ps` do not wait: a daemon that is not running is
+reported at once, with the advice to start it.
+
+The daemon says who it is (version, build, pid) when a front-end connects. That is how each one
+tells a restart from an update:
+
+| What happened | `lev serve` | `lev dash` | `lev agent-client` |
+|---|---|---|---|
+| The daemon restarted on the same build | Logs it, and sends WebSocket clients a `daemon_link` event | A log line and a toast | Follows the run onto the new daemon, silently |
+| The daemon came back on a different build | Logs a warning, and the `daemon_link` event carries the advice | A log line, a toast, and a chip on the run list | Says so in the conversation |
+
+The advice is always the same: restart that front-end, so both ends run the same code. Requests
+keep working while the two still understand each other. One that fails because they no longer do
+is reported as exactly that (`lev serve` answers 502 rather than 503), since a daemon restart
+cannot fix it.
+
+> [!NOTE]
+> After `lev update`, the next `lev` command restarts the daemon onto the new build. A `lev serve`
+> or `lev dash` that was already running is now the older half of the pair, and says so. Restart
+> it when convenient.
+
 ## Run it unattended
 
 For an always-on setup, install the daemon under your operating system's service manager. It then

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -44,6 +44,11 @@ panel and answer. `lev respond` does the same from the shell.
 - **Mouse support**: wheel scroll, click-drag select with copy-on-release, OSC52 copy over SSH,
   `y` to yank a pane, Shift+drag for native selection.
 - **`m`** opens the MCP management screen without leaving the dashboard.
+- **The daemon link**: the dashboard polls the [daemon](/docs/daemon) ten times a second, so a
+  daemon restart costs it nothing but a moment. It says so in the log pane and a toast when the
+  daemon stops answering and again when it is back. While the daemon is unreachable, or came back
+  on a different build than this dashboard, the run list wears a chip beside the sort chip. The
+  second case is the one that asks something of you: restart `lev dash` so both run the same code.
 
 ## Keys
 


### PR DESCRIPTION
## What

`lev serve`, `lev dash`, and `lev agent-client` now ride out a daemon restart, and can tell a restart from an update.

**Measured first.** On `main`, `lev serve` already survived a plain `lev daemon restart` (the token refresh from 20eac56f plus the event loop's re-subscribe). What still broke: a request landing *in* the outage window failed outright (503 / ACP `refusal`), the ACP bridge ended a turn mid-answer when the stream dropped, and nothing on the wire said which daemon *build* a front-end reconnected to, so an old `lev serve` under a freshly updated daemon had no way to know.

### Control client (leviath-runtime)
- **Reconnect grace** (`with_reconnect_grace(RESTART_GRACE)`, 10s): a request that cannot reach the daemon retries with backoff while the outage is younger than the grace. The outage clock is shared by every clone and starts at the first failure, so a daemon that is really gone costs one caller the grace and every caller after that fails fast. Only connect-stage failures, read-only requests, and the daemon's own "shutting down" reply are retried; a spawn or message that got no reply is reported, never sent twice.
- **Identity handshake**: `Authenticate { hello: true }` is answered with `Welcome { version, build, pid }`. Both are invisible to a peer that predates them. `client.link()` reports the daemon, a restart count, and reachability; `client.code_mismatch()` says when the two ends run different code (version always, build when both known).
- A reply this build cannot read, or a request the daemon cannot read, *when the builds differ*, becomes `ErrorKind::Unsupported` naming both builds and the remedy (restart this process).
- One-shot commands are unchanged: `for_home` keeps zero grace, so `lev ps` with a stopped daemon still fails at once. `main.rs` opts serve/dash/agent-client in via `long_lived_control_client()` (needs the `allow-main-rs-change` label; also passes the daemon's build id into `handle_connection_as`).
- The client moved to `control_socket/client.rs` (the structure check's 1200-line limit).

### Front-ends
- **serve**: `LinkWatch` logs the event stream dropping/returning once each and broadcasts a `daemon_link` WS event (`connected`, `daemon`, `restarted`, `restart_advised`). New subscribers get a `daemon_link` greeting only when the daemon is down or on other code; a healthy stream is byte-identical to before. A request that fails on the code mismatch is a **502** with the advice; an absent daemon stays 503.
- **dash**: the render loop polls with a zero-grace clone (never freezes); background command loops keep the patient client. `sync_daemon_link` announces, once, "stopped answering" / "reconnected" (or "restarted, now …") / the mismatch, as log line + toast, and the run list wears a chip while unreachable or updated.
- **agent-client**: a stream that drops mid-turn is re-subscribed and the run followed onto the new daemon (bounded by three consecutive silent drops); a daemon back on other code is named in the conversation.

### Docs
`daemon.md` (new section), `api.md` (the `daemon_link` frame, 502 vs 503), `dashboard.md`, `agent-client-protocol.md`, CHANGELOG.

## Live-verified (isolated `LEVIATH_HOME`, mock provider)
- 60 requests at 100ms across a 3s `daemon stop` / `daemon start`: all 60 answered by a daemon; one waited 3.3s. WS listener saw `daemon_link` down/up with the new pid.
- Old-build `lev serve` under a daemon restarted by a newer build: warning in the log, `daemon_link` with `restart_advised`, per-run subscribers greeted with it, requests still 404/200 as before.
- ACP turn streamed through a mid-turn `lev daemon restart` to `end_turn` (previously ended early).
- `lev dash` in a pty: chip + log lines during a 2.5s outage; the mismatch chip against a newer daemon.
- `lev ps` with the daemon stopped: fails in 11ms.

Coverage gates green for `leviath-runtime` and `leviath-cli`; `cargo xtask docs` clean.

## Worth a follow-up (not in this PR)
An older `lev` binary's `ensure_daemon_running` treats any build that differs from its own as stale, so an old `lev run` after an update **downgrades** the daemon back. Pre-existing; the identity handshake now makes that visible.
