### PR TITLE
feat(dash): one graph canvas for explorer, band and preview; focus hides untaken stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,9 +91,10 @@ same list.
 - New: `lev validate --graph` prints the same stage graph as plain text
   (`--width` caps how wide).
 - New: the detail view's stage row is the blueprint's graph on a terminal
-  at least 32 rows tall: one box per stage, edges between them, the stage
-  the run is in lit up, `←`/`→` and `1`-`9` moving through it as they did
-  through the tabs. The flat strip stays on shorter terminals.
+  at least 36 rows tall, drawn by the explorer's canvas: the same boxes,
+  edges and colours, the stage the run is in lit up, the selected box the
+  open stage tab. `←`/`→` walk the graph, `1`-`9` jump by number, a click
+  picks a box, and boxes drag. The flat strip stays on shorter terminals.
 - New: the new-run screen previews the selected blueprint's stage graph
   above the task, bundled blueprints included before they are installed,
   and says so when a manifest cannot be read.
@@ -106,9 +107,11 @@ same list.
   animation runs at a walking pace, a dotted grid sits under the graph, and
   boxes can be dragged into an arrangement of your own, which the explorer
   keeps for the run.
-- Changed: while a run is on the canvas the graph draws only the
-  transitions it took and the ones it can take from where it is; `t` shows
-  them all. Hint bars fit the terminal: what does not fit gives way from
+- Changed: while a run is on the canvas the graph draws only the path and
+  the options: the stages the run has been through and is in, the
+  transitions between them, and what it can do from here with the stages
+  that leads to. A stage no line reaches is not drawn either; `t` shows the
+  whole graph. Hint bars fit the terminal: what does not fit gives way from
   the end (the explorer's) or the middle (the dashboard's, keeping help and
   back), with an ellipsis where it went, and the graph pane's title
   shortens on a narrow pane.

--- a/crates/leviath-cli/src/commands/dashboard/detail_band.rs
+++ b/crates/leviath-cli/src/commands/dashboard/detail_band.rs
@@ -1,11 +1,13 @@
-//! The detail view's graph band: the blueprint's stage graph, one row per
-//! stage box, in the rows the flat tab strip used to have.
+//! The detail view's graph band: the blueprint's stage graph in the rows the
+//! flat tab strip used to have, drawn by the same canvas as the explorer.
 //!
 //! The strip said "3 of 7" and which stage was selected; the band says the
 //! same and also where the run has been, where it is, and how the stages
-//! connect. It is a viewer, not a second explorer: `←`/`→` and `1-9` still
-//! move the selection, `g` opens the full-screen graph, and the mouse only
-//! pans. On a terminal too short to give it its rows the strip stays.
+//! connect. The selection on the canvas is the stage tab: `←`/`→` move it
+//! through the graph, `1`-`9` jump to a stage by number, a click picks a
+//! box, and the content panes below follow. Boxes drag, the canvas pans,
+//! and `g` opens the full-screen explorer. On a terminal too short to give
+//! it its rows the strip stays.
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -16,15 +18,14 @@ use ratatui::widgets::{Block, BorderType, Borders};
 use super::state::Dashboard;
 use super::theme::*;
 use super::types::*;
-use crate::tui::flowgraph::{FlowView, NodeStyle};
+use crate::tui::flowgraph::{FlowView, Selection};
 
-/// Rows the band takes: a border, up to three stacked stage boxes with a
-/// gap between them, and one lane under them for a revisit loop.
-pub(super) const BAND_HEIGHT: u16 = 8;
+/// Rows the band takes: a border, a row of boxes, and lanes for the loops.
+pub(super) const BAND_HEIGHT: u16 = 12;
 
 /// The detail area must be at least this tall for the band to replace the
 /// three-row strip; below it every other pane needs the rows more.
-pub(super) const BAND_MIN_AREA_HEIGHT: u16 = 32;
+pub(super) const BAND_MIN_AREA_HEIGHT: u16 = 36;
 
 /// The band's canvas, kept between frames so the viewport survives a
 /// redraw. Rebuilt when the selected run changes.
@@ -42,6 +43,72 @@ impl Dashboard {
             BAND_HEIGHT
         } else {
             3
+        }
+    }
+
+    /// Whether the band drew last frame, so the stage keys go through it.
+    pub(super) fn band_shown(&self) -> bool {
+        self.pane_rects
+            .iter()
+            .any(|(id, _)| *id == PaneId::DetailBand)
+    }
+
+    /// The tab index of a stage on the band: the ledger's position when it
+    /// has one, the blueprint's order otherwise.
+    fn band_stage_index(&self, name: &str) -> Option<usize> {
+        self.selected_agent().and_then(|a| {
+            a.stages
+                .iter()
+                .position(|s| s.name == name)
+                .or_else(|| a.graph.as_ref().and_then(|g| g.stage_index(name)))
+        })
+    }
+
+    /// The name of the stage tab `index`, the same way round.
+    fn band_stage_name(&self, index: usize) -> Option<String> {
+        self.selected_agent().and_then(|a| {
+            a.stages.get(index).map(|s| s.name.clone()).or_else(|| {
+                a.graph
+                    .as_ref()
+                    .and_then(|g| g.ids().nth(index).map(str::to_string))
+            })
+        })
+    }
+
+    /// The band's selection is the stage tab: adopt it, and reset what a
+    /// tab change resets.
+    pub(super) fn adopt_band_selection(&mut self) {
+        let picked = match self.detail_band.as_ref().map(|b| b.view.selection()) {
+            Some(Selection::Node(id)) => self.band_stage_index(&id),
+            _ => None,
+        };
+        if let Some(index) = picked
+            && index != self.selected_stage
+        {
+            self.selected_stage = index;
+            self.detail_scroll = 0;
+            self.review_scroll = 0;
+            self.search_mode = false;
+            self.search_query.clear();
+            self.search_match_idx = 0;
+        }
+    }
+
+    /// `←`/`→` (or any canvas key) on the band: move the selection through
+    /// the graph and follow it.
+    pub(super) fn band_key(&mut self, code: crossterm::event::KeyCode) {
+        if let Some(band) = self.detail_band.as_mut() {
+            band.view.handle_key(code);
+        }
+        self.adopt_band_selection();
+    }
+
+    /// The tab was set by number: point the band at it.
+    pub(super) fn band_select_tab(&mut self, index: usize) {
+        if let Some(name) = self.band_stage_name(index)
+            && let Some(band) = self.detail_band.as_mut()
+        {
+            band.view.select_stage(&name);
         }
     }
 
@@ -63,9 +130,16 @@ impl Dashboard {
             };
             self.detail_band = Some(DetailBand {
                 run_id: agent.id.clone(),
-                view: FlowView::new(graph, NodeStyle::Compact, true),
+                view: FlowView::new(graph, false),
             });
+            // A fresh canvas starts on the tab that is open.
+            self.band_select_tab(self.selected_stage);
+        } else {
+            // A click since the last frame picked a box: that is the tab now.
+            self.adopt_band_selection();
         }
+        // Visits (the taken edges, the counts) come from the archive.
+        self.ensure_history(&agent.id);
         let live = self.live_overlay_for(agent);
         let stage_count = agent
             .stages
@@ -73,28 +147,13 @@ impl Dashboard {
             .max(agent.graph.as_ref().map(|g| g.stage_count()).unwrap_or(0))
             .max(1);
         let selected = self.selected_stage.min(stage_count - 1);
-        // The ledger names the stage when it has one; the blueprint's own
-        // order otherwise (a run that has not written its ledger yet).
-        let selected_name = agent
-            .stages
-            .get(selected)
-            .map(|s| s.name.clone())
-            .or_else(|| {
-                agent
-                    .graph
-                    .as_ref()
-                    .and_then(|g| g.ids().nth(selected).map(str::to_string))
-            })
-            .unwrap_or_default();
-
         let band = self
             .detail_band
             .as_mut()
             .expect("built above when missing or stale");
         band.view.apply_live(&live);
-        band.view.select_stage(&selected_name);
         let title = format!(
-            " Stages ←/→ to switch  stage {}/{}  ·  [g] graph  ·  drag to pan ",
+            " Stages ←/→ select  1-9 jump  stage {}/{}  ·  [g] graph  ·  click, drag ",
             selected + 1,
             stage_count
         );
@@ -118,7 +177,9 @@ mod tests {
         make_test_dashboard, rendered_buffer, style_at_text,
     };
     use crate::tui::flowgraph::StageGraph;
-    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    use crossterm::event::{
+        KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+    };
     use leviath_core::manifest::parse_manifest;
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
@@ -185,6 +246,10 @@ condition = "llm_choice"
         terminal
     }
 
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
     fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
         MouseEvent {
             kind,
@@ -194,30 +259,56 @@ condition = "llm_choice"
         }
     }
 
