### PR TITLE
Let an agent find out what day it is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ same list.
   so a seed reaches nothing the agent could not, and a tool set to `ask` is
   refused rather than prompted because a seed runs before any prompt exists.
   `lev validate` lists them as `tool-seed`.
+- Fixed: `deep-researcher`, `researcher` and `wide-researcher` now know what day
+  it is. Each seeds a pinned `environment` region from `current_time` and
+  `locale_info`, and their research stages are told to judge "recent", "current"
+  and "latest" against it rather than against whatever they remember. This is
+  the bug that prompted the tools above: with no way to ask the date, a research
+  run reasoned from its training cutoff and worked a stale news cycle.
 - Fixed: `environment_info` reports credential-shaped environment variables by
   name with the value withheld, through the same `[security] allow_env_vars`
   gate a Rhai `env_var` read answers to, so an agent can tell a key is set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@ same list.
   so a seed reaches nothing the agent could not, and a tool set to `ask` is
   refused rather than prompted because a seed runs before any prompt exists.
   `lev validate` lists them as `tool-seed`.
+- New: `refresh = "each_stage"` on a tool seed re-runs its calls whenever a
+  stage is entered, for a seeded region whose answer moves. The stage waits for
+  the refreshed region before its first request, so the values are in place for
+  the turn that reads them; a failed call leaves the region as it was rather
+  than blanking it. The default stays `once`, which is what every other seed
+  kind does.
 - Fixed: `deep-researcher`, `researcher` and `wide-researcher` now know what day
   it is. Each seeds a pinned `environment` region from `current_time` and
   `locale_info`, and their research stages are told to judge "recent", "current"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,15 @@ same list.
   `allow` and take no action. This closes a real gap: a research agent with no
   way to ask the date reasoned from its training cutoff and worked a stale news
   cycle.
+- New: a region can seed itself from tool calls -
+  `seed = { tools = ["current_time", "system_info"] }` - so an agent's first
+  inference already carries what those tools would have said. Several calls fill
+  one region, each under a heading naming the tool. Any tool the agent could
+  call works: a built-in, an MCP server's, or a Rhai script's. Each call
+  resolves against the same `[tool_permissions]` the tool lane applies mid-run,
+  so a seed reaches nothing the agent could not, and a tool set to `ask` is
+  refused rather than prompted because a seed runs before any prompt exists.
+  `lev validate` lists them as `tool-seed`.
 - Fixed: `environment_info` reports credential-shaped environment variables by
   name with the value withheld, through the same `[security] allow_env_vars`
   gate a Rhai `env_var` read answers to, so an agent can tell a key is set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,23 @@ same list.
   daemon restart cannot fix. `lev dash` says the same in its log and a toast,
   and wears a chip on the run list while the daemon is unreachable or
   updated. The ACP bridge tells the editor in the conversation.
