### PR TITLE
feat(blueprint): an editing model for agent.leviath, and a shared picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2456,9 +2456,11 @@ dependencies = [
  "socket2",
  "temp-env",
  "tempfile",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-rustls",
  "toml",
+ "toml_edit",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -4814,6 +4816,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
+ "toml_writer",
  "winnow",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,10 @@ opentelemetry-otlp = { version = "0.32", default-features = false, features = ["
 opentelemetry-appender-tracing = "0.32"
 thiserror = "2.0"
 toml = { version = "1.0", features = ["preserve_order"] }
+# The dashboard's agent editor edits a manifest as a document, so a file's
+# comments, key order and formatting survive an edit session (`toml` re-emits
+# from values and would drop every comment a bundled agent carries).
+toml_edit = "0.25"
 anyhow = "1.0"
 chrono = "0.4"
 # The IANA zone name (`America/Chicago`) behind the `current_time` tool. Already

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -53,6 +53,8 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
+thiserror = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/leviath-cli/src/blueprint_edit/catalog.rs
+++ b/crates/leviath-cli/src/blueprint_edit/catalog.rs
@@ -1,0 +1,192 @@
+//! The agents a builder can open, and where a built one goes.
+//!
+//! The same catalog `lev list` and the dashboard's new-run picker show
+//! (installed under the agents directory, configured in `agent_paths`, the
+//! local `agent.leviath`, and the bundled ones not installed yet), with the
+//! manifest text alongside so an editor can open it without a second read.
+
+use std::path::{Path, PathBuf};
+
+use crate::bundled::{
+    AgentAction, BUNDLED_AGENTS, BundledAgent, install_bundled, plan_agent_actions,
+};
+use crate::commands::list::{ListFilter, build_list_report};
+use crate::config::Config;
+
+/// Where an agent lives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// Under the agents directory (`~/.leviath/agents/<name>`).
+    Installed,
+    /// Under a directory named in the config's `agent_paths`.
+    Configured,
+    /// The `agent.leviath` of the working directory.
+    Local,
+    /// Embedded in this binary and not installed; editing it installs it.
+    Bundled,
+}
+
+impl Source {
+    /// The word the catalog shows.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Source::Installed => "installed",
+            Source::Configured => "configured",
+            Source::Local => "local",
+            Source::Bundled => "bundled",
+        }
+    }
+}
+
+/// One agent in the catalog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogEntry {
+    /// `[agent].name`.
+    pub name: String,
+    /// `[agent].version`.
+    pub version: String,
+    /// `[agent].description`.
+    pub description: String,
+    /// Where it lives.
+    pub source: Source,
+    /// Its directory on disk; `None` for a bundled agent not installed.
+    pub dir: Option<PathBuf>,
+    /// The manifest text, when it could be read (always, for a bundled one).
+    pub manifest: Option<String>,
+    /// Its stage names, in the runtime's order.
+    pub stages: Vec<String>,
+    /// This binary bundles an agent of the same name.
+    pub bundled: bool,
+    /// An installed bundled agent whose files differ from the embedded copy:
+    /// edited here, or from another version. Reset puts the embedded copy
+    /// back.
+    pub differs_from_bundled: bool,
+}
+
+impl CatalogEntry {
+    /// Whether the entry can be deleted from here: only what lives under the
+    /// agents directory. Configured and local agents are edited in place but
+    /// belong to wherever they are.
+    pub fn deletable(&self) -> bool {
+        self.source == Source::Installed
+    }
+}
+
+/// Every agent the builder can open, name-sorted.
+pub fn discover(agents_dir: &Path, cwd: &Path, config: &Config) -> Vec<CatalogEntry> {
+    let report = build_list_report(agents_dir, cwd, config, ListFilter::All);
+    let plan = plan_agent_actions(agents_dir);
+    let mut entries: Vec<CatalogEntry> = report
+        .agents
+        .iter()
+        .map(|a| {
+            let path = PathBuf::from(&a.path);
+            let (dir, manifest_path) = if path.is_dir() {
+                (path.clone(), path.join("agent.leviath"))
+            } else {
+                (
+                    path.parent().map(Path::to_path_buf).unwrap_or_default(),
+                    path.clone(),
+                )
+            };
+            let manifest = std::fs::read_to_string(&manifest_path).ok();
+            let stages = manifest
+                .as_deref()
+                .and_then(|m| leviath_core::manifest::parse_manifest(m).ok())
+                .map(|bp| bp.stages.iter().map(|s| s.name.clone()).collect())
+                .unwrap_or_default();
+            let source = match a.source {
+                "installed" => Source::Installed,
+                "configured" => Source::Configured,
+                _ => Source::Local,
+            };
+            let bundled = plan.iter().find(|(b, _)| b.name == a.info.name);
+            CatalogEntry {
+                name: a.info.name.clone(),
+                version: a.info.version.clone(),
+                description: a.info.description.clone(),
+                source,
+                dir: Some(dir),
+                manifest,
+                stages,
+                bundled: bundled.is_some(),
+                differs_from_bundled: source == Source::Installed
+                    && bundled.is_some_and(|(_, action)| !matches!(action, AgentAction::UpToDate)),
+            }
+        })
+        .collect();
+    for (agent, action) in &plan {
+        if *action == AgentAction::Install && !entries.iter().any(|e| e.name == agent.name) {
+            let manifest = bundled_manifest(agent);
+            entries.push(CatalogEntry {
+                name: agent.name.to_string(),
+                version: agent.version.to_string(),
+                description: leviath_core::manifest::parse_manifest(manifest)
+                    .map(|bp| bp.description)
+                    .unwrap_or_default(),
+                source: Source::Bundled,
+                dir: None,
+                manifest: Some(manifest.to_string()),
+                stages: leviath_core::manifest::parse_manifest(manifest)
+                    .map(|bp| bp.stages.iter().map(|s| s.name.clone()).collect())
+                    .unwrap_or_default(),
+                bundled: true,
+                differs_from_bundled: false,
+            });
+        }
+    }
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
+}
+
+/// The bundled agent of that name, when there is one.
+pub fn bundled(name: &str) -> Option<&'static BundledAgent> {
+    BUNDLED_AGENTS.iter().find(|a| a.name == name)
+}
+
+/// The embedded `agent.leviath` of a bundled agent.
+pub fn bundled_manifest(agent: &BundledAgent) -> &'static str {
+    agent
+        .files
+        .iter()
+        .find(|(rel, _)| *rel == "agent.leviath")
+        .map(|(_, text)| *text)
+        .expect("every bundled agent has a manifest")
+}
+
+/// Write an agent's manifest under the agents directory, creating its
+/// directory. Returns the directory.
+pub fn write_agent(agents_dir: &Path, name: &str, manifest: &str) -> std::io::Result<PathBuf> {
+    let dir = agents_dir.join(name);
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(dir.join("agent.leviath"), manifest)?;
+    Ok(dir)
+}
+
+/// Copy the files of a bundled agent other than its manifest (its `tools/`
+/// scripts) into an agent's directory, for an agent cloned from it.
+pub fn copy_bundled_extras(
+    agents_dir: &Path,
+    name: &str,
+    from: &BundledAgent,
+) -> std::io::Result<()> {
+    let dir = agents_dir.join(name);
+    for (rel, contents) in from.files.iter().filter(|(rel, _)| *rel != "agent.leviath") {
+        let path = dir.join(rel);
+        // A joined path always has a parent.
+        std::fs::create_dir_all(path.parent().unwrap_or(&dir))?;
+        std::fs::write(path, contents)?;
+    }
+    Ok(())
+}
+
+/// Delete an installed agent's directory.
+pub fn delete_agent(agents_dir: &Path, name: &str) -> std::io::Result<()> {
+    std::fs::remove_dir_all(agents_dir.join(name))
+}
+
+/// Put the embedded copy of a bundled agent back.
+pub fn reset_bundled(agents_dir: &Path, name: &str) -> Result<(), String> {
+    let agent = bundled(name).ok_or_else(|| format!("{name} is not a bundled agent"))?;
+    install_bundled(agent, agents_dir).map_err(|e| e.to_string())
+}

--- a/crates/leviath-cli/src/blueprint_edit/check.rs
+++ b/crates/leviath-cli/src/blueprint_edit/check.rs
@@ -1,0 +1,149 @@
+//! What is wrong with a manifest, the way `lev validate` and the daemon's
+//! `POST /api/blueprints/validate` would say it: parse, then
+//! `Blueprint::validate`, then the lint, with lint errors blocking a save
+//! and warnings and notes shown.
+
+use std::path::Path;
+
+use leviath_core::ValidationError;
+use leviath_core::manifest::parse_manifest;
+
+use crate::lint::{LintEnv, LintSeverity, lint_manifest};
+
+/// How much a problem matters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    /// The manifest will not run, or will not save.
+    Error,
+    /// A decision left to a default the author may not know about.
+    Warning,
+    /// Worth knowing, nothing to fix.
+    Note,
+}
+
+impl Severity {
+    /// A short tag for a status line.
+    pub fn tag(self) -> &'static str {
+        match self {
+            Severity::Error => "error",
+            Severity::Warning => "warning",
+            Severity::Note => "note",
+        }
+    }
+}
+
+/// One thing to tell the author.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Problem {
+    /// How much it matters.
+    pub severity: Severity,
+    /// A stable slug: a lint code, or `parse` / `validate` for the two
+    /// stages before the lint.
+    pub code: &'static str,
+    /// The stage it belongs to, when the message names one.
+    pub stage: Option<String>,
+    /// What is wrong.
+    pub message: String,
+    /// What to do about it, when the lint knows.
+    pub fix: Option<String>,
+}
+
+/// Everything wrong with a manifest, most serious first.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct Problems {
+    /// In the order found: errors, then warnings, then notes.
+    pub items: Vec<Problem>,
+}
+
+impl Problems {
+    /// How many are errors.
+    pub fn error_count(&self) -> usize {
+        self.count(Severity::Error)
+    }
+
+    /// How many are warnings.
+    pub fn warning_count(&self) -> usize {
+        self.count(Severity::Warning)
+    }
+
+    fn count(&self, severity: Severity) -> usize {
+        self.items.iter().filter(|p| p.severity == severity).count()
+    }
+
+    /// Whether the manifest may be saved: no errors.
+    pub fn is_saveable(&self) -> bool {
+        self.error_count() == 0
+    }
+
+    /// The problems that name `stage`.
+    pub fn for_stage(&self, stage: &str) -> Vec<&Problem> {
+        self.items
+            .iter()
+            .filter(|p| p.stage.as_deref() == Some(stage))
+            .collect()
+    }
+
+    /// The most serious problem, for a one-line summary.
+    pub fn first(&self) -> Option<&Problem> {
+        self.items.first()
+    }
+}
+
+/// Check a manifest as the runtime would. `dir` is the blueprint's directory
+/// (for the tools its scripts define); a blueprint not yet saved anywhere
+/// can pass any directory.
+pub fn check(text: &str, dir: &Path) -> Problems {
+    let bp = match parse_manifest(text) {
+        Ok(bp) => bp,
+        Err(e) => {
+            return Problems {
+                items: vec![Problem {
+                    severity: Severity::Error,
+                    code: "parse",
+                    stage: None,
+                    message: e.to_string(),
+                    fix: None,
+                }],
+            };
+        }
+    };
+    if let Err(e) = bp.validate() {
+        let stage = match &e {
+            ValidationError::Stage { stage, .. }
+            | ValidationError::Transition { from: stage, .. } => Some(stage.clone()),
+            _ => None,
+        };
+        return Problems {
+            items: vec![Problem {
+                severity: Severity::Error,
+                code: "validate",
+                stage,
+                message: e.to_string(),
+                fix: None,
+            }],
+        };
+    }
+    let env = LintEnv::offline(dir);
+    let mut items: Vec<Problem> = lint_manifest(text, &bp, &env)
+        .into_iter()
+        .map(|f| Problem {
+            severity: match f.severity {
+                LintSeverity::Error => Severity::Error,
+                LintSeverity::Warning => Severity::Warning,
+                LintSeverity::Note => Severity::Note,
+            },
+            code: f.code,
+            stage: f.stage,
+            message: f.message,
+            fix: f.fix,
+        })
+        .collect();
+    // Errors first, then warnings, then notes; the lint's own order within
+    // each, since it walks the stages in order.
+    items.sort_by_key(|p| match p.severity {
+        Severity::Error => 0,
+        Severity::Warning => 1,
+        Severity::Note => 2,
+    });
+    Problems { items }
+}