+    fn record(name: &str, index: usize, entered: bool) -> leviath_core::run_meta::StageRecord {
+        let mut r = leviath_core::run_meta::StageRecord::new(name.to_string(), index);
+        r.entered = entered;
+        r
+    }
+
+    /// A run at implement that came through plan: the ledger names both.
+    fn run_at_implement(id: &str) -> DashboardAgent {
+        let mut run = agent(id);
+        run.stages = vec![
+            record("plan", 0, true),
+            record("implement", 1, true),
+            record("review", 2, false),
+            record("done", 3, false),
+        ];
+        run
+    }
+
     #[test]
     fn a_tall_detail_view_draws_the_band_with_the_current_stage_lit_and_the_tab_selected() {
         let mut dash = make_test_dashboard();
-        dash.agents.push(agent("run-1"));
+        dash.agents.push(run_at_implement("run-1"));
         dash.update_display_indices();
         dash.detail_view = true;
         dash.selected_stage = 0;
         let terminal = draw(&mut dash, 160, 40);
         let text = rendered_buffer(&terminal);
         assert!(text.contains("stage 1/4"), "{text}");
-        assert!(text.contains("drag to pan"), "{text}");
-        for stage in ["plan", "implement", "review", "done"] {
+        assert!(text.contains("click, drag"), "{text}");
+        // The same picture as the explorer: the path so far and what comes
+        // next, in boxes; done hangs off review and waits for its turn.
+        for stage in ["plan", "implement", "review"] {
             assert!(text.contains(&format!(" {stage} ")), "{stage}: {text}");
         }
+        assert!(!text.contains(" done "), "{text}");
         // The stage the run is in is drawn in the active colour; the selected
-        // tab has the bright brackets; a pending stage is dim.
+        // tab (plan, the open one) has the thick frame; review is dim.
         assert_eq!(style_at_text(&terminal, "implement").fg, Some(C_ACTIVE));
-        assert_eq!(style_at_text(&terminal, "[ ▶").fg, Some(C_BORDER_FOCUS));
-        assert_eq!(style_at_text(&terminal, "done").fg, Some(C_DIM));
+        assert_eq!(style_at_text(&terminal, "┏").fg, Some(C_BORDER_FOCUS));
+        assert_eq!(style_at_text(&terminal, "review").fg, Some(C_DIM));
+        assert_eq!(
+            dash.detail_band.as_ref().unwrap().view.selection(),
+            Selection::Node("plan".into())
+        );
         assert!(
             dash.pane_rects
                 .iter()
                 .any(|(id, _)| *id == PaneId::DetailBand)
         );
+        assert!(dash.band_shown());
         // The strip's own chrome is gone.
         assert!(!text.contains("←/→ to switch  stage 1/4 ·  [g]"), "{text}");
     }
@@ -231,8 +322,9 @@ condition = "llm_choice"
         let terminal = draw(&mut dash, 160, 24);
         let text = rendered_buffer(&terminal);
         assert!(text.contains("stage 1/4"), "{text}");
-        assert!(!text.contains("drag to pan"), "{text}");
+        assert!(!text.contains("click, drag"), "{text}");
         assert!(dash.detail_band.is_none());
+        assert!(!dash.band_shown());
         assert_eq!(Dashboard::stage_row_height(24, &agent("run-1")), 3);
         assert_eq!(
             Dashboard::stage_row_height(40, &agent("run-1")),
@@ -274,19 +366,88 @@ condition = "llm_choice"
         dash.selected_stage = 40;
         let terminal = draw(&mut dash, 160, 40);
         assert!(rendered_buffer(&terminal).contains("stage 4/4"));
+        // Opening the detail view afresh drops the canvas, so the selection
+        // starts on the tab that opens.
+        dash.open_detail_view();
+        assert!(dash.detail_band.is_none());
+    }
+
+    #[test]
+    fn the_selection_is_the_stage_tab_both_ways() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(run_at_implement("run-1"));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.selected_stage = 0;
+        draw(&mut dash, 160, 40);
+        // `→` walks the graph and the tab follows, resetting the scrolls.
+        dash.detail_scroll = 5;
+        dash.handle_key(key(KeyCode::Right));
+        assert_eq!(dash.selected_stage, 1);
+        assert_eq!(dash.detail_scroll, 0);
+        assert_eq!(
+            dash.detail_band.as_ref().unwrap().view.selection(),
+            Selection::Node("implement".into())
+        );
+        dash.handle_key(key(KeyCode::Right));
+        assert_eq!(dash.selected_stage, 2, "review");
+        // Nothing to the right of review on show: the tab stays.
+        dash.handle_key(key(KeyCode::Right));
+        assert_eq!(dash.selected_stage, 2);
+        dash.handle_key(key(KeyCode::Left));
+        assert_eq!(dash.selected_stage, 1);
+        // A number jumps the tab and points the canvas at it.
+        dash.handle_key(key(KeyCode::Char('1')));
+        assert_eq!(dash.selected_stage, 0);
+        assert_eq!(
+            dash.detail_band.as_ref().unwrap().view.selection(),
+            Selection::Node("plan".into())
+        );
+        // A selection picked on the canvas (a click) is adopted at the next
+        // draw; a selection the ledger does not know is left alone.
+        dash.detail_band
+            .as_mut()
+            .unwrap()
+            .view
+            .select_stage("review");
+        draw(&mut dash, 160, 40);
+        assert_eq!(dash.selected_stage, 2);
+        dash.detail_band
+            .as_mut()
+            .unwrap()
+            .view
+            .select_stage("nowhere");
+        dash.adopt_band_selection();
+        assert_eq!(dash.selected_stage, 2);
+        // Without a band the helpers are inert.
+        dash.detail_band = None;
+        dash.band_key(KeyCode::Left);
+        dash.band_select_tab(0);
+        assert_eq!(dash.selected_stage, 2);
+        // A run whose ledger is empty falls back to the blueprint's order.
+        let mut dash = make_test_dashboard();
+        dash.agents.push(agent("run-1"));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.selected_stage = 2;
+        draw(&mut dash, 160, 40);
+        assert_eq!(
+            dash.detail_band.as_ref().unwrap().view.selection(),
+            Selection::Node("review".into())
+        );
+        dash.detail_band
+            .as_mut()
+            .unwrap()
+            .view
+            .select_stage("implement");
+        dash.adopt_band_selection();
+        assert_eq!(dash.selected_stage, 1);
     }
 
     #[test]
     fn the_band_takes_the_mouse_and_ticks() {
         let mut dash = make_test_dashboard();
-        let mut run = agent("run-1");
-        // A ledger names the stages: the selection follows it rather than
-        // the blueprint's order.
-        run.stages = vec![
-            leviath_core::run_meta::StageRecord::new("plan".to_string(), 0),
-            leviath_core::run_meta::StageRecord::new("implement".to_string(), 1),
-        ];
-        dash.agents.push(run);
+        dash.agents.push(run_at_implement("run-1"));
         dash.update_display_indices();
         dash.detail_view = true;
         dash.selected_stage = 1;
@@ -294,14 +455,9 @@ condition = "llm_choice"
         // A second draw of the same run keeps the canvas it built.
         let terminal = draw(&mut dash, 160, 40);
         assert_eq!(
-            style_at_text(&terminal, "[ ▶").fg,
-            Some(C_DIM),
-            "plan is pending, not selected"
-        );
-        assert_eq!(
-            style_at_text(&terminal, "implement ]").fg,
-            Some(C_ACTIVE),
-            "the ledger's second stage is the selected one and the current one"
+            style_at_text(&terminal, "┏").fg,
+            Some(C_BORDER_FOCUS),
+            "the ledger's second stage is the selected one"
         );
         let canvas = dash
             .pane_rects
@@ -319,6 +475,19 @@ condition = "llm_choice"
         dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x - 10, y));
         dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x - 10, y));
         assert_ne!(dash.detail_band.as_ref().unwrap().view.pan(), pan);
+        // A click on a box picks it, and the tab follows at the next draw.
+        let (nx, ny, _, _) = dash
+            .detail_band
+            .as_ref()
+            .unwrap()
+            .view
+            .node_rect("plan")
+            .expect("plan is drawn");
+        let (nx, ny) = (nx as u16 + 1, ny as u16 + 1);
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), nx, ny));
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), nx, ny));
+        draw(&mut dash, 160, 40);
+        assert_eq!(dash.selected_stage, 0);
         dash.tick_graphs(std::time::Duration::from_millis(100));
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -12,12 +12,19 @@ use crossterm::event::{KeyCode, MouseButton, MouseEvent, MouseEventKind};
 use super::history::{clock, last_visit, visit_count};
 use super::state::Dashboard;
 use super::types::*;
