### PR TITLE
feat(serve): manage Rhai providers through the scripts API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,30 @@ same list.
 
 ## Unreleased
 
+- New: the scripts API manages Rhai model providers. `provider` joins `tool`,
+  `region_hook`, `stage_hook` and `output_validator` as a `kind` on
+  `GET /api/scripts`, `GET/PUT/DELETE /api/scripts/{kind}/{name}` and
+  `POST /api/scripts/validate`, so a console can list, open, edit, validate and
+  save the drop-in providers in `~/.leviath/providers` instead of leaving them
+  as the one extension point that needed a text editor on the host. A provider
+  belongs to the machine rather than to an agent, so it is listed either way and
+  the routes refuse an `?agent=` rather than quietly scoping themselves to a
+  directory nothing loads. Each entry carries what the script's `// @` comments
+  declare, so a listing can show a provider's description and default model
+  without fetching every file. Announced as `scripts.providers`; the API
+  contract version is now 0.4.0.
+- Fixed: a provider script that defines `initialize` but not `inference` is
+  refused when it loads, rather than compiling, initializing, caching, and then
+  failing at the first inference part-way into a run. It is now skipped with a
+  warning like any other broken script, so model selection falls through to the
+  next configured model, and `POST /api/scripts/validate` reports it before the
+  file is even saved. Validation still runs nothing: the entry points are read
+  off the compiled script, never called.
+- Fixed: a `[model_providers.<name>]` entry no longer prints its credentials
+  through `Debug`. Both the `api_key` and the extra keys forwarded into the
+  script's `initialize` were printable, where the first-party provider config
+  had been careful not to be; the two now agree, reporting whether the key is
+  set and the names in the extra table and nothing more.
 - Fixed: `lev serve`, `lev dash`, and `lev agent-client` ride out a daemon
   restart instead of breaking. A request that lands while the daemon is down
   (a `lev daemon restart`, a supervisor relaunch, or the restart that follows

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -42,7 +42,7 @@ pub(super) struct RedactedConfig {
 /// The API contract version. Held equal to the OpenAPI spec's `info.version` by
 /// a test, because a version that can silently disagree with the document it
 /// names is worse than no version at all.
-pub(super) const API_VERSION: &str = "0.3.0";
+pub(super) const API_VERSION: &str = "0.4.0";
 
 /// Every capability a client may check for.
 pub(super) const API_CAPABILITIES: &[&str] = &[
@@ -93,6 +93,12 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // finds out the same way it finds out about the MCP admin routes - by
     // calling one and reading the status.
     "scripts.write",
+    // `provider` as a fifth `kind` on the scripts routes: the drop-in model
+    // providers in `~/.leviath/providers`, which are global to the machine and
+    // take no `?agent=`. Separate from `scripts.read` because a build can serve
+    // the four agent-owned kinds without serving this one, and a console that
+    // offered the kind anyway would put an editor in front of a 400.
+    "scripts.providers",
     "config.gateways",
 ];
 

--- a/crates/leviath-cli/src/commands/serve/scripts.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts.rs
@@ -1,22 +1,27 @@
-//! Read and write the Rhai scripts an agent runs.
+//! Read and write the Rhai scripts a machine runs.
 //!
-//! Four extension points share one API because they share one editor: a script
-//! tool, a region hook, a stage hook and an output validator are all a `.rhai`
-//! file in the agent's directory, and only the `kind` says which compiler has to
-//! accept it.
+//! Five extension points share one API because they share one editor: a script
+//! tool, a region hook, a stage hook, an output validator and a model provider
+//! are all a `.rhai` file somewhere under the home directory, and only the
+//! `kind` says which compiler has to accept it.
 //!
 //! # Where each kind actually lives
 //!
-//! Only **script tools** have a directory convention: `<agent>/tools/*.rhai`,
-//! scanned at spawn, plus the global `~/.leviath/tools/` every agent gets. The
-//! other three are named by path in the manifest and resolved relative to the
-//! agent's own directory, with `resolve_*_scripts` in the daemon refusing any
-//! that lands outside it. There is no `hooks/` or `validators/` directory to
-//! list, so the listing derives those three from what the manifest declares,
-//! and the read/write routes address them at `<agent>/<name>.rhai` - the path a
-//! bare declared filename already resolves to. There is likewise no global
-//! directory for them: a hook only ever loads from beside the agent that
-//! declares it.
+//! Only **script tools** have a directory convention an agent owns:
+//! `<agent>/tools/*.rhai`, scanned at spawn, plus the global `~/.leviath/tools/`
+//! every agent gets. The hooks and the validator are named by path in the
+//! manifest and resolved relative to the agent's own directory, with
+//! `resolve_*_scripts` in the daemon refusing any that lands outside it. There
+//! is no `hooks/` or `validators/` directory to list, so the listing derives
+//! those three from what the manifest declares, and the read/write routes
+//! address them at `<agent>/<name>.rhai` - the path a bare declared filename
+//! already resolves to. There is likewise no global directory for them: a hook
+//! only ever loads from beside the agent that declares it.
+//!
+//! A **provider** is the inverse: `~/.leviath/providers/<name>.rhai` and nothing
+//! else. No agent owns one, and a stage reaches it by name rather than by path,
+//! so this route takes no `?agent=` and refuses one rather than inventing a
+//! per-agent layout that nothing would load.
 //!
 //! # Why the write half is gated
 //!
@@ -49,6 +54,8 @@ pub(super) enum ScriptKind {
     StageHook,
     /// A validator that decides whether an agent's output may be handed back.
     OutputValidator,
+    /// A drop-in model provider, global to the machine.
+    Provider,
 }
 
 impl ScriptKind {
@@ -59,6 +66,7 @@ impl ScriptKind {
             Self::RegionHook => "region_hook",
             Self::StageHook => "stage_hook",
             Self::OutputValidator => "output_validator",
+            Self::Provider => "provider",
         }
     }
 
@@ -70,10 +78,14 @@ impl ScriptKind {
             "region_hook" => Some(Self::RegionHook),
             "stage_hook" => Some(Self::StageHook),
             "output_validator" => Some(Self::OutputValidator),
+            "provider" => Some(Self::Provider),
             _ => None,
         }
     }
 }
+
+/// The kinds, spelled the way the 400s list them.
+const KIND_LIST: &str = "tool, region_hook, stage_hook, output_validator or provider";
 
 /// The global drop-in directory, `~/.leviath/tools`.
 ///
@@ -82,6 +94,13 @@ impl ScriptKind {
 /// a write lands nowhere rather than in the process's working directory.
 fn global_tools_dir() -> PathBuf {
     leviath_core::tools_dir().unwrap_or_default()
+}
+
+/// The drop-in provider directory, `~/.leviath/providers`.
+///
+/// Empty when no home resolves, for the same reason [`global_tools_dir`] is.
+fn global_providers_dir() -> PathBuf {
+    leviath_core::providers_dir().unwrap_or_default()
 }
 
 /// One resolved script file: which directory owns it, what it is called there,
@@ -117,10 +136,7 @@ fn resolve(kind: &str, name: &str, agent: Option<&str>) -> Result<Target, ApiErr
     let Some(kind) = ScriptKind::parse(kind) else {
         return Err(err(
             StatusCode::BAD_REQUEST,
-            format!(
-                "Unknown script kind '{kind}': expected tool, region_hook, stage_hook \
-                 or output_validator"
-            ),
+            format!("Unknown script kind '{kind}': expected {KIND_LIST}"),
         ));
     };
     let stem = name.strip_suffix(".rhai").unwrap_or(name);
@@ -134,8 +150,18 @@ fn resolve(kind: &str, name: &str, agent: Option<&str>) -> Result<Target, ApiErr
         ));
     }
 