+- New: six read-only environment tools, so an agent can ground itself in the
+  world it is actually running in. `current_time` reports the date and time in
+  UTC and local with the timezone and offset; `system_info` the operating
+  system, version, architecture, CPU count, hostname and free disk;
+  `locale_info` the user's language and region; `environment_info` the working
+  directory, the well-known directories, `PATH` and the environment variables
+  the agent may see; `which_command` whether a program is installed and where;
+  and `runtime_info` this run's own agent, stage, iteration, model, context use
+  and whether anyone is available to answer a question. All six default to
+  `allow` and take no action. This closes a real gap: a research agent with no
+  way to ask the date reasoned from its training cutoff and worked a stale news
+  cycle.
+- Fixed: `environment_info` reports credential-shaped environment variables by
+  name with the value withheld, through the same `[security] allow_env_vars`
+  gate a Rhai `env_var` read answers to, so an agent can tell a key is set
+  without being handed it.
+
 - New: `lev dash` draws a run's blueprint as a stage graph. The stage
   explorer (`g` in the detail view) is a canvas now: stages are boxes on
   layers, transitions are routed edges, the stage the run is in spins in

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2618,6 +2618,7 @@ dependencies = [
  "keyring-core",
  "leviath-testkit",
  "nix 0.31.3",
+ "sys-locale",
  "temp-env",
  "tempfile",
  "tokio",
@@ -2653,7 +2654,10 @@ name = "leviath-tools"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "csv",
+ "dirs",
+ "iana-time-zone",
  "jsonschema",
  "leviath-core",
  "leviath-providers",
@@ -3501,7 +3505,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3926,7 +3930,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3983,7 +3987,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4434,6 +4438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sys-locale"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eab9a99a024a169fe8a903cf9d4a3b3601109bcc13bd9e3c6fff259138626c4"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4485,7 +4498,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5383,7 +5396,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,6 +144,14 @@ thiserror = "2.0"
 toml = { version = "1.0", features = ["preserve_order"] }
 anyhow = "1.0"
 chrono = "0.4"
+# The IANA zone name (`America/Chicago`) behind the `current_time` tool. Already
+# in the lock file transitively via chrono, which uses it for `Local`; named here
+# so the tool reports the same zone chrono resolved rather than a second answer.
+iana-time-zone = "0.1"
+# The user's locale for the `locale_info` tool. `std` exposes none: Unix has
+# `LANG`/`LC_ALL`, Windows and macOS answer only through an OS call, and the
+# workspace forbids `unsafe`, so the three-platform lookup is delegated.
+sys-locale = "0.3"
 rhai = { version = "1.25", features = ["sync", "serde"] }
 glob = "0.3"
 # Free-space queries for the disk guard (`leviath-sys::disk`). Pure Rust over
@@ -190,7 +198,7 @@ libc = "0.2"
 # "socket" is for the control socket's peer-credential check (SO_PEERCRED on
 # Linux, LOCAL_PEERCRED on macOS/BSD), which is what stops another local user
 # from driving the daemon.
-nix = { version = "0.31", default-features = false, features = ["signal", "process", "user", "socket"] }
+nix = { version = "0.31", default-features = false, features = ["signal", "process", "user", "socket", "hostname"] }
 temp-env = "0.3"
 crossterm = "0.29"
 # unstable-rendered-line-info: `Paragraph::line_count`, which the dashboard

--- a/crates/leviath-agent-client/src/mapping.rs
+++ b/crates/leviath-agent-client/src/mapping.rs
@@ -218,6 +218,13 @@ fn permission_title(request: &InteractionRequest) -> String {
 fn tool_kind_for(tool_name: Option<&str>) -> ToolKind {
     match tool_name {
         Some("read_file" | "read_files" | "list_files" | "grep") => ToolKind::Read,
+        // The environment tools read the host and the run rather than a file,
+        // but `Read` is the closest kind the protocol has and is what a host
+        // should show: a lookup that returns information and changes nothing.
+        Some(
+            "current_time" | "system_info" | "locale_info" | "environment_info" | "which_command"
+            | "runtime_info",
+        ) => ToolKind::Read,
         Some("write_file" | "edit_file" | "apply_patch") => ToolKind::Edit,
         Some("delete_file") => ToolKind::Delete,
         Some("move_file") => ToolKind::Move,
@@ -484,6 +491,15 @@ this trailing text is ignored";
             ("read_files", ToolKind::Read),
             ("list_files", ToolKind::Read),
             ("grep", ToolKind::Read),
+            // The environment tools read the host and the run rather than a
+            // file, but a lookup that returns information and changes nothing
+            // is what `Read` means to a host picking an icon.
+            ("current_time", ToolKind::Read),
+            ("system_info", ToolKind::Read),
+            ("locale_info", ToolKind::Read),
+            ("environment_info", ToolKind::Read),
+            ("which_command", ToolKind::Read),
+            ("runtime_info", ToolKind::Read),
             ("write_file", ToolKind::Edit),
             ("edit_file", ToolKind::Edit),
             ("apply_patch", ToolKind::Edit),

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.1.1"
+version = "0.2.0"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
@@ -10,6 +10,7 @@ read_file  = "allow"
 list_dir   = "allow"
 web_search = "allow"
 web_fetch  = "allow"
+current_time = "allow"
 write_file = "ask"
 bash       = "ask"
 
@@ -19,7 +20,7 @@ mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather primary sources and key references on the topic"
 # web_search / web_fetch are provided by this agent's tools/ (issue #97).
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time"]
 max_iterations = 25
 max_revisits = 3
 system_prompt = """
@@ -31,6 +32,10 @@ authoritative references, not a broad skim.
   question, then web_fetch the most authoritative results for detail. Prefer
   primary sources (papers, standards, official docs) over summaries. read_file for
   local documents. Raw content lands in `sources`.
+- Today's date is in the `environment` region. Treat it as authoritative over
+  anything you remember: your training has a cutoff and this run does not. Judge
+  "recent", "current" and "latest" against it, and say how old a source is when
+  its age bears on the claim. Call current_time if you need the clock again.
 - For every source you actually use, append one bibliography line to
   `sources_index` (context_append): `[n] <title> - <url/path> - <date> -
   credibility: <high/med/low + why>`.
@@ -135,7 +140,7 @@ transform = "compact"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Analyze findings, cross-reference claims, and decide the next move"
-available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
+available_tools = ["read_file", "web_fetch", "context_write", "context_append", "current_time"]
 max_iterations = 20
 max_revisits = 3
 transition_prompt = """
@@ -186,7 +191,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Pull and read specific cited sources flagged during analysis"
-available_tools = ["web_fetch", "web_search", "read_file", "context_append"]
+available_tools = ["web_fetch", "web_search", "read_file", "context_append", "current_time"]
 max_iterations = 12
 max_revisits = 3
 system_prompt = """
@@ -302,6 +307,7 @@ is worse than no summary.
 [context.regions]
 query          = { kind = "pinned", budget = "1%", max_tokens = 1500, required = true, seed = "task", required_message = "State the research topic via --task.", volatility = "stable" }
 scope          = { kind = "pinned", budget = "1%", max_tokens = 1500, seed = "scope", volatility = "stable" }
+environment    = { kind = "pinned", budget = "1%", max_tokens = 600, seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
 sources_index  = { kind = "pinned", budget = "4%", max_tokens = 4000, volatility = "grows" }
 format         = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Mark each key finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
 

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.0.3"
+version = "0.1.0"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
@@ -10,6 +10,7 @@ read_file  = "allow"
 list_dir   = "allow"
 web_search = "allow"
 web_fetch  = "allow"
+current_time = "allow"
 write_file = "ask"
 bash       = "ask"
 
@@ -19,7 +20,7 @@ mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather relevant information on the topic"
 # web_search / web_fetch are provided by the agent's script tools (issue #97).
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time"]
 max_iterations = 8
 max_revisits = 2
 system_prompt = """
@@ -35,6 +36,11 @@ Be efficient - do not search exhaustively:
    `sources_index` region with context_append:
    `[n] <title> - <url or path> - credibility: <high/med/low + why>`.
 
+
+Today's date is in the `environment` region. Treat it as authoritative over
+anything you remember: your training has a cutoff and this run does not. Judge
+"recent", "current" and "latest" against it, and note how old a source is when
+its age bears on the claim. Call current_time if you need the clock again.
 Prefer primary sources and well-established outlets; note when something is a blog,
 forum, or vendor claim. Once you have solid coverage of the sub-topics, transition
 to analyze - don't keep searching for marginal additions. The analyze stage will
@@ -67,7 +73,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Analyze and synthesize findings"
-available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
+available_tools = ["read_file", "web_fetch", "context_write", "context_append", "current_time"]
 max_iterations = 20
 max_revisits = 3
 transition_prompt = """
@@ -193,6 +199,7 @@ query          = { kind = "pinned", budget = "1%", max_tokens = 1000, required =
 # Optional caller bounds: --scope "peer-reviewed sources since 2020 only".
 scope          = { kind = "pinned", budget = "1%", max_tokens = 1000, seed = "scope", volatility = "stable" }
 # Growing bibliography with credibility notes (curated by the agent).
+environment    = { kind = "pinned", budget = "1%", max_tokens = 600, seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
 sources_index  = { kind = "pinned", budget = "3%", max_tokens = 3000, volatility = "grows" }
 # Citation/confidence rules (seeded with a sensible default the agent follows).
 format         = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Mark each finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.1.1"
+version = "0.2.0"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 
@@ -9,6 +9,7 @@ read_file  = "allow"
 list_dir   = "allow"
 web_search = "allow"
 web_fetch  = "allow"
+current_time = "allow"
 write_file = "ask"
 bash       = "ask"
 
@@ -17,7 +18,7 @@ bash       = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Survey the landscape across multiple sub-topics"
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time"]
 max_iterations = 25
 max_revisits = 2
 system_prompt = """
@@ -32,6 +33,11 @@ For each source you use, append a bibliography line to `sources_index`
 (context_append): `[n] <title> - <url/path> - credibility: <high/med/low>`.
 Note interesting threads worth pulling on later. If sent back, focus on the named
 coverage gap.
+
+Today's date is in the `environment` region. Treat it as authoritative over
+anything you remember: your training has a cutoff and this run does not. Judge
+"recent", "current", "active" and "state of the art" against it, and note how
+old a source is when its age bears on the claim. Call current_time for the clock.
 """
 
 [stages.survey.tool_routing]
@@ -128,7 +134,7 @@ transform = "compact"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Compare and contrast approaches across the landscape"
-available_tools = ["read_file", "web_fetch", "context_write", "context_append"]
+available_tools = ["read_file", "web_fetch", "context_write", "context_append", "current_time"]
 max_iterations = 15
 max_revisits = 2
 transition_prompt = """
@@ -175,7 +181,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Focused deep read on one interesting thread flagged during comparison"
-available_tools = ["web_search", "web_fetch", "read_file", "context_append"]
+available_tools = ["web_search", "web_fetch", "read_file", "context_append", "current_time"]
 max_iterations = 12
 max_revisits = 2
 system_prompt = """
@@ -288,6 +294,7 @@ file you wrote.
 [context.regions]
 query              = { kind = "pinned", budget = "1%", max_tokens = 1000, required = true, seed = "task", required_message = "State the survey topic/area via --task.", volatility = "stable" }
 scope              = { kind = "pinned", budget = "1%", max_tokens = 1500, seed = "scope", volatility = "stable" }
+environment        = { kind = "pinned", budget = "1%", max_tokens = 600, seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
 sources_index      = { kind = "pinned", budget = "3%", max_tokens = 4000, volatility = "grows" }
 format             = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Prefer comparison tables where they clarify tradeoffs." }, volatility = "stable" }
 

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -15,6 +15,7 @@ pub mod recovery;
 pub mod sandbox_manager;
 pub mod script_host;
 pub mod seed_command;
+pub mod seed_tool;
 pub mod setup;
 pub mod spawn;
 pub mod subagent;

--- a/crates/leviath-cli/src/daemon/seed_tool.rs
+++ b/crates/leviath-cli/src/daemon/seed_tool.rs
@@ -1,0 +1,507 @@
+//! Execution of `seed = { tools = [...] }` region seeds.
+//!
+//! A tool seed calls the run's own tools at spawn and writes their combined
+//! output into a context region, so an agent starts its first inference already
+//! knowing what the tools would have told it. The motivating case is the clock:
+//! a research agent that cannot ask the date reasons from its training cutoff,
+//! and a tool it is never prompted to call does not help.
+//!
+//! # Why any tool is allowed here
+//!
+//! Unlike a `command` seed, which runs a shell line and therefore needs the
+//! `[safe_commands]` list and the `allow_seed_commands` switch to hem it in, a
+//! tool seed reaches nothing new: every call goes through
+//! [`crate::tools::resolve_policy`], the same resolution the tool lane applies
+//! mid-run, so a user's `[tool_permissions]` decides exactly as it would there.
+//! A seed cannot call what the agent could not call.
+//!
+//! That is what lets the list be open. A built-in, an MCP server's tool, a Rhai
+//! script tool - all are callable, spelled as the agent would spell them.
+//!
+//! # Why `ask` cannot run
+//!
+//! A seed runs before the first inference and therefore before any approval
+//! prompt exists; there is nobody to ask. Rather than silently escalating an
+//! `ask` to an allow (which would make seeding a way around the permission
+//! layer) or blocking forever, an `ask` tool is refused with a message naming
+//! the setting that would let it run. `allow` runs, `deny` is refused, and both
+//! read the same as they would mid-run.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use leviath_core::layout::SeedToolCall;
+
+use crate::config::ToolPolicy;
+
+/// Runs one seeded tool call: `(name, args) -> result text`.
+///
+/// Injected rather than called directly so every failure arm is testable
+/// without a live MCP connection or a compiled Rhai engine. Mirrors
+/// [`crate::daemon::seed_command::SeedCommandRunner`].
+pub type SeedToolRunner =
+    Arc<dyn Fn(&str, &serde_json::Value) -> Result<String, String> + Send + Sync>;
+
+/// How tool seeds are executed for one spawn.
+#[derive(Clone)]
+pub struct SeedToolPolicy {
+    /// The executor.
+    pub runner: SeedToolRunner,
+}
+
+impl SeedToolPolicy {
+    /// A policy over an explicit runner.
+    pub fn new(runner: SeedToolRunner) -> Self {
+        Self { runner }
+    }
+
+    /// A policy that runs nothing - the reload/restore path, where the window is
+    /// restored from a snapshot and re-running seeds would overwrite it.
+    pub fn disabled() -> Self {
+        Self {
+            runner: Arc::new(|name, _| Err(format!("tool seeds are not resolved here ('{name}')"))),
+        }
+    }
+
+    /// Run `call`, or report why it did not.
+    pub fn run(&self, call: &SeedToolCall) -> Result<String, String> {
+        (self.runner)(&call.name, &call.args)
+    }
+}
+
+/// Whether a seed may run `policy`, and what to say when it may not.
+///
+/// Separated from the running so the decision is testable on its own, and so
+/// the refusal text is written once rather than at each call site.
+pub fn seed_policy_refusal(name: &str, policy: ToolPolicy) -> Option<String> {
+    match policy {
+        ToolPolicy::Allow => None,
+        ToolPolicy::Deny => Some(format!(
+            "tool '{name}' is denied by `[tool_permissions]`, so it cannot seed a region"
+        )),
+        ToolPolicy::Ask => Some(format!(
+            "tool '{name}' is set to `ask`, and a seed runs before the first inference - \
+             there is nobody to prompt. Set `[tool_permissions] {name} = \"allow\"` if this \
+             agent is meant to call it at spawn."
+        )),
+    }
+}
+
+/// Render one call's result as the block that goes into the region.
+///
+/// Headed with the tool's name, following the `--- <path> ---` headings the
+/// `files` and `glob` seeds already use, so a region seeded from several
+/// sources reads the same however it was filled.
+pub fn seed_block(name: &str, result: &str) -> String {
+    format!("--- {name} ---\n{}", result.trim_end())
+}
+
+/// Join the blocks of one region's seed.
+pub fn join_blocks(blocks: Vec<String>) -> Option<String> {
+    (!blocks.is_empty()).then(|| blocks.join("\n\n"))
+}
+
+/// The policy layers a seed resolves each call against.
+///
+/// Borrowed from the spawn path rather than rebuilt, so a seed and a mid-run
+/// call cannot disagree about what the user configured.
+pub struct SeedToolPermissions<'a> {
+    /// `--allow` / `--ask` / `--deny` / `--yolo` for this run.
+    pub launch: &'a HashMap<String, ToolPolicy>,
+    /// The entry stage's `[stages.<name>.tool_permissions]`.
+    pub stage: &'a HashMap<String, String>,
+    /// The agent's `[tool_permissions]`.
+    pub agent: &'a HashMap<String, String>,
+    /// The user's `config.toml` `[tool_permissions]`.
+    pub global: &'a HashMap<String, ToolPolicy>,
+    /// Whether this blueprint may loosen a tool below its built-in default.
+    pub may_loosen: bool,
+}
+
+impl SeedToolPermissions<'_> {
+    /// The resolved policy for `name`.
+    pub fn resolve(&self, name: &str, is_builtin: bool) -> ToolPolicy {
+        crate::tools::resolve_policy(
+            name,
+            is_builtin,
+            self.launch,
+            self.stage,
+            self.agent,
+            self.global,
+            self.may_loosen,
+        )
+    }
+}
+
+/// Everything the production runner needs to answer one seeded call.
+///
+/// Cloned into the closure rather than borrowed, because the runner outlives
+/// the borrow of the spawn locals it is built from.
+pub struct SeedToolContext {
+    /// The agent's built-in tools, over its workdir.
+    pub builtins: Arc<leviath_tools::BuiltinTools>,
+    /// Which names dispatch to `builtins` rather than to MCP.
+    pub builtin_names: std::collections::HashSet<String>,
+    /// The agent's compiled Rhai tools.
+    pub script_tools: leviath_scripting::ScriptToolSet,
+    /// The host those scripts run against.
+    pub script_host: Arc<dyn leviath_scripting::ScriptHost>,
+    /// The shared MCP executor.
+    pub mcp: Arc<tokio::sync::Mutex<leviath_mcp::ToolExecutor>>,
+}
+
+/// Decides one seeded call's policy: `(tool name, is_builtin) -> policy`.
+///
+/// A closure rather than [`SeedToolPermissions`] itself, so the spawn path can
+/// hand over the layered resolution it already built without this module
+/// learning its shape or borrowing its four maps for the runner's lifetime.
+pub type SeedPolicyResolver = Arc<dyn Fn(&str, bool) -> ToolPolicy + Send + Sync>;
+
+/// Build the runner a real spawn uses.
+///
+pub fn production_runner(ctx: SeedToolContext, resolve: SeedPolicyResolver) -> SeedToolRunner {
+    Arc::new(move |name: &str, args: &serde_json::Value| {
+        let is_builtin = ctx.builtin_names.contains(name);
+        if let Some(refusal) = seed_policy_refusal(name, resolve(name, is_builtin)) {
+            return Err(refusal);
+        }
+        // A script tool is checked first, exactly as the tool lane checks it
+        // first, so a discovered `.rhai` dispatches to the engine. The Rhai
+        // engine is synchronous, so this branch needs no runtime at all.
+        if let Some(tool) = ctx.script_tools.get(name) {
+            return Ok(leviath_scripting::execute_script_tool(
+                tool,
+                args.clone(),
+                ctx.script_host.clone(),
+            ));
+        }
+        match is_builtin {
+            true => block_on_daemon(ctx.builtins.execute(name, args.clone())),
+            false => {
+                let mcp = ctx.mcp.clone();
+                let name = name.to_string();
+                let args = args.clone();
+                block_on_daemon(async move {
+                    let mut mcp = mcp.lock().await;
+                    mcp_text(mcp.execute(&name, args).await)
+                })
+            }
+        }
+    })
+}
+
+/// What an MCP call reports back, as the seed records it.
+///
+/// A named function rather than arms inside the call, because covering those
+/// arms in place would mean spawning a real MCP server: here the same three
+/// outcomes are ordinary values. A tool that ran and said it failed is an
+/// `[error]` just as much as one that could not be reached - the seed treats
+/// both as "no block", and the model never sees a failure dressed as data.
+fn mcp_text(result: anyhow::Result<leviath_mcp::execution::ExecutionResult>) -> String {
+    match result {
+        Ok(r) if r.success => r.text,
+        Ok(r) => format!("[error] {}", r.text),
+        Err(e) => format!("[error] tool error: {e}"),
+    }
+}
+
+/// Await `fut` from the synchronous spawn path.
+///
+/// The spawn path is sync and is called from inside the daemon's runtime (the
+/// fan-out spawner runs it from an ECS system), so neither `block_on` on the
+/// current handle nor a second runtime on this thread is allowed. `block_in_place`
+/// moves this thread out of the scheduler for the duration and lets the handle
+/// drive the future *on the daemon's own runtime* - which matters for MCP,
+/// whose transports have tasks living there. A fresh runtime would leave those
+/// tasks unpolled and the call would simply hang.
+///
+/// Without an ambient runtime - a unit test calling the runner directly - a
+/// current-thread runtime is correct and sufficient, because a built-in tool
+/// awaits nothing that belongs to another reactor.
+fn block_on_daemon<F>(fut: F) -> Result<String, String>
+where
+    F: std::future::Future<Output = String> + Send,
+{
+    match tokio::runtime::Handle::try_current() {
+        Ok(handle) => Ok(tokio::task::block_in_place(|| handle.block_on(fut))),
+        // Building a current-thread runtime with none already present fails
+        // only on OS resource exhaustion, at which point the spawn this seed
+        // belongs to is doomed anyway - the same stance `run_seed_command`
+        // takes, and for the same reason.
+        Err(_) => Ok(tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("a current-thread runtime for a seed call always builds")
+            .block_on(fut)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_allowed_tool_has_nothing_to_refuse() {
+        assert_eq!(seed_policy_refusal("current_time", ToolPolicy::Allow), None);
+    }
+
+    /// A denied tool is refused in the seed exactly as it would be mid-run: the
+    /// point of routing seeds through policy resolution is that a configured
+    /// `deny` is terminal everywhere, not only where a model asked.
+    #[test]
+    fn a_denied_tool_says_so() {
+        let refusal = seed_policy_refusal("shell", ToolPolicy::Deny).expect("refused");
+        assert!(refusal.contains("shell"));
+        assert!(refusal.contains("denied"));
+    }
+
+    /// The interesting one. There is nobody to prompt at spawn, so `ask` cannot
+    /// quietly become an allow - that would make a tool seed a way around the
+    /// permission layer for any tool a blueprint chose to name.
+    #[test]
+    fn an_ask_tool_is_refused_and_names_the_setting_that_would_let_it_run() {
+        let refusal = seed_policy_refusal("write_file", ToolPolicy::Ask).expect("refused");
+        assert!(refusal.contains("nobody to prompt"), "{refusal}");
+        assert!(
+            refusal.contains("write_file = \"allow\""),
+            "the fix is spelled out: {refusal}"
+        );
+    }
+
+    #[test]
+    fn a_block_is_headed_with_the_tool_that_produced_it() {
+        assert_eq!(
+            seed_block("current_time", "{\"utc\": \"2026-08-18T19:32:07Z\"}"),
+            "--- current_time ---\n{\"utc\": \"2026-08-18T19:32:07Z\"}"
+        );
+        // Trailing whitespace is dropped so the join spaces blocks evenly
+        // however a tool chose to end its output.
+        assert_eq!(seed_block("t", "x\n\n\n"), "--- t ---\nx");
+    }
+
+    #[test]
+    fn blocks_join_with_a_blank_line_and_nothing_joins_to_nothing() {
+        assert_eq!(
+            join_blocks(vec!["--- a ---\n1".into(), "--- b ---\n2".into()]),
+            Some("--- a ---\n1\n\n--- b ---\n2".to_string())
+        );
+        assert_eq!(
+            join_blocks(vec!["--- a ---\n1".into()]),
+            Some("--- a ---\n1".to_string())
+        );
+        // Every call having failed leaves the region unseeded rather than
+        // holding an empty string, which reads downstream as content.
+        assert_eq!(join_blocks(Vec::new()), None);
+    }
+
+    #[test]
+    fn a_disabled_policy_runs_nothing_and_names_the_tool_it_skipped() {
+        let policy = SeedToolPolicy::disabled();
+        let err = policy
+            .run(&SeedToolCall::new("current_time"))
+            .expect_err("disabled");
+        assert!(err.contains("current_time"), "{err}");
+    }
+
+    /// The runner really is the seam: what it answers is what the seed records,
+    /// and the arguments reach it unchanged.
+    #[test]
+    fn the_injected_runner_receives_the_call_as_written() {
+        let policy = SeedToolPolicy::new(Arc::new(|name, args| Ok(format!("{name}:{args}"))));
+        let call =
+            SeedToolCall::with_args("which_command", serde_json::json!({ "command": "git" }));
+        assert_eq!(
+            policy.run(&call).expect("ran"),
+            "which_command:{\"command\":\"git\"}"
+        );
+        // A call with no arguments carries an empty object, not a null.
+        assert_eq!(
+            policy.run(&SeedToolCall::new("current_time")).expect("ran"),
+            "current_time:{}"
+        );
+    }
+
+    /// A server that ran the tool and reported failure is not data. Reporting
+    /// its text plainly would put a diagnostic into the region under a heading
+    /// that says the tool answered.
+    #[test]
+    fn an_mcp_failure_is_marked_as_one_however_it_failed() {
+        let ok = leviath_mcp::execution::ExecutionResult {
+            success: true,
+            data: serde_json::Value::Null,
+            text: "the answer".to_string(),
+        };
+        assert_eq!(mcp_text(Ok(ok)), "the answer");
+
+        let failed = leviath_mcp::execution::ExecutionResult {
+            success: false,
+            data: serde_json::Value::Null,
+            text: "no such record".to_string(),
+        };
+        assert_eq!(mcp_text(Ok(failed)), "[error] no such record");
+
+        let unreachable = mcp_text(Err(anyhow::anyhow!("connection refused")));
+        assert_eq!(unreachable, "[error] tool error: connection refused");
+    }
+
+    // ── the production runner ────────────────────────────────────────────
+
+    /// A context whose script set and MCP executor are empty, so a call falls
+    /// through to the built-ins. `dir` is the agent's workdir.
+    fn ctx_over(
+        dir: &std::path::Path,
+        scripts: leviath_scripting::ScriptToolSet,
+    ) -> SeedToolContext {
+        let builtins = Arc::new(leviath_tools::BuiltinTools::new(
+            leviath_tools::ToolContext::new(dir.to_path_buf()),
+        ));
+        let builtin_names = builtins.names().into_iter().collect();
+        SeedToolContext {
+            builtins,
+            builtin_names,
+            script_tools: scripts,
+            script_host: Arc::new(crate::daemon::script_host::DaemonScriptHost::new(
+                // Nothing the seeded script needs here: the tool under test
+                // computes its answer without reaching the network, the shell
+                // or the filesystem.
+                crate::daemon::script_host::ScriptAllow {
+                    http_get: false,
+                    http_post: false,
+                    shell: false,
+                    read_file: false,
+                    write_file: false,
+                    env_var: false,
+                },
+                dir.to_path_buf(),
+            )),
+            mcp: Arc::new(tokio::sync::Mutex::new(leviath_mcp::ToolExecutor::new())),
+        }
+    }
+
+    /// Every call allowed, which is what an unconfigured environment tool
+    /// already resolves to.
+    fn allow_all() -> SeedPolicyResolver {
+        Arc::new(|_, _| ToolPolicy::Allow)
+    }
+
+    /// No ambient runtime: `block_on_daemon` builds one of its own, which is
+    /// the branch a plain `#[test]` takes and a `lev run` without a daemon
+    /// would take too.
+    #[test]
+    fn a_builtin_seeds_without_an_ambient_runtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = production_runner(ctx_over(dir.path(), Default::default()), allow_all());
+        let out = runner("current_time", &serde_json::json!({})).expect("ran");
+        let v: serde_json::Value = serde_json::from_str(&out).expect("the tool's JSON");
+        assert!(v["utc"].as_str().is_some(), "{out}");
+    }
+
+    /// Inside the daemon's runtime the call must be driven on *that* runtime -
+    /// a second one would leave an MCP transport's tasks unpolled and the call
+    /// would hang. Multi-thread because `block_in_place` requires it, which is
+    /// what the daemon actually runs.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_builtin_seeds_on_the_daemons_own_runtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = production_runner(ctx_over(dir.path(), Default::default()), allow_all());
+        let out = runner("system_info", &serde_json::json!({})).expect("ran");
+        let v: serde_json::Value = serde_json::from_str(&out).expect("the tool's JSON");
+        assert_eq!(v["os"], std::env::consts::OS);
+    }
+
+    /// The policy gate runs before anything else, so a denied tool is never
+    /// executed - not executed and then discarded.
+    #[test]
+    fn a_denied_tool_is_refused_before_it_runs() {
+        let dir = tempfile::tempdir().unwrap();
+        let refuse: SeedPolicyResolver = Arc::new(|_, _| ToolPolicy::Deny);
+        let runner = production_runner(ctx_over(dir.path(), Default::default()), refuse);
+        let err = runner("current_time", &serde_json::json!({})).expect_err("refused");
+        assert!(err.contains("denied"), "{err}");
+        // An `ask` is refused too, for want of anyone to ask.
+        let ask: SeedPolicyResolver = Arc::new(|_, _| ToolPolicy::Ask);
+        let runner = production_runner(ctx_over(dir.path(), Default::default()), ask);
+        let err = runner("current_time", &serde_json::json!({})).expect_err("refused");
+        assert!(err.contains("nobody to prompt"), "{err}");
+    }
+
+    /// Whether a name is a built-in is what the resolver is told, and it is the
+    /// question `default_tool_policy` turns on for an unknown tool.
+    #[test]
+    fn the_resolver_is_told_whether_the_name_is_a_builtin() {
+        let dir = tempfile::tempdir().unwrap();
+        let seen = Arc::new(std::sync::Mutex::new(Vec::<(String, bool)>::new()));
+        let captured = seen.clone();
+        let resolver: SeedPolicyResolver = Arc::new(move |name: &str, is_builtin: bool| {
+            captured
+                .lock()
+                .unwrap()
+                .push((name.to_string(), is_builtin));
+            ToolPolicy::Deny
+        });
+        let runner = production_runner(ctx_over(dir.path(), Default::default()), resolver);
+        let _ = runner("current_time", &serde_json::json!({}));
+        let _ = runner("acme__thing", &serde_json::json!({}));
+        assert_eq!(
+            seen.lock().unwrap().as_slice(),
+            [
+                ("current_time".to_string(), true),
+                ("acme__thing".to_string(), false),
+            ]
+        );
+    }
+
+    /// A Rhai script tool is checked before the built-ins, exactly as the tool
+    /// lane checks it first, and runs synchronously - no runtime involved.
+    #[test]
+    fn a_script_tool_seeds_through_the_rhai_engine() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools_dir = dir.path().join("tools");
+        std::fs::create_dir(&tools_dir).unwrap();
+        std::fs::write(
+            tools_dir.join("greet.rhai"),
+            "// @tool greet
+// @param who string required Who to greet
+`hello ` + params.who",
+        )
+        .unwrap();
+        let (set, skipped) = leviath_scripting::ScriptToolSet::discover(&[tools_dir]);
+        assert!(skipped.is_empty(), "{skipped:?}");
+        let runner = production_runner(ctx_over(dir.path(), set), allow_all());
+        let out = runner("greet", &serde_json::json!({ "who": "world" })).expect("ran");
+        assert!(out.contains("hello world"), "{out}");
+    }
+
+    /// A name that is neither a built-in nor a script is an MCP tool. With no
+    /// server connected there is nothing to answer it, and that comes back as a
+    /// tool error rather than a panic or a hang.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn an_unconnected_mcp_tool_reports_an_error_rather_than_hanging() {
+        let dir = tempfile::tempdir().unwrap();
+        let runner = production_runner(ctx_over(dir.path(), Default::default()), allow_all());
+        let out = runner("acme__do_thing", &serde_json::json!({})).expect("answered");
+        assert!(out.starts_with("[error]"), "{out}");
+    }
+
+    #[test]
+    fn permissions_resolve_through_the_same_path_the_tool_lane_uses() {
+        let launch = HashMap::new();
+        let stage = HashMap::new();
+        let agent = HashMap::new();
+        let mut global = HashMap::new();
+        global.insert("current_time".to_string(), ToolPolicy::Deny);
+        let perms = SeedToolPermissions {
+            launch: &launch,
+            stage: &stage,
+            agent: &agent,
+            global: &global,
+            may_loosen: false,
+        };
+        // The user's config is honoured at seed time, not only mid-run.
+        assert_eq!(perms.resolve("current_time", true), ToolPolicy::Deny);
+        // And an unconfigured environment tool keeps its built-in `allow`.
+        assert_eq!(perms.resolve("system_info", true), ToolPolicy::Allow);
+        // While a mutating one still defaults to `ask`, which a seed refuses.
+        assert_eq!(perms.resolve("write_file", true), ToolPolicy::Ask);
+    }
+}

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -624,6 +624,74 @@ fn build_agent_inner(
         .first()
         .map(|s| format!("{}/{}", s.provider_name, s.model));
 
+    // The tool-permission layers and the Rhai script host, resolved here
+    // rather than beside the tool-state registration below because a
+    // `seed = { tools = [...] }` needs them: a seeded call answers to the
+    // same policy a mid-run call does, and a seeded *script* tool needs the
+    // host it would run under. Everything they read is already bound.
+    // Launch overrides: `--yolo` allows every tool (`*` wildcard); `--allow X`
+    // allows tool `X` outright.
+    let mut launch_overrides: HashMap<String, crate::config::ToolPolicy> = HashMap::new();
+    if args.yolo {
+        launch_overrides.insert("*".to_string(), crate::config::ToolPolicy::Allow);
+    }
+    for tool in &args.allow {
+        launch_overrides.insert(tool.clone(), crate::config::ToolPolicy::Allow);
+    }
+    // Rhai script-tool host (Layer 3): resolve `[tool_script_permissions]` once,
+    // with `read_file`/`shell` `inherit` deferring to the agent's own resolved
+    // policy for that built-in (evaluated against the entry stage).
+    let entry_stage_perms = stage_perms_by_index
+        .get(entry_index)
+        .cloned()
+        .unwrap_or_default();
+    // The agent may carry its own `[tool_script_permissions]` (it can ship its own
+    // tool scripts), overlaid per field on the global deps.config.
+    let effective_script_perms = crate::daemon::script_host::effective_script_permissions(
+        &deps.config.tool_script_permissions,
+        &content,
+    );
+    // Same ceiling `build_tool_state` resolves for the built-in tools: the
+    // global `[tool_permissions]` with this agent's `[agent_tool_permissions]`
+    // grants overlaid. Passing the raw global map here would silently ignore a
+    // per-agent grant when a script tool's `inherit` defers to the built-in.
+    let agent_scoped_perms = deps.config.permissions_for_agent(&agent_name);
+    let script_allow = crate::daemon::script_host::resolve_script_permissions(
+        &effective_script_perms,
+        &|builtin| {
+            crate::tools::resolve_policy(
+                builtin,
+                true,
+                &launch_overrides,
+                &entry_stage_perms,
+                &agent_perms,
+                &agent_scoped_perms,
+                deps.config.security.allow_blueprint_permissions,
+            )
+        },
+    );
+    let script_host: Arc<dyn leviath_scripting::ScriptHost> = Arc::new(
+        crate::daemon::script_host::DaemonScriptHost::new(
+            script_allow,
+            std::path::PathBuf::from(&args.workdir),
+        )
+        // Route a script `shell()` through the agent's per-stage sandbox (so a
+        // script can't escape the isolation the stage declared) and cap it at the
+        // configured wall-clock timeout.
+        .with_shell(
+            sandbox.clone(),
+            std::time::Duration::from_secs(deps.config.limits.script_shell_timeout_secs),
+            shell_env_policy(deps.config),
+        )
+        // `[security] allow_local_network`. Off by default, so a `web_fetch` URL
+        // the model picked out of attacker-influenced context cannot reach cloud
+        // metadata, the user's own `lev serve`, or their LAN.
+        .with_local_network(deps.config.security.allow_local_network)
+        // `[security] allow_env_vars`. Empty by default, so a script tool cannot
+        // read the user's provider keys and post them somewhere.
+        .with_env_allowlist(deps.config.security.allow_env_vars.clone()),
+    );
+
     // 5. Resolve region seeds (caller input + blueprint-declared sources) into
     // concrete content. On a fresh spawn (`enforce_seeds`), required caller-input
     // regions that weren't provided fail here - before any inference, so no
@@ -648,7 +716,43 @@ fn build_agent_inner(
             sandbox.clone(),
             shell_env_policy(deps.config),
         );
-        resolve_seeds(&blueprint, args, &args.workdir, &policy, &seed_read_paths)?
+        // A tool seed answers to the same layered resolution the tool lane
+        // applies mid-run, so a user's `[tool_permissions]` counts at spawn
+        // too - and a seed can reach nothing the agent could not reach.
+        let seed_launch = launch_overrides.clone();
+        let seed_stage = entry_stage_perms.clone();
+        let seed_agent = agent_perms.clone();
+        let seed_global = agent_scoped_perms.clone();
+        let seed_may_loosen = deps.config.security.allow_blueprint_permissions;
+        let tool_policy = crate::daemon::seed_tool::SeedToolPolicy::new(
+            crate::daemon::seed_tool::production_runner(
+                crate::daemon::seed_tool::SeedToolContext {
+                    builtins: builtins.clone(),
+                    builtin_names: builtin_names.clone(),
+                    script_tools: script_tools.clone(),
+                    script_host: script_host.clone(),
+                    mcp: deps.shared_mcp.clone(),
+                },
+                Arc::new(move |name: &str, is_builtin: bool| {
+                    crate::daemon::seed_tool::SeedToolPermissions {
+                        launch: &seed_launch,
+                        stage: &seed_stage,
+                        agent: &seed_agent,
+                        global: &seed_global,
+                        may_loosen: seed_may_loosen,
+                    }
+                    .resolve(name, is_builtin)
+                }),
+            ),
+        );
+        resolve_seeds(
+            &blueprint,
+            args,
+            &args.workdir,
+            &policy,
+            &tool_policy,
+            &seed_read_paths,
+        )?
     } else {
         HashMap::new()
     };
@@ -728,15 +832,6 @@ fn build_agent_inner(
     );
 
     // 8. Register the per-agent tool state.
-    // Launch overrides: `--yolo` allows every tool (`*` wildcard); `--allow X`
-    // allows tool `X` outright.
-    let mut launch_overrides: HashMap<String, crate::config::ToolPolicy> = HashMap::new();
-    if args.yolo {
-        launch_overrides.insert("*".to_string(), crate::config::ToolPolicy::Allow);
-    }
-    for tool in &args.allow {
-        launch_overrides.insert(tool.clone(), crate::config::ToolPolicy::Allow);
-    }
     let subagent = SubAgentHandle {
         sender: deps.subagent_tx,
         parent_run_id: args.run_id.clone(),
@@ -745,59 +840,6 @@ fn build_agent_inner(
         no_seed_commands: args.no_seed_commands,
         unattended: args.yolo,
     };
-    // Rhai script-tool host (Layer 3): resolve `[tool_script_permissions]` once,
-    // with `read_file`/`shell` `inherit` deferring to the agent's own resolved
-    // policy for that built-in (evaluated against the entry stage).
-    let entry_stage_perms = stage_perms_by_index
-        .get(entry_index)
-        .cloned()
-        .unwrap_or_default();
-    // The agent may carry its own `[tool_script_permissions]` (it can ship its own
-    // tool scripts), overlaid per field on the global deps.config.
-    let effective_script_perms = crate::daemon::script_host::effective_script_permissions(
-        &deps.config.tool_script_permissions,
-        &content,
-    );
-    // Same ceiling `build_tool_state` resolves for the built-in tools: the
-    // global `[tool_permissions]` with this agent's `[agent_tool_permissions]`
-    // grants overlaid. Passing the raw global map here would silently ignore a
-    // per-agent grant when a script tool's `inherit` defers to the built-in.
-    let agent_scoped_perms = deps.config.permissions_for_agent(&agent_name);
-    let script_allow = crate::daemon::script_host::resolve_script_permissions(
-        &effective_script_perms,
-        &|builtin| {
-            crate::tools::resolve_policy(
-                builtin,
-                true,
-                &launch_overrides,
-                &entry_stage_perms,
-                &agent_perms,
-                &agent_scoped_perms,
-                deps.config.security.allow_blueprint_permissions,
-            )
-        },
-    );
-    let script_host: Arc<dyn leviath_scripting::ScriptHost> = Arc::new(
-        crate::daemon::script_host::DaemonScriptHost::new(
-            script_allow,
-            std::path::PathBuf::from(&args.workdir),
-        )
-        // Route a script `shell()` through the agent's per-stage sandbox (so a
-        // script can't escape the isolation the stage declared) and cap it at the
-        // configured wall-clock timeout.
-        .with_shell(
-            sandbox.clone(),
-            std::time::Duration::from_secs(deps.config.limits.script_shell_timeout_secs),
-            shell_env_policy(deps.config),
-        )
-        // `[security] allow_local_network`. Off by default, so a `web_fetch` URL
-        // the model picked out of attacker-influenced context cannot reach cloud
-        // metadata, the user's own `lev serve`, or their LAN.
-        .with_local_network(deps.config.security.allow_local_network)
-        // `[security] allow_env_vars`. Empty by default, so a script tool cannot
-        // read the user's provider keys and post them somewhere.
-        .with_env_allowlist(deps.config.security.allow_env_vars.clone()),
-    );
     // Build the dynamic-tools re-resolution context (issue #97 escape hatch) and
     // tag the entity `DynamicTools` so the runtime polls it for mid-run re-scans.
     let dynamic = dynamic_tools.then(|| {
@@ -1581,6 +1623,86 @@ system = { kind = "pinned", max_tokens = 1000 }
             assert!(err.contains("workspace"), "got: {err}");
             assert!(err.contains(&workdir), "got: {err}");
         }
+    }
+
+    /// A real spawn, end to end: the blueprint seeds a region from a tool, and
+    /// the region the agent starts with holds that tool's answer.
+    ///
+    /// The unit tests above drive `resolve_seeds` with a stub runner, so they
+    /// prove the shape but not the wiring. What this one covers is the wiring:
+    /// that the spawn path builds a runner over the agent's real tools, that
+    /// the policy layers reach it, and that the result lands in the window
+    /// rather than in a map nobody reads.
+    ///
+    /// Multi-thread because the seeded call is awaited on the ambient runtime -
+    /// see `block_on_daemon`, which is what a daemon spawn does too.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn build_agent_seeds_a_region_from_a_real_tool_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            "[agent]\nname = \"seeded\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\n\
+             [stages.main]\nmodel = { provider = \"anthropic\", model = \"m\" }\n\n\
+             [context.regions]\n\
+             task = { kind = \"pinned\", max_tokens = 4000, seed = \"task_input\" }\n\
+             environment = { kind = \"pinned\", max_tokens = 1000, \
+             seed = { tools = [\"current_time\", \"locale_info\"] } }\n",
+        )
+        .unwrap();
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
+        let mut args = spawn_args(&manifest.to_string_lossy());
+        args.workdir = dir.path().to_string_lossy().to_string();
+        let entity = build_agent(
+            world.world_mut(),
+            SpawnDeps {
+                tool_service: cli.as_ref(),
+                config: &Config::default(),
+                shared_mcp: mcp,
+                mcp_tool_defs: &[],
+                mcp_tool_owners: &Default::default(),
+                hub: &hub,
+                now_secs: 100,
+                subagent_tx: sub_tx(),
+            },
+            &args,
+        )
+        .expect("spawn succeeds");
+
+        let window = world
+            .world()
+            .get::<leviath_runtime::components::ContextWindow>(entity)
+            .expect("the agent has a window");
+        let region = window
+            .regions
+            .iter()
+            .find(|r| r.name == "environment")
+            .expect("the seeded region exists");
+        let content: String = region
+            .content
+            .iter()
+            .map(|e| e.content.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        // Both calls ran, each under its own heading.
+        assert!(content.contains("--- current_time ---"), "{content}");
+        assert!(content.contains("--- locale_info ---"), "{content}");
+        // And it is the tool's real answer, not a placeholder: the clock's
+        // reading parses back as the instant it claims to be.
+        let (_, after) = content
+            .split_once("--- current_time ---")
+            .expect("the clock block");
+        let (json, _) = after
+            .split_once("--- locale_info ---")
+            .unwrap_or((after, ""));
+        let v: serde_json::Value =
+            serde_json::from_str(json.trim()).expect("the clock answered with JSON");
+        assert!(
+            chrono::DateTime::parse_from_rfc3339(v["utc"].as_str().expect("utc")).is_ok(),
+            "{json}"
+        );
     }
 
     #[tokio::test]
@@ -3389,6 +3511,13 @@ conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
 
     /// A blueprint that declares no `[read_paths]`, which is the normal case
     /// and the one where seed paths are confined to the workdir outright.
+    /// A tool-seed policy that runs nothing, for the seed tests that are about
+    /// the other seed kinds. A `{ tools = [...] }` seed under it fails every
+    /// call, which is the same shape as a tool that is not installed.
+    fn no_seed_tools() -> crate::daemon::seed_tool::SeedToolPolicy {
+        crate::daemon::seed_tool::SeedToolPolicy::disabled()
+    }
+
     fn no_read_paths() -> leviath_core::ReadPathPolicy {
         leviath_core::ReadPathPolicy {
             agent: "a".to_string(),
@@ -3420,7 +3549,15 @@ criteria = { kind = "pinned", max_tokens = 2000, seed = "input" }"#,
             HashMap::from([("criteria".to_string(), "be safe".to_string())]),
             "/tmp",
         );
-        let seeds = resolve_seeds(&bp, &args, "/tmp", &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert_eq!(seeds.get("task").map(String::as_str), Some("build it"));
         assert_eq!(seeds.get("criteria").map(String::as_str), Some("be safe"));
     }
@@ -3430,7 +3567,15 @@ criteria = { kind = "pinned", max_tokens = 2000, seed = "input" }"#,
         let bp =
             bp(r#"spec = { kind = "pinned", max_tokens = 2000, seed = "input", required = true }"#);
         let args = args_with("t", HashMap::new(), "/tmp");
-        let err = resolve_seeds(&bp, &args, "/tmp", &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("spec"), "got: {err}");
     }
 
@@ -3438,7 +3583,15 @@ criteria = { kind = "pinned", max_tokens = 2000, seed = "input" }"#,
     fn resolve_seeds_optional_caller_input_missing_is_omitted() {
         let bp = bp(r#"notes = { kind = "pinned", max_tokens = 2000, seed = "input" }"#);
         let args = args_with("t", HashMap::new(), "/tmp");
-        let seeds = resolve_seeds(&bp, &args, "/tmp", &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert!(!seeds.contains_key("notes"));
     }
 
@@ -3457,6 +3610,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             &args,
             &dir.path().to_string_lossy(),
             &seed_policy(),
+            &no_seed_tools(),
             &no_read_paths(),
         )
         .unwrap();
@@ -3475,7 +3629,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             bp(r#"specs = { kind = "pinned", max_tokens = 4000, seed = { glob = "specs/*.md" } }"#);
         let wd = dir.path().to_string_lossy().to_string();
         let args = args_with("t", HashMap::new(), &wd);
-        let seeds = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         let specs = seeds.get("specs").unwrap();
         assert!(specs.contains("spec one") && specs.contains("spec two"));
     }
@@ -3494,7 +3656,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         );
         let wd = dir.path().to_string_lossy().to_string();
         let args = args_with("hello", HashMap::new(), &wd);
-        let seeds = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert_eq!(
             seeds.get("scripted").map(String::as_str),
             Some("seeded: hello")
@@ -3510,13 +3680,29 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["missing.txt"] }, required = true }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&req, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &req,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("missing.txt"), "got: {err}");
         // Optional + a missing file → the region is simply omitted.
         let opt = bp(
             r#"docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["missing.txt"] } }"#,
         );
-        let seeds = resolve_seeds(&opt, &args, &wd, &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &opt,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert!(!seeds.contains_key("docs"));
     }
 
@@ -3529,12 +3715,28 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         let req = bp(
             r#"specs = { kind = "pinned", max_tokens = 2000, seed = { glob = "none/*.md" }, required = true }"#,
         );
-        let err = resolve_seeds(&req, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &req,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("matched no files"), "got: {err}");
         // Optional glob with no matches → region omitted.
         let opt =
             bp(r#"specs = { kind = "pinned", max_tokens = 2000, seed = { glob = "none/*.md" } }"#);
-        let seeds = resolve_seeds(&opt, &args, &wd, &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &opt,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert!(!seeds.contains_key("specs"));
     }
 
@@ -3545,7 +3747,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         let wd = dir.path().to_string_lossy().to_string();
         let bp = bp(r#"specs = { kind = "pinned", max_tokens = 2000, seed = { glob = "[" } }"#);
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("bad glob"), "got: {err}");
     }
 
@@ -3559,11 +3769,220 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "boom.rhai" } }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("rhai seed failed"), "got: {err}");
     }
 
     // ─── command seeds (issue #108) ──────────────────────────────────────────
+
+    // ── tool seeds ────────────────────────────────────────────────────────
+
+    /// A tool-seed policy whose runner answers from a table, so a test can say
+    /// what each tool returns without a live MCP connection or a Rhai engine.
+    fn stub_tools(
+        answers: Vec<(&'static str, Result<String, String>)>,
+    ) -> crate::daemon::seed_tool::SeedToolPolicy {
+        let map: HashMap<String, Result<String, String>> = answers
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect();
+        crate::daemon::seed_tool::SeedToolPolicy::new(std::sync::Arc::new(move |name, _| {
+            map.get(name)
+                .cloned()
+                .unwrap_or_else(|| Err(format!("no such tool '{name}'")))
+        }))
+    }
+
+    fn tool_bp(seed: &str, required: bool) -> leviath_core::Blueprint {
+        let req = if required { ", required = true" } else { "" };
+        bp(&format!(
+            r#"environment = {{ kind = "pinned", max_tokens = 500, seed = {seed}{req} }}"#
+        ))
+    }
+
+    /// Several tools write into one region, in the order the blueprint listed
+    /// them, each under a heading naming the tool that produced it. The heading
+    /// matters: without it the model reads one undifferentiated blob.
+    #[test]
+    fn a_tool_seed_writes_every_call_into_one_region_in_order() {
+        let bp = tool_bp(r#"{ tools = ["current_time", "system_info"] }"#, false);
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &stub_tools(vec![
+                ("current_time", Ok("{\"date\": \"2026-08-18\"}".to_string())),
+                ("system_info", Ok("{\"os\": \"macos\"}".to_string())),
+            ]),
+            &no_read_paths(),
+        )
+        .unwrap();
+        assert_eq!(
+            seeds.get("environment").map(String::as_str),
+            Some(
+                "--- current_time ---\n{\"date\": \"2026-08-18\"}\n\n\
+                 --- system_info ---\n{\"os\": \"macos\"}"
+            )
+        );
+    }
+
+    /// One tool being unavailable must not cost the others their output. A
+    /// region seeded from three sources where one is missing is still worth
+    /// two thirds of what it was for.
+    #[test]
+    fn a_failed_call_is_skipped_and_the_rest_still_seed() {
+        let bp = tool_bp(
+            r#"{ tools = ["current_time", "acme__missing", "locale_info"] }"#,
+            false,
+        );
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &stub_tools(vec![
+                ("current_time", Ok("now".to_string())),
+                ("locale_info", Ok("en-US".to_string())),
+            ]),
+            &no_read_paths(),
+        )
+        .unwrap();
+        let content = seeds.get("environment").expect("still seeded");
+        assert!(content.contains("--- current_time ---\nnow"));
+        assert!(content.contains("--- locale_info ---\nen-US"));
+        assert!(!content.contains("acme__missing"), "{content}");
+    }
+
+    /// A tool that answers with nothing contributes no block, rather than a
+    /// heading over emptiness that reads as "this tool says the answer is
+    /// blank".
+    #[test]
+    fn a_call_that_returns_nothing_contributes_no_block() {
+        let bp = tool_bp(r#"{ tools = ["current_time", "quiet"] }"#, false);
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &stub_tools(vec![
+                ("current_time", Ok("now".to_string())),
+                ("quiet", Ok("   \n".to_string())),
+            ]),
+            &no_read_paths(),
+        )
+        .unwrap();
+        assert_eq!(
+            seeds.get("environment").map(String::as_str),
+            Some("--- current_time ---\nnow")
+        );
+    }
+
+    /// Optional and everything failed: the region is left unseeded rather than
+    /// holding an empty string, which downstream reads as content.
+    #[test]
+    fn an_optional_region_whose_calls_all_fail_stays_unseeded() {
+        let bp = tool_bp(r#"{ tool = "current_time" }"#, false);
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &stub_tools(vec![("current_time", Err("denied".to_string()))]),
+            &no_read_paths(),
+        )
+        .unwrap();
+        assert!(!seeds.contains_key("environment"));
+    }
+
+    /// A `required` region is the author saying the run is not worth starting
+    /// without it, so a failed call there is a spawn error naming the tool -
+    /// the same stance the files, glob and command seeds take.
+    #[test]
+    fn a_required_region_fails_the_spawn_when_its_tool_does() {
+        let bp = tool_bp(r#"{ tool = "current_time" }"#, true);
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &stub_tools(vec![(
+                "current_time",
+                Err("set to `ask`, nobody to prompt".to_string()),
+            )]),
+            &no_read_paths(),
+        )
+        .unwrap_err();
+        assert!(err.contains("environment"), "{err}");
+        assert!(err.contains("current_time"), "{err}");
+        assert!(err.contains("nobody to prompt"), "{err}");
+    }
+
+    /// Required, and every call merely answered with nothing: still an error,
+    /// because an empty required region is the state the flag exists to refuse.
+    #[test]
+    fn a_required_region_fails_when_nothing_was_produced() {
+        let bp = tool_bp(r#"{ tool = "quiet" }"#, true);
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &stub_tools(vec![("quiet", Ok(String::new()))]),
+            &no_read_paths(),
+        )
+        .unwrap_err();
+        assert!(err.contains("no tool seed produced anything"), "{err}");
+    }
+
+    /// The arguments a blueprint wrote reach the tool unchanged - the case that
+    /// would otherwise silently call `which_command` with no program name.
+    #[test]
+    fn a_call_carries_the_arguments_the_blueprint_wrote() {
+        let bp = tool_bp(
+            r#"{ tools = [{ name = "which_command", args = { command = "git" } }] }"#,
+            false,
+        );
+        let args = args_with("t", HashMap::new(), "/tmp");
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::<String>::new()));
+        let captured = seen.clone();
+        let policy =
+            crate::daemon::seed_tool::SeedToolPolicy::new(std::sync::Arc::new(move |name, a| {
+                captured.lock().unwrap().push(format!("{name}:{a}"));
+                Ok("found".to_string())
+            }));
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &policy,
+            &no_read_paths(),
+        )
+        .unwrap();
+        assert_eq!(
+            seeds.get("environment").map(String::as_str),
+            Some("--- which_command ---\nfound")
+        );
+        assert_eq!(
+            seen.lock().unwrap().as_slice(),
+            ["which_command:{\"command\":\"git\"}".to_string()]
+        );
+    }
 
     /// A blueprint with one command-seeded region, optionally `required`.
     fn command_bp(required: bool) -> leviath_core::Blueprint {
@@ -3582,6 +4001,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             &args,
             "/tmp",
             &stub_policy(Ok("src/lib.rs\nsrc/main.rs".to_string())),
+            &no_seed_tools(),
             &no_read_paths(),
         )
         .unwrap();
@@ -3608,7 +4028,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
                 ))
             }),
         };
-        let seeds = resolve_seeds(&bp, &args, "/work", &policy, &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/work",
+            &policy,
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert_eq!(
             seeds.get("facts").map(String::as_str),
             Some("scan-repo@/work#9")
@@ -3624,6 +4052,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             &args,
             "/tmp",
             &stub_policy(Err("timed out".to_string())),
+            &no_seed_tools(),
             &no_read_paths(),
         )
         .unwrap();
@@ -3642,6 +4071,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             &args,
             "/tmp",
             &stub_policy(Err("boom".to_string())),
+            &no_seed_tools(),
             &no_read_paths(),
         )
         .unwrap_err();
@@ -3658,6 +4088,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             &args,
             "/tmp",
             &stub_policy(Ok("   \n".to_string())),
+            &no_seed_tools(),
             &no_read_paths(),
         )
         .unwrap();
@@ -3673,6 +4104,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             &args,
             "/tmp",
             &stub_policy(Ok(String::new())),
+            &no_seed_tools(),
             &no_read_paths(),
         )
         .unwrap_err();
@@ -3688,7 +4120,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         let args = args_with("t", HashMap::new(), "/tmp");
         let mut policy = stub_policy(Ok("SHOULD NOT BE USED".to_string()));
         policy.allowed = false;
-        let seeds = resolve_seeds(&bp, &args, "/tmp", &policy, &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &policy,
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert!(!seeds.contains_key("facts"));
     }
 
@@ -3703,6 +4143,7 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             &args,
             "/tmp",
             &SeedCommandPolicy::disabled(),
+            &no_seed_tools(),
             &no_read_paths(),
         )
         .unwrap_err();
@@ -3720,7 +4161,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"specs = { kind = "pinned", max_tokens = 2000, seed = { glob = "sub*" }, required = true }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("read seed file"), "got: {err}");
     }
 
@@ -3732,7 +4181,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "nope.rhai" } }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("read rhai seed"), "got: {err}");
     }
 
@@ -3746,13 +4203,29 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         let req = bp(
             r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "empty.rhai" }, required = true }"#,
         );
-        let err = resolve_seeds(&req, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &req,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("returned empty"), "got: {err}");
         // Optional + empty → region omitted (no error).
         let opt = bp(
             r#"scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "empty.rhai" } }"#,
         );
-        let seeds = resolve_seeds(&opt, &args, &wd, &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &opt,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert!(!seeds.contains_key("scripted"));
     }
 
@@ -3766,7 +4239,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             HashMap::from([("ghost".to_string(), "x".to_string())]),
             "/tmp",
         );
-        let seeds = resolve_seeds(&bp, &args, "/tmp", &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/tmp",
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert_eq!(seeds.get("task").map(String::as_str), Some("t"));
         assert!(!seeds.contains_key("ghost"));
     }
@@ -3793,7 +4274,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"notes = { kind = "pinned", max_tokens = 2000, seed = { files = ["../config.toml"] } }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("outside the working directory"), "{err}");
         assert!(err.contains("read_paths"), "{err}");
     }
@@ -3808,7 +4297,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"notes = { kind = "pinned", max_tokens = 2000, seed = { files = ["notes.md"] } }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let seeds = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap();
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
         assert!(seeds.get("notes").is_some_and(|s| s.contains("hello")));
     }
 
@@ -3820,7 +4317,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         let bp =
             bp(r#"notes = { kind = "pinned", max_tokens = 2000, seed = { glob = "../*.toml" } }"#);
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("outside the working directory"), "{err}");
     }
 
@@ -3844,7 +4349,8 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"notes = { kind = "pinned", max_tokens = 2000, seed = { files = ["../config.toml"] } }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let seeds = resolve_seeds(&bp, &args, &wd, &seed_policy(), &policy).unwrap();
+        let seeds =
+            resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_seed_tools(), &policy).unwrap();
         assert!(seeds.get("notes").is_some_and(|s| s.contains("sk-SECRET")));
     }
 
@@ -3898,7 +4404,8 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"notes = { kind = "pinned", max_tokens = 2000, seed = { files = ["../config.toml"] } }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&bp, &args, &wd, &seed_policy(), &policy).unwrap_err();
+        let err =
+            resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_seed_tools(), &policy).unwrap_err();
         assert!(err.contains("outside the working directory"), "{err}");
     }
 
@@ -3909,7 +4416,15 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
             r#"notes = { kind = "pinned", max_tokens = 2000, seed = { rhai = "../config.toml" } }"#,
         );
         let args = args_with("t", HashMap::new(), &wd);
-        let err = resolve_seeds(&bp, &args, &wd, &seed_policy(), &no_read_paths()).unwrap_err();
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap_err();
         assert!(err.contains("outside the working directory"), "{err}");
     }
 
@@ -4009,8 +4524,15 @@ conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
         // spent a full turn on a question nobody asked.
         let bp = bp_taking_no_task(r#"notes = { kind = "pinned", max_tokens = 100 }"#);
         let args = args_with("do the thing", HashMap::new(), "/w");
-        let err = resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths())
-            .expect_err("a task with nowhere to go should be refused");
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            "/w",
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .expect_err("a task with nowhere to go should be refused");
         assert!(err.contains("declares no region to put it in"), "{err}");
         // The message has to say what the agent *does* take, or the user is left
         // guessing which flag to reach for instead.
@@ -4022,8 +4544,15 @@ conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
         let bp =
             bp_taking_no_task(r#"diff = { kind = "pinned", max_tokens = 100, seed = "diff" }"#);
         let args = args_with("do the thing", HashMap::new(), "/w");
-        let err =
-            resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths()).expect_err("refused");
+        let err = resolve_seeds(
+            &bp,
+            &args,
+            "/w",
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .expect_err("refused");
         assert!(err.contains("it takes: diff"), "{err}");
     }
 
@@ -4036,8 +4565,15 @@ conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
         let mut regions = HashMap::new();
         regions.insert("diff".to_string(), "a patch".to_string());
         let args = args_with("", regions, "/w");
-        let seeds = resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths())
-            .expect("no task was supplied, so there is nothing to refuse");
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            "/w",
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .expect("no task was supplied, so there is nothing to refuse");
         assert_eq!(seeds.get("diff").map(String::as_str), Some("a patch"));
     }
 
@@ -4045,8 +4581,15 @@ conversation = {{ kind = "sliding_window", max_items = 20, max_tokens = 10000 }}
     fn a_whitespace_only_task_is_not_treated_as_a_task() {
         let bp = bp_taking_no_task(r#"notes = { kind = "pinned", max_tokens = 100 }"#);
         let args = args_with("   \n ", HashMap::new(), "/w");
-        resolve_seeds(&bp, &args, "/w", &seed_policy(), &no_read_paths())
-            .expect("blank is the same as absent");
+        resolve_seeds(
+            &bp,
+            &args,
+            "/w",
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .expect("blank is the same as absent");
     }
 
     /// Every bundled agent that tells the user to pass `--task` can hold one.

--- a/crates/leviath-cli/src/daemon/spawn/seeds.rs
+++ b/crates/leviath-cli/src/daemon/spawn/seeds.rs
@@ -7,6 +7,7 @@
 //! is written once and used twice.
 
 use super::*;
+use crate::daemon::seed_tool;
 
 /// Resolve a blueprint-declared seed path against the run's working directory.
 ///
@@ -67,6 +68,10 @@ pub(super) fn seed_path_within(
 /// - `Command` runs a shell command in the workdir under `commands` -
 ///   sandboxed, time- and size-capped, and skippable. Every failure is
 ///   non-fatal unless the region is `required`.
+/// - `Tools` calls the run's own tools under `tools`, each through the same
+///   permission resolution the tool lane applies, and writes their combined
+///   output into the region. Failures are non-fatal on the same terms, per
+///   call, so one unavailable tool does not cost the others.
 /// - Any caller key (other than `task`) that isn't a declared `CallerInput`
 ///   region is rejected (typo protection, mirrors the CLI-side check).
 pub(super) fn resolve_seeds(
@@ -74,6 +79,7 @@ pub(super) fn resolve_seeds(
     args: &SpawnArgs,
     workdir: &str,
     commands: &SeedCommandPolicy,
+    tools: &crate::daemon::seed_tool::SeedToolPolicy,
     read_paths: &leviath_core::ReadPathPolicy,
 ) -> Result<HashMap<String, String>, String> {
     use leviath_core::layout::RegionSeed;
@@ -241,6 +247,52 @@ pub(super) fn resolve_seeds(
                             "command seed failed; region left empty"
                         );
                     }
+                }
+            }
+            // A tool seed also executes at spawn, but through the run's own
+            // tool layer rather than a shell, so each call already answers to
+            // the user's `[tool_permissions]` - see `seed_tool`. Failures are
+            // per call: one unavailable tool leaves its block out rather than
+            // emptying the region the others filled.
+            RegionSeed::Tools { calls } => {
+                let mut blocks = Vec::new();
+                for call in calls {
+                    match tools.run(call) {
+                        Ok(text) if !text.trim().is_empty() => {
+                            blocks.push(seed_tool::seed_block(&call.name, &text));
+                        }
+                        Ok(_) => tracing::warn!(
+                            region = %region.name,
+                            tool = %call.name,
+                            "tool seed returned nothing; skipped"
+                        ),
+                        Err(e) => {
+                            if region.required {
+                                return Err(format!(
+                                    "required region '{}': tool seed '{}' failed: {e}",
+                                    region.name, call.name
+                                ));
+                            }
+                            tracing::warn!(
+                                region = %region.name,
+                                tool = %call.name,
+                                error = %e,
+                                "tool seed failed; skipped"
+                            );
+                        }
+                    }
+                }
+                match seed_tool::join_blocks(blocks) {
+                    Some(content) => {
+                        seeds.insert(region.name.clone(), content);
+                    }
+                    None if region.required => {
+                        return Err(format!(
+                            "required region '{}': no tool seed produced anything",
+                            region.name
+                        ));
+                    }
+                    None => {}
                 }
             }
         }

--- a/crates/leviath-cli/src/daemon/spawn/seeds.rs
+++ b/crates/leviath-cli/src/daemon/spawn/seeds.rs
@@ -254,7 +254,10 @@ pub(super) fn resolve_seeds(
             // the user's `[tool_permissions]` - see `seed_tool`. Failures are
             // per call: one unavailable tool leaves its block out rather than
             // emptying the region the others filled.
-            RegionSeed::Tools { calls } => {
+            // `refresh` is not consulted here: spawn is the first stage entry,
+            // so an `each_stage` seed resolves here too and the runtime takes
+            // it from the next entry onward.
+            RegionSeed::Tools { calls, refresh: _ } => {
                 let mut blocks = Vec::new();
                 for call in calls {
                     match tools.run(call) {

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -265,6 +265,7 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
 
     findings.extend(lint_dropped_seeds(&declared, blueprint));
     findings.extend(lint_command_seeds(blueprint));
+    findings.extend(lint_tool_seeds(blueprint));
     findings.extend(lint_read_paths(blueprint, env));
     findings.extend(lint_safe_commands(blueprint, env));
     findings.extend(lint_held_checkpoints(blueprint));

--- a/crates/leviath-cli/src/lint/security.rs
+++ b/crates/leviath-cli/src/lint/security.rs
@@ -104,6 +104,51 @@ pub(super) fn lint_command_seeds(blueprint: &Blueprint) -> Vec<LintFinding> {
     ]
 }
 
+/// List the tools a blueprint calls at spawn.
+///
+/// The sibling of [`lint_command_seeds`], and an audit line for the same
+/// reason: these run before the first inference and therefore before any
+/// approval prompt, so somebody about to `lev add` a blueprint they did not
+/// write should see them first.
+///
+/// Unlike a command seed there is no pre-approval to report. A seeded call
+/// resolves against the same `[tool_permissions]` a mid-run call does, so the
+/// question "will this run" has the same answer as "may this agent call it",
+/// which the permission table already states.
+pub(super) fn lint_tool_seeds(blueprint: &Blueprint) -> Vec<LintFinding> {
+    let seeds: Vec<String> = blueprint
+        .context_layout
+        .regions
+        .iter()
+        .filter_map(|r| match &r.seed {
+            Some(leviath_core::layout::RegionSeed::Tools { calls }) => {
+                let names: Vec<&str> = calls.iter().map(|c| c.name.as_str()).collect();
+                Some(format!("{}: {}", r.name, names.join(", ")))
+            }
+            _ => None,
+        })
+        .collect();
+    if seeds.is_empty() {
+        return Vec::new();
+    }
+    vec![
+        LintFinding::new(
+            LintSeverity::Note,
+            "tool-seed",
+            format!(
+                "{} region(s) call tools at spawn, before the first inference and \
+                 before any tool-approval prompt: {}",
+                seeds.len(),
+                seeds.join("; ")
+            ),
+        )
+        .with_fix(
+            "each call answers to `[tool_permissions]` exactly as a mid-run call would; \
+             a tool set to `ask` is refused at spawn because there is nobody to prompt",
+        ),
+    ]
+}
+
 /// Whether the *default* safe list covers `command`.
 ///
 /// Reports against the shipped defaults rather than the reader's own config:

--- a/crates/leviath-cli/src/lint/security.rs
+++ b/crates/leviath-cli/src/lint/security.rs
@@ -121,9 +121,15 @@ pub(super) fn lint_tool_seeds(blueprint: &Blueprint) -> Vec<LintFinding> {
         .regions
         .iter()
         .filter_map(|r| match &r.seed {
-            Some(leviath_core::layout::RegionSeed::Tools { calls }) => {
+            Some(leviath_core::layout::RegionSeed::Tools { calls, refresh }) => {
                 let names: Vec<&str> = calls.iter().map(|c| c.name.as_str()).collect();
-                Some(format!("{}: {}", r.name, names.join(", ")))
+                // A seed that re-runs on every stage entry is worth saying so:
+                // it is a tool call per stage for the life of the run, not one.
+                let when = match refresh {
+                    leviath_core::layout::SeedRefresh::Once => "",
+                    leviath_core::layout::SeedRefresh::EachStage => " (on every stage entry)",
+                };
+                Some(format!("{}: {}{when}", r.name, names.join(", ")))
             }
             _ => None,
         })

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -1279,6 +1279,57 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
     assert!(fix.contains("allow_seed_commands"), "{fix}");
 }
 
+/// The tools a blueprint calls at spawn are an audit line for the same reason
+/// the commands are: they run before any approval prompt, so whoever is about
+/// to install a manifest they did not write should see them first.
+#[test]
+fn tool_seeds_are_listed_per_region() {
+    let toml = r#"
+[agent]
+name = "x"
+description = "d"
+entry_stage = "main"
+
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+description = "Main stage"
+max_iterations = 5
+
+[context.regions]
+environment = { kind = "pinned", max_tokens = 1000, seed = { tools = ["current_time", "system_info"] } }
+toolchain = { kind = "pinned", max_tokens = 1000, seed = { tool = "which_command" } }
+plain = { kind = "pinned", max_tokens = 1000 }
+conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
+"#;
+    let findings = lint(toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["tool-seed"]);
+    let message = &findings[0].message;
+    assert!(message.contains("2 region(s)"), "{message}");
+    // Named per region, and every tool in it, so the reader sees what runs and
+    // where its output lands.
+    assert!(
+        message.contains("environment: current_time, system_info"),
+        "{message}"
+    );
+    assert!(message.contains("toolchain: which_command"), "{message}");
+    // A region with no tool seed is not named.
+    assert!(!message.contains("plain"), "{message}");
+    // Unlike a command seed there is no separate switch to name; the answer to
+    // "will this run" is the permission table, so the fix says so.
+    let fix = findings[0]
+        .fix
+        .as_deref()
+        .expect("a seed note offers a fix");
+    assert!(fix.contains("tool_permissions"), "{fix}");
+    assert!(fix.contains("ask"), "{fix}");
+}
+
+#[test]
+fn no_tool_seeds_means_no_note() {
+    assert!(!codes(&lint(&manifest(CLEAN_STAGE), &LintEnv::default())).contains(&"tool-seed"));
+}
+
 #[test]
 fn no_command_seeds_means_no_note() {
     assert!(!codes(&lint(&manifest(CLEAN_STAGE), &LintEnv::default())).contains(&"command-seed"));

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -1298,7 +1298,7 @@ max_iterations = 5
 
 [context.regions]
 environment = { kind = "pinned", max_tokens = 1000, seed = { tools = ["current_time", "system_info"] } }
-toolchain = { kind = "pinned", max_tokens = 1000, seed = { tool = "which_command" } }
+toolchain = { kind = "pinned", max_tokens = 1000, seed = { tool = "which_command", refresh = "each_stage" } }
 plain = { kind = "pinned", max_tokens = 1000 }
 conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
 "#;
@@ -1312,7 +1312,19 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
         message.contains("environment: current_time, system_info"),
         "{message}"
     );
-    assert!(message.contains("toolchain: which_command"), "{message}");
+    // A refreshing seed says so: it is a tool call per stage for the life of
+    // the run, not one at spawn, and that is the part a reader should weigh.
+    assert!(
+        message.contains("toolchain: which_command (on every stage entry)"),
+        "{message}"
+    );
+    // While a seed that runs once carries no such note - the suffix appears
+    // exactly once in the message, on the entry that earned it.
+    assert_eq!(
+        message.matches("(on every stage entry)").count(),
+        1,
+        "{message}"
+    );
     // A region with no tool seed is not named.
     assert!(!message.contains("plain"), "{message}");
     // Unlike a command seed there is no separate switch to name; the answer to

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -232,6 +232,17 @@ pub fn default_tool_policy(tool_name: &str, is_builtin: bool) -> ToolPolicy {
         // own context and touch nothing outside it, and prompting per item
         // would make tracking work cost more than not tracking it.
         | "todo_add" | "todo_done" | "todo_note" => ToolPolicy::Allow,
+        // The environment tools report the clock, the machine, the locale, the
+        // paths and the run's own state. They read nothing the agent could not
+        // already infer from a `shell` call it was granted, mutate nothing, and
+        // reach no network. Prompting for the date would make grounding a run
+        // in the present cost an approval, which is how it would end up unused.
+        //
+        // `environment_info` is on this list despite naming environment
+        // variables because it answers to `[security] allow_env_vars` for their
+        // *values*: a credential-shaped name comes back listed, not read.
+        "current_time" | "system_info" | "locale_info" | "environment_info" | "which_command"
+        | "runtime_info" => ToolPolicy::Allow,
         "write_file" | "edit_file" | "shell" => ToolPolicy::Ask,
         // The sub-agent tools default to `Allow`, and the point of routing them
         // through this function at all is the *config*, not the prompt.
@@ -2317,6 +2328,17 @@ mod policy_tests {
         "ask_user_choice",
         "ask_user_confirm",
         "edit_document",
+        // Reviewed: read-only reports about the host and the run - the clock,
+        // the OS, the locale, the well-known directories, whether a program is
+        // installed, and this run's own stage and limits. None of them mutates
+        // anything, and `environment_info` withholds credential-shaped values
+        // under the same `allow_env_vars` rule a Rhai `env_var` read answers to.
+        "current_time",
+        "system_info",
+        "locale_info",
+        "environment_info",
+        "which_command",
+        "runtime_info",
     ];
 
     /// Every tool the runtime actually advertises, discovered rather than

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -458,6 +458,50 @@ pub enum RegionSeed {
         /// The shell command line, run with the platform shell in the workdir.
         command: String,
     },
+    /// The combined output of one or more tool calls, run at spawn.
+    ///
+    /// Like [`Command`](Self::Command) this *executes* something, but through
+    /// the run's own tool layer rather than a shell: any tool the agent could
+    /// call is callable here - a built-in, an MCP server's, a Rhai script's -
+    /// and each call answers to the same `tool_permissions` and taint rules it
+    /// would answer to mid-run. That is what makes an unrestricted list safe:
+    /// a seed can reach nothing the agent was not already granted.
+    ///
+    /// Several calls write into one region, in the order given, each under its
+    /// own heading. A failed call is skipped with a warning unless the region is
+    /// `required`, so one unavailable tool does not cost the others.
+    Tools {
+        /// The calls to run, in order.
+        calls: Vec<SeedToolCall>,
+    },
+}
+
+/// One tool call in a [`RegionSeed::Tools`] seed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SeedToolCall {
+    /// The tool to call, spelled as the agent would spell it (so an MCP tool
+    /// keeps its `<server>__<tool>` qualification).
+    pub name: String,
+    /// The arguments object. Empty for the many tools that take none.
+    pub args: serde_json::Value,
+}
+
+impl SeedToolCall {
+    /// A call with no arguments.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            args: serde_json::Value::Object(serde_json::Map::new()),
+        }
+    }
+
+    /// A call with an arguments object.
+    pub fn with_args(name: impl Into<String>, args: serde_json::Value) -> Self {
+        Self {
+            name: name.into(),
+            args,
+        }
+    }
 }
 
 /// Definition of a region in a layout.

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -473,7 +473,45 @@ pub enum RegionSeed {
     Tools {
         /// The calls to run, in order.
         calls: Vec<SeedToolCall>,
+        /// Whether the calls run once, or again on every stage entry.
+        refresh: SeedRefresh,
     },
+}
+
+/// When a [`RegionSeed::Tools`] seed runs again.
+///
+/// Every other seed kind resolves once, at spawn, and this defaults to the
+/// same: a region seeded from the filesystem or a literal has no reason to be
+/// re-read, and re-running a call on every stage entry costs a tool call and
+/// rewrites a region the cache was holding still.
+///
+/// [`EachStage`](Self::EachStage) is for the seeds where the answer moves.
+/// A clock is the clear case: a run that spends an hour in one stage and then
+/// enters another should date the second stage from when it started, not from
+/// when the run did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SeedRefresh {
+    /// Resolve once, at spawn. The default, and what every other seed does.
+    #[default]
+    Once,
+    /// Resolve again whenever a stage is entered, replacing the region.
+    EachStage,
+}
+
+impl SeedRefresh {
+    /// Parse the manifest spelling, or `None` for a word that is neither.
+    ///
+    /// A wrong spelling is rejected rather than defaulted, so
+    /// `refresh = "each stage"` is reported instead of quietly meaning `once` -
+    /// which would read as the feature not working.
+    pub fn from_str_loose(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "once" | "spawn" => Some(Self::Once),
+            "each_stage" | "stage" => Some(Self::EachStage),
+            _ => None,
+        }
+    }
 }
 
 /// One tool call in a [`RegionSeed::Tools`] seed.
@@ -501,6 +539,49 @@ impl SeedToolCall {
             name: name.into(),
             args,
         }
+    }
+}
+
+#[cfg(test)]
+mod seed_refresh_tests {
+    use super::*;
+
+    #[test]
+    fn both_spellings_and_their_aliases_parse() {
+        assert_eq!(SeedRefresh::from_str_loose("once"), Some(SeedRefresh::Once));
+        assert_eq!(
+            SeedRefresh::from_str_loose("spawn"),
+            Some(SeedRefresh::Once)
+        );
+        assert_eq!(
+            SeedRefresh::from_str_loose("each_stage"),
+            Some(SeedRefresh::EachStage)
+        );
+        assert_eq!(
+            SeedRefresh::from_str_loose("stage"),
+            Some(SeedRefresh::EachStage)
+        );
+        // Case and surrounding space are not the author's problem.
+        assert_eq!(
+            SeedRefresh::from_str_loose("  EACH_STAGE "),
+            Some(SeedRefresh::EachStage)
+        );
+    }
+
+    /// A word that is neither is rejected rather than defaulted. Defaulting
+    /// would make `refresh = "each stage"` silently mean `once`, which reads as
+    /// the feature not working rather than as a typo.
+    #[test]
+    fn an_unrecognised_word_is_not_quietly_once() {
+        assert_eq!(SeedRefresh::from_str_loose("each stage"), None);
+        assert_eq!(SeedRefresh::from_str_loose("always"), None);
+        assert_eq!(SeedRefresh::from_str_loose(""), None);
+    }
+
+    /// The default matches every other seed kind: resolve at spawn, once.
+    #[test]
+    fn the_default_is_once() {
+        assert_eq!(SeedRefresh::default(), SeedRefresh::Once);
     }
 }
 

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -2,6 +2,7 @@
 //! budget, seed, and the tool-output routing that targets it.
 
 use super::*;
+use crate::layout::SeedToolCall;
 
 /// Parse a `[context.regions]` (or `[stages.<name>.context.regions]`) table into
 /// region definitions plus the summed absolute-budget total.
@@ -319,11 +320,39 @@ pub(super) fn parse_region_mapping(v: &toml::Value) -> RegionMapping {
 /// text); any other string → caller input keyed by that string, with the
 /// convenience alias `"input"` meaning "keyed by this region's own name".
 /// Table forms: `{ glob = "…" }`, `{ files = [...] }`, `{ literal = "…" }`,
-/// `{ rhai = "…" }`, `{ command = "…" }`, or `{ caller = "…" }`.
+/// `{ rhai = "…" }`, `{ command = "…" }`, `{ tool = "…" }`, `{ tools = [...] }`,
+/// or `{ caller = "…" }`.
 ///
 /// Back-compat: a region literally named `task` with no `seed` gets an implicit
 /// `CallerInput { name: "task" }`, so unmodified blueprints seed the task text
 /// exactly as before.
+/// One entry of a `{ tools = [...] }` list.
+///
+/// Two spellings, because most calls take no arguments and should not have to
+/// look like they might: a bare string is the tool's name, and a table is
+/// `{ name = "...", args = { ... } }`. `args` is converted through
+/// `serde_json` because that is the shape a tool call carries everywhere else;
+/// a table with no readable `name` is dropped.
+fn parse_seed_tool_call(value: &toml::Value) -> Option<SeedToolCall> {
+    match value {
+        toml::Value::String(name) => Some(SeedToolCall::new(name.as_str())),
+        toml::Value::Table(t) => {
+            let name = t.get("name").and_then(|v| v.as_str())?;
+            match t.get("args") {
+                // Every TOML value has a JSON counterpart - the conversion has
+                // no failing case for a value that was itself parsed from TOML.
+                // A fallback here would be a branch nothing could reach.
+                Some(args) => Some(SeedToolCall::with_args(
+                    name,
+                    serde_json::to_value(args).expect("a parsed TOML value converts to JSON"),
+                )),
+                None => Some(SeedToolCall::new(name)),
+            }
+        }
+        _ => None,
+    }
+}
+
 pub(super) fn parse_region_seed(
     region_name: &str,
     value: Option<&toml::Value>,
@@ -369,6 +398,18 @@ pub(super) fn parse_region_seed(
                 Some(RegionSeed::Command {
                     command: command.to_string(),
                 })
+            } else if let Some(name) = t.get("tool").and_then(|v| v.as_str()) {
+                Some(RegionSeed::Tools {
+                    calls: vec![SeedToolCall::new(name)],
+                })
+            } else if let Some(list) = t.get("tools").and_then(|v| v.as_array()) {
+                let calls: Vec<SeedToolCall> =
+                    list.iter().filter_map(parse_seed_tool_call).collect();
+                // An empty or wholly unreadable list is not a tool seed. Falling
+                // through leaves the region unseeded and `lev validate` reports
+                // `region-seed-not-understood`, which is a better answer than a
+                // seed that silently runs nothing.
+                (!calls.is_empty()).then_some(RegionSeed::Tools { calls })
             } else {
                 t.get("caller")
                     .and_then(|v| v.as_str())

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -326,33 +326,6 @@ pub(super) fn parse_region_mapping(v: &toml::Value) -> RegionMapping {
 /// Back-compat: a region literally named `task` with no `seed` gets an implicit
 /// `CallerInput { name: "task" }`, so unmodified blueprints seed the task text
 /// exactly as before.
-/// One entry of a `{ tools = [...] }` list.
-///
-/// Two spellings, because most calls take no arguments and should not have to
-/// look like they might: a bare string is the tool's name, and a table is
-/// `{ name = "...", args = { ... } }`. `args` is converted through
-/// `serde_json` because that is the shape a tool call carries everywhere else;
-/// a table with no readable `name` is dropped.
-fn parse_seed_tool_call(value: &toml::Value) -> Option<SeedToolCall> {
-    match value {
-        toml::Value::String(name) => Some(SeedToolCall::new(name.as_str())),
-        toml::Value::Table(t) => {
-            let name = t.get("name").and_then(|v| v.as_str())?;
-            match t.get("args") {
-                // Every TOML value has a JSON counterpart - the conversion has
-                // no failing case for a value that was itself parsed from TOML.
-                // A fallback here would be a branch nothing could reach.
-                Some(args) => Some(SeedToolCall::with_args(
-                    name,
-                    serde_json::to_value(args).expect("a parsed TOML value converts to JSON"),
-                )),
-                None => Some(SeedToolCall::new(name)),
-            }
-        }
-        _ => None,
-    }
-}
-
 pub(super) fn parse_region_seed(
     region_name: &str,
     value: Option<&toml::Value>,
@@ -401,6 +374,7 @@ pub(super) fn parse_region_seed(
             } else if let Some(name) = t.get("tool").and_then(|v| v.as_str()) {
                 Some(RegionSeed::Tools {
                     calls: vec![SeedToolCall::new(name)],
+                    refresh: parse_seed_refresh(t),
                 })
             } else if let Some(list) = t.get("tools").and_then(|v| v.as_array()) {
                 let calls: Vec<SeedToolCall> =
@@ -409,13 +383,56 @@ pub(super) fn parse_region_seed(
                 // through leaves the region unseeded and `lev validate` reports
                 // `region-seed-not-understood`, which is a better answer than a
                 // seed that silently runs nothing.
-                (!calls.is_empty()).then_some(RegionSeed::Tools { calls })
+                (!calls.is_empty()).then_some(RegionSeed::Tools {
+                    calls,
+                    refresh: parse_seed_refresh(t),
+                })
             } else {
                 t.get("caller")
                     .and_then(|v| v.as_str())
                     .map(|name| RegionSeed::CallerInput {
                         name: name.to_string(),
                     })
+            }
+        }
+        _ => None,
+    }
+}
+
+/// The `refresh` key of a tool seed, defaulting to [`SeedRefresh::Once`].
+///
+/// An unreadable value falls back to the default rather than failing the
+/// manifest, matching how the rest of this parser treats a key it cannot make
+/// sense of; `lev validate` is where a typo is reported.
+fn parse_seed_refresh(table: &toml::value::Table) -> crate::layout::SeedRefresh {
+    table
+        .get("refresh")
+        .and_then(|v| v.as_str())
+        .and_then(crate::layout::SeedRefresh::from_str_loose)
+        .unwrap_or_default()
+}
+
+/// One entry of a `{ tools = [...] }` list.
+///
+/// Two spellings, because most calls take no arguments and should not have to
+/// look like they might: a bare string is the tool's name, and a table is
+/// `{ name = "...", args = { ... } }`. `args` is converted through
+/// `serde_json` because that is the shape a tool call carries everywhere else;
+/// a table with no readable `name` is dropped.
+fn parse_seed_tool_call(value: &toml::Value) -> Option<SeedToolCall> {
+    match value {
+        toml::Value::String(name) => Some(SeedToolCall::new(name.as_str())),
+        toml::Value::Table(t) => {
+            let name = t.get("name").and_then(|v| v.as_str())?;
+            match t.get("args") {
+                // Every TOML value has a JSON counterpart - the conversion has
+                // no failing case for a value that was itself parsed from TOML.
+                // A fallback here would be a branch nothing could reach.
+                Some(args) => Some(SeedToolCall::with_args(
+                    name,
+                    serde_json::to_value(args).expect("a parsed TOML value converts to JSON"),
+                )),
+                None => Some(SeedToolCall::new(name)),
             }
         }
         _ => None,

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -6,6 +6,7 @@
 //! quarter of that.
 
 use super::*;
+use crate::layout::SeedToolCall;
 
 // ─── [stages.<name>.hooks] ────────────────────────────────────────────
 
@@ -971,6 +972,9 @@ config = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.yaml", "b.ya
 lit = { kind = "pinned", max_tokens = 500, seed = { literal = "hello" } }
 scripted = { kind = "pinned", max_tokens = 500, seed = { rhai = "init.rhai" } }
 facts = { kind = "pinned", max_tokens = 500, seed = { command = "git ls-files" } }
+clock = { kind = "pinned", max_tokens = 500, seed = { tool = "current_time" } }
+env = { kind = "pinned", max_tokens = 500, seed = { tools = ["current_time", "system_info"] } }
+toolchain = { kind = "pinned", max_tokens = 500, seed = { tools = [{ name = "which_command", args = { command = "git" } }, { name = "system_info" }, "locale_info"] } }
 plain = { kind = "pinned", max_tokens = 500 }
 conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
 "#;
@@ -1026,9 +1030,99 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
             command: "git ls-files".to_string()
         })
     );
+    // `{ tool = "..." }` is the one-call shorthand, and carries no arguments.
+    assert_eq!(
+        region("clock"),
+        Some(RegionSeed::Tools {
+            calls: vec![SeedToolCall::new("current_time")]
+        })
+    );
+    // A list of bare names is a list of argument-free calls, in order.
+    assert_eq!(
+        region("env"),
+        Some(RegionSeed::Tools {
+            calls: vec![
+                SeedToolCall::new("current_time"),
+                SeedToolCall::new("system_info"),
+            ]
+        })
+    );
+    // The two entry spellings mix in one list, because most calls take no
+    // arguments and should not have to look like they might.
+    assert_eq!(
+        region("toolchain"),
+        Some(RegionSeed::Tools {
+            calls: vec![
+                SeedToolCall::with_args("which_command", serde_json::json!({ "command": "git" })),
+                // The table form without `args` means the same as the bare
+                // string: a call with no arguments, not one with null args.
+                SeedToolCall::new("system_info"),
+                SeedToolCall::new("locale_info"),
+            ]
+        })
+    );
     assert!(
         region("plain").is_none(),
         "a non-task region with no seed stays None"
+    );
+}
+
+/// A `tools` list that names nothing usable is not a tool seed. Leaving it
+/// unparsed is what makes `lev validate` report `region-seed-not-understood`,
+/// which is a better answer than a seed that silently runs nothing.
+#[test]
+fn a_tool_seed_with_no_readable_call_is_not_a_seed() {
+    let base = r#"
+[agent]
+name = "seed-test"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 4000, seed = "task_input" }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#;
+    let seed_of = |line: &str| {
+        let toml = format!("{base}{line}\n");
+        parse_manifest(&toml)
+            .unwrap()
+            .context_layout
+            .get_region("r")
+            .unwrap()
+            .seed
+            .clone()
+    };
+    // An empty list.
+    assert_eq!(
+        seed_of(r#"r = { kind = "pinned", max_tokens = 500, seed = { tools = [] } }"#),
+        None
+    );
+    // Entries of a shape that names no tool.
+    assert_eq!(
+        seed_of(r#"r = { kind = "pinned", max_tokens = 500, seed = { tools = [1, 2] } }"#),
+        None
+    );
+    // A table with no `name`.
+    assert_eq!(
+        seed_of(
+            r#"r = { kind = "pinned", max_tokens = 500, seed = { tools = [{ args = { a = 1 } }] } }"#
+        ),
+        None
+    );
+    // But one readable entry among unreadable ones still seeds, carrying only
+    // the entries that named something.
+    assert_eq!(
+        seed_of(
+            r#"r = { kind = "pinned", max_tokens = 500, seed = { tools = [1, "current_time"] } }"#
+        ),
+        Some(RegionSeed::Tools {
+            calls: vec![SeedToolCall::new("current_time")]
+        })
     );
 }
 

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -1034,7 +1034,8 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
     assert_eq!(
         region("clock"),
         Some(RegionSeed::Tools {
-            calls: vec![SeedToolCall::new("current_time")]
+            calls: vec![SeedToolCall::new("current_time")],
+            refresh: crate::layout::SeedRefresh::Once,
         })
     );
     // A list of bare names is a list of argument-free calls, in order.
@@ -1044,7 +1045,8 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
             calls: vec![
                 SeedToolCall::new("current_time"),
                 SeedToolCall::new("system_info"),
-            ]
+            ],
+            refresh: crate::layout::SeedRefresh::Once,
         })
     );
     // The two entry spellings mix in one list, because most calls take no
@@ -1058,12 +1060,90 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
                 // string: a call with no arguments, not one with null args.
                 SeedToolCall::new("system_info"),
                 SeedToolCall::new("locale_info"),
-            ]
+            ],
+            refresh: crate::layout::SeedRefresh::Once,
         })
     );
     assert!(
         region("plain").is_none(),
         "a non-task region with no seed stays None"
+    );
+}
+
+/// `refresh` decides whether a tool seed runs again on every stage entry. It
+/// defaults to `once`, which is what every other seed kind does, so the key's
+/// absence must not be read as an opt-in.
+#[test]
+fn a_tool_seed_refreshes_only_when_it_says_so() {
+    let base = r#"
+[agent]
+name = "seed-test"
+
+[stages.main]
+mode = "autonomous"
+
+[stages.main.model]
+provider = "anthropic"
+model = "claude-sonnet-5"
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 4000, seed = "task_input" }
+conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
+"#;
+    let refresh_of = |line: &str| {
+        let toml = format!("{base}{line}\n");
+        match parse_manifest(&toml)
+            .unwrap()
+            .context_layout
+            .get_region("r")
+            .unwrap()
+            .seed
+            .clone()
+        {
+            Some(RegionSeed::Tools { refresh, .. }) => Some(refresh),
+            _ => None,
+        }
+    };
+    use crate::layout::SeedRefresh;
+    // Unset is `once`, for both spellings of a tool seed.
+    assert_eq!(
+        refresh_of(
+            r#"r = { kind = "pinned", max_tokens = 500, seed = { tool = "current_time" } }"#
+        ),
+        Some(SeedRefresh::Once)
+    );
+    assert_eq!(
+        refresh_of(
+            r#"r = { kind = "pinned", max_tokens = 500, seed = { tools = ["current_time"] } }"#
+        ),
+        Some(SeedRefresh::Once)
+    );
+    // And set, again for both.
+    assert_eq!(
+        refresh_of(
+            r#"r = { kind = "pinned", max_tokens = 500, seed = { tool = "current_time", refresh = "each_stage" } }"#
+        ),
+        Some(SeedRefresh::EachStage)
+    );
+    assert_eq!(
+        refresh_of(
+            r#"r = { kind = "pinned", max_tokens = 500, seed = { tools = ["current_time"], refresh = "each_stage" } }"#
+        ),
+        Some(SeedRefresh::EachStage)
+    );
+    // A value that is not a word at all falls back rather than failing the
+    // whole manifest, as the rest of this parser does with a key it cannot read.
+    assert_eq!(
+        refresh_of(
+            r#"r = { kind = "pinned", max_tokens = 500, seed = { tool = "current_time", refresh = 7 } }"#
+        ),
+        Some(SeedRefresh::Once)
+    );
+    assert_eq!(
+        refresh_of(
+            r#"r = { kind = "pinned", max_tokens = 500, seed = { tool = "current_time", refresh = "every stage" } }"#
+        ),
+        Some(SeedRefresh::Once)
     );
 }
 
@@ -1121,7 +1201,8 @@ conversation = { kind = "sliding_window", max_items = 20, max_tokens = 10000 }
             r#"r = { kind = "pinned", max_tokens = 500, seed = { tools = [1, "current_time"] } }"#
         ),
         Some(RegionSeed::Tools {
-            calls: vec![SeedToolCall::new("current_time")]
+            calls: vec![SeedToolCall::new("current_time")],
+            refresh: crate::layout::SeedRefresh::Once,
         })
     );
 }

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -502,6 +502,26 @@ pub fn builtin_tool_classification(tool_name: &str) -> ToolClassification {
             ToolDirection::Outbound,
             TaintLevel::Public,
         ),
+        // The environment tools bring facts about the host *in*; none of them
+        // sends anything out, so none is a channel the gate needs to watch.
+        //
+        // `current_time` and `locale_info` are Public: the date and the user's
+        // language are not secrets. The other three are Internal because they
+        // name this machine, its directory layout, its installed software and
+        // the run's own configuration - not secret, but not for publishing
+        // either, so a Public-clearance outbound tool cannot forward them.
+        "current_time" | "locale_info" => ToolClassification::new(
+            TaintLevel::Public,
+            ToolDirection::Inbound,
+            TaintLevel::Public,
+        ),
+        "system_info" | "environment_info" | "which_command" | "runtime_info" => {
+            ToolClassification::new(
+                TaintLevel::Internal,
+                ToolDirection::Inbound,
+                TaintLevel::Public,
+            )
+        }
         "ask_user_text" | "ask_user_choice" | "ask_user_confirm" | "present_for_review" => {
             ToolClassification::new(
                 TaintLevel::Internal,
@@ -941,6 +961,55 @@ mod tests {
             let tc = builtin_tool_classification(name);
             assert_eq!(tc.sensitivity, TaintLevel::Public, "{name}");
             assert_eq!(tc.direction, ToolDirection::Outbound, "{name}");
+        }
+    }
+
+    /// The environment tools bring facts about the host in and send nothing
+    /// out, so none of them is a channel the gate needs to watch. Getting this
+    /// wrong is silent: the `_` fallback is outbound, so an unclassified
+    /// environment tool would be gated in every taint-tracking run, and asking
+    /// what day it is would raise a leak prompt.
+    #[test]
+    fn environment_tools_are_inbound_and_never_gated() {
+        for name in [
+            "current_time",
+            "system_info",
+            "locale_info",
+            "environment_info",
+            "which_command",
+            "runtime_info",
+        ] {
+            let tc = builtin_tool_classification(name);
+            assert_eq!(tc.direction, ToolDirection::Inbound, "{name}");
+            // Inbound tools are not gated at all, whatever the context holds.
+            assert_eq!(tc.clearance, TaintLevel::Public, "{name}");
+        }
+    }
+
+    /// The date and the user's language are not secrets; the machine's name,
+    /// its directory layout, its installed software and the run's own
+    /// configuration are not for publishing. The split matters because the
+    /// sensitivity is what an *outbound* tool later has to be cleared for.
+    #[test]
+    fn environment_tools_are_graded_by_what_they_reveal() {
+        for name in ["current_time", "locale_info"] {
+            assert_eq!(
+                builtin_tool_classification(name).sensitivity,
+                TaintLevel::Public,
+                "{name}"
+            );
+        }
+        for name in [
+            "system_info",
+            "environment_info",
+            "which_command",
+            "runtime_info",
+        ] {
+            assert_eq!(
+                builtin_tool_classification(name).sensitivity,
+                TaintLevel::Internal,
+                "{name}"
+            );
         }
     }
 

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -415,6 +415,13 @@ mod tests {
                 "literal",
             ),
             (
+                RegionSeed::Tools {
+                    calls: vec![leviath_core::layout::SeedToolCall::new("current_time")],
+                    refresh: leviath_core::layout::SeedRefresh::Once,
+                },
+                "tools",
+            ),
+            (
                 RegionSeed::Glob {
                     pattern: "p".to_string(),
                 },

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -233,6 +233,7 @@ fn seed_kind_name(seed: &leviath_core::layout::RegionSeed) -> &'static str {
         RegionSeed::Files { .. } => "files",
         RegionSeed::Rhai { .. } => "rhai",
         RegionSeed::Command { .. } => "command",
+        RegionSeed::Tools { .. } => "tools",
     }
 }
 

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -90,6 +90,7 @@ pub mod provider_creds;
 pub(crate) mod providers;
 pub(crate) mod repetition;
 pub mod restore;
+pub mod runtime_info_tool;
 pub mod script_provider;
 pub mod taint;
 pub mod telemetry;

--- a/crates/leviath-runtime/src/lib.rs
+++ b/crates/leviath-runtime/src/lib.rs
@@ -92,6 +92,7 @@ pub(crate) mod repetition;
 pub mod restore;
 pub mod runtime_info_tool;
 pub mod script_provider;
+pub mod stage_seeds;
 pub mod taint;
 pub mod telemetry;
 pub(crate) mod tick_scope;

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -4092,6 +4092,239 @@ fn runtime_info_is_answered_from_the_world_and_never_reaches_the_lane() {
     );
 }
 
+/// The stage-entry refresh, end to end through the two systems that implement
+/// it: entering a stage dispatches the region's calls and holds the stage, and
+/// the landed batch fills the region and lets the stage go.
+///
+/// The hold is the part worth proving. Without it the stage's first request is
+/// built from the previous stage's values and the refresh changes nothing that
+/// the model ever sees.
+#[test]
+fn a_refreshing_region_holds_the_stage_until_its_seed_lands() {
+    use crate::stage_seeds::{PendingStageSeeds, apply_stage_seeds, start_stage_seeds};
+
+    let mut world = World::new();
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+
+    // One region that refreshes, one that does not.
+    let mut layout = leviath_core::layout::ContextLayout::new(
+        vec![
+            leviath_core::layout::RegionDefinition::new(
+                "conversation".to_string(),
+                RegionKind::Clearable,
+                10_000,
+            ),
+            leviath_core::layout::RegionDefinition::new(
+                "environment".to_string(),
+                RegionKind::Pinned,
+                1000,
+            ),
+            leviath_core::layout::RegionDefinition::new(
+                "machine".to_string(),
+                RegionKind::Pinned,
+                1000,
+            ),
+        ],
+        12_000,
+    );
+    layout.regions[1].seed = Some(leviath_core::layout::RegionSeed::Tools {
+        calls: vec![leviath_core::layout::SeedToolCall::new("current_time")],
+        refresh: leviath_core::layout::SeedRefresh::EachStage,
+    });
+    layout.regions[2].seed = Some(leviath_core::layout::RegionSeed::Tools {
+        calls: vec![leviath_core::layout::SeedToolCall::new("system_info")],
+        refresh: leviath_core::layout::SeedRefresh::Once,
+    });
+    let stages = vec![leviath_core::Stage::new(
+        "main".to_string(),
+        leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+    )];
+    let bp = leviath_core::Blueprint::new("t".to_string(), "d".to_string(), stages, layout);
+
+    let mut window = ContextWindow::new(12_000);
+    window.add_region(Region::new(
+        "environment".to_string(),
+        RegionKind::Pinned,
+        1000,
+    ));
+    // What the previous stage left behind, so "kept" and "replaced" are
+    // distinguishable rather than both looking like an empty region.
+    window.replace_region("environment", "--- current_time ---\nSTALE".to_string(), 10);
+
+    let e = world
+        .spawn((
+            agent_state(),
+            AgentBlueprint(bp),
+            window,
+            StageJustEntered {
+                index: 0,
+                name: "main".to_string(),
+            },
+            ReadyToInfer,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(start_stage_seeds);
+    s.run(&mut world);
+
+    // The stage is held, and the calls went out.
+    assert!(
+        world.get::<ReadyToInfer>(e).is_none(),
+        "the stage must not run before its seed lands"
+    );
+    let pending = world
+        .get::<PendingStageSeeds>(e)
+        .expect("the batch is recorded")
+        .clone();
+    // Only the refreshing region was dispatched: a `once` seed already ran at
+    // spawn and must not cost a call per stage for the rest of the run.
+    assert_eq!(pending.sites.len(), 1);
+    assert_eq!(pending.sites[0].region, "environment");
+    assert_eq!(pending.sites[0].tool, "current_time");
+    let job = jrx.try_recv().expect("a job was queued");
+    assert_eq!(job.entity, e);
+
+    // The batch lands.
+    // Applied through a system rather than by hand, because that is how
+    // `collect_tools` calls it - including the deferred commands that release
+    // the stage.
+    let results = vec![(pending.sites[0].id.clone(), "FRESH".to_string())];
+    let mut apply = Schedule::default();
+    apply.add_systems(
+        move |mut q: Query<(Entity, &PendingStageSeeds, &mut ContextWindow)>,
+              mut commands: Commands| {
+            for (entity, pending, mut window) in q.iter_mut() {
+                apply_stage_seeds(entity, pending, &results, &mut window, &mut commands);
+            }
+        },
+    );
+    apply.run(&mut world);
+
+    // The region carries the new answer, and the stage is released.
+    let text = world
+        .get::<ContextWindow>(e)
+        .unwrap()
+        .get_region("environment")
+        .unwrap()
+        .content
+        .iter()
+        .map(|entry| entry.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(text.contains("--- current_time ---\nFRESH"), "{text}");
+    assert!(!text.contains("STALE"), "the stale value is gone: {text}");
+    assert!(
+        world.get::<ReadyToInfer>(e).is_some(),
+        "the stage is released"
+    );
+    assert!(world.get::<PendingStageSeeds>(e).is_none());
+}
+
+/// A seed batch rides the same lane as a model's tool calls, so it arrives on
+/// the same channel `collect_tools` drains. It has to be claimed there rather
+/// than by a second system: a channel has one receiver, and a second drainer
+/// would take whichever outcomes it reached first while the other kind vanished.
+///
+/// What this proves is that the claim happens - the region is filled and the
+/// stage released - and that the results are NOT appended to the conversation
+/// as tool results for calls the model never made.
+#[test]
+fn collect_tools_routes_a_seed_batch_to_its_region_not_to_the_conversation() {
+    use crate::stage_seeds::{PendingStageSeeds, SeedCallSite};
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolResults(rx));
+
+    let mut window = conv_window();
+    window.add_region(Region::new(
+        "environment".to_string(),
+        RegionKind::Pinned,
+        1000,
+    ));
+    let e = world
+        .spawn((
+            window,
+            PendingStageSeeds {
+                sites: vec![SeedCallSite {
+                    id: "stage-seed-0".to_string(),
+                    region: "environment".to_string(),
+                    tool: "current_time".to_string(),
+                }],
+            },
+        ))
+        .id();
+    tx.send(ToolOutcome {
+        elapsed: std::time::Duration::ZERO,
+        entity: e,
+        results: vec![("stage-seed-0".to_string(), "NOW".to_string())],
+    })
+    .unwrap();
+
+    run_collect_tools(&mut world);
+
+    let window = world.get::<ContextWindow>(e).unwrap();
+    let env = window
+        .get_region("environment")
+        .expect("the seeded region")
+        .content
+        .iter()
+        .map(|entry| entry.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(env.contains("--- current_time ---\nNOW"), "{env}");
+    // The conversation is untouched: a seed is not a turn.
+    assert!(
+        window
+            .get_region("conversation")
+            .expect("the conversation region")
+            .content
+            .is_empty(),
+        "a seed batch must not be appended to the conversation"
+    );
+    // And the stage is released, with the hold cleared.
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+    assert!(world.get::<PendingStageSeeds>(e).is_none());
+}
+
+/// A stage entry for an agent with no refreshing region must not hold the
+/// stage - every transition in every ordinary run passes through this system.
+#[test]
+fn a_stage_entry_with_nothing_to_refresh_is_not_held() {
+    use crate::stage_seeds::{PendingStageSeeds, start_stage_seeds};
+
+    let mut world = World::new();
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let e = world
+        .spawn((
+            agent_state(),
+            AgentBlueprint(blueprint(vec![leviath_core::Stage::new(
+                "main".to_string(),
+                leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+            )])),
+            conv_window(),
+            StageJustEntered {
+                index: 0,
+                name: "main".to_string(),
+            },
+            ReadyToInfer,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(start_stage_seeds);
+    s.run(&mut world);
+
+    assert!(world.get::<ReadyToInfer>(e).is_some(), "not held");
+    assert!(world.get::<PendingStageSeeds>(e).is_none());
+    assert!(jrx.try_recv().is_err(), "nothing was queued");
+}
+
 fn ctx_call(id: &str, region: &str, content: &str) -> crate::components::ToolCall {
     crate::components::ToolCall {
         tool_id: id.to_string(),

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -3987,6 +3987,111 @@ fn infer_with(
     )
 }
 
+/// `runtime_info` is advertised by `leviath-tools` but answered here, because
+/// the stage, the iteration counts and the window occupancy exist only in the
+/// world. The failure this guards is the tool reaching the async lane, where
+/// `BuiltinTools::execute` would hand the model
+/// `[error] runtime_info must be handled by the runtime` instead of an answer.
+#[test]
+fn runtime_info_is_answered_from_the_world_and_never_reaches_the_lane() {
+    let mut world = World::new();
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let (offers, result) = infer_with(vec![tc("c1", "runtime_info")]);
+    let mut metadata = run_metadata();
+    metadata.unattended = true;
+    metadata.num_stages = 4;
+    // Four stages, and the one under the cursor caps its iterations. The cap is
+    // read from the blueprint at the cursor's index rather than from the agent,
+    // so a blueprint with distinct caps is what proves the right one is read.
+    let stages: Vec<leviath_core::Stage> = ["a", "b", "gather", "d"]
+        .iter()
+        .enumerate()
+        .map(|(i, name)| {
+            let mut st = leviath_core::Stage::new(
+                (*name).to_string(),
+                leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+            );
+            st.max_iterations = Some(10 + i);
+            st
+        })
+        .collect();
+    let e = world
+        .spawn((
+            agent_state(),
+            metadata,
+            AgentBlueprint(blueprint(stages)),
+            offers,
+            result,
+            conv_window(),
+            StageCursor { index: 2 },
+            crate::pipeline::response::StageProgress {
+                iterations: 3,
+                ..Default::default()
+            },
+            ReadyForTools,
+        ))
+        .id();
+
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    // Nothing was queued: the whole point is that it is answered inline.
+    assert!(
+        jrx.try_recv().is_err(),
+        "runtime_info must not be handed to the tool lane"
+    );
+
+    // A batch with nothing lane-bound applies its results straight into the
+    // window and never stashes them, so the window is the only record.
+    let window = world.get::<ContextWindow>(e).expect("the window survives");
+    let conversation = window
+        .regions
+        .iter()
+        .find(|r| r.name == "conversation")
+        .expect("the conversation region");
+    let text = conversation
+        .content
+        .iter()
+        .map(|entry| entry.content.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let (_, from_brace) = text
+        .split_once('{')
+        .expect("the JSON answer is in the window");
+    let (body, _) = from_brace
+        .rsplit_once('}')
+        .expect("the JSON answer is closed");
+    let v: serde_json::Value =
+        serde_json::from_str(&format!("{{{body}}}")).expect("runtime_info answers with JSON");
+    // And the agent is released to infer on the answer rather than left waiting
+    // on a lane that was never given anything.
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+    // The facts really came from this world rather than from defaults.
+    assert_eq!(v["run_id"], "run-1");
+    assert_eq!(v["agent"], "a");
+    assert_eq!(v["stage"]["name"], "s");
+    assert_eq!(v["stage"]["index"], 2);
+    assert_eq!(v["stage"]["of"], 4);
+    assert_eq!(v["stage"]["iterations"], 3);
+    // The cap of stage index 2, not of the first stage or the last.
+    assert_eq!(v["stage"]["max_iterations"], 12);
+    assert_eq!(v["stage"]["iterations_remaining"], 9);
+    assert_eq!(v["provider"], "p");
+    assert_eq!(v["model"], "m");
+    assert_eq!(v["working_directory"], "/w");
+    // And the field the model is meant to act on carries through.
+    assert_eq!(v["unattended"], true);
+    assert!(
+        v["interaction"]
+            .as_str()
+            .is_some_and(|g| g.contains("ask_user_text")),
+        "an unattended run is told which tools nobody will answer"
+    );
+}
+
 fn ctx_call(id: &str, region: &str, content: &str) -> crate::components::ToolCall {
     crate::components::ToolCall {
         tool_id: id.to_string(),

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -363,11 +363,36 @@ type ToolQuery = (
 pub fn collect_tools(
     mut results: ResMut<ToolResults>,
     mut agents: Query<ToolQuery, With<AwaitingTools>>,
+    // Stage-entry seed batches ride the same lane, so they arrive on the same
+    // channel. They are claimed here rather than in a system of their own
+    // because a channel has one receiver: a second drainer would take whichever
+    // outcomes it happened to reach first, and the other kind would vanish.
+    mut seeding: Query<
+        (
+            &crate::stage_seeds::PendingStageSeeds,
+            &mut crate::components::ContextWindow,
+        ),
+        Without<AwaitingTools>,
+    >,
     sink: Option<Res<crate::host::WorldEventSink>>,
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
     while let Ok(outcome) = results.0.try_recv() {
+        // A seed batch is not a turn: its results fill regions and release the
+        // stage, rather than being appended to the conversation as tool results
+        // for calls the model never made.
+        if let Ok((pending, mut window)) = seeding.get_mut(outcome.entity) {
+            crate::tick_scope::enter(outcome.entity);
+            crate::stage_seeds::apply_stage_seeds(
+                outcome.entity,
+                pending,
+                &outcome.results,
+                &mut window,
+                &mut commands,
+            );
+            continue;
+        }
         let Ok((
             mut window,
             infer,

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -281,7 +281,17 @@ type DispatchToolsQuery = (
     Option<&'static crate::components::GateAutoApprove>,
     Option<&'static InFlightWork>,
     Option<&'static StageCursor>,
-    Option<&'static RunMetadata>,
+    // Nested rather than two more members: `QueryData` is implemented up to a
+    // fixed arity and this tuple had reached it. Grouping the two run-context
+    // components keeps the list inside the limit without splitting the system.
+    //
+    // `StageProgress` is here for `runtime_info`: `AgentState.iteration` is
+    // run-cumulative, so the per-stage count to compare against the stage's own
+    // cap comes from there.
+    (
+        Option<&'static RunMetadata>,
+        Option<&'static crate::pipeline::response::StageProgress>,
+    ),
     Option<&'static crate::components::OutputValidators>,
     // For the submit_output guard: a submission that is exactly the name of a
     // stage in this blueprint is a routing token, not an answer.
@@ -359,7 +369,7 @@ pub fn dispatch_tools(
         auto_gate,
         in_flight,
         cursor,
-        metadata,
+        (metadata, stage_progress),
         validators,
         blueprint,
     ) in agents.iter_mut()
@@ -420,6 +430,36 @@ pub fn dispatch_tools(
             // gate-prompt re-run of the same batch refuses identically.
             if let Some(refusal) = invalid_args_refusal(stage_inf, &c.name, &c.arguments) {
                 context_results.push((c.tool_id.clone(), refusal));
+                continue;
+            }
+            // Answered inline for the same reason the context tools are: the
+            // stage, the iteration counts and the window occupancy it reports
+            // live in the world, which the async lane cannot reach.
+            if crate::runtime_info_tool::is_runtime_info_tool(&c.name) {
+                let stage_max = blueprint
+                    .zip(cursor)
+                    .and_then(|(bp, cur)| bp.0.stages.get(cur.index))
+                    .and_then(|s| s.max_iterations);
+                let facts = crate::runtime_info_tool::RuntimeFacts {
+                    version: env!("CARGO_PKG_VERSION"),
+                    run_id: metadata.map(|m| m.run_id.as_str()),
+                    agent: metadata.map(|m| m.agent_name.as_str()),
+                    stage: &state.current_stage,
+                    stage_index: cursor
+                        .zip(metadata)
+                        .map(|(cur, m)| (cur.index, m.num_stages)),
+                    stage_iterations: (
+                        stage_progress.map(|p| p.iterations).unwrap_or(0),
+                        stage_max,
+                    ),
+                    total_iterations: state.iteration,
+                    provider_model: (&stage_inf.provider_name, &stage_inf.model),
+                    tools: stage_inf.tools.iter().map(|t| t.name.as_str()).collect(),
+                    unattended: metadata.is_some_and(|m| m.unattended),
+                    workdir: metadata.map(|m| m.workdir.as_str()),
+                };
+                let text = crate::runtime_info_tool::handle_runtime_info(&facts, &window);
+                context_results.push((c.tool_id.clone(), text));
                 continue;
             }
             if crate::context_tools::is_context_tool(&c.name) {

--- a/crates/leviath-runtime/src/repetition.rs
+++ b/crates/leviath-runtime/src/repetition.rs
@@ -52,6 +52,12 @@ const READONLY_TOOLS: &[&str] = &[
     "search",
     "context_read",
     "context_list",
+    "current_time",
+    "system_info",
+    "locale_info",
+    "environment_info",
+    "which_command",
+    "runtime_info",
 ];
 
 /// Tools considered "productive" (produce side effects / forward progress).

--- a/crates/leviath-runtime/src/runtime_info_tool.rs
+++ b/crates/leviath-runtime/src/runtime_info_tool.rs
@@ -1,0 +1,276 @@
+//! The `runtime_info` tool: a run reporting on itself.
+//!
+//! Everything it answers - which stage is running, how many iterations are
+//! left, which model is being called, how much of the context window is spent,
+//! whether anyone is there to answer a question - exists only in the live
+//! world. So unlike the other environment tools it is advertised by
+//! `leviath-tools` and handled here, alongside the `context_*` tools, for the
+//! same reason they are: the async tool lane cannot reach the ECS window.
+//!
+//! The field that changes behaviour most is `unattended`. An agent that cannot
+//! tell will call `ask_user_text` in a run with nobody watching and park there
+//! until something times it out; one that can tell will write its question into
+//! its output instead.
+
+use crate::components::ContextWindow;
+
+/// Whether `name` is the runtime self-report tool.
+pub fn is_runtime_info_tool(name: &str) -> bool {
+    name == "runtime_info"
+}
+
+/// Everything `runtime_info` reports, gathered by the caller from the world.
+///
+/// A struct rather than a dozen arguments because the caller assembles it from
+/// six different components, and a positional list of that length is one
+/// transposition away from reporting the stage index as the iteration count.
+pub struct RuntimeFacts<'a> {
+    /// The `lev` version this run is executing under.
+    pub version: &'a str,
+    /// The run's id, as it appears in `lev ps` and on disk.
+    pub run_id: Option<&'a str>,
+    /// The blueprint's name.
+    pub agent: Option<&'a str>,
+    /// The stage running right now.
+    pub stage: &'a str,
+    /// Which stage this is, and how many the blueprint has.
+    pub stage_index: Option<(usize, usize)>,
+    /// Inferences run in this stage, and the stage's own cap when it sets one.
+    pub stage_iterations: (usize, Option<usize>),
+    /// Inferences run across the whole run so far.
+    pub total_iterations: usize,
+    /// The provider and model being called for this stage.
+    pub provider_model: (&'a str, &'a str),
+    /// The tool names this stage advertises.
+    pub tools: Vec<&'a str>,
+    /// Whether the run was launched with nobody available to answer a prompt.
+    pub unattended: bool,
+    /// The run's working directory.
+    pub workdir: Option<&'a str>,
+}
+
+/// Render the facts as the object the model reads.
+///
+/// Pure over [`RuntimeFacts`] so every field can be asserted without building a
+/// world: the caller's job is to gather, this one's is to shape.
+pub fn describe_runtime(facts: &RuntimeFacts<'_>, window: &ContextWindow) -> serde_json::Value {
+    let used = window.calculate_tokens();
+    let (stage_iterations, stage_max) = facts.stage_iterations;
+    let (provider, model) = facts.provider_model;
+    serde_json::json!({
+        "leviath_version": facts.version,
+        "run_id": facts.run_id,
+        "agent": facts.agent,
+        "working_directory": facts.workdir,
+        "stage": {
+            "name": facts.stage,
+            "index": facts.stage_index.map(|(i, _)| i),
+            "of": facts.stage_index.map(|(_, n)| n),
+            "iterations": stage_iterations,
+            "max_iterations": stage_max,
+            // The number the model can actually act on. Absent when the stage
+            // sets no cap, which is a different thing from "none left".
+            "iterations_remaining": stage_max.map(|m| m.saturating_sub(stage_iterations)),
+        },
+        "total_iterations": facts.total_iterations,
+        "provider": provider,
+        "model": model,
+        "context": {
+            "used_tokens": used,
+            "window_tokens": window.max_tokens,
+            "remaining_tokens": window.max_tokens.saturating_sub(used),
+        },
+        "available_tools": facts.tools,
+        "unattended": facts.unattended,
+        // Spelled out rather than left for the model to infer from the flag,
+        // because the inference is the part that goes wrong: an agent reads
+        // `unattended: true` and still asks, having no rule attached to it.
+        "interaction": match facts.unattended {
+            true => "This run is unattended: nobody will answer ask_user_text, \
+                     ask_user_choice, ask_user_confirm or present_for_review. \
+                     Decide for yourself and record the assumption in your output.",
+            false => "A person is available to answer ask_user_text, \
+                      ask_user_choice, ask_user_confirm and present_for_review.",
+        },
+    })
+}
+
+/// Answer one `runtime_info` call.
+pub fn handle_runtime_info(facts: &RuntimeFacts<'_>, window: &ContextWindow) -> String {
+    let value = describe_runtime(facts, window);
+    // Indented to match what the `leviath-tools` environment tools return, so
+    // the family reads the same however it is dispatched. Serializing a `Value`
+    // of primitives cannot fail, and a fallback rendering would be a branch
+    // nothing could reach or test.
+    serde_json::to_string_pretty(&value).expect("a Value of primitives always serializes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn facts<'a>() -> RuntimeFacts<'a> {
+        RuntimeFacts {
+            version: "0.4.0",
+            run_id: Some("deep-researcher-1787093177-d5005a3cfc4d"),
+            agent: Some("deep-researcher"),
+            stage: "gather",
+            stage_index: Some((0, 7)),
+            stage_iterations: (3, Some(20)),
+            total_iterations: 11,
+            provider_model: ("anthropic", "claude-sonnet-5"),
+            tools: vec!["web_search", "current_time"],
+            unattended: false,
+            workdir: Some("/work"),
+        }
+    }
+
+    #[test]
+    fn the_report_names_the_run_the_stage_and_the_model() {
+        let window = ContextWindow::new(200_000);
+        let v = describe_runtime(&facts(), &window);
+        assert_eq!(v["leviath_version"], "0.4.0");
+        assert_eq!(v["run_id"], "deep-researcher-1787093177-d5005a3cfc4d");
+        assert_eq!(v["agent"], "deep-researcher");
+        assert_eq!(v["working_directory"], "/work");
+        assert_eq!(v["stage"]["name"], "gather");
+        assert_eq!(v["stage"]["index"], 0);
+        assert_eq!(v["stage"]["of"], 7);
+        assert_eq!(v["stage"]["iterations"], 3);
+        assert_eq!(v["stage"]["max_iterations"], 20);
+        assert_eq!(v["total_iterations"], 11);
+        assert_eq!(v["provider"], "anthropic");
+        assert_eq!(v["model"], "claude-sonnet-5");
+        assert_eq!(
+            v["available_tools"],
+            serde_json::json!(["web_search", "current_time"])
+        );
+        assert_eq!(v["context"]["window_tokens"], 200_000);
+    }
+
+    /// The number a model can act on is what is *left*, and deriving it from
+    /// two others is exactly the arithmetic it gets wrong under pressure.
+    #[test]
+    fn the_remaining_iterations_are_computed_rather_than_left_to_be_inferred() {
+        let window = ContextWindow::new(1000);
+        let v = describe_runtime(&facts(), &window);
+        assert_eq!(v["stage"]["iterations_remaining"], 17);
+
+        // Past the cap floors at zero rather than wrapping to a huge number,
+        // which is what a plain subtraction on `usize` would produce.
+        let mut over = facts();
+        over.stage_iterations = (25, Some(20));
+        let v = describe_runtime(&over, &window);
+        assert_eq!(v["stage"]["iterations_remaining"], 0);
+
+        // An uncapped stage reports null: "no limit" is not "none left".
+        let mut uncapped = facts();
+        uncapped.stage_iterations = (3, None);
+        let v = describe_runtime(&uncapped, &window);
+        assert_eq!(v["stage"]["max_iterations"], serde_json::Value::Null);
+        assert_eq!(v["stage"]["iterations_remaining"], serde_json::Value::Null);
+    }
+
+    /// The whole point of the field: an unattended run says so in words the
+    /// model can act on, naming the tools that will not be answered.
+    #[test]
+    fn an_unattended_run_is_told_not_to_ask() {
+        let window = ContextWindow::new(1000);
+        let mut f = facts();
+        f.unattended = true;
+        let v = describe_runtime(&f, &window);
+        assert_eq!(v["unattended"], true);
+        let guidance = v["interaction"].as_str().expect("guidance is a string");
+        assert!(guidance.contains("unattended"));
+        for tool in [
+            "ask_user_text",
+            "ask_user_choice",
+            "ask_user_confirm",
+            "present_for_review",
+        ] {
+            assert!(guidance.contains(tool), "{tool} must be named");
+        }
+
+        // And an attended run says the opposite rather than staying silent.
+        let attended = describe_runtime(&facts(), &window);
+        assert_eq!(attended["unattended"], false);
+        let guidance = attended["interaction"].as_str().unwrap();
+        assert!(guidance.contains("A person is available"));
+    }
+
+    /// A bare world - `lev run` with no daemon behind it - has no run metadata
+    /// and no stage catalogue. Every such field reports null rather than the
+    /// call failing: an agent asking what it is running under should not be
+    /// punished for running somewhere thin.
+    #[test]
+    fn a_run_without_metadata_reports_nulls_rather_than_refusing() {
+        let window = ContextWindow::new(1000);
+        let bare = RuntimeFacts {
+            version: "0.4.0",
+            run_id: None,
+            agent: None,
+            stage: "main",
+            stage_index: None,
+            stage_iterations: (0, None),
+            total_iterations: 0,
+            provider_model: ("", ""),
+            tools: Vec::new(),
+            unattended: false,
+            workdir: None,
+        };
+        let v = describe_runtime(&bare, &window);
+        assert_eq!(v["run_id"], serde_json::Value::Null);
+        assert_eq!(v["agent"], serde_json::Value::Null);
+        assert_eq!(v["working_directory"], serde_json::Value::Null);
+        assert_eq!(v["stage"]["index"], serde_json::Value::Null);
+        assert_eq!(v["stage"]["of"], serde_json::Value::Null);
+        assert_eq!(v["available_tools"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn context_use_is_reported_against_the_window_it_is_measured_in() {
+        let mut window = ContextWindow::new(500);
+        let before = describe_runtime(&facts(), &window);
+        assert_eq!(before["context"]["used_tokens"], 0);
+        assert_eq!(before["context"]["remaining_tokens"], 500);
+
+        window.add_region(leviath_core::Region::new(
+            "notes".to_string(),
+            leviath_core::RegionKind::Pinned,
+            400,
+        ));
+        window.replace_region("notes", "some content".to_string(), 120);
+        let after = describe_runtime(&facts(), &window);
+        assert_eq!(after["context"]["used_tokens"], 120);
+        assert_eq!(after["context"]["remaining_tokens"], 380);
+    }
+
+    /// An overfull window floors at zero rather than wrapping, the same way the
+    /// iteration remainder does.
+    #[test]
+    fn an_overfull_window_reports_nothing_remaining() {
+        let mut window = ContextWindow::new(100);
+        window.add_region(leviath_core::Region::new(
+            "notes".to_string(),
+            leviath_core::RegionKind::Pinned,
+            1000,
+        ));
+        window.replace_region("notes", "lots".to_string(), 250);
+        let v = describe_runtime(&facts(), &window);
+        assert_eq!(v["context"]["remaining_tokens"], 0);
+    }
+
+    #[test]
+    fn the_handler_answers_only_to_its_own_name_and_renders_indented_json() {
+        assert!(is_runtime_info_tool("runtime_info"));
+        assert!(!is_runtime_info_tool("current_time"));
+        assert!(!is_runtime_info_tool("context_read"));
+
+        let window = ContextWindow::new(1000);
+        let text = handle_runtime_info(&facts(), &window);
+        assert!(text.contains("\n  \""), "rendered indented: {text}");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&text).expect("the handler returns JSON");
+        assert_eq!(parsed["stage"]["name"], "gather");
+    }
+}

--- a/crates/leviath-runtime/src/stage_seeds.rs
+++ b/crates/leviath-runtime/src/stage_seeds.rs
@@ -1,0 +1,398 @@
+//! Re-running a `refresh = "each_stage"` tool seed when a stage is entered.
+//!
+//! A seed normally resolves once, at spawn, in the daemon's spawner. That is
+//! right for a region filled from files or a literal, and wrong for one filled
+//! from a clock: a run that spends an hour in `gather` and then enters `analyze`
+//! should date the second stage from when it started, not from when the run did.
+//!
+//! # Why this lives here and not in the spawner
+//!
+//! Only the runtime knows a stage was entered, and only the tool lane can run a
+//! call without blocking the tick - an MCP tool may take seconds, and the tick
+//! loop drives every other agent in the daemon. So the calls go out on the same
+//! lane a model's tool calls use, and land on a later tick.
+//!
+//! # Holding the stage back
+//!
+//! Stage entry sets `ReadyToInfer`. A refreshed region has to be in place
+//! *before* the stage's first request is built, or the stage would run its first
+//! turn against the previous stage's values and the refresh would be pointless.
+//! So [`start_stage_seeds`] takes `ReadyToInfer` away and [`apply_stage_seeds`]
+//! puts it back - the same hold-and-release the interaction-point lane uses.
+//!
+//! A failed call leaves the region as it was rather than blanking it: the
+//! previous value is merely stale, and stale beats absent.
+
+use bevy_ecs::prelude::*;
+use leviath_core::layout::{RegionSeed, SeedRefresh, SeedToolCall};
+
+use crate::components::ContextWindow;
+use crate::pipeline::{AgentBlueprint, ReadyToInfer, StageJustEntered, ToolServiceRes, ToolStage};
+
+/// One dispatched stage-entry seed call, and where its answer belongs.
+///
+/// The lane answers with `(id, result)` pairs and has no notion of a region or
+/// a heading, so both travel with the id rather than being recovered from it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeedCallSite {
+    /// The tool-call id the lane will answer under.
+    pub id: String,
+    /// The region this answer fills.
+    pub region: String,
+    /// The tool called, which is also the heading its block carries.
+    pub tool: String,
+}
+
+/// An agent whose stage-entry seed calls are out on the tool lane.
+#[derive(Component, Debug, Clone)]
+pub struct PendingStageSeeds {
+    /// The dispatched calls, in order.
+    pub sites: Vec<SeedCallSite>,
+}
+
+/// The regions of `blueprint` that re-seed on every stage entry, with their
+/// calls.
+///
+/// Pure over the blueprint so the selection is testable without a world.
+pub fn refreshing_regions(blueprint: &leviath_core::Blueprint) -> Vec<(&str, &[SeedToolCall])> {
+    blueprint
+        .context_layout
+        .regions
+        .iter()
+        .filter_map(|r| match &r.seed {
+            Some(RegionSeed::Tools {
+                calls,
+                refresh: SeedRefresh::EachStage,
+            }) => Some((r.name.as_str(), calls.as_slice())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// The call sites for one stage entry, numbered in dispatch order.
+///
+/// Ids are prefixed so they cannot collide with a provider-minted one, and
+/// numbered because one region can make several calls and the lane answers with
+/// a flat list.
+pub fn call_sites(regions: &[(&str, &[SeedToolCall])]) -> Vec<SeedCallSite> {
+    let mut sites = Vec::new();
+    for (region, calls) in regions {
+        for call in *calls {
+            sites.push(SeedCallSite {
+                id: format!("stage-seed-{}", sites.len()),
+                region: (*region).to_string(),
+                tool: call.name.clone(),
+            });
+        }
+    }
+    sites
+}
+
+/// The agents [`start_stage_seeds`] considers: those that just entered a stage
+/// and do not already have a batch out.
+///
+/// A named alias rather than the type inline, because it is long enough that
+/// the workspace's `type_complexity` lint refuses it at a call site.
+type StageSeedQuery<'w, 's> = Query<
+    'w,
+    's,
+    (Entity, &'static AgentBlueprint),
+    (With<StageJustEntered>, Without<PendingStageSeeds>),
+>;
+
+/// Dispatch every refreshing region's calls for an agent that just entered a
+/// stage, and hold the stage until they land.
+///
+/// Ordered with the other `StageJustEntered` systems, before `sync_tool_stages`
+/// consumes that marker.
+pub fn start_stage_seeds(
+    agents: StageSeedQuery,
+    service: Res<ToolServiceRes>,
+    stage: Res<ToolStage>,
+    mut commands: Commands,
+) {
+    crate::tick_scope::clear();
+    for (entity, blueprint) in agents.iter() {
+        crate::tick_scope::enter(entity);
+        let regions = refreshing_regions(&blueprint.0);
+        let sites = call_sites(&regions);
+        if sites.is_empty() {
+            continue;
+        }
+        let calls = regions
+            .iter()
+            .flat_map(|(_, calls)| calls.iter())
+            .zip(sites.iter())
+            .map(|(call, site)| leviath_providers::ToolCall {
+                id: site.id.clone(),
+                name: call.name.clone(),
+                arguments: call.args.clone(),
+                thought_signature: None,
+            })
+            .collect();
+        let exec = service
+            .0
+            .exec_for(entity, calls, crate::pipeline::noop_progress());
+        stage.stats.enqueued();
+        // A failed send means the lane is gone, which only happens at shutdown.
+        // The hold stays on: releasing it would start the stage against a region
+        // that was never refreshed, and a shutting-down daemon has nowhere to
+        // run the stage anyway.
+        let _ = stage.jobs.send(crate::tool_bridge::ToolJob {
+            entity,
+            exec,
+            cancel: crate::cancel::CancelToken::new(),
+        });
+        commands
+            .entity(entity)
+            .remove::<ReadyToInfer>()
+            .insert(PendingStageSeeds { sites });
+    }
+}
+
+/// Group one landed batch into `(region, content)` pairs.
+///
+/// Pure over the sites and the results, so the grouping is testable without a
+/// lane. A region whose every call failed is absent from the result, which is
+/// what leaves its previous content in place.
+pub fn seeded_content(
+    sites: &[SeedCallSite],
+    results: &[(String, String)],
+) -> Vec<(String, String)> {
+    let mut per_region: Vec<(String, Vec<String>)> = Vec::new();
+    for site in sites {
+        let Some((_, text)) = results.iter().find(|(id, _)| *id == site.id) else {
+            continue;
+        };
+        // The tool layer reports refusal and failure in-band and prefixed - the
+        // same contract the spawn-time seed reads. Neither is data, so neither
+        // gets a heading claiming the tool answered.
+        if text.trim().is_empty() || text.starts_with("[error]") || text.starts_with("[denied]") {
+            continue;
+        }
+        let block = format!("--- {} ---\n{}", site.tool, text.trim_end());
+        match per_region.iter_mut().find(|(r, _)| *r == site.region) {
+            Some((_, blocks)) => blocks.push(block),
+            None => per_region.push((site.region.clone(), vec![block])),
+        }
+    }
+    per_region
+        .into_iter()
+        .map(|(region, blocks)| (region, blocks.join("\n\n")))
+        .collect()
+}
+
+/// Apply a landed stage-entry seed batch and release the stage.
+pub fn apply_stage_seeds(
+    entity: Entity,
+    pending: &PendingStageSeeds,
+    results: &[(String, String)],
+    window: &mut ContextWindow,
+    commands: &mut Commands,
+) {
+    for (region, content) in seeded_content(&pending.sites, results) {
+        let tokens = leviath_core::estimate_tokens(&content);
+        window.replace_region(&region, content, tokens);
+    }
+    commands
+        .entity(entity)
+        .remove::<PendingStageSeeds>()
+        .insert(ReadyToInfer);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::layout::{ContextLayout, RegionDefinition};
+    use leviath_core::{RegionKind, Stage};
+
+    fn blueprint_with(seeds: Vec<(&str, Option<RegionSeed>)>) -> leviath_core::Blueprint {
+        let regions = seeds
+            .into_iter()
+            .map(|(name, seed)| {
+                let mut r = RegionDefinition::new(name.to_string(), RegionKind::Pinned, 1000);
+                r.seed = seed;
+                r
+            })
+            .collect();
+        let layout = ContextLayout::new(regions, 10_000);
+        let stages = vec![Stage::new(
+            "main".to_string(),
+            leviath_core::blueprint::ModelConfig::new("p".to_string(), "m".to_string()),
+        )];
+        leviath_core::Blueprint::new("t".to_string(), "d".to_string(), stages, layout)
+    }
+
+    fn tools(names: &[&str], refresh: SeedRefresh) -> RegionSeed {
+        RegionSeed::Tools {
+            calls: names.iter().map(|n| SeedToolCall::new(*n)).collect(),
+            refresh,
+        }
+    }
+
+    /// Only `each_stage` seeds re-run. A `once` tool seed, and every other seed
+    /// kind, resolved at spawn and must not be called again on every entry -
+    /// that would be a tool call per stage for the life of the run.
+    #[test]
+    fn only_each_stage_tool_seeds_are_refreshed() {
+        let bp = blueprint_with(vec![
+            (
+                "clock",
+                Some(tools(&["current_time"], SeedRefresh::EachStage)),
+            ),
+            ("machine", Some(tools(&["system_info"], SeedRefresh::Once))),
+            (
+                "readme",
+                Some(RegionSeed::Files {
+                    paths: vec!["README.md".to_string()],
+                }),
+            ),
+            ("notes", None),
+        ]);
+        let picked = refreshing_regions(&bp);
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].0, "clock");
+        assert_eq!(picked[0].1.len(), 1);
+        assert_eq!(picked[0].1[0].name, "current_time");
+    }
+
+    #[test]
+    fn a_blueprint_with_no_refreshing_region_dispatches_nothing() {
+        let bp = blueprint_with(vec![(
+            "machine",
+            Some(tools(&["system_info"], SeedRefresh::Once)),
+        )]);
+        assert!(refreshing_regions(&bp).is_empty());
+        assert!(call_sites(&refreshing_regions(&bp)).is_empty());
+    }
+
+    /// Ids are unique across the whole batch, not per region: the lane answers
+    /// with one flat list, and two regions calling the same tool would otherwise
+    /// collide and file both answers under whichever matched first.
+    #[test]
+    fn call_sites_are_numbered_across_the_whole_batch() {
+        let bp = blueprint_with(vec![
+            (
+                "a",
+                Some(tools(
+                    &["current_time", "system_info"],
+                    SeedRefresh::EachStage,
+                )),
+            ),
+            ("b", Some(tools(&["current_time"], SeedRefresh::EachStage))),
+        ]);
+        let sites = call_sites(&refreshing_regions(&bp));
+        assert_eq!(
+            sites,
+            vec![
+                SeedCallSite {
+                    id: "stage-seed-0".into(),
+                    region: "a".into(),
+                    tool: "current_time".into()
+                },
+                SeedCallSite {
+                    id: "stage-seed-1".into(),
+                    region: "a".into(),
+                    tool: "system_info".into()
+                },
+                SeedCallSite {
+                    id: "stage-seed-2".into(),
+                    region: "b".into(),
+                    tool: "current_time".into()
+                },
+            ]
+        );
+        // The ids really are distinct, which is the property the grouping needs.
+        let unique: std::collections::HashSet<&String> = sites.iter().map(|s| &s.id).collect();
+        assert_eq!(unique.len(), sites.len());
+    }
+
+    fn sites_for(pairs: &[(&str, &str, &str)]) -> Vec<SeedCallSite> {
+        pairs
+            .iter()
+            .map(|(id, region, tool)| SeedCallSite {
+                id: (*id).to_string(),
+                region: (*region).to_string(),
+                tool: (*tool).to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn results_are_grouped_per_region_under_their_tool_headings() {
+        let sites = sites_for(&[
+            ("s0", "env", "current_time"),
+            ("s1", "env", "locale_info"),
+            ("s2", "tools", "which_command"),
+        ]);
+        let results = vec![
+            ("s0".to_string(), "{\"date\":\"2026-08-18\"}".to_string()),
+            ("s1".to_string(), "{\"locale\":\"en-US\"}".to_string()),
+            ("s2".to_string(), "{\"found\":true}".to_string()),
+        ];
+        let grouped = seeded_content(&sites, &results);
+        assert_eq!(
+            grouped,
+            vec![
+                (
+                    "env".to_string(),
+                    "--- current_time ---\n{\"date\":\"2026-08-18\"}\n\n\
+                     --- locale_info ---\n{\"locale\":\"en-US\"}"
+                        .to_string()
+                ),
+                (
+                    "tools".to_string(),
+                    "--- which_command ---\n{\"found\":true}".to_string()
+                ),
+            ]
+        );
+    }
+
+    /// A refused or failed call is not data. The region keeps whatever it had,
+    /// which is stale rather than wrong - and a heading over `[error] ...` would
+    /// read to the model as the tool having answered that.
+    #[test]
+    fn refused_failed_and_empty_answers_contribute_nothing() {
+        let sites = sites_for(&[
+            ("s0", "env", "current_time"),
+            ("s1", "env", "system_info"),
+            ("s2", "env", "locale_info"),
+            ("s3", "env", "which_command"),
+        ]);
+        let results = vec![
+            ("s0".to_string(), "[error] tool error: nope".to_string()),
+            ("s1".to_string(), "[denied] not allowed".to_string()),
+            ("s2".to_string(), "   \n".to_string()),
+            ("s3".to_string(), "found".to_string()),
+        ];
+        let grouped = seeded_content(&sites, &results);
+        assert_eq!(
+            grouped,
+            vec![(
+                "env".to_string(),
+                "--- which_command ---\nfound".to_string()
+            )]
+        );
+    }
+
+    /// Every call failing leaves the region out of the result entirely, which is
+    /// what stops `apply_stage_seeds` from replacing good content with nothing.
+    #[test]
+    fn a_region_whose_every_call_failed_is_left_alone() {
+        let sites = sites_for(&[("s0", "env", "current_time")]);
+        let results = vec![("s0".to_string(), "[error] nope".to_string())];
+        assert!(seeded_content(&sites, &results).is_empty());
+    }
+
+    /// A call the lane never answered - cancelled mid-batch - is skipped rather
+    /// than filed as an empty block.
+    #[test]
+    fn a_call_with_no_answer_is_skipped() {
+        let sites = sites_for(&[("s0", "env", "current_time"), ("s1", "env", "locale_info")]);
+        let results = vec![("s1".to_string(), "en-US".to_string())];
+        assert_eq!(
+            seeded_content(&sites, &results),
+            vec![("env".to_string(), "--- locale_info ---\nen-US".to_string())]
+        );
+    }
+}

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -488,7 +488,15 @@ impl PipelineWorld {
                 // consumes the `StageJustEntered` marker it fires on - so the
                 // hook sees the stage's layout and prompt already in place, and
                 // whatever it writes is in the stage's first request.
-                run_stage_enter_hooks,
+                // Both fire on `StageJustEntered`, and both must precede
+                // `sync_tool_stages`, which consumes it. Nested for the 20-system
+                // `.chain()` limit, as the pairs above are.
+                //
+                // The seed re-runs any `refresh = "each_stage"` tool seed for
+                // the stage just entered, holding `ReadyToInfer` until the
+                // answers land - so the stage's first request carries the fresh
+                // values rather than the previous stage's.
+                (run_stage_enter_hooks, crate::stage_seeds::start_stage_seeds).chain(),
                 sync_tool_stages,
                 // Store any finished run title, then start newly-marked ones.
                 // Collect precedes persistence so a landed title is written on

--- a/crates/leviath-sys/Cargo.toml
+++ b/crates/leviath-sys/Cargo.toml
@@ -30,6 +30,12 @@ tracing = { workspace = true }
 # is otherwise pure Rust plus its TLS stack.
 fs4 = { workspace = true }
 
+# The user's locale (`locale`). As with free space above, there is no `std` API
+# and this crate forbids `unsafe`, so the platform call is delegated: Unix reads
+# the `LC_*`/`LANG` variables, macOS asks CoreFoundation and Windows calls
+# `GetUserDefaultLocaleName`.
+sys-locale = { workspace = true }
+
 # Only for `tokio::process::Command`, so the console-window decision can be made
 # once for both command flavours here rather than duplicated in every crate that
 # spawns children. `process` alone - this crate runs no runtime of its own.

--- a/crates/leviath-sys/src/lib.rs
+++ b/crates/leviath-sys/src/lib.rs
@@ -33,6 +33,8 @@ pub mod browser;
 pub mod disk;
 pub mod editor;
 pub mod keychain;
+pub mod locale;
+pub mod osinfo;
 pub mod perms;
 pub mod process;
 pub mod sandbox;

--- a/crates/leviath-sys/src/locale.rs
+++ b/crates/leviath-sys/src/locale.rs
@@ -1,0 +1,48 @@
+//! The user's locale, as a BCP-47 language tag.
+
+/// The host's current locale tag, or `None` when the platform has no answer.
+///
+/// There is no `std` API for this and the shapes differ per platform: Unix
+/// reports through `LC_ALL`/`LC_MESSAGES`/`LANG` (often as `en_US.UTF-8`),
+/// macOS answers through CoreFoundation and Windows through
+/// `GetUserDefaultLocaleName`. `sys-locale` covers all three, so the branching
+/// lives in that crate rather than in a `#[cfg]` here.
+///
+/// The tag comes back exactly as the platform gave it. Normalizing it is the
+/// caller's business, and the caller (`leviath-tools`' `locale_info`) has a pure
+/// splitter that is testable against every shape without an OS to ask.
+pub fn current_tag() -> Option<String> {
+    usable(sys_locale::get_locale())
+}
+
+/// A tag the caller can act on, or `None`.
+///
+/// Blank is not an answer: a locale reported as `""` flows downstream as one
+/// nobody can act on, which is worse than saying the platform did not answer.
+/// Split out from [`current_tag`] so the rule is testable without a host that
+/// happens to be configured the right way - CI runners differ, and a test that
+/// only checks the rule when the machine sets a locale checks it nowhere.
+fn usable(tag: Option<String>) -> Option<String> {
+    tag.filter(|t| !t.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_blank_tag_is_no_answer_at_all() {
+        assert_eq!(usable(Some("en-US".to_string())), Some("en-US".to_string()));
+        assert_eq!(usable(Some(String::new())), None);
+        assert_eq!(usable(Some("   ".to_string())), None);
+        assert_eq!(usable(None), None);
+    }
+
+    /// The real lookup runs, whatever this host answers. CI runners vary - some
+    /// set no locale at all - so there is nothing to assert about the value
+    /// beyond the rule above, which is tested against every shape directly.
+    #[test]
+    fn the_real_lookup_runs_on_this_host() {
+        let _ = current_tag();
+    }
+}

--- a/crates/leviath-sys/src/osinfo.rs
+++ b/crates/leviath-sys/src/osinfo.rs
@@ -1,0 +1,265 @@
+//! The operating system's display name and version.
+//!
+//! `std::env::consts::OS` names the *target* (`macos`, `linux`, `windows`) and
+//! nothing more. The release a machine actually runs is a per-platform file, so
+//! it is read here rather than in a caller: Linux publishes `/etc/os-release`
+//! and macOS a `SystemVersion.plist`, both plain text this can parse without a
+//! dependency.
+//!
+//! Windows has no equivalent file. Its version lives in the registry or behind
+//! `cmd /c ver`, and neither is reachable without either a new dependency or
+//! spawning a process - which this crate will not do to answer a question this
+//! minor. [`version_for`] reports `None` there, and the caller says so plainly
+//! rather than guessing.
+//!
+//! Every function is pure over an injected reader except [`current_version`], so
+//! the Linux and macOS branches are both reachable under test from any host.
+
+/// Where each platform records its release, or `None` for a platform that does
+/// not record it in a readable file.
+///
+/// Pure over `os` rather than `#[cfg]`-switched, following
+/// [`crate::editor::default_editors_for`], so every arm is testable anywhere.
+pub fn version_path_for(os: &str) -> Option<&'static str> {
+    match os {
+        "linux" | "android" => Some("/etc/os-release"),
+        "macos" | "ios" => Some("/System/Library/CoreServices/SystemVersion.plist"),
+        _ => None,
+    }
+}
+
+/// A human display name for the target `os`, for a model that would otherwise
+/// read the bare target triple word.
+///
+/// Falls back to the raw value, which is right for a platform this predates: a
+/// caller reporting `freebsd` verbatim is more use than one reporting `unknown`.
+pub fn display_name_for(os: &str) -> &str {
+    match os {
+        "macos" => "macOS",
+        "linux" => "Linux",
+        "windows" => "Windows",
+        "freebsd" => "FreeBSD",
+        "netbsd" => "NetBSD",
+        "openbsd" => "OpenBSD",
+        "android" => "Android",
+        "ios" => "iOS",
+        other => other,
+    }
+}
+
+/// `PRETTY_NAME` from an `/etc/os-release`, falling back to `VERSION_ID`.
+///
+/// `PRETTY_NAME` first because it is the one line that already reads as an
+/// answer (`Ubuntu 24.04.1 LTS`); `VERSION_ID` alone (`24.04`) is the useful
+/// remainder on a distribution that omits it. Values may be quoted with either
+/// quote character, or not at all - all three spellings occur in the wild.
+pub fn parse_os_release(contents: &str) -> Option<String> {
+    let value_of = |key: &str| {
+        contents.lines().find_map(|line| {
+            let rest = line.trim().strip_prefix(key)?.strip_prefix('=')?;
+            let unquoted = rest
+                .strip_prefix('"')
+                .and_then(|r| r.strip_suffix('"'))
+                .or_else(|| rest.strip_prefix('\'').and_then(|r| r.strip_suffix('\'')))
+                .unwrap_or(rest);
+            (!unquoted.trim().is_empty()).then(|| unquoted.trim().to_string())
+        })
+    };
+    value_of("PRETTY_NAME").or_else(|| value_of("VERSION_ID"))
+}
+
+/// `ProductVersion` from a macOS `SystemVersion.plist`.
+///
+/// Scanned rather than parsed as XML: the file is a fixed, Apple-generated
+/// `<key>`/`<string>` sequence, and a plist parser would be a dependency bought
+/// to read one value out of one known file.
+pub fn parse_system_version_plist(contents: &str) -> Option<String> {
+    let after_key = contents.split("<key>ProductVersion</key>").nth(1)?;
+    // `split_once` rather than `find` plus a range: byte offsets into a `str`
+    // panic when they land inside a multi-byte character, and the workspace
+    // denies `clippy::string_slice` for exactly that reason.
+    let (_, after_open) = after_key.split_once("<string>")?;
+    let (value, _) = after_open.split_once("</string>")?;
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+/// The OS release for `os`, reading through `read`.
+///
+/// `&dyn Fn` rather than `impl Fn`: one monomorphization, so coverage is
+/// attributed to a single instantiation rather than split across several.
+pub fn version_for(os: &str, read: &dyn Fn(&str) -> Option<String>) -> Option<String> {
+    let contents = read(version_path_for(os)?)?;
+    match os {
+        "macos" | "ios" => parse_system_version_plist(&contents),
+        _ => parse_os_release(&contents),
+    }
+}
+
+/// Read a file to a string, discarding the reason it could not be read.
+///
+/// A named `fn` rather than a closure at the [`current_version`] call site: a
+/// closure written there would be a region the non-matching platform never
+/// reaches, and so an uncovered one.
+fn read_to_string(path: &str) -> Option<String> {
+    std::fs::read_to_string(path).ok()
+}
+
+/// The running OS release, or `None` where the platform does not publish one.
+pub fn current_version() -> Option<String> {
+    version_for(std::env::consts::OS, &read_to_string)
+}
+
+/// This machine's hostname, or `None` when the platform will not say.
+///
+/// Delegated to this crate's internal platform module, where the per-OS branch
+/// lives: Unix asks `gethostname`, Windows reads `COMPUTERNAME`, and a target
+/// that is neither reports nothing.
+pub fn hostname() -> Option<String> {
+    crate::platform::hostname()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_paths_are_known_for_the_platforms_that_publish_one() {
+        assert_eq!(version_path_for("linux"), Some("/etc/os-release"));
+        assert_eq!(version_path_for("android"), Some("/etc/os-release"));
+        assert_eq!(
+            version_path_for("macos"),
+            Some("/System/Library/CoreServices/SystemVersion.plist")
+        );
+        assert_eq!(version_path_for("ios"), version_path_for("macos"));
+        // Windows publishes no readable file, which is a `None` rather than a
+        // path that would always fail to open.
+        assert_eq!(version_path_for("windows"), None);
+        assert_eq!(version_path_for("freebsd"), None);
+    }
+
+    #[test]
+    fn display_names_are_capitalized_and_unknown_ones_pass_through() {
+        assert_eq!(display_name_for("macos"), "macOS");
+        assert_eq!(display_name_for("linux"), "Linux");
+        assert_eq!(display_name_for("windows"), "Windows");
+        assert_eq!(display_name_for("freebsd"), "FreeBSD");
+        assert_eq!(display_name_for("netbsd"), "NetBSD");
+        assert_eq!(display_name_for("openbsd"), "OpenBSD");
+        assert_eq!(display_name_for("android"), "Android");
+        assert_eq!(display_name_for("ios"), "iOS");
+        // A platform this predates reports its own name rather than "unknown".
+        assert_eq!(display_name_for("solaris"), "solaris");
+    }
+
+    /// All three quoting styles occur across distributions, and the whole line
+    /// must match the key - `VERSION_ID` must not be answered by
+    /// `IMAGE_VERSION_ID`.
+    #[test]
+    fn os_release_prefers_pretty_name_over_version_id() {
+        let text = "NAME=\"Ubuntu\"\nVERSION_ID=\"24.04\"\nPRETTY_NAME=\"Ubuntu 24.04.1 LTS\"\n";
+        assert_eq!(parse_os_release(text), Some("Ubuntu 24.04.1 LTS".into()));
+    }
+
+    #[test]
+    fn os_release_falls_back_to_version_id_and_accepts_every_quoting() {
+        assert_eq!(
+            parse_os_release("NAME=\"Alpine Linux\"\nVERSION_ID=3.20.3\n"),
+            Some("3.20.3".into())
+        );
+        assert_eq!(
+            parse_os_release("PRETTY_NAME='Debian GNU/Linux 12'\n"),
+            Some("Debian GNU/Linux 12".into())
+        );
+    }
+
+    /// An empty value is not an answer: reporting `""` as the OS version would
+    /// read downstream as a version that is known to be blank.
+    #[test]
+    fn os_release_without_a_usable_value_is_none() {
+        assert_eq!(parse_os_release(""), None);
+        assert_eq!(
+            parse_os_release("ID=ubuntu\nHOME_URL=\"https://x\"\n"),
+            None
+        );
+        assert_eq!(parse_os_release("PRETTY_NAME=\"\"\nID=x\n"), None);
+        // A key with no `=` is not a definition.
+        assert_eq!(parse_os_release("PRETTY_NAME\n"), None);
+    }
+
+    #[test]
+    fn plist_reads_the_product_version() {
+        let text = "<dict>\n\t<key>ProductName</key>\n\t<string>macOS</string>\n\
+                    \t<key>ProductVersion</key>\n\t<string>15.5</string>\n</dict>";
+        assert_eq!(parse_system_version_plist(text), Some("15.5".into()));
+    }
+
+    #[test]
+    fn plist_without_the_key_or_its_value_is_none() {
+        assert_eq!(parse_system_version_plist(""), None);
+        assert_eq!(
+            parse_system_version_plist("<key>ProductName</key><string>macOS</string>"),
+            None
+        );
+        // The key is present but its `<string>` is never opened or never closed.
+        assert_eq!(
+            parse_system_version_plist("<key>ProductVersion</key>\n"),
+            None
+        );
+        assert_eq!(
+            parse_system_version_plist("<key>ProductVersion</key><string>15.5"),
+            None
+        );
+        assert_eq!(
+            parse_system_version_plist("<key>ProductVersion</key><string> </string>"),
+            None
+        );
+    }
+
+    /// Both readable platforms are exercised from whichever host runs this, and
+    /// each is routed to its own parser - a plist parsed as an os-release, or
+    /// the reverse, yields nothing.
+    #[test]
+    fn version_for_routes_each_platform_to_its_own_format() {
+        let linux = |path: &str| {
+            (path == "/etc/os-release").then(|| "PRETTY_NAME=\"Fedora 41\"\n".to_string())
+        };
+        assert_eq!(version_for("linux", &linux), Some("Fedora 41".into()));
+
+        let mac = |_: &str| Some("<key>ProductVersion</key><string>14.6.1</string>".to_string());
+        assert_eq!(version_for("macos", &mac), Some("14.6.1".into()));
+
+        // Crossed formats parse to nothing rather than to something wrong.
+        assert_eq!(version_for("macos", &linux), None);
+        assert_eq!(version_for("linux", &mac), None);
+    }
+
+    #[test]
+    fn version_for_is_none_when_the_platform_or_the_file_has_no_answer() {
+        let missing = |_: &str| None;
+        // No path for the platform, so the reader is never consulted at all.
+        assert_eq!(version_for("windows", &missing), None);
+        // A platform that has a path, but a file that cannot be read.
+        assert_eq!(version_for("linux", &missing), None);
+    }
+
+    /// The real lookup runs against the real host. There is nothing to assert
+    /// about the value - a container may publish no release file at all - and
+    /// the "never blank" rule is already proved against every input shape by
+    /// the parser tests above.
+    #[test]
+    fn the_real_version_lookup_runs_on_this_host() {
+        let _ = current_version();
+        // And the reader it injects really does report an unreadable path as
+        // no answer, rather than propagating the io error.
+        assert_eq!(read_to_string("/definitely/not/a/file"), None);
+    }
+
+    /// The hostname is whatever this machine is called, and CI runners are
+    /// called different things - so what is asserted is the invariant the
+    /// callers rely on: an answer, when there is one, names something.
+    #[test]
+    fn the_hostname_is_absent_or_names_the_machine() {
+        assert!(hostname().is_none_or(|h| !h.trim().is_empty()));
+    }
+}

--- a/crates/leviath-sys/src/platform/fallback.rs
+++ b/crates/leviath-sys/src/platform/fallback.rs
@@ -53,3 +53,9 @@ pub(crate) fn current_uid() -> u32 {
 pub(crate) fn kill_process_group(_pgid: u32) -> io::Result<()> {
     Ok(())
 }
+
+/// No hostname API on such a target, so the caller reports that it is unknown
+/// rather than inventing a name for the machine.
+pub(crate) fn hostname() -> Option<String> {
+    None
+}

--- a/crates/leviath-sys/src/platform/unix.rs
+++ b/crates/leviath-sys/src/platform/unix.rs
@@ -174,6 +174,19 @@ pub(crate) fn kill_process_group(pgid: u32) -> io::Result<()> {
         .map_err(|e| io::Error::from_raw_os_error(e as i32))
 }
 
+/// This machine's hostname, or `None` when the OS declines to give one.
+///
+/// `nix::unistd::gethostname` rather than reading `$HOSTNAME`: that variable is
+/// a shell convenience, not part of the environment a process inherits, so it is
+/// usually unset for a daemon and would report "no hostname" on a machine that
+/// plainly has one.
+pub(crate) fn hostname() -> Option<String> {
+    nix::unistd::gethostname()
+        .ok()
+        .and_then(|h| h.into_string().ok())
+        .filter(|h| !h.trim().is_empty())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -249,6 +262,15 @@ mod tests {
         // must surface as an error the caller can ignore, not a panic.
         let err = kill_process_group(0x7FFF_FFFF).expect_err("no such group");
         assert!(err.raw_os_error().is_some());
+    }
+
+    /// `gethostname` answers on every Unix CI runner, but what it answers
+    /// varies - so the assertion is the property the caller depends on, not the
+    /// name: a reported hostname is never blank, because `system_info` would
+    /// otherwise show the machine as having an empty name.
+    #[test]
+    fn hostname_is_absent_or_non_empty() {
+        assert!(hostname().is_none_or(|h| !h.trim().is_empty()));
     }
 
     #[test]

--- a/crates/leviath-sys/src/platform/windows.rs
+++ b/crates/leviath-sys/src/platform/windows.rs
@@ -241,6 +241,18 @@ fn interpret_icacls(success: bool, stderr: &[u8], path: &Path) -> io::Result<()>
 /// the coverage gate reads that as an uncovered region. A poisoned guard only
 /// happens when a test holding it has already failed, and failing the others
 /// with "poisoned" alongside it is no loss.
+/// This machine's hostname, or `None` when the OS declines to give one.
+///
+/// `COMPUTERNAME` rather than `GetComputerNameW`: Windows sets it for every
+/// process, and reaching the API directly would mean raw FFI in a workspace that
+/// forbids `unsafe`. The Unix side cannot use its environment equivalent for the
+/// opposite reason - `$HOSTNAME` there is a shell variable that is not exported.
+pub(crate) fn hostname() -> Option<String> {
+    std::env::var("COMPUTERNAME")
+        .ok()
+        .filter(|h| !h.trim().is_empty())
+}
+
 #[cfg(test)]
 pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 

--- a/crates/leviath-tools/Cargo.toml
+++ b/crates/leviath-tools/Cargo.toml
@@ -24,6 +24,14 @@ yaml-rust2 = { workspace = true }
 csv = { workspace = true }
 anyhow = { workspace = true }
 tokio = { workspace = true }
+# The clock behind `current_time`, plus the IANA zone name chrono's `Local`
+# already resolved internally but does not expose.
+chrono = { workspace = true }
+iana-time-zone = { workspace = true }
+# The per-user config/data directories `environment_info` reports. Already the
+# workspace's answer for "where does this platform put these", so the tool says
+# the same thing the rest of Leviath acts on.
+dirs = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -432,6 +432,65 @@ impl BuiltinTools {
                     "required": ["content"]
                 }),
             },
+            Tool {
+                name: "current_time".to_string(),
+                description: "Get the current date and time, in UTC and in this machine's local timezone. Your training data has a cutoff date; this does not. Call this before reasoning about anything current, recent, upcoming, or dated - what year it is, how old something is, whether a release has happened, or what counts as recent news. Do not assume today's date from memory.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }),
+            },
+            Tool {
+                name: "system_info".to_string(),
+                description: "Describe the machine this agent runs on: operating system and version, CPU architecture, core count, hostname, the path separator and line ending convention, and free disk space in the working directory. Use this before writing platform-specific paths or commands.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }),
+            },
+            Tool {
+                name: "locale_info".to_string(),
+                description: "Report the user's language and region (for example en-US), as the operating system has it configured. Use this to decide what language to write in, and how to format dates, numbers and currency for this user.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }),
+            },
+            Tool {
+                name: "environment_info".to_string(),
+                description: "Report the working directory, the home, temporary, config and data directories for this platform, the entries on PATH, and the environment variables this agent may see. Credential-shaped variables are named but their values are withheld, so you can tell a variable is set without seeing its secret.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }),
+            },
+            Tool {
+                name: "which_command".to_string(),
+                description: "Check whether a program is installed and report where it lives, the way `which` or `where` would. Looks the name up on PATH without running anything. Use this before writing a shell command that depends on a tool being present.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The program name to look up, such as \"git\" or \"python3\""
+                        }
+                    },
+                    "required": ["command"]
+                }),
+            },
+            Tool {
+                name: "runtime_info".to_string(),
+                description: "Report this run's own state: the agent and stage running now, which iteration this is and the limit, the model and provider in use, how much of the context window is spent, and whether anyone is available to answer a question. Check whether the run is unattended before using ask_user_text, ask_user_choice, ask_user_confirm or present_for_review - unattended, those have nobody to answer them.".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }),
+            },
         ];
         defs.retain(|t| self.available(&t.name));
         defs
@@ -586,6 +645,12 @@ impl BuiltinTools {
             "todo_add",
             "todo_done",
             "todo_note",
+            "current_time",
+            "system_info",
+            "locale_info",
+            "environment_info",
+            "which_command",
+            "runtime_info",
             crate::SUBMIT_OUTPUT_TOOL,
         ]
         .iter()

--- a/crates/leviath-tools/src/env.rs
+++ b/crates/leviath-tools/src/env.rs
@@ -1,0 +1,1013 @@
+//! The environment tools: what time it is, what machine this is, what locale
+//! the user works in, where the interesting directories are, and whether a
+//! given program is installed.
+//!
+//! These exist because a model has no way to know any of it. Its training data
+//! has a cutoff and the run does not, so an agent asked about anything current
+//! will otherwise reason from whenever it was trained. Everything here is
+//! read-only and side-effect free, which is why the tools default to `allow`
+//! and are classified inbound.
+//!
+//! # How the platform differences are handled
+//!
+//! Every branch that depends on the operating system is a *pure function taking
+//! the platform as an argument*, following
+//! [`BuiltinTools::detect_shell_for`](crate::BuiltinTools) and
+//! `leviath_sys::editor::default_editors_for`. Nothing here is `#[cfg]`-gated,
+//! so the Windows answer is reachable under test from macOS and the Linux
+//! answer from Windows. The impure edges - reading the clock, the environment,
+//! the filesystem - are thin wrappers that pass what they found into those
+//! functions.
+//!
+//! # Why these are synchronous
+//!
+//! None of them does I/O worth awaiting. [`BuiltinTools::execute`] is `async`
+//! because of the shell and the file tools, so its arms delegate here; but the
+//! region-seeding path resolves tool calls outside that lane and would
+//! otherwise have to build a runtime to await a function that never yields.
+
+use super::*;
+use chrono::{DateTime, Datelike, FixedOffset, Local, Timelike, Utc};
+
+// ── current_time ──────────────────────────────────────────────────────────
+
+/// Render one instant as the object `current_time` returns.
+///
+/// Takes both renderings of the same moment plus the zone name, rather than
+/// reading the clock itself, so every field can be asserted against a fixed
+/// instant. A function that called `Utc::now()` internally could only be tested
+/// against itself.
+///
+/// `local` is a [`FixedOffset`] rather than a `Local`: it carries the offset as
+/// data, so a test can build any zone without the host being in it.
+pub(crate) fn describe_instant(
+    utc: DateTime<Utc>,
+    local: DateTime<FixedOffset>,
+    zone: Option<&str>,
+) -> Value {
+    let iso = local.iso_week();
+    json!({
+        "utc": utc.to_rfc3339_opts(chrono::SecondsFormat::Secs, true),
+        "local": local.to_rfc3339_opts(chrono::SecondsFormat::Secs, false),
+        "timezone": zone,
+        "utc_offset": local.offset().to_string(),
+        "unix": utc.timestamp(),
+        "date": local.format("%Y-%m-%d").to_string(),
+        "time": local.format("%H:%M:%S").to_string(),
+        "weekday": local.format("%A").to_string(),
+        "iso_week": format!("{}-W{:02}", iso.year(), iso.week()),
+        "day_of_year": local.ordinal(),
+        "hour_24": local.hour(),
+    })
+}
+
+// ── system_info ───────────────────────────────────────────────────────────
+
+/// What a filesystem has room for, as reported to the model.
+///
+/// A pair rather than two arguments so the "neither is known" case is one
+/// `None` rather than two that could disagree.
+pub(crate) struct DiskSpace {
+    /// Free bytes on the filesystem holding the working directory.
+    pub available: Option<u64>,
+    /// Total bytes of that filesystem.
+    pub total: Option<u64>,
+}
+
+/// The facts `system_info` reports, over values the caller looked up.
+///
+/// `os_version` is `None` on any platform that does not publish its release in
+/// a readable file (Windows, today). It is reported as `null` rather than
+/// omitted, so the model can tell "this machine did not say" from "the tool
+/// forgot to look".
+pub(crate) fn describe_system(
+    os: &str,
+    arch: &str,
+    family: &str,
+    version: Option<&str>,
+    host: Option<&str>,
+    cpus: usize,
+    disk: &DiskSpace,
+) -> Value {
+    json!({
+        "os": os,
+        "os_name": leviath_sys::osinfo::display_name_for(os),
+        "os_version": version,
+        "os_family": family,
+        "arch": arch,
+        "cpu_count": cpus,
+        "hostname": host,
+        "path_separator": path_separator_for(family),
+        "line_ending": line_ending_name_for(family),
+        "executable_suffix": std::env::consts::EXE_SUFFIX,
+        "disk": {
+            "available_bytes": disk.available,
+            "total_bytes": disk.total,
+        },
+    })
+}
+
+/// The character that separates entries in `PATH` on a platform of this family.
+///
+/// Keyed on the *family* rather than the OS, because that is the axis the
+/// answer actually turns on: every Unix uses `:` and Windows uses `;`.
+pub(crate) fn path_separator_for(family: &str) -> &'static str {
+    match family {
+        "windows" => ";",
+        _ => ":",
+    }
+}
+
+/// How a platform of this family ends a line, named rather than written.
+///
+/// The name, because the literal would arrive at the model as an actual newline
+/// inside a JSON string, which reads as formatting rather than as an answer.
+pub(crate) fn line_ending_name_for(family: &str) -> &'static str {
+    match family {
+        "windows" => "crlf",
+        _ => "lf",
+    }
+}
+
+// ── locale_info ───────────────────────────────────────────────────────────
+
+/// Split a platform locale tag into `(normalized, language, region)`.
+///
+/// Handles the shapes that actually turn up: `en_US.UTF-8` from a Unix
+/// environment variable, `en-US` from Windows and macOS, a bare `en`, and the
+/// `C`/`POSIX` sentinels that mean "no locale configured" rather than naming
+/// one. The normalized form uses `-`, per BCP-47, whichever separator arrived.
+///
+/// The charset suffix and any `@modifier` are dropped: they describe encoding
+/// and collation, and nothing downstream asks about either.
+pub(crate) fn split_locale_tag(tag: &str) -> Option<(String, String, Option<String>)> {
+    let head = tag.trim().split(['.', '@']).next().unwrap_or("").trim();
+    // `C` and `POSIX` are the absence of a locale spelled as a value. Reporting
+    // them as a language would have the model believe the user works in a
+    // language called "C".
+    if head.is_empty() || head.eq_ignore_ascii_case("c") || head.eq_ignore_ascii_case("posix") {
+        return None;
+    }
+    let mut parts = head.split(['_', '-']).filter(|p| !p.is_empty());
+    let language = parts.next()?.to_ascii_lowercase();
+    let region = parts.next().map(|r| r.to_ascii_uppercase());
+    let normalized = match &region {
+        Some(r) => format!("{language}-{r}"),
+        None => language.clone(),
+    };
+    Some((normalized, language, region))
+}
+
+/// The object `locale_info` returns for a platform-reported tag.
+///
+/// An unreadable or unset locale is reported as nulls with the raw tag kept, so
+/// the model can see *what* the platform said even when it could not be split.
+pub(crate) fn describe_locale(tag: Option<&str>) -> Value {
+    let parsed = tag.and_then(split_locale_tag);
+    match parsed {
+        Some((normalized, language, region)) => json!({
+            "locale": normalized,
+            "language": language,
+            "region": region,
+            "raw": tag,
+        }),
+        None => json!({
+            "locale": Value::Null,
+            "language": Value::Null,
+            "region": Value::Null,
+            "raw": tag,
+        }),
+    }
+}
+
+// ── environment_info ──────────────────────────────────────────────────────
+
+/// The directories `environment_info` reports, as the caller resolved them.
+///
+/// Every field is optional because every one of them can be absent: a daemon
+/// with no home directory, a platform with no notion of a config directory.
+#[derive(Default)]
+pub(crate) struct WellKnownDirs {
+    /// The user's home directory.
+    pub home: Option<PathBuf>,
+    /// The system temporary directory.
+    pub temp: Option<PathBuf>,
+    /// The per-user configuration directory.
+    pub config: Option<PathBuf>,
+    /// The per-user data directory.
+    pub data: Option<PathBuf>,
+}
+
+/// Partition environment variables into those an agent may see and the names it
+/// may not.
+///
+/// The rule is [`leviath_core::script_env_allowed`] - the same one a Rhai
+/// `env_var` read answers to - so there is a single answer to "may
+/// agent-supplied code see this variable" rather than one per surface.
+///
+/// Withheld names are *listed*, not dropped. An agent that can see
+/// `ANTHROPIC_API_KEY` exists but not its value can reason about the machine's
+/// configuration without the secret; silently omitting it would instead have it
+/// conclude the variable is unset and suggest setting it.
+pub(crate) fn partition_env<'a>(
+    vars: impl Iterator<Item = (&'a str, &'a str)>,
+    allowlist: &[String],
+) -> (serde_json::Map<String, Value>, Vec<String>) {
+    let mut visible = serde_json::Map::new();
+    let mut withheld = Vec::new();
+    for (name, value) in vars {
+        match leviath_core::script_env_allowed(name, allowlist) {
+            true => {
+                visible.insert(name.to_string(), Value::String(value.to_string()));
+            }
+            false => withheld.push(name.to_string()),
+        }
+    }
+    withheld.sort();
+    (visible, withheld)
+}
+
+/// The object `environment_info` returns.
+///
+/// `path_entries` is split here rather than handed over as one string, because
+/// the model would otherwise have to know the platform's separator to read it -
+/// and the separator is the very thing this tool exists to report.
+pub(crate) fn describe_environment(
+    workdir: &Path,
+    dirs: &WellKnownDirs,
+    family: &str,
+    path_var: Option<&str>,
+    env: (serde_json::Map<String, Value>, Vec<String>),
+) -> Value {
+    let separator = path_separator_for(family);
+    let entries: Vec<&str> = path_var
+        .map(|p| p.split(separator).filter(|e| !e.is_empty()).collect())
+        .unwrap_or_default();
+    let (visible, withheld) = env;
+    json!({
+        "working_directory": workdir.display().to_string(),
+        "home_directory": dirs.home.as_ref().map(|p| p.display().to_string()),
+        "temp_directory": dirs.temp.as_ref().map(|p| p.display().to_string()),
+        "config_directory": dirs.config.as_ref().map(|p| p.display().to_string()),
+        "data_directory": dirs.data.as_ref().map(|p| p.display().to_string()),
+        "path_separator": separator,
+        "path_entries": entries,
+        "environment_variables": visible,
+        "withheld_variables": withheld,
+    })
+}
+
+// ── which_command ─────────────────────────────────────────────────────────
+
+/// The candidate file names for `program` on a platform of this family.
+///
+/// On Windows a bare `git` is spelled `git.exe` on disk, and which suffixes
+/// count is `PATHEXT`'s business - so a lookup that only tried the bare name
+/// would report every program missing. A name that already carries one of those
+/// suffixes is tried as written, and only as written.
+pub(crate) fn candidate_names_for(
+    program: &str,
+    family: &str,
+    pathext: Option<&str>,
+) -> Vec<String> {
+    if family != "windows" {
+        return vec![program.to_string()];
+    }
+    let exts: Vec<String> = pathext
+        .unwrap_or(".COM;.EXE;.BAT;.CMD")
+        .split(';')
+        .map(|e| e.trim())
+        .filter(|e| !e.is_empty())
+        .map(|e| e.to_ascii_lowercase())
+        .collect();
+    let lower = program.to_ascii_lowercase();
+    if exts.iter().any(|e| lower.ends_with(e.as_str())) {
+        return vec![program.to_string()];
+    }
+    exts.iter().map(|e| format!("{program}{e}")).collect()
+}
+
+/// Join a `PATH` directory to a candidate file name using the separator a
+/// platform of this family uses.
+///
+/// [`Path::join`] would use the *host's* separator, which is wrong twice over:
+/// it makes the Windows branch unreachable in any meaningful sense from a Unix
+/// test, and it is the reason this function exists rather than being inlined.
+/// A directory that already ends in a separator is not given a second one.
+pub(crate) fn join_for(dir: &str, name: &str, family: &str) -> PathBuf {
+    let separator = match family {
+        "windows" => '\\',
+        _ => '/',
+    };
+    match dir.ends_with(['/', '\\']) {
+        true => PathBuf::from(format!("{dir}{name}")),
+        false => PathBuf::from(format!("{dir}{separator}{name}")),
+    }
+}
+
+/// Resolve `program` against `path_var`, reporting the first match.
+///
+/// `exists` is injected as `&dyn Fn` rather than `impl Fn` so there is one
+/// monomorphization: a generic parameter here produced a coverage report where
+/// every source position had a covered instantiation and the summary still
+/// counted misses.
+///
+/// A program named with a separator in it is a path, not a `PATH` lookup, and is
+/// probed where it points. That is what a shell does, and an agent that has just
+/// been told `./scripts/build` is missing because `PATH` has no such entry would
+/// be told something untrue.
+pub(crate) fn resolve_on_path(
+    program: &str,
+    path_var: Option<&str>,
+    pathext: Option<&str>,
+    family: &str,
+    exists: &dyn Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let names = candidate_names_for(program, family, pathext);
+    if program.contains('/') || (family == "windows" && program.contains('\\')) {
+        return names
+            .iter()
+            .map(PathBuf::from)
+            .find(|candidate| exists(candidate));
+    }
+    let separator = path_separator_for(family);
+    path_var?
+        .split(separator)
+        .filter(|dir| !dir.is_empty())
+        .flat_map(|dir| names.iter().map(move |name| join_for(dir, name, family)))
+        .find(|candidate| exists(candidate))
+}
+
+/// Whether `path` is a file that exists.
+///
+/// A named `fn` rather than a closure at the call site, so it is one region
+/// covered by the tool's own tests instead of a closure written inside a
+/// call the tests reach by only one route.
+fn is_existing_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+// ── dispatch ──────────────────────────────────────────────────────────────
+
+impl BuiltinTools {
+    /// Run one of the environment tools, or `None` when `name` is not one.
+    ///
+    /// Synchronous: see the module docs. The `Option` is what lets a caller ask
+    /// "is this one of mine?" and dispatch in the same step, which is what keeps
+    /// the shortcut in [`BuiltinTools::execute`] free of an arm nothing reaches.
+    pub fn execute_env_tool(&self, name: &str, args: &Value) -> Option<String> {
+        match name {
+            "current_time" => Some(self.current_time()),
+            "system_info" => Some(self.system_info()),
+            "locale_info" => Some(Self::locale_info()),
+            "environment_info" => Some(self.environment_info()),
+            "which_command" => Some(Self::which_command(args)),
+            _ => None,
+        }
+    }
+
+    /// The current instant, in UTC and in the host's local zone.
+    fn current_time(&self) -> String {
+        let now = Utc::now();
+        let local = Local::now().fixed_offset();
+        let zone = iana_time_zone::get_timezone().ok();
+        pretty(&describe_instant(now, local, zone.as_deref()))
+    }
+
+    /// What machine this is.
+    fn system_info(&self) -> String {
+        let disk = DiskSpace {
+            available: leviath_sys::disk::available_bytes(&self.ctx.workdir),
+            total: leviath_sys::disk::total_bytes(&self.ctx.workdir),
+        };
+        let version = leviath_sys::osinfo::current_version();
+        let host = leviath_sys::osinfo::hostname();
+        // `available_parallelism` fails only where the platform will not report
+        // it, and one is the honest answer there rather than a refusal: the
+        // question is "how much can I do at once", and the answer is "one".
+        let cpus = std::thread::available_parallelism().map_or(1, |n| n.get());
+        pretty(&describe_system(
+            std::env::consts::OS,
+            std::env::consts::ARCH,
+            std::env::consts::FAMILY,
+            version.as_deref(),
+            host.as_deref(),
+            cpus,
+            &disk,
+        ))
+    }
+
+    /// The user's language and region.
+    fn locale_info() -> String {
+        let tag = leviath_sys::locale::current_tag();
+        pretty(&describe_locale(tag.as_deref()))
+    }
+
+    /// Where the interesting directories are, and what is in the environment.
+    fn environment_info(&self) -> String {
+        let dirs = WellKnownDirs {
+            home: leviath_core::home_dir(),
+            temp: Some(std::env::temp_dir()),
+            config: dirs::config_dir(),
+            data: dirs::data_dir(),
+        };
+        let vars: Vec<(String, String)> = std::env::vars().collect();
+        let partitioned = partition_env(
+            vars.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+            &self.ctx.shell_env.allow_env_vars,
+        );
+        let path_var = std::env::var("PATH").ok();
+        pretty(&describe_environment(
+            &self.ctx.workdir,
+            &dirs,
+            std::env::consts::FAMILY,
+            path_var.as_deref(),
+            partitioned,
+        ))
+    }
+
+    /// Whether a program is installed, and where.
+    fn which_command(args: &Value) -> String {
+        let Some(program) = args.get("command").and_then(|v| v.as_str()) else {
+            return "[error] which_command requires a 'command' string".to_string();
+        };
+        if program.trim().is_empty() {
+            return "[error] which_command requires a non-empty 'command'".to_string();
+        }
+        let path_var = std::env::var("PATH").ok();
+        let pathext = std::env::var("PATHEXT").ok();
+        let found = resolve_on_path(
+            program,
+            path_var.as_deref(),
+            pathext.as_deref(),
+            std::env::consts::FAMILY,
+            &is_existing_file,
+        );
+        pretty(&json!({
+            "command": program,
+            "found": found.is_some(),
+            "path": found.map(|p| p.display().to_string()),
+        }))
+    }
+}
+
+/// Render a value the way these tools hand it back.
+///
+/// Indented rather than compact: the same text is what a seeded context region
+/// holds, and that region is read by people in the dashboard as well as by the
+/// model. The objects are a dozen fields each, so the whitespace costs little.
+fn pretty(value: &Value) -> String {
+    // Serializing a `Value` fails only for a map with non-string keys or a
+    // non-finite float, and every value here is built by `json!` from strings,
+    // integers, booleans and nulls. A fallback rendering would be a second
+    // formatting decision that nothing could ever reach or test.
+    serde_json::to_string_pretty(value).expect("a Value of primitives always serializes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tools(dir: &Path) -> BuiltinTools {
+        BuiltinTools::new(ToolContext::new(dir.to_path_buf()))
+    }
+
+    /// A fixed instant, so every field is asserted against a known answer
+    /// rather than against whatever the clock said. 2026-08-18 is a Tuesday,
+    /// day 230 of the year, in ISO week 34.
+    fn fixed() -> (DateTime<Utc>, DateTime<FixedOffset>) {
+        let utc = DateTime::parse_from_rfc3339("2026-08-18T19:32:07Z")
+            .expect("a literal RFC3339 instant parses")
+            .with_timezone(&Utc);
+        let local = DateTime::parse_from_rfc3339("2026-08-18T14:32:07-05:00")
+            .expect("a literal RFC3339 instant parses");
+        (utc, local)
+    }
+
+    #[test]
+    fn an_instant_is_described_in_both_zones_with_its_calendar_position() {
+        let (utc, local) = fixed();
+        let v = describe_instant(utc, local, Some("America/Chicago"));
+        assert_eq!(v["utc"], "2026-08-18T19:32:07Z");
+        assert_eq!(v["local"], "2026-08-18T14:32:07-05:00");
+        assert_eq!(v["timezone"], "America/Chicago");
+        assert_eq!(v["utc_offset"], "-05:00");
+        assert_eq!(v["unix"], 1787081527_i64);
+        assert_eq!(v["date"], "2026-08-18");
+        assert_eq!(v["time"], "14:32:07");
+        assert_eq!(v["weekday"], "Tuesday");
+        assert_eq!(v["iso_week"], "2026-W34");
+        assert_eq!(v["day_of_year"], 230);
+        assert_eq!(v["hour_24"], 14);
+    }
+
+    /// The calendar fields follow the *local* rendering, not UTC. Here the two
+    /// fall on different days, which is the case that catches reading the wrong
+    /// one: it is already the 19th in UTC while the user is still on the 18th.
+    #[test]
+    fn calendar_fields_follow_the_local_day_not_the_utc_one() {
+        let utc = DateTime::parse_from_rfc3339("2026-08-19T02:30:00Z")
+            .expect("literal parses")
+            .with_timezone(&Utc);
+        let local = DateTime::parse_from_rfc3339("2026-08-18T21:30:00-05:00").expect("literal");
+        let v = describe_instant(utc, local, None);
+        assert_eq!(v["date"], "2026-08-18");
+        assert_eq!(v["weekday"], "Tuesday");
+        assert_eq!(v["utc"], "2026-08-19T02:30:00Z");
+        // An unresolvable zone is reported as null rather than guessed at.
+        assert_eq!(v["timezone"], Value::Null);
+    }
+
+    /// The real clock. What can be asserted without re-implementing the tool is
+    /// that it answers with parseable JSON whose instants agree with each other.
+    #[test]
+    fn current_time_reports_the_real_clock_as_parseable_json() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = tools(dir.path()).execute_env_tool("current_time", &json!({}));
+        let v: Value = serde_json::from_str(&out.expect("current_time is an env tool"))
+            .expect("the tool returns JSON");
+        let utc = v["utc"].as_str().expect("utc is a string");
+        let local = v["local"].as_str().expect("local is a string");
+        // Same moment, two renderings: parsed back to UTC they must agree.
+        let a = DateTime::parse_from_rfc3339(utc).expect("utc round-trips");
+        let b = DateTime::parse_from_rfc3339(local).expect("local round-trips");
+        assert_eq!(a.timestamp(), b.timestamp());
+        assert_eq!(v["unix"].as_i64(), Some(a.timestamp()));
+    }
+
+    #[test]
+    fn system_facts_report_what_the_caller_found() {
+        let disk = DiskSpace {
+            available: Some(1024),
+            total: Some(4096),
+        };
+        let v = describe_system(
+            "linux",
+            "aarch64",
+            "unix",
+            Some("Ubuntu 24.04"),
+            Some("builder"),
+            8,
+            &disk,
+        );
+        assert_eq!(v["os"], "linux");
+        assert_eq!(v["os_name"], "Linux");
+        assert_eq!(v["os_version"], "Ubuntu 24.04");
+        assert_eq!(v["os_family"], "unix");
+        assert_eq!(v["arch"], "aarch64");
+        assert_eq!(v["cpu_count"], 8);
+        assert_eq!(v["hostname"], "builder");
+        assert_eq!(v["path_separator"], ":");
+        assert_eq!(v["line_ending"], "lf");
+        assert_eq!(v["disk"]["available_bytes"], 1024);
+        assert_eq!(v["disk"]["total_bytes"], 4096);
+    }
+
+    /// A platform that publishes no version and no hostname reports nulls, not
+    /// omitted keys: "this machine did not say" has to be distinguishable from
+    /// "the tool did not look".
+    #[test]
+    fn unknown_system_facts_are_null_rather_than_absent() {
+        let disk = DiskSpace {
+            available: None,
+            total: None,
+        };
+        let v = describe_system("windows", "x86_64", "windows", None, None, 1, &disk);
+        assert_eq!(v["os_name"], "Windows");
+        assert!(v.get("os_version").is_some());
+        assert_eq!(v["os_version"], Value::Null);
+        assert_eq!(v["hostname"], Value::Null);
+        assert_eq!(v["disk"]["available_bytes"], Value::Null);
+        // The Windows answers for both family-keyed fields, from any host.
+        assert_eq!(v["path_separator"], ";");
+        assert_eq!(v["line_ending"], "crlf");
+    }
+
+    #[test]
+    fn family_keyed_answers_cover_both_platforms_from_either() {
+        assert_eq!(path_separator_for("windows"), ";");
+        assert_eq!(path_separator_for("unix"), ":");
+        assert_eq!(line_ending_name_for("windows"), "crlf");
+        assert_eq!(line_ending_name_for("unix"), "lf");
+    }
+
+    #[test]
+    fn system_info_answers_for_the_real_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = tools(dir.path()).execute_env_tool("system_info", &json!({}));
+        let v: Value = serde_json::from_str(&out.expect("system_info is an env tool")).unwrap();
+        assert_eq!(v["os"], std::env::consts::OS);
+        assert_eq!(v["arch"], std::env::consts::ARCH);
+        // Whatever the host reports, it must be able to do at least one thing
+        // at a time - a zero here would mean the fallback was mis-wired.
+        assert!(v["cpu_count"].as_u64().unwrap_or(0) >= 1);
+    }
+
+    #[test]
+    fn locale_tags_split_on_both_separators_and_drop_encoding() {
+        assert_eq!(
+            split_locale_tag("en_US.UTF-8"),
+            Some(("en-US".into(), "en".into(), Some("US".into())))
+        );
+        assert_eq!(
+            split_locale_tag("en-US"),
+            Some(("en-US".into(), "en".into(), Some("US".into())))
+        );
+        // Case is normalized in both directions: language down, region up.
+        assert_eq!(
+            split_locale_tag("PT_br"),
+            Some(("pt-BR".into(), "pt".into(), Some("BR".into())))
+        );
+        // A modifier describes collation, not language.
+        assert_eq!(
+            split_locale_tag("de_DE@euro"),
+            Some(("de-DE".into(), "de".into(), Some("DE".into())))
+        );
+        // A bare language has no region rather than an invented one.
+        assert_eq!(
+            split_locale_tag("fr"),
+            Some(("fr".into(), "fr".into(), None))
+        );
+    }
+
+    /// `C` and `POSIX` are how a platform spells "no locale set". Reporting
+    /// either as a language would have the model believe the user works in a
+    /// language called C.
+    #[test]
+    fn the_absent_locale_sentinels_are_not_languages() {
+        assert_eq!(split_locale_tag("C"), None);
+        assert_eq!(split_locale_tag("c"), None);
+        assert_eq!(split_locale_tag("POSIX"), None);
+        assert_eq!(split_locale_tag("C.UTF-8"), None);
+        assert_eq!(split_locale_tag(""), None);
+        assert_eq!(split_locale_tag("   "), None);
+        // A tag that is only separators names no language.
+        assert_eq!(split_locale_tag("_"), None);
+        assert_eq!(split_locale_tag(".UTF-8"), None);
+    }
+
+    #[test]
+    fn a_locale_that_cannot_be_split_keeps_its_raw_tag() {
+        let v = describe_locale(Some("C"));
+        assert_eq!(v["locale"], Value::Null);
+        assert_eq!(v["language"], Value::Null);
+        assert_eq!(v["region"], Value::Null);
+        assert_eq!(v["raw"], "C");
+
+        // And an unset locale reports nulls throughout, raw included.
+        let none = describe_locale(None);
+        assert_eq!(none["locale"], Value::Null);
+        assert_eq!(none["raw"], Value::Null);
+
+        let ok = describe_locale(Some("en_GB.UTF-8"));
+        assert_eq!(ok["locale"], "en-GB");
+        assert_eq!(ok["language"], "en");
+        assert_eq!(ok["region"], "GB");
+        assert_eq!(ok["raw"], "en_GB.UTF-8");
+        // A language with no region reports the region as null.
+        assert_eq!(describe_locale(Some("ja"))["region"], Value::Null);
+    }
+
+    #[test]
+    fn locale_info_answers_for_the_real_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = tools(dir.path()).execute_env_tool("locale_info", &json!({}));
+        let v: Value = serde_json::from_str(&out.expect("locale_info is an env tool")).unwrap();
+        // The host may have no locale at all; what must hold is that the object
+        // always carries every key, so the model never has to test for absence.
+        for key in ["locale", "language", "region", "raw"] {
+            assert!(v.get(key).is_some(), "{key} must always be present");
+        }
+    }
+
+    /// The credential-name rule is `leviath_core`'s, not a second copy: a
+    /// key-shaped name is withheld and listed, an ordinary one passes, and the
+    /// user's allowlist releases the specific name they named.
+    #[test]
+    fn environment_variables_are_partitioned_by_the_shared_credential_rule() {
+        let vars = [
+            ("LANG", "en_US.UTF-8"),
+            ("ANTHROPIC_API_KEY", "sk-ant-secret"),
+            ("EDITOR", "vim"),
+        ];
+        let (visible, withheld) = partition_env(vars.iter().copied(), &[]);
+        assert_eq!(visible["LANG"], "en_US.UTF-8");
+        assert_eq!(visible["EDITOR"], "vim");
+        assert!(!visible.contains_key("ANTHROPIC_API_KEY"));
+        // Named, so the agent knows it exists without seeing it.
+        assert_eq!(withheld, vec!["ANTHROPIC_API_KEY".to_string()]);
+        // The value really is nowhere in the output.
+        assert!(!serde_json::to_string(&visible).unwrap().contains("sk-ant"));
+
+        // The user's allowlist is what releases it.
+        let (visible, withheld) =
+            partition_env(vars.iter().copied(), &["anthropic_api_key".to_string()]);
+        assert_eq!(visible["ANTHROPIC_API_KEY"], "sk-ant-secret");
+        assert!(withheld.is_empty());
+    }
+
+    /// Withheld names are sorted, so two runs on the same machine produce the
+    /// same region text - an unstable order would look like a change to every
+    /// digest and cache comparison downstream.
+    #[test]
+    fn withheld_names_come_back_in_a_stable_order() {
+        let vars = [("ZZ_TOKEN", "a"), ("AA_SECRET", "b"), ("MM_PASSWORD", "c")];
+        let (_, withheld) = partition_env(vars.iter().copied(), &[]);
+        assert_eq!(withheld, vec!["AA_SECRET", "MM_PASSWORD", "ZZ_TOKEN"]);
+    }
+
+    #[test]
+    fn the_path_is_split_with_the_platforms_own_separator() {
+        let dirs = WellKnownDirs {
+            home: Some(PathBuf::from("/home/u")),
+            temp: Some(PathBuf::from("/tmp")),
+            config: None,
+            data: None,
+        };
+        let v = describe_environment(
+            Path::new("/work"),
+            &dirs,
+            "unix",
+            Some("/usr/bin:/bin::/opt/x"),
+            (serde_json::Map::new(), Vec::new()),
+        );
+        assert_eq!(v["working_directory"], "/work");
+        assert_eq!(v["home_directory"], "/home/u");
+        assert_eq!(v["config_directory"], Value::Null);
+        // Empty entries are dropped rather than reported as a directory named "".
+        assert_eq!(v["path_entries"], json!(["/usr/bin", "/bin", "/opt/x"]));
+
+        // The Windows split, from any host.
+        let w = describe_environment(
+            Path::new("C:\\work"),
+            &WellKnownDirs::default(),
+            "windows",
+            Some("C:\\bin;C:\\tools"),
+            (serde_json::Map::new(), Vec::new()),
+        );
+        assert_eq!(w["path_separator"], ";");
+        assert_eq!(w["path_entries"], json!(["C:\\bin", "C:\\tools"]));
+        // Every directory absent is four nulls, not four missing keys.
+        assert_eq!(w["home_directory"], Value::Null);
+        assert_eq!(w["temp_directory"], Value::Null);
+        assert_eq!(w["data_directory"], Value::Null);
+        // And an unset PATH is an empty list rather than a missing key.
+        let n = describe_environment(
+            Path::new("/w"),
+            &WellKnownDirs::default(),
+            "unix",
+            None,
+            (serde_json::Map::new(), Vec::new()),
+        );
+        assert_eq!(n["path_entries"], json!([]));
+    }
+
+    #[test]
+    fn environment_info_answers_for_the_real_host() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = tools(dir.path()).execute_env_tool("environment_info", &json!({}));
+        let v: Value =
+            serde_json::from_str(&out.expect("environment_info is an env tool")).unwrap();
+        // The workdir it reports is the fence the file tools resolve against,
+        // canonicalized - not the path as handed in.
+        assert_eq!(
+            v["working_directory"],
+            std::fs::canonicalize(dir.path())
+                .unwrap()
+                .display()
+                .to_string()
+        );
+        assert!(v["environment_variables"].is_object());
+        assert!(v["withheld_variables"].is_array());
+    }
+
+    #[test]
+    fn windows_candidates_come_from_pathext_and_a_suffixed_name_is_left_alone() {
+        assert_eq!(
+            candidate_names_for("git", "windows", Some(".COM;.EXE;.BAT")),
+            vec!["git.com", "git.exe", "git.bat"]
+        );
+        // Already suffixed: tried as written, and only as written.
+        assert_eq!(
+            candidate_names_for("git.exe", "windows", Some(".COM;.EXE")),
+            vec!["git.exe"]
+        );
+        // No PATHEXT set: the documented Windows default still applies.
+        assert!(candidate_names_for("git", "windows", None).contains(&"git.exe".to_string()));
+        // Blank entries in PATHEXT contribute no candidate.
+        assert_eq!(
+            candidate_names_for("g", "windows", Some(".EXE;;  ;.BAT")),
+            vec!["g.exe", "g.bat"]
+        );
+        // Unix takes the name as given, whatever PATHEXT says.
+        assert_eq!(
+            candidate_names_for("git", "unix", Some(".EXE")),
+            vec!["git"]
+        );
+    }
+
+    /// The join uses the *named* platform's separator, not the host's, which
+    /// is the whole reason it exists: `Path::join` on a Unix test host would
+    /// build `C:\\tools/git.exe` and quietly never match.
+    #[test]
+    fn path_entries_are_joined_with_the_named_platforms_separator() {
+        assert_eq!(
+            join_for("/usr/bin", "git", "unix"),
+            PathBuf::from("/usr/bin/git")
+        );
+        assert_eq!(
+            join_for("C:\\tools", "git.exe", "windows"),
+            PathBuf::from("C:\\tools\\git.exe")
+        );
+        // A directory that already ends in a separator does not get a second.
+        assert_eq!(
+            join_for("/usr/bin/", "git", "unix"),
+            PathBuf::from("/usr/bin/git")
+        );
+        assert_eq!(
+            join_for("C:\\", "git.exe", "windows"),
+            PathBuf::from("C:\\git.exe")
+        );
+    }
+
+    /// Both platforms' lookups, driven from whichever host runs this: the
+    /// probe is injected, so no file has to exist for either to be exercised.
+    #[test]
+    fn a_program_is_resolved_against_each_platforms_path() {
+        let unix_hit = |p: &Path| p == Path::new("/usr/bin/git");
+        assert_eq!(
+            resolve_on_path("git", Some("/bin:/usr/bin"), None, "unix", &unix_hit),
+            Some(PathBuf::from("/usr/bin/git"))
+        );
+        // First match wins, in PATH order.
+        let all = |_: &Path| true;
+        assert_eq!(
+            resolve_on_path("git", Some("/bin:/usr/bin"), None, "unix", &all),
+            Some(PathBuf::from("/bin/git"))
+        );
+        // Windows finds the suffixed name behind a bare request.
+        let win_hit = |p: &Path| p == Path::new("C:\\tools\\git.exe");
+        assert_eq!(
+            resolve_on_path(
+                "git",
+                Some("C:\\bin;C:\\tools"),
+                Some(".EXE"),
+                "windows",
+                &win_hit
+            ),
+            Some(PathBuf::from("C:\\tools\\git.exe"))
+        );
+    }
+
+    #[test]
+    fn a_lookup_with_nothing_to_search_or_nothing_to_find_is_none() {
+        let none = |_: &Path| false;
+        assert_eq!(
+            resolve_on_path("git", Some("/bin"), None, "unix", &none),
+            None
+        );
+        // No PATH at all: nothing to search, and no panic reaching for it.
+        let all = |_: &Path| true;
+        assert_eq!(resolve_on_path("git", None, None, "unix", &all), None);
+        // Empty PATH entries are skipped rather than probed as the empty dir.
+        assert_eq!(resolve_on_path("git", Some("::"), None, "unix", &all), None);
+    }
+
+    /// A name with a separator is a path. Resolving it against `PATH` would
+    /// report `./scripts/build` missing because no `PATH` entry contains a
+    /// directory called `scripts`, which is both wrong and confusing.
+    #[test]
+    fn a_pathlike_name_is_probed_where_it_points() {
+        let hit = |p: &Path| p == Path::new("./scripts/build");
+        assert_eq!(
+            resolve_on_path("./scripts/build", Some("/bin"), None, "unix", &hit),
+            Some(PathBuf::from("./scripts/build"))
+        );
+        let none = |_: &Path| false;
+        assert_eq!(
+            resolve_on_path("./scripts/build", Some("/bin"), None, "unix", &none),
+            None
+        );
+        // Windows separators count on Windows.
+        let win = |p: &Path| p == Path::new("C:\\t\\b.exe");
+        assert_eq!(
+            resolve_on_path("C:\\t\\b", None, Some(".EXE"), "windows", &win),
+            Some(PathBuf::from("C:\\t\\b.exe"))
+        );
+    }
+
+    #[test]
+    fn which_command_finds_a_program_that_is_really_installed() {
+        let dir = tempfile::tempdir().unwrap();
+        let t = tools(dir.path());
+        // The test binary itself, rather than a program named per platform:
+        // every host has exactly one of these and its path is absolute, so the
+        // real `is_existing_file` probe runs on a file that certainly exists
+        // without a `cfg!` arm that is dead on whichever host is running.
+        let exe = std::env::current_exe().expect("the test binary has a path");
+        let probe = exe.display().to_string();
+        let out = t
+            .execute_env_tool("which_command", &json!({ "command": probe }))
+            .expect("which_command is an env tool");
+        let v: Value = serde_json::from_str(&out).unwrap();
+        assert_eq!(v["command"], probe);
+        assert_eq!(v["found"], true);
+        assert_eq!(v["path"], probe);
+
+        // A name nothing could plausibly install reports not-found with a null
+        // path, rather than an error.
+        let missing = t
+            .execute_env_tool(
+                "which_command",
+                &json!({ "command": "leviath-no-such-program-xyzzy" }),
+            )
+            .unwrap();
+        let v: Value = serde_json::from_str(&missing).unwrap();
+        assert_eq!(v["found"], false);
+        assert_eq!(v["path"], Value::Null);
+        // The real probe really does answer false for a path nothing created.
+        assert!(!is_existing_file(Path::new("/definitely/not/here")));
+    }
+
+    #[test]
+    fn which_command_refuses_a_call_with_no_usable_program_name() {
+        let dir = tempfile::tempdir().unwrap();
+        let t = tools(dir.path());
+        let missing = t.execute_env_tool("which_command", &json!({})).unwrap();
+        assert!(missing.starts_with("[error]"), "{missing}");
+        assert!(missing.contains("'command'"));
+        // A non-string argument is the same refusal, not a panic.
+        let wrong = t
+            .execute_env_tool("which_command", &json!({ "command": 7 }))
+            .unwrap();
+        assert!(wrong.starts_with("[error]"));
+        // Present but blank is refused too: it would otherwise probe every
+        // PATH directory for a file with no name.
+        let blank = t
+            .execute_env_tool("which_command", &json!({ "command": "  " }))
+            .unwrap();
+        assert!(blank.starts_with("[error]"), "{blank}");
+        assert!(blank.contains("non-empty"));
+    }
+
+    /// The tools this module owns, as the dispatch answers for them. Kept as a
+    /// list so the advertising side can be checked against it: a tool defined
+    /// in `defs.rs` with no arm here would be advertised and then reported
+    /// unknown, which is the failure mode this pairing exists to catch.
+    pub(crate) const NATIVE_ENV_TOOLS: &[&str] = &[
+        "current_time",
+        "system_info",
+        "locale_info",
+        "environment_info",
+        "which_command",
+    ];
+
+    #[test]
+    fn every_environment_tool_dispatches_and_nothing_else_does() {
+        let dir = tempfile::tempdir().unwrap();
+        let t = tools(dir.path());
+        for name in NATIVE_ENV_TOOLS {
+            // `is_some_and` rather than an unwrap with a panicking closure:
+            // that closure is a region only a failing run would ever enter, so
+            // it reads as uncovered on every passing one.
+            assert!(
+                t.execute_env_tool(name, &json!({ "command": "sh" }))
+                    .is_some_and(|out| serde_json::from_str::<Value>(&out).is_ok()),
+                "{name} must dispatch and answer with JSON"
+            );
+        }
+        // `runtime_info` is advertised by this crate but answered by the
+        // runtime, so it must NOT dispatch here - a native arm for it would
+        // report a run's stage as whatever this process happened to know.
+        assert!(t.execute_env_tool("runtime_info", &json!({})).is_none());
+        assert!(t.execute_env_tool("read_file", &json!({})).is_none());
+    }
+
+    /// The env tools are reachable through the ordinary `execute` entry point,
+    /// not only through `execute_env_tool`. That shortcut sits ahead of the
+    /// dispatch match, so this is what proves the match is not shadowing it.
+    #[tokio::test]
+    async fn the_ordinary_dispatch_entry_point_routes_environment_tools() {
+        let dir = tempfile::tempdir().unwrap();
+        let t = tools(dir.path());
+        let out = t.execute("current_time", json!({})).await;
+        let v: Value = serde_json::from_str(&out).expect("execute returns the tool's JSON");
+        assert!(v["utc"].as_str().is_some());
+
+        // `runtime_info` is advertised by this crate but answered by the
+        // runtime, so reaching it here is a refusal naming where it belongs -
+        // never a native answer with invented stage or iteration numbers.
+        let refused = t.execute("runtime_info", json!({})).await;
+        assert_eq!(
+            refused,
+            "[error] runtime_info must be handled by the runtime"
+        );
+    }
+
+    /// Every environment tool renders as indented JSON, because the same text
+    /// is what a seeded region shows a person in the dashboard.
+    #[test]
+    fn results_are_rendered_as_indented_json() {
+        assert_eq!(pretty(&json!({"a": 1})), "{\n  \"a\": 1\n}");
+    }
+}

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -12,6 +12,14 @@ impl BuiltinTools {
         if !self.available(canonical) {
             return format!("[error] tool '{}' is not available on this platform", name);
         }
+        // The environment tools do no awaiting of their own (see `env.rs`), so
+        // they answer here rather than through five arms that each `.await`
+        // something which never yields. Taken before the match so the
+        // "is this one of mine" test and the dispatch are a single step -
+        // a guard arm would need a fallback branch nothing can reach.
+        if let Some(result) = self.execute_env_tool(canonical, &args) {
+            return result;
+        }
         match canonical {
             "read_file" => self.read_file(&args).await,
             "read_files" => self.read_files(&args).await,
@@ -19,6 +27,9 @@ impl BuiltinTools {
             "edit_file" => self.edit_file(&args).await,
             "list_dir" => self.list_dir(&args).await,
             "shell" => self.shell(&args).await,
+            // Like the context tools, this one needs the live world: the stage,
+            // iteration and token counts it reports exist only there.
+            "runtime_info" => "[error] runtime_info must be handled by the runtime".to_string(),
             n if n.starts_with("context_") => {
                 "[error] context tools must be handled by the runtime".to_string()
             }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -15,6 +15,7 @@ use tokio::time::{Duration, timeout};
 // its constructors.
 mod context;
 mod defs;
+mod env;
 mod exec;
 pub use exec::is_null_device;
 mod platform;
@@ -167,11 +168,11 @@ mod tests {
     // ── Tool definitions ──────────────────────────────────────────────────
 
     #[test]
-    fn tool_defs_returns_twenty_tools() {
+    fn tool_defs_returns_the_whole_catalog() {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
         let defs = tools.tool_defs();
-        assert_eq!(defs.len(), 20);
+        assert_eq!(defs.len(), 26);
     }
 
     #[test]
@@ -420,10 +421,10 @@ mod tests {
     }
 
     #[test]
-    fn names_returns_twenty_one_entries() {
+    fn names_returns_every_tool_and_alias() {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
-        assert_eq!(tools.names().len(), 21);
+        assert_eq!(tools.names().len(), 27);
     }
 
     // ── Sub-agent tool definitions ────────────────────────────────────────
@@ -2098,7 +2099,7 @@ mod tests {
         let names: Vec<String> = tools.tool_defs().iter().map(|t| t.name.clone()).collect();
         assert!(!names.contains(&"shell".to_string()));
         // The other 16 built-ins remain.
-        assert_eq!(tools.tool_defs().len(), 19);
+        assert_eq!(tools.tool_defs().len(), 25);
         assert!(names.contains(&"read_file".to_string()));
         assert!(names.contains(&"context_write".to_string()));
         assert!(names.contains(&"present_for_review".to_string()));

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -273,9 +273,29 @@ answer costs it no turn.
 > lists every tool a blueprint seeds from, as `tool-seed`.
 
 A failed call is skipped with a warning and the other calls still fill the region; if the region is
-`required`, a failure is a spawn error naming the tool. Seeds resolve once, at spawn, and do not
-re-run when a run is reloaded, so a long run should call `current_time` again rather than trust a
-region stamped hours ago.
+`required`, a failure is a spawn error naming the tool.
+
+#### Refreshing on every stage
+
+Seeds resolve once, at spawn, like every other kind. `refresh = "each_stage"` resolves them again
+whenever a stage is entered:
+
+```toml
+environment = { kind = "pinned", seed = { tools = ["current_time"], refresh = "each_stage" } }
+```
+
+Use it where the answer moves. A run that spends an hour in one stage and then enters another
+should date the second stage from when it started, not from when the run did. The stage waits for
+the refreshed region before its first request, so the values are in place for the turn that reads
+them.
+
+It costs a tool call per stage entry for the life of the run, and rewrites a region that would
+otherwise sit still in the cached prefix, so leave it at the default for anything that does not
+actually change. A call that fails leaves the region as it was rather than blanking it: the
+previous value is merely stale, and stale beats absent. `lev validate` marks a refreshing seed
+"on every stage entry".
+
+Seeds do not re-run when a run is reloaded from a snapshot, whatever their `refresh` setting.
 
 `files`, `glob` and `rhai` seeds resolve against the run's working directory and may not leave it.
 A path that does is refused at spawn, before anything is read.

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -189,6 +189,8 @@ readme    = { kind = "pinned", seed = { files = ["README.md"] } }
 layout    = { kind = "temporary", seed = { glob = "src/**/*.rs" } }
 rules     = { kind = "pinned", seed = { literal = "Never edit generated files." } }
 env       = { kind = "pinned", seed = { command = "git log --oneline -20" } }
+clock     = { kind = "pinned", seed = { tool = "current_time" } }
+machine   = { kind = "pinned", seed = { tools = ["current_time", "system_info"] } }
 computed  = { kind = "temporary", seed = { rhai = "seeds/plan.rhai" } }
 inherited = { kind = "pinned", seed = { caller = "brief" } }
 ```
@@ -223,6 +225,57 @@ task refuses a task outright rather than running without it.
 > run once: a daemon restart does not replay them.
 
 #### Seed paths stay in the working directory
+
+### Seeding from tools
+
+A `tools` seed calls the run's own tools at spawn and writes their output into the region, so the
+agent's first inference already knows what the tools would have told it. Several calls fill one
+region, in order, each under a heading naming the tool:
+
+```toml
+environment = { kind = "pinned", budget = "1%", volatility = "stable", seed = { tools = [
+  "current_time",
+  "system_info",
+  "locale_info",
+] } }
+```
+
+```
+--- current_time ---
+{ "utc": "2026-08-18T19:32:07Z", ... }
+
+--- system_info ---
+{ "os": "macos", ... }
+```
+
+Any tool the agent could call works, spelled as the agent would spell it: a built-in, an
+[MCP server's](/docs/mcp) `<server>__<tool>`, or a [Rhai script tool](/docs/rhai-tools). A call that
+takes arguments uses the table form, and the two spellings mix in one list:
+
+```toml
+toolchain = { kind = "pinned", seed = { tools = [
+  { name = "which_command", args = { command = "git" } },
+  "locale_info",
+] } }
+```
+
+Use it for anything the agent should not have to think to ask for. The clearest case is the date: a
+research agent that never calls `current_time` reasons from its training cutoff, and seeding the
+answer costs it no turn.
+
+> [!IMPORTANT]
+> Unlike a `command` seed there is no separate kill switch, because a tool seed reaches nothing
+> new. Every call resolves against the same `[tool_permissions]` the tool lane applies mid-run, so a
+> seed can call exactly what the agent could call and nothing more, and a `deny` counts here too.
+>
+> A tool set to `ask` is **refused**, not prompted: a seed runs before the first inference, so there
+> is nobody to answer. Set it to `allow` if the agent is meant to call it at spawn. `lev validate`
+> lists every tool a blueprint seeds from, as `tool-seed`.
+
+A failed call is skipped with a warning and the other calls still fill the region; if the region is
+`required`, a failure is a spawn error naming the tool. Seeds resolve once, at spawn, and do not
+re-run when a run is reloaded, so a long run should call `current_time` again rather than trust a
+region stamped hours ago.
 
 `files`, `glob` and `rhai` seeds resolve against the run's working directory and may not leave it.
 A path that does is refused at spawn, before anything is read.

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -194,6 +194,52 @@ A child reports whatever it submitted through [`submit_output`](/docs/outputs). 
 submitted nothing says so, rather than returning an empty result. `output_format` asks the child for
 a particular shape, overriding what its blueprint declares.
 
+## Environment
+
+What time it is, what machine this is, and what the run itself is doing. A model has no way to
+know any of it: its training data has a cutoff and your run does not, so an agent asked about
+anything current will otherwise reason from whenever it was trained.
+
+| Tool | Purpose | Arguments |
+| --- | --- | --- |
+| `current_time` | The date and time now, in UTC and local, with the IANA timezone, UTC offset, weekday, ISO week and unix epoch. | none |
+| `system_info` | Operating system and version, architecture, CPU count, hostname, path separator, line ending, and free disk space in the working directory. | none |
+| `locale_info` | The user's language and region as a BCP-47 tag, such as `en-US`. | none |
+| `environment_info` | The working directory, the home, temporary, config and data directories, the entries on `PATH`, and the environment variables this agent may see. | none |
+| `which_command` | Whether a program is installed and where, the way `which` or `where` would. Looks the name up on `PATH` without running it. | `command` |
+| `runtime_info` | This run reporting on itself: agent, stage, iteration and limit, model and provider, context tokens spent, and whether anyone is available to answer a question. | none |
+
+All six are read-only, take no action, and default to `allow`, so grounding a run in the present
+costs no approval prompt.
+
+> [!TIP]
+> If an agent researches current events, cites release dates, or reasons about what is recent, give
+> it `current_time` and say so in the stage prompt. A tool that is advertised but never called
+> changes nothing.
+
+> [!NOTE]
+> `runtime_info` is the one to reach for before `ask_user_text`, `ask_user_choice`,
+> `ask_user_confirm` or `present_for_review`. It reports whether the run is unattended, and an
+> unattended run has nobody to answer those, so an agent that checks first can decide and record
+> the assumption instead of waiting.
+
+### What these tools do not reveal
+
+`environment_info` reports environment variables through the same gate a Rhai `env_var` read
+answers to. A credential-shaped name is listed under `withheld_variables` with its value omitted,
+so an agent can tell `ANTHROPIC_API_KEY` is set without seeing it. Name it in
+`[security] allow_env_vars` to hand the value over. See
+[environment variables](/docs/configuration#environment-variables).
+
+`system_info` reports the machine's hostname, and `environment_info` reports absolute paths that
+usually contain the user's account name. Both travel to whichever provider the stage calls, like
+everything else in the context window. Neither is granted to a stage that does not list it in
+`available_tools`.
+
+Not every platform answers every question. `os_version` is read from `/etc/os-release` on Linux and
+`SystemVersion.plist` on macOS; Windows publishes neither, so it reports `null` there rather than
+guessing. Fields that cannot be answered are always present and null, never missing.
+
 ## Web access
 
 Web tools are not built in. They ship as [Rhai script tools](/docs/rhai-tools) beside the agents
@@ -272,10 +318,13 @@ With nothing configured, tools fall back to these:
 | `todo_add`, `todo_done`, `todo_note` | `allow` |
 | `ask_user_text`, `ask_user_choice`, `ask_user_confirm`, `edit_document` | `allow` |
 | `spawn_agent`, `check_agent`, `wait_for_agent`, `send_to_agent`, `kill_agent` | `allow` |
+| `current_time`, `system_info`, `locale_info`, `environment_info`, `which_command`, `runtime_info` | `allow` |
 | Everything else, built-in or MCP | `ask` |
 
 Read-only built-ins and the agent's own context tools run freely, mutating ones ask, and
 human-in-the-loop tools are always allowed because prompting before a prompt would be circular.
+The environment tools read the host and the run and change nothing, so they are allowed on the same
+grounds as the file readers.
 
 ### How a policy is resolved
 

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -442,6 +442,32 @@
               "type": "string",
               "description": "A shell command run at spawn. The only seed that executes anything, and it runs before the first inference and so before any approval prompt. Gated by [security] allow_seed_commands and --no-seed-commands."
             },
+            "tool": {
+              "type": "string",
+              "description": "One tool to call at spawn, whose output fills the region. Shorthand for a single-entry `tools` list."
+            },
+            "tools": {
+              "type": "array",
+              "description": "Tools to call at spawn, in order, each writing a headed block into the region. Any tool the agent could call: a built-in, an MCP server's, or a Rhai script's. Each call resolves against the same [tool_permissions] the tool lane applies, so a seed reaches nothing the agent could not; a tool set to `ask` is refused, because a seed runs before any prompt exists.",
+              "minItems": 1,
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "A tool name, for the many tools that take no arguments."
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["name"],
+                    "properties": {
+                      "name": { "type": "string", "description": "The tool to call." },
+                      "args": { "type": "object", "description": "The arguments object." }
+                    }
+                  }
+                ]
+              }
+            },
             "caller": {
               "type": "string",
               "description": "The caller-input key to fill from, the table form of the plain string."

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -468,6 +468,11 @@
                 ]
               }
             },
+            "refresh": {
+              "enum": ["once", "each_stage"],
+              "default": "once",
+              "description": "For `tool`/`tools`: when the calls run again. `once` (the default, and what every other seed kind does) resolves at spawn. `each_stage` resolves again on every stage entry, for a seed whose answer moves - a clock, say - at the cost of a tool call per stage."
+            },
             "caller": {
               "type": "string",
               "description": "The caller-input key to fill from, the table form of the plain string."


### PR DESCRIPTION
## Why

Run `deep-researcher-1787093177-d5005a3cfc4d` researched a stale news cycle. Its research stages
grant `web_search`, `web_fetch`, `read_file`, `list_dir` and `context_append`; `bash` appears only
in `error_recovery`, and is `ask`. So no stage doing research could run `date`, and the model dated
everything from its training cutoff. The blueprint asks it to record each source's date and never
says what today is.

Nothing in the catalog reported the date, the machine, or the locale, and the engine injects no
environment preamble either - the only framework-authored system blocks are the batch-tool hint and
the Windows shell hint.

## What

**Six read-only environment tools**, all defaulting to `allow` because grounding a run in the
present should not cost an approval:

| Tool | Reports |
| --- | --- |
| `current_time` | UTC and local, IANA zone, offset, weekday, ISO week, epoch |
| `system_info` | OS and version, arch, CPUs, hostname, separators, free disk |
| `locale_info` | the user's language and region as a BCP-47 tag |
| `environment_info` | workdir, well-known directories, `PATH`, environment |
| `which_command` | whether a program is installed, and where |
| `runtime_info` | this run's agent, stage, iteration, model, context, tenancy |

`environment_info` reads the environment through `leviath_core::script_env_allowed` - the same rule
a Rhai `env_var` read answers to - so a credential-shaped name comes back listed under
`withheld_variables` with its value omitted.

`runtime_info` is answered in the runtime rather than in `leviath-tools`, beside the context tools
and for the same reason: the stage, the iteration counts and the window occupancy live in the
world, which the async tool lane cannot reach. Its `unattended` field is the one that changes
behaviour - an agent that cannot tell will call `ask_user_text` in a run with nobody watching and
park there.

**A tool-backed region seed.** A tool only helps an agent that decides to call it, and
`available_tools` is an allowlist, so the tools alone would not have fixed the reported run:

```toml
environment = { kind = "pinned", volatility = "stable", seed = { tools = [
  "current_time", "system_info", "locale_info",
] } }
```

Any tool the agent could call works - a built-in, an MCP server's `<server>__<tool>`, a Rhai
script's. That openness is safe for a specific reason rather than by assumption: every call goes
through `resolve_policy`, the same resolution the tool lane applies mid-run, so a seed reaches
nothing the agent was not already granted and a configured `deny` counts here too. That is why this
needs no `allow_seed_commands` equivalent. A tool set to `ask` is refused rather than prompted -
a seed runs before the first inference, so there is nobody to answer, and silently promoting it
would make seeding the way around the permission layer.

`refresh = "each_stage"` re-runs the calls on every stage entry, holding `ReadyToInfer` until they
land so the stage's first request carries the fresh values. Default stays `once`.

**The three research blueprints** seed an `environment` region and are told to judge "recent",
"current" and "latest" against it. This is the part that closes the reported bug.

## Verification

Every crate at 100% (`leviath-tools`, `leviath-sys`, `leviath-core`, `leviath-runtime`,
`leviath-cli`, `leviath-agent-client`), clippy `-D warnings`, `cargo deny`, docs and structure
gates green.

Green tests would not have shown whether any of this reaches the model, so this was live-tested
against a running daemon with a recording provider. Three discriminating pairs:

**The seeded region arrives in the system prompt**, with the real clock, zone, locale, and a
`which_command` call carrying arguments:

```
## environment
--- current_time ---
{ "date": "2026-08-18", "weekday": "Tuesday",
  "local": "2026-08-18T18:15:45-07:00", "utc": "2026-08-19T01:15:45Z",
  "timezone": "America/Los_Angeles", ... }
--- which_command ---
{ "command": "git", "found": true, "path": "/usr/bin/git" }
```

Note the local day and the UTC day differ there - the calendar fields follow the local one, which
is the case the unit tests pin.

**The permission layer reaches seed time.** With `[tool_permissions] current_time = "deny"` the
block is simply absent, `--yolo` does not lift it, and the other two calls still fill the region -
per-call failure isolation, observed rather than assumed.

**The refresh really refreshes.** One run, one blueprint, two seeded regions differing only in the
`refresh` key, against a provider slow enough that the stages land in different seconds:

```
stage one   clock=1787103531  frozen=1787103531
stage two   clock=1787103535  frozen=1787103531
                  +4s               +0s
```

## Worth a reviewer's eye

- **A reordering in `build_agent_inner`.** The launch overrides and the Rhai script host now
  resolve ahead of seed resolution rather than beside the tool-state registration below it, so a
  seeded script tool has a host to run under. Everything they read was already bound at that point.
- **`block_on_daemon` uses `block_in_place` on the ambient handle** rather than building a runtime.
  MCP transports have tasks living on the daemon's runtime; a second one would leave them unpolled
  and the call would hang rather than fail.
- **Seed batches ride the shared tool lane**, so they arrive on the channel `collect_tools` drains
  and are claimed there rather than by a system of their own - a channel has one receiver, and a
  second drainer would take whichever outcomes it reached first while the other kind vanished.
- **`taint.rs` classification is required, not optional.** The fallback arm is outbound, so an
  unclassified environment tool would be gated in every taint-tracking run and asking the date
  would raise a leak prompt.
- **One new dependency**, `sys-locale`. There is no std API for the locale, Windows has no `LANG`,
  and the workspace forbids unsafe. OS version is read without a dependency, from `/etc/os-release`
  and `SystemVersion.plist`; Windows publishes neither, so it reports `null` rather than guessing.
- **The three blueprints get minor version bumps** - a new pinned region and changed stage prompts
  are a behaviour change for anyone who has them installed. The workspace version is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