-use crate::tui::flowgraph::{
-    FlowView, LiveOverlay, NodeStyle, RunPhase, Selection, StageLive, WorkerCounts,
-};
+use crate::tui::flowgraph::{FlowView, LiveOverlay, RunPhase, Selection, StageLive, WorkerCounts};
 use leviath_core::run_meta::StageRunStatus;
 
 impl Dashboard {
+    /// A detail view opened afresh starts its exploration afresh: the
+    /// context tree folded, no explorer, and a band that will start on the
+    /// tab that opens.
+    pub(super) fn reset_exploration(&mut self) {
+        self.context_tree = ContextTreeState::default();
+        self.stage_explorer = None;
+        self.detail_band = None;
+    }
+
     /// `g` in the detail view: open the explorer on the selected run. Every
     /// run has a graph (a linear blueprint is a chain); the one that has not
     /// is a run whose manifest could not be read, and that is said out loud
@@ -34,7 +41,7 @@ impl Dashboard {
                 // back as it was: viewport, dragged boxes, direction, toggles.
                 let view = match self.explorer_cache.take() {
                     Some((cached_run, view)) if cached_run == run_id => view,
-                    _ => FlowView::new(graph, NodeStyle::Full, false),
+                    _ => FlowView::new(graph, false),
                 };
                 self.stage_explorer = Some(ExplorerState::new(run_id, view));
             }
@@ -508,8 +515,8 @@ condition = "llm_choice"
             dash.stage_explorer.as_ref().unwrap().view.selection(),
             Selection::Node("plan".into())
         );
-        dash.handle_key(key(KeyCode::Char('u')));
-        assert!(!dash.stage_explorer.as_ref().unwrap().view.show_unvisited());
+        dash.handle_key(key(KeyCode::Char('t')));
+        assert!(dash.stage_explorer.as_ref().unwrap().view.show_all());
         dash.handle_key(key(KeyCode::Char('e')));
         assert!(dash.stage_explorer.as_ref().unwrap().view.show_escape());
         dash.handle_key(key(KeyCode::Char('r')));
@@ -542,7 +549,7 @@ condition = "llm_choice"
             dash.stage_explorer.as_ref().unwrap().view.selection(),
             Selection::Node("plan".into())
         );
-        assert!(!dash.stage_explorer.as_ref().unwrap().view.show_unvisited());
+        assert!(dash.stage_explorer.as_ref().unwrap().view.show_all());
         dash.handle_key(key(KeyCode::Enter));
         assert!(dash.stage_explorer.is_none());
         // Enter with nothing selected keeps the explorer open; Enter on an

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -411,7 +411,9 @@ impl Dashboard {
                     self.reset_context_history();
                 }
             }