-    let (dir, scope, owner) = match agent {
-        Some(agent) => {
+    let (dir, scope, owner) = match (agent, kind) {
+        // A provider is machine-wide. Scoping one to an agent would write a file
+        // nothing loads, so the agent is refused rather than ignored.
+        (Some(_), ScriptKind::Provider) => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                "A provider is global to the machine and lives in ~/.leviath/providers, \
+                 so this route takes no ?agent="
+                    .to_string(),
+            ));
+        }
+        (Some(agent), _) => {
             let base = agent_dir(agent)?;
             // Tools are scanned out of `tools/`; a hook or validator is named by
             // a manifest path that resolves against the agent's own directory.
@@ -145,19 +171,18 @@ fn resolve(kind: &str, name: &str, agent: Option<&str>) -> Result<Target, ApiErr
             };
             (dir, "agent", Some(agent.to_string()))
         }
-        None => match kind {
-            ScriptKind::Tool => (global_tools_dir(), "global", None),
-            _ => {
-                return Err(err(
-                    StatusCode::BAD_REQUEST,
-                    format!(
-                        "A {} is only ever loaded from beside the agent that declares it, \
-                         so this route needs ?agent=<name>",
-                        kind.as_str()
-                    ),
-                ));
-            }
-        },
+        (None, ScriptKind::Tool) => (global_tools_dir(), "global", None),
+        (None, ScriptKind::Provider) => (global_providers_dir(), "global", None),
+        (None, _) => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                format!(
+                    "A {} is only ever loaded from beside the agent that declares it, \
+                     so this route needs ?agent=<name>",
+                    kind.as_str()
+                ),
+            ));
+        }
     };
 
     let path = dir.join(format!("{stem}.rhai"));
@@ -228,29 +253,36 @@ fn guard(target: &Target, presence: Presence) -> Result<(), ApiError> {
 
 /// Compile `content` as `kind` and say only whether it worked.
 ///
-/// Each arm is the same compiler the daemon uses at spawn, so a script this
-/// accepts is one a run will accept. `hooks` is what a stage-hook file was named
-/// for; an empty slice asks only that it compiles, which is all that can be
-/// asked of a file no manifest points at yet.
+/// Each arm is the same compiler the daemon uses when it loads the script, so a
+/// script this accepts is one a run will accept. `hooks` is what a stage-hook
+/// file was named for; an empty slice asks only that it compiles, which is all
+/// that can be asked of a file no manifest points at yet.
+///
+/// Every arm stops at the AST. That is what lets `POST /api/scripts/validate`
+/// stay ungated: a provider's `initialize` is script code, and `check_source`
+/// reads it off the compiled AST rather than running it.
 fn compile_status(
     kind: ScriptKind,
     label: &str,
     content: &str,
     hooks: &[&str],
 ) -> Result<(), String> {
-    let outcome = match kind {
-        ScriptKind::Tool => leviath_scripting::tool::check_source(label, content).map(drop),
-        ScriptKind::RegionHook => leviath_scripting::region_hook::compile(label, content).map(drop),
-        ScriptKind::StageHook => {
-            leviath_scripting::stage_hook::compile(label, content, hooks).map(drop)
-        }
-        ScriptKind::OutputValidator => {
-            leviath_scripting::output_validator::compile(label, content).map(drop)
-        }
-    };
-    match outcome {
-        Ok(()) => Ok(()),
-        Err(e) => Err(e.to_string()),
+    match kind {
+        ScriptKind::Tool => leviath_scripting::tool::check_source(label, content)
+            .map(drop)
+            .map_err(|e| e.to_string()),
+        ScriptKind::RegionHook => leviath_scripting::region_hook::compile(label, content)
+            .map(drop)
+            .map_err(|e| e.to_string()),
+        ScriptKind::StageHook => leviath_scripting::stage_hook::compile(label, content, hooks)
+            .map(drop)
+            .map_err(|e| e.to_string()),
+        ScriptKind::OutputValidator => leviath_scripting::output_validator::compile(label, content)
+            .map(drop)
+            .map_err(|e| e.to_string()),
+        ScriptKind::Provider => leviath_providers::rhai_provider::check_source(label, content)
+            .map(drop)
+            .map_err(|e| e.to_string()),
     }
 }
 
@@ -272,10 +304,64 @@ pub(super) struct ScriptQuery {
     agent: Option<String>,
 }
 
+/// What a provider script's leading `// @` comments declare.
+///
+/// Carried as one nested object rather than as six more optional fields on
+/// every script: only a provider has any of it, and a shape whose fields are
+/// absent for four kinds out of five is a shape nobody can read. A console
+/// needs it to show which model a provider defaults to and how big a context it
+/// claims, without fetching and re-parsing the source.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ProviderScriptMeta {
+    /// `// @provider`: the name the script claims, which is informational.
+    /// Selection goes by the filename stem, or by the `[model_providers]` key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) provider: Option<String>,
+    /// `// @description`, empty when the script declares none.
+    pub(super) description: String,
+    /// `// @default_model`, used to fill an empty stage model.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) default_model: Option<String>,
+    /// `// @max_context_tokens`, defaulted when unset.
+    pub(super) max_context_tokens: usize,
+    /// `// @max_output_tokens`, defaulted when unset.
+    pub(super) max_output_tokens: usize,
+    /// `// @supports_streaming`. Advisory: real streaming follows whether the
+    /// script defines `stream`.
+    pub(super) supports_streaming: bool,
+}
+
+impl From<leviath_providers::rhai_provider::ProviderMeta> for ProviderScriptMeta {
+    fn from(meta: leviath_providers::rhai_provider::ProviderMeta) -> Self {
+        Self {
+            provider: meta.provider,
+            description: meta.description,
+            default_model: meta.default_model,
+            max_context_tokens: meta.max_context_tokens,
+            max_output_tokens: meta.max_output_tokens,
+            supports_streaming: meta.supports_streaming,
+        }
+    }
+}
+
+/// A provider script's annotations, for a script that is one.
+///
+/// Parsing never fails - an unrecognized or unparseable directive is ignored
+/// and the default kept - so this is independent of whether the script
+/// compiles, and a draft that does not compile still reports what it declares.
+fn provider_meta(kind: ScriptKind, content: &str) -> Option<ProviderScriptMeta> {
+    match kind {
+        ScriptKind::Provider => {
+            Some(leviath_providers::rhai_provider::parse_provider_annotations(content).into())
+        }
+        _ => None,
+    }
+}
+
 /// One script in the listing.
 #[derive(Debug, Serialize, Deserialize)]
 pub(super) struct ScriptItem {
-    /// `tool`, `region_hook`, `stage_hook` or `output_validator`.
+    /// `tool`, `region_hook`, `stage_hook`, `output_validator` or `provider`.
     pub(super) kind: String,
     /// The `{name}` the read and write routes address it by.
     pub(super) name: String,
@@ -291,6 +377,9 @@ pub(super) struct ScriptItem {
     /// Why not, when it does not.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) error: Option<String>,
+    /// What the script declares about itself, for `kind: "provider"` only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) provider: Option<ProviderScriptMeta>,
 }
 
 /// The body of `GET /api/scripts`.
@@ -321,6 +410,9 @@ pub(super) struct ScriptSource {
     /// Why not, when it does not.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) error: Option<String>,
+    /// What the script declares about itself, for `kind: "provider"` only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) provider: Option<ProviderScriptMeta>,
 }
 
 /// The body of `PUT /api/scripts/{kind}/{name}`.
@@ -439,6 +531,25 @@ fn declared_scripts(bp: &leviath_core::Blueprint) -> BTreeMap<(ScriptKind, Strin
     declared
 }
 
+/// The `.rhai` files one drop-in directory holds, sorted.
+///
+/// Sorted because a listing that reorders itself between two calls is a listing
+/// nobody can edit against, and `read_dir` order is whatever the filesystem
+/// feels like. A directory that cannot be read is an empty one: the tools and
+/// providers directories are both optional, and neither missing one is an
+/// error to report.
+fn rhai_files(dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .filter(|path| path.extension().is_some_and(|ext| ext == "rhai"))
+        .collect();
+    paths.sort();
+    paths
+}
+
 /// List the `.rhai` files in one tools directory, with the compile verdict
 /// `discover` already reached for each.
 ///
@@ -450,16 +561,7 @@ fn collect_tools(dir: &Path, scope: &'static str, agent: Option<&str>, out: &mut
     let reasons: HashMap<PathBuf, String> =
         failed.into_iter().map(|f| (f.path, f.reason)).collect();
 
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return;
-    };
-    let mut paths: Vec<PathBuf> = entries
-        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
-        .filter(|path| path.extension().is_some_and(|ext| ext == "rhai"))
-        .collect();
-    paths.sort();
-
-    for path in paths {
+    for path in rhai_files(dir) {
         let (compiles, error) = match reasons.get(&path) {
             Some(reason) => (false, Some(reason.clone())),
             None => (true, None),
@@ -476,6 +578,44 @@ fn collect_tools(dir: &Path, scope: &'static str, agent: Option<&str>, out: &mut
             path: path.display().to_string(),
             compiles,
             error,
+            provider: None,
+        });
+    }
+}
+
+/// List the `.rhai` files in the providers directory.
+///
+/// There is no `discover` to lean on the way [`collect_tools`] does: nothing
+/// scans this directory ahead of time, because a provider script is compiled
+/// only when an agent first names it. So each file is checked here, with the
+/// same `check_source` a write and a validate use.
+///
+/// Every entry is `global`. A provider belongs to the machine, not to an agent,
+/// which is why this runs whether or not the request named one.
+fn collect_providers(dir: &Path, out: &mut Vec<ScriptItem>) {
+    for path in rhai_files(dir) {
+        let label = path.display().to_string();
+        let (compiles, error, meta) = match std::fs::read_to_string(&path) {
+            Ok(content) => {
+                let (compiles, error) =
+                    status_pair(compile_status(ScriptKind::Provider, &label, &content, &[]));
+                (
+                    compiles,
+                    error,
+                    provider_meta(ScriptKind::Provider, &content),
+                )
+            }
+            Err(e) => (false, Some(format!("cannot read '{label}': {e}")), None),
+        };
+        out.push(ScriptItem {
+            kind: ScriptKind::Provider.as_str().to_string(),
+            name: stem_of(&path),
+            source: "global".to_string(),
+            agent: None,
+            path: label,
+            compiles,
+            error,
+            provider: meta,
         });
     }
 }
@@ -515,6 +655,7 @@ fn collect_declared(dir: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
             path: path.display().to_string(),
             compiles,
             error,
+            provider: None,
         });
     }
 }