--- a/crates/leviath-cli/src/blueprint_edit/doc.rs
+++ b/crates/leviath-cli/src/blueprint_edit/doc.rs
@@ -1,0 +1,777 @@
+//! The document and the typed views read from it.
+//!
+//! Every view is derived on demand from the `toml_edit` document and never
+//! cached, so a mutator cannot leave a view stale. A view surfaces only the
+//! keys the editor knows how to write; whatever else a table carries stays
+//! in the document and comes back out of [`ManifestDoc::to_toml`] as it went
+//! in.
+
+use leviath_core::Blueprint;
+use leviath_core::manifest::parse_manifest;
+use toml_edit::{DocumentMut, Item, TableLike, Value};
+
+use super::tables::{as_table, child, get_bool, get_int, get_str, get_strings, table_keys};
+use super::{EditError, order};
+
+/// An `agent.leviath` manifest held as a document: comments, key order and
+/// formatting included.
+#[derive(Debug, Clone)]
+pub struct ManifestDoc {
+    doc: DocumentMut,
+}
+
+/// The `[agent]` table as the editor shows it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AgentView {
+    /// `name`, or empty when the table has none.
+    pub name: String,
+    /// `version`, or empty.
+    pub version: String,
+    /// `description`, or empty.
+    pub description: String,
+    /// `entry_stage`, when written.
+    pub entry_stage: Option<String>,
+    /// The `provider/model` every stage tries first, when they all agree;
+    /// `None` when they differ (or no stage names one). Not a key of the
+    /// manifest: The Lair shows it as the agent's "default model" and writes
+    /// it back to every stage.
+    pub default_model: Option<String>,
+}
+
+/// A stage's `mode`, as the editor shows and sets it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StageModeView {
+    /// `autonomous`, or no `mode` at all.
+    Autonomous,
+    /// `interactive`.
+    Interactive,
+    /// `interactive_points`.
+    InteractivePoints,
+    /// `fan_out`.
+    FanOut,
+    /// `output`.
+    Output,
+    /// A spelling the runtime would reject; shown as written, never rewritten
+    /// unless the author picks another.
+    Other(String),
+}
+
+impl StageModeView {
+    /// The manifest spelling.
+    pub fn as_str(&self) -> &str {
+        match self {
+            StageModeView::Autonomous => "autonomous",
+            StageModeView::Interactive => "interactive",
+            StageModeView::InteractivePoints => "interactive_points",
+            StageModeView::FanOut => "fan_out",
+            StageModeView::Output => "output",
+            StageModeView::Other(s) => s,
+        }
+    }
+
+    /// From the manifest spelling.
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "autonomous" => StageModeView::Autonomous,
+            "interactive" => StageModeView::Interactive,
+            "interactive_points" => StageModeView::InteractivePoints,
+            "fan_out" => StageModeView::FanOut,
+            "output" => StageModeView::Output,
+            other => StageModeView::Other(other.to_string()),
+        }
+    }
+
+    /// The modes the editor offers, in the order it offers them.
+    pub const CHOICES: [StageModeView; 4] = [
+        StageModeView::Autonomous,
+        StageModeView::InteractivePoints,
+        StageModeView::FanOut,
+        StageModeView::Output,
+    ];
+
+    /// What the editor calls the mode.
+    pub fn label(&self) -> &str {
+        match self {
+            StageModeView::Autonomous => "Works alone",
+            StageModeView::Interactive => "Interactive",
+            StageModeView::InteractivePoints => "Checks in with you",
+            StageModeView::FanOut => "Fans out to workers",
+            StageModeView::Output => "Hands back the result",
+            StageModeView::Other(s) => s,
+        }
+    }
+}
+
+/// Where a fan-out stage gets its workers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerKind {
+    /// `worker_agent`: a separate installed blueprint.
+    Agent,
+    /// `worker_stage`: a stage of this blueprint.
+    Stage,
+    /// `worker_query`: matched against installed blueprints at run time.
+    Query,
+}
+
+impl WorkerKind {
+    /// The manifest key.
+    pub fn key(self) -> &'static str {
+        match self {
+            WorkerKind::Agent => "worker_agent",
+            WorkerKind::Stage => "worker_stage",
+            WorkerKind::Query => "worker_query",
+        }
+    }
+}
+
+/// A stage's fan-out keys. Meaningful when its mode is `fan_out`; read
+/// regardless, so nothing is lost when a mode flips back and forth.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct FanOutView {
+    /// Which of `worker_agent`/`worker_stage`/`worker_query` is written, and
+    /// its value; the first found when several are.
+    pub worker: Option<(WorkerKind, String)>,
+    /// `merge_stage`.
+    pub merge_stage: Option<String>,
+    /// `max_workers` (0 = unlimited).
+    pub max_workers: Option<u64>,
+    /// `max_items` (0 reads as unlimited too).
+    pub max_items: Option<u64>,
+    /// `on_worker_failure`: `continue` or `fail_all`.
+    pub on_worker_failure: Option<String>,
+}
+
+/// One `[stages.<name>]` table as the editor shows it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StageView {
+    /// The table key.
+    pub name: String,
+    /// `mode`.
+    pub mode: StageModeView,
+    /// `description`, or empty.
+    pub description: String,
+    /// `max_iterations`.
+    pub max_iterations: Option<u64>,
+    /// `max_revisits`.
+    pub max_revisits: Option<u64>,
+    /// `allow_complete`, when written.
+    pub allow_complete: Option<bool>,
+    /// The `provider/model` fallback chain; a bare-string `model` reads as
+    /// one entry.
+    pub models: Vec<String>,
+    /// `available_tools`.
+    pub tools: Vec<String>,
+    /// `system_prompt`, or empty.
+    pub system_prompt: String,
+    /// `transition_prompt`, or empty.
+    pub transition_prompt: String,
+    /// The fan-out keys.
+    pub fan_out: FanOutView,
+    /// Whether the stage declares `[stages.<name>.context.regions]` of its
+    /// own instead of inheriting the agent's.
+    pub has_own_layout: bool,
+    /// Whether the stage has a `transitions` table with nothing in it: the
+    /// run can end here.
+    pub is_terminal: bool,
+}
+
+/// When a path is taken.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EdgeKind {
+    /// A `hint = "..."` the model routes on (no `condition` key).
+    Hint,
+    /// `condition = "always"`.
+    Always,
+    /// `condition = "llm_choice"`, or neither `condition` nor `hint`.
+    LlmChoice,
+    /// `condition = "error"`.
+    Error,
+    /// `condition = "max_iterations"`.
+    MaxIterations,
+    /// `condition = "stuck"`.
+    Stuck,
+    /// `condition = "dead_end"`.
+    DeadEnd,
+}
+
+impl EdgeKind {
+    /// The kinds the editor offers, in the order it offers them.
+    pub const CHOICES: [EdgeKind; 7] = [
+        EdgeKind::Always,
+        EdgeKind::Hint,
+        EdgeKind::LlmChoice,
+        EdgeKind::Error,
+        EdgeKind::Stuck,
+        EdgeKind::MaxIterations,
+        EdgeKind::DeadEnd,
+    ];
+
+    /// The `condition` spelling; `Hint` has none (it is a `hint` key).
+    pub fn condition(self) -> Option<&'static str> {
+        match self {
+            EdgeKind::Hint => None,
+            EdgeKind::Always => Some("always"),
+            EdgeKind::LlmChoice => Some("llm_choice"),
+            EdgeKind::Error => Some("error"),
+            EdgeKind::MaxIterations => Some("max_iterations"),
+            EdgeKind::Stuck => Some("stuck"),
+            EdgeKind::DeadEnd => Some("dead_end"),
+        }
+    }
+
+    /// The `condition` spelling read back; `None` for one the editor does not
+    /// know, which it then leaves alone.
+    pub fn from_condition(s: &str) -> Option<Self> {
+        Self::CHOICES.into_iter().find(|k| k.condition() == Some(s))
+    }
+
+    /// What the editor calls the kind.
+    pub fn label(self) -> &'static str {
+        match self {
+            EdgeKind::Hint => "model decides (hint)",
+            EdgeKind::Always => "always continue",
+            EdgeKind::LlmChoice => "model decides",
+            EdgeKind::Error => "on error",
+            EdgeKind::MaxIterations => "after too many tries",
+            EdgeKind::Stuck => "when stuck",
+            EdgeKind::DeadEnd => "when nothing else is left",
+        }
+    }
+
+    /// The short word the canvas puts on the edge.
+    pub fn short(self) -> &'static str {
+        match self {
+            EdgeKind::Hint => "hint",
+            EdgeKind::Always => "always",
+            EdgeKind::LlmChoice => "model's choice",
+            EdgeKind::Error => "on error",
+            EdgeKind::MaxIterations => "too many tries",
+            EdgeKind::Stuck => "when stuck",
+            EdgeKind::DeadEnd => "dead end",
+        }
+    }
+}
+
+/// How context crosses a path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransformKind {
+    /// Carry everything: `transform` absent or `"direct"`.
+    Direct,
+    /// Keep only pinned regions.
+    Clear,
+    /// Summarize everything: `"compact"`, and `"summarize"` until changed.
+    Compact,
+    /// Per-region rules in `transform_config`.
+    Custom,
+    /// A spelling the editor does not know; shown as written.
+    Other(String),
+}
+
+impl TransformKind {
+    /// The choices the editor offers.
+    pub const CHOICES: [TransformKind; 4] = [
+        TransformKind::Direct,
+        TransformKind::Clear,
+        TransformKind::Compact,
+        TransformKind::Custom,
+    ];
+
+    /// The manifest spelling; `Direct` is written as absent.
+    pub fn as_str(&self) -> &str {
+        match self {
+            TransformKind::Direct => "direct",
+            TransformKind::Clear => "clear",
+            TransformKind::Compact => "compact",
+            TransformKind::Custom => "custom",
+            TransformKind::Other(s) => s,
+        }
+    }
+
+    /// From the manifest spelling (absent reads as `Direct`).
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "" | "direct" => TransformKind::Direct,
+            "clear" => TransformKind::Clear,
+            "compact" | "summarize" => TransformKind::Compact,
+            "custom" => TransformKind::Custom,
+            other => TransformKind::Other(other.to_string()),
+        }
+    }
+
+    /// What the editor calls it.
+    pub fn label(&self) -> &str {
+        match self {
+            TransformKind::Direct => "Carry everything",
+            TransformKind::Clear => "Keep only pinned",
+            TransformKind::Compact => "Summarize everything",
+            TransformKind::Custom => "Per-region rules",
+            TransformKind::Other(s) => s,
+        }
+    }
+}
+
+/// A path's `transform_config`, as typed lists.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct TransformRules {
+    /// Regions carried as they are.
+    pub carry: Vec<String>,
+    /// Regions summarized.
+    pub compact: Vec<String>,
+    /// Regions dropped.
+    pub clear: Vec<String>,
+    /// `compact_prompt`, or empty.
+    pub compact_prompt: String,
+    /// Whether the table exists at all: the cue to seed it when a path first
+    /// turns custom.
+    pub present: bool,
+}
+
+/// One `[stages.<from>.transitions.<to>]` table as the editor shows it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EdgeView {
+    /// The stage the path leaves.
+    pub from: String,
+    /// The stage it enters.
+    pub to: String,
+    /// When it is taken.
+    pub kind: EdgeKind,
+    /// The `hint`, when written (kept even under a `condition`).
+    pub hint: Option<String>,
+    /// Whether a `gate` is written.
+    pub gated: bool,
+    /// How context crosses.
+    pub transform: TransformKind,
+    /// The per-region rules.
+    pub rules: TransformRules,
+}
+
+/// One region of a layout as the editor shows it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RegionView {
+    /// The table key.
+    pub name: String,
+    /// `kind`, or empty.
+    pub kind: String,
+    /// The `budget = "N%"` percentage, when it parses.
+    pub budget_percent: Option<f64>,
+    /// `max_tokens`.
+    pub max_tokens: Option<u64>,
+    /// `required = true`.
+    pub required: bool,
+    /// `required_message`, or empty.
+    pub required_message: String,
+    /// A string `seed`; a table-shaped seed reads as empty and is never
+    /// clobbered (see `seed_is_table`).
+    pub seed: String,
+    /// The `seed` is a table (`{ files = [...] }`, ...) the editor cannot
+    /// display, so clearing the field will not touch it.
+    pub seed_is_table: bool,
+    /// `max_items` (sliding windows).
+    pub max_items: Option<u64>,
+    /// `strategy` (sliding windows), or empty.
+    pub strategy: String,
+    /// `overflow` (sliding windows).
+    pub overflow: Option<u64>,
+    /// `description`, or empty.
+    pub description: String,
+}
+
+/// The layout a stage runs with.
+#[derive(Debug, Clone, PartialEq)]
+pub struct EffectiveRegions {
+    /// The regions, in document order.
+    pub regions: Vec<RegionView>,
+    /// `true` when they are the agent's shared regions, `false` when the
+    /// stage has its own `[stages.<name>.context.regions]`.
+    pub inherited: bool,
+}
+
+/// A stage's `tool_routing`.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ToolRouting {
+    /// `default_region`.
+    pub default_region: Option<String>,
+    /// `overrides`, tool to region, in document order.
+    pub overrides: Vec<(String, String)>,
+}
+
+impl ManifestDoc {
+    /// Read a manifest. Refuses text that is not TOML, has no `[agent]`
+    /// table, or has no stage table: the editor needs those to stand on.
+    pub fn parse(text: &str) -> Result<Self, EditError> {
+        let doc: DocumentMut = text
+            .parse()
+            .map_err(|e: toml_edit::TomlError| EditError::Toml(e.to_string()))?;
+        if doc.get("agent").and_then(as_table).is_none() {
+            return Err(EditError::NoAgent);
+        }
+        let this = Self { doc };
+        if this.stage_names().is_empty() {
+            return Err(EditError::NoStages);
+        }
+        Ok(this)
+    }
+
+    /// The manifest text, exactly as it will be written.
+    pub fn to_toml(&self) -> String {
+        self.doc.to_string()
+    }
+
+    /// The manifest as the runtime reads it, or the runtime's parse error.
+    pub fn blueprint(&self) -> Result<Blueprint, String> {
+        parse_manifest(&self.to_toml()).map_err(|e| e.to_string())
+    }
+
+    pub(super) fn doc(&self) -> &DocumentMut {
+        &self.doc
+    }
+
+    pub(super) fn doc_mut(&mut self) -> &mut DocumentMut {
+        &mut self.doc
+    }
+
+    /// The `[agent]` table.
+    pub(super) fn agent_table(&self) -> &dyn TableLike {
+        self.doc
+            .get("agent")
+            .and_then(as_table)
+            .expect("parse() checked [agent] is a table")
+    }
+
+    /// The `[stages.<name>]` item.
+    pub(super) fn stage_item(&self, name: &str) -> Option<&Item> {
+        self.doc
+            .get("stages")
+            .and_then(Item::as_table_like)
+            .and_then(|t| t.get(name))
+            .filter(|i| i.as_table_like().is_some())
+    }
+
+    /// The `[stages.<name>]` item, mutably.
+    pub(super) fn stage_item_mut(&mut self, name: &str) -> Option<&mut Item> {
+        self.doc
+            .get_mut("stages")
+            .and_then(Item::as_table_like_mut)
+            .and_then(|t| t.get_mut(name))
+            .filter(|i| i.as_table_like().is_some())
+    }
+
+    /// The `[agent]` view.
+    pub fn agent(&self) -> AgentView {
+        let agent = self.agent_table();
+        let firsts: Vec<Option<String>> = self
+            .stages()
+            .iter()
+            .map(|s| s.models.first().cloned())
+            .collect();
+        let default_model = match firsts.first() {
+            Some(Some(first)) if firsts.iter().all(|m| m.as_ref() == Some(first)) => {
+                Some(first.clone())
+            }
+            _ => None,
+        };
+        AgentView {
+            name: get_str(agent, "name").unwrap_or_default().to_string(),
+            version: get_str(agent, "version").unwrap_or_default().to_string(),
+            description: get_str(agent, "description")
+                .unwrap_or_default()
+                .to_string(),
+            entry_stage: get_str(agent, "entry_stage").map(str::to_string),
+            default_model,
+        }
+    }
+
+    /// The stage names, in the order the file shows them.
+    pub fn stage_names(&self) -> Vec<String> {
+        order::stage_order(&self.doc)
+    }
+
+    /// Whether a stage of that name exists.
+    pub fn has_stage(&self, name: &str) -> bool {
+        self.stage_item(name).is_some()
+    }
+
+    /// One stage's view.
+    pub fn stage(&self, name: &str) -> Option<StageView> {
+        self.stage_item(name).map(|item| stage_view(name, item))
+    }
+}
+
+fn stage_view(name: &str, item: &Item) -> StageView {
+    {
+        let table = as_table(item).expect("stage_item is a table");
+        let transitions = child(item, "transitions");
+        let worker = [WorkerKind::Agent, WorkerKind::Stage, WorkerKind::Query]
+            .into_iter()
+            .find_map(|k| get_str(table, k.key()).map(|v| (k, v.to_string())));
+        StageView {
+            name: name.to_string(),
+            mode: get_str(table, "mode")
+                .map(StageModeView::parse)
+                .unwrap_or(StageModeView::Autonomous),
+            description: get_str(table, "description")
+                .unwrap_or_default()
+                .to_string(),
+            max_iterations: get_int(table, "max_iterations").and_then(|n| u64::try_from(n).ok()),
+            max_revisits: get_int(table, "max_revisits").and_then(|n| u64::try_from(n).ok()),
+            allow_complete: get_bool(table, "allow_complete"),
+            models: model_chain(table.get("model")),
+            tools: get_strings(table, "available_tools"),
+            system_prompt: get_str(table, "system_prompt")
+                .unwrap_or_default()
+                .to_string(),
+            transition_prompt: get_str(table, "transition_prompt")
+                .unwrap_or_default()
+                .to_string(),
+            fan_out: FanOutView {
+                worker,
+                merge_stage: get_str(table, "merge_stage").map(str::to_string),
+                max_workers: get_int(table, "max_workers").and_then(|n| u64::try_from(n).ok()),
+                max_items: get_int(table, "max_items").and_then(|n| u64::try_from(n).ok()),
+                on_worker_failure: get_str(table, "on_worker_failure").map(str::to_string),
+            },
+            has_own_layout: child(item, "context")
+                .and_then(|c| c.get("regions"))
+                .and_then(Item::as_table_like)
+                .is_some(),
+            is_terminal: transitions.is_some_and(|t| t.is_empty()),
+        }
+    }
+}
+
+impl ManifestDoc {
+    /// Every stage's view, in file order.
+    pub fn stages(&self) -> Vec<StageView> {
+        self.stage_names()
+            .iter()
+            .filter_map(|n| self.stage(n))
+            .collect()
+    }
+
+    /// Every path, grouped by the stage it leaves, in file order. A path
+    /// whose `condition` the editor does not know is left out (and left
+    /// alone).
+    pub fn edges(&self) -> Vec<EdgeView> {
+        self.stage_names()
+            .into_iter()
+            .filter_map(|from| {
+                self.stage_item(&from)
+                    .and_then(|item| child(item, "transitions"))
+                    .map(|transitions| (from, transitions))
+            })
+            .flat_map(|(from, transitions)| {
+                transitions
+                    .iter()
+                    .filter_map(|(to, edge)| edge_view(&from, to, edge))
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
+    /// One path's view.
+    pub fn edge(&self, from: &str, to: &str) -> Option<EdgeView> {
+        self.stage_item(from)
+            .and_then(|item| child(item, "transitions"))
+            .and_then(|transitions| transitions.get(to))
+            .and_then(|edge| edge_view(from, to, edge))
+    }
+
+    /// The `[context.regions]` item of a scope: the agent's, or a stage's own.
+    pub(super) fn regions_item(&self, stage: Option<&str>) -> Option<&Item> {
+        let parent = match stage {
+            None => Some(self.doc.as_item()),
+            Some(name) => self.stage_item(name),
+        };
+        parent
+            .and_then(Item::as_table_like)
+            .and_then(|p| p.get("context"))
+            .and_then(Item::as_table_like)
+            .and_then(|c| c.get("regions"))
+            .filter(|r| r.as_table_like().is_some())
+    }
+
+    /// The regions of a scope, in document order; empty when the scope has
+    /// no `regions` table.
+    pub fn regions(&self, stage: Option<&str>) -> Vec<RegionView> {
+        self.regions_item(stage)
+            .map(|item| {
+                table_keys(item)
+                    .into_iter()
+                    .filter_map(|name| child(item, &name).map(|table| region_view(&name, table)))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// One region's view.
+    pub fn region(&self, stage: Option<&str>, name: &str) -> Option<RegionView> {
+        self.regions_item(stage)
+            .and_then(|item| child(item, name))
+            .map(|table| region_view(name, table))
+    }
+
+    /// The layout a stage runs with: its own when it declares one, the
+    /// agent's otherwise. `None` asks for the agent's.
+    pub fn effective_regions(&self, stage: Option<&str>) -> EffectiveRegions {
+        match stage {
+            Some(name) if self.regions_item(Some(name)).is_some() => EffectiveRegions {
+                regions: self.regions(Some(name)),
+                inherited: false,
+            },
+            _ => EffectiveRegions {
+                regions: self.regions(None),
+                inherited: true,
+            },
+        }
+    }
+
+    /// A stage's tool routing; empty when it has none.
+    pub fn tool_routing(&self, stage: &str) -> ToolRouting {
+        let Some(routing) = self
+            .stage_item(stage)
+            .and_then(|i| child(i, "tool_routing"))
+        else {
+            return ToolRouting::default();
+        };
+        let overrides = routing
+            .get("overrides")
+            .and_then(Item::as_table_like)
+            .map(|o| {
+                o.iter()
+                    .filter_map(|(tool, region)| {
+                        region.as_str().map(|r| (tool.to_string(), r.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        ToolRouting {
+            default_region: get_str(routing, "default_region").map(str::to_string),
+            overrides,
+        }
+    }
+
+    /// The stages whose tool routing (default or an override) lands in
+    /// `region`: what deleting the region would break.
+    pub fn stages_routing_into(&self, region: &str) -> Vec<String> {
+        self.stage_names()
+            .into_iter()
+            .filter(|s| {
+                let r = self.tool_routing(s);
+                r.default_region.as_deref() == Some(region)
+                    || r.overrides.iter().any(|(_, to)| to == region)
+            })
+            .collect()
+    }
+
+    /// Every tool named by any stage, sorted and deduplicated.
+    pub fn known_tools(&self) -> Vec<String> {
+        let mut tools: Vec<String> = self.stages().into_iter().flat_map(|s| s.tools).collect();
+        tools.sort();
+        tools.dedup();
+        tools
+    }
+
+    /// Every `provider/model` named by any stage, sorted and deduplicated.
+    pub fn known_models(&self) -> Vec<String> {
+        let mut models: Vec<String> = self.stages().into_iter().flat_map(|s| s.models).collect();
+        models.sort();
+        models.dedup();
+        models
+    }
+}
+
+/// The `provider/model` chain a stage's `model` value stands for. A bare
+/// string is one entry (The Lair's reading; the runtime ignores that form,
+/// which is why the editor never writes it).
+fn model_chain(value: Option<&Item>) -> Vec<String> {
+    let Some(value) = value else {
+        return Vec::new();
+    };
+    if let Some(s) = value.as_str() {
+        return vec![s.to_string()];
+    }
+    let Some(table) = value.as_table_like() else {
+        return Vec::new();
+    };
+    let Some(models) = table.get("models").and_then(Item::as_array) else {
+        return Vec::new();
+    };
+    models
+        .iter()
+        .filter_map(|entry| {
+            let t = entry.as_inline_table()?;
+            match (
+                t.get("provider").and_then(Value::as_str),
+                t.get("model").and_then(Value::as_str),
+            ) {
+                (Some(provider), Some(model)) => Some(format!("{provider}/{model}")),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+fn edge_view(from: &str, to: &str, edge: &Item) -> Option<EdgeView> {
+    edge.as_table_like()
+        .and_then(|table| edge_table_view(from, to, table))
+}
+
+fn edge_table_view(from: &str, to: &str, table: &dyn TableLike) -> Option<EdgeView> {
+    let hint = get_str(table, "hint").map(str::to_string);
+    let kind = match get_str(table, "condition") {
+        Some(c) => EdgeKind::from_condition(c)?,
+        None if hint.is_some() => EdgeKind::Hint,
+        None => EdgeKind::LlmChoice,
+    };
+    let config = table.get("transform_config").and_then(Item::as_table_like);
+    let rules = TransformRules {
+        carry: config.map(|c| get_strings(c, "carry")).unwrap_or_default(),
+        compact: config
+            .map(|c| get_strings(c, "compact"))
+            .unwrap_or_default(),
+        clear: config.map(|c| get_strings(c, "clear")).unwrap_or_default(),
+        compact_prompt: config
+            .and_then(|c| get_str(c, "compact_prompt"))
+            .unwrap_or_default()
+            .to_string(),
+        present: config.is_some(),
+    };
+    Some(EdgeView {
+        from: from.to_string(),
+        to: to.to_string(),
+        kind,
+        hint,
+        gated: table.contains_key("gate"),
+        transform: TransformKind::parse(get_str(table, "transform").unwrap_or_default()),
+        rules,
+    })
+}
+
+fn region_view(name: &str, table: &dyn TableLike) -> RegionView {
+    let seed = table.get("seed");
+    RegionView {
+        name: name.to_string(),
+        kind: get_str(table, "kind").unwrap_or_default().to_string(),
+        budget_percent: get_str(table, "budget").and_then(parse_percent),
+        max_tokens: get_int(table, "max_tokens").and_then(|n| u64::try_from(n).ok()),
+        required: get_bool(table, "required") == Some(true),
+        required_message: get_str(table, "required_message")
+            .unwrap_or_default()
+            .to_string(),
+        seed: seed.and_then(Item::as_str).unwrap_or_default().to_string(),
+        seed_is_table: seed.is_some_and(|s| s.as_table_like().is_some()),
+        max_items: get_int(table, "max_items").and_then(|n| u64::try_from(n).ok()),
+        strategy: get_str(table, "strategy").unwrap_or_default().to_string(),
+        overflow: get_int(table, "overflow").and_then(|n| u64::try_from(n).ok()),
+        description: get_str(table, "description")
+            .unwrap_or_default()
+            .to_string(),
+    }
+}
+
+/// `"35%"` as 35.0; anything else as `None`.
+pub(super) fn parse_percent(s: &str) -> Option<f64> {
+    s.trim()
+        .strip_suffix('%')
+        .and_then(|digits| digits.trim().parse().ok())
+}

--- a/crates/leviath-cli/src/blueprint_edit/edges.rs
+++ b/crates/leviath-cli/src/blueprint_edit/edges.rs
@@ -1,0 +1,250 @@
+//! Mutators for `[stages.<from>.transitions.<to>]`: the paths.
+
+use toml_edit::{InlineTable, Item, Value};
+
+use super::EditError;
+use super::doc::{EdgeKind, ManifestDoc, TransformKind};
+use super::tables::{
+    child_mut, ensure_child, get_strings, new_table, set_or_remove_str, set_str, set_strings,
+};
+
+/// What a custom transform does with one region.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Rule {
+    /// Carried as it is.
+    Carry,
+    /// Summarized.
+    Compact,
+    /// Dropped.
+    Clear,
+}
+
+impl Rule {
+    /// The `transform_config` list the rule files a region under.
+    pub fn key(self) -> &'static str {
+        match self {
+            Rule::Carry => "carry",
+            Rule::Compact => "compact",
+            Rule::Clear => "clear",
+        }
+    }
+
+    /// Every rule, in the order the editor offers them.
+    pub const ALL: [Rule; 3] = [Rule::Carry, Rule::Compact, Rule::Clear];
+
+    /// What the editor calls it.
+    pub fn label(self) -> &'static str {
+        match self {
+            Rule::Carry => "Carry",
+            Rule::Compact => "Summarize",
+            Rule::Clear => "Drop",
+        }
+    }
+}
+
+/// The hint a path starts life with.
+pub const NEW_EDGE_HINT: &str = "Continue here when appropriate";
+
+impl ManifestDoc {
+    /// Add a path from one stage to another (or to itself: a self-loop) as a
+    /// hint the model routes on. Both stages must exist; a path that already
+    /// exists is left as it is.
+    pub fn add_edge(&mut self, from: &str, to: &str) -> Result<(), EditError> {
+        self.require_stage(from)?;
+        self.require_stage(to)?;
+        let transitions = self.transitions_mut(from)?;
+        let inline = transitions.is_inline_table();
+        let table = transitions
+            .as_table_like_mut()
+            .expect("transitions_mut checked");
+        if table.contains_key(to) {
+            return Ok(());
+        }
+        let mut edge = new_table(inline);
+        set_str(
+            edge.as_table_like_mut().expect("just built"),
+            "hint",
+            NEW_EDGE_HINT,
+        );
+        table.insert(to, edge);
+        Ok(())
+    }
+
+    /// Delete a path.
+    pub fn delete_edge(&mut self, from: &str, to: &str) -> Result<(), EditError> {
+        let stage = self
+            .stage_item_mut(from)
+            .ok_or_else(|| EditError::NoSuchStage(from.to_string()))?;
+        let removed = child_mut(stage, "transitions")
+            .and_then(|t| t.as_table_like_mut().expect("child_mut checked").remove(to));
+        if removed.is_none() {
+            return Err(EditError::NoSuchEdge(from.to_string(), to.to_string()));
+        }
+        Ok(())
+    }
+
+    /// Set when a path is taken. `Hint` writes a `hint` (keeping the text
+    /// already there, or an empty one) and drops `condition`; every other
+    /// kind writes `condition` and drops `hint`.
+    pub fn set_edge_kind(&mut self, from: &str, to: &str, kind: EdgeKind) -> Result<(), EditError> {
+        let edge = self.edge_table_mut(from, to)?;
+        match kind.condition() {
+            None => {
+                edge.remove("condition");
+                if !edge.contains_key("hint") {
+                    set_str(edge, "hint", "");
+                }
+            }
+            Some(condition) => {
+                set_str(edge, "condition", condition);
+                edge.remove("hint");
+            }
+        }
+        Ok(())
+    }
+
+    /// Set a path's hint text.
+    pub fn set_edge_hint(&mut self, from: &str, to: &str, hint: &str) -> Result<(), EditError> {
+        let edge = self.edge_table_mut(from, to)?;
+        set_str(edge, "hint", hint);
+        Ok(())
+    }
+
+    /// Require (or stop requiring) approval on a path. Turning it on adds
+    /// the smallest gate there is only when the path has none, so a richer
+    /// gate an author wrote survives; turning it off deletes whatever gate
+    /// is there.
+    pub fn set_edge_gate(&mut self, from: &str, to: &str, gated: bool) -> Result<(), EditError> {
+        let edge = self.edge_table_mut(from, to)?;
+        if gated {
+            if !edge.contains_key("gate") {
+                let mut gate = InlineTable::new();
+                gate.insert("message", Value::from("Approve to continue"));
+                edge.insert("gate", Item::Value(Value::InlineTable(gate)));
+            }
+        } else {
+            edge.remove("gate");
+        }
+        Ok(())
+    }
+
+    /// Set how context crosses a path. `Direct` is written as absent. The
+    /// first switch to `Custom` seeds `transform_config` with every
+    /// non-pinned region the leaving stage sees filed under `carry`; the
+    /// config is otherwise left alone, so switching away and back costs
+    /// nothing.
+    pub fn set_transform(
+        &mut self,
+        from: &str,
+        to: &str,
+        kind: &TransformKind,
+    ) -> Result<(), EditError> {
+        let seed: Option<Vec<String>> = if *kind == TransformKind::Custom
+            && self.edge(from, to).is_some_and(|e| !e.rules.present)
+        {
+            Some(
+                self.effective_regions(Some(from))
+                    .regions
+                    .into_iter()
+                    .filter(|r| r.kind != "pinned")
+                    .map(|r| r.name)
+                    .collect(),
+            )
+        } else {
+            None
+        };
+        let item = self.edge_item_mut(from, to)?;
+        let spelling = match kind {
+            TransformKind::Direct => "",
+            other => other.as_str(),
+        };
+        set_or_remove_str(
+            item.as_table_like_mut().expect("edge_item_mut checked"),
+            "transform",
+            spelling,
+        );
+        if let Some(carry) = seed
+            && !carry.is_empty()
+        {
+            let config = ensure_child(item, "transform_config")?;
+            let table = config.as_table_like_mut().expect("ensure_child checked");
+            set_strings(table, "carry", &carry);
+        }
+        Ok(())
+    }
+
+    /// File a region under exactly one of carry/compact/clear on a path,
+    /// creating `transform_config` when missing; emptied lists are deleted.
+    pub fn set_transform_rule(
+        &mut self,
+        from: &str,
+        to: &str,
+        region: &str,
+        rule: Rule,
+    ) -> Result<(), EditError> {
+        let item = self.edge_item_mut(from, to)?;
+        let config = ensure_child(item, "transform_config")?;
+        let table = config.as_table_like_mut().expect("ensure_child checked");
+        for candidate in Rule::ALL {
+            let mut kept: Vec<String> = get_strings(table, candidate.key())
+                .into_iter()
+                .filter(|r| r != region)
+                .collect();
+            if candidate == rule {
+                kept.push(region.to_string());
+            }
+            if kept.is_empty() {
+                table.remove(candidate.key());
+            } else {
+                set_strings(table, candidate.key(), &kept);
+            }
+        }
+        Ok(())
+    }
+
+    /// Set the custom transform's summarizing instructions; empty deletes
+    /// them (and never creates the config just to hold nothing).
+    pub fn set_compact_prompt(
+        &mut self,
+        from: &str,
+        to: &str,
+        prompt: &str,
+    ) -> Result<(), EditError> {
+        let item = self.edge_item_mut(from, to)?;
+        if prompt.is_empty() {
+            if let Some(config) = child_mut(item, "transform_config") {
+                config
+                    .as_table_like_mut()
+                    .expect("child_mut checked")
+                    .remove("compact_prompt");
+            }
+            return Ok(());
+        }
+        let config = ensure_child(item, "transform_config")?;
+        set_str(
+            config.as_table_like_mut().expect("ensure_child checked"),
+            "compact_prompt",
+            prompt,
+        );
+        Ok(())
+    }
+
+    /// The path's item, or [`EditError::NoSuchEdge`].
+    fn edge_item_mut(&mut self, from: &str, to: &str) -> Result<&mut Item, EditError> {
+        let missing = || EditError::NoSuchEdge(from.to_string(), to.to_string());
+        let stage = self.stage_item_mut(from).ok_or_else(missing)?;
+        let transitions = child_mut(stage, "transitions").ok_or_else(missing)?;
+        child_mut(transitions, to).ok_or_else(missing)
+    }
+
+    fn edge_table_mut(
+        &mut self,
+        from: &str,
+        to: &str,
+    ) -> Result<&mut dyn toml_edit::TableLike, EditError> {
+        Ok(self
+            .edge_item_mut(from, to)?
+            .as_table_like_mut()
+            .expect("edge_item_mut checked"))
+    }
+}

--- a/crates/leviath-cli/src/blueprint_edit/layout_store.rs
+++ b/crates/leviath-cli/src/blueprint_edit/layout_store.rs
@@ -1,0 +1,90 @@
+//! Where the boxes were left.
+//!
+//! An arrangement dragged into shape on the editor's canvas is worth keeping,
+//! but it is not part of the agent: The Lair keeps it in the browser, keyed by
+//! agent name, and this keeps it in one small file per home the same way.
+//! Positions are world coordinates on the canvas; a stage without one is laid
+//! out by the layered layout as usual.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Stage name to `(x, y)` on the canvas.
+pub type Positions = BTreeMap<String, (f64, f64)>;
+
+/// The saved arrangements, keyed by agent name.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct LayoutStore {
+    path: Option<PathBuf>,
+    layouts: BTreeMap<String, Positions>,
+}
+
+impl LayoutStore {
+    /// The file under the data directory: `dash/graph-layouts.json`.
+    pub fn default_path() -> Option<PathBuf> {
+        leviath_core::paths::data_dir().map(|d| d.join("dash").join("graph-layouts.json"))
+    }
+
+    /// Read the store at `path`; a missing or unreadable file is an empty
+    /// store that will write there on the next save.
+    pub fn open(path: PathBuf) -> Self {
+        let layouts = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|text| serde_json::from_str(&text).ok())
+            .unwrap_or_default();
+        Self {
+            path: Some(path),
+            layouts,
+        }
+    }
+
+    /// A store that never touches disk.
+    pub fn in_memory() -> Self {
+        Self::default()
+    }
+
+    /// The file this store writes to, when it has one.
+    pub fn path(&self) -> Option<&Path> {
+        self.path.as_deref()
+    }
+
+    /// The saved positions of an agent's stages.
+    pub fn positions(&self, agent: &str) -> Option<&Positions> {
+        self.layouts.get(agent)
+    }
+
+    /// Remember an agent's arrangement (in memory; `save` writes it).
+    pub fn set(&mut self, agent: &str, positions: Positions) {
+        if positions.is_empty() {
+            self.layouts.remove(agent);
+        } else {
+            self.layouts.insert(agent.to_string(), positions);
+        }
+    }
+
+    /// Drop an agent's arrangement (a deleted or reset agent).
+    pub fn forget(&mut self, agent: &str) {
+        self.layouts.remove(agent);
+    }
+
+    /// Carry an arrangement over to a new name (a cloned agent).
+    pub fn copy(&mut self, from: &str, to: &str) {
+        if let Some(p) = self.layouts.get(from).cloned() {
+            self.layouts.insert(to.to_string(), p);
+        }
+    }
+
+    /// Write the store, creating its directory. A store without a path does
+    /// nothing.
+    pub fn save(&self) -> std::io::Result<()> {
+        let Some(path) = &self.path else {
+            return Ok(());
+        };
+        // A relative file name has an empty parent, which `create_dir_all`
+        // treats as already there.
+        std::fs::create_dir_all(path.parent().unwrap_or(Path::new("")))?;
+        let text =
+            serde_json::to_string_pretty(&self.layouts).expect("a map of numbers serializes");
+        std::fs::write(path, text)
+    }
+}

--- a/crates/leviath-cli/src/blueprint_edit/mod.rs
+++ b/crates/leviath-cli/src/blueprint_edit/mod.rs
@@ -1,0 +1,110 @@
+//! Editing an agent blueprint (`agent.leviath`) as a document.
+//!
+//! The dashboard's agent editor needs to change one thing about a manifest at
+//! a time and hand back a file the author would still recognise: their
+//! comments, their key order, their formatting. Nothing in the tree could do
+//! that. `parse_manifest` reads a manifest into a [`Blueprint`], but there is
+//! no writer for one, and `toml` re-emits from values, so every comment a
+//! bundled agent carries would vanish on the first edit. So the editing model
+//! keeps the manifest as a `toml_edit` document, the one source of truth, and
+//! derives typed views from it on demand: [`ManifestDoc::stages`],
+//! [`ManifestDoc::edges`], [`ManifestDoc::effective_regions`]. Keys the views
+//! do not surface (fan-out policies the editor leaves alone, `[compaction]`,
+//! table-shaped seeds, custom gates) round-trip untouched.
+//!
+//! The mutators refuse rather than produce a broken document: a name that is
+//! not a name, a duplicate, a transition to a stage that does not exist, the
+//! last stage deleted, all come back as an [`EditError`] and leave the
+//! document as it was. What they cannot refuse (a stage with no model, an
+//! unreachable stage) is [`check`]'s job, which runs the same parse, validate
+//! and lint pass `lev validate` and the daemon's `POST /api/blueprints/validate`
+//! run.
+//!
+//! The rules match The Lair's editor field for field (`blueprint/editable.ts`
+//! in the leviath.dev repo), so an agent built here and one built there are
+//! the same file: an empty string deletes a key rather than writing `""`; a
+//! `direct` transform is written as absent; a new path is `hint = "Continue
+//! here when appropriate"`; a new region is `pinned`, `5%`, `4000` tokens.
+//!
+//! [`Blueprint`]: leviath_core::Blueprint
+
+pub mod catalog;
+pub mod check;
+mod doc;
+mod edges;
+mod layout_store;
+mod order;
+mod regions;
+mod stages;
+mod tables;
+pub mod templates;
+
+pub use doc::{
+    AgentView, EdgeKind, EdgeView, EffectiveRegions, FanOutView, ManifestDoc, RegionView,
+    StageModeView, StageView, ToolRouting, TransformKind, TransformRules, WorkerKind,
+};
+pub use edges::Rule;
+pub use layout_store::{LayoutStore, Positions};
+pub use regions::{RegionField, RegionScope, RegionValue};
+pub use stages::{FanOutField, StageText};
+
+/// Why an edit was refused. The document is untouched whenever one of these
+/// comes back.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum EditError {
+    /// The text is not TOML.
+    #[error("not valid TOML: {0}")]
+    Toml(String),
+    /// The manifest has no `[agent]` table.
+    #[error("the manifest has no [agent] table")]
+    NoAgent,
+    /// The manifest has no `[stages.<name>]` table at all.
+    #[error("the manifest has no stages")]
+    NoStages,
+    /// A stage, region or agent name outside the runtime's charset.
+    #[error("\"{0}\" will not work as a name: letters, digits, `.`, `_` and `-` only")]
+    BadName(String),
+    /// A stage or region of that name already exists where it would go.
+    #[error("\"{0}\" is already taken")]
+    Taken(String),
+    /// No stage of that name.
+    #[error("there is no stage named \"{0}\"")]
+    NoSuchStage(String),
+    /// No region of that name in that layout.
+    #[error("there is no region named \"{0}\"")]
+    NoSuchRegion(String),
+    /// No transition from the first stage to the second.
+    #[error("there is no path from \"{0}\" to \"{1}\"")]
+    NoSuchEdge(String, String),
+    /// Deleting this stage would leave the agent with none.
+    #[error("an agent needs at least one stage")]
+    LastStage,
+    /// The key exists but holds something other than a table, and the editor
+    /// will not clobber what it cannot display.
+    #[error("`{0}` is not a table this editor can write into")]
+    NotATable(String),
+    /// A number outside what the key accepts.
+    #[error("{0}")]
+    OutOfRange(String),
+}
+
+/// Whether `name` can be a stage, region or agent name: the charset the
+/// runtime accepts, and what The Lair's editor enforces.
+pub fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+/// A name check that says why it failed.
+pub(crate) fn require_name(name: &str) -> Result<(), EditError> {
+    if is_valid_name(name) {
+        Ok(())
+    } else {
+        Err(EditError::BadName(name.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/leviath-cli/src/blueprint_edit/order.rs
+++ b/crates/leviath-cli/src/blueprint_edit/order.rs
@@ -1,0 +1,173 @@
+//! Where tables land in the file.
+//!
+//! `toml_edit` writes headed tables in the order of their `position`, a
+//! number each table got when the document was parsed; a table added since
+//! has none and is written right after whichever positioned table the writer
+//! visited last, ties broken by the order the tables sit in memory. The stage
+//! views must list stages in the order the file will show them, and adding a
+//! stage "after plan" or moving one up must land it there, so this module
+//! reproduces the writer's order and renumbers on demand.
+
+use toml_edit::{DocumentMut, Item, Table};
+
+/// One step down into the document: a key, or an element of an array of
+/// tables (`[[stages.plan.interaction_points]]`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Seg {
+    Key(String),
+    Index(usize),
+}
+
+/// The path of every headed table, root excluded, in the order the writer
+/// emits them.
+pub(super) fn written_order(doc: &DocumentMut) -> Vec<Vec<Seg>> {
+    let mut found: Vec<(isize, Vec<Seg>)> = Vec::new();
+    let mut last = 0;
+    let mut path = Vec::new();
+    visit(doc.as_table(), &mut path, &mut last, &mut found);
+    // The writer sorts by position and keeps arrival order for ties.
+    found.sort_by_key(|(pos, _)| *pos);
+    found.into_iter().map(|(_, p)| p).collect()
+}
+
+fn visit(table: &Table, path: &mut Vec<Seg>, last: &mut isize, out: &mut Vec<(isize, Vec<Seg>)>) {
+    if !path.is_empty() && !table.is_dotted() {
+        if let Some(pos) = table.position() {
+            *last = pos;
+        }
+        out.push((*last, path.clone()));
+    }
+    for (key, item) in table.iter() {
+        match item {
+            Item::Table(t) => {
+                path.push(Seg::Key(key.to_string()));
+                visit(t, path, last, out);
+                path.pop();
+            }
+            Item::ArrayOfTables(a) => {
+                for (i, t) in a.iter().enumerate() {
+                    path.push(Seg::Key(key.to_string()));
+                    path.push(Seg::Index(i));
+                    visit(t, path, last, out);
+                    path.pop();
+                    path.pop();
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+/// The table at `path`, mutably.
+fn table_at_mut<'a>(doc: &'a mut DocumentMut, path: &[Seg]) -> Option<&'a mut Table> {
+    walk_item(doc.as_item_mut(), path)
+}
+
+fn walk_item<'a>(item: &'a mut Item, path: &[Seg]) -> Option<&'a mut Table> {
+    match path.split_first() {
+        None => item.as_table_mut(),
+        // `Item::get_mut` would create the key; the trait's `get_mut` only
+        // finds it.
+        Some((Seg::Key(k), rest)) => walk_item(item.as_table_like_mut()?.get_mut(k)?, rest),
+        Some((Seg::Index(n), rest)) => {
+            let table = item.as_array_of_tables_mut()?.get_mut(*n)?;
+            walk_table(table, rest)
+        }
+    }
+}
+
+fn walk_table<'a>(table: &'a mut Table, path: &[Seg]) -> Option<&'a mut Table> {
+    match path.split_first() {
+        None => Some(table),
+        Some((Seg::Key(k), rest)) => walk_item(table.get_mut(k)?, rest),
+        // An index only ever follows the key of an array of tables.
+        Some((Seg::Index(_), _)) => None,
+    }
+}
+
+/// Give every headed table a position matching `order` (0, 1, 2, ...), so
+/// the file is written in exactly that order.
+pub(super) fn renumber(doc: &mut DocumentMut, order: &[Vec<Seg>]) {
+    for (i, path) in order.iter().enumerate() {
+        if let Some(table) = table_at_mut(doc, path) {
+            table.set_position(Some(i as isize));
+        }
+    }
+}
+
+/// The names of the `[stages.*]` tables in the order the file shows them.
+/// A stage written inline (`stages = { plan = {...} }`, or `plan = {...}`
+/// under `[stages]`) has no position and comes first, as the writer puts a
+/// table's values before its subtables.
+pub(super) fn stage_order(doc: &DocumentMut) -> Vec<String> {
+    let Some(stages) = doc.get("stages") else {
+        return Vec::new();
+    };
+    let Some(table) = stages.as_table_like() else {
+        return Vec::new();
+    };
+    let mut inline: Vec<String> = Vec::new();
+    let mut headed: Vec<String> = Vec::new();
+    for (name, item) in table.iter() {
+        if item.is_inline_table() {
+            inline.push(name.to_string());
+        } else if item.is_table() {
+            headed.push(name.to_string());
+        }
+    }
+    let written = written_order(doc);
+    let rank = |name: &str| {
+        written
+            .iter()
+            .position(|p| {
+                p.first() == Some(&Seg::Key("stages".into()))
+                    && p.get(1) == Some(&Seg::Key(name.into()))
+            })
+            .unwrap_or(usize::MAX)
+    };
+    headed.sort_by_key(|n| rank(n));
+    inline.extend(headed);
+    inline
+}
+
+/// The paths of the tables that make up stage `name`: its own and every
+/// table under it, in written order.
+pub(super) fn stage_block(order: &[Vec<Seg>], name: &str) -> Vec<Vec<Seg>> {
+    order
+        .iter()
+        .filter(|p| {
+            p.first() == Some(&Seg::Key("stages".into()))
+                && p.get(1) == Some(&Seg::Key(name.into()))
+        })
+        .cloned()
+        .collect()
+}
+
+/// Move stage `name`'s block of tables to just before (`before = true`) or
+/// just after the block of `other`, and renumber the file to match.
+pub(super) fn move_stage_block(doc: &mut DocumentMut, name: &str, other: &str, before: bool) {
+    let order = written_order(doc);
+    let block = stage_block(&order, name);
+    let anchor = stage_block(&order, other);
+    if name == other || block.is_empty() || anchor.is_empty() {
+        return;
+    }
+    let mut rest: Vec<Vec<Seg>> = order
+        .iter()
+        .filter(|p| !block.contains(p))
+        .cloned()
+        .collect();
+    // The anchor is in the order and not in the block, so it is in `rest`.
+    let at = if before {
+        rest.iter()
+            .position(|p| p == &anchor[0])
+            .expect("the anchor's first table is in the rest")
+    } else {
+        rest.iter()
+            .position(|p| p == anchor.last().expect("non-empty"))
+            .expect("the anchor's last table is in the rest")
+            + 1
+    };
+    rest.splice(at..at, block);
+    renumber(doc, &rest);
+}

--- a/crates/leviath-cli/src/blueprint_edit/regions.rs
+++ b/crates/leviath-cli/src/blueprint_edit/regions.rs
@@ -1,0 +1,398 @@
+//! Mutators for context regions (`[context.regions]` and a stage's own
+//! `[stages.<name>.context.regions]`) and for a stage's `tool_routing`.
+//!
+//! Both layouts have the same table schema, so one set of internals serves
+//! both; [`RegionScope`] says which.
+
+use toml_edit::{InlineTable, Item, Value};
+
+use super::doc::ManifestDoc;
+use super::stages::set_or_remove_int;
+use super::tables::{
+    child_mut, ensure_child, get_str, remove_and_report_empty, rename_key, set_bool,
+    set_or_remove_str, set_str,
+};
+use super::{EditError, require_name};
+
+/// Whose regions: the agent's shared layout, or one stage's own.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegionScope {
+    /// `[context.regions]`.
+    Shared,
+    /// `[stages.<name>.context.regions]`.
+    Stage(String),
+}
+
+impl RegionScope {
+    /// The stage name, for [`ManifestDoc::regions`] and friends.
+    pub fn stage(&self) -> Option<&str> {
+        match self {
+            RegionScope::Shared => None,
+            RegionScope::Stage(s) => Some(s),
+        }
+    }
+}
+
+/// The per-region keys the editor writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionField {
+    /// `kind` (never deleted: a region always has one).
+    Kind,
+    /// `budget = "N%"`, 0 to 100.
+    BudgetPercent,
+    /// `max_tokens`, at least 1.
+    MaxTokens,
+    /// `required = true`; off deletes the key.
+    Required,
+    /// `required_message`.
+    RequiredMessage,
+    /// A string `seed`. A table-shaped seed is never touched.
+    Seed,
+    /// `max_items`, at least 1.
+    MaxItems,
+    /// `strategy`.
+    Strategy,
+    /// `overflow`, at least 1.
+    Overflow,
+    /// `description`.
+    Description,
+}
+
+/// A value for a [`RegionField`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegionValue {
+    /// For the text keys; empty deletes.
+    Text(String),
+    /// For the numeric keys; `None` deletes.
+    Number(Option<u64>),
+    /// For `required`.
+    Flag(bool),
+}
+
+impl ManifestDoc {
+    /// Add a region to a layout with starter values (`pinned`, `5%`, `4000`
+    /// tokens), creating `[context.regions]` when the scope has none.
+    pub fn add_region(&mut self, scope: &RegionScope, name: &str) -> Result<(), EditError> {
+        require_name(name)?;
+        let regions = self.regions_item_ensure(scope)?;
+        let table = regions
+            .as_table_like_mut()
+            .expect("regions_item_ensure checked");
+        if table.contains_key(name) {
+            return Err(EditError::Taken(name.to_string()));
+        }
+        let mut region = InlineTable::new();
+        region.insert("kind", Value::from("pinned"));
+        region.insert("budget", Value::from("5%"));
+        region.insert("max_tokens", Value::from(4000));
+        // Inline whichever shape the parent has: a headed `[context.regions]`
+        // lists its regions as one-line inline tables, the way every bundled
+        // agent writes them.
+        table.insert(name, Item::Value(Value::InlineTable(region)));
+        Ok(())
+    }
+
+    /// Rename a region, rewriting the tool routing that named it: every
+    /// stage's for a shared region (except stages with their own layout,
+    /// whose routing names their own regions), that stage's for its own.
+    pub fn rename_region(
+        &mut self,
+        scope: &RegionScope,
+        from: &str,
+        to: &str,
+    ) -> Result<(), EditError> {
+        if from == to {
+            return Ok(());
+        }
+        require_name(to)?;
+        let regions = self
+            .regions_item_mut(scope)
+            .ok_or_else(|| EditError::NoSuchRegion(from.to_string()))?;
+        let table = regions
+            .as_table_like_mut()
+            .expect("regions_item_mut checked");
+        if !table.contains_key(from) {
+            return Err(EditError::NoSuchRegion(from.to_string()));
+        }
+        if table.contains_key(to) {
+            return Err(EditError::Taken(to.to_string()));
+        }
+        rename_key(table, from, to);
+        self.retarget_routing(scope, from, Some(to));
+        Ok(())
+    }
+
+    /// Delete a region, and stop routing tool results into it wherever the
+    /// scope's routing did.
+    pub fn delete_region(&mut self, scope: &RegionScope, name: &str) -> Result<(), EditError> {
+        let regions = self
+            .regions_item_mut(scope)
+            .ok_or_else(|| EditError::NoSuchRegion(name.to_string()))?;
+        let table = regions
+            .as_table_like_mut()
+            .expect("regions_item_mut checked");
+        if table.remove(name).is_none() {
+            return Err(EditError::NoSuchRegion(name.to_string()));
+        }
+        self.retarget_routing(scope, name, None);
+        Ok(())
+    }
+
+    /// Write one key of a region.
+    pub fn set_region_field(
+        &mut self,
+        scope: &RegionScope,
+        name: &str,
+        field: RegionField,
+        value: RegionValue,
+    ) -> Result<(), EditError> {
+        let regions = self
+            .regions_item_mut(scope)
+            .ok_or_else(|| EditError::NoSuchRegion(name.to_string()))?;
+        let region =
+            child_mut(regions, name).ok_or_else(|| EditError::NoSuchRegion(name.to_string()))?;
+        let table = region.as_table_like_mut().expect("child_mut checked");
+        match (field, value) {
+            (RegionField::Kind, RegionValue::Text(kind)) => {
+                if !kind.is_empty() {
+                    set_str(table, "kind", &kind);
+                }
+            }
+            (RegionField::BudgetPercent, RegionValue::Number(Some(pct))) => {
+                set_str(table, "budget", &format!("{}%", pct.min(100)));
+            }
+            (RegionField::BudgetPercent, RegionValue::Number(None)) => {
+                table.remove("budget");
+            }
+            (RegionField::MaxTokens, RegionValue::Number(n)) => {
+                set_or_remove_int(table, "max_tokens", n.map(|n| n.max(1)));
+            }
+            (RegionField::MaxItems, RegionValue::Number(n)) => {
+                set_or_remove_int(table, "max_items", n.map(|n| n.max(1)));
+            }
+            (RegionField::Overflow, RegionValue::Number(n)) => {
+                set_or_remove_int(table, "overflow", n.map(|n| n.max(1)));
+            }
+            (RegionField::Required, RegionValue::Flag(on)) => {
+                if on {
+                    set_bool(table, "required", true);
+                } else {
+                    table.remove("required");
+                }
+            }
+            (RegionField::RequiredMessage, RegionValue::Text(t)) => {
+                set_or_remove_str(table, "required_message", &t);
+            }
+            (RegionField::Strategy, RegionValue::Text(t)) => {
+                set_or_remove_str(table, "strategy", &t)
+            }
+            (RegionField::Description, RegionValue::Text(t)) => {
+                set_or_remove_str(table, "description", &t);
+            }
+            (RegionField::Seed, RegionValue::Text(t)) => {
+                let is_table = table
+                    .get("seed")
+                    .is_some_and(|s| s.as_table_like().is_some());
+                if !t.is_empty() {
+                    set_str(table, "seed", &t);
+                } else if !is_table {
+                    table.remove("seed");
+                }
+            }
+            (field, value) => {
+                return Err(EditError::OutOfRange(format!(
+                    "{field:?} does not take {value:?}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Give a stage its own layout: a deep copy of the shared regions as they
+    /// are now, so it starts from what it inherited. A stage that already
+    /// has one is left alone.
+    pub fn create_stage_override(&mut self, stage: &str) -> Result<(), EditError> {
+        self.require_stage(stage)?;
+        if self.regions_item(Some(stage)).is_some() {
+            return Ok(());
+        }
+        let shared: Option<Item> = self.regions_item(None).cloned();
+        let stage_item = self.stage_item_mut(stage).expect("require_stage checked");
+        let context = ensure_child(stage_item, "context")?;
+        let inline = context.is_inline_table();
+        let regions = match shared {
+            Some(item) if !inline => item,
+            Some(item) => {
+                // An inline `context = {}` needs an inline copy.
+                Item::Value(item.into_value().expect("a table converts to a value"))
+            }
+            None => super::tables::new_table(inline),
+        };
+        context
+            .as_table_like_mut()
+            .expect("ensure_child checked")
+            .insert("regions", regions);
+        Ok(())
+    }
+
+    /// Drop a stage's own layout, `[stages.<name>.context]` and everything in
+    /// it, so it inherits the shared regions again.
+    pub fn remove_stage_override(&mut self, stage: &str) -> Result<(), EditError> {
+        let table = self.stage_table_mut(stage)?;
+        table.remove("context");
+        Ok(())
+    }
+
+    /// Set a stage's default region for tool results; empty removes it (and
+    /// the `tool_routing` table when nothing else keeps it).
+    pub fn set_tool_routing_default(&mut self, stage: &str, region: &str) -> Result<(), EditError> {
+        let stage_item = self
+            .stage_item_mut(stage)
+            .ok_or_else(|| EditError::NoSuchStage(stage.to_string()))?;
+        if region.is_empty() {
+            if let Some(routing) = child_mut(stage_item, "tool_routing")
+                && remove_and_report_empty(
+                    routing.as_table_like_mut().expect("child_mut checked"),
+                    "default_region",
+                )
+            {
+                stage_item
+                    .as_table_like_mut()
+                    .expect("a stage is a table")
+                    .remove("tool_routing");
+            }
+            return Ok(());
+        }
+        let routing = ensure_child(stage_item, "tool_routing")?;
+        set_str(
+            routing.as_table_like_mut().expect("ensure_child checked"),
+            "default_region",
+            region,
+        );
+        Ok(())
+    }
+
+    /// Route one tool's results to a region; an empty region stops routing
+    /// it, tidying emptied `overrides`/`tool_routing` tables away.
+    pub fn set_tool_routing_override(
+        &mut self,
+        stage: &str,
+        tool: &str,
+        region: &str,
+    ) -> Result<(), EditError> {
+        let stage_item = self
+            .stage_item_mut(stage)
+            .ok_or_else(|| EditError::NoSuchStage(stage.to_string()))?;
+        if region.is_empty() {
+            let Some(routing) = child_mut(stage_item, "tool_routing") else {
+                return Ok(());
+            };
+            if let Some(overrides) = child_mut(routing, "overrides")
+                && remove_and_report_empty(
+                    overrides.as_table_like_mut().expect("child_mut checked"),
+                    tool,
+                )
+                && remove_and_report_empty(
+                    routing.as_table_like_mut().expect("child_mut checked"),
+                    "overrides",
+                )
+            {
+                stage_item
+                    .as_table_like_mut()
+                    .expect("a stage is a table")
+                    .remove("tool_routing");
+            }
+            return Ok(());
+        }
+        let routing = ensure_child(stage_item, "tool_routing")?;
+        let overrides = ensure_child(routing, "overrides")?;
+        set_str(
+            overrides.as_table_like_mut().expect("ensure_child checked"),
+            tool,
+            region,
+        );
+        Ok(())
+    }
+
+    /// The scope's `regions` item, mutably, when it exists.
+    fn regions_item_mut(&mut self, scope: &RegionScope) -> Option<&mut Item> {
+        let parent: &mut Item = match scope {
+            RegionScope::Shared => self.doc_mut().as_item_mut(),
+            RegionScope::Stage(name) => self.stage_item_mut(name)?,
+        };
+        let context = child_mut(parent, "context")?;
+        child_mut(context, "regions")
+    }
+
+    /// The scope's `regions` item, created (with `context`) when missing.
+    fn regions_item_ensure(&mut self, scope: &RegionScope) -> Result<&mut Item, EditError> {
+        let parent: &mut Item = match scope {
+            RegionScope::Shared => self.doc_mut().as_item_mut(),
+            RegionScope::Stage(name) => self
+                .stage_item_mut(name)
+                .ok_or_else(|| EditError::NoSuchStage(name.clone()))?,
+        };
+        let context = ensure_child(parent, "context")?;
+        ensure_child(context, "regions")
+    }
+
+    /// Rewrite (or, with `None`, clear) tool-routing references to a region.
+    /// A shared region's rename touches every stage that inherits the shared
+    /// layout; a stage region's touches that stage only.
+    fn retarget_routing(&mut self, scope: &RegionScope, from: &str, to: Option<&str>) {
+        let names = self.stage_names();
+        for name in names {
+            match scope {
+                RegionScope::Stage(s) if s != &name => continue,
+                RegionScope::Shared if self.regions_item(Some(&name)).is_some() => continue,
+                _ => {}
+            }
+            let stage_item = self.stage_item_mut(&name).expect("listed stage exists");
+            let Some(routing) = child_mut(stage_item, "tool_routing") else {
+                continue;
+            };
+            let table = routing.as_table_like_mut().expect("child_mut checked");
+            if get_str(table, "default_region") == Some(from) {
+                match to {
+                    Some(t) => set_str(table, "default_region", t),
+                    None => {
+                        table.remove("default_region");
+                    }
+                }
+            }
+            if let Some(overrides) = child_mut(routing, "overrides") {
+                let o = overrides.as_table_like_mut().expect("child_mut checked");
+                let hits: Vec<String> = o
+                    .iter()
+                    .filter(|(_, v)| v.as_str() == Some(from))
+                    .map(|(k, _)| k.to_string())
+                    .collect();
+                for tool in hits {
+                    match to {
+                        Some(t) => set_str(o, &tool, t),
+                        None => {
+                            o.remove(&tool);
+                        }
+                    }
+                }
+                if to.is_none() && o.is_empty() {
+                    routing
+                        .as_table_like_mut()
+                        .expect("child_mut checked")
+                        .remove("overrides");
+                }
+            }
+            if to.is_none()
+                && routing
+                    .as_table_like()
+                    .expect("child_mut checked")
+                    .is_empty()
+            {
+                stage_item
+                    .as_table_like_mut()
+                    .expect("a stage is a table")
+                    .remove("tool_routing");
+            }
+        }
+    }
+}

--- a/crates/leviath-cli/src/blueprint_edit/stages.rs
+++ b/crates/leviath-cli/src/blueprint_edit/stages.rs
@@ -1,0 +1,430 @@
+//! Mutators for `[agent]` and the `[stages.<name>]` tables.
+
+use toml_edit::{Array, InlineTable, Item, Value};
+
+use super::doc::{ManifestDoc, StageModeView, WorkerKind};
+use super::tables::{
+    as_table, child_mut, ensure_child, get_str, new_table, rename_key, set_bool, set_int,
+    set_or_remove_str, set_str, set_strings,
+};
+use super::{EditError, order, require_name};
+
+/// The free-text keys of a stage the editor writes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StageText {
+    /// `description`.
+    Description,
+    /// `system_prompt`.
+    SystemPrompt,
+    /// `transition_prompt`.
+    TransitionPrompt,
+}
+
+impl StageText {
+    fn key(self) -> &'static str {
+        match self {
+            StageText::Description => "description",
+            StageText::SystemPrompt => "system_prompt",
+            StageText::TransitionPrompt => "transition_prompt",
+        }
+    }
+}
+
+/// One fan-out key of a stage. `None` deletes the key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FanOutField {
+    /// Which of `worker_agent`/`worker_stage`/`worker_query` is written, and
+    /// its value; the other two are removed, because the runtime wants
+    /// exactly one.
+    Worker(Option<(WorkerKind, String)>),
+    /// `merge_stage`.
+    MergeStage(Option<String>),
+    /// `max_workers`.
+    MaxWorkers(Option<u64>),
+    /// `max_items`.
+    MaxItems(Option<u64>),
+    /// `on_worker_failure`.
+    OnWorkerFailure(Option<String>),
+}
+
+const FAN_OUT_KEYS: [&str; 9] = [
+    "worker_agent",
+    "worker_stage",
+    "worker_query",
+    "merge_stage",
+    "max_workers",
+    "max_items",
+    "on_worker_failure",
+    "split_prompt",
+    "results_region",
+];
+
+impl ManifestDoc {
+    /// Set `[agent].name`.
+    pub fn set_agent_name(&mut self, name: &str) -> Result<(), EditError> {
+        require_name(name)?;
+        let agent = self
+            .doc_mut()
+            .get_mut("agent")
+            .and_then(Item::as_table_like_mut)
+            .expect("parse() checked [agent] is a table");
+        set_str(agent, "name", name);
+        Ok(())
+    }
+
+    /// Set `[agent].description`; empty deletes it.
+    pub fn set_description(&mut self, text: &str) {
+        let agent = self
+            .doc_mut()
+            .get_mut("agent")
+            .and_then(Item::as_table_like_mut)
+            .expect("parse() checked [agent] is a table");
+        set_or_remove_str(agent, "description", text);
+    }
+
+    /// Point `[agent].entry_stage` at `stage`, which must exist.
+    pub fn set_entry_stage(&mut self, stage: &str) -> Result<(), EditError> {
+        self.require_stage(stage)?;
+        let agent = self
+            .doc_mut()
+            .get_mut("agent")
+            .and_then(Item::as_table_like_mut)
+            .expect("parse() checked [agent] is a table");
+        set_str(agent, "entry_stage", stage);
+        Ok(())
+    }
+
+    /// Make `model` (`provider/model`) the first model every stage tries,
+    /// keeping the rest of each stage's chain behind it.
+    pub fn set_default_model(&mut self, model: &str) {
+        for stage in self.stages() {
+            let mut chain: Vec<String> = vec![model.to_string()];
+            chain.extend(stage.models.into_iter().filter(|m| m != model));
+            self.set_models(&stage.name, &chain)
+                .expect("a listed stage exists");
+        }
+    }
+
+    /// Add a stage after `after` (or at the end): autonomous, twenty tries,
+    /// nowhere to go yet.
+    pub fn add_stage(&mut self, name: &str, after: Option<&str>) -> Result<(), EditError> {
+        require_name(name)?;
+        if self.stages_key_taken(name) {
+            return Err(EditError::Taken(name.to_string()));
+        }
+        // Without an anchor the new stage goes after the last one; a table
+        // with no position of its own would otherwise be written wherever the
+        // writer last was, which after a reorder is not the end.
+        let after = match after {
+            Some(a) => {
+                self.require_stage(a)?;
+                a.to_string()
+            }
+            None => self
+                .stage_names()
+                .last()
+                .cloned()
+                .expect("parse() checked a stage exists"),
+        };
+        let stages = self
+            .doc_mut()
+            .get_mut("stages")
+            .expect("parse() checked a stage exists");
+        let inline = stages.is_inline_table();
+        let mut stage = new_table(inline);
+        {
+            let table = stage.as_table_like_mut().expect("just built a table");
+            set_str(table, "mode", "autonomous");
+            set_int(table, "max_iterations", 20);
+            table.insert("transitions", new_table(inline));
+        }
+        stages
+            .as_table_like_mut()
+            .expect("parse() checked [stages] is a table")
+            .insert(name, stage);
+        order::move_stage_block(self.doc_mut(), name, &after, false);
+        Ok(())
+    }
+
+    /// Rename a stage, rewriting every path into it, `entry_stage`, and any
+    /// `worker_stage`/`merge_stage` naming it.
+    pub fn rename_stage(&mut self, from: &str, to: &str) -> Result<(), EditError> {
+        if from == to {
+            return Ok(());
+        }
+        require_name(to)?;
+        self.require_stage(from)?;
+        if self.stages_key_taken(to) {
+            return Err(EditError::Taken(to.to_string()));
+        }
+        let names = self.stage_names();
+        let stages = self
+            .doc_mut()
+            .get_mut("stages")
+            .and_then(Item::as_table_like_mut)
+            .expect("parse() checked [stages] is a table");
+        rename_key(stages, from, to);
+        for name in &names {
+            let stage = self
+                .stage_item_mut(if name == from { to } else { name })
+                .expect("every listed stage exists");
+            if let Some(transitions) = child_mut(stage, "transitions") {
+                rename_key(
+                    transitions.as_table_like_mut().expect("child_mut checked"),
+                    from,
+                    to,
+                );
+            }
+            let table = stage.as_table_like_mut().expect("a stage is a table");
+            for key in ["worker_stage", "merge_stage"] {
+                if get_str(table, key) == Some(from) {
+                    set_str(table, key, to);
+                }
+            }
+        }
+        let agent = self
+            .doc_mut()
+            .get_mut("agent")
+            .and_then(Item::as_table_like_mut)
+            .expect("parse() checked [agent] is a table");
+        if get_str(agent, "entry_stage") == Some(from) {
+            set_str(agent, "entry_stage", to);
+        }
+        Ok(())
+    }
+
+    /// Delete a stage and every path into it. Refuses the last stage; deleting
+    /// the entry stage points the entry at the first stage left.
+    pub fn delete_stage(&mut self, name: &str) -> Result<(), EditError> {
+        self.require_stage(name)?;
+        let remaining: Vec<String> = self
+            .stage_names()
+            .into_iter()
+            .filter(|n| n != name)
+            .collect();
+        let Some(first) = remaining.first().cloned() else {
+            return Err(EditError::LastStage);
+        };
+        self.doc_mut()
+            .get_mut("stages")
+            .and_then(Item::as_table_like_mut)
+            .expect("parse() checked [stages] is a table")
+            .remove(name);
+        for other in &remaining {
+            let stage = self.stage_item_mut(other).expect("listed stage exists");
+            if let Some(transitions) = child_mut(stage, "transitions") {
+                transitions
+                    .as_table_like_mut()
+                    .expect("child_mut checked")
+                    .remove(name);
+            }
+        }
+        let agent = self
+            .doc_mut()
+            .get_mut("agent")
+            .and_then(Item::as_table_like_mut)
+            .expect("parse() checked [agent] is a table");
+        if get_str(agent, "entry_stage") == Some(name) {
+            set_str(agent, "entry_stage", &first);
+        }
+        Ok(())
+    }
+
+    /// Swap a stage with its neighbour in the file (`up` = towards the
+    /// start). At either end nothing happens.
+    pub fn move_stage(&mut self, name: &str, up: bool) -> Result<(), EditError> {
+        self.require_stage(name)?;
+        let names = self.stage_names();
+        let index = names.iter().position(|n| n == name).expect("listed");
+        let other = if up {
+            index.checked_sub(1).map(|i| &names[i])
+        } else {
+            names.get(index + 1)
+        };
+        if let Some(other) = other {
+            order::move_stage_block(self.doc_mut(), name, other, up);
+        }
+        Ok(())
+    }
+
+    /// Set a stage's `mode`. Leaving `fan_out` deletes the fan-out keys.
+    pub fn set_stage_mode(&mut self, name: &str, mode: &StageModeView) -> Result<(), EditError> {
+        let stage = self.stage_table_mut(name)?;
+        set_str(stage, "mode", mode.as_str());
+        if *mode != StageModeView::FanOut {
+            for key in FAN_OUT_KEYS {
+                stage.remove(key);
+            }
+        }
+        Ok(())
+    }
+
+    /// Set one of a stage's text keys; empty deletes it.
+    pub fn set_stage_text(
+        &mut self,
+        name: &str,
+        which: StageText,
+        text: &str,
+    ) -> Result<(), EditError> {
+        let stage = self.stage_table_mut(name)?;
+        set_or_remove_str(stage, which.key(), text);
+        Ok(())
+    }
+
+    /// Set `max_iterations` (at least 1); `None` deletes it.
+    pub fn set_max_iterations(&mut self, name: &str, value: Option<u64>) -> Result<(), EditError> {
+        let stage = self.stage_table_mut(name)?;
+        match value {
+            Some(n) => set_int(stage, "max_iterations", clamp_i64(n.max(1))),
+            None => {
+                stage.remove("max_iterations");
+            }
+        }
+        Ok(())
+    }
+
+    /// Set `max_revisits`; `None` deletes it.
+    pub fn set_max_revisits(&mut self, name: &str, value: Option<u64>) -> Result<(), EditError> {
+        let stage = self.stage_table_mut(name)?;
+        match value {
+            Some(n) => set_int(stage, "max_revisits", clamp_i64(n)),
+            None => {
+                stage.remove("max_revisits");
+            }
+        }
+        Ok(())
+    }
+
+    /// Set `allow_complete`; `None` deletes it (the runtime's default).
+    pub fn set_allow_complete(&mut self, name: &str, value: Option<bool>) -> Result<(), EditError> {
+        let stage = self.stage_table_mut(name)?;
+        match value {
+            Some(b) => set_bool(stage, "allow_complete", b),
+            None => {
+                stage.remove("allow_complete");
+            }
+        }
+        Ok(())
+    }
+
+    /// Set a stage's model chain (`provider/model` each) as
+    /// `model = { models = [...] }`, keeping any other key of an existing
+    /// `model` table. An empty chain deletes `model`.
+    pub fn set_models(&mut self, name: &str, chain: &[String]) -> Result<(), EditError> {
+        let stage = self.stage_table_mut(name)?;
+        if chain.is_empty() {
+            stage.remove("model");
+            return Ok(());
+        }
+        let mut models = Array::new();
+        for entry in chain {
+            let (provider, model) = entry.split_once('/').unwrap_or(("", entry.as_str()));
+            let mut t = InlineTable::new();
+            t.insert("provider", Value::from(provider));
+            t.insert("model", Value::from(model));
+            models.push(Value::InlineTable(t));
+        }
+        let keeps_table = stage
+            .get("model")
+            .is_some_and(|m| m.as_table_like().is_some());
+        if !keeps_table {
+            stage.insert("model", Item::Value(Value::InlineTable(InlineTable::new())));
+        }
+        let model = stage
+            .get_mut("model")
+            .and_then(Item::as_table_like_mut)
+            .expect("a table now");
+        model.insert("models", Item::Value(Value::Array(models)));
+        Ok(())
+    }
+
+    /// Set `available_tools`; an empty list deletes it.
+    pub fn set_tools(&mut self, name: &str, tools: &[String]) -> Result<(), EditError> {
+        let stage = self.stage_table_mut(name)?;
+        if tools.is_empty() {
+            stage.remove("available_tools");
+        } else {
+            set_strings(stage, "available_tools", tools);
+        }
+        Ok(())
+    }
+
+    /// Set one fan-out key of a stage.
+    pub fn set_fan_out(&mut self, name: &str, field: FanOutField) -> Result<(), EditError> {
+        let stage = self.stage_table_mut(name)?;
+        match field {
+            FanOutField::Worker(worker) => {
+                for kind in [WorkerKind::Agent, WorkerKind::Stage, WorkerKind::Query] {
+                    stage.remove(kind.key());
+                }
+                if let Some((kind, value)) = worker {
+                    set_str(stage, kind.key(), &value);
+                }
+            }
+            FanOutField::MergeStage(v) => {
+                set_or_remove_str(stage, "merge_stage", v.as_deref().unwrap_or(""))
+            }
+            FanOutField::MaxWorkers(v) => set_or_remove_int(stage, "max_workers", v),
+            FanOutField::MaxItems(v) => set_or_remove_int(stage, "max_items", v),
+            FanOutField::OnWorkerFailure(v) => {
+                set_or_remove_str(stage, "on_worker_failure", v.as_deref().unwrap_or(""))
+            }
+        }
+        Ok(())
+    }
+
+    /// The stage's table, mutably, or [`EditError::NoSuchStage`].
+    pub(super) fn stage_table_mut(
+        &mut self,
+        name: &str,
+    ) -> Result<&mut dyn toml_edit::TableLike, EditError> {
+        let item = self
+            .stage_item_mut(name)
+            .ok_or_else(|| EditError::NoSuchStage(name.to_string()))?;
+        Ok(item.as_table_like_mut().expect("stage_item_mut checked"))
+    }
+
+    /// The stage's `transitions` table, created when missing. The stage must
+    /// exist (callers check).
+    pub(super) fn transitions_mut(&mut self, name: &str) -> Result<&mut Item, EditError> {
+        let item = self
+            .stage_item_mut(name)
+            .expect("callers check the stage exists");
+        ensure_child(item, "transitions")
+    }
+
+    pub(super) fn require_stage(&self, name: &str) -> Result<(), EditError> {
+        if self.has_stage(name) {
+            Ok(())
+        } else {
+            Err(EditError::NoSuchStage(name.to_string()))
+        }
+    }
+
+    /// Whether the agent's `[stages]` holds `name` as any kind of value (a
+    /// non-table entry still takes the key).
+    pub(super) fn stages_key_taken(&self, name: &str) -> bool {
+        self.doc()
+            .get("stages")
+            .and_then(as_table)
+            .is_some_and(|t| t.contains_key(name))
+    }
+}
+
+pub(super) fn set_or_remove_int(
+    table: &mut dyn toml_edit::TableLike,
+    key: &str,
+    value: Option<u64>,
+) {
+    match value {
+        Some(n) => set_int(table, key, clamp_i64(n)),
+        None => {
+            table.remove(key);
+        }
+    }
+}
+
+/// TOML integers are signed 64-bit; anything bigger is written as the top.
+pub(super) fn clamp_i64(n: u64) -> i64 {
+    n.min(i64::MAX as u64) as i64
+}

--- a/crates/leviath-cli/src/blueprint_edit/tables.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tables.rs
@@ -1,0 +1,179 @@
+//! Reading and writing table-shaped TOML without caring which of the two
+//! shapes it is in.
+//!
+//! A manifest writes the same thing two ways: `[stages.plan.transitions.x]`
+//! as a table with a header, or `transitions = { x = { hint = "..." } }`
+//! inline. `toml_edit` keeps them as different types (`Table` and
+//! `InlineTable`) behind one trait, `TableLike`. Everything here works on the
+//! trait, and when it has to create a child it creates one of the parent's
+//! shape, so an edit never turns an author's inline table into a headed one
+//! or the other way round.
+
+use toml_edit::{Array, InlineTable, Item, Key, Table, TableLike, Value};
+
+use super::EditError;
+
+/// The table an item is, if it is one.
+pub(super) fn as_table(item: &Item) -> Option<&dyn TableLike> {
+    item.as_table_like()
+}
+
+/// A child of `item` that is itself a table.
+pub(super) fn child<'a>(item: &'a Item, key: &str) -> Option<&'a dyn TableLike> {
+    item.as_table_like()
+        .and_then(|t| t.get(key))
+        .and_then(Item::as_table_like)
+}
+
+/// A child of `item` that is a table, mutably.
+pub(super) fn child_mut<'a>(item: &'a mut Item, key: &str) -> Option<&'a mut Item> {
+    item.as_table_like_mut()
+        .and_then(|t| t.get_mut(key))
+        .filter(|c| c.as_table_like().is_some())
+}
+
+/// The child table `key` of `item` (which must be a table), created (empty,
+/// in the parent's shape) when missing. Refuses when the key holds
+/// something that is not a table.
+pub(super) fn ensure_child<'a>(item: &'a mut Item, key: &str) -> Result<&'a mut Item, EditError> {
+    let inline = item.is_inline_table();
+    let table = item.as_table_like_mut().expect("callers pass a table");
+    if !table.contains_key(key) {
+        table.insert(key, new_table(inline));
+    }
+    let child = table.get_mut(key).expect("inserted or present just above");
+    if child.as_table_like().is_none() {
+        return Err(EditError::NotATable(key.to_string()));
+    }
+    Ok(child)
+}
+
+/// An empty table of the shape a parent uses.
+pub(super) fn new_table(inline: bool) -> Item {
+    if inline {
+        Item::Value(Value::InlineTable(InlineTable::new()))
+    } else {
+        let mut table = Table::new();
+        table.set_implicit(false);
+        Item::Table(table)
+    }
+}
+
+/// A string value under `key`, when it is one.
+pub(super) fn get_str<'a>(table: &'a dyn TableLike, key: &str) -> Option<&'a str> {
+    table.get(key)?.as_str()
+}
+
+/// An integer under `key`, when it is one.
+pub(super) fn get_int(table: &dyn TableLike, key: &str) -> Option<i64> {
+    table.get(key)?.as_integer()
+}
+
+/// A boolean under `key`, when it is one.
+pub(super) fn get_bool(table: &dyn TableLike, key: &str) -> Option<bool> {
+    table.get(key)?.as_bool()
+}
+
+/// The strings of an array under `key`; anything else in it is skipped.
+pub(super) fn get_strings(table: &dyn TableLike, key: &str) -> Vec<String> {
+    table
+        .get(key)
+        .and_then(Item::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(Value::as_str)
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Write a string, or remove the key when it is empty: an absent key and an
+/// empty string mean the same thing to the runtime, and absent keeps the
+/// file tidy.
+pub(super) fn set_or_remove_str(table: &mut dyn TableLike, key: &str, value: &str) {
+    if value.is_empty() {
+        table.remove(key);
+    } else {
+        set_str(table, key, value);
+    }
+}
+
+/// Write a string, keeping the key's place when it already exists.
+pub(super) fn set_str(table: &mut dyn TableLike, key: &str, value: &str) {
+    replace_value(table, key, Value::from(value));
+}
+
+/// Write an integer, keeping the key's place when it already exists.
+pub(super) fn set_int(table: &mut dyn TableLike, key: &str, value: i64) {
+    replace_value(table, key, Value::from(value));
+}
+
+/// Write a boolean, keeping the key's place when it already exists.
+pub(super) fn set_bool(table: &mut dyn TableLike, key: &str, value: bool) {
+    replace_value(table, key, Value::from(value));
+}
+
+/// Write an array of strings, keeping the key's place when it exists.
+pub(super) fn set_strings(table: &mut dyn TableLike, key: &str, values: &[String]) {
+    let mut array = Array::new();
+    for v in values {
+        array.push(v.as_str());
+    }
+    replace_value(table, key, Value::Array(array));
+}
+
+/// Put `value` under `key` in place: an existing value keeps its position
+/// and its surrounding whitespace, a new one goes at the end.
+fn replace_value(table: &mut dyn TableLike, key: &str, mut value: Value) {
+    if let Some(existing) = table.get_mut(key).and_then(Item::as_value_mut) {
+        // Keep the author's spacing around the old value.
+        *value.decor_mut() = existing.decor().clone();
+        *existing = value;
+    } else {
+        table.insert(key, Item::Value(value));
+    }
+}
+
+/// Rename a key in place: the entry keeps its position among its siblings
+/// and the comments above it. `false` when `from` is not there.
+pub(super) fn rename_key(table: &mut dyn TableLike, from: &str, to: &str) -> bool {
+    if !table.contains_key(from) {
+        return false;
+    }
+    let entries: Vec<(Key, Item)> = table
+        .iter()
+        .map(|(name, item)| {
+            let key = table.key(name).expect("iterated key exists").clone();
+            (key, item.clone())
+        })
+        .collect();
+    table.clear();
+    for (key, item) in entries {
+        let key = if key.get() == from {
+            Key::new(to).with_leaf_decor(key.leaf_decor().clone())
+        } else {
+            key
+        };
+        table.entry_format(&key).or_insert(item);
+    }
+    true
+}
+
+/// Remove `key` and, when that leaves the table empty, say so.
+pub(super) fn remove_and_report_empty(table: &mut dyn TableLike, key: &str) -> bool {
+    table.remove(key);
+    table.is_empty()
+}
+
+/// The names of the child tables of `item`, in document order.
+pub(super) fn table_keys(item: &Item) -> Vec<String> {
+    item.as_table_like()
+        .map(|t| {
+            t.iter()
+                .filter(|(_, v)| v.as_table_like().is_some())
+                .map(|(k, _)| k.to_string())
+                .collect()
+        })
+        .unwrap_or_default()
+}

--- a/crates/leviath-cli/src/blueprint_edit/templates.rs
+++ b/crates/leviath-cli/src/blueprint_edit/templates.rs
@@ -1,0 +1,44 @@
+//! Where a new agent starts: a two-stage starter, or a copy of one that
+//! exists.
+
+use super::{EditError, ManifestDoc};
+
+/// The smallest agent that does something: `work` then `finish`, with
+/// placeholder prompts. The same starter The Lair's "Start simple" gives.
+pub fn empty_blueprint(name: &str) -> Result<String, EditError> {
+    let mut doc = ManifestDoc::parse(EMPTY).expect("the starter is a valid manifest");
+    doc.set_agent_name(name)?;
+    Ok(doc.to_toml())
+}
+
+const EMPTY: &str = r#"[agent]
+name = "my-agent"
+version = "0.0.1"
+description = "Describe what this agent does."
+entry_stage = "work"
+
+[stages.work]
+mode = "autonomous"
+description = "Do the task"
+max_iterations = 25
+system_prompt = "You are a capable, careful agent. Work on the task you were given step by step, and verify your work as you go."
+
+[stages.work.transitions.finish]
+hint = "The work is done and verified"
+
+[stages.finish]
+mode = "autonomous"
+description = "Wrap up and report"
+max_iterations = 5
+system_prompt = "Summarize what was done, what changed, and anything left open."
+
+[stages.finish.transitions]
+"#;
+
+/// A copy of an existing manifest under a new name: only `[agent].name`
+/// changes.
+pub fn clone_of(text: &str, new_name: &str) -> Result<String, EditError> {
+    let mut doc = ManifestDoc::parse(text)?;
+    doc.set_agent_name(new_name)?;
+    Ok(doc.to_toml())
+}

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -1,0 +1,1659 @@
+//! The editing model, exercised on the bundled agents and on the starter.
+
+use super::check::{Severity, check};
+use super::*;
+use crate::bundled::BUNDLED_AGENTS;
+
+fn bundled_text(name: &str) -> &'static str {
+    let agent = BUNDLED_AGENTS
+        .iter()
+        .find(|a| a.name == name)
+        .expect("bundled agent exists");
+    catalog::bundled_manifest(agent)
+}
+
+fn coder() -> ManifestDoc {
+    ManifestDoc::parse(bundled_text("coder")).expect("coder parses")
+}
+
+fn reviewer() -> ManifestDoc {
+    ManifestDoc::parse(bundled_text("reviewer")).expect("reviewer parses")
+}
+
+fn starter() -> ManifestDoc {
+    ManifestDoc::parse(&templates::empty_blueprint("demo").unwrap()).unwrap()
+}
+
+/// The manifest re-read by the runtime after an edit: every mutator must
+/// leave something it accepts.
+fn runtime_ok(doc: &ManifestDoc) -> leviath_core::Blueprint {
+    let text = doc.to_toml();
+    doc.blueprint()
+        .unwrap_or_else(|e| panic!("the runtime rejected the edited manifest: {e}\n{text}"))
+}
+
+#[test]
+fn names_are_the_runtimes_charset() {
+    for ok in ["plan", "error_recovery", "v1.2", "step-3", "A9"] {
+        assert!(is_valid_name(ok), "{ok}");
+        assert_eq!(require_name(ok), Ok(()));
+    }
+    for bad in ["", "two words", "naïve", "a/b", "tab\t"] {
+        assert!(!is_valid_name(bad), "{bad:?}");
+        assert_eq!(require_name(bad), Err(EditError::BadName(bad.to_string())));
+    }
+}
+
+#[test]
+fn errors_read_as_sentences() {
+    assert_eq!(
+        EditError::Taken("plan".into()).to_string(),
+        "\"plan\" is already taken"
+    );
+    assert_eq!(
+        EditError::NoSuchEdge("a".into(), "b".into()).to_string(),
+        "there is no path from \"a\" to \"b\""
+    );
+    assert_eq!(
+        EditError::LastStage.to_string(),
+        "an agent needs at least one stage"
+    );
+    assert_eq!(
+        EditError::NoStages.to_string(),
+        "the manifest has no stages"
+    );
+    assert_eq!(
+        EditError::NoAgent.to_string(),
+        "the manifest has no [agent] table"
+    );
+    assert_eq!(
+        EditError::NoSuchRegion("r".into()).to_string(),
+        "there is no region named \"r\""
+    );
+    assert_eq!(
+        EditError::NotATable("k".into()).to_string(),
+        "`k` is not a table this editor can write into"
+    );
+    assert_eq!(EditError::OutOfRange("x".into()).to_string(), "x");
+    assert!(
+        EditError::BadName("a b".into())
+            .to_string()
+            .contains("will not work as a name")
+    );
+    assert_eq!(
+        EditError::NoSuchStage("s".into()).to_string(),
+        "there is no stage named \"s\""
+    );
+}
+
+// ─── parse and round-trip ────────────────────────────────────────────────────
+
+#[test]
+fn every_bundled_manifest_round_trips_byte_for_byte() {
+    for agent in BUNDLED_AGENTS {
+        let text = catalog::bundled_manifest(agent);
+        let doc = ManifestDoc::parse(text).expect(agent.name);
+        assert_eq!(
+            doc.to_toml(),
+            text,
+            "{} changed on the way through",
+            agent.name
+        );
+        let bp = runtime_ok(&doc);
+        assert_eq!(bp.name, agent.name);
+        // The views see every stage the runtime sees.
+        let mut names = doc.stage_names();
+        names.sort();
+        let mut runtime: Vec<String> = bp.stages.iter().map(|s| s.name.clone()).collect();
+        runtime.sort();
+        assert_eq!(names, runtime, "{}", agent.name);
+    }
+}
+
+#[test]
+fn parse_refuses_what_the_editor_cannot_stand_on() {
+    assert!(matches!(
+        ManifestDoc::parse("not = [toml"),
+        Err(EditError::Toml(_))
+    ));
+    assert_eq!(
+        ManifestDoc::parse("[stages.a]\nmode = \"autonomous\"\n").unwrap_err(),
+        EditError::NoAgent
+    );
+    assert_eq!(
+        ManifestDoc::parse("agent = 3\n[stages.a]\n").unwrap_err(),
+        EditError::NoAgent
+    );
+    assert_eq!(
+        ManifestDoc::parse("[agent]\nname = \"x\"\n").unwrap_err(),
+        EditError::NoStages
+    );
+    assert_eq!(
+        ManifestDoc::parse("[agent]\nname = \"x\"\n[stages]\nplan = 3\n").unwrap_err(),
+        EditError::NoStages
+    );
+    let err = ManifestDoc::parse("not = [toml").unwrap_err().to_string();
+    assert!(err.starts_with("not valid TOML: "), "{err}");
+}
+
+#[test]
+fn the_views_read_the_coder_the_way_the_lair_does() {
+    let doc = coder();
+    let agent = doc.agent();
+    assert_eq!(agent.name, "coder");
+    assert_eq!(agent.version, "0.1.0");
+    assert_eq!(agent.entry_stage.as_deref(), Some("discover"));
+    assert!(agent.description.starts_with("Coding agent"));
+    assert_eq!(
+        agent.default_model, None,
+        "stages start with different models"
+    );
+
+    let names = doc.stage_names();
+    assert_eq!(names[0], "discover");
+    assert_eq!(names[1], "plan");
+    assert!(names.contains(&"summary".to_string()));
+
+    let discover = doc.stage("discover").unwrap();
+    assert_eq!(discover.mode, StageModeView::Autonomous);
+    assert_eq!(discover.max_iterations, Some(8));
+    assert_eq!(discover.max_revisits, Some(2));
+    assert_eq!(discover.models[0], "anthropic/claude-sonnet-5");
+    assert_eq!(discover.models.len(), 5);
+    assert_eq!(
+        discover.tools,
+        ["read_file", "list_dir", "bash", "context_write"]
+    );
+    assert!(discover.system_prompt.contains("Before any planning"));
+    assert!(!discover.is_terminal);
+    assert!(!discover.has_own_layout);
+    assert_eq!(discover.allow_complete, None);
+    assert_eq!(discover.fan_out, FanOutView::default());
+
+    let plan = doc.stage("plan").unwrap();
+    assert_eq!(plan.mode, StageModeView::InteractivePoints);
+
+    let edges = doc.edges();
+    let to_plan = edges
+        .iter()
+        .find(|e| e.from == "discover" && e.to == "plan")
+        .unwrap();
+    assert_eq!(to_plan.kind, EdgeKind::Hint);
+    assert_eq!(to_plan.transform, TransformKind::Direct);
+    assert!(!to_plan.gated);
+    let recovery = doc.edge("discover", "error_recovery").unwrap();
+    assert_eq!(recovery.kind, EdgeKind::Error);
+    let dead = doc.edge("discover", "summary").unwrap();
+    assert_eq!(dead.kind, EdgeKind::DeadEnd);
+    let review = doc.edge("implement", "review").unwrap();
+    assert!(review.gated);
+    assert_eq!(review.transform, TransformKind::Compact);
+    let reassess = doc.edge("implement", "reassess").unwrap();
+    assert_eq!(reassess.kind, EdgeKind::Stuck);
+    assert_eq!(reassess.transform, TransformKind::Custom);
+    assert!(reassess.rules.present);
+    assert!(reassess.rules.carry.contains(&"plan".to_string()));
+    assert_eq!(reassess.rules.compact, ["conversation"]);
+    assert_eq!(reassess.rules.clear, ["scratch"]);
+    assert!(
+        reassess
+            .rules
+            .compact_prompt
+            .starts_with("Summarize what was attempted")
+    );
+    assert!(doc.edge("discover", "nowhere").is_none());
+    assert!(doc.edge("nowhere", "plan").is_none());
+
+    let shared = doc.effective_regions(None);
+    assert!(shared.inherited);
+    let task = shared.regions.iter().find(|r| r.name == "task").unwrap();
+    assert_eq!(task.kind, "pinned");
+    assert_eq!(task.budget_percent, Some(2.0));
+    assert_eq!(task.max_tokens, Some(4000));
+    assert!(task.required);
+    assert!(task.required_message.starts_with("Describe the task"));
+    let conventions = shared
+        .regions
+        .iter()
+        .find(|r| r.name == "conventions")
+        .unwrap();
+    assert!(conventions.seed_is_table);
+    assert_eq!(conventions.seed, "");
+    let constraints = shared
+        .regions
+        .iter()
+        .find(|r| r.name == "constraints")
+        .unwrap();
+    assert_eq!(constraints.seed, "constraints");
+    assert!(!constraints.seed_is_table);
+    // A stage without its own layout inherits.
+    assert!(doc.effective_regions(Some("plan")).inherited);
+    assert_eq!(doc.region(None, "task").unwrap().name, "task");
+    assert!(doc.region(None, "nope").is_none());
+    assert!(doc.regions(Some("plan")).is_empty());
+
+    let routing = doc.tool_routing("discover");
+    assert_eq!(routing.default_region.as_deref(), Some("conversation"));
+    assert!(
+        routing
+            .overrides
+            .contains(&("read_file".to_string(), "codebase".to_string()))
+    );
+    assert_eq!(doc.tool_routing("nowhere"), ToolRouting::default());
+    let into_codebase = doc.stages_routing_into("codebase");
+    assert!(into_codebase.contains(&"discover".to_string()));
+    assert!(doc.stages_routing_into("no-such-region").is_empty());
+
+    let tools = doc.known_tools();
+    assert!(tools.contains(&"read_file".to_string()));
+    assert!(tools.windows(2).all(|w| w[0] < w[1]), "sorted, deduped");
+    let models = doc.known_models();
+    assert!(models.contains(&"anthropic/claude-opus-5".to_string()));
+    assert!(models.windows(2).all(|w| w[0] < w[1]));
+}
+
+#[test]
+fn the_reviewer_shows_its_fan_out_and_worker() {
+    let doc = reviewer();
+    let split = doc.stage("split_review").unwrap();
+    assert_eq!(split.mode, StageModeView::FanOut);
+    assert_eq!(
+        split.fan_out.worker,
+        Some((WorkerKind::Stage, "review_worker".to_string()))
+    );
+    assert_eq!(split.fan_out.merge_stage.as_deref(), Some("deep_review"));
+    let worker = doc.stage("review_worker").unwrap();
+    assert!(worker.is_terminal);
+}
+
+#[test]
+fn a_bare_string_model_and_odd_shapes_read_gently() {
+    let doc = ManifestDoc::parse(
+        r#"[agent]
+name = "odd"
+[stages.a]
+model = "gpt-4"
+mode = "weird"
+[stages.a.transitions.b]
+condition = "someday"
+[stages.a.transitions.c]
+[stages.b]
+model = { provider = "anthropic", model = "old-form" }
+[stages.c]
+model = 3
+[stages.c.transitions]
+"#,
+    )
+    .unwrap();
+    let a = doc.stage("a").unwrap();
+    assert_eq!(a.models, ["gpt-4"]);
+    assert_eq!(a.mode, StageModeView::Other("weird".into()));
+    assert_eq!(a.mode.as_str(), "weird");
+    assert_eq!(a.mode.label(), "weird");
+    // The unknown condition is left out; the bare table reads as the model's
+    // choice.
+    let edges = doc.edges();
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].to, "c");
+    assert_eq!(edges[0].kind, EdgeKind::LlmChoice);
+    assert!(doc.edge("a", "b").is_none());
+    assert!(doc.stage("b").unwrap().models.is_empty(), "no models list");
+    assert!(doc.stage("c").unwrap().models.is_empty());
+    assert_eq!(doc.agent().default_model, None);
+    assert_eq!(doc.agent().entry_stage, None);
+    assert!(doc.stage("ghost").is_none());
+    assert!(doc.edge("b", "c").is_none(), "b has no transitions table");
+    assert!(doc.regions(Some("ghost")).is_empty());
+    assert!(doc.region(Some("ghost"), "x").is_none());
+    assert!(doc.regions(Some("b")).is_empty(), "no context table");
+    assert!(doc.blueprint().is_err(), "the runtime rejects the odd mode");
+    let mut odd = doc.clone();
+    odd.rename_stage("c", "d").unwrap();
+    assert!(odd.edge("a", "d").is_some());
+    odd.delete_stage("d").unwrap();
+    assert!(odd.edge("a", "d").is_none());
+    assert_eq!(odd.stage_names(), ["a", "b"]);
+    // Odder shapes: model entries missing a half, a non-table path, an
+    // override that is not a string, a budget that is not a percentage, an
+    // unreadable `stages` value, a stage whose transitions are not a table.
+    let odder = ManifestDoc::parse(
+        r#"[agent]
+name = "odder"
+[context.regions]
+r = { kind = "pinned", budget = "lots" }
+[stages.a]
+model = { models = [3, { provider = "x" }, { model = "y" }, { provider = "p", model = "m" }] }
+transitions = { b = 3, c = { hint = "go" } }
+[stages.a.tool_routing.overrides]
+bash = 3
+read_file = "r"
+[stages.c]
+transitions = 4
+"#,
+    )
+    .unwrap();
+    assert_eq!(odder.stage("a").unwrap().models, ["p/m"]);
+    let edges = odder.edges();
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].to, "c");
+    assert_eq!(
+        odder.tool_routing("a").overrides,
+        [("read_file".to_string(), "r".to_string())]
+    );
+    assert_eq!(odder.region(None, "r").unwrap().budget_percent, None);
+    let mut odder = odder;
+    assert_eq!(
+        odder.set_edge_hint("c", "a", "x"),
+        Err(EditError::NoSuchEdge("c".into(), "a".into())),
+        "transitions is not a table"
+    );
+    assert_eq!(
+        odder.set_edge_hint("b", "a", "x"),
+        Err(EditError::NoSuchEdge("b".into(), "a".into())),
+        "no such stage reads as no such path"
+    );
+    assert_eq!(
+        odder.set_edge_gate("a", "ghost", true),
+        Err(EditError::NoSuchEdge("a".into(), "ghost".into()))
+    );
+    assert_eq!(
+        ManifestDoc::parse("stages = 3\n[agent]\nname = \"x\"\n").unwrap_err(),
+        EditError::NoStages
+    );
+}
+
+#[test]
+fn enums_spell_and_label_themselves() {
+    for kind in EdgeKind::CHOICES {
+        assert!(!kind.label().is_empty());
+        assert!(!kind.short().is_empty());
+        match kind.condition() {
+            Some(c) => assert_eq!(EdgeKind::from_condition(c), Some(kind)),
+            None => assert_eq!(kind, EdgeKind::Hint),
+        }
+    }
+    assert_eq!(EdgeKind::from_condition("nope"), None);
+    for mode in StageModeView::CHOICES {
+        assert_eq!(StageModeView::parse(mode.as_str()), mode);
+        assert!(!mode.label().is_empty());
+    }
+    assert_eq!(
+        StageModeView::parse("interactive"),
+        StageModeView::Interactive
+    );
+    assert_eq!(StageModeView::Interactive.label(), "Interactive");
+    assert_eq!(StageModeView::Interactive.as_str(), "interactive");
+    for t in TransformKind::CHOICES {
+        assert_eq!(TransformKind::parse(t.as_str()), t);
+        assert!(!t.label().is_empty());
+    }
+    assert_eq!(TransformKind::parse(""), TransformKind::Direct);
+    assert_eq!(TransformKind::parse("summarize"), TransformKind::Compact);
+    let other = TransformKind::parse("teleport");
+    assert_eq!(other, TransformKind::Other("teleport".into()));
+    assert_eq!(other.as_str(), "teleport");
+    assert_eq!(other.label(), "teleport");
+    assert_eq!(WorkerKind::Agent.key(), "worker_agent");
+    assert_eq!(WorkerKind::Query.key(), "worker_query");
+    for rule in Rule::ALL {
+        assert!(!rule.label().is_empty());
+        assert!(!rule.key().is_empty());
+    }
+    assert_eq!(RegionScope::Shared.stage(), None);
+    assert_eq!(RegionScope::Stage("a".into()).stage(), Some("a"));
+    assert_eq!(Severity::Warning.tag(), "warning");
+    assert_eq!(Severity::Note.tag(), "note");
+    assert_eq!(Severity::Error.tag(), "error");
+    assert_eq!(catalog::Source::Configured.as_str(), "configured");
+    assert_eq!(catalog::Source::Local.as_str(), "local");
+    assert_eq!(catalog::Source::Installed.as_str(), "installed");
+    assert_eq!(catalog::Source::Bundled.as_str(), "bundled");
+}
+
+// ─── agent and stage mutators ────────────────────────────────────────────────
+
+#[test]
+fn agent_level_edits() {
+    let mut doc = starter();
+    doc.set_agent_name("renamed").unwrap();
+    assert_eq!(doc.agent().name, "renamed");
+    assert_eq!(
+        doc.set_agent_name("two words"),
+        Err(EditError::BadName("two words".into()))
+    );
+    doc.set_description("Does things");
+    assert_eq!(doc.agent().description, "Does things");
+    doc.set_description("");
+    assert_eq!(doc.agent().description, "");
+    let text = doc.to_toml();
+    let agent_table = text.split("[stages").next().unwrap();
+    assert!(
+        !agent_table.contains("description ="),
+        "empty deletes the key: {agent_table}"
+    );
+    doc.set_entry_stage("finish").unwrap();
+    assert_eq!(doc.agent().entry_stage.as_deref(), Some("finish"));
+    assert_eq!(
+        doc.set_entry_stage("nope"),
+        Err(EditError::NoSuchStage("nope".into()))
+    );
+    // A default model rewrites every stage's chain, keeping the rest behind.
+    doc.set_models("work", &["openai/gpt-5".into(), "anthropic/x".into()])
+        .unwrap();
+    doc.set_default_model("anthropic/x");
+    assert_eq!(doc.agent().default_model.as_deref(), Some("anthropic/x"));
+    assert_eq!(
+        doc.stage("work").unwrap().models,
+        ["anthropic/x", "openai/gpt-5"]
+    );
+    assert_eq!(doc.stage("finish").unwrap().models, ["anthropic/x"]);
+    runtime_ok(&doc);
+}
+
+#[test]
+fn stages_are_added_in_place_and_refused_when_wrong() {
+    let mut doc = starter();
+    doc.add_stage("review", Some("work")).unwrap();
+    assert_eq!(doc.stage_names(), ["work", "review", "finish"]);
+    let review = doc.stage("review").unwrap();
+    assert_eq!(review.mode, StageModeView::Autonomous);
+    assert_eq!(review.max_iterations, Some(20));
+    assert!(review.is_terminal, "nowhere to go yet");
+    // The file shows it between the two, and the runtime reads it.
+    let text = doc.to_toml();
+    let work = text.find("[stages.work]").unwrap();
+    let rev = text.find("[stages.review]").unwrap();
+    let fin = text.find("[stages.finish]").unwrap();
+    assert!(work < rev && rev < fin, "{text}");
+    runtime_ok(&doc);
+    doc.add_stage("last", None).unwrap();
+    assert_eq!(doc.stage_names(), ["work", "review", "finish", "last"]);
+    // Refusals leave the document alone.
+    let before = doc.to_toml();
+    assert_eq!(
+        doc.add_stage("review", None),
+        Err(EditError::Taken("review".into()))
+    );
+    assert_eq!(
+        doc.add_stage("bad name", None),
+        Err(EditError::BadName("bad name".into()))
+    );
+    assert_eq!(
+        doc.add_stage("x", Some("ghost")),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    assert_eq!(doc.to_toml(), before);
+    // Re-read: the positions survive a round trip.
+    let again = ManifestDoc::parse(&doc.to_toml()).unwrap();
+    assert_eq!(again.stage_names(), ["work", "review", "finish", "last"]);
+}
+
+#[test]
+fn renaming_a_stage_rewrites_what_names_it() {
+    let mut doc = reviewer();
+    doc.rename_stage("review_worker", "checker").unwrap();
+    assert!(doc.has_stage("checker") && !doc.has_stage("review_worker"));
+    assert_eq!(
+        doc.stage("split_review").unwrap().fan_out.worker,
+        Some((WorkerKind::Stage, "checker".to_string()))
+    );
+    doc.rename_stage("discover", "orient").unwrap();
+    assert_eq!(doc.agent().entry_stage.as_deref(), Some("orient"));
+    // Paths into the renamed stage follow it; the file order does not move.
+    doc.rename_stage("report", "wrap_up").unwrap();
+    assert!(doc.edge("deep_review", "wrap_up").is_some());
+    assert!(doc.edge("deep_review", "report").is_none());
+    let names = doc.stage_names();
+    assert_eq!(names[0], "orient");
+    assert_eq!(
+        names.last().map(String::as_str),
+        doc.stage_names().last().map(String::as_str)
+    );
+    // The comment above the renamed stage's header is still above it.
+    let text = doc.to_toml();
+    assert!(text.contains("# ─── Stage 1: Discover"), "{text}");
+    let comment = text.find("# ─── Stage 1: Discover").unwrap();
+    let header = text.find("[stages.orient]").unwrap();
+    assert!(comment < header, "{text}");
+    let between = text.get(comment..header).unwrap();
+    assert!(between.matches('\n').count() <= 4, "{text}");
+    runtime_ok(&doc);
+    // No-op and refusals.
+    let before = doc.to_toml();
+    doc.rename_stage("orient", "orient").unwrap();
+    assert_eq!(
+        doc.rename_stage("orient", "scan"),
+        Err(EditError::Taken("scan".into()))
+    );
+    assert_eq!(
+        doc.rename_stage("orient", "a b"),
+        Err(EditError::BadName("a b".into()))
+    );
+    assert_eq!(
+        doc.rename_stage("ghost", "x"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    assert_eq!(doc.to_toml(), before);
+}
+
+#[test]
+fn deleting_a_stage_takes_its_paths_and_repoints_the_entry() {
+    let mut doc = starter();
+    doc.add_stage("review", Some("work")).unwrap();
+    doc.add_edge("review", "finish").unwrap();
+    doc.delete_stage("work").unwrap();
+    assert_eq!(doc.stage_names(), ["review", "finish"]);
+    assert_eq!(doc.agent().entry_stage.as_deref(), Some("review"));
+    assert!(doc.edges().iter().all(|e| e.to != "work"));
+    doc.delete_stage("finish").unwrap();
+    assert!(doc.edges().is_empty(), "the path into finish went with it");
+    assert_eq!(doc.delete_stage("review"), Err(EditError::LastStage));
+    assert_eq!(
+        doc.delete_stage("ghost"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    assert_eq!(doc.stage_names(), ["review"]);
+}
+
+#[test]
+fn moving_a_stage_swaps_it_with_its_neighbour_in_the_file() {
+    let mut doc = coder();
+    let names = doc.stage_names();
+    doc.move_stage("plan", true).unwrap();
+    let moved = doc.stage_names();
+    assert_eq!(moved[0], "plan");
+    assert_eq!(moved[1], "discover");
+    assert_eq!(&moved[2..], &names[2..]);
+    // The file agrees, subtables and all, and still parses.
+    let text = doc.to_toml();
+    assert!(text.find("[stages.plan]").unwrap() < text.find("[stages.discover]").unwrap());
+    assert!(
+        text.find("[stages.plan.transitions.implement]").unwrap()
+            < text.find("[stages.discover]").unwrap()
+    );
+    assert!(
+        text.find("[[stages.plan.interaction_points]]").unwrap()
+            < text.find("[stages.discover]").unwrap()
+    );
+    runtime_ok(&doc);
+    doc.move_stage("plan", false).unwrap();
+    assert_eq!(doc.stage_names(), names);
+    // At the ends nothing moves; a ghost is refused.
+    doc.move_stage("discover", true).unwrap();
+    assert_eq!(doc.stage_names(), names);
+    let last = names.last().unwrap().clone();
+    doc.move_stage(&last, false).unwrap();
+    assert_eq!(doc.stage_names(), names);
+    assert_eq!(
+        doc.move_stage("ghost", true),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    // Re-read after renumbering: same order.
+    assert_eq!(
+        ManifestDoc::parse(&doc.to_toml()).unwrap().stage_names(),
+        names
+    );
+}
+
+#[test]
+fn stage_fields_write_and_delete_the_way_the_lair_does() {
+    let mut doc = starter();
+    doc.set_stage_mode("work", &StageModeView::FanOut).unwrap();
+    doc.set_fan_out(
+        "work",
+        FanOutField::Worker(Some((WorkerKind::Stage, "finish".into()))),
+    )
+    .unwrap();
+    doc.set_fan_out("work", FanOutField::MergeStage(Some("finish".into())))
+        .unwrap();
+    doc.set_fan_out("work", FanOutField::MaxWorkers(Some(4)))
+        .unwrap();
+    doc.set_fan_out("work", FanOutField::MaxItems(Some(9)))
+        .unwrap();
+    doc.set_fan_out(
+        "work",
+        FanOutField::OnWorkerFailure(Some("fail_all".into())),
+    )
+    .unwrap();
+    let work = doc.stage("work").unwrap();
+    assert_eq!(work.mode, StageModeView::FanOut);
+    assert_eq!(
+        work.fan_out,
+        FanOutView {
+            worker: Some((WorkerKind::Stage, "finish".into())),
+            merge_stage: Some("finish".into()),
+            max_workers: Some(4),
+            max_items: Some(9),
+            on_worker_failure: Some("fail_all".into()),
+        }
+    );
+    // Switching the worker kind drops the other keys; clearing removes.
+    doc.set_fan_out(
+        "work",
+        FanOutField::Worker(Some((WorkerKind::Agent, "researcher".into()))),
+    )
+    .unwrap();
+    assert!(!doc.to_toml().contains("worker_stage"));
+    doc.set_fan_out("work", FanOutField::Worker(None)).unwrap();
+    doc.set_fan_out("work", FanOutField::MergeStage(None))
+        .unwrap();
+    doc.set_fan_out("work", FanOutField::MaxWorkers(None))
+        .unwrap();
+    doc.set_fan_out("work", FanOutField::MaxItems(None))
+        .unwrap();
+    doc.set_fan_out("work", FanOutField::OnWorkerFailure(None))
+        .unwrap();
+    assert_eq!(doc.stage("work").unwrap().fan_out, FanOutView::default());
+    // Leaving fan-out sweeps the fan-out keys.
+    doc.set_fan_out("work", FanOutField::MaxWorkers(Some(2)))
+        .unwrap();
+    doc.set_stage_mode("work", &StageModeView::Autonomous)
+        .unwrap();
+    assert!(!doc.to_toml().contains("max_workers"));
+
+    doc.set_stage_text("work", StageText::Description, "Plan it")
+        .unwrap();
+    doc.set_stage_text("work", StageText::SystemPrompt, "line one\nline two\n")
+        .unwrap();
+    doc.set_stage_text("work", StageText::TransitionPrompt, "pick")
+        .unwrap();
+    let work = doc.stage("work").unwrap();
+    assert_eq!(work.description, "Plan it");
+    assert_eq!(work.system_prompt, "line one\nline two\n");
+    assert_eq!(work.transition_prompt, "pick");
+    assert!(
+        doc.to_toml().contains("\"\"\""),
+        "a multi-line prompt is a multi-line string"
+    );
+    doc.set_stage_text("work", StageText::TransitionPrompt, "")
+        .unwrap();
+    assert!(!doc.to_toml().contains("transition_prompt"));
+
+    doc.set_max_iterations("work", Some(0)).unwrap();
+    assert_eq!(
+        doc.stage("work").unwrap().max_iterations,
+        Some(1),
+        "at least one"
+    );
+    doc.set_max_iterations("work", None).unwrap();
+    assert_eq!(doc.stage("work").unwrap().max_iterations, None);
+    doc.set_max_revisits("work", Some(3)).unwrap();
+    assert_eq!(doc.stage("work").unwrap().max_revisits, Some(3));
+    doc.set_max_revisits("work", None).unwrap();
+    assert_eq!(doc.stage("work").unwrap().max_revisits, None);
+    doc.set_allow_complete("work", Some(true)).unwrap();
+    assert_eq!(doc.stage("work").unwrap().allow_complete, Some(true));
+    doc.set_allow_complete("work", None).unwrap();
+    assert_eq!(doc.stage("work").unwrap().allow_complete, None);
+
+    doc.set_tools("work", &["read_file".into(), "bash".into()])
+        .unwrap();
+    assert_eq!(doc.stage("work").unwrap().tools, ["read_file", "bash"]);
+    doc.set_tools("work", &[]).unwrap();
+    assert!(!doc.to_toml().contains("available_tools"));
+
+    // Models: the table form, keeping a sibling key; slashless keeps the
+    // model visible with an empty provider; empty deletes.
+    doc.set_models("work", &["anthropic/claude".into(), "gpt-4".into()])
+        .unwrap();
+    let text = doc.to_toml();
+    assert!(text.contains(r#"model = { models = [{ provider = "anthropic", model = "claude" }, { provider = "", model = "gpt-4" }] }"#), "{text}");
+    assert_eq!(
+        doc.stage("work").unwrap().models,
+        ["anthropic/claude", "/gpt-4"]
+    );
+    let mut kept = ManifestDoc::parse(
+        "[agent]\nname = \"m\"\n[stages.a]\nmodel = { allow_user_default = false, models = [{ provider = \"x\", model = \"y\" }] }\n",
+    )
+    .unwrap();
+    kept.set_models("a", &["openai/o".into()]).unwrap();
+    assert!(
+        kept.to_toml().contains("allow_user_default = false"),
+        "{}",
+        kept.to_toml()
+    );
+    assert_eq!(kept.stage("a").unwrap().models, ["openai/o"]);
+    kept.set_models("a", &[]).unwrap();
+    assert!(!kept.to_toml().contains("model"));
+    runtime_ok(&doc);
+
+    for err in [
+        doc.set_stage_mode("ghost", &StageModeView::Output),
+        doc.set_stage_text("ghost", StageText::Description, "x"),
+        doc.set_max_iterations("ghost", None),
+        doc.set_max_revisits("ghost", None),
+        doc.set_allow_complete("ghost", None),
+        doc.set_models("ghost", &[]),
+        doc.set_tools("ghost", &[]),
+        doc.set_fan_out("ghost", FanOutField::MaxItems(None)),
+    ] {
+        assert_eq!(err, Err(EditError::NoSuchStage("ghost".into())));
+    }
+}
+
+// ─── paths ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn paths_are_added_kinded_gated_and_deleted() {
+    let mut doc = starter();
+    doc.add_edge("finish", "work").unwrap();
+    let edge = doc.edge("finish", "work").unwrap();
+    assert_eq!(edge.kind, EdgeKind::Hint);
+    assert_eq!(edge.hint.as_deref(), Some(edges::NEW_EDGE_HINT));
+    // Again: left alone. To itself: a self-loop, the runtime's shape.
+    doc.set_edge_hint("finish", "work", "Go round again")
+        .unwrap();
+    doc.add_edge("finish", "work").unwrap();
+    assert_eq!(
+        doc.edge("finish", "work").unwrap().hint.as_deref(),
+        Some("Go round again")
+    );
+    doc.add_edge("work", "work").unwrap();
+    assert!(doc.edge("work", "work").is_some());
+    assert_eq!(
+        doc.add_edge("work", "ghost"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    assert_eq!(
+        doc.add_edge("ghost", "work"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+
+    // Hint on a path that has a hint keeps the text.
+    doc.set_edge_kind("finish", "work", EdgeKind::Hint).unwrap();
+    assert_eq!(
+        doc.edge("finish", "work").unwrap().hint.as_deref(),
+        Some("Go round again")
+    );
+    for kind in EdgeKind::CHOICES {
+        doc.set_edge_kind("finish", "work", kind).unwrap();
+        let edge = doc.edge("finish", "work").unwrap();
+        assert_eq!(edge.kind, kind, "{kind:?}");
+        if kind == EdgeKind::Hint {
+            assert!(edge.hint.is_some(), "a hint kind keeps or makes a hint");
+        } else {
+            assert_eq!(edge.hint, None, "a condition drops the hint");
+        }
+    }
+    // Back to hint with no text left: an empty hint appears.
+    doc.set_edge_kind("finish", "work", EdgeKind::Hint).unwrap();
+    assert_eq!(
+        doc.edge("finish", "work").unwrap().hint.as_deref(),
+        Some("")
+    );
+
+    doc.set_edge_gate("finish", "work", true).unwrap();
+    assert!(doc.edge("finish", "work").unwrap().gated);
+    assert!(
+        doc.to_toml()
+            .contains(r#"gate = { message = "Approve to continue" }"#)
+    );
+    // A richer gate survives "on"; "off" removes whatever is there.
+    let mut rich = coder();
+    rich.set_edge_gate("implement", "review", true).unwrap();
+    assert!(rich.to_toml().contains("require_modifications = true"));
+    rich.set_edge_gate("implement", "review", false).unwrap();
+    assert!(!rich.edge("implement", "review").unwrap().gated);
+
+    doc.delete_edge("finish", "work").unwrap();
+    assert!(doc.edge("finish", "work").is_none());
+    assert_eq!(
+        doc.delete_edge("finish", "work"),
+        Err(EditError::NoSuchEdge("finish".into(), "work".into()))
+    );
+    assert_eq!(
+        doc.delete_edge("ghost", "work"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    assert_eq!(
+        doc.set_edge_kind("work", "ghost", EdgeKind::Always),
+        Err(EditError::NoSuchEdge("work".into(), "ghost".into()))
+    );
+    assert_eq!(
+        doc.set_edge_hint("ghost", "work", "x"),
+        Err(EditError::NoSuchEdge("ghost".into(), "work".into()))
+    );
+    runtime_ok(&doc);
+}
+
+#[test]
+fn transforms_and_their_rules() {
+    let mut doc = coder();
+    // Direct is written as absent; the others by name; an unknown one as is.
+    doc.set_transform("discover", "plan", &TransformKind::Clear)
+        .unwrap();
+    assert_eq!(
+        doc.edge("discover", "plan").unwrap().transform,
+        TransformKind::Clear
+    );
+    doc.set_transform("discover", "plan", &TransformKind::Direct)
+        .unwrap();
+    assert!(!edge_text(&doc, "discover", "plan").contains("transform ="));
+    doc.set_transform("discover", "plan", &TransformKind::Other("teleport".into()))
+        .unwrap();
+    assert_eq!(
+        doc.edge("discover", "plan").unwrap().transform,
+        TransformKind::Other("teleport".into())
+    );
+    // The first switch to custom seeds carry with every non-pinned region the
+    // stage sees; a second switch does not touch the config.
+    doc.set_transform("discover", "plan", &TransformKind::Custom)
+        .unwrap();
+    let rules = doc.edge("discover", "plan").unwrap().rules;
+    assert!(rules.present);
+    assert!(rules.carry.contains(&"conversation".to_string()));
+    assert!(
+        !rules.carry.contains(&"task".to_string()),
+        "pinned regions are always carried"
+    );
+    doc.set_transform_rule("discover", "plan", "conversation", Rule::Compact)
+        .unwrap();
+    doc.set_transform("discover", "plan", &TransformKind::Compact)
+        .unwrap();
+    doc.set_transform("discover", "plan", &TransformKind::Custom)
+        .unwrap();
+    let rules = doc.edge("discover", "plan").unwrap().rules;
+    assert_eq!(rules.compact, ["conversation"]);
+    assert!(!rules.carry.contains(&"conversation".to_string()));
+    // A region files under exactly one list; emptied lists go.
+    doc.set_transform_rule("discover", "plan", "conversation", Rule::Clear)
+        .unwrap();
+    let rules = doc.edge("discover", "plan").unwrap().rules;
+    assert_eq!(rules.clear, ["conversation"]);
+    assert!(rules.compact.is_empty());
+    assert!(!edge_text(&doc, "discover", "plan").contains("compact = ["));
+    doc.set_compact_prompt("discover", "plan", "Keep the gist")
+        .unwrap();
+    assert_eq!(
+        doc.edge("discover", "plan").unwrap().rules.compact_prompt,
+        "Keep the gist"
+    );
+    doc.set_compact_prompt("discover", "plan", "").unwrap();
+    assert_eq!(
+        doc.edge("discover", "plan").unwrap().rules.compact_prompt,
+        ""
+    );
+    runtime_ok(&doc);
+    // A prompt on a path with no config makes one; clearing one that has no
+    // config does nothing.
+    let mut fresh = starter();
+    fresh.set_compact_prompt("work", "finish", "").unwrap();
+    assert!(!fresh.edge("work", "finish").unwrap().rules.present);
+    fresh
+        .set_compact_prompt("work", "finish", "Summarize")
+        .unwrap();
+    assert!(fresh.edge("work", "finish").unwrap().rules.present);
+    // Custom on a stage with no regions at all still turns custom.
+    fresh
+        .set_transform("work", "finish", &TransformKind::Custom)
+        .unwrap();
+    assert_eq!(
+        fresh.edge("work", "finish").unwrap().transform,
+        TransformKind::Custom
+    );
+    assert!(fresh.edge("work", "finish").unwrap().rules.carry.is_empty());
+    for err in [
+        fresh.set_transform("work", "ghost", &TransformKind::Clear),
+        fresh.set_transform_rule("work", "ghost", "r", Rule::Carry),
+        fresh.set_compact_prompt("work", "ghost", "x"),
+    ] {
+        assert_eq!(
+            err,
+            Err(EditError::NoSuchEdge("work".into(), "ghost".into()))
+        );
+    }
+    // A `transform_config` that is not a table is refused, not clobbered.
+    let mut odd = ManifestDoc::parse(
+        "[agent]\nname = \"o\"\n[context.regions]\nr = { kind = \"temporary\" }\n[stages.a]\n[stages.a.transitions.b]\ntransform_config = 3\n[stages.b]\n",
+    )
+    .unwrap();
+    for err in [
+        odd.set_transform("a", "b", &TransformKind::Custom),
+        odd.set_transform_rule("a", "b", "r", Rule::Carry),
+        odd.set_compact_prompt("a", "b", "x"),
+    ] {
+        assert_eq!(err, Err(EditError::NotATable("transform_config".into())));
+    }
+}
+
+fn edge_text(doc: &ManifestDoc, from: &str, to: &str) -> String {
+    let text = doc.to_toml();
+    let header = format!("[stages.{from}.transitions.{to}]");
+    let start = text.find(&header).expect("edge header");
+    let rest = text.get(start + header.len()..).unwrap();
+    let end = rest.find("\n[").unwrap_or(rest.len());
+    rest.get(..end).unwrap().to_string()
+}
+
+// ─── regions and routing ─────────────────────────────────────────────────────
+
+#[test]
+fn regions_are_added_renamed_deleted_and_edited_in_both_scopes() {
+    let mut doc = starter();
+    assert!(doc.regions(None).is_empty());
+    doc.add_region(&RegionScope::Shared, "notes").unwrap();
+    let notes = doc.region(None, "notes").unwrap();
+    assert_eq!(
+        (notes.kind.as_str(), notes.budget_percent, notes.max_tokens),
+        ("pinned", Some(5.0), Some(4000))
+    );
+    assert!(
+        doc.to_toml().contains("[context.regions]"),
+        "{}",
+        doc.to_toml()
+    );
+    assert_eq!(
+        doc.add_region(&RegionScope::Shared, "notes"),
+        Err(EditError::Taken("notes".into()))
+    );
+    assert_eq!(
+        doc.add_region(&RegionScope::Shared, "no way"),
+        Err(EditError::BadName("no way".into()))
+    );
+    assert_eq!(
+        doc.add_region(&RegionScope::Stage("ghost".into()), "x"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    // Routing follows a rename in inheriting stages, and clears on delete.
+    // A default alone follows a rename; overrides alone follow one too.
+    doc.set_tool_routing_default("work", "notes").unwrap();
+    doc.rename_region(&RegionScope::Shared, "notes", "notes2")
+        .unwrap();
+    assert_eq!(
+        doc.tool_routing("work").default_region.as_deref(),
+        Some("notes2")
+    );
+    doc.set_tool_routing_default("finish", "").unwrap();
+    doc.set_tool_routing_override("finish", "bash", "notes2")
+        .unwrap();
+    doc.rename_region(&RegionScope::Shared, "notes2", "notes")
+        .unwrap();
+    assert_eq!(
+        doc.tool_routing("finish").overrides,
+        [("bash".to_string(), "notes".to_string())]
+    );
+    doc.set_tool_routing_override("finish", "bash", "").unwrap();
+    doc.set_tool_routing_override("work", "bash", "notes")
+        .unwrap();
+    doc.rename_region(&RegionScope::Shared, "notes", "memo")
+        .unwrap();
+    assert_eq!(
+        doc.tool_routing("work").default_region.as_deref(),
+        Some("memo")
+    );
+    assert_eq!(
+        doc.tool_routing("work").overrides,
+        [("bash".to_string(), "memo".to_string())]
+    );
+    assert_eq!(doc.stages_routing_into("memo"), ["work"]);
+    doc.rename_region(&RegionScope::Shared, "memo", "memo")
+        .unwrap();
+    assert_eq!(
+        doc.rename_region(&RegionScope::Shared, "memo", "a b"),
+        Err(EditError::BadName("a b".into()))
+    );
+    assert_eq!(
+        doc.rename_region(&RegionScope::Shared, "ghost", "x"),
+        Err(EditError::NoSuchRegion("ghost".into()))
+    );
+    assert_eq!(
+        doc.rename_region(&RegionScope::Stage("finish".into()), "memo", "x"),
+        Err(EditError::NoSuchRegion("memo".into())),
+        "finish has no layout of its own"
+    );
+    for err in [
+        doc.rename_region(&RegionScope::Stage("ghost".into()), "memo", "x"),
+        doc.delete_region(&RegionScope::Stage("ghost".into()), "memo"),
+        doc.set_region_field(
+            &RegionScope::Stage("ghost".into()),
+            "memo",
+            RegionField::Kind,
+            RegionValue::Text("pinned".into()),
+        ),
+    ] {
+        assert_eq!(err, Err(EditError::NoSuchRegion("memo".into())));
+    }
+    doc.add_region(&RegionScope::Shared, "other").unwrap();
+    assert_eq!(
+        doc.rename_region(&RegionScope::Shared, "memo", "other"),
+        Err(EditError::Taken("other".into()))
+    );
+    // Deleting a region another override still shares the table with keeps
+    // the table; deleting the last reference tidies it away.
+    doc.add_region(&RegionScope::Shared, "keep").unwrap();
+    doc.set_tool_routing_override("work", "read_file", "keep")
+        .unwrap();
+    doc.delete_region(&RegionScope::Shared, "memo").unwrap();
+    assert_eq!(
+        doc.tool_routing("work").overrides,
+        [("read_file".to_string(), "keep".to_string())]
+    );
+    assert_eq!(doc.tool_routing("work").default_region, None);
+    doc.delete_region(&RegionScope::Shared, "keep").unwrap();
+    assert_eq!(doc.tool_routing("work"), ToolRouting::default());
+    assert!(
+        !doc.to_toml().contains("tool_routing"),
+        "tidied away: {}",
+        doc.to_toml()
+    );
+    assert_eq!(
+        doc.delete_region(&RegionScope::Shared, "memo"),
+        Err(EditError::NoSuchRegion("memo".into()))
+    );
+    assert_eq!(
+        doc.delete_region(&RegionScope::Stage("finish".into()), "x"),
+        Err(EditError::NoSuchRegion("x".into()))
+    );
+
+    // A stage's own layout: a copy of the shared regions, then independent.
+    doc.create_stage_override("finish").unwrap();
+    let own = doc.effective_regions(Some("finish"));
+    assert!(!own.inherited);
+    assert_eq!(
+        own.regions
+            .iter()
+            .map(|r| r.name.as_str())
+            .collect::<Vec<_>>(),
+        ["other"]
+    );
+    doc.create_stage_override("finish").unwrap(); // already has one: no change
+    doc.add_region(&RegionScope::Stage("finish".into()), "scratch")
+        .unwrap();
+    assert_eq!(doc.regions(Some("finish")).len(), 2);
+    assert_eq!(doc.regions(None).len(), 1, "the shared layout is untouched");
+    assert!(doc.stage("finish").unwrap().has_own_layout);
+    // A stage region's routing rename touches that stage only; the shared
+    // rename skips stages with their own layout.
+    doc.set_tool_routing_override("finish", "read_file", "scratch")
+        .unwrap();
+    doc.set_tool_routing_override("work", "read_file", "other")
+        .unwrap();
+    doc.rename_region(&RegionScope::Stage("finish".into()), "scratch", "pad")
+        .unwrap();
+    assert_eq!(
+        doc.tool_routing("finish").overrides,
+        [("read_file".to_string(), "pad".to_string())]
+    );
+    doc.set_tool_routing_override("finish", "bash", "other")
+        .unwrap();
+    doc.rename_region(&RegionScope::Shared, "other", "shared_other")
+        .unwrap();
+    assert_eq!(
+        doc.tool_routing("work").overrides,
+        [("read_file".to_string(), "shared_other".to_string())]
+    );
+    assert_eq!(
+        doc.tool_routing("finish")
+            .overrides
+            .iter()
+            .find(|(t, _)| t == "bash")
+            .unwrap()
+            .1,
+        "other",
+        "its own layout: not rewritten"
+    );
+    doc.remove_stage_override("finish").unwrap();
+    assert!(doc.effective_regions(Some("finish")).inherited);
+    assert!(!doc.stage("finish").unwrap().has_own_layout);
+    assert_eq!(
+        doc.remove_stage_override("ghost"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    assert_eq!(
+        doc.create_stage_override("ghost"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    // Override on an agent with no shared regions starts empty.
+    let mut bare = starter();
+    bare.create_stage_override("work").unwrap();
+    assert!(!bare.effective_regions(Some("work")).inherited);
+    assert!(bare.effective_regions(Some("work")).regions.is_empty());
+    runtime_ok(&doc);
+}
+
+#[test]
+fn region_fields_write_the_lairs_way() {
+    use RegionField as F;
+    use RegionValue as V;
+    let mut doc = starter();
+    doc.add_region(&RegionScope::Shared, "r").unwrap();
+    let s = RegionScope::Shared;
+    doc.set_region_field(&s, "r", F::Kind, V::Text("sliding_window".into()))
+        .unwrap();
+    doc.set_region_field(&s, "r", F::Kind, V::Text("".into()))
+        .unwrap();
+    assert_eq!(
+        doc.region(None, "r").unwrap().kind,
+        "sliding_window",
+        "kind is never emptied"
+    );
+    doc.set_region_field(&s, "r", F::BudgetPercent, V::Number(Some(150)))
+        .unwrap();
+    assert_eq!(
+        doc.region(None, "r").unwrap().budget_percent,
+        Some(100.0),
+        "clamped"
+    );
+    doc.set_region_field(&s, "r", F::BudgetPercent, V::Number(None))
+        .unwrap();
+    assert_eq!(doc.region(None, "r").unwrap().budget_percent, None);
+    doc.set_region_field(&s, "r", F::MaxTokens, V::Number(Some(0)))
+        .unwrap();
+    assert_eq!(doc.region(None, "r").unwrap().max_tokens, Some(1));
+    doc.set_region_field(&s, "r", F::MaxTokens, V::Number(None))
+        .unwrap();
+    assert_eq!(doc.region(None, "r").unwrap().max_tokens, None);
+    doc.set_region_field(&s, "r", F::MaxItems, V::Number(Some(12)))
+        .unwrap();
+    doc.set_region_field(&s, "r", F::Overflow, V::Number(Some(3)))
+        .unwrap();
+    doc.set_region_field(&s, "r", F::Strategy, V::Text("bulk".into()))
+        .unwrap();
+    let r = doc.region(None, "r").unwrap();
+    assert_eq!(
+        (r.max_items, r.overflow, r.strategy.as_str()),
+        (Some(12), Some(3), "bulk")
+    );
+    doc.set_region_field(&s, "r", F::Required, V::Flag(true))
+        .unwrap();
+    doc.set_region_field(&s, "r", F::RequiredMessage, V::Text("Fill me".into()))
+        .unwrap();
+    doc.set_region_field(&s, "r", F::Description, V::Text("What it holds".into()))
+        .unwrap();
+    let r = doc.region(None, "r").unwrap();
+    assert!(r.required);
+    assert_eq!(r.required_message, "Fill me");
+    assert_eq!(r.description, "What it holds");
+    doc.set_region_field(&s, "r", F::Required, V::Flag(false))
+        .unwrap();
+    assert!(!doc.region(None, "r").unwrap().required);
+    assert!(!doc.to_toml().contains("required = "));
+    doc.set_region_field(&s, "r", F::Seed, V::Text("task".into()))
+        .unwrap();
+    assert_eq!(doc.region(None, "r").unwrap().seed, "task");
+    doc.set_region_field(&s, "r", F::Seed, V::Text("".into()))
+        .unwrap();
+    assert_eq!(doc.region(None, "r").unwrap().seed, "");
+    assert!(!doc.to_toml().contains("seed"));
+    // A table seed is displayed empty and never clobbered by clearing.
+    let mut coder = coder();
+    coder
+        .set_region_field(&s, "conventions", F::Seed, V::Text("".into()))
+        .unwrap();
+    assert!(coder.region(None, "conventions").unwrap().seed_is_table);
+    // Mismatched value shapes are refused, unknown regions too.
+    assert!(matches!(
+        doc.set_region_field(&s, "r", F::Kind, V::Flag(true)),
+        Err(EditError::OutOfRange(_))
+    ));
+    assert_eq!(
+        doc.set_region_field(&s, "ghost", F::Kind, V::Text("x".into())),
+        Err(EditError::NoSuchRegion("ghost".into()))
+    );
+    assert_eq!(
+        doc.set_region_field(
+            &RegionScope::Stage("finish".into()),
+            "r",
+            F::Kind,
+            V::Text("x".into())
+        ),
+        Err(EditError::NoSuchRegion("r".into()))
+    );
+    runtime_ok(&doc);
+}
+
+#[test]
+fn tool_routing_is_created_and_tidied() {
+    let mut doc = starter();
+    doc.set_tool_routing_default("work", "").unwrap();
+    assert!(!doc.to_toml().contains("tool_routing"));
+    doc.set_tool_routing_override("work", "bash", "").unwrap();
+    assert!(!doc.to_toml().contains("tool_routing"));
+    doc.set_tool_routing_default("work", "conversation")
+        .unwrap();
+    doc.set_tool_routing_override("work", "bash", "scratch")
+        .unwrap();
+    doc.set_tool_routing_override("work", "read_file", "scratch")
+        .unwrap();
+    let routing = doc.tool_routing("work");
+    assert_eq!(routing.default_region.as_deref(), Some("conversation"));
+    assert_eq!(routing.overrides.len(), 2);
+    doc.set_tool_routing_override("work", "bash", "").unwrap();
+    assert_eq!(doc.tool_routing("work").overrides.len(), 1);
+    // The default goes but an override keeps the table.
+    doc.set_tool_routing_default("work", "").unwrap();
+    assert!(doc.to_toml().contains("tool_routing"));
+    doc.set_tool_routing_override("work", "read_file", "")
+        .unwrap();
+    assert!(!doc.to_toml().contains("tool_routing"), "{}", doc.to_toml());
+    // Clearing an override that is not there, with a routing table that has
+    // no overrides, is a no-op.
+    doc.set_tool_routing_default("work", "conversation")
+        .unwrap();
+    doc.set_tool_routing_override("work", "bash", "").unwrap();
+    assert!(doc.to_toml().contains("tool_routing"));
+    doc.set_tool_routing_default("work", "").unwrap();
+    assert_eq!(
+        doc.set_tool_routing_default("ghost", "x"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    assert_eq!(
+        doc.set_tool_routing_override("ghost", "t", "x"),
+        Err(EditError::NoSuchStage("ghost".into()))
+    );
+    let mut odd = ManifestDoc::parse(
+        "[agent]\nname = \"o\"\n[stages.a]\n[stages.a.tool_routing]\noverrides = 3\n",
+    )
+    .unwrap();
+    assert_eq!(
+        odd.set_tool_routing_override("a", "bash", "r"),
+        Err(EditError::NotATable("overrides".into()))
+    );
+}
+
+#[test]
+fn odd_content_is_refused_rather_than_clobbered() {
+    let mut doc = ManifestDoc::parse(
+        "[agent]\nname = \"odd\"\n[stages.a]\ncontext = \"nope\"\ntool_routing = 4\ntransitions = 7\n",
+    )
+    .unwrap();
+    assert_eq!(
+        doc.add_region(&RegionScope::Stage("a".into()), "r"),
+        Err(EditError::NotATable("context".into()))
+    );
+    assert_eq!(
+        doc.create_stage_override("a"),
+        Err(EditError::NotATable("context".into()))
+    );
+    assert_eq!(
+        doc.set_tool_routing_default("a", "r"),
+        Err(EditError::NotATable("tool_routing".into()))
+    );
+    assert_eq!(
+        doc.set_tool_routing_override("a", "t", "r"),
+        Err(EditError::NotATable("tool_routing".into()))
+    );
+    assert_eq!(
+        doc.add_edge("a", "a"),
+        Err(EditError::NotATable("transitions".into()))
+    );
+    // A `[stages]` written inline gets inline children.
+    let mut inline = ManifestDoc::parse(
+        "stages = { a = { mode = \"autonomous\", transitions = { } } }\n[agent]\nname = \"i\"\n",
+    )
+    .unwrap();
+    inline.add_stage("b", Some("a")).unwrap();
+    inline.add_edge("a", "b").unwrap();
+    assert_eq!(inline.stage_names(), ["a", "b"]);
+    let text = inline.to_toml();
+    assert!(text.contains("b = { mode = \"autonomous\""), "{text}");
+    assert!(inline.edge("a", "b").is_some());
+    runtime_ok(&inline);
+    inline.rename_stage("a", "start").unwrap();
+    assert!(inline.edge("start", "b").is_some());
+    inline.move_stage("b", true).unwrap();
+    assert_eq!(
+        inline.stage_names(),
+        ["start", "b"],
+        "inline stages have no position to move"
+    );
+    // An inline `context = {}` gets an inline copy of the shared regions.
+    let mut ctx = ManifestDoc::parse(
+        "[agent]\nname = \"c\"\n[context.regions]\nnotes = { kind = \"pinned\" }\n[stages.a]\ncontext = { }\n",
+    )
+    .unwrap();
+    ctx.create_stage_override("a").unwrap();
+    assert!(!ctx.effective_regions(Some("a")).inherited);
+    assert_eq!(ctx.regions(Some("a"))[0].name, "notes");
+}
+
+// ─── check ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn check_reports_parse_validate_and_lint_in_that_order() {
+    let dir = std::env::temp_dir().join("lev-blueprint-edit-check");
+    let _ = std::fs::create_dir_all(&dir);
+    let parse = check("not = [toml", &dir);
+    assert_eq!(parse.error_count(), 1);
+    assert_eq!(parse.items[0].code, "parse");
+    assert!(!parse.is_saveable());
+    assert_eq!(parse.first().map(|p| p.severity), Some(Severity::Error));
+
+    let mut doc = starter();
+    doc.add_edge("work", "ghost").unwrap_err();
+    // A dangling worker stage fails validation on the stage.
+    doc.set_stage_mode("work", &StageModeView::FanOut).unwrap();
+    doc.set_fan_out(
+        "work",
+        FanOutField::Worker(Some((WorkerKind::Stage, "nope".into()))),
+    )
+    .unwrap();
+    let invalid = check(&doc.to_toml(), &dir);
+    assert_eq!(invalid.items[0].code, "validate");
+    assert_eq!(invalid.items[0].stage.as_deref(), Some("work"));
+    assert_eq!(invalid.for_stage("work").len(), 1);
+    // A validation error that names no stage.
+    let mut noentry = starter();
+    noentry
+        .set_stage_mode("work", &StageModeView::Autonomous)
+        .unwrap();
+    let text = noentry
+        .to_toml()
+        .replace("entry_stage = \"work\"", "entry_stage = \"ghost\"");
+    let graph = check(&text, &dir);
+    assert_eq!(graph.items[0].code, "validate");
+    assert_eq!(graph.items[0].stage, None);
+
+    // A path into a stage that is not there is a transition error, filed
+    // under the stage it leaves.
+    let dangling = starter().to_toml().replace(
+        "[stages.finish]",
+        "[stages.work.transitions.ghost]\nhint = \"x\"\n\n[stages.finish]",
+    );
+    let problems = check(&dangling, &dir);
+    assert_eq!(problems.items[0].code, "validate");
+    assert_eq!(
+        problems.items[0].stage.as_deref(),
+        Some("work"),
+        "{problems:?}"
+    );
+    // A command seed is worth a note, which sorts after warnings.
+    let noted = starter().to_toml()
+        + "\n[context.regions]\nenv = { kind = \"pinned\", seed = { command = \"echo hi\" } }\n";
+    let problems = check(&noted, &dir);
+    assert!(
+        problems
+            .items
+            .iter()
+            .any(|p| p.severity == Severity::Note && p.code == "command-seed"),
+        "{problems:?}"
+    );
+    let last = problems.items.last().unwrap();
+    assert_eq!(last.severity, Severity::Note);
+    // The starter itself: no errors, warnings about what it leaves to defaults.
+    let starter_problems = check(&starter().to_toml(), &dir);
+    assert!(starter_problems.is_saveable(), "{starter_problems:?}");
+    assert!(starter_problems.warning_count() > 0);
+    assert!(
+        starter_problems
+            .items
+            .iter()
+            .all(|p| p.severity != Severity::Error)
+    );
+    assert!(
+        starter_problems
+            .items
+            .iter()
+            .any(|p| p.code == "stage-missing-model" && p.stage.as_deref() == Some("work"))
+    );
+    // Errors sort before warnings; a lint error blocks a save.
+    let mut lint_err = starter();
+    lint_err
+        .set_tools("work", &["no_such_tool".into()])
+        .unwrap();
+    let problems = check(&lint_err.to_toml(), &dir);
+    assert!(!problems.is_saveable());
+    assert_eq!(problems.items[0].severity, Severity::Error);
+    assert_eq!(problems.items[0].code, "unknown-tool");
+    assert!(problems.items[0].fix.is_some() || problems.items[0].message.contains("no_such_tool"));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ─── templates ───────────────────────────────────────────────────────────────
+
+#[test]
+fn the_starter_and_the_clone() {
+    let text = templates::empty_blueprint("demo").unwrap();
+    let doc = ManifestDoc::parse(&text).unwrap();
+    assert_eq!(doc.agent().name, "demo");
+    assert_eq!(doc.stage_names(), ["work", "finish"]);
+    assert_eq!(
+        doc.edge("work", "finish").unwrap().hint.as_deref(),
+        Some("The work is done and verified")
+    );
+    assert!(doc.stage("finish").unwrap().is_terminal);
+    runtime_ok(&doc);
+    assert_eq!(
+        templates::empty_blueprint("no way"),
+        Err(EditError::BadName("no way".into()))
+    );
+    let clone = templates::clone_of(bundled_text("coder"), "my-coder").unwrap();
+    let cloned = ManifestDoc::parse(&clone).unwrap();
+    assert_eq!(cloned.agent().name, "my-coder");
+    assert_eq!(cloned.stage_names(), coder().stage_names());
+    assert!(matches!(
+        templates::clone_of("nope = [", "x"),
+        Err(EditError::Toml(_))
+    ));
+    assert_eq!(
+        templates::clone_of(bundled_text("coder"), "no way"),
+        Err(EditError::BadName("no way".into()))
+    );
+}
+
+// ─── layout store ────────────────────────────────────────────────────────────
+
+#[test]
+fn the_layout_store_remembers_per_agent_and_survives_a_reload() {
+    let dir = std::env::temp_dir().join("lev-blueprint-edit-layouts");
+    let _ = std::fs::remove_dir_all(&dir);
+    let path = dir.join("nested").join("graph-layouts.json");
+    let mut store = LayoutStore::open(path.clone());
+    assert_eq!(store.path(), Some(path.as_path()));
+    assert!(store.positions("coder").is_none());
+    let mut positions = Positions::new();
+    positions.insert("plan".into(), (10.0, 4.5));
+    store.set("coder", positions.clone());
+    store.copy("coder", "my-coder");
+    store.copy("ghost", "nothing");
+    store.set("empty", Positions::new());
+    store.save().unwrap();
+    let again = LayoutStore::open(path.clone());
+    assert_eq!(again.positions("coder"), Some(&positions));
+    assert_eq!(again.positions("my-coder"), Some(&positions));
+    assert!(again.positions("nothing").is_none());
+    assert!(again.positions("empty").is_none());
+    let mut again = again;
+    again.forget("coder");
+    again.set("my-coder", Positions::new());
+    assert!(again.positions("coder").is_none());
+    again.save().unwrap();
+    let reloaded = LayoutStore::open(path);
+    assert!(reloaded.positions("coder").is_none());
+    assert!(
+        reloaded.positions("my-coder").is_none(),
+        "an empty arrangement is forgotten"
+    );
+    // Garbage on disk reads as empty; a memory store never writes.
+    std::fs::write(dir.join("bad.json"), "{{{").unwrap();
+    assert!(
+        LayoutStore::open(dir.join("bad.json"))
+            .positions("x")
+            .is_none()
+    );
+    // A path under a file cannot be created.
+    std::fs::write(dir.join("blocker"), "x").unwrap();
+    let mut blocked = LayoutStore::open(dir.join("blocker").join("sub").join("l.json"));
+    blocked.set("a", positions.clone());
+    assert!(blocked.save().is_err());
+    let mut mem = LayoutStore::in_memory();
+    mem.set("a", positions);
+    mem.save().unwrap();
+    assert_eq!(mem.path(), None);
+    assert!(LayoutStore::default_path().is_some_and(|p| p.ends_with("dash/graph-layouts.json")));
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+// ─── catalog ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_catalog_lists_every_source_and_writes_deletes_and_resets() {
+    use catalog::{Source, discover};
+    let root =
+        std::env::temp_dir().join(format!("lev-blueprint-edit-catalog-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let agents = root.join("agents");
+    let configured = root.join("configured");
+    let cwd = root.join("cwd");
+    std::fs::create_dir_all(&agents).unwrap();
+    std::fs::create_dir_all(configured.join("mine")).unwrap();
+    std::fs::create_dir_all(&cwd).unwrap();
+    // An installed agent of our own, an installed bundled one (edited), a
+    // configured one, a local one.
+    catalog::write_agent(&agents, "own", &templates::empty_blueprint("own").unwrap()).unwrap();
+    catalog::reset_bundled(&agents, "coder").unwrap();
+    let coder_manifest = agents.join("coder").join("agent.leviath");
+    let edited = std::fs::read_to_string(&coder_manifest)
+        .unwrap()
+        .replace("entry_stage = \"discover\"", "entry_stage = \"plan\"");
+    std::fs::write(&coder_manifest, edited).unwrap();
+    std::fs::write(
+        configured.join("mine").join("agent.leviath"),
+        templates::empty_blueprint("mine").unwrap(),
+    )
+    .unwrap();
+    std::fs::write(
+        cwd.join("agent.leviath"),
+        templates::empty_blueprint("here").unwrap(),
+    )
+    .unwrap();
+    // A directory without a readable manifest is skipped by the list.
+    std::fs::create_dir_all(agents.join("junk")).unwrap();
+    std::fs::write(agents.join("junk").join("agent.leviath"), "not = [").unwrap();
+    let config = crate::config::Config {
+        agent_paths: vec![configured.clone()],
+        ..Default::default()
+    };
+
+    let entries = discover(&agents, &cwd, &config);
+    let by_name = |n: &str| {
+        entries
+            .iter()
+            .find(|e| e.name == n)
+            .unwrap_or_else(|| panic!("{n} in {entries:?}"))
+    };
+    let own = by_name("own");
+    assert_eq!(own.source, Source::Installed);
+    assert!(own.deletable());
+    assert!(!own.bundled);
+    assert_eq!(own.stages, ["work", "finish"]);
+    assert!(own.manifest.as_deref().unwrap().contains("name = \"own\""));
+    assert_eq!(own.dir.as_deref(), Some(agents.join("own").as_path()));
+    let coder = by_name("coder");
+    assert_eq!(coder.source, Source::Installed);
+    assert!(coder.bundled && coder.differs_from_bundled);
+    let mine = by_name("mine");
+    assert_eq!(mine.source, Source::Configured);
+    assert!(!mine.deletable());
+    let here = by_name("here");
+    assert_eq!(here.source, Source::Local);
+    assert_eq!(here.dir.as_deref(), Some(cwd.as_path()));
+    let reviewer = by_name("reviewer");
+    assert_eq!(reviewer.source, Source::Bundled);
+    assert!(reviewer.bundled && !reviewer.differs_from_bundled);
+    assert!(reviewer.dir.is_none());
+    assert!(reviewer.manifest.is_some());
+    assert!(reviewer.stages.contains(&"split_review".to_string()));
+    assert!(reviewer.description.starts_with("Code review agent"));
+    assert!(entries.windows(2).all(|w| w[0].name <= w[1].name), "sorted");
+    assert!(!entries.iter().any(|e| e.name == "junk"));
+
+    // Reset puts the embedded copy back; the entry no longer differs.
+    catalog::reset_bundled(&agents, "coder").unwrap();
+    assert!(
+        !discover(&agents, &cwd, &config)
+            .iter()
+            .find(|e| e.name == "coder")
+            .unwrap()
+            .differs_from_bundled
+    );
+    assert!(
+        catalog::reset_bundled(&agents, "own")
+            .unwrap_err()
+            .contains("not a bundled agent")
+    );
+    // Extras of a bundled agent land next to a cloned manifest.
+    let researcher = catalog::bundled("researcher").unwrap();
+    catalog::write_agent(
+        &agents,
+        "my-researcher",
+        &templates::clone_of(catalog::bundled_manifest(researcher), "my-researcher").unwrap(),
+    )
+    .unwrap();
+    catalog::copy_bundled_extras(&agents, "my-researcher", researcher).unwrap();
+    assert!(
+        agents
+            .join("my-researcher")
+            .join("tools")
+            .join("web_search.rhai")
+            .exists()
+    );
+    // A script whose path is already a directory cannot be written.
+    let clash = agents.join("clash");
+    std::fs::create_dir_all(clash.join("tools").join("web_search.rhai")).unwrap();
+    assert!(catalog::copy_bundled_extras(&agents, "clash", researcher).is_err());
+    assert!(catalog::bundled("nope").is_none());
+    // Writes into a directory that is a file fail, and so does a reset there.
+    let blocked = root.join("blocked");
+    std::fs::write(&blocked, "x").unwrap();
+    assert!(catalog::write_agent(&blocked, "own", "x").is_err());
+    assert!(catalog::copy_bundled_extras(&blocked, "own", researcher).is_err());
+    assert!(catalog::reset_bundled(&blocked, "coder").is_err());
+    // A manifest that cannot be written where its directory could.
+    let dir_as_file = agents.join("taken");
+    std::fs::create_dir_all(&dir_as_file).unwrap();
+    std::fs::create_dir_all(dir_as_file.join("agent.leviath")).unwrap();
+    assert!(catalog::write_agent(&agents, "taken", "x").is_err());
+    // Delete.
+    catalog::delete_agent(&agents, "own").unwrap();
+    assert!(!agents.join("own").exists());
+    assert!(catalog::delete_agent(&agents, "own").is_err());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── order ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_written_order_walks_arrays_of_tables_and_renumbers_them() {
+    use order::{Seg, renumber, written_order};
+    let mut doc: toml_edit::DocumentMut = "[a]\nv = 1\n[[b]]\nx = 1\n[[b]]\nx = 2\n[b.c]\n[d]\n"
+        .parse()
+        .unwrap();
+    let order = written_order(&doc);
+    assert_eq!(
+        order,
+        vec![
+            vec![Seg::Key("a".into())],
+            vec![Seg::Key("b".into()), Seg::Index(0)],
+            vec![Seg::Key("b".into()), Seg::Index(1)],
+            vec![Seg::Key("b".into()), Seg::Index(1), Seg::Key("c".into())],
+            vec![Seg::Key("d".into())],
+        ]
+    );
+    // Reversed and renumbered: the file follows.
+    let mut reversed = order.clone();
+    reversed.reverse();
+    // A path that leads nowhere is skipped, an index under a plain table too.
+    reversed.push(vec![Seg::Key("ghost".into())]);
+    reversed.push(vec![Seg::Key("a".into()), Seg::Key("ghost".into())]);
+    reversed.push(vec![
+        Seg::Key("a".into()),
+        Seg::Key("v".into()),
+        Seg::Key("w".into()),
+    ]);
+    reversed.push(vec![Seg::Key("a".into()), Seg::Index(0)]);
+    reversed.push(vec![Seg::Key("b".into()), Seg::Index(9)]);
+    reversed.push(vec![Seg::Key("b".into()), Seg::Index(1), Seg::Index(0)]);
+    reversed.push(vec![
+        Seg::Key("b".into()),
+        Seg::Index(1),
+        Seg::Key("ghost".into()),
+    ]);
+    renumber(&mut doc, &reversed);
+    let text = doc.to_string();
+    assert!(
+        text.find("[d]").unwrap() < text.find("[a]").unwrap(),
+        "{text}"
+    );
+    assert_eq!(written_order(&doc)[0], vec![Seg::Key("d".into())]);
+}

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -93,9 +93,11 @@ fn every_bundled_manifest_round_trips_byte_for_byte() {
     for agent in BUNDLED_AGENTS {
         let text = catalog::bundled_manifest(agent);
         let doc = ManifestDoc::parse(text).expect(agent.name);
+        // A Windows checkout carries CRLF; the writer keeps them inside
+        // strings and normalises the rest, so compare line endings apart.
         assert_eq!(
-            doc.to_toml(),
-            text,
+            doc.to_toml().replace("\r\n", "\n"),
+            text.replace("\r\n", "\n"),
             "{} changed on the way through",
             agent.name
         );

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -53,7 +53,7 @@ pub struct ListArgs {
 #[derive(serde::Serialize)]
 pub(crate) struct AgentInfo {
     pub(crate) name: String,
-    version: String,
+    pub(crate) version: String,
     pub(crate) description: String,
     /// The agent's `[read_paths]` grant status under the active config, when it
     /// declares any. Shown because a declaration nothing grants is inert, and

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -24,6 +24,7 @@ use crate::tui::keymap;
 use crate::tui::widgets::confirm::ConfirmOutcome;
 use crate::tui::widgets::help::handle_help_key;
 use crate::tui::widgets::line_edit::{EditOutcome, LineEdit};
+use crate::tui::widgets::picker::PickerOutcome;
 
 /// What the loop should do after a key press.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -139,57 +140,28 @@ impl Wizard {
         }
     }
 
-    /// The mouse while the chooser is open: the wheel moves within the list, a
-    /// click on a row takes it.
-    ///
-    /// A click outside the list is ignored rather than closing the chooser.
-    /// Closing on a stray click would discard a search somebody was halfway
-    /// through typing, and Esc is right there.
+    /// The mouse while the chooser is open: the widget moves or chooses, and
+    /// a choice is written back to the field.
     fn handle_picker_mouse(&mut self, mouse: MouseEvent, area: Rect, mut picker: Picker) {
-        match mouse.kind {
-            MouseEventKind::ScrollDown => picker.move_cursor(1),
-            MouseEventKind::ScrollUp => picker.move_cursor(-1),
-            MouseEventKind::Down(MouseButton::Left) => {
-                if let Some(row) = super::render::picker_row_at(area, &picker, mouse.row) {
-                    picker.cursor = row;
-                    self.commit_picker(picker);
-                    return;
-                }
-            }
-            _ => {}
-        }
-        self.picker = Some(picker);
+        let outcome = picker.handle_mouse(&mouse, area);
+        self.settle_picker(picker, outcome);
     }
 
-    /// Keys while the chooser is open.
-    ///
-    /// Everything that is not navigation goes to the search box, so letters
-    /// type rather than acting: `q` in a chooser means the user is looking for
-    /// Qwen, and quitting setup instead would be indefensible.
+    /// Keys while the chooser is open: the widget filters, moves or chooses.
     fn handle_picker_key(&mut self, key: KeyEvent, mut picker: Picker) {
-        match key.code {
-            KeyCode::Up => picker.move_cursor(-1),
-            KeyCode::Down => picker.move_cursor(1),
-            KeyCode::PageUp => picker.move_cursor(-Wizard::PAGE),
-            KeyCode::PageDown => picker.move_cursor(Wizard::PAGE),
-            KeyCode::Home => picker.cursor = 0,
-            KeyCode::End => picker.move_cursor(isize::MAX),
-            _ => {
-                match picker.query.handle_key(&key) {
-                    EditOutcome::Commit => {
-                        self.commit_picker(picker);
-                        return;
-                    }
-                    // Esc closes without choosing, leaving the field as it was.
-                    EditOutcome::Cancel => return,
-                    EditOutcome::Pending => {}
-                }
-                // The filter just changed under the cursor, so a selection
-                // that has been filtered away must not linger off the end.
-                picker.move_cursor(0);
-            }
+        let outcome = picker.handle_key(&key);
+        self.settle_picker(picker, outcome);
+    }
+
+    /// What the chooser decided: keep it open, or close it with or without a
+    /// value. The wizard's chooser is single-select, so a many-choice never
+    /// arrives; treated as a cancel should the widget ever send one.
+    fn settle_picker(&mut self, picker: Picker, outcome: PickerOutcome) {
+        match outcome {
+            PickerOutcome::Pending => self.picker = Some(picker),
+            PickerOutcome::Chosen(index) => self.commit_picker(index),
+            PickerOutcome::Cancelled | PickerOutcome::ChosenMany(_) => {}
         }
-        self.picker = Some(picker);
     }
 
     /// Keys while a text field is open.

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1426,13 +1426,7 @@ fn clicking_a_row_in_the_chooser_takes_it_and_the_wheel_moves_within_it() {
     assert!(w.picker.is_some());
 
     let row = (0..AREA.height)
-        .find(|y| {
-            crate::commands::setup::render::picker_row_at(
-                AREA,
-                w.picker.as_ref().expect("open"),
-                *y,
-            ) == Some(2)
-        })
+        .find(|y| w.picker.as_ref().expect("open").row_at(AREA, *y) == Some(2))
         .expect("the third match is on screen");
     w.handle_mouse(click(6, row), AREA);
 

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -20,15 +20,14 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Margin, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, Wrap},
+    widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
 };
 
 use super::catalog::{self, Credential};
-use super::state::{FieldValue, Picker, Step, Wizard};
+use super::state::{FieldValue, Step, Wizard};
 use crate::tui::theme::*;
 use crate::tui::widgets::footer::{Hint, draw_hint_bar, hint};
 use crate::tui::widgets::help::{HelpSection, draw_help};
-use crate::tui::widgets::popup::{centered, popup_frame};
 
 /// The smallest window the wizard will try to draw in. Below this there is no
 /// honest layout left, and half a bordered pane reads as a broken program
@@ -66,112 +65,10 @@ pub fn draw(frame: &mut Frame, wizard: &Wizard) {
     if let Some(pending) = &wizard.confirm {
         pending.dialog.draw(frame, frame.area());
     } else if let Some(picker) = &wizard.picker {
-        draw_picker(frame, frame.area(), picker);
+        picker.draw(frame, frame.area());
     } else if wizard.show_help {
         draw_help(frame, frame.area(), &help_sections(), &wizard.help_scroll);
     }
-}
-
-/// The chooser's split: prose, search box, then the list with the rest.
-fn picker_layout(inner: Rect, picker: &Picker) -> std::rc::Rc<[Rect]> {
-    let explain = (picker.explain.len() as u16 + 2).min(inner.height.saturating_sub(4));
-    Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([
-            Constraint::Length(explain),
-            Constraint::Length(2),
-            Constraint::Min(1),
-        ])
-        .split(inner)
-}
-
-/// Which option a click in the chooser landed on, as an index into the
-/// filtered list. Shares `picker_layout` with the drawing, so a click cannot
-/// resolve against rows that were not on screen.
-pub fn picker_row_at(area: Rect, picker: &Picker, row: u16) -> Option<usize> {
-    let popup = centered(80, 88, area);
-    // What `popup_frame` leaves after its border.
-    let inner = Block::default().borders(Borders::ALL).inner(popup);
-    if inner.height < 4 {
-        return None;
-    }
-    let list = picker_layout(inner, picker)[2];
-    if row < list.y || row >= list.y + list.height {
-        return None;
-    }
-    let height = list.height as usize;
-    let offset = picker.cursor.saturating_sub(height.saturating_sub(1));
-    let position = offset + (row - list.y) as usize;
-    (position < picker.matches().len()).then_some(position)
-}
-
-/// Draw the chooser over everything else.
-///
-/// It takes most of the window rather than a small popup: the whole complaint
-/// it answers is that a long list read through one line is unreadable, and the
-/// prose above it is the other half of the answer.
-fn draw_picker(frame: &mut Frame, area: Rect, picker: &Picker) {
-    let popup = centered(80, 88, area);
-    let inner = popup_frame(frame, popup, picker.title, C_BORDER_FOCUS);
-    let chunks = picker_layout(inner, picker);
-
-    let mut lines: Vec<Line<'static>> = picker
-        .explain
-        .iter()
-        .map(|text| Line::from(Span::styled(*text, Style::default().fg(C_MUTED))))
-        .collect();
-    lines.push(Line::from(""));
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), chunks[0]);
-
-    let mut search = vec![Span::styled("Search  ", Style::default().fg(C_DIM))];
-    search.extend(picker.query.display_spans(true).spans);
-    frame.render_widget(
-        Paragraph::new(vec![Line::from(search), Line::from("")]),
-        chunks[1],
-    );
-
-    let matches = picker.matches();
-    if matches.is_empty() {
-        frame.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                "Nothing matches that.",
-                Style::default().fg(C_WARN),
-            ))),
-            chunks[2],
-        );
-        return;
-    }
-
-    let height = chunks[2].height as usize;
-    // Keep the cursor in view without a stored offset: the list is rebuilt
-    // every frame anyway, so the window into it is arithmetic, not state.
-    let offset = picker.cursor.saturating_sub(height.saturating_sub(1));
-    let rows: Vec<Line<'static>> = matches
-        .iter()
-        .enumerate()
-        .skip(offset)
-        .take(height)
-        .map(|(position, option)| {
-            let option = &picker.options[*option];
-            let selected = position == picker.cursor;
-            Line::from(vec![
-                Span::styled(
-                    if selected { "› " } else { "  " },
-                    Style::default().fg(C_ACCENT),
-                ),
-                Span::styled(
-                    format!("{:<38}", option.value),
-                    if selected {
-                        Style::default().fg(C_ACTIVE).add_modifier(Modifier::BOLD)
-                    } else {
-                        Style::default().fg(C_WHITE)
-                    },
-                ),
-                Span::styled(option.detail.clone(), Style::default().fg(C_DIM)),
-            ])
-        })
-        .collect();
-    frame.render_widget(Paragraph::new(rows), chunks[2]);
 }
 
 /// The help overlay's content, matching the bindings in `input.rs`.
@@ -1445,9 +1342,9 @@ mod tests {
 
         // `draw` refuses to draw anything under its own floor, so this size
         // only reaches the hit test - which a real 5-row terminal can.
-        assert_eq!(picker_row_at(Rect::new(0, 0, 60, 5), picker, 3), None);
+        assert_eq!(picker.row_at(Rect::new(0, 0, 60, 5), 3), None);
         // A click outside the list is not a row either.
-        assert_eq!(picker_row_at(Rect::new(0, 0, 90, 40), picker, 1), None);
+        assert_eq!(picker.row_at(Rect::new(0, 0, 90, 40), 1), None);
     }
 
     /// Hit-testing agrees with drawing about what is on screen: nothing below

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -102,7 +102,9 @@ pub struct Wizard {
     /// why it is a `Cell`.
     pub help_scroll: std::cell::Cell<usize>,
     /// The open chooser for a Defaults value, if one is open.
-    pub picker: Option<Picker>,
+    pub(crate) picker: Option<Picker>,
+    /// Which Defaults field the open chooser is choosing for.
+    pub(crate) picker_field: usize,
 }
 
 /// The environment variables the wizard reports as already-supplying a
@@ -218,6 +220,7 @@ impl Wizard {
             show_advanced: false,
             help_scroll: std::cell::Cell::new(0),
             picker: None,
+            picker_field: 0,
         };
         wizard.rebuild_defaults();
         wizard
@@ -734,16 +737,18 @@ impl Wizard {
                 PickerOption { value, detail }
             })
             .collect();
-        self.picker = Some(Picker {
-            field,
+        self.picker_field = field;
+        // Opening on the current value rather than at the top: the list is
+        // long, and "where am I now" is the first thing you look for.
+        self.picker = Some(Picker::new(
             title,
-            explain: Self::precedence_explanation(field == Self::PROVIDER_FIELD),
-            query: crate::tui::widgets::line_edit::LineEdit::new(String::new(), false),
+            Self::precedence_explanation(field == Self::PROVIDER_FIELD)
+                .into_iter()
+                .map(str::to_string)
+                .collect(),
             options,
-            // Opening on the current value rather than at the top: the list is
-            // long, and "where am I now" is the first thing you look for.
-            cursor: index,
-        });
+            index,
+        ));
     }
 
     /// What a provider id is, for the chooser's second column.
@@ -775,22 +780,18 @@ impl Wizard {
         format!("reported by {}", reported.join(", "))
     }
 
-    /// Take the chooser's answer, writing it back into the field it came from.
-    pub(super) fn commit_picker(&mut self, picker: Picker) {
-        let Some(chosen) = picker.selected() else {
-            // An empty filter has nothing to choose; closing without a change
-            // is the only honest outcome.
-            return;
-        };
+    /// Take the chooser's answer (an index into its options), writing it
+    /// back into the field it came from.
+    pub(super) fn commit_picker(&mut self, chosen: usize) {
         // The chooser's options were built from this field's, one for one and
-        // in order, so the match index *is* the field's index. Indexing rather
+        // in order, so the option index *is* the field's index. Indexing rather
         // than looking up: the field is where it was when the chooser opened,
         // and nothing rebuilds the form while one is on screen.
-        self.defaults[picker.field].value.set_index(chosen);
+        self.defaults[self.picker_field].value.set_index(chosen);
         self.dirty = true;
         // The concurrency default follows the provider, so an Ollama-first
         // setup does not inherit a number meant for hosted APIs.
-        if picker.field == Self::PROVIDER_FIELD {
+        if self.picker_field == Self::PROVIDER_FIELD {
             self.apply_provider_concurrency_default();
         }
     }

--- a/crates/leviath-cli/src/commands/setup/state/types.rs
+++ b/crates/leviath-cli/src/commands/setup/state/types.rs
@@ -123,73 +123,13 @@ pub struct McpRow {
     pub name: String,
 }
 
-/// A full-screen chooser for one of the Defaults screen's list values.
+/// The full-screen chooser the Defaults screen opens for a list value.
 ///
 /// The arrows cycle those fields in place, which is fine for three providers
-/// and hopeless for eighty models: you read the list one value at a time
-/// through a single line, and the only way back is round again. The picker
-/// shows the list, filters it as you type, and says what the value decides -
-/// which the field could not, in the one line it had.
-pub struct Picker {
-    /// Which Defaults field this is choosing for.
-    pub field: usize,
-    /// Its heading, taken from the field it opened from.
-    pub title: &'static str,
-    /// What the value actually decides, and what it does not.
-    pub explain: Vec<&'static str>,
-    /// The search box. Crate-visible like the widget it holds, which is not
-    /// part of any public surface.
-    pub(crate) query: crate::tui::widgets::line_edit::LineEdit,
-    /// Every option, in the field's own order.
-    pub options: Vec<PickerOption>,
-    /// Cursor into the *filtered* list, not into `options`.
-    pub cursor: usize,
-}
-
-/// One row of a [`Picker`].
-pub struct PickerOption {
-    /// The value that would be written.
-    pub value: String,
-    /// Where it came from, or what it is, in a few words.
-    pub detail: String,
-}
-
-impl Picker {
-    /// The options matching the query, as indices into `options`.
-    ///
-    /// Every whitespace-separated term has to appear somewhere in the row, so
-    /// "claude sonnet" finds the model whichever order the id puts them in,
-    /// and a term can match the provider that reported it as easily as the
-    /// name itself.
-    pub fn matches(&self) -> Vec<usize> {
-        let query = self.query.value().to_lowercase();
-        let terms: Vec<&str> = query.split_whitespace().collect();
-        self.options
-            .iter()
-            .enumerate()
-            .filter(|(_, option)| {
-                let haystack = format!("{} {}", option.value, option.detail).to_lowercase();
-                terms.iter().all(|term| haystack.contains(term))
-            })
-            .map(|(index, _)| index)
-            .collect()
-    }
-
-    /// Which option the cursor is on, if the filter left anything.
-    pub fn selected(&self) -> Option<usize> {
-        self.matches().get(self.cursor).copied()
-    }
-
-    /// Move within the filtered list, clamped to it.
-    ///
-    /// Clamping rather than wrapping: at eighty models, wrapping from the top
-    /// to the bottom looks like the list jumped rather than moved.
-    pub fn move_cursor(&mut self, delta: isize) {
-        let count = self.matches().len();
-        let next = self.cursor as isize + delta;
-        self.cursor = next.clamp(0, count.saturating_sub(1) as isize) as usize;
-    }
-}
+/// and hopeless for eighty models. The chooser shows the list, filters it as
+/// you type, and says what the value decides. It lives with the shared
+/// widgets now, because the dashboard's agent editor chooses the same way.
+pub(crate) use crate::tui::widgets::picker::{Picker, PickerOption};
 
 /// A thing the credential screen can do, offered as its own row.
 ///

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -12,6 +12,7 @@
 //! struct around it says which command it belongs to.
 
 pub mod approvals;
+pub mod blueprint_edit;
 pub mod bundled;
 pub mod commands;
 pub mod config;

--- a/crates/leviath-cli/src/tui/widgets/mod.rs
+++ b/crates/leviath-cli/src/tui/widgets/mod.rs
@@ -9,5 +9,6 @@ pub(crate) mod confirm;
 pub(crate) mod footer;
 pub(crate) mod help;
 pub(crate) mod line_edit;
+pub(crate) mod picker;
 pub(crate) mod popup;
 pub(crate) mod scroll;

--- a/crates/leviath-cli/src/tui/widgets/picker.rs
+++ b/crates/leviath-cli/src/tui/widgets/picker.rs
@@ -1,0 +1,482 @@
+//! A full-screen chooser: a list, filtered as you type, with a line or two
+//! saying what the choice decides.
+//!
+//! The setup wizard grew this for its Defaults screen, where the arrows
+//! cycled a field's values in place, which is fine for three providers and
+//! hopeless for eighty models. The dashboard's agent editor picks models,
+//! stages, regions and tools the same way, so the chooser lives here and
+//! both use it. A multi-select mode (space toggles, enter is done) serves
+//! the tools list.
+
+use std::collections::BTreeSet;
+
+use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+
+use super::line_edit::{EditOutcome, LineEdit};
+use super::popup::{centered, popup_frame};
+use crate::tui::theme::{C_ACCENT, C_ACTIVE, C_BORDER_FOCUS, C_DIM, C_MUTED, C_WARN, C_WHITE};
+
+/// Rows a page key moves.
+const PAGE: isize = 8;
+
+/// One row of a [`Picker`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct PickerOption {
+    /// The value that would be written.
+    pub(crate) value: String,
+    /// Where it came from, or what it is, in a few words.
+    pub(crate) detail: String,
+}
+
+/// What a key or click did to the chooser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PickerOutcome {
+    /// Still choosing.
+    Pending,
+    /// One option chosen (single-select): its index into `options`.
+    Chosen(usize),
+    /// Done choosing (multi-select): the chosen indices, in list order.
+    ChosenMany(Vec<usize>),
+    /// Closed without choosing.
+    Cancelled,
+}
+
+/// The chooser's state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Picker {
+    /// Its heading.
+    pub(crate) title: String,
+    /// What the value actually decides, and what it does not.
+    pub(crate) explain: Vec<String>,
+    /// The search box.
+    pub(crate) query: LineEdit,
+    /// Every option, in the caller's order.
+    pub(crate) options: Vec<PickerOption>,
+    /// Cursor into the *filtered* list, not into `options`.
+    pub(crate) cursor: usize,
+    /// Multi-select: the chosen indices into `options`. `None` = one choice.
+    pub(crate) multi: Option<BTreeSet<usize>>,
+}
+
+impl Picker {
+    /// A single-select chooser open on `cursor` (an index into `options`,
+    /// so a list opens on its current value rather than at the top).
+    pub(crate) fn new(
+        title: impl Into<String>,
+        explain: Vec<String>,
+        options: Vec<PickerOption>,
+        cursor: usize,
+    ) -> Self {
+        Self {
+            title: title.into(),
+            explain,
+            query: LineEdit::new(String::new(), false),
+            options,
+            cursor,
+            multi: None,
+        }
+    }
+
+    /// The options matching the query, as indices into `options`.
+    ///
+    /// Every whitespace-separated term has to appear somewhere in the row, so
+    /// "claude sonnet" finds the model whichever order the id puts them in,
+    /// and a term can match the detail as easily as the value.
+    pub(crate) fn matches(&self) -> Vec<usize> {
+        let query = self.query.value().to_lowercase();
+        let terms: Vec<&str> = query.split_whitespace().collect();
+        self.options
+            .iter()
+            .enumerate()
+            .filter(|(_, option)| {
+                let haystack = format!("{} {}", option.value, option.detail).to_lowercase();
+                terms.iter().all(|term| haystack.contains(term))
+            })
+            .map(|(index, _)| index)
+            .collect()
+    }
+
+    /// Which option the cursor is on, if the filter left anything.
+    pub(crate) fn selected(&self) -> Option<usize> {
+        self.matches().get(self.cursor).copied()
+    }
+
+    /// Move within the filtered list, clamped to it.
+    ///
+    /// Clamping rather than wrapping: at eighty models, wrapping from the top
+    /// to the bottom looks like the list jumped rather than moved.
+    pub(crate) fn move_cursor(&mut self, delta: isize) {
+        let count = self.matches().len();
+        let next = self.cursor as isize + delta;
+        self.cursor = next.clamp(0, count.saturating_sub(1) as isize) as usize;
+    }
+
+    /// Whether an option is chosen (multi-select).
+    pub(crate) fn is_chosen(&self, index: usize) -> bool {
+        self.multi.as_ref().is_some_and(|m| m.contains(&index))
+    }
+
+    /// Flip the option under the cursor (multi-select).
+    fn toggle_selected(&mut self) {
+        if let Some(index) = self.selected()
+            && let Some(multi) = self.multi.as_mut()
+            && !multi.remove(&index)
+        {
+            multi.insert(index);
+        }
+    }
+
+    fn done(&self) -> PickerOutcome {
+        match &self.multi {
+            Some(multi) => PickerOutcome::ChosenMany(multi.iter().copied().collect()),
+            None => match self.selected() {
+                Some(index) => PickerOutcome::Chosen(index),
+                // An empty filter has nothing to choose; closing without a
+                // change is the only honest outcome.
+                None => PickerOutcome::Cancelled,
+            },
+        }
+    }
+
+    /// Keys while the chooser is open.
+    ///
+    /// Everything that is not navigation goes to the search box, so letters
+    /// type rather than acting: `q` in a chooser means the user is looking
+    /// for Qwen, and quitting instead would be indefensible.
+    pub(crate) fn handle_key(&mut self, key: &KeyEvent) -> PickerOutcome {
+        match key.code {
+            KeyCode::Up => self.move_cursor(-1),
+            KeyCode::Down => self.move_cursor(1),
+            KeyCode::PageUp => self.move_cursor(-PAGE),
+            KeyCode::PageDown => self.move_cursor(PAGE),
+            KeyCode::Home => self.cursor = 0,
+            KeyCode::End => self.move_cursor(isize::MAX),
+            KeyCode::Char(' ') if self.multi.is_some() => self.toggle_selected(),
+            _ => {
+                match self.query.handle_key(key) {
+                    EditOutcome::Commit => return self.done(),
+                    // Esc closes without choosing, leaving the field as it was.
+                    EditOutcome::Cancel => return PickerOutcome::Cancelled,
+                    EditOutcome::Pending => {}
+                }
+                // The filter just changed under the cursor, so a selection
+                // that has been filtered away must not linger off the end.
+                self.move_cursor(0);
+            }
+        }
+        PickerOutcome::Pending
+    }
+
+    /// The mouse while the chooser is open: the wheel moves within the list,
+    /// a click on a row takes it (or, multi-select, flips it).
+    ///
+    /// A click outside the list is ignored rather than closing the chooser.
+    /// Closing on a stray click would discard a search somebody was halfway
+    /// through typing, and Esc is right there.
+    pub(crate) fn handle_mouse(&mut self, mouse: &MouseEvent, area: Rect) -> PickerOutcome {
+        match mouse.kind {
+            MouseEventKind::ScrollDown => self.move_cursor(1),
+            MouseEventKind::ScrollUp => self.move_cursor(-1),
+            MouseEventKind::Down(MouseButton::Left) => {
+                if let Some(row) = self.row_at(area, mouse.row) {
+                    self.cursor = row;
+                    if self.multi.is_some() {
+                        self.toggle_selected();
+                    } else {
+                        return self.done();
+                    }
+                }
+            }
+            _ => {}
+        }
+        PickerOutcome::Pending
+    }
+
+    /// The chooser's split: prose, search box, then the list with the rest.
+    fn layout(&self, inner: Rect) -> std::rc::Rc<[Rect]> {
+        let explain = (self.explain.len() as u16 + 2).min(inner.height.saturating_sub(4));
+        Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(explain),
+                Constraint::Length(2),
+                Constraint::Min(1),
+            ])
+            .split(inner)
+    }
+
+    /// Which option a click landed on, as an index into the filtered list.
+    /// Shares the layout with the drawing, so a click cannot resolve against
+    /// rows that were not on screen.
+    pub(crate) fn row_at(&self, area: Rect, row: u16) -> Option<usize> {
+        let popup = centered(80, 88, area);
+        // What `popup_frame` leaves after its border.
+        let inner = Block::default().borders(Borders::ALL).inner(popup);
+        if inner.height < 4 {
+            return None;
+        }
+        let list = self.layout(inner)[2];
+        if row < list.y || row >= list.y + list.height {
+            return None;
+        }
+        let height = list.height as usize;
+        let offset = self.cursor.saturating_sub(height.saturating_sub(1));
+        let position = offset + (row - list.y) as usize;
+        (position < self.matches().len()).then_some(position)
+    }
+
+    /// Draw the chooser over everything else.
+    ///
+    /// It takes most of the window rather than a small popup: the whole
+    /// complaint it answers is that a long list read through one line is
+    /// unreadable, and the prose above it is the other half of the answer.
+    pub(crate) fn draw(&self, frame: &mut Frame, area: Rect) {
+        let popup = centered(80, 88, area);
+        let inner = popup_frame(frame, popup, &self.title, C_BORDER_FOCUS);
+        let chunks = self.layout(inner);
+
+        let mut lines: Vec<Line<'static>> = self
+            .explain
+            .iter()
+            .map(|text| Line::from(Span::styled(text.clone(), Style::default().fg(C_MUTED))))
+            .collect();
+        if self.multi.is_some() {
+            lines.push(Line::from(Span::styled(
+                "Space picks or drops a row; Enter keeps what is picked.",
+                Style::default().fg(C_MUTED),
+            )));
+        }
+        lines.push(Line::from(""));
+        frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), chunks[0]);
+
+        let mut search = vec![Span::styled("Search  ", Style::default().fg(C_DIM))];
+        search.extend(self.query.display_spans(true).spans);
+        frame.render_widget(
+            Paragraph::new(vec![Line::from(search), Line::from("")]),
+            chunks[1],
+        );
+
+        let matches = self.matches();
+        if matches.is_empty() {
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    "Nothing matches that.",
+                    Style::default().fg(C_WARN),
+                ))),
+                chunks[2],
+            );
+            return;
+        }
+
+        let height = chunks[2].height as usize;
+        // Keep the cursor in view without a stored offset: the list is rebuilt
+        // every frame anyway, so the window into it is arithmetic, not state.
+        let offset = self.cursor.saturating_sub(height.saturating_sub(1));
+        let rows: Vec<Line<'static>> = matches
+            .iter()
+            .enumerate()
+            .skip(offset)
+            .take(height)
+            .map(|(position, index)| {
+                let option = &self.options[*index];
+                let selected = position == self.cursor;
+                let mark = match &self.multi {
+                    Some(_) if self.is_chosen(*index) => "[x] ",
+                    Some(_) => "[ ] ",
+                    None => "",
+                };
+                Line::from(vec![
+                    Span::styled(
+                        if selected { "› " } else { "  " },
+                        Style::default().fg(C_ACCENT),
+                    ),
+                    Span::styled(mark, Style::default().fg(C_ACCENT)),
+                    Span::styled(
+                        format!("{:<38}", option.value),
+                        if selected {
+                            Style::default().fg(C_ACTIVE).add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(C_WHITE)
+                        },
+                    ),
+                    Span::styled(option.detail.clone(), Style::default().fg(C_DIM)),
+                ])
+            })
+            .collect();
+        frame.render_widget(Paragraph::new(rows), chunks[2]);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn options() -> Vec<PickerOption> {
+        ["alpha", "beta", "gamma", "delta"]
+            .iter()
+            .map(|v| PickerOption {
+                value: v.to_string(),
+                detail: format!("the letter {v}"),
+            })
+            .collect()
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::empty(),
+        }
+    }
+
+    fn rendered(picker: &Picker, w: u16, h: u16) -> String {
+        let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+        terminal.draw(|f| picker.draw(f, f.area())).unwrap();
+        terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn typing_filters_and_enter_chooses() {
+        let mut p = Picker::new("Pick", vec!["what it decides".into()], options(), 1);
+        assert_eq!(p.selected(), Some(1));
+        for c in "ta".chars() {
+            assert_eq!(p.handle_key(&key(KeyCode::Char(c))), PickerOutcome::Pending);
+        }
+        assert_eq!(p.matches(), [1, 3], "beta and delta");
+        assert_eq!(p.cursor, 1);
+        assert_eq!(p.handle_key(&key(KeyCode::Down)), PickerOutcome::Pending);
+        assert_eq!(
+            p.handle_key(&key(KeyCode::Down)),
+            PickerOutcome::Pending,
+            "clamped"
+        );
+        assert_eq!(p.handle_key(&key(KeyCode::Enter)), PickerOutcome::Chosen(3));
+        assert_eq!(p.handle_key(&key(KeyCode::Home)), PickerOutcome::Pending);
+        assert_eq!(p.cursor, 0);
+        assert_eq!(p.handle_key(&key(KeyCode::End)), PickerOutcome::Pending);
+        assert_eq!(p.cursor, 1);
+        assert_eq!(p.handle_key(&key(KeyCode::PageUp)), PickerOutcome::Pending);
+        assert_eq!(
+            p.handle_key(&key(KeyCode::PageDown)),
+            PickerOutcome::Pending
+        );
+        assert_eq!(p.handle_key(&key(KeyCode::Up)), PickerOutcome::Pending);
+        assert_eq!(p.handle_key(&key(KeyCode::Esc)), PickerOutcome::Cancelled);
+        // Nothing matches: Enter cannot choose.
+        for c in "zz".chars() {
+            p.handle_key(&key(KeyCode::Char(c)));
+        }
+        assert!(p.selected().is_none());
+        assert_eq!(p.handle_key(&key(KeyCode::Enter)), PickerOutcome::Cancelled);
+        assert!(rendered(&p, 80, 30).contains("Nothing matches that."));
+    }
+
+    #[test]
+    fn multi_select_toggles_with_space_and_click() {
+        let mut p = Picker::new("Tools", vec![], options(), 0);
+        p.multi = Some([2].into_iter().collect());
+        assert!(p.is_chosen(2));
+        assert_eq!(
+            p.handle_key(&key(KeyCode::Char(' '))),
+            PickerOutcome::Pending
+        );
+        assert!(p.is_chosen(0));
+        assert_eq!(
+            p.handle_key(&key(KeyCode::Char(' '))),
+            PickerOutcome::Pending
+        );
+        assert!(!p.is_chosen(0), "space again drops it");
+        let area = Rect::new(0, 0, 80, 30);
+        let row = (0..30)
+            .find(|y| p.row_at(area, *y) == Some(1))
+            .expect("beta on screen");
+        assert_eq!(
+            p.handle_mouse(
+                &mouse(MouseEventKind::Down(MouseButton::Left), 10, row),
+                area
+            ),
+            PickerOutcome::Pending
+        );
+        assert!(p.is_chosen(1));
+        let text = rendered(&p, 80, 30);
+        assert!(text.contains("[x] beta"), "{text}");
+        assert!(text.contains("[ ] alpha"), "{text}");
+        assert!(text.contains("Space picks or drops"), "{text}");
+        assert_eq!(
+            p.handle_key(&key(KeyCode::Enter)),
+            PickerOutcome::ChosenMany(vec![1, 2])
+        );
+        // Space with an empty filter is nothing to toggle.
+        for c in "zz".chars() {
+            p.handle_key(&key(KeyCode::Char(c)));
+        }
+        assert_eq!(
+            p.handle_key(&key(KeyCode::Char(' '))),
+            PickerOutcome::Pending
+        );
+        assert_eq!(
+            p.handle_key(&key(KeyCode::Enter)),
+            PickerOutcome::ChosenMany(vec![1, 2])
+        );
+    }
+
+    #[test]
+    fn the_mouse_scrolls_and_clicks_a_row() {
+        let mut p = Picker::new("Pick", vec!["a".into()], options(), 0);
+        let area = Rect::new(0, 0, 80, 30);
+        assert_eq!(
+            p.handle_mouse(&mouse(MouseEventKind::ScrollDown, 1, 1), area),
+            PickerOutcome::Pending
+        );
+        assert_eq!(p.cursor, 1);
+        assert_eq!(
+            p.handle_mouse(&mouse(MouseEventKind::ScrollUp, 1, 1), area),
+            PickerOutcome::Pending
+        );
+        assert_eq!(p.cursor, 0);
+        // Outside the list: ignored. A move: ignored.
+        assert_eq!(
+            p.handle_mouse(&mouse(MouseEventKind::Down(MouseButton::Left), 1, 0), area),
+            PickerOutcome::Pending
+        );
+        assert_eq!(
+            p.handle_mouse(&mouse(MouseEventKind::Moved, 1, 1), area),
+            PickerOutcome::Pending
+        );
+        let row = (0..30)
+            .find(|y| p.row_at(area, *y) == Some(2))
+            .expect("gamma on screen");
+        assert_eq!(
+            p.handle_mouse(
+                &mouse(MouseEventKind::Down(MouseButton::Left), 10, row),
+                area
+            ),
+            PickerOutcome::Chosen(2)
+        );
+        // Too short a window has no rows; below the last row is not a row.
+        assert_eq!(p.row_at(Rect::new(0, 0, 60, 5), 3), None);
+        assert_eq!(p.row_at(area, 29), None);
+        let text = rendered(&p, 80, 30);
+        assert!(text.contains("Search"), "{text}");
+        assert!(text.contains("the letter gamma"), "{text}");
+    }
+}


### PR DESCRIPTION
## What

The first of three PRs for an agent builder in `lev dash` (an Agents screen and a graph editor with feature parity with The Lair's blueprint editor). This one is the model underneath, with no visible change yet:

- **`blueprint_edit`**: an `agent.leviath` held as a `toml_edit` document, the one source of truth, with typed views (`agent()`, `stages()`, `edges()`, `effective_regions()`, `tool_routing()`) derived on demand and mutators that refuse rather than break the document (`add_stage`, `rename_stage`, `delete_stage`, `move_stage`, `set_models`, `set_tools`, `add_edge`, `set_edge_kind`, `set_edge_gate`, `set_transform`, `set_transform_rule`, `add_region`, `rename_region`, `set_region_field`, `create_stage_override`, `set_tool_routing_*`, the fan-out keys, and so on). The rules are The Lair's `editable.ts` field for field: an empty string deletes a key, `direct` is written as absent, a new path is `hint = "Continue here when appropriate"`, a new region is `pinned`/`5%`/`4000`, a rename rewrites what named the thing, deleting tidies emptied tables away. Comments, key order and formatting survive: every bundled manifest round-trips byte for byte, and a renamed stage keeps the comment above its header. `check()` runs the same parse, validate and lint pass `lev validate` and `POST /api/blueprints/validate` run. Also the "start simple" starter, `clone_of`, a per-home store for canvas arrangements, and the catalog (installed, configured, local, bundled) with write/delete/reset.
- **`tui::widgets::picker`**: the setup wizard's type-to-search chooser moved to the shared widgets (with a multi-select mode for the tools list) so the editor can use it; the wizard is switched over with no change in behaviour.

Why `toml_edit`: there is no Blueprint-to-TOML writer anywhere in the tree, every writer writes text, and `toml` re-emits from values, so the first edit would have dropped every comment a bundled agent carries. `toml_edit` was already in the lock file.

## How

- `crates/leviath-cli/src/blueprint_edit/{doc,tables,order,stages,edges,regions,check,templates,layout_store,catalog}.rs`, tests in `tests.rs`. `order.rs` reproduces `toml_edit`'s table-writing order so "add after plan" and "move up" land where the file will show them, and renumbers positions after a move.
- `crates/leviath-cli/src/tui/widgets/picker.rs`; `setup/state/types.rs` re-exports it, `setup/input.rs` and `setup/render.rs` delegate to it (`render.rs` lost sixty lines).
- Cargo: `toml_edit = "0.25"`, `thiserror` for the CLI crate.

## Checks

- `cargo xtask coverage --package leviath-cli` 100%.
- `cargo deny check licenses`, `cargo xtask docs`, clippy `-D warnings`.