-            // Stage tab navigation
+            // Stage tab navigation: through the graph band when it is on
+            // screen (its selection is the tab), by index otherwise.
+            KeyCode::Left | KeyCode::Right if self.band_shown() => self.band_key(key_code),
             KeyCode::Left => {
                 if self.selected_stage > 0 {
                     self.selected_stage -= 1;
@@ -450,6 +452,7 @@ impl Dashboard {
                     self.search_mode = false;
                     self.search_query.clear();
                     self.search_match_idx = 0;
+                    self.band_select_tab(idx);
                 }
             }
             // Content mode toggle

--- a/crates/leviath-cli/src/commands/dashboard/new_run_preview.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run_preview.rs
@@ -17,15 +17,15 @@ use super::graph::{bundled_stage_graph, load_stage_graph};
 use super::state::Dashboard;
 use super::theme::*;
 use super::types::*;
-use crate::tui::flowgraph::{FlowView, NodeStyle};
+use crate::tui::flowgraph::FlowView;
 
 /// The rows the task editor keeps for itself; the preview only appears
 /// when the pane has this many left over for it.
 pub(super) const TASK_MIN_HEIGHT: u16 = 8;
-/// The preview's smallest useful height (a border, two rows of boxes, a lane).
-pub(super) const PREVIEW_MIN_HEIGHT: u16 = 8;
+/// The preview's smallest useful height: a border, a row of boxes, a lane.
+pub(super) const PREVIEW_MIN_HEIGHT: u16 = 10;
 /// And its largest: more rows than this only show empty canvas.
-pub(super) const PREVIEW_MAX_HEIGHT: u16 = 14;
+pub(super) const PREVIEW_MAX_HEIGHT: u16 = 18;
 
 /// The preview canvas for one catalog row, kept between frames.
 #[derive(Debug)]
@@ -68,7 +68,7 @@ impl Dashboard {
             load_stage_graph(&agent.path)
         };
         let view = match graph {
-            Some(graph) => Ok(FlowView::new(graph, NodeStyle::Compact, true)),
+            Some(graph) => Ok(FlowView::new(graph, true)),
             None => Err(format!(
                 "no preview: could not read a blueprint at {}",
                 agent.path

--- a/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/graph_view.rs
@@ -26,34 +26,35 @@ use crate::tui::widgets::footer::{draw_hint_bar, hint};
 fn graph_title(
     width: u16,
     direction: FlowDirection,
-    show_untaken: bool,
+    show_all: bool,
     show_escape: bool,
-    show_unvisited: bool,
     zoom: f64,
 ) -> String {
     let on_off = |on: bool| if on { "on" } else { "off" };
-    if width < 110 {
+    let arrow = match direction {
+        FlowDirection::LeftToRight => "→",
+        FlowDirection::TopToBottom => "↓",
+    };
+    let what = if show_all {
+        "whole graph"
+    } else {
+        "path + options"
+    };
+    if width < 90 {
         return format!(
-            " Graph · {} · t:{} e:{} u:{} · {:.0}% ",
-            match direction {
-                FlowDirection::LeftToRight => "→",
-                FlowDirection::TopToBottom => "↓",
-            },
-            on_off(show_untaken),
+            " Graph · {arrow} · {} (t) · e:{} · {:.0}% ",
+            if show_all { "all" } else { "path" },
             on_off(show_escape),
-            on_off(show_unvisited),
             zoom * 100.0,
         );
     }
     format!(
-        " Graph · {} (r) · untaken edges {} (t) · escapes {} (e) · unvisited {} (u) · zoom {:.0}% ",
+        " Graph · {} (r) · {what} (t) · escapes {} (e) · zoom {:.0}% ",
         match direction {
             FlowDirection::LeftToRight => "left to right",
             FlowDirection::TopToBottom => "top to bottom",
         },
-        on_off(show_untaken),
         on_off(show_escape),
-        on_off(show_unvisited),
         zoom * 100.0,
     )
 }
@@ -145,9 +146,8 @@ impl Dashboard {
                 hint("enter", "open tab"),
                 hint("tab", "timeline"),
                 hint("?", "help"),
-                hint("t", "all edges"),
+                hint("t", "whole graph"),
                 hint("e", "escapes"),
-                hint("u", "unvisited"),
                 hint("r", "rotate"),
                 hint("f", "fit"),
                 hint("+ -", "zoom"),
@@ -179,9 +179,8 @@ impl Dashboard {
         let title = graph_title(
             area.width,
             explorer.view.direction(),
-            explorer.view.show_untaken(),
+            explorer.view.show_all(),
             explorer.view.show_escape(),
-            explorer.view.show_unvisited(),
             explorer.view.zoom(),
         );
         let block = Block::default()
@@ -334,7 +333,7 @@ mod tests {
         make_test_dashboard, rendered_buffer, style_at_text,
     };
     use crate::commands::dashboard::types::*;
-    use crate::tui::flowgraph::{FlowView, NodeStyle, StageGraph};
+    use crate::tui::flowgraph::{FlowView, StageGraph};
     use crate::tui::theme::*;
     use crossterm::event::KeyCode;
     use leviath_core::manifest::parse_manifest;
@@ -408,10 +407,7 @@ mode = "output"
     }
 
     fn explorer() -> ExplorerState {
-        ExplorerState::new(
-            "run-1".to_string(),
-            FlowView::new(stage_graph(), NodeStyle::Full, false),
-        )
+        ExplorerState::new("run-1".to_string(), FlowView::new(stage_graph(), false))
     }
 
     fn seed(dash: &mut crate::commands::dashboard::state::Dashboard, stages: &[(&str, i64)]) {
@@ -486,24 +482,31 @@ mode = "output"
 
         let (terminal, text) = rendered_at(&mut dash, 200, 50);
         assert!(text.contains("Stage explorer"), "{text}");
+        // By default the canvas is the path and the options: the stages the
+        // run has been through and where it can go from implement. Island
+        // hangs off review (not the current stage) and recover is behind an
+        // escape, so neither is drawn until `t`.
+        for stage in ["plan", "implement", "review"] {
+            assert!(text.contains(stage), "{stage}: {text}");
+        }
+        for stage in ["recover", "island"] {
+            assert!(!text.contains(stage), "{stage} hidden: {text}");
+        }
+        assert!(text.contains("implement ×2"), "revisit count: {text}");
+        assert!(text.contains("[llm_choice]"), "taken edge's label: {text}");
+        assert!(text.contains("escapes off (e)"), "{text}");
+        assert!(text.contains("path + options (t)"), "{text}");
+        assert!(text.contains("←→↑↓ select"), "hint bar: {text}");
+        assert!(text.contains("Select a stage with the arrows"), "{text}");
+        // The current stage is drawn in the active colour.
+        assert_eq!(style_at_text(&terminal, "implement ×2").fg, Some(C_ACTIVE));
+        // `t` brings the whole graph back, pending stages dim.
+        dash.stage_explorer.as_mut().unwrap().view.toggle_all();
+        let (terminal, text) = rendered_at(&mut dash, 200, 50);
         for stage in ["plan", "implement", "review", "recover", "island"] {
             assert!(text.contains(stage), "{stage}: {text}");
         }
-        assert!(text.contains("implement ×2"), "revisit count: {text}");
-        assert!(text.contains("[llm_choice]"), "condition label: {text}");
-        assert!(text.contains("escapes off (e)"), "{text}");
-        assert!(text.contains("untaken edges off (t)"), "{text}");
-        assert!(text.contains("←→↑↓ select"), "hint bar: {text}");
-        // Untaken edges are hidden by default: review's edge to island (never
-        // taken, and review is not the current stage) is not drawn; the path
-        // taken and the current stage's options are.
-        assert!(
-            !text.contains("[llm_choice]") || text.contains("implement ×2"),
-            "{text}"
-        );
-        assert!(text.contains("Select a stage with the arrows"), "{text}");
-        // The current stage is drawn in the active colour, a pending one dim.
-        assert_eq!(style_at_text(&terminal, "implement ×2").fg, Some(C_ACTIVE));
+        assert!(text.contains("whole graph (t)"), "{text}");
         assert_eq!(style_at_text(&terminal, "island").fg, Some(C_DIM));
         // The graph pane registered its canvas for the mouse.
         assert!(
@@ -568,11 +571,15 @@ mode = "output"
         // A narrow pane gets the short title, and the graph turns to fit it
         // (the title says so from the frame after the turn: the dashboard
         // redraws ten times a second).
-        rendered_at(&mut dash, 90, 40);
-        let (_, text) = rendered_at(&mut dash, 90, 40);
+        rendered_at(&mut dash, 80, 40);
+        let (_, text) = rendered_at(&mut dash, 80, 40);
         assert!(
-            text.contains("Graph · ↓ · t:off e:on u:on · 100%"),
+            text.contains("Graph · ↓ · path (t) · e:on · 100%"),
             "{text}"
+        );
+        assert_eq!(
+            super::graph_title(60, super::FlowDirection::LeftToRight, true, false, 1.0),
+            " Graph · → · all (t) · e:off · 100% "
         );
         // An edge: pick one directly on the canvas. The first carries a hint
         // and no condition; the loop back from review carries the reverse.
@@ -596,26 +603,26 @@ mode = "output"
     }
 
     #[test]
-    fn u_hides_unvisited_stages_from_the_graph_but_never_the_current_one() {
+    fn the_current_stage_and_its_options_show_even_before_the_archive_has_them() {
         let mut dash = make_test_dashboard();
         let mut agent = graph_agent();
         agent.stage = "review".to_string(); // current but never archived
         dash.agents.push(agent);
         dash.update_display_indices();
         seed(&mut dash, &[("plan", 10), ("implement", 70)]);
-        let mut explorer = explorer();
-        explorer.view.toggle_unvisited();
-        dash.stage_explorer = Some(explorer);
+        dash.stage_explorer = Some(explorer());
 
         let text = rendered(&mut dash);
-        assert!(!text.contains("island"), "{text}");
-        assert!(!text.contains("recover"), "{text}");
+        assert!(!text.contains("recover"), "behind an escape: {text}");
         assert!(text.contains("plan"), "{text}");
         assert!(
             text.contains("review"),
             "the current stage never hides: {text}"
         );
-        assert!(text.contains("unvisited off (u)"), "{text}");
+        assert!(
+            text.contains("island"),
+            "where the current stage can go: {text}"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -724,11 +724,7 @@ mod tests {
         dash.detail_view = true;
         dash.stage_explorer = Some(crate::commands::dashboard::types::ExplorerState::new(
             "run-exp".to_string(),
-            crate::tui::flowgraph::FlowView::new(
-                graph,
-                crate::tui::flowgraph::NodeStyle::Full,
-                false,
-            ),
+            crate::tui::flowgraph::FlowView::new(graph, false),
         ));
         terminal.draw(|f| dash.draw(f)).unwrap();
         let text: String = terminal

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -175,10 +175,9 @@ fn detail_sections() -> Vec<HelpSection> {
                 ("r", "turn the graph: left to right / top to bottom"),
                 (
                     "t",
-                    "show every edge, or only the path taken and what comes next",
+                    "the whole graph, or only the path taken and what comes next",
                 ),
                 ("e", "show or hide the escape edges (error, dead_end, ...)"),
-                ("u", "show or hide stages the run never entered"),
                 ("↑ ↓ / k j", "timeline: step through visits"),
                 ("drag", "move a box; on empty canvas, pan"),
                 ("wheel / click", "zoom / select on the canvas"),

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -391,9 +391,7 @@ impl Dashboard {
         self.detail_scroll = 0;
         // Default to the stage the run is actually on.
         self.selected_stage = self.selected_agent().map(|a| a.stage_index).unwrap_or(0);
-        // Fresh run, fresh exploration state.
-        self.context_tree = ContextTreeState::default();
-        self.stage_explorer = None;
+        self.reset_exploration();
     }
 
     pub(super) fn selected_agent(&self) -> Option<&DashboardAgent> {

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -108,8 +108,8 @@ pub(super) struct ExplorerState {
     pub(super) tab: ExplorerTab,
     /// Selected row on the timeline tab.
     pub(super) timeline_selected: usize,
-    /// The graph canvas. Owns the toggles (`u` unvisited, `e` escape edges),
-    /// the selection, the direction and the viewport.
+    /// The graph canvas. Owns the toggles (`t` whole graph, `e` escape
+    /// edges), the selection, the direction and the viewport.
     pub(super) view: FlowView,
 }
 

--- a/crates/leviath-cli/src/tui/flowgraph/content.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/content.rs
@@ -98,33 +98,13 @@ impl NodeStatus {
     }
 }
 
-/// How much of the box to draw.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum NodeStyle {
-    /// A bordered box with a title row and two detail rows.
-    Full,
-    /// One row: `[ glyph name ×n ]`.
-    Compact,
-}
+/// A box's height on the canvas: a border, the title, two detail rows.
+pub(crate) const NODE_HEIGHT: f64 = 4.0;
 
-impl NodeStyle {
-    /// Node height on the canvas.
-    pub(crate) fn height(self) -> f64 {
-        match self {
-            NodeStyle::Full => 4.0,
-            NodeStyle::Compact => 1.0,
-        }
-    }
-
-    /// Node width for the longest id on the graph.
-    pub(crate) fn width(self, longest_id: usize) -> f64 {
-        match self {
-            // `╭ ▶ ⠋ name ×12 ╮`, and room for `⑂ 3 run · 1 done · 0 fail`.
-            NodeStyle::Full => (longest_id + 10).max(28) as f64,
-            // `[ ⠋ name ×12 ]`
-            NodeStyle::Compact => (longest_id + 9).max(14) as f64,
-        }
-    }
+/// A box's width for the longest id on the graph: `╭ ▶ ⠋ name ×12 ╮`, and
+/// room for `⑂ 3 run · 1 done · 0 fail`.
+pub(crate) fn node_width(longest_id: usize) -> f64 {
+    (longest_id + 10).max(28) as f64
 }
 
 /// Live counts of a fan-out stage's workers.
@@ -145,7 +125,6 @@ pub(crate) struct StageNodeContent {
     pub(crate) is_entry: bool,
     pub(crate) is_terminal: bool,
     pub(crate) self_loop: bool,
-    pub(crate) style: NodeStyle,
     // ── live ──
     pub(crate) status: NodeStatus,
     /// The run's iteration count, when this is the current stage. It counts
@@ -160,7 +139,7 @@ pub(crate) struct StageNodeContent {
 
 impl StageNodeContent {
     /// The blueprint's view of a node, before any run touched it.
-    pub(crate) fn from_node(node: &StageNode, style: NodeStyle) -> Self {
+    pub(crate) fn from_node(node: &StageNode) -> Self {
         Self {
             name: node.id.trim_start_matches("ext:").to_string(),
             kind_label: node.kind_label(),
@@ -168,7 +147,6 @@ impl StageNodeContent {
             is_entry: node.is_entry,
             is_terminal: node.is_terminal || node.allow_complete,
             self_loop: node.self_loop,
-            style,
             status: NodeStatus::Pending,
             iteration: None,
             last_seen: None,
@@ -278,8 +256,8 @@ impl NodeContent for StageNodeContent {
             Style::default().fg(colour)
         };
         let width = area.width as usize;
-        // Compact, or a box zoomed down to a row: brackets are the bounds.
-        if self.style == NodeStyle::Compact || area.height < 2 {
+        // A box zoomed down to a row: brackets are the bounds.
+        if area.height < 2 {
             let mut line = self.title(ctx.selected, width.saturating_sub(2));
             line.spans.insert(0, Span::styled("[", border_style));
             line.spans.push(Span::styled("]", border_style));
@@ -373,8 +351,8 @@ mod tests {
         }
     }
 
-    fn content(style: NodeStyle) -> StageNodeContent {
-        StageNodeContent::from_node(&node("plan", NodeKind::Stage(StageKind::Autonomous)), style)
+    fn content() -> StageNodeContent {
+        StageNodeContent::from_node(&node("plan", NodeKind::Stage(StageKind::Autonomous)))
     }
 
     fn draw(content: &StageNodeContent, area: Rect, selected: bool) -> (Buffer, String) {
@@ -410,7 +388,7 @@ mod tests {
     #[test]
     fn pending_visited_and_every_current_run_phase_render_their_glyph_and_colour() {
         let area = Rect::new(0, 0, 40, 4);
-        let mut c = content(NodeStyle::Full);
+        let mut c = content();
         let (buf, text) = draw(&c, area, false);
         assert!(text.contains(&format!("{GLYPH_PENDING} plan")), "{text}");
         assert_eq!(style_at(&buf, "plan").fg, Some(C_DIM));
@@ -488,7 +466,7 @@ mod tests {
         n.is_entry = true;
         n.self_loop = true;
         n.allow_complete = true;
-        let mut c = StageNodeContent::from_node(&n, NodeStyle::Full);
+        let mut c = StageNodeContent::from_node(&n);
         assert_eq!(c.kind_label, "fan-out");
         c.last_seen = Some("14:22:01".to_string());
         c.workers = Some(WorkerCounts {
@@ -504,10 +482,7 @@ mod tests {
         assert_eq!(c.status, NodeStatus::Pending);
         assert!(c.workers.is_none() && c.last_seen.is_none() && c.iteration.is_none());
 
-        let ext = StageNodeContent::from_node(
-            &node("ext:researcher", NodeKind::ExternalBlueprint),
-            NodeStyle::Full,
-        );
+        let ext = StageNodeContent::from_node(&node("ext:researcher", NodeKind::ExternalBlueprint));
         assert!(ext.is_external);
         assert_eq!(ext.name, "researcher");
         let (_, text) = draw(&ext, Rect::new(0, 0, 24, 4), false);
@@ -520,7 +495,7 @@ mod tests {
 
     #[test]
     fn a_short_area_keeps_its_bounds_and_the_name_gives_way_first() {
-        let c = content(NodeStyle::Full);
+        let c = content();
         // One row: brackets, always closed.
         let (_, text) = draw(&c, Rect::new(0, 0, 12, 1), false);
         assert!(
@@ -542,7 +517,7 @@ mod tests {
         assert!(text.contains("╰"), "{text}");
         assert!(!text.contains("autonomous"), "{text}");
         // A visit count survives the cut before the name does.
-        let mut counted = content(NodeStyle::Compact);
+        let mut counted = content();
         counted.status = NodeStatus::Visited {
             times: 12,
             errored: false,
@@ -558,7 +533,7 @@ mod tests {
         assert_eq!(fit("plan", 1), "…");
         assert_eq!(fit("plan", 0), "");
 
-        let compact = content(NodeStyle::Compact);
+        let compact = content();
         let (buf, text) = draw(&compact, Rect::new(0, 0, 14, 1), true);
         assert!(
             text.contains(&format!("[ {GLYPH_PENDING} plan ]")),
@@ -570,17 +545,14 @@ mod tests {
         let title = style_at(&buf, "plan");
         assert!(title.add_modifier.contains(Modifier::BOLD));
         assert!(!title.add_modifier.contains(Modifier::REVERSED));
-        assert_eq!(NodeStyle::Compact.height(), 1.0);
-        assert_eq!(NodeStyle::Full.height(), 4.0);
-        assert_eq!(NodeStyle::Compact.width(3), 14.0);
-        assert_eq!(NodeStyle::Compact.width(10), 19.0);
-        assert_eq!(NodeStyle::Full.width(10), 28.0);
-        assert_eq!(NodeStyle::Full.width(20), 30.0);
+        assert_eq!(NODE_HEIGHT, 4.0);
+        assert_eq!(node_width(10), 28.0);
+        assert_eq!(node_width(20), 30.0);
     }
 
     #[test]
     fn a_selected_full_node_gets_a_thick_focus_border_and_a_plain_bold_title() {
-        let mut c = content(NodeStyle::Full);
+        let mut c = content();
         c.status = NodeStatus::Current {
             run: RunPhase::Active,
             times: 1,

--- a/crates/leviath-cli/src/tui/flowgraph/mod.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/mod.rs
@@ -20,7 +20,7 @@ pub(crate) mod model;
 pub(crate) mod text;
 pub(crate) mod view;
 
-pub(crate) use content::{NodeStyle, RunPhase, WorkerCounts};
+pub(crate) use content::{RunPhase, WorkerCounts};
 pub(crate) use layout::Direction;
 pub(crate) use model::StageGraph;
 pub(crate) use view::{FlowView, LiveOverlay, Selection, StageLive};

--- a/crates/leviath-cli/src/tui/flowgraph/text.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/text.rs
@@ -8,14 +8,13 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::widgets::Widget;
 
-use super::content::NodeStyle;
 use super::model::StageGraph;
 use super::view::FlowView;
 
 /// Draw `graph` at most `width` columns wide. Escape edges are included:
 /// there is no key to reveal them on paper.
 pub(crate) fn render_to_text(graph: &StageGraph, width: u16) -> String {
-    let mut view = FlowView::new(Arc::new(graph.clone()), NodeStyle::Full, true);
+    let mut view = FlowView::new(Arc::new(graph.clone()), true);
     view.toggle_escape();
     view.fit();
     let (world_w, world_h) = view.world_extent();

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -23,7 +23,8 @@ use ratatui::widgets::Block;
 use crate::tui::theme::C_ACCENT;
 
 use super::content::{
-    NodeStatus, NodeStyle, RunPhase, StageNodeContent, WorkerCounts, edge_style, palette,
+    NODE_HEIGHT, NodeStatus, RunPhase, StageNodeContent, WorkerCounts, edge_style, node_width,
+    palette,
 };
 use super::layout::{self, Direction, GraphLayout};
 use super::model::{EdgeClass, StageEdge, StageGraph};
@@ -89,18 +90,17 @@ pub(crate) struct FlowView {
     graph: Arc<StageGraph>,
     layout: GraphLayout,
     edges: Vec<EdgeMeta>,
-    style: NodeStyle,
     locked: bool,
     direction: Direction,
     /// Until the user turns the graph by hand, the first draw picks the
     /// direction that fits.
     auto_direction: bool,
     show_escape: bool,
-    show_unvisited: bool,
-    /// Edges the run has not followed and cannot follow next: hidden by
-    /// default once a run is on the canvas, so the picture is the path
-    /// taken plus what can happen from here. `t` shows the whole graph.
-    show_untaken: bool,
+    /// The whole graph, or (the default once a run is on the canvas) the
+    /// path taken plus what can happen from here: the stages visited, the
+    /// current one, the transitions between them, and the current stage's
+    /// options with the stages they lead to. `t` toggles.
+    show_all: bool,
     /// Transitions the run followed, from the last overlay.
     taken: HashSet<(String, String)>,
     /// The stage the run is in, from the last overlay.
@@ -119,13 +119,9 @@ pub(crate) struct FlowView {
     max_stem: f64,
 }
 
-/// Box size and gaps for a node style: `(node_w, node_h, gap_x, gap_y)`.
-fn metrics(style: NodeStyle, longest_id: usize) -> (f64, f64, f64, f64) {
-    let (gap_x, gap_y) = match style {
-        NodeStyle::Full => (8.0, 1.0),
-        NodeStyle::Compact => (6.0, 1.0),
-    };
-    (style.width(longest_id), style.height(), gap_x, gap_y)
+/// Box size and gaps: `(node_w, node_h, gap_x, gap_y)`.
+fn metrics(longest_id: usize) -> (f64, f64, f64, f64) {
+    (node_width(longest_id), NODE_HEIGHT, 8.0, 1.0)
 }
 
 /// Which sides an edge leaves and enters on, and how far it travels before
@@ -178,7 +174,7 @@ impl std::fmt::Debug for FlowView {
             .field("nodes", &self.graph.nodes.len())
             .field("direction", &self.direction)
             .field("show_escape", &self.show_escape)
-            .field("show_unvisited", &self.show_unvisited)
+            .field("show_all", &self.show_all)
             .finish()
     }
 }
@@ -235,7 +231,6 @@ fn handles(direction: Direction) -> Vec<Handle> {
 fn build(
     graph: &StageGraph,
     layout: &GraphLayout,
-    style: NodeStyle,
     locked: bool,
     direction: Direction,
 ) -> (Flow<StageNodeContent, StepEdge>, Vec<EdgeMeta>, f64) {
@@ -245,13 +240,7 @@ fn build(
         .map(|n| n.id.trim_start_matches("ext:").chars().count())
         .max()
         .unwrap_or(0);
-    let (node_w, node_h, gap_x, gap_y) = metrics(style, longest);
-    // A one-row box has no room to shrink: below zoom 1 it is zero rows
-    // tall and gone. Compact canvases stay at 1.0 and pan instead.
-    let min_zoom = match style {
-        NodeStyle::Full => 0.5,
-        NodeStyle::Compact => 1.0,
-    };
+    let (node_w, node_h, gap_x, gap_y) = metrics(longest);
 
     let nodes: Vec<Node<StageNodeContent>> = graph
         .nodes
@@ -261,7 +250,7 @@ fn build(
                 n.id.clone(),
                 (0.0, 0.0),
                 (node_w, node_h),
-                StageNodeContent::from_node(n, style),
+                StageNodeContent::from_node(n),
             )
             .with_handles(handles(direction))
             .with_connectable(false)
@@ -308,7 +297,9 @@ fn build(
     let mut flow = Flow::with_graph(nodes, edges)
         .expect("a StageGraph has unique ids, no self-loops and no dangling edges")
         .with_theme(Theme::Custom(palette()))
-        .with_min_zoom(min_zoom)
+        // Zoomed out by hand a box still keeps its frame down to a couple
+        // of rows; the fit itself never goes below 1.0.
+        .with_min_zoom(0.5)
         .with_max_zoom(1.0)
         // Marching ants at a walking pace; the default is a sprint.
         .with_animation_speed(220)
@@ -327,21 +318,19 @@ impl FlowView {
     /// pans and nothing selects or moves, for the band and the preview; the
     /// explorer is unlocked, so boxes can be dragged into a better
     /// arrangement and clicked to select.
-    pub(crate) fn new(graph: Arc<StageGraph>, style: NodeStyle, locked: bool) -> Self {
+    pub(crate) fn new(graph: Arc<StageGraph>, locked: bool) -> Self {
         let layout = layout::layout(&graph);
-        let (flow, edges, max_stem) = build(&graph, &layout, style, locked, Direction::LeftToRight);
+        let (flow, edges, max_stem) = build(&graph, &layout, locked, Direction::LeftToRight);
         Self {
             flow,
             graph,
             layout,
             edges,
-            style,
             locked,
             direction: Direction::LeftToRight,
             auto_direction: true,
             show_escape: false,
-            show_unvisited: true,
-            show_untaken: false,
+            show_all: false,
             taken: HashSet::new(),
             current: None,
             reveal: None,
@@ -368,13 +357,7 @@ impl FlowView {
 
     fn rebuild(&mut self, direction: Direction) {
         let selected = self.flow.first_selected_node_id();
-        let (flow, edges, max_stem) = build(
-            &self.graph,
-            &self.layout,
-            self.style,
-            self.locked,
-            direction,
-        );
+        let (flow, edges, max_stem) = build(&self.graph, &self.layout, self.locked, direction);
         self.flow = flow;
         self.edges = edges;
         self.max_stem = max_stem;
@@ -411,19 +394,14 @@ impl FlowView {
         self.show_escape
     }
 
-    /// Unvisited stages shown or hidden.
-    pub(crate) fn show_unvisited(&self) -> bool {
-        self.show_unvisited
+    /// The whole graph, or the run's path and options.
+    pub(crate) fn show_all(&self) -> bool {
+        self.show_all
     }
 
-    /// Untaken edges shown or hidden.
-    pub(crate) fn show_untaken(&self) -> bool {
-        self.show_untaken
-    }
-
-    /// Show or hide the edges the run has not followed.
-    pub(crate) fn toggle_untaken(&mut self) {
-        self.show_untaken = !self.show_untaken;
+    /// Switch between the whole graph and the run's path and options.
+    pub(crate) fn toggle_all(&mut self) {
+        self.show_all = !self.show_all;
         self.sync_visibility();
     }
 
@@ -510,7 +488,7 @@ impl FlowView {
                 .map(|n| n.id.trim_start_matches("ext:").chars().count())
                 .max()
                 .unwrap_or(0);
-            let (node_w, node_h, gap_x, gap_y) = metrics(self.style, longest);
+            let (node_w, node_h, gap_x, gap_y) = metrics(longest);
             self.layout.extent(dir, node_w, node_h, gap_x, gap_y)
         };
         let other = self.direction.rotated();
@@ -545,12 +523,6 @@ impl FlowView {
         self.sync_visibility();
     }
 
-    /// Show or hide stages the run has never entered.
-    pub(crate) fn toggle_unvisited(&mut self) {
-        self.show_unvisited = !self.show_unvisited;
-        self.sync_visibility();
-    }
-
     /// Keys the canvas answers to. Returns whether it took the key.
     pub(crate) fn handle_key(&mut self, code: KeyCode) -> bool {
         let action = match code {
@@ -573,8 +545,7 @@ impl FlowView {
             KeyCode::Char('f') => self.fit(),
             KeyCode::Char('r') => self.rotate(),
             KeyCode::Char('e') => self.toggle_escape(),
-            KeyCode::Char('u') => self.toggle_unvisited(),
-            KeyCode::Char('t') => self.toggle_untaken(),
+            KeyCode::Char('t') => self.toggle_all(),
             _ => return false,
         }
         true
@@ -661,34 +632,51 @@ impl FlowView {
         self.sync_visibility();
     }
 
-    /// Hidden nodes and edges follow the toggles: a node hides when it is
-    /// unvisited and unvisited stages are off; an edge hides when it is an
-    /// escape with escapes off, when a run is on the canvas and it is neither
-    /// a transition the run took nor one it can take from where it is (with
-    /// untaken edges off), or when either end is hidden (the canvas would
-    /// otherwise draw an arrow into nothing).
+    /// Hidden nodes and edges follow the toggles. With a run on the canvas
+    /// and `show_all` off, an edge shows when the run took it or can take it
+    /// from where it is, and a node shows when the run has been in it, is in
+    /// it, or can go to it next: no box without a line to it, no line into
+    /// nothing. Escape edges hide with escapes off whatever else is on.
     fn sync_visibility(&mut self) {
-        let hidden_nodes: Vec<String> = self
-            .flow
-            .nodes()
-            .filter(|n| !self.show_unvisited && n.content.status == NodeStatus::Pending)
-            .map(|n| n.id.clone())
-            .collect();
-        let hidden: HashSet<&str> = hidden_nodes.iter().map(String::as_str).collect();
+        let focused = self.current.is_some() && !self.show_all;
+        let current = self.current.clone().unwrap_or_default();
+        let live_edge = |edge: &StageEdge| {
+            self.taken.contains(&(edge.from.clone(), edge.to.clone())) || edge.from == current
+        };
+        let mut shown_nodes: HashSet<String> = HashSet::new();
+        if focused {
+            shown_nodes.insert(current.clone());
+            for meta in &self.edges {
+                let escape_hidden = meta.edge.class == EdgeClass::Escape && !self.show_escape;
+                if live_edge(&meta.edge) && !escape_hidden {
+                    shown_nodes.insert(meta.edge.from.clone());
+                    shown_nodes.insert(meta.edge.to.clone());
+                }
+            }
+            // A stage visited on the way, whichever edge brought the run.
+            for node in self.flow.nodes() {
+                if matches!(node.content.status, NodeStatus::Visited { .. }) {
+                    shown_nodes.insert(node.id.clone());
+                }
+            }
+        }
+        let mut changed = false;
         for id in self.graph.ids() {
-            self.flow.set_node_hidden(id, hidden.contains(id));
+            let hide = focused && !shown_nodes.contains(id);
+            changed |= self.flow.node(id).is_some_and(|n| n.hidden != hide);
+            self.flow.set_node_hidden(id, hide);
+        }
+        // A different set of boxes is a different picture: fit it again at
+        // the next draw (the fit follows the boxes on show).
+        if changed {
+            self.last_area = Rect::default();
         }
         for meta in &self.edges {
-            let untaken = self.current.is_some()
-                && !self.show_untaken
-                && !self
-                    .taken
-                    .contains(&(meta.edge.from.clone(), meta.edge.to.clone()))
-                && self.current.as_deref() != Some(meta.edge.from.as_str());
             let hide = (meta.edge.class == EdgeClass::Escape && !self.show_escape)
-                || untaken
-                || hidden.contains(meta.edge.from.as_str())
-                || hidden.contains(meta.edge.to.as_str());
+                || (focused && !live_edge(&meta.edge))
+                || (focused
+                    && !(shown_nodes.contains(&meta.edge.from)
+                        && shown_nodes.contains(&meta.edge.to)));
             self.flow.set_edge_hidden(&meta.id, hide);
         }
     }
@@ -745,6 +733,7 @@ impl FlowView {
     pub(crate) fn world_extent(&self) -> (f64, f64) {
         self.flow
             .nodes()
+            .filter(|n| !n.hidden)
             .map(|n| n.bounds())
             .fold((0.0_f64, 0.0_f64), |(w, h), b| {
                 (
@@ -813,7 +802,7 @@ mode = "output"
     }
 
     fn view() -> FlowView {
-        FlowView::new(graph(), NodeStyle::Full, false)
+        FlowView::new(graph(), false)
     }
 
     fn draw(view: &mut FlowView, w: u16, h: u16) -> (Terminal<TestBackend>, String) {
@@ -904,13 +893,14 @@ mode = "output"
         assert!(v.handle_key(KeyCode::Char('e')));
         assert!(v.show_escape());
         assert!(!v.edge_hidden("implement", "recover"));
-        assert!(v.handle_key(KeyCode::Char('u')));
-        assert!(!v.show_unvisited());
-        // Nothing has run, so every node is unvisited and hides, edges too.
-        assert!(v.node_hidden("plan"));
-        assert!(v.edge_hidden("plan", "implement"));
-        assert!(v.handle_key(KeyCode::Char('u')));
-        assert!(!v.node_hidden("plan"));
+        // No run on the canvas: `t` flips the flag and nothing hides either
+        // way, because there is no path to focus on.
+        assert!(!v.show_all());
+        assert!(v.handle_key(KeyCode::Char('t')));
+        assert!(v.show_all());
+        assert!(!v.node_hidden("plan") && !v.edge_hidden("plan", "implement"));
+        assert!(v.handle_key(KeyCode::Char('t')));
+        assert!(!v.node_hidden("plan") && !v.edge_hidden("plan", "implement"));
         assert!(v.handle_key(KeyCode::Char('f')));
         assert!(!v.handle_key(KeyCode::Char('x')));
         assert!(!v.handle_key(KeyCode::Enter));
@@ -994,35 +984,43 @@ mode = "output"
         assert_eq!(v.node_status("recover"), Some(NodeStatus::Pending));
         assert!(v.edge_animated("implement", "review"));
         assert!(!v.edge_animated("plan", "implement"));
-        // Untaken edges hide once a run is on the canvas: the path taken and
-        // the current stage's own options stay, the rest goes until `t`.
+        // With a run on the canvas the picture is the path and the options:
+        // the stages visited, the current one, what it can go to next, and
+        // the edges between them. The rest goes until `t`.
         assert!(!v.edge_hidden("plan", "implement"), "taken");
         assert!(
             !v.edge_hidden("review", "done"),
             "an option from the current stage"
         );
+        assert!(!v.node_hidden("done"), "where an option leads");
         assert!(
             v.edge_hidden("recover", "plan"),
             "neither taken nor available"
         );
-        assert!(!v.show_untaken());
+        assert!(v.node_hidden("recover"), "no line to it, no box");
+        // Escapes stay off even in focus: the escape into recover does not
+        // bring the box back...
+        assert!(v.edge_hidden("implement", "recover"));
+        // ...and turning escapes on does not either, because implement is
+        // not where the run is: in focus, `e` shows the escapes from here.
+        v.toggle_escape();
+        assert!(v.edge_hidden("implement", "recover"), "not on the path");
+        assert!(v.node_hidden("recover"));
+        v.toggle_escape();
+        assert!(!v.show_all());
         assert!(v.handle_key(KeyCode::Char('t')));
-        assert!(v.show_untaken());
+        assert!(v.show_all());
         assert!(!v.edge_hidden("recover", "plan"));
-        v.toggle_untaken();
+        assert!(!v.node_hidden("recover"));
+        v.toggle_all();
         assert!(v.edge_hidden("recover", "plan"));
+        assert!(v.node_hidden("recover"));
         // A non-fan-out current stage never shows worker counts.
         let (_, text) = draw(&mut v, 220, 50);
         assert!(!text.contains(" run ·"), "{text}");
         assert!(text.contains("iter 2"), "{text}");
         assert!(text.contains("10:00:00"), "{text}");
         assert!(text.contains("implement ×2"), "{text}");
-
-        // With unvisited hidden, the pending stages and their edges go.
-        v.toggle_unvisited();
-        assert!(v.node_hidden("done") && v.node_hidden("recover"));
-        assert!(v.edge_hidden("review", "done"));
-        assert!(!v.node_hidden("review"));
 
         // Moving on: the new current stage is revealed at the next draw, the
         // last one becomes visited, and a run that finished spins nothing.
@@ -1098,7 +1096,7 @@ merge_stage = "merge"
             )
             .unwrap(),
         ));
-        let mut v = FlowView::new(g, NodeStyle::Full, false);
+        let mut v = FlowView::new(g, false);
         v.apply_live(&LiveOverlay {
             current: Some("split".into()),
             run: Some(RunPhase::Waiting),
@@ -1136,7 +1134,7 @@ merge_stage = "merge"
     #[test]
     fn mouse_drag_pans_and_wheel_zooms_also_when_locked() {
         for locked in [false, true] {
-            let mut v = FlowView::new(graph(), NodeStyle::Compact, locked);
+            let mut v = FlowView::new(graph(), locked);
             draw(&mut v, 60, 12);
             v.select_stage("plan");
             let pan = v.pan();
@@ -1154,12 +1152,12 @@ merge_stage = "merge"
                 Selection::Node("plan".into()),
                 "a pan keeps the selection (locked={locked})"
             );
-            // A compact canvas cannot zoom out: its boxes are one row tall.
+            // The wheel zooms, locked or not.
             v.handle_mouse(mouse(MouseEventKind::ScrollDown, x, y));
-            assert_eq!(v.zoom(), 1.0, "locked={locked}");
+            assert!(v.zoom() < 1.0, "locked={locked}");
             v.tick(Duration::from_millis(100));
         }
-        // A full canvas zooms at the wheel.
+        // And zooms back in.
         let mut v = view();
         draw(&mut v, 220, 50);
         let c = v.canvas();
@@ -1173,19 +1171,19 @@ merge_stage = "merge"
 
     #[test]
     fn a_canvas_the_graph_overflows_starts_top_left_and_boxes_are_never_shrunk() {
-        let mut v = FlowView::new(graph(), NodeStyle::Compact, true);
+        let mut v = FlowView::new(graph(), true);
         draw(&mut v, 60, 12);
         assert_eq!(v.pan(), (1.0, 1.0), "the entry stage is on screen");
         assert_eq!(v.node_rect("plan").map(|r| r.0), Some(2));
         assert_eq!(v.direction(), Direction::LeftToRight);
         // Wide enough: centred like any other fit.
-        let mut v = FlowView::new(graph(), NodeStyle::Compact, true);
+        let mut v = FlowView::new(graph(), true);
         draw(&mut v, 200, 20);
         assert_ne!(v.pan(), (1.0, 1.0));
         assert_eq!(v.zoom(), 1.0);
         // A full canvas that overflows both ways keeps its boxes whole and
         // starts at the corner too, rather than shrinking them to fit.
-        let mut v = FlowView::new(graph(), NodeStyle::Full, false);
+        let mut v = FlowView::new(graph(), false);
         draw(&mut v, 60, 20);
         assert_eq!(v.zoom(), 1.0);
         assert_eq!(v.pan(), (1.0, 1.0));
@@ -1196,7 +1194,7 @@ merge_stage = "merge"
     fn a_tall_narrow_canvas_turns_the_graph_top_to_bottom_and_r_turns_it_back() {
         // Five stages of full boxes: 172 cells wide left to right, 24 rows
         // top to bottom. A 70x40 canvas fits only the second.
-        let mut v = FlowView::new(graph(), NodeStyle::Full, false);
+        let mut v = FlowView::new(graph(), false);
         v.select_stage("review");
         v.toggle_escape();
         draw(&mut v, 70, 40);
@@ -1246,11 +1244,11 @@ merge_stage = "merge"
         let moved = v.node_rect("plan").unwrap();
         assert!(moved.0 > x as i32 - 2 + 3, "{moved:?}");
         // A minimap appears when the graph is bigger than the canvas.
-        let mut v = FlowView::new(graph(), NodeStyle::Full, false);
+        let mut v = FlowView::new(graph(), false);
         let (_, text) = draw(&mut v, 90, 24);
         assert!(text.contains('▄'), "{text}");
         // And not when everything is on screen already.
-        let mut v = FlowView::new(graph(), NodeStyle::Full, false);
+        let mut v = FlowView::new(graph(), false);
         let (_, text) = draw(&mut v, 220, 50);
         assert!(!text.contains('▄'), "{text}");
         // Turning a canvas with nothing selected selects nothing after.

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -106,8 +106,9 @@ skips marked runs that have already finished.
 Agent blueprints on the left, the task on the right, and above the task the selected blueprint's
 stage graph, so you can see what an agent will do before you give it a task: how many stages, in
 what order, where it loops back. It follows the selection, previews bundled blueprints that are not
-installed yet from the copy inside the binary, and says so when a manifest cannot be read. Drag to
-pan it; on a screen too short to fit both, the task keeps its rows and the preview is skipped. Once
+installed yet from the copy inside the binary, and says so when a manifest cannot be read. It is
+the explorer's canvas showing the whole graph: drag to pan, wheel to zoom; on a screen too short to
+fit both, the task keeps its rows and the preview is skipped. Once
 the run starts, the dashboard opens that run's page, and `Esc` from there goes back to the list
 rather than back into the form.
 
@@ -130,15 +131,17 @@ interaction timeout expires. The setting is off again every time the screen open
 
 ### Detail view
 
-On a terminal at least 32 rows tall the stage row is the blueprint's graph: one box per stage,
-transitions as edges, the stage the run is in in the run's colour, visited stages with their
-visit count, the selected stage reversed. `←` / `→` and `1`-`9` move through it exactly as they
-did through the tabs, and dragging pans it. On a shorter terminal, and for a run whose blueprint
-could not be read, the flat tab strip stays.
+On a terminal at least 36 rows tall the stage row is the blueprint's graph, drawn by the same
+canvas as the explorer: the path the run took and the options from where it is, boxes on layers,
+the stage the run is in in the run's colour, visited stages with their visit count. The selected
+box is the open stage tab, in a thick bright frame: `←` / `→` move it through the graph, `1`-`9`
+jump to a stage by number, and a click on a box picks it. Drag a box to move it, drag empty canvas
+to pan, `g` opens the same graph full screen with the rest of its keys. On a shorter terminal, and
+for a run whose blueprint could not be read, the flat tab strip stays.
 
 | Key | Action |
 |---|---|
-| `←` / `→` | Switch stage tab (`h` / `l` are not aliases here: `l` is Logs) |
+| `←` / `→` | Switch stage tab, through the graph when it is on screen (`h` / `l` are not aliases here: `l` is Logs) |
 | `1`–`9` | Jump to that stage tab |
 | `↑` / `↓` (or `k` / `j`) | Scroll the pane; in the Context view, move the tree cursor |
 | `PgUp` / `PgDn` | Scroll ten lines |
@@ -184,13 +187,16 @@ chain; a graph blueprint is a graph):
   with a minimap in the corner when there is more graph than screen. The stage the run is in
   spins in the run's colour, stages it has been through show a visit count (`×2`) and the time of
   their last visit, the last transition it took is animated, and revisit loops run along a lane
-  beside the boxes. While a run is on the canvas only the transitions it took and the ones it can
-  take from where it is are drawn (`t` shows them all), and the escape edges (`error`, `dead_end`,
-  `stuck`, `max_iterations`) are hidden until you ask for them, because nearly every stage has one
-  to the same hub. A fan-out stage that
-  is running shows its worker counts. Selecting a stage or an edge describes it on the line under
-  the canvas. Boxes can be dragged into an arrangement you prefer; the explorer remembers it, and
-  the view, for as long as the dashboard is open.
+  beside the boxes. While a run is on the canvas the picture is the path and the options: the
+  stages the run has been through and the one it is in, the transitions between them, and the
+  transitions it can take from where it is with the stages they lead to. Everything else waits
+  off screen until `t` shows the whole graph, so a stage never sits there without a line to it.
+  The escape edges (`error`, `dead_end`, `stuck`, `max_iterations`) are hidden until you ask for
+  them, because nearly every stage has one to the same hub; with the path in focus, `e` shows the
+  escapes from the current stage. A fan-out stage that is running shows its worker counts.
+  Selecting a stage or an edge describes it on the line under the canvas. Boxes can be dragged
+  into an arrangement you prefer; the explorer remembers it, and the view, for as long as the
+  dashboard is open.
 - **Timeline** lists each actual visit in order, with when it started, how long it lasted, and how
   many iterations it ran. `Enter` on a visit opens the context window exactly as it was at that
   point.
@@ -203,9 +209,8 @@ chain; a graph blueprint is a graph):
 | `+` / `-` , `0` | Zoom in / out, back to 100% |
 | `f` | Fit the whole graph on screen |
 | `r` | Turn the graph: left to right or top to bottom |
-| `t` | Show every edge, or only the path taken and what comes next |
+| `t` | The whole graph, or only the path taken and what comes next |
 | `e` | Show or hide the escape edges |
-| `u` | Show or hide stages the run has never entered |
 | `Tab` / `Shift-Tab` | Switch between Graph and Timeline |
 | `?` / `F1` | Help |
 | `Esc` / `g` | Close the explorer |


### PR DESCRIPTION
## What

Two things from looking at the graphs side by side:

- **One canvas everywhere.** The detail band and the new-run preview drew a one-row "compact" box style with its own sizing and no selection; the explorer drew full boxes. Now there is one `FlowView` (full boxes, dots, minimap, thick frame on the selected box, drag, wheel) and the three surfaces differ only in what they let you do: the explorer takes every key, the band's selection *is* the stage tab (`←`/`→` walk the graph, `1`-`9` jump, a click on a box picks it, boxes drag), the preview is a viewer (pan, zoom). The band grew from 8 to 12 rows and asks for a 36-row terminal instead of 32; the strip stays below that.
- **The path in focus hides the stages too.** Hiding untaken edges but drawing every box left stages floating with nothing attached. Now, with a run on the canvas, the picture is the path and the options: the stages the run has been through and is in, the transitions between them, and what it can do from here with the stages that leads to. `t` shows the whole graph. `u` is gone (it was "hide unvisited", which the focus subsumes). Escapes stay behind `e`; with the path in focus, `e` shows the escapes from the current stage.

Detail view, live (real daemon + mock provider), 200x50, after `→` `→`:

```
╭ Stages ←/→ select  1-9 jump  stage 3/5  ·  [g] graph  ·  click, drag ─────────────────────────────╮
│                                                                                                     │
│       ·       ·       ·       ·       ·       ·       ·       ·       ·       ·       ·       ·     │
│                                                                                                     │
│   ╭ ▶ ✓ plan ────────────────╮        ╭ ⠹ implement ─────────────╮        ┏ ○ review ━━━━━━━━━━━━━━━━┓
│   │ autonomous               │        │ autonomous · iter 3      │        ┃ autonomous               ┃
│   │ 21:49:55                 │─ ── ──▶│ 21:50:04                 │───────▶┃                          ┃
│   ╰──────────────────────────╯        ╰──────────────────────────╯        ┗━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

`recover` and `done` are off screen until the run can reach them (or `t`); a click on `review` set the tab to 3/5.

Also: when the set of boxes on show changes (a transition reveals a stage, `t`, `e`) the canvas fits again, because rataflow's fit follows the visible boxes and a fit computed over three boxes put the fourth off screen. The band now loads the run's visit history the way the explorer does, so its taken edges show; before, only the current stage's edges did.

## How

- `tui/flowgraph/content.rs`: `NodeStyle` removed; `NODE_HEIGHT` and `node_width`.
- `tui/flowgraph/view.rs`: `FlowView::new(graph, locked)`; `show_all`/`toggle_all`/`t`; `sync_visibility` computes the shown node set (current, ends of taken edges and of the current stage's edges, visited) and hides the rest, edges too; a change in the shown set re-settles at the next draw; `world_extent` over visible nodes; `min_zoom` 0.5 for every canvas.
- `dashboard/detail_band.rs`: unlocked `FlowView`, `BAND_HEIGHT` 12, `BAND_MIN_AREA_HEIGHT` 36, `band_shown`, `adopt_band_selection`, `band_key`, `band_select_tab`; `input.rs` routes `←`/`→` through the band when it is on screen and points it at the tab on `1`-`9`; `open_detail_view` drops the band so a fresh view starts on the open tab.
- `dashboard/new_run_preview.rs`: same canvas, locked; 10 to 18 rows.
- `graph_view.rs` title and hints, overlay, docs, CHANGELOG.

## Checks

- `cargo xtask coverage --package leviath-cli` 100%.
- `cargo xtask docs`, clippy `-D warnings`.
- Live pty run at 200x50 (band: arrows, `1`, click, drag; explorer; preview) and 100x30 (strip, hints fit).