@@ -524,9 +665,13 @@ fn collect_declared(dir: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
 /// `GET /api/scripts[?agent=<name>]`: every script this scope can see.
 ///
 /// With an agent, that is the agent's own `tools/`, the hooks and validators its
-/// manifest declares, and the global tools directory. Without one, the global
-/// directory alone. `source` is what separates "this agent has it" from
+/// manifest declares, and the machine's global scripts. Without one, the global
+/// scripts alone. `source` is what separates "this agent has it" from
 /// "everything on this machine has it".
+///
+/// Providers are listed either way. Nothing scopes one to an agent, so leaving
+/// them out of the agent view would only mean a console had to make a second
+/// request to draw the same page.
 pub(super) async fn list_scripts(
     Query(q): Query<ScriptQuery>,
 ) -> Result<Json<ScriptsResp>, ApiError> {
@@ -537,6 +682,7 @@ pub(super) async fn list_scripts(
         collect_declared(&dir, name, &mut scripts);
     }
     collect_tools(&global_tools_dir(), "global", None, &mut scripts);
+    collect_providers(&global_providers_dir(), &mut scripts);
     Ok(Json(ScriptsResp { scripts }))
 }
 
@@ -563,6 +709,14 @@ fn read_script(target: &Target) -> Result<Json<ScriptSource>, ApiError> {
     };
     let label = target.path.display().to_string();
     let (compiles, error) = status_pair(compile_status(target.kind, &label, &content, &[]));
+    let meta = provider_meta(target.kind, &content);
+    // Returned verbatim. A provider takes its key from `initialize(config)`,
+    // which `/api/config` already redacts to a boolean and a list of key names,
+    // or from `env_var`, which reads the daemon's environment and never the
+    // file. Nothing puts a secret into the source that the author did not type
+    // there, so there is nothing here that redacting would protect and a great
+    // deal that it would break: an editor that saved what it was shown would
+    // write the redaction back over the real script.
     Ok(Json(ScriptSource {
         kind: target.kind.as_str().to_string(),
         name: stem_of(&target.path),
@@ -572,6 +726,7 @@ fn read_script(target: &Target) -> Result<Json<ScriptSource>, ApiError> {
         content,
         compiles,
         error,
+        provider: meta,
     }))
 }
 
@@ -656,11 +811,7 @@ pub(super) async fn validate_script(
     let Some(kind) = ScriptKind::parse(&body.kind) else {
         return Err(err(
             StatusCode::BAD_REQUEST,
-            format!(
-                "Unknown script kind '{}': expected tool, region_hook, stage_hook \
-                 or output_validator",
-                body.kind
-            ),
+            format!("Unknown script kind '{}': expected {KIND_LIST}", body.kind),
         ));
     };
     let hooks: Vec<&str> = body.hooks.iter().map(String::as_str).collect();

--- a/crates/leviath-cli/src/commands/serve/scripts_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts_tests.rs
@@ -24,6 +24,11 @@ fn global_root(home: &Path) -> PathBuf {
     home.join(".leviath").join("tools")
 }
 
+/// The global providers directory under a scratch `LEVIATH_HOME`.
+fn providers_root(home: &Path) -> PathBuf {
+    home.join(".leviath").join("providers")
+}
+
 /// Every script route, mounted the way production mounts them under
 /// `--allow-admin`, so a test drives the real handlers.
 fn admin_router() -> Router {
@@ -73,6 +78,15 @@ async fn send(method: &str, uri: &str, body: serde_json::Value) -> (StatusCode, 
 /// A tool script that compiles.
 const GOOD_TOOL: &str = "// @tool summarize\n// @description sums up\n\"ok\"";
 
+/// A provider script that compiles, with every annotation the listing reports.
+const GOOD_PROVIDER: &str = "// @provider groq\n\
+                             // @description an OpenAI-compatible gateway\n\
+                             // @default_model llama-3.3-70b\n\
+                             // @max_context_tokens 128000\n\
+                             // @supports_streaming true\n\
+                             fn initialize(config) { #{ url: config.base_url } }\n\
+                             fn inference(state, request) { #{ content: \"ok\" } }";
+
 // ─── ScriptKind ─────────────────────────────────────────────────────────────
 
 #[test]
@@ -82,10 +96,11 @@ fn every_kind_round_trips_through_its_wire_spelling() {
         ScriptKind::RegionHook,
         ScriptKind::StageHook,
         ScriptKind::OutputValidator,
+        ScriptKind::Provider,
     ] {
         assert_eq!(ScriptKind::parse(kind.as_str()), Some(kind));
     }
-    assert_eq!(ScriptKind::parse("provider"), None);
+    assert_eq!(ScriptKind::parse("model_provider"), None);
 }
 
 // ─── compile_status ─────────────────────────────────────────────────────────
@@ -121,6 +136,40 @@ fn each_kind_is_compiled_by_its_own_compiler() {
         )
         .is_ok()
     );
+    assert!(compile_status(ScriptKind::Provider, "p", GOOD_PROVIDER, &[]).is_ok());
+}
+
+/// The other half of the same claim: a refusal carries the words of the
+/// compiler that refused it, so an editor shows the author what a run would
+/// have told them rather than a generic "does not compile".
+#[test]
+fn each_kind_reports_its_own_compilers_refusal() {
+    let refuse = |kind, content| {
+        compile_status(kind, "s", content, &[]).expect_err("the compiler refuses it")
+    };
+    let tool = refuse(ScriptKind::Tool, "// nothing at all\nlet");
+    assert!(tool.contains("@tool"), "{tool}");
+    let region = refuse(ScriptKind::RegionHook, "fn other(ctx) { () }");
+    assert!(region.contains("fn render(ctx)"), "{region}");
+    let hook = refuse(ScriptKind::StageHook, "let");
+    assert!(hook.contains("s:"), "{hook}");
+    let validator = refuse(ScriptKind::OutputValidator, "fn other(content) { () }");
+    assert!(validator.contains("fn validate(content)"), "{validator}");
+}
+
+/// The provider compiler reads the AST for both entry points. Before it
+/// existed, a script with no `inference` compiled, initialized, cached, and
+/// failed at the first inference - mid-run, looking like a provider outage.
+#[test]
+fn a_provider_that_is_missing_inference_fails() {
+    let status = compile_status(
+        ScriptKind::Provider,
+        "p",
+        "fn initialize(config) { #{} }",
+        &[],
+    );
+    let reason = status.expect_err("inference is required");
+    assert!(reason.contains("inference"), "{reason}");
 }
 
 /// A stage hook named for a hook it does not define is a spawn error, so it is
@@ -202,7 +251,7 @@ async fn a_name_that_already_carries_the_extension_is_the_same_file() {
 #[tokio::test]
 async fn an_unknown_kind_is_refused() {
     with_home(|_home| async move {
-        let (status, _) = resolve("provider", "x", None).expect_err("no such kind");
+        let (status, _) = resolve("model_provider", "x", None).expect_err("no such kind");
         assert_eq!(status, StatusCode::BAD_REQUEST);
     })
     .await;
@@ -341,7 +390,7 @@ notes = { kind = "custom", script = "notes.rhai", max_tokens = 500 }
 "#
 }
 
-/// Both scopes and all four kinds in one answer, which is the listing's whole
+/// Both scopes and all five kinds in one answer, which is the listing's whole
 /// job: what is here, what it plugs into, and whether it works.
 #[tokio::test]
 async fn the_listing_carries_every_kind_and_both_scopes() {
@@ -356,6 +405,7 @@ async fn the_listing_carries_every_kind_and_both_scopes() {
             "fn validate(content) { #{ valid: true } }",
         );
         write(&global_root(&home).join("shared.rhai"), GOOD_TOOL);
+        write(&providers_root(&home).join("groq.rhai"), GOOD_PROVIDER);
 
         let (status, body) = get_json("/api/scripts?agent=researcher").await;
         assert_eq!(status, StatusCode::OK);
@@ -374,6 +424,8 @@ async fn the_listing_carries_every_kind_and_both_scopes() {
         assert_eq!(find("output_validator", "check")["compiles"], true);
         assert_eq!(find("tool", "shared")["source"], "global");
         assert!(find("tool", "shared").get("agent").is_none());
+        assert_eq!(find("provider", "groq")["source"], "global");
+        assert_eq!(find("provider", "groq")["compiles"], true);
     })
     .await;
 }
@@ -579,7 +631,7 @@ async fn a_file_that_is_not_text_is_reported_rather_than_returned() {
 #[tokio::test]
 async fn reading_with_an_unknown_kind_is_a_400() {
     with_home(|_home| async move {
-        let (status, _) = get_json("/api/scripts/provider/x").await;
+        let (status, _) = get_json("/api/scripts/model_provider/x").await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
     })
     .await;
@@ -810,11 +862,267 @@ async fn validating_an_unknown_kind_is_a_400() {
         let (status, _) = send(
             "POST",
             "/api/scripts/validate",
-            serde_json::json!({ "kind": "provider", "content": "1" }),
+            serde_json::json!({ "kind": "model_provider", "content": "1" }),
         )
         .await;
 
         assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+// ─── Providers ──────────────────────────────────────────────────────────────
+
+/// A provider is the one kind with a machine-wide directory and no agent-owned
+/// one, which is the inverse of the hooks.
+#[tokio::test]
+async fn a_provider_resolves_into_the_providers_directory() {
+    with_home(|home| async move {
+        let target = resolve("provider", "groq", None).expect("a provider is global");
+        assert_eq!(target.path, providers_root(&home).join("groq.rhai"));
+        assert_eq!(target.scope, "global");
+        assert!(target.agent.is_none());
+    })
+    .await;
+}
+
+/// Nothing scopes a provider to an agent, so an `?agent=` would write a file
+/// nothing would ever load. Refused rather than quietly ignored.
+#[tokio::test]
+async fn a_provider_with_an_agent_is_refused() {
+    with_home(|_home| async move {
+        let (status, body) = resolve("provider", "groq", Some("researcher")).expect_err("global");
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(body.0.error.contains("?agent="), "{}", body.0.error);
+    })
+    .await;
+}
+
+/// Listed whether or not the request named an agent, because the answer is the
+/// same either way and a console draws one page from one call.
+#[tokio::test]
+async fn the_listing_carries_providers_in_both_scopes() {
+    with_home(|home| async move {
+        write(&providers_root(&home).join("groq.rhai"), GOOD_PROVIDER);
+        write(&agent_root(&home, "researcher").join("agent.leviath"), "");
+
+        for uri in ["/api/scripts", "/api/scripts?agent=researcher"] {
+            let (status, body) = get_json(uri).await;
+            assert_eq!(status, StatusCode::OK, "{uri}");
+            let scripts = body["scripts"].as_array().expect("a scripts array");
+            let listed = scripts
+                .iter()
+                .find(|s| s["kind"] == "provider")
+                .unwrap_or_else(|| panic!("no provider listed for {uri}"));
+            assert_eq!(listed["name"], "groq");
+            assert_eq!(listed["source"], "global");
+            assert!(listed.get("agent").is_none());
+            assert_eq!(listed["compiles"], true);
+        }
+    })
+    .await;
+}
+
+/// What the console shows without fetching and re-parsing every script.
+#[tokio::test]
+async fn a_listed_provider_carries_what_it_declares_about_itself() {
+    with_home(|home| async move {
+        write(&providers_root(&home).join("groq.rhai"), GOOD_PROVIDER);
+        let (status, body) = get_json("/api/scripts").await;
+
+        assert_eq!(status, StatusCode::OK);
+        let meta = &body["scripts"][0]["provider"];
+        assert_eq!(meta["provider"], "groq");
+        assert_eq!(meta["description"], "an OpenAI-compatible gateway");
+        assert_eq!(meta["default_model"], "llama-3.3-70b");
+        assert_eq!(meta["max_context_tokens"], 128_000);
+        assert_eq!(meta["supports_streaming"], true);
+    })
+    .await;
+}
+
+/// Only a provider has annotations to report, so nothing else carries the key
+/// at all rather than carrying it empty.
+#[tokio::test]
+async fn a_listed_tool_carries_no_provider_metadata() {
+    with_home(|home| async move {
+        write(&global_root(&home).join("shared.rhai"), GOOD_TOOL);
+        let (_, body) = get_json("/api/scripts").await;
+        assert!(body["scripts"][0].get("provider").is_none());
+    })
+    .await;
+}
+
+/// A directory sitting where a script should be cannot be read, and the listing
+/// says so instead of leaving the entry out. Portable: `read_to_string` refuses
+/// a directory on every platform, so this needs no `cfg(unix)` twin.
+#[tokio::test]
+async fn a_provider_that_cannot_be_read_is_listed_as_failing() {
+    with_home(|home| async move {
+        std::fs::create_dir_all(providers_root(&home).join("groq.rhai")).expect("the directory");
+        let (status, body) = get_json("/api/scripts").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["scripts"][0]["kind"], "provider");
+        assert_eq!(body["scripts"][0]["compiles"], false);
+        assert!(
+            body["scripts"][0]["error"]
+                .as_str()
+                .expect("a reason")
+                .contains("cannot read"),
+            "{}",
+            body["scripts"][0]["error"]
+        );
+    })
+    .await;
+}
+
+/// Returned verbatim. The credential a provider uses comes from the config or
+/// the environment, not from the source, so there is nothing here to redact and
+/// an editor that saved what it was shown would overwrite the real script.
+#[tokio::test]
+async fn reading_a_provider_returns_its_source_and_its_annotations() {
+    with_home(|home| async move {
+        write(&providers_root(&home).join("groq.rhai"), GOOD_PROVIDER);
+        let (status, body) = get_json("/api/scripts/provider/groq").await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["content"], GOOD_PROVIDER);
+        assert_eq!(body["kind"], "provider");
+        assert_eq!(body["source"], "global");
+        assert_eq!(body["compiles"], true);
+        assert_eq!(body["provider"]["default_model"], "llama-3.3-70b");
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn reading_a_provider_with_an_agent_is_a_400() {
+    with_home(|home| async move {
+        write(&providers_root(&home).join("groq.rhai"), GOOD_PROVIDER);
+        let (status, _) = get_json("/api/scripts/provider/groq?agent=researcher").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn writing_a_provider_creates_it_in_the_providers_directory() {
+    with_home(|home| async move {
+        let (status, body) = send(
+            "PUT",
+            "/api/scripts/provider/groq",
+            serde_json::json!({ "content": GOOD_PROVIDER }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["compiles"], true);
+        let path = providers_root(&home).join("groq.rhai");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("the file"),
+            GOOD_PROVIDER
+        );
+    })
+    .await;
+}
+
+/// The draft is still saved. A provider that will not load is skipped with a
+/// warning and selection falls through, so refusing the write would cost the
+/// author their work without protecting anything.
+#[tokio::test]
+async fn writing_a_provider_that_is_missing_inference_saves_it_and_says_so() {
+    with_home(|home| async move {
+        let (status, body) = send(
+            "PUT",
+            "/api/scripts/provider/half",
+            serde_json::json!({ "content": "fn initialize(config) { #{} }" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["compiles"], false);
+        assert!(
+            body["error"]
+                .as_str()
+                .expect("a reason")
+                .contains("inference"),
+            "{}",
+            body["error"]
+        );
+        assert!(providers_root(&home).join("half.rhai").exists());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn deleting_a_provider_removes_it() {
+    with_home(|home| async move {
+        let path = providers_root(&home).join("groq.rhai");
+        write(&path, GOOD_PROVIDER);
+        let (status, _) = send(
+            "DELETE",
+            "/api/scripts/provider/groq",
+            serde_json::json!({}),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        assert!(!path.exists());
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn validating_a_provider_answers_both_ways() {
+    with_home(|_home| async move {
+        let (status, body) = send(
+            "POST",
+            "/api/scripts/validate",
+            serde_json::json!({ "kind": "provider", "content": GOOD_PROVIDER }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["valid"], true);
+
+        let (status, body) = send(
+            "POST",
+            "/api/scripts/validate",
+            serde_json::json!({ "kind": "provider", "content": "fn initialize(config) { #{} }" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["valid"], false);
+        assert!(
+            body["error"]
+                .as_str()
+                .expect("a reason")
+                .contains("inference"),
+            "{}",
+            body["error"]
+        );
+    })
+    .await;
+}
+
+/// Validating compiles and reads the AST. It must never run the script, or an
+/// ungated route would execute whatever was posted to it.
+#[tokio::test]
+async fn validating_a_provider_does_not_run_initialize() {
+    with_home(|_home| async move {
+        let (status, body) = send(
+            "POST",
+            "/api/scripts/validate",
+            serde_json::json!({
+                "kind": "provider",
+                "content": "fn initialize(config) { throw \"it ran\"; }\n\
+                            fn inference(state, request) { #{} }",
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["valid"], true);
     })
     .await;
 }

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -2615,6 +2615,40 @@ google_api_key = "AIza-existing"
         assert!(empty.contains("<unset>"), "{empty}");
     }
 
+    /// A gateway's key and its `extra` table are both credential-carrying:
+    /// `extra` is forwarded verbatim into a provider script's `initialize`,
+    /// which is where a second credential goes when the gateway wants one under
+    /// its own name. Names, never values.
+    #[test]
+    fn model_provider_config_debug_never_prints_the_keys() {
+        let gateway = ModelProviderConfig {
+            script: Some("groq.rhai".to_string()),
+            api_key: Some("gsk-SECRET-VALUE".to_string()),
+            base_url: Some("https://api.groq.example".to_string()),
+            rate_limit: None,
+            extra: HashMap::from([
+                (
+                    "org_token".to_string(),
+                    toml::Value::String("org-SECRET-VALUE".to_string()),
+                ),
+                ("region".to_string(), toml::Value::String("eu".to_string())),
+            ]),
+        };
+        let rendered = format!("{gateway:?}");
+        assert!(!rendered.contains("SECRET-VALUE"), "key leaked: {rendered}");
+        assert!(rendered.contains("api_key: \"<set>\""), "{rendered}");
+        // Sorted, so two runs of the same daemon print the same line.
+        assert!(
+            rendered.contains("extra_keys: [\"org_token\", \"region\"]"),
+            "{rendered}"
+        );
+        // What is not a secret is still worth reading.
+        assert!(rendered.contains("api.groq.example"), "{rendered}");
+
+        let bare = format!("{:?}", ModelProviderConfig::default());
+        assert!(bare.contains("api_key: \"<unset>\""), "{bare}");
+    }
+
     /// Unix-only: the assertion is about POSIX mode bits, which Windows does
     /// not have. `write_private`'s Windows path is a plain write, exercised by
     /// every other `save_to_path` test.

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -133,7 +133,7 @@ fn redacted(value: &Option<String>) -> &'static str {
 /// Every field is optional. Keys not recognized below flow into [`Self::extra`]
 /// and are forwarded to the script's `initialize(config)` alongside `base_url`
 /// and `api_key`.
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Clone, Serialize, Deserialize, Default)]
 pub struct ModelProviderConfig {
     /// Script filename stem or path. Defaults to `<name>.rhai` in the providers
     /// directory (`~/.leviath/providers/`).
@@ -156,4 +156,26 @@ pub struct ModelProviderConfig {
     /// Any additional keys, forwarded verbatim into the script's `initialize`.
     #[serde(flatten)]
     pub extra: HashMap<String, toml::Value>,
+}
+
+/// Hand-written for the same reason [`ProviderConfig`]'s is, and with one extra
+/// hazard: `extra` is forwarded verbatim into the script's `initialize`, which
+/// is exactly where a second credential goes when a gateway wants one under its
+/// own name. A derived `Debug` would print both `api_key` and every value in
+/// `extra`, so this reports whether the key is set and the *names* in `extra`
+/// and nothing else - the same shape `GatewayInfo` puts on the wire.
+impl std::fmt::Debug for ModelProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Sorted: a `HashMap` iterates differently between two calls, and a
+        // debug line that reorders itself is one nobody can diff.
+        let mut extra_keys: Vec<&str> = self.extra.keys().map(String::as_str).collect();
+        extra_keys.sort_unstable();
+        f.debug_struct("ModelProviderConfig")
+            .field("script", &self.script)
+            .field("api_key", &redacted(&self.api_key))
+            .field("base_url", &self.base_url)
+            .field("rate_limit", &self.rate_limit)
+            .field("extra_keys", &extra_keys)
+            .finish()
+    }
 }

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -50,6 +50,61 @@ use host::{BrokerJob, HostHttpError, HttpExecutor};
 
 pub use meta::{ProviderMeta, parse_provider_annotations};
 
+/// The entry points every provider script must define, as the error messages
+/// spell them: the name, how many parameters it takes, and the parameter list
+/// to show whoever has to fix it.
+const REQUIRED_FNS: [(&str, usize, &str); 2] = [
+    ("initialize", 1, "config"),
+    ("inference", 2, "state, request"),
+];
+
+/// Compile a provider script and check its shape without running any of it.
+///
+/// The counterpart to `leviath_scripting::tool::check_source` and
+/// `region_hook::compile`: what lets an editor find out whether a script is
+/// usable before a run does. It stops at the AST on purpose, because
+/// `initialize` is script code and the caller compiling arbitrary submitted
+/// text is an ungated HTTP route.
+///
+/// The engine is the one [`RhaiProvider::from_source`] compiles with rather
+/// than a bare `Engine::new`, so the verdict is the one a load would reach.
+/// That is not cosmetic: the shared hardening raises Rhai's expression-depth
+/// limits, which are low enough in a debug build to reject legitimate scripts.
+pub fn check_source(label: &str, src: &str) -> Result<ProviderMeta> {
+    let meta = parse_provider_annotations(src);
+    let ast = build_init_engine(Arc::new(Vec::new()))
+        .compile(src)
+        .map_err(|e| ProviderError::Other(format!("compile provider script {label}: {e}")))?;
+    require_entry_points(label, &ast)?;
+    Ok(meta)
+}
+
+/// Check that a compiled script defines `initialize` and `inference`.
+///
+/// Both are required, but only `initialize` used to be caught at load, because
+/// loading calls it. A script with no `inference` compiled, initialized and
+/// cached, then failed at the first real inference - by which point a run had
+/// started and the failure looked like a provider outage rather than a typo.
+/// Reading it off the AST moves that to the moment the script is read.
+fn require_entry_points(label: &str, ast: &AST) -> Result<()> {
+    for (name, params, signature) in REQUIRED_FNS {
+        if has_fn(ast, name, params) {
+            continue;
+        }
+        let found = ast
+            .iter_functions()
+            .find(|f| f.name == name)
+            .map(|f| f.params.len());
+        return Err(ProviderError::Other(match found {
+            Some(n) => {
+                format!("{label}: fn {name} must take {params} parameters ({signature}), found {n}")
+            }
+            None => format!("{label}: script must define fn {name}({signature})"),
+        }));
+    }
+    Ok(())
+}
+
 /// A boxed script-function call: builds the `Scope` and invokes one Rhai
 /// function on the given engine, returning its `Dynamic` result. Boxed (not a
 /// generic) so [`RhaiProvider::dispatch`] has a single instantiation.
@@ -139,6 +194,11 @@ impl RhaiProvider {
         let ast = init_engine
             .compile(src)
             .map_err(|e| ProviderError::Other(format!("compile provider script {name}: {e}")))?;
+        // Before `initialize` runs, so a script with no `inference` is refused
+        // here rather than at the first inference. A refused script is skipped
+        // with a warning and selection falls through to the next model, the
+        // same way a syntax error already behaves.
+        require_entry_points(&name, &ast)?;
 
         // Run initialize(config) offline (no network host fns registered).
         let config_dyn = rhai::serde::to_dynamic(init_config).unwrap_or(Dynamic::UNIT);

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -814,3 +814,99 @@ fn a_script_sees_each_system_block_region_and_volatility() {
     let response = tokio_block(p.infer(&request)).expect("the script runs");
     assert_eq!(response.content, "task:stable,findings:grows");
 }
+
+// ── check_source ─────────────────────────────────────────────────────────────
+
+/// The smallest script that is a usable provider.
+const GOOD_PROVIDER: &str = "// @provider mock\n\
+                             // @description a mock\n\
+                             // @default_model mock-1\n\
+                             fn initialize(config) { #{} }\n\
+                             fn inference(state, request) { #{ content: \"hi\" } }";
+
+/// The `Other` message a shape or compile failure carries.
+fn refusal(err: ProviderError) -> String {
+    let ProviderError::Other(message) = err else {
+        unreachable!("a compile or shape failure is Other")
+    };
+    message
+}
+
+#[test]
+fn check_source_accepts_a_provider_and_returns_its_annotations() {
+    let meta = check_source("mock.rhai", GOOD_PROVIDER).expect("a usable provider");
+    assert_eq!(meta.provider.as_deref(), Some("mock"));
+    assert_eq!(meta.description, "a mock");
+    assert_eq!(meta.default_model.as_deref(), Some("mock-1"));
+}
+
+#[test]
+fn check_source_reports_a_syntax_error() {
+    let message = refusal(check_source("mock.rhai", "fn inference( { oops").unwrap_err());
+    assert!(
+        message.contains("compile provider script mock.rhai"),
+        "{message}"
+    );
+}
+
+/// The gap this exists to close: a script with no `inference` used to compile,
+/// initialize and cache, then fail at the first real inference.
+#[test]
+fn check_source_rejects_a_script_with_no_inference() {
+    let message = refusal(check_source("mock.rhai", "fn initialize(config) { #{} }").unwrap_err());
+    assert!(
+        message.contains("must define fn inference(state, request)"),
+        "{message}"
+    );
+}
+
+#[test]
+fn check_source_rejects_a_script_with_no_initialize() {
+    let message =
+        refusal(check_source("mock.rhai", "fn inference(state, request) { #{} }").unwrap_err());
+    assert!(
+        message.contains("must define fn initialize(config)"),
+        "{message}"
+    );
+}
+
+/// A function of the right name and the wrong shape is the likelier typo, and
+/// "not defined" would be a lie about a name that is right there in the file.
+#[test]
+fn check_source_names_the_arity_a_wrong_entry_point_has() {
+    let message = refusal(
+        check_source(
+            "mock.rhai",
+            "fn initialize(config) { #{} }\nfn inference(state) { #{} }",
+        )
+        .unwrap_err(),
+    );
+    assert!(
+        message.contains("fn inference must take 2 parameters (state, request), found 1"),
+        "{message}"
+    );
+}
+
+/// `check_source` compiles and introspects; it must not run the script, or the
+/// ungated validate route would be executing whatever was posted to it.
+#[test]
+fn check_source_does_not_run_initialize() {
+    let src = "fn initialize(config) { throw \"initialize ran\"; }\n\
+               fn inference(state, request) { #{} }";
+    check_source("mock.rhai", src).expect("the throw is never reached");
+}
+
+/// The loader agrees with the route: what `check_source` refuses, a load
+/// refuses too, so a script the API accepts is one a run will accept.
+#[test]
+fn from_source_rejects_a_script_with_no_inference() {
+    let message = refusal(
+        build("fn initialize(config) { #{} }", FakeExecutor::new())
+            .err()
+            .expect("inference is required"),
+    );
+    assert!(
+        message.contains("fn inference(state, request)"),
+        "{message}"
+    );
+}

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -175,7 +175,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
 | `GET /api/models` | Enumerate models |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
-| `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the agent's Rhai. Writes need admin. See [below](#tools-and-scripts) |
+| `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
 | `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
@@ -453,18 +453,18 @@ with the reason each was passed over, so a file with a syntax error does not sim
 nobody wrote. MCP tools are not here: they depend on a server being reachable rather than on
 anything installed, and `/api/mcp/servers/{name}` already answers for them.
 
-`GET /api/scripts` is the same ground from the editor's side, over the four kinds of Rhai an agent
-can carry: `tool`, `region_hook`, `stage_hook` and `output_validator`. Only tools have a directory of
-their own (`<agent>/tools/`, plus the global one); the other three are named by path in the manifest
-and resolved against the agent's own directory, so the listing derives them from what the manifest
-declares and the read and write routes address them at `<agent>/<name>.rhai`. A hook a manifest
-declares inside a subdirectory is outside what `{name}` can address, and is left out rather than
-listed under a name that would fetch nothing.
+`GET /api/scripts` is the same ground from the editor's side, over the five kinds of Rhai a machine
+can carry: `tool`, `region_hook`, `stage_hook`, `output_validator` and `provider`. Only tools have a
+directory an agent owns (`<agent>/tools/`, plus the global one); the hooks and the validator are
+named by path in the manifest and resolved against the agent's own directory, so the listing derives
+them from what the manifest declares and the read and write routes address them at
+`<agent>/<name>.rhai`. A hook a manifest declares inside a subdirectory is outside what `{name}` can
+address, and is left out rather than listed under a name that would fetch nothing.
 
 `GET/PUT/DELETE /api/scripts/{kind}/{name}` reads and writes one file, scoped by `?agent=<name>` or,
-with no `agent`, the global tools directory. `POST /api/scripts/validate` takes `kind` and `content`
-and compiles without writing, so an editor can check before saving instead of saving and waiting for
-a run to fail.
+with no `agent`, the machine's own directory for that kind. `POST /api/scripts/validate` takes `kind`
+and `content` and compiles without writing, so an editor can check before saving instead of saving
+and waiting for a run to fail.
 
 > [!WARNING]
 > `PUT` and `DELETE` are **not mounted at all** without `lev serve --allow-admin`, exactly like the
@@ -475,6 +475,33 @@ a run to fail.
 A write that does not compile is still saved, with `compiles: false` and the compiler's complaint in
 the response. A draft is worth keeping, and a tool that does not compile is skipped at spawn rather
 than breaking the agent.
+
+### Providers
+
+A [provider](/docs/rhai-providers) is the one kind no agent owns. It lives in `~/.leviath/providers/`
+and a stage reaches it by name, so these routes take **no** `?agent=` and refuse one rather than
+writing a file into an agent's directory that nothing would ever load. Providers are listed with or
+without an `agent`, since the answer is the same either way.
+
+Each listed provider carries a `provider` object with what its leading `// @` comments declare:
+`description`, `default_model`, `max_context_tokens`, `max_output_tokens` and `supports_streaming`.
+That is what lets a console show the catalog without fetching and re-parsing every script. No other
+kind carries the key at all.
+
+Validation checks more than syntax here. A provider needs `initialize(config)` and
+`inference(state, request)`, and a script defining only the first used to compile, initialize, cache
+and then fail at the first inference, part-way into a run. `POST /api/scripts/validate` with
+`kind: "provider"` answers that before the file is saved, and the loader refuses the same script
+rather than accepting one the API called invalid. Nothing runs during validation: `initialize` is
+read off the compiled AST, never called.
+
+`GET` returns the source verbatim. A provider's key comes from `initialize(config)`, which is the
+`[model_providers.<name>]` table `GET /api/config` already reports as a boolean plus a list of key
+names, or from `env_var`, which reads the daemon's environment. Neither value is in the file, so
+there is nothing here for redaction to protect, and an editor that saved what it was shown would
+write the redaction back over the real script.
+
+Check `scripts.providers` in the `capabilities` list before offering the kind.
 
 ## Feature detection
 

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -75,7 +75,9 @@ tokens_per_minute   = 100000
 ## The script contract
 
 A provider defines `initialize` and `inference` (required) and may add `stream`, `count_tokens`, and
-`list_models`. Metadata comes from leading `// @key value` comments.
+`list_models`. Metadata comes from leading `// @key value` comments. Both required functions are
+checked when the script loads, so one that is missing or takes the wrong number of parameters is
+skipped with a warning, the same as a syntax error, rather than failing part-way into a run.
 
 `initialize(config)` runs once when the provider loads. It runs **offline**, so no HTTP host
 functions are available here. Return a state map that is persisted and passed to every later call.
@@ -347,6 +349,12 @@ lev run <agent> --task "..."      # a live run through a stage that references t
 > so a syntax error looks like "my agent quietly used the wrong model". Run
 > `lev models list --provider <name>` first; a compile or auth error surfaces there instead of
 > hiding behind a fallback.
+
+If `lev serve` is running, `POST /api/scripts/validate` with `kind: "provider"` answers the same
+question without a run and without a key: it compiles the text and checks that `initialize(config)`
+and `inference(state, request)` are both there. The rest of the [scripts
+API](/docs/api#tools-and-scripts) manages the directory itself, so a console can list, open, edit and
+save a provider the same way it does a script tool.
 
 ## Not in scope
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": {
       "name": "MIT"
@@ -1238,7 +1238,7 @@
           "scripts"
         ],
         "summary": "Rhai scripts this scope can see",
-        "description": "Script tools from the agent's `tools/` and the global directory, plus the region hooks, stage hooks and output validators the agent's manifest declares. Each entry carries its kind, its source (`agent` or `global`) and whether it compiles right now.",
+        "description": "Script tools from the agent's `tools/` and the global directory, the region hooks, stage hooks and output validators the agent's manifest declares, and the model providers in `~/.leviath/providers`. Each entry carries its kind, its source (`agent` or `global`) and whether it compiles right now; a provider also carries a `provider` object with what its `// @` annotations declare. Providers are listed with or without `agent`, since nothing scopes one to an agent.",
         "parameters": [
           {
             "name": "agent",
@@ -1262,7 +1262,7 @@
           "scripts"
         ],
         "summary": "Compile a script without writing it",
-        "description": "Takes `kind` and `content`, plus `hooks` for a stage hook, and answers with `valid` and the compiler's complaint. Writes nothing and runs nothing: every compiler here stops at the AST.",
+        "description": "Takes `kind` and `content`, plus `hooks` for a stage hook, and answers with `valid` and the compiler's complaint. Writes nothing and runs nothing: every compiler here stops at the AST, a provider's `initialize` included. A provider that does not define `initialize(config)` and `inference(state, request)` fails here rather than at the first inference.",
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
@@ -1287,7 +1287,8 @@
                 "tool",
                 "region_hook",
                 "stage_hook",
-                "output_validator"
+                "output_validator",
+                "provider"
               ]
             }
           },
@@ -1306,7 +1307,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Scope to this agent's own directory."
+            "description": "Scope to this agent's own directory. A `provider` is global to the machine and refuses this parameter."
           }
         ],
         "responses": {
@@ -1332,7 +1333,8 @@
                 "tool",
                 "region_hook",
                 "stage_hook",
-                "output_validator"
+                "output_validator",
+                "provider"
               ]
             }
           },
@@ -1351,7 +1353,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Scope to this agent's own directory."
+            "description": "Scope to this agent's own directory. A `provider` is global to the machine and refuses this parameter."
           }
         ],
         "responses": {
@@ -1377,7 +1379,8 @@
                 "tool",
                 "region_hook",
                 "stage_hook",
-                "output_validator"
+                "output_validator",
+                "provider"
               ]
             }
           },
@@ -1396,7 +1399,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "Scope to this agent's own directory."
+            "description": "Scope to this agent's own directory. A `provider` is global to the machine and refuses this parameter."
           }
         ],
         "responses": {


### PR DESCRIPTION
Closes #509.

`/api/scripts` covered four kinds of Rhai and left out the one that is global to the machine. A drop-in model provider lives in `~/.leviath/providers/`, belongs to no agent, and could only be authored with a text editor on the host, so a console could manage every extension point except the one it was best placed to manage.

## What this adds

`provider` is a fifth `kind` on `GET /api/scripts`, `GET/PUT/DELETE /api/scripts/{kind}/{name}` and `POST /api/scripts/validate`.

It is the inverse of the hooks: global only, no `?agent=`, and an `agent` is **refused** rather than silently scoping the write into an agent directory nothing would ever load from. Providers are listed with or without an `agent`, since the answer is the same either way.

Each listed provider carries a `provider` object with what its leading `// @` comments declare (`description`, `default_model`, `max_context_tokens`, `max_output_tokens`, `supports_streaming`), so a catalog can be drawn without fetching and re-parsing every file. No other kind carries the key at all.

Announced as `scripts.providers`. The API contract version moves 0.3.0 → 0.4.0, matched in `docs/schema/openapi.json`.

## The validator that did not exist

A provider requires `initialize(config)` and `inference(state, request)`, but only the first was caught when the script loaded, because loading calls it. A script with no `inference` compiled, initialized, cached, and then failed at the **first real inference** — part-way into a run, looking like a provider outage rather than a typo.

`leviath_providers::rhai_provider::check_source` reads both entry points off the compiled AST, and `RhaiProvider::from_source` now uses the same check. So a script the API refuses is one a run refuses too, and it is skipped with a warning like any other broken script, with selection falling through to the next configured model.

**Behaviour change:** a provider script defining `initialize` but not `inference` used to load and fail later; it now never loads.

Nothing runs during validation — that is what lets `POST /api/scripts/validate` stay ungated.

## Secrets

`GET` returns the source verbatim, deliberately. A provider's key comes from `initialize(config)` (the `[model_providers]` table that `/api/config` already reports as a boolean plus a list of key **names**) or from `env_var`, gated by `[security] allow_env_vars`. Neither value is in the file, so there is nothing for redaction to protect — and an editor that saved what it was shown would write the redaction back over the real script.

## One thing found on the way

`ModelProviderConfig` derived `Debug` with a plain `api_key`, and with the `extra` table that is forwarded verbatim into the script's `initialize` — which is exactly where a second credential goes when a gateway wants one under its own name. `ProviderConfig` directly above it hand-writes `Debug` so keys cannot reach a log; the two now agree.

## Verification

- `cargo xtask coverage`: all 13 packages at 100%.
- `cargo test --workspace`, `cargo clippy --workspace --all-targets --all-features`, `cargo xtask docs`: clean.
- **Live**, against a real `lev serve --allow-admin` in an isolated home, with a local OpenAI-shaped mock and no API key:
  - `GET /api/config` reports `api_version: "0.4.0"` and `scripts.providers`.
  - `POST /api/scripts/validate` on a provider missing `inference` → `valid: false`, `"script must define fn inference(state, request)"`.
  - `PUT /api/scripts/provider/mock` wrote the script; `GET /api/scripts` listed it with its annotations; `GET /api/scripts/provider/mock` returned it byte-identical; `?agent=` → 400.
  - **A run then completed through the provider the route had written**, its output being the mock server's line — including picking up a corrected script written through the route, with no daemon restart.
  - Breaking that provider (removing `inference`) and re-running: the daemon refuses it at spawn and selection falls through, instead of failing mid-run.
  - `DELETE` → 204, file gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
