### PR TITLE
feat(dash): an Agents screen and a graph editor for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ same list.
 
 ## Unreleased
 
+<<<<<<< Updated upstream
 - New: the scripts API manages Rhai model providers. `provider` joins `tool`,
   `region_hook`, `stage_hook` and `output_validator` as a `kind` on
   `GET /api/scripts`, `GET/PUT/DELETE /api/scripts/{kind}/{name}` and
@@ -37,6 +38,23 @@ same list.
   script's `initialize` were printable, where the first-party provider config
   had been careful not to be; the two now agree, reporting whether the key is
   set and the names in the extra table and nothing more.
+=======
+- New: `lev dash` has an Agents screen (`a`): the catalog of agents this
+  machine can run, with each one's graph, and an editor that builds one on
+  the same canvas the explorer draws. Stages are boxes you add (`a`),
+  connect (`c`, or drag a handle), select and delete; an inspector edits
+  whatever is selected (the agent's description, entry stage and default
+  model; a stage's mode, description, tries, revisits, allow-complete and
+  fan-out settings; a path's kind, hint and approval gate). Every edit is
+  checked as `lev validate` would check the file, with the problems on a
+  line under the graph and a `!` on the stage they name; saving is refused
+  while there are errors. Undo and redo, a view of the exact file that
+  will be saved, and arrangements kept per agent. New agents start from a
+  two-stage starter or as a copy of any agent in the catalog; a bundled
+  agent opens from its embedded copy and installs when saved; an edited
+  bundled agent can be reset to the bundle. The editor keeps a file's
+  comments, order and formatting: it edits the manifest as a document.
+>>>>>>> Stashed changes
 - Fixed: `lev serve`, `lev dash`, and `lev agent-client` ride out a daemon
   restart instead of breaking. A request that lands while the daemon is down
   (a `lev daemon restart`, a supervisor relaunch, or the restart that follows

--- a/crates/leviath-cli/src/blueprint_edit/edges.rs
+++ b/crates/leviath-cli/src/blueprint_edit/edges.rs
@@ -67,6 +67,11 @@ impl ManifestDoc {
             NEW_EDGE_HINT,
         );
         table.insert(to, edge);
+        // A headed `[stages.x.transitions]` with paths under it is implied
+        // by them; only an empty one (a terminal stage) is written out.
+        if let Item::Table(t) = transitions {
+            t.set_implicit(true);
+        }
         Ok(())
     }
 
@@ -75,10 +80,19 @@ impl ManifestDoc {
         let stage = self
             .stage_item_mut(from)
             .ok_or_else(|| EditError::NoSuchStage(from.to_string()))?;
-        let removed = child_mut(stage, "transitions")
-            .and_then(|t| t.as_table_like_mut().expect("child_mut checked").remove(to));
-        if removed.is_none() {
+        let Some(transitions) = child_mut(stage, "transitions") else {
             return Err(EditError::NoSuchEdge(from.to_string(), to.to_string()));
+        };
+        let table = transitions.as_table_like_mut().expect("child_mut checked");
+        if table.remove(to).is_none() {
+            return Err(EditError::NoSuchEdge(from.to_string(), to.to_string()));
+        }
+        // The last path gone: the empty table is what says "terminal", so
+        // it has to be written.
+        if let Item::Table(t) = transitions
+            && t.is_empty()
+        {
+            t.set_implicit(false);
         }
         Ok(())
     }

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -470,6 +470,22 @@ fn stages_are_added_in_place_and_refused_when_wrong() {
     runtime_ok(&doc);
     doc.add_stage("last", None).unwrap();
     assert_eq!(doc.stage_names(), ["work", "review", "finish", "last"]);
+    // A path out of the new stage: its transitions table stops being written
+    // as an empty header, and comes back when the last path goes.
+    doc.add_edge("review", "finish").unwrap();
+    let text = doc.to_toml();
+    assert!(!text.contains("[stages.review.transitions]\n"), "{text}");
+    assert!(
+        text.contains("[stages.review.transitions.finish]"),
+        "{text}"
+    );
+    doc.delete_edge("review", "finish").unwrap();
+    assert!(
+        doc.to_toml().contains("[stages.review.transitions]\n"),
+        "{}",
+        doc.to_toml()
+    );
+    assert!(doc.stage("review").unwrap().is_terminal);
     // Refusals leave the document alone.
     let before = doc.to_toml();
     assert_eq!(
@@ -806,6 +822,12 @@ fn paths_are_added_kinded_gated_and_deleted() {
     assert_eq!(
         doc.delete_edge("ghost", "work"),
         Err(EditError::NoSuchStage("ghost".into()))
+    );
+    let mut bare = ManifestDoc::parse("[agent]\nname = \"b\"\n[stages.a]\n").unwrap();
+    assert_eq!(
+        bare.delete_edge("a", "a"),
+        Err(EditError::NoSuchEdge("a".into(), "a".into())),
+        "no transitions table"
     );
     assert_eq!(
         doc.set_edge_kind("work", "ghost", EdgeKind::Always),

--- a/crates/leviath-cli/src/commands/dashboard/agents/catalog.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/catalog.rs
@@ -1,0 +1,310 @@
+//! The catalog half of the Agents screen: the list, its filter, the preview,
+//! and the actions on the selected agent.
+
+use std::sync::Arc;
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::text::Line;
+
+use super::super::state::Dashboard;
+use super::super::types::*;
+use crate::blueprint_edit::catalog::{self, CatalogEntry, Source};
+use crate::config::Config;
+use crate::tui::flowgraph::{FlowView, StageGraph};
+use crate::tui::widgets::confirm::Confirm;
+
+/// The catalog's state.
+#[derive(Default)]
+pub(in crate::commands::dashboard) struct Catalog {
+    /// Every agent found, name-sorted.
+    pub(in crate::commands::dashboard) entries: Vec<CatalogEntry>,
+    /// The filter text; matched against name and description.
+    pub(in crate::commands::dashboard) filter: String,
+    /// `/` opened the filter and letters go into it until Enter or Esc.
+    pub(in crate::commands::dashboard) filtering: bool,
+    /// Cursor into the filtered list.
+    pub(in crate::commands::dashboard) selected: usize,
+    /// The graph of the entry the cursor is on, keyed by its name so it is
+    /// rebuilt only when the cursor moves to another agent.
+    pub(in crate::commands::dashboard) preview: Option<(String, Result<FlowView, String>)>,
+}
+
+impl Catalog {
+    /// Read the catalog again, keeping the cursor on the same agent when
+    /// it is still there.
+    pub(in crate::commands::dashboard) fn refresh(&mut self, ctx: &NewRunContext, config: &Config) {
+        let keep = self.selected_entry().map(|e| e.name.clone());
+        self.entries = catalog::discover(&ctx.agents_dir, &ctx.workdir, config);
+        if let Some(name) = keep
+            && let Some(at) = self
+                .visible()
+                .iter()
+                .position(|i| self.entries[*i].name == name)
+        {
+            self.selected = at;
+        }
+        self.clamp();
+    }
+
+    /// Indices into `entries` that pass the filter, in list order.
+    pub(in crate::commands::dashboard) fn visible(&self) -> Vec<usize> {
+        let query = self.filter.to_lowercase();
+        self.entries
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| {
+                query.is_empty()
+                    || e.name.to_lowercase().contains(&query)
+                    || e.description.to_lowercase().contains(&query)
+            })
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// The entry under the cursor.
+    pub(in crate::commands::dashboard) fn selected_entry(&self) -> Option<&CatalogEntry> {
+        self.visible()
+            .get(self.selected)
+            .and_then(|i| self.entries.get(*i))
+    }
+
+    /// Keep the cursor inside the filtered list.
+    pub(in crate::commands::dashboard) fn clamp(&mut self) {
+        let len = self.visible().len();
+        self.selected = self.selected.min(len.saturating_sub(1));
+    }
+
+    /// Move the cursor, clamped.
+    pub(in crate::commands::dashboard) fn move_by(&mut self, delta: isize) {
+        let len = self.visible().len() as isize;
+        let next = (self.selected as isize + delta).clamp(0, (len - 1).max(0));
+        self.selected = next as usize;
+    }
+
+    /// Bring the preview in line with the cursor: build the selected agent's
+    /// graph when it is not the one built.
+    pub(in crate::commands::dashboard) fn sync_preview(&mut self) {
+        let Some(entry) = self.selected_entry() else {
+            self.preview = None;
+            return;
+        };
+        if self
+            .preview
+            .as_ref()
+            .is_some_and(|(name, _)| *name == entry.name)
+        {
+            return;
+        }
+        let name = entry.name.clone();
+        let view = match entry.manifest.as_deref() {
+            Some(text) => leviath_core::manifest::parse_manifest(text)
+                .map(|bp| FlowView::new(Arc::new(StageGraph::from_blueprint(&bp)), true))
+                .map_err(|e| e.to_string()),
+            None => Err("the manifest could not be read".to_string()),
+        };
+        self.preview = Some((name, view));
+    }
+}
+
+impl Dashboard {
+    /// Keys on the catalog.
+    pub(in crate::commands::dashboard) fn handle_catalog_key(&mut self, key: KeyEvent) {
+        let code = key.code;
+        let filtering = self.agents().catalog.filtering;
+        if filtering {
+            let catalog = &mut self.agents().catalog;
+            match code {
+                KeyCode::Esc => {
+                    catalog.filter.clear();
+                    catalog.filtering = false;
+                }
+                KeyCode::Enter => catalog.filtering = false,
+                KeyCode::Backspace => {
+                    catalog.filter.pop();
+                }
+                KeyCode::Char(c) => catalog.filter.push(c),
+                _ => {}
+            }
+            catalog.clamp();
+            return;
+        }
+        match code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                let catalog = &mut self.agents().catalog;
+                if catalog.filter.is_empty() {
+                    self.close_agents_screen();
+                } else {
+                    catalog.filter.clear();
+                    catalog.clamp();
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') => self.agents().catalog.move_by(-1),
+            KeyCode::Down | KeyCode::Char('j') => self.agents().catalog.move_by(1),
+            KeyCode::Home => self.agents().catalog.selected = 0,
+            KeyCode::End => self.agents().catalog.move_by(isize::MAX / 2),
+            KeyCode::PageUp => self.agents().catalog.move_by(-8),
+            KeyCode::PageDown => self.agents().catalog.move_by(8),
+            KeyCode::Char('/') => self.agents().catalog.filtering = true,
+            KeyCode::Enter | KeyCode::Char('e') => self.edit_selected_agent(),
+            KeyCode::Char('n') => self.open_chooser(),
+            KeyCode::Char('d') => self.request_agent_delete(),
+            KeyCode::Char('r') => self.request_agent_reset(),
+            KeyCode::Char('l') => self.launch_selected_agent(),
+            KeyCode::Char('?') | KeyCode::F(1) => self.show_help = true,
+            _ => {}
+        }
+    }
+
+    /// Open the editor on the agent under the cursor. A bundled agent not
+    /// installed opens from its embedded copy and installs when saved.
+    fn edit_selected_agent(&mut self) {
+        let Some(entry) = self.agents().catalog.selected_entry().cloned() else {
+            return;
+        };
+        let Some(text) = entry.manifest.clone() else {
+            self.toast("That agent's manifest could not be read", ToastLevel::Error);
+            return;
+        };
+        self.open_editor(
+            super::editor::EditTarget::Existing {
+                name: entry.name.clone(),
+                dir: entry.dir.clone(),
+                bundled_from: entry.bundled.then(|| entry.name.clone()),
+            },
+            &text,
+        );
+    }
+
+    /// `d`: confirm deleting the selected agent, when it can be deleted from
+    /// here.
+    fn request_agent_delete(&mut self) {
+        let Some(entry) = self.agents().catalog.selected_entry().cloned() else {
+            return;
+        };
+        if !entry.deletable() {
+            let where_ = match entry.source {
+                Source::Bundled => "It is not installed; there is nothing to delete.",
+                _ => "It lives outside the agents directory; delete it where it is.",
+            };
+            self.toast(
+                format!("{} is not deletable from here. {where_}", entry.name),
+                ToastLevel::Info,
+            );
+            return;
+        }
+        let dialog = Confirm::new(
+            "Delete agent?",
+            vec![Line::from(format!(
+                "Delete '{}' and everything in its directory? This cannot be undone.",
+                entry.name
+            ))],
+            "Delete",
+            "Cancel",
+        )
+        .danger();
+        self.pending_confirm = Some((ConfirmAction::AgentDelete { name: entry.name }, dialog));
+    }
+
+    /// The confirmed delete.
+    pub(in crate::commands::dashboard) fn perform_agent_delete(&mut self, name: &str) {
+        let dir = self.new_run_ctx.agents_dir.clone();
+        match catalog::delete_agent(&dir, name) {
+            Ok(()) => {
+                self.toast(format!("Deleted {name}"), ToastLevel::Info);
+                let mut store = self.layout_store();
+                store.forget(name);
+                let _ = store.save();
+            }
+            Err(e) => self.toast(format!("Could not delete {name}: {e}"), ToastLevel::Error),
+        }
+        self.refresh_catalog();
+    }
+
+    /// `r`: confirm putting a bundled agent's embedded copy back.
+    fn request_agent_reset(&mut self) {
+        let Some(entry) = self.agents().catalog.selected_entry().cloned() else {
+            return;
+        };
+        if !entry.bundled || !entry.differs_from_bundled {
+            self.toast(
+                format!(
+                    "{} is not an edited bundled agent; nothing to reset",
+                    entry.name
+                ),
+                ToastLevel::Info,
+            );
+            return;
+        }
+        let dialog = Confirm::new(
+            "Reset to original?",
+            vec![Line::from(format!(
+                "Replace '{}' with the copy bundled in this binary? Your edits to it are lost.",
+                entry.name
+            ))],
+            "Reset",
+            "Cancel",
+        )
+        .danger();
+        self.pending_confirm = Some((ConfirmAction::AgentReset { name: entry.name }, dialog));
+    }
+
+    /// The confirmed reset.
+    pub(in crate::commands::dashboard) fn perform_agent_reset(&mut self, name: &str) {
+        let dir = self.new_run_ctx.agents_dir.clone();
+        match catalog::reset_bundled(&dir, name) {
+            Ok(()) => self.toast(
+                format!("Reset {name} to the bundled copy"),
+                ToastLevel::Info,
+            ),
+            Err(e) => self.toast(format!("Could not reset {name}: {e}"), ToastLevel::Error),
+        }
+        self.refresh_catalog();
+    }
+
+    /// `l`: leave for the new-run screen with this agent picked.
+    fn launch_selected_agent(&mut self) {
+        let Some(name) = self
+            .agents()
+            .catalog
+            .selected_entry()
+            .map(|e| e.name.clone())
+        else {
+            return;
+        };
+        self.close_agents_screen();
+        self.open_new_run_screen();
+        // The new-run picker lists the same catalog, so the agent is there.
+        self.new_run_selected = self
+            .new_run_agents
+            .iter()
+            .position(|a| a.name == name)
+            .unwrap_or(0);
+    }
+
+    /// Read the catalog again after something changed on disk, and keep the
+    /// preview honest.
+    pub(in crate::commands::dashboard) fn refresh_catalog(&mut self) {
+        let config = self.agents_config();
+        let ctx = NewRunContext {
+            agents_dir: self.new_run_ctx.agents_dir.clone(),
+            config_path: self.new_run_ctx.config_path.clone(),
+            workdir: self.new_run_ctx.workdir.clone(),
+        };
+        let catalog = &mut self.agents().catalog;
+        catalog.refresh(&ctx, &config);
+        catalog.preview = None;
+        // The new-run picker shows the same agents.
+        self.refresh_new_run_agents();
+    }
+
+    /// The layout store, opened at the configured path (or in memory when
+    /// there is none).
+    pub(in crate::commands::dashboard) fn layout_store(
+        &self,
+    ) -> crate::blueprint_edit::LayoutStore {
+        match &self.layout_store_path {
+            Some(path) => crate::blueprint_edit::LayoutStore::open(path.clone()),
+            None => crate::blueprint_edit::LayoutStore::in_memory(),
+        }
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/chooser.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/chooser.rs
@@ -1,0 +1,165 @@
+//! Where a new agent starts: "Start simple", or a copy of an agent from the
+//! catalog, under a name of your choosing.
+
+use crossterm::event::{KeyCode, KeyEvent};
+
+use super::super::state::Dashboard;
+use super::super::types::ToastLevel;
+use crate::blueprint_edit::catalog::CatalogEntry;
+use crate::blueprint_edit::{is_valid_name, templates};
+use crate::tui::widgets::line_edit::{EditOutcome, LineEdit};
+
+/// One row of the chooser.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) struct Template {
+    /// What the row says.
+    pub(in crate::commands::dashboard) label: String,
+    /// What it is, in a few words.
+    pub(in crate::commands::dashboard) detail: String,
+    /// The name suggested for the new agent.
+    pub(in crate::commands::dashboard) suggested: String,
+    /// The manifest to start from; `None` is the two-stage starter.
+    pub(in crate::commands::dashboard) manifest: Option<String>,
+    /// The bundled agent it is a copy of, whose scripts come along.
+    pub(in crate::commands::dashboard) bundled_from: Option<String>,
+}
+
+/// The chooser's state.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) struct Chooser {
+    pub(in crate::commands::dashboard) templates: Vec<Template>,
+    pub(in crate::commands::dashboard) cursor: usize,
+    /// The name field. Follows the row's suggestion until the user types
+    /// into it.
+    pub(in crate::commands::dashboard) name: LineEdit,
+    pub(in crate::commands::dashboard) name_touched: bool,
+    /// Why the name will not do, on a reserved line under the field.
+    pub(in crate::commands::dashboard) problem: Option<String>,
+}
+
+impl Chooser {
+    /// The rows: the starter first, then every agent in the catalog.
+    pub(in crate::commands::dashboard) fn new(entries: &[CatalogEntry]) -> Self {
+        let mut templates = vec![Template {
+            label: "Start simple".to_string(),
+            detail: "two stages, work then finish, with placeholder prompts".to_string(),
+            suggested: "my-agent".to_string(),
+            manifest: None,
+            bundled_from: None,
+        }];
+        for entry in entries.iter().filter(|e| e.manifest.is_some()) {
+            templates.push(Template {
+                label: format!("Clone {}", entry.name),
+                detail: format!("{} · {}", entry.source.as_str(), entry.description),
+                suggested: format!("my-{}", entry.name),
+                manifest: entry.manifest.clone(),
+                bundled_from: (entry.source == crate::blueprint_edit::catalog::Source::Bundled
+                    || entry.bundled)
+                    .then(|| entry.name.clone()),
+            });
+        }
+        Self {
+            templates,
+            cursor: 0,
+            name: LineEdit::new("my-agent", false),
+            name_touched: false,
+            problem: None,
+        }
+    }
+
+    /// The row under the cursor.
+    pub(in crate::commands::dashboard) fn selected(&self) -> &Template {
+        &self.templates[self.cursor.min(self.templates.len() - 1)]
+    }
+
+    fn move_by(&mut self, delta: isize) {
+        let len = self.templates.len() as isize;
+        self.cursor = (self.cursor as isize + delta).clamp(0, len - 1) as usize;
+        if !self.name_touched {
+            self.name = LineEdit::new(self.selected().suggested.clone(), false);
+        }
+    }
+
+    /// Whether the name will do, and if not why. `taken` are the names
+    /// already in the catalog.
+    pub(in crate::commands::dashboard) fn check_name(&mut self, taken: &[String]) -> bool {
+        let name = self.name.value().to_string();
+        self.problem = if !is_valid_name(&name) {
+            Some("Letters, digits, `.`, `_` and `-` only.".to_string())
+        } else if taken.contains(&name) {
+            Some(format!("An agent named {name} already exists."))
+        } else {
+            None
+        };
+        self.problem.is_none()
+    }
+}
+
+impl Dashboard {
+    /// `n` on the catalog: open the chooser.
+    pub(in crate::commands::dashboard) fn open_chooser(&mut self) {
+        let chooser = Chooser::new(&self.agents().catalog.entries);
+        self.agents().chooser = Some(chooser);
+    }
+
+    /// Keys on the chooser: the arrows pick a template, anything else types
+    /// the name; Enter opens the editor on it, Esc closes the chooser.
+    pub(in crate::commands::dashboard) fn handle_chooser_key(&mut self, key: KeyEvent) {
+        let taken: Vec<String> = self
+            .agents()
+            .catalog
+            .entries
+            .iter()
+            .map(|e| e.name.clone())
+            .collect();
+        let chooser = self.agents().chooser.as_mut().expect("callers check");
+        match key.code {
+            KeyCode::Up => chooser.move_by(-1),
+            KeyCode::Down => chooser.move_by(1),
+            _ => {
+                let was = chooser.name.value().to_string();
+                match chooser.name.handle_key(&key) {
+                    EditOutcome::Cancel => {
+                        self.agents().chooser = None;
+                        return;
+                    }
+                    EditOutcome::Commit => {
+                        if chooser.check_name(&taken) {
+                            let template = chooser.selected().clone();
+                            let name = chooser.name.value().to_string();
+                            self.agents().chooser = None;
+                            self.start_from_template(&template, &name);
+                        }
+                        return;
+                    }
+                    EditOutcome::Pending => {}
+                }
+                if chooser.name.value() != was {
+                    chooser.name_touched = true;
+                    chooser.check_name(&taken);
+                }
+            }
+        }
+    }
+
+    /// Open the editor on a fresh, unsaved agent from a template.
+    fn start_from_template(&mut self, template: &Template, name: &str) {
+        let text = match &template.manifest {
+            Some(text) => templates::clone_of(text, name),
+            None => templates::empty_blueprint(name),
+        };
+        match text {
+            Ok(text) => self.open_editor(
+                super::editor::EditTarget::New {
+                    name: name.to_string(),
+                    bundled_from: template.bundled_from.clone(),
+                },
+                &text,
+            ),
+            Err(e) => self.toast(
+                format!("Could not start from that template: {e}"),
+                ToastLevel::Error,
+            ),
+        }
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
@@ -1,0 +1,877 @@
+//! The agent editor's state: the document, the canvas, what is selected,
+//! what is being edited, and the save/undo/problems machinery around them.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ratatui::text::Line;
+
+use super::super::state::Dashboard;
+use super::super::types::*;
+use super::inspector::{self, Field, FieldId, FieldValue, Panel, StageTab};
+use crate::blueprint_edit::check::{Problems, check};
+use crate::blueprint_edit::{
+    EdgeKind, EditError, LayoutStore, ManifestDoc, StageModeView, WorkerKind, catalog,
+};
+use crate::tui::flowgraph::{FlowView, Selection, StageGraph};
+use crate::tui::widgets::confirm::Confirm;
+use crate::tui::widgets::line_edit::LineEdit;
+use crate::tui::widgets::picker::Picker;
+
+/// Which pane the keys go to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum Focus {
+    /// The graph: arrows move between boxes, `a`/`c`/`x` edit the graph.
+    Canvas,
+    /// The inspector: arrows move between fields, Enter edits one.
+    Inspector,
+}
+
+/// What a chooser is choosing for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum PickerFor {
+    /// A field's value, from the field's list.
+    Field(FieldId),
+    /// The other end of a new path from this stage.
+    ConnectFrom(String),
+}
+
+/// A full-screen overlay over the editor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum Overlay {
+    /// The exact manifest that will be saved, scrolled by `scroll` lines.
+    Definition { scroll: usize },
+}
+
+/// What is being opened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum EditTarget {
+    /// An agent from the catalog: saved back where it lives (or installed,
+    /// for a bundled one not installed yet).
+    Existing {
+        name: String,
+        dir: Option<PathBuf>,
+        bundled_from: Option<String>,
+    },
+    /// A new agent from a template, saved under the agents directory.
+    New {
+        name: String,
+        bundled_from: Option<String>,
+    },
+}
+
+/// The editor.
+pub(in crate::commands::dashboard) struct Editor {
+    /// The agent's name; the directory it saves to is named after it.
+    pub(in crate::commands::dashboard) name: String,
+    /// Not saved anywhere yet.
+    pub(in crate::commands::dashboard) is_new: bool,
+    /// Where `agent.leviath` is written.
+    pub(in crate::commands::dashboard) dir: PathBuf,
+    pub(in crate::commands::dashboard) doc: ManifestDoc,
+    /// The manifest before each edit, newest last.
+    pub(in crate::commands::dashboard) undo: Vec<String>,
+    pub(in crate::commands::dashboard) redo: Vec<String>,
+    pub(in crate::commands::dashboard) view: FlowView,
+    pub(in crate::commands::dashboard) graph: Arc<StageGraph>,
+    pub(in crate::commands::dashboard) panel: Panel,
+    pub(in crate::commands::dashboard) focus: Focus,
+    /// The inspector's cursor, into `fields()`.
+    pub(in crate::commands::dashboard) cursor: usize,
+    /// A field being typed into.
+    pub(in crate::commands::dashboard) line: Option<(FieldId, LineEdit)>,
+    /// A chooser on top of everything.
+    pub(in crate::commands::dashboard) picker: Option<(PickerFor, Picker)>,
+    /// The name of a stage about to be added.
+    pub(in crate::commands::dashboard) add_stage: Option<LineEdit>,
+    pub(in crate::commands::dashboard) overlay: Option<Overlay>,
+    pub(in crate::commands::dashboard) problems: Problems,
+    /// The problems list expanded under the canvas.
+    pub(in crate::commands::dashboard) problems_open: bool,
+    pub(in crate::commands::dashboard) layout: LayoutStore,
+    pub(in crate::commands::dashboard) dirty: bool,
+    /// The last thing the editor said, on the status line.
+    pub(in crate::commands::dashboard) message: Option<String>,
+    /// `provider/model` ids the model chooser offers.
+    pub(in crate::commands::dashboard) models: Vec<String>,
+}
+
+/// Snapshots kept for undo.
+const UNDO_DEPTH: usize = 100;
+
+/// An edit to run on the document.
+type Mutation<'a> = Box<dyn FnOnce(&mut ManifestDoc) -> Result<(), EditError> + 'a>;
+
+/// A linear chain of `names`, for a manifest the runtime cannot read yet.
+fn chain_graph(names: &[String]) -> Arc<StageGraph> {
+    let mut text = String::from("[agent]\nname = \"chain\"\n");
+    for name in names {
+        text.push_str(&format!("[stages.{name}]\n"));
+    }
+    let bp = leviath_core::manifest::parse_manifest(&text)
+        .expect("stage names passed the manifest's charset");
+    Arc::new(StageGraph::from_blueprint(&bp))
+}
+
+impl Editor {
+    /// The graph the runtime would run; when the runtime rejects the
+    /// manifest, the last graph that parsed, or a bare chain of the stage
+    /// names so there is still something to point at.
+    fn graph_of(doc: &ManifestDoc, fallback: Option<&Arc<StageGraph>>) -> Arc<StageGraph> {
+        match doc.blueprint() {
+            Ok(bp) => Arc::new(StageGraph::from_blueprint(&bp)),
+            Err(_) => fallback
+                .cloned()
+                .unwrap_or_else(|| chain_graph(&doc.stage_names())),
+        }
+    }
+
+    /// The inspector's rows for the current panel.
+    pub(in crate::commands::dashboard) fn fields(&self) -> Vec<Field> {
+        inspector::fields(&self.doc, &self.panel)
+    }
+
+    /// The row under the inspector cursor.
+    pub(in crate::commands::dashboard) fn current_field(&self) -> Option<Field> {
+        self.fields().into_iter().nth(self.cursor)
+    }
+
+    /// Bring the panel in line with the canvas selection, keeping a stage
+    /// panel's tab across stages.
+    pub(in crate::commands::dashboard) fn sync_panel(&mut self) {
+        let tab = match &self.panel {
+            Panel::Stage { tab, .. } => *tab,
+            _ => StageTab::Behaviour,
+        };
+        let next = match self.view.selection() {
+            Selection::Node(id) => match id.strip_prefix("ext:") {
+                Some(name) => Panel::External(name.to_string()),
+                None => Panel::Stage { name: id, tab },
+            },
+            Selection::Edge(edge) => Panel::Edge {
+                from: edge.from,
+                to: edge.to,
+            },
+            Selection::Nothing => Panel::Agent,
+        };
+        if next != self.panel {
+            self.panel = next;
+            self.cursor = 0;
+        }
+        let count = self.fields().len();
+        self.cursor = self.cursor.min(count.saturating_sub(1));
+    }
+
+    /// Re-read everything derived from the document after an edit: the
+    /// graph and canvas, the problems, the badges.
+    pub(in crate::commands::dashboard) fn refresh(&mut self) {
+        self.graph = Self::graph_of(&self.doc, Some(&self.graph));
+        let positions = self.view.positions();
+        self.view.replace_graph(self.graph.clone(), positions);
+        self.problems = check(&self.doc.to_toml(), &self.dir);
+        self.apply_flags();
+        self.sync_panel();
+    }
+
+    /// The `!` and `▣` badges on the boxes. Only an error earns the `!`: a
+    /// warning on every new stage (no model yet) would mark every box.
+    fn apply_flags(&mut self) {
+        for stage in self.doc.stages() {
+            let problem = self
+                .problems
+                .for_stage(&stage.name)
+                .iter()
+                .any(|p| p.severity == crate::blueprint_edit::check::Severity::Error);
+            self.view
+                .set_flags(&stage.name, problem, stage.has_own_layout);
+        }
+    }
+
+    /// Run a mutator: the manifest before it goes on the undo stack, and a
+    /// refusal comes back as its message with nothing changed. Tests drive
+    /// the document through here; the dashboard goes through
+    /// [`Dashboard::editor_mutate`].
+    #[cfg(test)]
+    pub(in crate::commands::dashboard) fn mutate(
+        &mut self,
+        f: impl FnOnce(&mut ManifestDoc) -> Result<(), EditError>,
+    ) -> Result<(), String> {
+        self.mutate_boxed(Box::new(f))
+    }
+
+    /// One function whatever closure the caller passes, so coverage sees its
+    /// branches once rather than per call site.
+    fn mutate_boxed(&mut self, f: Mutation<'_>) -> Result<(), String> {
+        let before = self.doc.to_toml();
+        match f(&mut self.doc) {
+            Ok(()) => {
+                if self.doc.to_toml() != before {
+                    self.undo.push(before);
+                    if self.undo.len() > UNDO_DEPTH {
+                        self.undo.remove(0);
+                    }
+                    self.redo.clear();
+                    self.dirty = true;
+                    self.refresh();
+                }
+                Ok(())
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    /// Back one edit.
+    pub(in crate::commands::dashboard) fn undo(&mut self) -> bool {
+        let Some(text) = self.undo.pop() else {
+            return false;
+        };
+        self.redo.push(self.doc.to_toml());
+        self.doc = ManifestDoc::parse(&text).expect("an undo snapshot parsed once");
+        self.dirty = true;
+        self.refresh();
+        true
+    }
+
+    /// Forward one edit.
+    pub(in crate::commands::dashboard) fn redo(&mut self) -> bool {
+        let Some(text) = self.redo.pop() else {
+            return false;
+        };
+        self.undo.push(self.doc.to_toml());
+        self.doc = ManifestDoc::parse(&text).expect("a redo snapshot parsed once");
+        self.dirty = true;
+        self.refresh();
+        true
+    }
+
+    /// The name of the stage the panel is on, when it is on one.
+    pub(in crate::commands::dashboard) fn panel_stage(&self) -> Option<String> {
+        match &self.panel {
+            Panel::Stage { name, .. } => Some(name.clone()),
+            _ => None,
+        }
+    }
+
+    /// The path the panel is on, when it is on one.
+    pub(in crate::commands::dashboard) fn panel_edge(&self) -> Option<(String, String)> {
+        match &self.panel {
+            Panel::Edge { from, to } => Some((from.clone(), to.clone())),
+            _ => None,
+        }
+    }
+}
+
+impl Dashboard {
+    /// Open the editor on `text`.
+    pub(in crate::commands::dashboard) fn open_editor(&mut self, target: EditTarget, text: &str) {
+        let doc = match ManifestDoc::parse(text) {
+            Ok(doc) => doc,
+            Err(e) => {
+                self.toast(format!("Cannot edit that manifest: {e}"), ToastLevel::Error);
+                return;
+            }
+        };
+        let (name, is_new, dir, bundled_from) = match target {
+            EditTarget::Existing {
+                name,
+                dir,
+                bundled_from,
+            } => {
+                let dir = dir.unwrap_or_else(|| self.new_run_ctx.agents_dir.join(&name));
+                (name, false, dir, bundled_from)
+            }
+            EditTarget::New { name, bundled_from } => {
+                let dir = self.new_run_ctx.agents_dir.join(&name);
+                (name, true, dir, bundled_from)
+            }
+        };
+        // A copy of a bundled agent brings its scripts along now, so the
+        // lint sees the tools they define; an unsaved new agent's directory
+        // is removed again when the editor closes without saving.
+        if is_new
+            && !dir.exists()
+            && let Some(from) = bundled_from.as_deref().and_then(catalog::bundled)
+        {
+            let _ = catalog::copy_bundled_extras(&self.new_run_ctx.agents_dir, &name, from);
+        }
+        let layout = self.layout_store();
+        let positions = layout.positions(&name).cloned().unwrap_or_default();
+        let graph = Editor::graph_of(&doc, None);
+        let view = FlowView::new_editor(graph.clone(), positions);
+        let problems = check(text, &dir);
+        let mut models: Vec<String> = crate::commands::models::closed_catalog_models()
+            .into_iter()
+            .map(|(p, m)| format!("{p}/{m}"))
+            .collect();
+        models.extend(doc.known_models());
+        models.sort();
+        models.dedup();
+        let mut editor = Editor {
+            name,
+            is_new,
+            dir,
+            doc,
+            undo: Vec::new(),
+            redo: Vec::new(),
+            view,
+            graph,
+            panel: Panel::Agent,
+            focus: Focus::Canvas,
+            cursor: 0,
+            line: None,
+            picker: None,
+            add_stage: None,
+            overlay: None,
+            problems,
+            problems_open: false,
+            layout,
+            dirty: is_new,
+            message: None,
+            models,
+        };
+        editor.apply_flags();
+        self.agents().editor = Some(editor);
+    }
+
+    /// The open editor.
+    pub(in crate::commands::dashboard) fn editor(&mut self) -> &mut Editor {
+        self.agents()
+            .editor
+            .as_mut()
+            .expect("callers check the editor is open")
+    }
+
+    /// Run a mutator on the open editor and say when it was refused.
+    pub(in crate::commands::dashboard) fn editor_mutate(
+        &mut self,
+        f: impl FnOnce(&mut ManifestDoc) -> Result<(), EditError>,
+    ) -> bool {
+        self.editor_mutate_boxed(Box::new(f))
+    }
+
+    fn editor_mutate_boxed(&mut self, f: Mutation<'_>) -> bool {
+        match self.editor().mutate_boxed(f) {
+            Ok(()) => true,
+            Err(message) => {
+                self.editor().message = Some(message);
+                false
+            }
+        }
+    }
+
+    /// Ctrl-S: check, then write. Errors block the save and open the
+    /// problems list, so the reason is on screen.
+    pub(in crate::commands::dashboard) fn editor_save(&mut self) {
+        let text = self.editor().doc.to_toml();
+        let dir = self.editor().dir.clone();
+        let problems = check(&text, &dir);
+        self.editor().problems = problems.clone();
+        if !problems.is_saveable() {
+            self.editor().problems_open = true;
+            let n = problems.error_count();
+            self.editor().message = Some(format!(
+                "Not saved: {n} problem{} to fix first",
+                if n == 1 { "" } else { "s" }
+            ));
+            return;
+        }
+        let name = self.editor().name.clone();
+        let written = std::fs::create_dir_all(&dir)
+            .and_then(|()| std::fs::write(dir.join("agent.leviath"), &text));
+        if let Err(e) = written {
+            self.editor().message = Some(format!("Could not write {}: {e}", dir.display()));
+            return;
+        }
+        let positions = self.editor().view.positions();
+        {
+            let editor = self.editor();
+            editor.layout.set(&name, positions);
+            let _ = editor.layout.save();
+            editor.dirty = false;
+            editor.is_new = false;
+            editor.message = Some(format!("Saved to {}", dir.join("agent.leviath").display()));
+        }
+        self.refresh_catalog();
+        self.toast(format!("Saved {name}"), ToastLevel::Info);
+    }
+
+    /// Esc on the canvas: close, asking first when there are unsaved edits.
+    pub(in crate::commands::dashboard) fn editor_close_requested(&mut self) {
+        if self.editor().dirty {
+            let dialog = Confirm::new(
+                "Discard your changes?",
+                vec![Line::from(
+                    "The agent has unsaved edits. Close the editor and lose them?",
+                )],
+                "Discard",
+                "Keep editing",
+            )
+            .danger();
+            self.pending_confirm = Some((ConfirmAction::EditorDiscard, dialog));
+            return;
+        }
+        self.close_editor();
+    }
+
+    /// Close the editor, back to the catalog.
+    pub(in crate::commands::dashboard) fn close_editor(&mut self) {
+        // The arrangement is worth keeping even when the manifest is not.
+        let (name, positions, unsaved_dir) = {
+            let editor = self.editor();
+            (
+                editor.name.clone(),
+                editor.view.positions(),
+                editor.is_new.then(|| editor.dir.clone()),
+            )
+        };
+        {
+            let editor = self.editor();
+            editor.layout.set(&name, positions);
+            let _ = editor.layout.save();
+        }
+        // A new agent never saved leaves nothing behind (its scripts were
+        // materialised for the lint's sake).
+        if let Some(dir) = unsaved_dir
+            && !dir.join("agent.leviath").exists()
+        {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+        self.agents().editor = None;
+        self.refresh_catalog();
+    }
+
+    /// Enter on an inspector row.
+    pub(in crate::commands::dashboard) fn editor_activate(&mut self) {
+        let Some(field) = self.editor().current_field() else {
+            return;
+        };
+        if !field.enabled {
+            return;
+        }
+        match field.value {
+            FieldValue::Text(text) => {
+                self.editor().line = Some((field.id, LineEdit::new(text, false)));
+            }
+            FieldValue::Number(n) => {
+                let text = n.map(|n| n.to_string()).unwrap_or_default();
+                self.editor().line = Some((field.id, LineEdit::new(text, false)));
+            }
+            FieldValue::Toggle(on) => self.editor_set_toggle(&field.id, !on),
+            FieldValue::Choice(_) => self.editor_open_choice(&field.id),
+            FieldValue::Row(_) => {}
+            FieldValue::Button => self.editor_button(&field.id),
+        }
+    }
+
+    /// `←`/`→` on an inspector row: cycle a choice, step a number, flip a
+    /// toggle.
+    pub(in crate::commands::dashboard) fn editor_adjust(&mut self, delta: isize) {
+        let Some(field) = self.editor().current_field() else {
+            return;
+        };
+        if !field.enabled {
+            return;
+        }
+        match field.value {
+            FieldValue::Toggle(on) => self.editor_set_toggle(&field.id, !on),
+            FieldValue::Number(n) => {
+                let next = match (n, delta) {
+                    (None, d) if d > 0 => Some(1),
+                    (None, _) => None,
+                    (Some(0), d) if d < 0 => None,
+                    (Some(v), d) => Some((v as i64 + d as i64).max(0) as u64),
+                };
+                self.editor_set_number(&field.id, next);
+            }
+            FieldValue::Choice(_) => {
+                let (options, current) = self.editor_choice_options(&field.id);
+                if options.is_empty() {
+                    return;
+                }
+                let at = current.unwrap_or(0) as isize + delta;
+                let at = at.rem_euclid(options.len() as isize) as usize;
+                self.editor_pick(&field.id, &options[at]);
+            }
+            FieldValue::Text(_) | FieldValue::Row(_) | FieldValue::Button => {}
+        }
+    }
+
+    pub(in crate::commands::dashboard) fn editor_set_toggle(&mut self, id: &FieldId, on: bool) {
+        match id {
+            FieldId::AllowComplete => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                self.editor_mutate(|d| d.set_allow_complete(&stage, on.then_some(true)));
+            }
+            FieldId::EdgeGate => {
+                let (from, to) = self.editor().panel_edge().expect("a path field");
+                self.editor_mutate(|d| d.set_edge_gate(&from, &to, on));
+            }
+            _ => {}
+        }
+    }
+
+    pub(in crate::commands::dashboard) fn editor_set_number(
+        &mut self,
+        id: &FieldId,
+        value: Option<u64>,
+    ) {
+        let stage = self.editor().panel_stage().expect("a stage field");
+        match id {
+            FieldId::MaxIterations => {
+                self.editor_mutate(|d| d.set_max_iterations(&stage, value));
+            }
+            FieldId::MaxRevisits => {
+                self.editor_mutate(|d| d.set_max_revisits(&stage, value));
+            }
+            FieldId::MaxWorkers => {
+                self.editor_mutate(|d| {
+                    d.set_fan_out(
+                        &stage,
+                        crate::blueprint_edit::FanOutField::MaxWorkers(value),
+                    )
+                });
+            }
+            FieldId::MaxItems => {
+                self.editor_mutate(|d| {
+                    d.set_fan_out(&stage, crate::blueprint_edit::FanOutField::MaxItems(value))
+                });
+            }
+            _ => {}
+        }
+    }
+
+    /// A field's choices, and which of them is current.
+    pub(in crate::commands::dashboard) fn editor_choice_options(
+        &mut self,
+        id: &FieldId,
+    ) -> (Vec<String>, Option<usize>) {
+        let editor = self.editor();
+        match id {
+            FieldId::EntryStage => {
+                let names = editor.doc.stage_names();
+                let current = editor
+                    .doc
+                    .agent()
+                    .entry_stage
+                    .and_then(|e| names.iter().position(|n| *n == e));
+                (names, current)
+            }
+            FieldId::DefaultModel => {
+                let current = editor
+                    .doc
+                    .agent()
+                    .default_model
+                    .and_then(|m| editor.models.iter().position(|n| *n == m));
+                (editor.models.clone(), current)
+            }
+            FieldId::StageMode => {
+                let stage = editor.panel_stage().expect("a stage field");
+                let mode = editor.doc.stage(&stage).map(|s| s.mode);
+                let options: Vec<String> = StageModeView::CHOICES
+                    .iter()
+                    .map(|m| m.as_str().to_string())
+                    .collect();
+                let current = mode.and_then(|m| options.iter().position(|o| *o == m.as_str()));
+                (options, current)
+            }
+            FieldId::WorkerKind => {
+                let stage = editor.panel_stage().expect("a stage field");
+                let kind = editor
+                    .doc
+                    .stage(&stage)
+                    .and_then(|s| s.fan_out.worker.map(|(k, _)| k));
+                let options: Vec<String> =
+                    [WorkerKind::Stage, WorkerKind::Agent, WorkerKind::Query]
+                        .iter()
+                        .map(|k| k.key().to_string())
+                        .collect();
+                let current = kind.and_then(|k| options.iter().position(|o| *o == k.key()));
+                (options, current)
+            }
+            FieldId::MergeStage => {
+                let stage = editor.panel_stage().expect("a stage field");
+                let mut names = vec!["(none)".to_string()];
+                names.extend(editor.doc.stage_names().into_iter().filter(|n| *n != stage));
+                let merge = editor.doc.stage(&stage).and_then(|s| s.fan_out.merge_stage);
+                let current = merge
+                    .and_then(|m| names.iter().position(|n| *n == m))
+                    .or(Some(0));
+                (names, current)
+            }
+            FieldId::OnWorkerFailure => {
+                let stage = editor.panel_stage().expect("a stage field");
+                let options = vec!["continue".to_string(), "fail_all".to_string()];
+                let policy = editor
+                    .doc
+                    .stage(&stage)
+                    .and_then(|s| s.fan_out.on_worker_failure);
+                let current = policy
+                    .and_then(|p| options.iter().position(|o| *o == p))
+                    .or(Some(0));
+                (options, current)
+            }
+            FieldId::EdgeKind => {
+                let (from, to) = editor.panel_edge().expect("a path field");
+                let options: Vec<String> = EdgeKind::CHOICES
+                    .iter()
+                    .map(|k| k.label().to_string())
+                    .collect();
+                let current = editor
+                    .doc
+                    .edge(&from, &to)
+                    .and_then(|e| EdgeKind::CHOICES.iter().position(|k| *k == e.kind));
+                (options, current)
+            }
+            _ => (Vec::new(), None),
+        }
+    }
+
+    /// Open the chooser for a choice field.
+    pub(in crate::commands::dashboard) fn editor_open_choice(&mut self, id: &FieldId) {
+        let (options, current) = self.editor_choice_options(id);
+        if options.is_empty() {
+            return;
+        }
+        let (title, explain, details): (&str, &str, Vec<String>) = match id {
+            FieldId::EntryStage => ("Starts at", "The stage a run begins in.", vec![]),
+            FieldId::DefaultModel => (
+                "Default model",
+                "The model every stage tries first; the rest of each stage's chain stays behind it.",
+                vec![],
+            ),
+            FieldId::StageMode => (
+                "How it works",
+                "What the stage does with its turn.",
+                StageModeView::CHOICES
+                    .iter()
+                    .map(|m| m.label().to_string())
+                    .collect(),
+            ),
+            FieldId::WorkerKind => (
+                "Workers come from",
+                "Where a fan-out stage gets its workers.",
+                [WorkerKind::Stage, WorkerKind::Agent, WorkerKind::Query]
+                    .iter()
+                    .map(|k| inspector::worker_kind_label(*k).to_string())
+                    .collect(),
+            ),
+            FieldId::MergeStage => (
+                "Merge stage",
+                "The stage that gathers the workers' results.",
+                vec![],
+            ),
+            FieldId::OnWorkerFailure => (
+                "If a worker fails",
+                "Carry on with the rest, or fail the whole fan-out.",
+                vec![],
+            ),
+            _ => (
+                "When to take this path",
+                "What makes the run follow this path out of the stage.",
+                EdgeKind::CHOICES
+                    .iter()
+                    .map(|k| k.short().to_string())
+                    .collect(),
+            ),
+        };
+        let rows: Vec<crate::tui::widgets::picker::PickerOption> = options
+            .iter()
+            .enumerate()
+            .map(|(i, value)| crate::tui::widgets::picker::PickerOption {
+                value: value.clone(),
+                detail: details.get(i).cloned().unwrap_or_default(),
+            })
+            .collect();
+        let picker = Picker::new(title, vec![explain.to_string()], rows, current.unwrap_or(0));
+        self.editor().picker = Some((PickerFor::Field(id.clone()), picker));
+    }
+
+    /// Write a chosen value into a choice field.
+    pub(in crate::commands::dashboard) fn editor_pick(&mut self, id: &FieldId, value: &str) {
+        let value = value.to_string();
+        match id {
+            FieldId::EntryStage => {
+                self.editor_mutate(|d| d.set_entry_stage(&value));
+            }
+            FieldId::DefaultModel => {
+                self.editor_mutate(|d| {
+                    d.set_default_model(&value);
+                    Ok(())
+                });
+            }
+            FieldId::StageMode => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let mode = StageModeView::parse(&value);
+                self.editor_mutate(|d| d.set_stage_mode(&stage, &mode));
+            }
+            FieldId::WorkerKind => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let kind = [WorkerKind::Stage, WorkerKind::Agent, WorkerKind::Query]
+                    .into_iter()
+                    .find(|k| k.key() == value)
+                    .expect("an offered kind");
+                let current = self
+                    .editor()
+                    .doc
+                    .stage(&stage)
+                    .and_then(|s| s.fan_out.worker.map(|(_, v)| v))
+                    .unwrap_or_default();
+                self.editor_mutate(|d| {
+                    d.set_fan_out(
+                        &stage,
+                        crate::blueprint_edit::FanOutField::Worker(Some((kind, current))),
+                    )
+                });
+            }
+            FieldId::MergeStage => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let merge = (value != "(none)").then_some(value);
+                self.editor_mutate(|d| {
+                    d.set_fan_out(
+                        &stage,
+                        crate::blueprint_edit::FanOutField::MergeStage(merge),
+                    )
+                });
+            }
+            FieldId::OnWorkerFailure => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                self.editor_mutate(|d| {
+                    d.set_fan_out(
+                        &stage,
+                        crate::blueprint_edit::FanOutField::OnWorkerFailure(Some(value)),
+                    )
+                });
+            }
+            FieldId::EdgeKind => {
+                let (from, to) = self.editor().panel_edge().expect("a path field");
+                let kind = EdgeKind::CHOICES
+                    .into_iter()
+                    .find(|k| k.label() == value)
+                    .expect("an offered kind");
+                self.editor_mutate(|d| d.set_edge_kind(&from, &to, kind));
+            }
+            _ => {}
+        }
+    }
+
+    /// Enter on a button row.
+    pub(in crate::commands::dashboard) fn editor_button(&mut self, id: &FieldId) {
+        match id {
+            FieldId::MoveUp | FieldId::MoveDown => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let up = *id == FieldId::MoveUp;
+                self.editor_mutate(|d| d.move_stage(&stage, up));
+            }
+            FieldId::DeleteStage => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                self.editor_request_delete_stage(&stage);
+            }
+            FieldId::DeletePath => {
+                let (from, to) = self.editor().panel_edge().expect("a path field");
+                self.editor_delete_edge(&from, &to);
+            }
+            _ => {}
+        }
+    }
+
+    /// Ask before a stage goes: every path in and out goes with it.
+    pub(in crate::commands::dashboard) fn editor_request_delete_stage(&mut self, stage: &str) {
+        if self.editor().doc.stage_names().len() < 2 {
+            self.editor().message =
+                Some("This is the only stage; an agent needs at least one.".to_string());
+            return;
+        }
+        let dialog = Confirm::new(
+            "Delete stage?",
+            vec![Line::from(format!(
+                "Delete '{stage}' and every path in or out of it?"
+            ))],
+            "Delete",
+            "Cancel",
+        )
+        .danger();
+        self.pending_confirm = Some((
+            ConfirmAction::StageDelete {
+                name: stage.to_string(),
+            },
+            dialog,
+        ));
+    }
+
+    /// The confirmed stage delete.
+    pub(in crate::commands::dashboard) fn editor_delete_stage(&mut self, stage: &str) {
+        let stage = stage.to_string();
+        if self.editor_mutate(|d| d.delete_stage(&stage)) {
+            self.editor().view.clear_selection();
+            self.editor().sync_panel();
+        }
+    }
+
+    /// Delete a path (no confirmation: The Lair asks none, and undo is one
+    /// key away).
+    pub(in crate::commands::dashboard) fn editor_delete_edge(&mut self, from: &str, to: &str) {
+        let (from, to) = (from.to_string(), to.to_string());
+        if self.editor_mutate(|d| d.delete_edge(&from, &to)) {
+            self.editor().view.select_stage(&from);
+            self.editor().sync_panel();
+        }
+    }
+
+    /// The text of a line editor, committed to its field.
+    pub(in crate::commands::dashboard) fn editor_commit_line(&mut self, id: &FieldId, text: &str) {
+        let text = text.trim().to_string();
+        match id {
+            FieldId::AgentDescription => {
+                self.editor_mutate(|d| {
+                    d.set_description(&text);
+                    Ok(())
+                });
+            }
+            FieldId::StageName => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                if self.editor_mutate(|d| d.rename_stage(&stage, &text)) {
+                    self.editor().view.select_stage(&text);
+                    self.editor().sync_panel();
+                }
+            }
+            FieldId::StageDescription => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                self.editor_mutate(|d| {
+                    d.set_stage_text(&stage, crate::blueprint_edit::StageText::Description, &text)
+                });
+            }
+            FieldId::MaxIterations
+            | FieldId::MaxRevisits
+            | FieldId::MaxWorkers
+            | FieldId::MaxItems => {
+                let value = match text.parse::<u64>() {
+                    Ok(n) => Some(n),
+                    Err(_) if text.is_empty() => None,
+                    Err(_) => {
+                        self.editor().message = Some(format!("\"{text}\" is not a whole number"));
+                        return;
+                    }
+                };
+                self.editor_set_number(id, value);
+            }
+            FieldId::WorkerRef => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let kind = self
+                    .editor()
+                    .doc
+                    .stage(&stage)
+                    .and_then(|s| s.fan_out.worker.map(|(k, _)| k))
+                    .unwrap_or(WorkerKind::Stage);
+                let worker = (!text.is_empty()).then_some((kind, text));
+                self.editor_mutate(|d| {
+                    d.set_fan_out(&stage, crate::blueprint_edit::FanOutField::Worker(worker))
+                });
+            }
+            FieldId::EdgeHint => {
+                let (from, to) = self.editor().panel_edge().expect("a path field");
+                self.editor_mutate(|d| d.set_edge_hint(&from, &to, &text));
+            }
+            _ => {}
+        }
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_keys.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_keys.rs
@@ -1,0 +1,326 @@
+//! Keys and mouse on the editor: who gets them (a chooser, a line editor,
+//! an overlay, the canvas, the inspector), and the canvas operations that
+//! change the graph.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
+use ratatui::layout::Rect;
+
+use super::super::state::Dashboard;
+use super::editor::{Focus, Overlay, PickerFor};
+use super::inspector::{Panel, StageTab};
+use crate::tui::flowgraph::CanvasEvent;
+use crate::tui::widgets::line_edit::{EditOutcome, LineEdit};
+use crate::tui::widgets::picker::{Picker, PickerOption, PickerOutcome};
+
+impl Dashboard {
+    /// Keys while the editor is open.
+    pub(in crate::commands::dashboard) fn handle_editor_key(&mut self, key: KeyEvent) {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        // Save works from anywhere in the editor, chooser and all: what is
+        // in the document is what is saved.
+        if ctrl && key.code == KeyCode::Char('s') {
+            self.editor_save();
+            return;
+        }
+        if self.editor().picker.is_some() {
+            self.editor_picker_key(&key);
+            return;
+        }
+        if self.editor().add_stage.is_some() {
+            self.editor_add_stage_key(&key);
+            return;
+        }
+        if self.editor().line.is_some() {
+            self.editor_line_key(&key);
+            return;
+        }
+        if self.editor().overlay.is_some() {
+            self.editor_overlay_key(&key);
+            return;
+        }
+        match key.code {
+            KeyCode::Char('?') | KeyCode::F(1) => self.show_help = true,
+            KeyCode::Char('u') => {
+                if !self.editor().undo() {
+                    self.editor().message = Some("Nothing to undo".to_string());
+                }
+            }
+            KeyCode::Char('r') if ctrl => {
+                if !self.editor().redo() {
+                    self.editor().message = Some("Nothing to redo".to_string());
+                }
+            }
+            KeyCode::Char('v') => {
+                self.editor().overlay = Some(Overlay::Definition { scroll: 0 });
+            }
+            KeyCode::Char('p') => {
+                let editor = self.editor();
+                editor.problems_open = !editor.problems_open;
+            }
+            KeyCode::Tab => {
+                let editor = self.editor();
+                editor.focus = match editor.focus {
+                    Focus::Canvas => Focus::Inspector,
+                    Focus::Inspector => Focus::Canvas,
+                };
+            }
+            _ => match self.editor().focus {
+                Focus::Canvas => self.editor_canvas_key(key.code),
+                Focus::Inspector => self.editor_inspector_key(key.code),
+            },
+        }
+    }
+
+    /// Keys on the canvas.
+    fn editor_canvas_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => self.editor_close_requested(),
+            KeyCode::Enter => {
+                let editor = self.editor();
+                editor.sync_panel();
+                editor.focus = Focus::Inspector;
+            }
+            KeyCode::Char('a') => {
+                self.editor().add_stage = Some(LineEdit::new(String::new(), false));
+            }
+            KeyCode::Char('c') => self.editor_open_connect(),
+            KeyCode::Char('x') | KeyCode::Delete => self.editor_delete_selected(),
+            KeyCode::Char('r') => {
+                self.editor().view.rotate();
+            }
+            KeyCode::Char('f') => {
+                self.editor().view.fit();
+            }
+            other => {
+                let editor = self.editor();
+                if editor.view.handle_key(other) {
+                    editor.sync_panel();
+                }
+            }
+        }
+    }
+
+    /// Keys on the inspector.
+    fn editor_inspector_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc => self.editor().focus = Focus::Canvas,
+            KeyCode::Up | KeyCode::Char('k') => {
+                let editor = self.editor();
+                editor.cursor = editor.cursor.saturating_sub(1);
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let editor = self.editor();
+                let last = editor.fields().len().saturating_sub(1);
+                editor.cursor = (editor.cursor + 1).min(last);
+            }
+            KeyCode::Home => self.editor().cursor = 0,
+            KeyCode::End => {
+                let editor = self.editor();
+                editor.cursor = editor.fields().len().saturating_sub(1);
+            }
+            KeyCode::Enter => self.editor_activate(),
+            KeyCode::Left | KeyCode::Char('h') => self.editor_adjust(-1),
+            KeyCode::Right | KeyCode::Char('l') => self.editor_adjust(1),
+            KeyCode::Char(c @ '1'..='3') => {
+                let tab = StageTab::ALL[(c as usize) - ('1' as usize)];
+                let editor = self.editor();
+                if let Panel::Stage { name, .. } = &editor.panel {
+                    editor.panel = Panel::Stage {
+                        name: name.clone(),
+                        tab,
+                    };
+                    editor.cursor = 0;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Keys while a field is being typed into.
+    fn editor_line_key(&mut self, key: &KeyEvent) {
+        let (id, mut line) = self.editor().line.take().expect("callers check");
+        match line.handle_key(key) {
+            EditOutcome::Pending => self.editor().line = Some((id, line)),
+            EditOutcome::Cancel => {}
+            EditOutcome::Commit => {
+                let text = line.value().to_string();
+                self.editor_commit_line(&id, &text);
+            }
+        }
+    }
+
+    /// Keys while the name of a new stage is being typed.
+    fn editor_add_stage_key(&mut self, key: &KeyEvent) {
+        let mut line = self.editor().add_stage.take().expect("callers check");
+        match line.handle_key(key) {
+            EditOutcome::Pending => self.editor().add_stage = Some(line),
+            EditOutcome::Cancel => {}
+            EditOutcome::Commit => {
+                let name = line.value().trim().to_string();
+                if name.is_empty() {
+                    return;
+                }
+                let after = self.editor().panel_stage();
+                if self.editor_mutate(|d| d.add_stage(&name, after.as_deref())) {
+                    let editor = self.editor();
+                    editor.view.select_stage(&name);
+                    editor.view.reveal(&name);
+                    editor.sync_panel();
+                    editor.focus = Focus::Inspector;
+                }
+            }
+        }
+    }
+
+    /// Keys on the chooser.
+    fn editor_picker_key(&mut self, key: &KeyEvent) {
+        let (purpose, mut picker) = self.editor().picker.take().expect("callers check");
+        let outcome = picker.handle_key(key);
+        self.editor_settle_picker(purpose, picker, outcome);
+    }
+
+    /// The mouse on the chooser, when one is open.
+    pub(in crate::commands::dashboard) fn editor_picker_mouse(
+        &mut self,
+        event: MouseEvent,
+        area: Rect,
+    ) -> bool {
+        let Some(editor) = self.agents().editor.as_mut() else {
+            return false;
+        };
+        let Some((purpose, mut picker)) = editor.picker.take() else {
+            return false;
+        };
+        let outcome = picker.handle_mouse(&event, area);
+        self.editor_settle_picker(purpose, picker, outcome);
+        true
+    }
+
+    fn editor_settle_picker(&mut self, purpose: PickerFor, picker: Picker, outcome: PickerOutcome) {
+        match outcome {
+            PickerOutcome::Pending => self.editor().picker = Some((purpose, picker)),
+            PickerOutcome::Cancelled | PickerOutcome::ChosenMany(_) => {}
+            PickerOutcome::Chosen(index) => {
+                let value = picker.options[index].value.clone();
+                match purpose {
+                    PickerFor::Field(id) => self.editor_pick(&id, &value),
+                    PickerFor::ConnectFrom(from) => self.editor_connect(&from, &value),
+                }
+            }
+        }
+    }
+
+    /// Keys on an overlay: the definition scrolls and closes.
+    fn editor_overlay_key(&mut self, key: &KeyEvent) {
+        let editor = self.editor();
+        let Overlay::Definition { scroll } = editor.overlay.as_mut().expect("callers check");
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('v') | KeyCode::Char('q') => editor.overlay = None,
+            KeyCode::Up | KeyCode::Char('k') => *scroll = scroll.saturating_sub(1),
+            KeyCode::Down | KeyCode::Char('j') => *scroll += 1,
+            KeyCode::PageUp => *scroll = scroll.saturating_sub(20),
+            KeyCode::PageDown => *scroll += 20,
+            KeyCode::Home => *scroll = 0,
+            KeyCode::End => *scroll = usize::MAX / 2,
+            KeyCode::Char('y') => {
+                let text = editor.doc.to_toml();
+                let copied = (self.yank_fn)(&text);
+                self.editor().message = Some(if copied {
+                    "Copied the definition".to_string()
+                } else {
+                    "Could not reach a clipboard".to_string()
+                });
+            }
+            _ => {}
+        }
+    }
+
+    /// `c`: connect the selected stage to another, picked from a list (or
+    /// to itself, which the canvas cannot draw as a drag).
+    fn editor_open_connect(&mut self) {
+        let Some(from) = self.editor().panel_stage() else {
+            self.editor().message = Some("Select a stage to connect from".to_string());
+            return;
+        };
+        let existing: Vec<String> = self
+            .editor()
+            .doc
+            .edges()
+            .into_iter()
+            .filter(|e| e.from == from)
+            .map(|e| e.to)
+            .collect();
+        let rows: Vec<PickerOption> = self
+            .editor()
+            .doc
+            .stage_names()
+            .into_iter()
+            .map(|name| PickerOption {
+                detail: if name == from {
+                    "itself: a loop, which needs max revisits".to_string()
+                } else if existing.contains(&name) {
+                    "already connected".to_string()
+                } else {
+                    String::new()
+                },
+                value: name,
+            })
+            .collect();
+        let picker = Picker::new(
+            format!("Connect {from} to"),
+            vec![
+                "A new path the model routes on; change what fires it in the inspector."
+                    .to_string(),
+            ],
+            rows,
+            0,
+        );
+        self.editor().picker = Some((PickerFor::ConnectFrom(from), picker));
+    }
+
+    /// Add the path, select it, and open its panel.
+    pub(in crate::commands::dashboard) fn editor_connect(&mut self, from: &str, to: &str) {
+        let (from, to) = (from.to_string(), to.to_string());
+        if self.editor_mutate(|d| d.add_edge(&from, &to)) {
+            let editor = self.editor();
+            if from == to {
+                editor.view.select_stage(&from);
+            } else {
+                editor.view.select_edge(&from, &to);
+            }
+            editor.sync_panel();
+            editor.focus = Focus::Inspector;
+        }
+    }
+
+    /// `x`: delete what is selected on the canvas.
+    fn editor_delete_selected(&mut self) {
+        match self.editor().panel.clone() {
+            Panel::Stage { name, .. } => self.editor_request_delete_stage(&name),
+            Panel::Edge { from, to } => self.editor_delete_edge(&from, &to),
+            Panel::Agent | Panel::External(_) => {
+                self.editor().message = Some("Select a stage or a path to delete".to_string());
+            }
+        }
+    }
+
+    /// After the canvas took the mouse: add the path a drag made, remember
+    /// where a box was dropped, and keep the panel on the selection.
+    pub(in crate::commands::dashboard) fn editor_drain_canvas(&mut self) {
+        let Some(editor) = self.agents().editor.as_mut() else {
+            return;
+        };
+        let events = editor.view.take_events();
+        for event in events {
+            match event {
+                CanvasEvent::Connected { from, to } => self.editor_connect(&from, &to),
+                CanvasEvent::Moved => {
+                    let editor = self.editor();
+                    let (name, positions) = (editor.name.clone(), editor.view.positions());
+                    editor.layout.set(&name, positions);
+                }
+            }
+        }
+        self.editor().sync_panel();
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
@@ -1,0 +1,370 @@
+//! What the inspector shows for the thing selected on the canvas, as a list
+//! of fields; the same panels, field for field, as The Lair's properties
+//! panel (This agent / Stage / Path), with the essentials it lacks (fan-out
+//! settings, revisits, allow-complete) in the same rows.
+//!
+//! A field that does not apply is disabled rather than hidden, so the panel
+//! never reflows under the cursor: the fan-out rows are there on every
+//! stage and greyed until the mode is `fan_out`; the hint row is there on
+//! every path and greyed unless the path is a hint.
+
+use crate::blueprint_edit::{EdgeKind, ManifestDoc, StageModeView, WorkerKind};
+
+/// Which tab of the stage panel is open.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum StageTab {
+    /// Mode, description, tries, prompts, fan-out.
+    Behaviour,
+    /// The model chain and the tools.
+    Model,
+    /// Regions and tool routing.
+    Context,
+}
+
+impl StageTab {
+    /// The three tabs, in order.
+    pub(in crate::commands::dashboard) const ALL: [StageTab; 3] =
+        [StageTab::Behaviour, StageTab::Model, StageTab::Context];
+
+    /// The tab's title.
+    pub(in crate::commands::dashboard) fn title(self) -> &'static str {
+        match self {
+            StageTab::Behaviour => "Behaviour",
+            StageTab::Model => "Model & tools",
+            StageTab::Context => "Context",
+        }
+    }
+}
+
+/// What the inspector is showing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum Panel {
+    /// Nothing selected: the agent itself.
+    Agent,
+    /// A stage box.
+    Stage { name: String, tab: StageTab },
+    /// A path between two stages.
+    Edge { from: String, to: String },
+    /// A worker blueprint drawn on the canvas, which is edited elsewhere.
+    External(String),
+}
+
+/// One thing the inspector can edit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum FieldId {
+    AgentDescription,
+    EntryStage,
+    DefaultModel,
+    /// A shared region, by name (opens it; a later change).
+    RegionRow(String),
+    StageName,
+    StageMode,
+    StageDescription,
+    MaxIterations,
+    MaxRevisits,
+    AllowComplete,
+    WorkerKind,
+    WorkerRef,
+    MergeStage,
+    MaxWorkers,
+    MaxItems,
+    OnWorkerFailure,
+    MoveUp,
+    MoveDown,
+    DeleteStage,
+    EdgeKind,
+    EdgeHint,
+    EdgeGate,
+    DeletePath,
+}
+
+/// What a field holds and how it edits.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum FieldValue {
+    /// Free text: Enter opens a line editor.
+    Text(String),
+    /// A number: Enter opens a line editor, `←`/`→` step it.
+    Number(Option<u64>),
+    /// On or off: Enter, `←` or `→` flips it.
+    Toggle(bool),
+    /// One of a list: Enter opens the chooser, `←`/`→` cycle.
+    Choice(String),
+    /// A row that opens something (a region).
+    Row(String),
+    /// Enter does the thing.
+    Button,
+}
+
+/// One row of the inspector.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) struct Field {
+    pub(in crate::commands::dashboard) id: FieldId,
+    pub(in crate::commands::dashboard) label: &'static str,
+    pub(in crate::commands::dashboard) value: FieldValue,
+    /// One line under the panel while the cursor is on the row.
+    pub(in crate::commands::dashboard) help: &'static str,
+    /// Greyed and inert when the field does not apply.
+    pub(in crate::commands::dashboard) enabled: bool,
+}
+
+impl Field {
+    fn new(id: FieldId, label: &'static str, value: FieldValue, help: &'static str) -> Self {
+        Self {
+            id,
+            label,
+            value,
+            help,
+            enabled: true,
+        }
+    }
+
+    fn enabled(mut self, on: bool) -> Self {
+        self.enabled = on;
+        self
+    }
+}
+
+/// The inspector's rows for a panel, read from the document.
+pub(in crate::commands::dashboard) fn fields(doc: &ManifestDoc, panel: &Panel) -> Vec<Field> {
+    match panel {
+        Panel::Agent => agent_fields(doc),
+        Panel::Stage { name, tab } => stage_fields(doc, name, *tab),
+        Panel::Edge { from, to } => edge_fields(doc, from, to),
+        Panel::External(_) => Vec::new(),
+    }
+}
+
+/// What the panel is called.
+pub(in crate::commands::dashboard) fn panel_title(panel: &Panel) -> String {
+    match panel {
+        Panel::Agent => "This agent".to_string(),
+        Panel::Stage { name, tab } => format!("Stage · {name} · {}", tab.title()),
+        Panel::Edge { from, to } => format!("Path · {from} → {to}"),
+        Panel::External(name) => format!("Worker blueprint · {name}"),
+    }
+}
+
+fn agent_fields(doc: &ManifestDoc) -> Vec<Field> {
+    let agent = doc.agent();
+    let mut out = vec![
+        Field::new(
+            FieldId::AgentDescription,
+            "What this agent does",
+            FieldValue::Text(agent.description),
+            "One line, shown wherever the agent is listed.",
+        ),
+        Field::new(
+            FieldId::EntryStage,
+            "Starts at",
+            FieldValue::Choice(
+                agent
+                    .entry_stage
+                    .unwrap_or_else(|| "(first stage)".to_string()),
+            ),
+            "The stage a run begins in.",
+        ),
+        Field::new(
+            FieldId::DefaultModel,
+            "Default model",
+            FieldValue::Choice(
+                agent
+                    .default_model
+                    .unwrap_or_else(|| "Mixed: stages differ".to_string()),
+            ),
+            "The model every stage tries first. Picking one rewrites every stage's chain.",
+        ),
+    ];
+    for region in doc.regions(None) {
+        let budget = region
+            .budget_percent
+            .map(|p| format!("{p}%"))
+            .unwrap_or_default();
+        let tokens = region
+            .max_tokens
+            .map(|t| format!("{t} tokens"))
+            .unwrap_or_default();
+        out.push(Field::new(
+            FieldId::RegionRow(region.name.clone()),
+            "Shared region",
+            FieldValue::Row(format!(
+                "{}  {}  {budget} {tokens}",
+                region.name, region.kind
+            )),
+            "A context region every stage sees unless it has a layout of its own.",
+        ));
+    }
+    out
+}
+
+fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
+    let Some(stage) = doc.stage(name) else {
+        return Vec::new();
+    };
+    match tab {
+        StageTab::Behaviour => {
+            let fan_out = stage.mode == StageModeView::FanOut;
+            let (worker_kind, worker_ref) = match &stage.fan_out.worker {
+                Some((kind, value)) => (worker_kind_label(*kind).to_string(), value.clone()),
+                None => ("(none)".to_string(), String::new()),
+            };
+            let names = doc.stage_names();
+            let index = names.iter().position(|n| n == name).unwrap_or(0);
+            vec![
+                Field::new(
+                    FieldId::StageName,
+                    "Name",
+                    FieldValue::Text(stage.name.clone()),
+                    "Renaming rewrites every path into the stage and the entry stage.",
+                ),
+                Field::new(
+                    FieldId::StageMode,
+                    "How it works",
+                    FieldValue::Choice(stage.mode.label().to_string()),
+                    "Works alone, checks in with you, fans out to workers, or hands back the result.",
+                ),
+                Field::new(
+                    FieldId::StageDescription,
+                    "What it does",
+                    FieldValue::Text(stage.description),
+                    "One line, shown on the stage's box and in listings.",
+                ),
+                Field::new(
+                    FieldId::MaxIterations,
+                    "Max tries",
+                    FieldValue::Number(stage.max_iterations),
+                    "Inference rounds before the stage is stopped. Empty leaves it to the runtime.",
+                ),
+                Field::new(
+                    FieldId::MaxRevisits,
+                    "Max revisits",
+                    FieldValue::Number(stage.max_revisits),
+                    "How often a run may come back to this stage. A stage that loops to itself needs one.",
+                ),
+                Field::new(
+                    FieldId::AllowComplete,
+                    "May finish the run",
+                    FieldValue::Toggle(stage.allow_complete.unwrap_or(false)),
+                    "The stage can call the run complete from inside, without a path out.",
+                ),
+                Field::new(
+                    FieldId::WorkerKind,
+                    "Workers come from",
+                    FieldValue::Choice(worker_kind),
+                    "A stage of this agent, another installed agent, or a query matched at run time.",
+                )
+                .enabled(fan_out),
+                Field::new(
+                    FieldId::WorkerRef,
+                    "Worker",
+                    FieldValue::Text(worker_ref),
+                    "The stage, agent or query the workers run as.",
+                )
+                .enabled(fan_out),
+                Field::new(
+                    FieldId::MergeStage,
+                    "Merge stage",
+                    FieldValue::Choice(
+                        stage
+                            .fan_out
+                            .merge_stage
+                            .clone()
+                            .unwrap_or_else(|| "(none)".to_string()),
+                    ),
+                    "The stage that gathers the workers' results.",
+                )
+                .enabled(fan_out),
+                Field::new(
+                    FieldId::MaxWorkers,
+                    "Max workers",
+                    FieldValue::Number(stage.fan_out.max_workers),
+                    "At once. Empty is the runtime's default; 0 is no limit.",
+                )
+                .enabled(fan_out),
+                Field::new(
+                    FieldId::MaxItems,
+                    "Max items",
+                    FieldValue::Number(stage.fan_out.max_items),
+                    "How many pieces the work is split into at most.",
+                )
+                .enabled(fan_out),
+                Field::new(
+                    FieldId::OnWorkerFailure,
+                    "If a worker fails",
+                    FieldValue::Choice(
+                        stage
+                            .fan_out
+                            .on_worker_failure
+                            .clone()
+                            .unwrap_or_else(|| "continue".to_string()),
+                    ),
+                    "Carry on with the rest, or fail the whole fan-out.",
+                )
+                .enabled(fan_out),
+                Field::new(
+                    FieldId::MoveUp,
+                    "Move up in the file",
+                    FieldValue::Button,
+                    "Order in the file only; the paths decide the flow.",
+                )
+                .enabled(index > 0),
+                Field::new(
+                    FieldId::MoveDown,
+                    "Move down in the file",
+                    FieldValue::Button,
+                    "Order in the file only; the paths decide the flow.",
+                )
+                .enabled(index + 1 < names.len()),
+                Field::new(
+                    FieldId::DeleteStage,
+                    "Delete stage",
+                    FieldValue::Button,
+                    "Removes the stage and every path in or out of it.",
+                )
+                .enabled(names.len() > 1),
+            ]
+        }
+        StageTab::Model | StageTab::Context => Vec::new(),
+    }
+}
+
+fn edge_fields(doc: &ManifestDoc, from: &str, to: &str) -> Vec<Field> {
+    let Some(edge) = doc.edge(from, to) else {
+        return Vec::new();
+    };
+    vec![
+        Field::new(
+            FieldId::EdgeKind,
+            "When to take it",
+            FieldValue::Choice(edge.kind.label().to_string()),
+            "Always, when the model decides, on error, when stuck, after too many tries, or as a last resort.",
+        ),
+        Field::new(
+            FieldId::EdgeHint,
+            "Hint the model routes on",
+            FieldValue::Text(edge.hint.clone().unwrap_or_default()),
+            "e.g. The work is done and verified",
+        )
+        .enabled(edge.kind == EdgeKind::Hint),
+        Field::new(
+            FieldId::EdgeGate,
+            "Needs your approval",
+            FieldValue::Toggle(edge.gated),
+            "The run pauses on this path until you approve it.",
+        ),
+        Field::new(
+            FieldId::DeletePath,
+            "Delete path",
+            FieldValue::Button,
+            "Removes the path; the stages stay.",
+        ),
+    ]
+}
+
+/// What the editor calls a worker source.
+pub(in crate::commands::dashboard) fn worker_kind_label(kind: WorkerKind) -> &'static str {
+    match kind {
+        WorkerKind::Stage => "a stage of this agent",
+        WorkerKind::Agent => "another agent",
+        WorkerKind::Query => "a query at run time",
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/mod.rs
@@ -1,0 +1,107 @@
+//! The Agents screen (`a` from the run list): the catalog of agents this
+//! dashboard can open, and the editor that builds one.
+//!
+//! The catalog is the same list `lev list` and the new-run picker show, with
+//! the selected agent's graph, description and stages on the right. From
+//! it: `Enter` edits, `n` starts a new agent from a template, `d` deletes an
+//! installed one, `r` puts a bundled one's embedded copy back, `l` launches
+//! it. The editor is a full screen of its own: the graph canvas on the
+//! left, an inspector on the right showing whatever is selected, the same
+//! shape as The Lair's editor.
+
+mod catalog;
+mod chooser;
+mod editor;
+mod editor_keys;
+mod inspector;
+mod render_catalog;
+mod render_editor;
+#[cfg(test)]
+mod tests;
+
+use ratatui::layout::Rect;
+
+pub(in crate::commands::dashboard) use catalog::Catalog;
+pub(in crate::commands::dashboard) use chooser::Chooser;
+pub(in crate::commands::dashboard) use editor::Editor;
+
+use super::state::Dashboard;
+use crate::config::Config;
+
+/// The screen's state while it is open.
+pub(in crate::commands::dashboard) struct AgentsScreen {
+    /// The list, the filter and the preview.
+    pub(in crate::commands::dashboard) catalog: Catalog,
+    /// The template chooser, when `n` opened it.
+    pub(in crate::commands::dashboard) chooser: Option<Chooser>,
+    /// The editor, when an agent is open in it.
+    pub(in crate::commands::dashboard) editor: Option<Editor>,
+    /// The whole terminal at the last draw, for overlays that take the mouse.
+    pub(in crate::commands::dashboard) last_area: Rect,
+}
+
+impl Dashboard {
+    /// Open the Agents screen on the catalog.
+    pub(in crate::commands::dashboard) fn open_agents_screen(&mut self) {
+        let mut catalog = Catalog::default();
+        let config = self.agents_config();
+        catalog.refresh(&self.new_run_ctx, &config);
+        self.agent_builder = Some(Box::new(AgentsScreen {
+            catalog,
+            chooser: None,
+            editor: None,
+            last_area: Rect::default(),
+        }));
+    }
+
+    /// Close the Agents screen, whatever it was showing.
+    pub(in crate::commands::dashboard) fn close_agents_screen(&mut self) {
+        self.agent_builder = None;
+    }
+
+    /// The config the catalog reads `agent_paths` from.
+    pub(in crate::commands::dashboard) fn agents_config(&self) -> Config {
+        Config::load_from_path_public(&self.new_run_ctx.config_path).unwrap_or_default()
+    }
+
+    /// The open screen, for the modules that drive it.
+    pub(in crate::commands::dashboard) fn agents(&mut self) -> &mut AgentsScreen {
+        self.agent_builder
+            .as_deref_mut()
+            .expect("callers check the screen is open")
+    }
+
+    /// Keys while the Agents screen is open. The editor takes them when it
+    /// is on; the chooser when it is; the catalog otherwise. Help is a
+    /// dashboard-wide overlay and closes through the dashboard.
+    pub(in crate::commands::dashboard) fn handle_agents_key(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+    ) {
+        if self.agents().editor.is_some() {
+            self.handle_editor_key(key);
+        } else if self.agents().chooser.is_some() {
+            self.handle_chooser_key(key);
+        } else {
+            self.handle_catalog_key(key);
+        }
+    }
+
+    /// The mouse while the Agents screen is open: the editor's chooser
+    /// takes it when open; the graph panes take it as everywhere else,
+    /// and the editor then acts on what the canvas did.
+    pub(in crate::commands::dashboard) fn handle_agents_mouse(
+        &mut self,
+        event: crossterm::event::MouseEvent,
+    ) -> bool {
+        let area = self.agents().last_area;
+        if self.editor_picker_mouse(event, area) {
+            return true;
+        }
+        if self.route_mouse_to_graph(event) {
+            self.editor_drain_canvas();
+            return true;
+        }
+        false
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_catalog.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_catalog.rs
@@ -1,0 +1,334 @@
+//! Drawing the Agents screen's catalog: the list on the left, the selected
+//! agent on the right (graph, description, stages), the chooser over it.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table, TableState, Wrap};
+
+use super::super::state::Dashboard;
+use super::super::theme::*;
+use super::super::types::PaneId;
+use crate::blueprint_edit::catalog::{CatalogEntry, Source};
+use crate::tui::widgets::footer::{draw_hint_bar, hint};
+use crate::tui::widgets::popup::{centered, popup_frame};
+
+impl Dashboard {
+    /// The whole Agents screen: catalog or editor, plus the chooser.
+    pub(in crate::commands::dashboard) fn draw_agents_screen(
+        &mut self,
+        frame: &mut Frame,
+        area: Rect,
+    ) {
+        self.agents().last_area = area;
+        if self.agents().editor.is_some() {
+            self.draw_editor(frame, area);
+            return;
+        }
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(area);
+        let panes = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
+            .split(rows[0]);
+        self.draw_catalog_list(frame, panes[0]);
+        self.draw_catalog_detail(frame, panes[1]);
+        self.draw_catalog_hints(frame, rows[1]);
+        if self.agents().chooser.is_some() {
+            self.draw_chooser(frame, area);
+        }
+    }
+
+    fn draw_catalog_list(&mut self, frame: &mut Frame, area: Rect) {
+        let catalog = &self.agents().catalog;
+        let visible = catalog.visible();
+        let header = Row::new(["Agent", "Source", "Description"].into_iter().map(|h| {
+            Cell::from(Span::styled(
+                h,
+                Style::default().add_modifier(Modifier::BOLD),
+            ))
+        }));
+        let rows: Vec<Row> = visible
+            .iter()
+            .filter_map(|i| catalog.entries.get(*i))
+            .map(|e| {
+                // An installed bundled agent that was edited says so in
+                // place of "installed": that it is installed goes without
+                // saying, and the column is narrow.
+                let source = if e.differs_from_bundled {
+                    "edited".to_string()
+                } else {
+                    e.source.as_str().to_string()
+                };
+                Row::new(vec![
+                    Cell::from(e.name.clone()),
+                    Cell::from(Span::styled(source, Style::default().fg(source_colour(e)))),
+                    Cell::from(Span::styled(
+                        e.description.clone(),
+                        Style::default().fg(C_DIM),
+                    )),
+                ])
+            })
+            .collect();
+        let title = if catalog.filter.is_empty() && !catalog.filtering {
+            format!(" Agents ({}) ", visible.len())
+        } else {
+            format!(
+                " Agents  /{}{}  {}/{} ",
+                catalog.filter,
+                if catalog.filtering { "▌" } else { "" },
+                visible.len(),
+                catalog.entries.len()
+            )
+        };
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Percentage(30),
+                Constraint::Percentage(24),
+                Constraint::Percentage(46),
+            ],
+        )
+        .header(header)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_type(BorderType::Rounded)
+                .border_style(Style::default().fg(C_BORDER_FOCUS))
+                .title(title),
+        )
+        .row_highlight_style(
+            Style::default()
+                .bg(Color::DarkGray)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("› ");
+        let mut state = TableState::default();
+        if !visible.is_empty() {
+            state.select(Some(catalog.selected.min(visible.len() - 1)));
+        }
+        let empty = visible.is_empty();
+        let filter = catalog.filter.clone();
+        frame.render_stateful_widget(table, area, &mut state);
+        if empty {
+            // The bundled agents are always in the catalog, so an empty list
+            // is always a filter that matched nothing.
+            let text = format!("No agents match \"{filter}\".");
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(text, Style::default().fg(C_DIM)))),
+                Rect {
+                    x: area.x + 2,
+                    y: area.y + 2,
+                    width: area.width.saturating_sub(4),
+                    height: 1,
+                },
+            );
+        }
+    }
+
+    /// The right half: the graph on top, then what the agent is and its
+    /// stages.
+    fn draw_catalog_detail(&mut self, frame: &mut Frame, area: Rect) {
+        self.agents().catalog.sync_preview();
+        let Some(entry) = self.agents().catalog.selected_entry().cloned() else {
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    " Pick an agent to see it.",
+                    Style::default().fg(C_DIM),
+                )))
+                .block(detail_block(" Agent ")),
+                area,
+            );
+            return;
+        };
+        let graph_h = (area.height * 55 / 100)
+            .max(8)
+            .min(area.height.saturating_sub(6));
+        let split = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(graph_h), Constraint::Min(1)])
+            .split(area);
+        let title = format!(
+            " {} · v{} · {} stage{} ",
+            entry.name,
+            entry.version,
+            entry.stages.len(),
+            if entry.stages.len() == 1 { "" } else { "s" }
+        );
+        let (_, preview) = self
+            .agents()
+            .catalog
+            .preview
+            .as_mut()
+            .expect("synced for the selected entry just above");
+        match preview {
+            Ok(view) => {
+                let canvas = view.render(frame, split[0], detail_block(&title));
+                self.pane_rects.push((PaneId::AgentsPreview, canvas));
+            }
+            Err(why) => {
+                let why = why.clone();
+                frame.render_widget(
+                    Paragraph::new(Line::from(Span::styled(
+                        format!(" {why}"),
+                        Style::default().fg(C_WARN),
+                    )))
+                    .wrap(Wrap { trim: false })
+                    .block(detail_block(&title)),
+                    split[0],
+                );
+            }
+        }
+        let mut lines: Vec<Line> = vec![
+            Line::from(Span::styled(
+                entry.description.clone(),
+                Style::default().fg(C_WHITE),
+            )),
+            Line::from(""),
+            Line::from(vec![
+                Span::styled("where  ", Style::default().fg(C_DIM)),
+                Span::raw(
+                    entry
+                        .dir
+                        .as_ref()
+                        .map(|d| d.display().to_string())
+                        .unwrap_or_else(|| {
+                            "bundled in this binary; saving installs it".to_string()
+                        }),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled("stages ", Style::default().fg(C_DIM)),
+                Span::raw(entry.stages.join(" → ")),
+            ]),
+        ];
+        if entry.differs_from_bundled {
+            lines.push(Line::from(Span::styled(
+                "Edited since it was installed: `r` puts the bundled copy back.",
+                Style::default().fg(C_WARN),
+            )));
+        }
+        frame.render_widget(
+            Paragraph::new(lines)
+                .wrap(Wrap { trim: false })
+                .block(detail_block(" About ")),
+            split[1],
+        );
+    }
+
+    fn draw_catalog_hints(&self, frame: &mut Frame, area: Rect) {
+        let filtering = self
+            .agent_builder
+            .as_ref()
+            .is_some_and(|s| s.catalog.filtering);
+        let hints = if filtering {
+            vec![
+                hint("type", "filter"),
+                hint("enter", "done"),
+                hint("esc", "clear"),
+            ]
+        } else {
+            vec![
+                hint("enter", "edit"),
+                hint("n", "new"),
+                hint("l", "launch"),
+                hint("d", "delete"),
+                hint("r", "reset"),
+                hint("/", "filter"),
+                hint("?", "help"),
+                hint("esc", "back"),
+            ]
+        };
+        draw_hint_bar(frame, area, None, &hints, false);
+    }
+
+    /// The template chooser: a list, and the name under it.
+    fn draw_chooser(&mut self, frame: &mut Frame, area: Rect) {
+        let chooser = self.agents().chooser.as_ref().expect("callers check");
+        let popup = centered(70, 70, area);
+        let inner = popup_frame(frame, popup, "New agent", C_BORDER_FOCUS);
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(2),
+                Constraint::Min(3),
+                Constraint::Length(4),
+            ])
+            .split(inner);
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(Span::styled(
+                    "Start from the two-stage starter, or from a copy of an agent you have.",
+                    Style::default().fg(C_MUTED),
+                )),
+                Line::from(""),
+            ])
+            .wrap(Wrap { trim: false }),
+            chunks[0],
+        );
+        let height = chunks[1].height as usize;
+        let offset = chooser.cursor.saturating_sub(height.saturating_sub(1));
+        let rows: Vec<Line> = chooser
+            .templates
+            .iter()
+            .enumerate()
+            .skip(offset)
+            .take(height)
+            .map(|(i, t)| {
+                let selected = i == chooser.cursor;
+                Line::from(vec![
+                    Span::styled(
+                        if selected { "› " } else { "  " },
+                        Style::default().fg(C_ACCENT),
+                    ),
+                    Span::styled(
+                        format!("{:<26}", t.label),
+                        if selected {
+                            Style::default().fg(C_ACTIVE).add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(C_WHITE)
+                        },
+                    ),
+                    Span::styled(t.detail.clone(), Style::default().fg(C_DIM)),
+                ])
+            })
+            .collect();
+        frame.render_widget(Paragraph::new(rows), chunks[1]);
+        let mut name = vec![Span::styled("Name  ", Style::default().fg(C_DIM))];
+        name.extend(chooser.name.display_spans(true).spans);
+        let problem = chooser.problem.clone().unwrap_or_default();
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(""),
+                Line::from(name),
+                Line::from(Span::styled(problem, Style::default().fg(C_WARN))),
+                Line::from(Span::styled(
+                    "↑↓ template · type the name · Enter open in the editor · Esc back",
+                    Style::default().fg(C_MUTED),
+                )),
+            ]),
+            chunks[2],
+        );
+    }
+}
+
+fn detail_block(title: &str) -> Block<'static> {
+    Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(C_BORDER))
+        .title(title.to_string())
+}
+
+/// Colour an agent's source: bundled-but-not-installed is the one that
+/// needs a step before it runs; edited stands out too.
+fn source_colour(entry: &CatalogEntry) -> Color {
+    match entry.source {
+        Source::Bundled => C_WARN,
+        _ if entry.differs_from_bundled => C_WARN,
+        _ => C_ACCENT,
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
@@ -1,0 +1,393 @@
+//! Drawing the editor: the canvas on the left, the inspector on the right,
+//! the problems line under the canvas, a hint bar, and the overlays.
+//!
+//! On a narrow terminal the two panes take turns: the one with the keys
+//! fills the width and `Tab` swaps.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
+
+use super::super::state::Dashboard;
+use super::super::theme::*;
+use super::super::types::PaneId;
+use super::editor::{Focus, Overlay};
+use super::inspector::{FieldValue, Panel, StageTab, panel_title};
+use crate::blueprint_edit::check::Severity;
+use crate::tui::widgets::footer::{draw_hint_bar, hint};
+use crate::tui::widgets::popup::{centered, popup_frame};
+
+/// Under this many columns the panes take turns.
+const SIDE_BY_SIDE_MIN_WIDTH: u16 = 110;
+/// The inspector's width when both panes are on.
+const INSPECTOR_WIDTH: u16 = 54;
+/// Rows the expanded problems list takes.
+const PROBLEMS_ROWS: u16 = 6;
+
+impl Dashboard {
+    /// The editor screen.
+    pub(super) fn draw_editor(&mut self, frame: &mut Frame, area: Rect) {
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Min(1),
+                Constraint::Length(1),
+            ])
+            .split(area);
+        self.draw_editor_title(frame, rows[0]);
+        let focus = self.editor().focus;
+        let narrow = area.width < SIDE_BY_SIDE_MIN_WIDTH;
+        let (canvas_area, inspector_area) = if narrow {
+            match focus {
+                Focus::Canvas => (Some(rows[1]), None),
+                Focus::Inspector => (None, Some(rows[1])),
+            }
+        } else {
+            let panes = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([Constraint::Min(1), Constraint::Length(INSPECTOR_WIDTH)])
+                .split(rows[1]);
+            (Some(panes[0]), Some(panes[1]))
+        };
+        if let Some(area) = canvas_area {
+            self.draw_editor_canvas(frame, area);
+        }
+        if let Some(area) = inspector_area {
+            self.draw_editor_inspector(frame, area);
+        }
+        self.draw_editor_hints(frame, rows[2]);
+        self.draw_editor_overlays(frame, area);
+    }
+
+    fn draw_editor_title(&mut self, frame: &mut Frame, area: Rect) {
+        let editor = self.editor();
+        let mut spans = vec![
+            Span::styled(" Agent editor · ", Style::default().fg(C_DIM)),
+            Span::styled(
+                editor.name.clone(),
+                Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
+            ),
+        ];
+        if editor.dirty {
+            spans.push(Span::styled("*", Style::default().fg(C_WARN)));
+        }
+        if editor.is_new {
+            spans.push(Span::styled(
+                "  (not saved yet)",
+                Style::default().fg(C_DIM),
+            ));
+        }
+        if let Some(message) = &editor.message {
+            spans.push(Span::styled(
+                format!("   {message}"),
+                Style::default().fg(C_MUTED),
+            ));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
+    /// The canvas, with the problems line (or list) under it.
+    fn draw_editor_canvas(&mut self, frame: &mut Frame, area: Rect) {
+        let open = self.editor().problems_open;
+        let problems_h = if open {
+            PROBLEMS_ROWS.min(area.height / 2)
+        } else {
+            1
+        };
+        let split = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(4), Constraint::Length(problems_h)])
+            .split(area);
+        let focused = self.editor().focus == Focus::Canvas;
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(if focused { C_BORDER_FOCUS } else { C_BORDER }))
+            .title(" Graph · a add · c connect · x delete · drag a ● to connect ");
+        let canvas = self.editor().view.render(frame, split[0], block);
+        self.pane_rects.push((PaneId::AgentEditorGraph, canvas));
+        self.draw_editor_problems(frame, split[1]);
+    }
+
+    fn draw_editor_problems(&mut self, frame: &mut Frame, area: Rect) {
+        let editor = self.editor();
+        let problems = &editor.problems;
+        let errors = problems.error_count();
+        let warnings = problems.warning_count();
+        let summary = if problems.items.is_empty() {
+            Span::styled(" ✓ no problems", Style::default().fg(C_SUCCESS))
+        } else {
+            let colour = if errors > 0 { C_ERROR } else { C_WARN };
+            let first = problems
+                .first()
+                .map(|p| match &p.stage {
+                    Some(stage) => format!("{stage}: {}", p.message),
+                    None => p.message.clone(),
+                })
+                .unwrap_or_default();
+            Span::styled(
+                format!(
+                    " ! {errors} error{} · {warnings} warning{} · {first}",
+                    if errors == 1 { "" } else { "s" },
+                    if warnings == 1 { "" } else { "s" }
+                ),
+                Style::default().fg(colour),
+            )
+        };
+        if !editor.problems_open || area.height <= 1 {
+            frame.render_widget(Paragraph::new(Line::from(summary)), area);
+            return;
+        }
+        let mut lines = vec![Line::from(summary)];
+        for p in problems.items.iter().take(area.height as usize - 1) {
+            let colour = match p.severity {
+                Severity::Error => C_ERROR,
+                Severity::Warning => C_WARN,
+                Severity::Note => C_DIM,
+            };
+            let mut text = format!("   {} ", p.severity.tag());
+            if let Some(stage) = &p.stage {
+                text.push_str(&format!("{stage}: "));
+            }
+            text.push_str(&p.message);
+            if let Some(fix) = &p.fix {
+                text.push_str(&format!("  ({fix})"));
+            }
+            lines.push(Line::from(Span::styled(text, Style::default().fg(colour))));
+        }
+        frame.render_widget(Paragraph::new(lines), area);
+    }
+
+    /// The inspector: the panel's title, its tabs when a stage, its rows,
+    /// and the focused row's help at the bottom.
+    fn draw_editor_inspector(&mut self, frame: &mut Frame, area: Rect) {
+        let editor = self.editor();
+        let focused = editor.focus == Focus::Inspector;
+        let title = panel_title(&editor.panel);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(if focused { C_BORDER_FOCUS } else { C_BORDER }))
+            .title(format!(" {title} "));
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+        let mut lines: Vec<Line> = Vec::new();
+        if let Panel::Stage { tab, .. } = &editor.panel {
+            let mut spans = Vec::new();
+            for (i, t) in StageTab::ALL.iter().enumerate() {
+                let on = t == tab;
+                spans.push(Span::styled(
+                    format!(" {} {} ", i + 1, t.title()),
+                    if on {
+                        Style::default()
+                            .fg(C_ACTIVE)
+                            .add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+                    } else {
+                        Style::default().fg(C_DIM)
+                    },
+                ));
+            }
+            lines.push(Line::from(spans));
+            lines.push(Line::from(""));
+        }
+        if let Panel::External(name) = &editor.panel {
+            lines.push(Line::from(Span::styled(
+                format!("{name} is a separate agent; edit it from the catalog."),
+                Style::default().fg(C_MUTED),
+            )));
+        }
+        let fields = editor.fields();
+        let label_w = 26usize;
+        let value_w = (inner.width as usize).saturating_sub(label_w + 3);
+        for (i, field) in fields.iter().enumerate() {
+            let on = focused && i == editor.cursor;
+            let editing = editor.line.as_ref().filter(|(id, _)| *id == field.id);
+            let label_style = if !field.enabled {
+                Style::default().fg(C_DIM)
+            } else if on {
+                Style::default().fg(C_ACTIVE).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(C_MUTED)
+            };
+            let mut spans = vec![
+                Span::styled(if on { "› " } else { "  " }, Style::default().fg(C_ACCENT)),
+                Span::styled(format!("{:<label_w$}", field.label), label_style),
+            ];
+            match editing {
+                Some((_, line)) => spans.extend(line.display_spans(true).spans),
+                None => {
+                    let (text, style) = value_text(&field.value, field.enabled, on);
+                    spans.push(Span::styled(fit(&text, value_w), style));
+                }
+            }
+            lines.push(Line::from(spans));
+        }
+        let help = fields
+            .get(editor.cursor)
+            .filter(|_| focused)
+            .map(|f| f.help.to_string())
+            .unwrap_or_else(|| match editor.panel {
+                Panel::Agent => {
+                    "Select a stage or a path on the canvas to edit it; Tab moves here.".to_string()
+                }
+                _ => {
+                    "Tab moves the keys here; ↑↓ pick a row, Enter edits it, ←→ change it in place."
+                        .to_string()
+                }
+            });
+        let body_h = inner.height.saturating_sub(3);
+        frame.render_widget(
+            Paragraph::new(lines).wrap(Wrap { trim: false }),
+            Rect {
+                height: body_h,
+                ..inner
+            },
+        );
+        let help_area = Rect {
+            y: inner.y + inner.height.saturating_sub(3),
+            height: inner.height.min(3),
+            ..inner
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(help, Style::default().fg(C_DIM))))
+                .wrap(Wrap { trim: true }),
+            help_area,
+        );
+    }
+
+    fn draw_editor_hints(&mut self, frame: &mut Frame, area: Rect) {
+        let editor = self.editor();
+        let hints = if editor.picker.is_some() {
+            vec![
+                hint("type", "search"),
+                hint("↑↓", "move"),
+                hint("enter", "choose"),
+                hint("esc", "cancel"),
+            ]
+        } else if editor.line.is_some() || editor.add_stage.is_some() {
+            vec![hint("enter", "apply"), hint("esc", "cancel")]
+        } else if editor.overlay.is_some() {
+            vec![
+                hint("↑↓", "scroll"),
+                hint("y", "copy"),
+                hint("esc", "close"),
+            ]
+        } else {
+            match editor.focus {
+                Focus::Canvas => vec![
+                    hint("^s", "save"),
+                    hint("tab", "inspector"),
+                    hint("a", "add stage"),
+                    hint("c", "connect"),
+                    hint("x", "delete"),
+                    hint("enter", "edit"),
+                    hint("u", "undo"),
+                    hint("^r", "redo"),
+                    hint("v", "definition"),
+                    hint("p", "problems"),
+                    hint("?", "help"),
+                    hint("r", "rotate"),
+                    hint("f", "fit"),
+                    hint("esc", "close"),
+                ],
+                Focus::Inspector => vec![
+                    hint("^s", "save"),
+                    hint("↑↓", "row"),
+                    hint("enter", "edit"),
+                    hint("←→", "change"),
+                    hint("1-3", "tab"),
+                    hint("tab", "canvas"),
+                    hint("u", "undo"),
+                    hint("?", "help"),
+                    hint("esc", "canvas"),
+                ],
+            }
+        };
+        draw_hint_bar(frame, area, None, &hints, false);
+    }
+
+    /// The chooser, the add-stage prompt, and the definition, on top.
+    fn draw_editor_overlays(&mut self, frame: &mut Frame, area: Rect) {
+        let editor = self.editor();
+        if let Some((_, picker)) = &editor.picker {
+            picker.draw(frame, area);
+            return;
+        }
+        if let Some(line) = &editor.add_stage {
+            let popup = centered(50, 20, area);
+            let popup = Rect {
+                height: popup.height.clamp(3, 5),
+                ..popup
+            };
+            let inner = popup_frame(frame, popup, "New stage", C_BORDER_FOCUS);
+            let mut spans = vec![Span::styled("Name  ", Style::default().fg(C_DIM))];
+            spans.extend(line.display_spans(true).spans);
+            frame.render_widget(
+                Paragraph::new(vec![
+                    Line::from(spans),
+                    Line::from(Span::styled(
+                        "Letters, digits, . _ - · Enter adds it after the selected stage",
+                        Style::default().fg(C_MUTED),
+                    )),
+                ]),
+                inner,
+            );
+            return;
+        }
+        if let Some(Overlay::Definition { scroll }) = &editor.overlay {
+            let text = editor.doc.to_toml();
+            let popup = centered(90, 90, area);
+            let inner = popup_frame(
+                frame,
+                popup,
+                "Definition · the file this editor will save",
+                C_BORDER_FOCUS,
+            );
+            let lines: Vec<Line> = text.lines().map(|l| Line::from(l.to_string())).collect();
+            let max_scroll = lines.len().saturating_sub(inner.height as usize);
+            let scroll = (*scroll).min(max_scroll);
+            frame.render_widget(Clear, inner);
+            frame.render_widget(Paragraph::new(lines).scroll((scroll as u16, 0)), inner);
+        }
+    }
+}
+
+/// How a field's value reads on its row.
+fn value_text(value: &FieldValue, enabled: bool, on: bool) -> (String, Style) {
+    let base = if !enabled {
+        Style::default().fg(C_DIM)
+    } else if on {
+        Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(C_WHITE)
+    };
+    match value {
+        FieldValue::Text(t) if t.is_empty() => ("(empty)".to_string(), Style::default().fg(C_DIM)),
+        FieldValue::Text(t) => (t.clone(), base),
+        FieldValue::Number(None) => ("(default)".to_string(), Style::default().fg(C_DIM)),
+        FieldValue::Number(Some(n)) => (n.to_string(), base),
+        // A toggle that is on is never a disabled one (the two toggles are
+        // always live), so it always shows in the success colour.
+        FieldValue::Toggle(true) => ("[x] on".to_string(), base.fg(C_SUCCESS)),
+        FieldValue::Toggle(false) => ("[ ] off".to_string(), base),
+        FieldValue::Choice(c) => (format!("‹ {c} ›"), base),
+        FieldValue::Row(r) => (r.clone(), base),
+        FieldValue::Button => (
+            "▸".to_string(),
+            base.fg(if enabled { C_ACCENT } else { C_DIM }),
+        ),
+    }
+}
+
+/// `text` cut to `room` cells with an ellipsis.
+fn fit(text: &str, room: usize) -> String {
+    if text.chars().count() <= room {
+        return text.to_string();
+    }
+    let mut cut: String = text.chars().take(room.saturating_sub(1)).collect();
+    cut.push('…');
+    cut
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
@@ -1,0 +1,1979 @@
+//! The Agents screen and the editor, driven the way a person drives them:
+//! keys and clicks against a temp home, frames rendered into a test
+//! terminal, the file on disk read back.
+
+use std::path::PathBuf;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+
+use super::editor::{EditTarget, Focus, Overlay};
+use super::inspector::{FieldId, Panel, StageTab};
+use crate::blueprint_edit::{catalog, templates};
+use crate::commands::dashboard::state::Dashboard;
+use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
+use crate::commands::dashboard::types::*;
+
+fn key(code: KeyCode) -> KeyEvent {
+    KeyEvent::new(code, KeyModifiers::empty())
+}
+
+fn ctrl(c: char) -> KeyEvent {
+    KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+}
+
+fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+    MouseEvent {
+        kind,
+        column,
+        row,
+        modifiers: KeyModifiers::empty(),
+    }
+}
+
+fn type_str(dash: &mut Dashboard, text: &str) {
+    for c in text.chars() {
+        dash.handle_key(key(KeyCode::Char(c)));
+    }
+}
+
+/// A dashboard whose agents directory is a fresh temp tree holding one
+/// agent of our own (`own`, the starter) and the installed coder.
+fn dashboard(tag: &str) -> (Dashboard, PathBuf) {
+    let root = std::env::temp_dir().join(format!("lev-agents-screen-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let agents = root.join("agents");
+    std::fs::create_dir_all(&agents).unwrap();
+    std::fs::create_dir_all(root.join("work")).unwrap();
+    catalog::write_agent(&agents, "own", &templates::empty_blueprint("own").unwrap()).unwrap();
+    catalog::reset_bundled(&agents, "coder").unwrap();
+    let mut dash = make_test_dashboard();
+    dash.new_run_ctx.agents_dir = agents;
+    dash.new_run_ctx.workdir = root.join("work");
+    dash.new_run_ctx.config_path = root.join("config.toml");
+    dash.layout_store_path = Some(root.join("dash").join("graph-layouts.json"));
+    (dash, root)
+}
+
+fn draw(dash: &mut Dashboard, w: u16, h: u16) -> Terminal<TestBackend> {
+    let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
+    terminal.draw(|f| dash.draw(f)).unwrap();
+    terminal
+}
+
+fn text(dash: &mut Dashboard) -> String {
+    rendered_buffer(&draw(dash, 160, 50))
+}
+
+fn open_editor_on(dash: &mut Dashboard, name: &str) {
+    dash.handle_key(key(KeyCode::Char('a')));
+    let at = dash
+        .agents()
+        .catalog
+        .visible()
+        .into_iter()
+        .position(|i| dash.agents().catalog.entries[i].name == name)
+        .expect("in the catalog");
+    dash.agents().catalog.selected = at;
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents().editor.is_some(),
+        "the editor opened on {name}"
+    );
+}
+
+// ─── the catalog ─────────────────────────────────────────────────────────────
+
+#[test]
+fn a_opens_the_catalog_with_every_source_and_esc_closes_it() {
+    let (mut dash, _root) = dashboard("catalog");
+    dash.handle_key(key(KeyCode::Char('a')));
+    assert!(dash.agent_builder.is_some());
+    let screen = text(&mut dash);
+    assert!(screen.contains("Agents ("), "{screen}");
+    for name in ["own", "coder", "reviewer"] {
+        assert!(screen.contains(name), "{name}: {screen}");
+    }
+    assert!(screen.contains("installed"), "{screen}");
+    assert!(screen.contains("bundled"), "{screen}");
+    // The first entry (coder, sorted) previews its graph and its about box.
+    assert!(screen.contains("coder · v0.1.0 · 8 stages"), "{screen}");
+    assert!(screen.contains("discover"), "{screen}");
+    assert!(screen.contains("stages discover"), "{screen}");
+    assert!(
+        screen.contains("[enter] edit") || screen.contains("enter edit") || screen.contains("edit"),
+        "{screen}"
+    );
+    // Move: the preview follows the cursor.
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Char('j')));
+    let screen = text(&mut dash);
+    assert!(!screen.contains("coder · v0.1.0"), "{screen}");
+    dash.handle_key(key(KeyCode::Char('k')));
+    dash.handle_key(key(KeyCode::End));
+    dash.handle_key(key(KeyCode::Home));
+    dash.handle_key(key(KeyCode::PageDown));
+    dash.handle_key(key(KeyCode::PageUp));
+    dash.handle_key(key(KeyCode::Up));
+    assert_eq!(dash.agents().catalog.selected, 0);
+    // The filter: `/`, letters, enter keeps it, esc clears it.
+    dash.handle_key(key(KeyCode::Char('/')));
+    type_str(&mut dash, "reviewerx");
+    dash.handle_key(key(KeyCode::Backspace));
+    let screen = text(&mut dash);
+    assert!(screen.contains("/reviewer▌"), "{screen}");
+    assert_eq!(dash.agents().catalog.visible().len(), 1, "reviewer");
+    dash.handle_key(key(KeyCode::Tab)); // ignored while filtering
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(!dash.agents().catalog.filtering);
+    assert!(text(&mut dash).contains("/reviewer  1/"), "kept");
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(
+        dash.agents().catalog.filter.is_empty(),
+        "esc clears the filter first"
+    );
+    dash.handle_key(key(KeyCode::Char('/')));
+    type_str(&mut dash, "zzz");
+    assert!(
+        text(&mut dash).contains("No agents match"),
+        "{}",
+        text(&mut dash)
+    );
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agents().catalog.filter.is_empty() && !dash.agents().catalog.filtering);
+    dash.handle_key(key(KeyCode::Char('?')));
+    assert!(dash.show_help);
+    assert!(text(&mut dash).contains("Agents (a)"));
+    dash.handle_key(key(KeyCode::Esc));
+    dash.handle_key(key(KeyCode::Char('q')));
+    assert!(dash.agent_builder.is_none(), "q closes the screen");
+    // An unknown key is nothing.
+    dash.handle_key(key(KeyCode::Char('a')));
+    dash.handle_key(key(KeyCode::Char('z')));
+    assert!(dash.agent_builder.is_some());
+    // The main list's help bar and overlay name the screen.
+    dash.handle_key(key(KeyCode::Esc));
+    let screen = text(&mut dash);
+    assert!(screen.contains("[a] agents"), "{screen}");
+}
+
+#[test]
+fn an_empty_home_says_so_and_a_broken_manifest_declines_the_preview() {
+    let (mut dash, root) = dashboard("empty");
+    let _ = std::fs::remove_dir_all(root.join("agents"));
+    std::fs::create_dir_all(root.join("agents").join("broken")).unwrap();
+    std::fs::write(
+        root.join("agents").join("broken").join("agent.leviath"),
+        "[agent]\nname = \"broken\"\n[stages.a]\nmode = \"weird\"\n",
+    )
+    .unwrap();
+    dash.handle_key(key(KeyCode::Char('a')));
+    // The bundled ones are still there; a broken installed one is not
+    // listed by the catalog (it cannot be parsed).
+    let screen = text(&mut dash);
+    assert!(screen.contains("coder"), "{screen}");
+    // Filter to nothing: the list says so, and the detail pane asks.
+    dash.handle_key(key(KeyCode::Char('/')));
+    type_str(&mut dash, "nothing-here");
+    dash.handle_key(key(KeyCode::Enter));
+    let screen = text(&mut dash);
+    assert!(screen.contains("No agents match"), "{screen}");
+    assert!(screen.contains("Pick an agent to see it."), "{screen}");
+    // Actions on nothing do nothing.
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Char('d')));
+    dash.handle_key(key(KeyCode::Char('r')));
+    dash.handle_key(key(KeyCode::Char('l')));
+    assert!(dash.agent_builder.is_some() && dash.agents().editor.is_none());
+    // A preview that cannot be built says why (an unreadable manifest, a
+    // manifest the runtime rejects); the second still opens in the editor,
+    // which edits TOML, not the runtime's view of it.
+    dash.agents().catalog.filter.clear();
+    let odd = catalog::CatalogEntry {
+        name: "odd".into(),
+        version: "0".into(),
+        description: String::new(),
+        source: catalog::Source::Installed,
+        dir: None,
+        manifest: Some("[agent]\nname = \"odd\"\n[stages.a]\nmode = \"weird\"\n".into()),
+        stages: vec![],
+        bundled: false,
+        differs_from_bundled: false,
+    };
+    let unread = catalog::CatalogEntry {
+        name: "unread".into(),
+        manifest: None,
+        ..odd.clone()
+    };
+    dash.agents().catalog.entries.push(unread);
+    let n = dash.agents().catalog.entries.len();
+    dash.agents().catalog.selected = n - 1;
+    let screen = text(&mut dash);
+    assert!(screen.contains("could not be read"), "{screen}");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.is_none(), "nothing to edit");
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("could not be read"))
+    );
+    dash.agents().catalog.entries.push(odd);
+    dash.agents().catalog.selected = n;
+    let screen = text(&mut dash);
+    assert!(screen.contains("mode"), "the runtime's complaint: {screen}");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.is_some());
+    dash.handle_key(key(KeyCode::Esc));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn delete_and_reset_ask_first_and_launch_goes_to_the_new_run_screen() {
+    let (mut dash, root) = dashboard("actions");
+    // Edit the installed coder so it differs from the bundle.
+    let manifest = root.join("agents").join("coder").join("agent.leviath");
+    let edited = std::fs::read_to_string(&manifest)
+        .unwrap()
+        .replace("entry_stage = \"discover\"", "entry_stage = \"plan\"");
+    std::fs::write(&manifest, edited).unwrap();
+    dash.handle_key(key(KeyCode::Char('a')));
+    let screen = text(&mut dash);
+    assert!(screen.contains("edited"), "{screen}");
+    assert!(screen.contains("puts the bundled copy back"), "{screen}");
+    // Reset: No keeps it, Yes restores it. The dialog draws over the screen.
+    dash.handle_key(key(KeyCode::Char('r')));
+    assert!(text(&mut dash).contains("Reset to original?"));
+    dash.tick_graphs(std::time::Duration::from_millis(100));
+    assert!(matches!(
+        dash.pending_confirm,
+        Some((ConfirmAction::AgentReset { .. }, _))
+    ));
+    dash.handle_key(key(KeyCode::Char('n')));
+    assert!(dash.pending_confirm.is_none());
+    dash.handle_key(key(KeyCode::Char('r')));
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(
+        std::fs::read_to_string(&manifest)
+            .unwrap()
+            .contains("entry_stage = \"discover\"")
+    );
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("Reset coder"))
+    );
+    // Reset on an agent that is not an edited bundled one is a toast.
+    dash.handle_key(key(KeyCode::Char('r')));
+    assert!(dash.pending_confirm.is_none());
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("nothing to reset"))
+    );
+    // Delete: only what lives under the agents dir.
+    let own = dash
+        .agents()
+        .catalog
+        .visible()
+        .into_iter()
+        .position(|i| dash.agents().catalog.entries[i].name == "own")
+        .unwrap();
+    dash.agents().catalog.selected = own;
+    dash.handle_key(key(KeyCode::Char('d')));
+    assert!(matches!(
+        dash.pending_confirm,
+        Some((ConfirmAction::AgentDelete { .. }, _))
+    ));
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(!root.join("agents").join("own").exists());
+    assert!(
+        !dash
+            .agents()
+            .catalog
+            .entries
+            .iter()
+            .any(|e| e.name == "own")
+    );
+    // A bundled-not-installed one is not deletable.
+    let reviewer = dash
+        .agents()
+        .catalog
+        .visible()
+        .into_iter()
+        .position(|i| dash.agents().catalog.entries[i].name == "reviewer")
+        .unwrap();
+    dash.agents().catalog.selected = reviewer;
+    dash.handle_key(key(KeyCode::Char('d')));
+    assert!(dash.pending_confirm.is_none());
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("not deletable"))
+    );
+    // Nor is one that lives elsewhere.
+    dash.agents().catalog.entries[0].source = catalog::Source::Configured;
+    dash.agents().catalog.selected = 0;
+    dash.handle_key(key(KeyCode::Char('d')));
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("delete it where it is"))
+    );
+    // A delete that fails on disk is a toast too.
+    dash.perform_agent_delete("ghost");
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("Could not delete ghost"))
+    );
+    dash.perform_agent_reset("own");
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("Could not reset own"))
+    );
+    // Launch: the new-run screen opens with the agent picked.
+    dash.agents().catalog.selected = reviewer;
+    dash.handle_key(key(KeyCode::Char('l')));
+    assert!(dash.agent_builder.is_none());
+    assert!(dash.new_run_screen);
+    assert_eq!(dash.new_run_agents[dash.new_run_selected].name, "reviewer");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── the chooser ─────────────────────────────────────────────────────────────
+
+#[test]
+fn the_chooser_starts_simple_or_clones_and_checks_the_name() {
+    let (mut dash, root) = dashboard("chooser");
+    dash.handle_key(key(KeyCode::Char('a')));
+    dash.handle_key(key(KeyCode::Char('n')));
+    assert!(dash.agents().chooser.is_some());
+    let screen = text(&mut dash);
+    assert!(screen.contains("New agent"), "{screen}");
+    assert!(screen.contains("Start simple"), "{screen}");
+    assert!(screen.contains("Clone coder"), "{screen}");
+    assert!(screen.contains("Name  my-agent"), "{screen}");
+    // The name follows the row until typed into.
+    dash.handle_key(key(KeyCode::Down));
+    assert!(
+        dash.agents()
+            .chooser
+            .as_ref()
+            .unwrap()
+            .name
+            .value()
+            .starts_with("my-")
+    );
+    dash.handle_key(key(KeyCode::Up));
+    assert_eq!(
+        dash.agents().chooser.as_ref().unwrap().name.value(),
+        "my-agent"
+    );
+    // A taken name, a bad name: said on the line, Enter refused.
+    for _ in 0..12 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    type_str(&mut dash, "own");
+    assert!(text(&mut dash).contains("already exists"));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().chooser.is_some(), "refused");
+    dash.handle_key(key(KeyCode::Backspace));
+    dash.handle_key(key(KeyCode::Backspace));
+    dash.handle_key(key(KeyCode::Backspace));
+    type_str(&mut dash, "no way");
+    assert!(text(&mut dash).contains("Letters, digits"));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().chooser.is_some());
+    // The row no longer changes the name once typed.
+    dash.handle_key(key(KeyCode::Down));
+    assert_eq!(
+        dash.agents().chooser.as_ref().unwrap().name.value(),
+        "no way"
+    );
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agents().chooser.is_none());
+    // Start simple under a good name opens the editor, unsaved.
+    dash.handle_key(key(KeyCode::Char('n')));
+    for _ in 0..12 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    type_str(&mut dash, "demo");
+    dash.handle_key(key(KeyCode::Enter));
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert!(editor.is_new && editor.dirty);
+    assert_eq!(editor.name, "demo");
+    assert_eq!(editor.doc.stage_names(), ["work", "finish"]);
+    assert!(text(&mut dash).contains("(not saved yet)"));
+    // Close it (dirty: asks; discard) and clone the coder instead.
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(matches!(
+        dash.pending_confirm,
+        Some((ConfirmAction::EditorDiscard, _))
+    ));
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(dash.agents().editor.is_none());
+    dash.handle_key(key(KeyCode::Char('n')));
+    dash.handle_key(key(KeyCode::Down)); // clone coder (sorted first)
+    dash.handle_key(key(KeyCode::Enter));
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert_eq!(editor.name, "my-coder");
+    assert!(editor.doc.has_stage("discover"));
+    // Save: the clone lands under the agents dir with the coder's scripts
+    // (it has none; the reviewer neither), and is no longer new.
+    dash.handle_key(ctrl('s'));
+    assert!(
+        root.join("agents")
+            .join("my-coder")
+            .join("agent.leviath")
+            .exists()
+    );
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert!(!editor.is_new && !editor.dirty);
+    assert!(text(&mut dash).contains("Saved to"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_clone_of_a_bundled_agent_with_scripts_takes_them_along() {
+    let (mut dash, root) = dashboard("clone-scripts");
+    dash.handle_key(key(KeyCode::Char('a')));
+    dash.handle_key(key(KeyCode::Char('n')));
+    let at = dash
+        .agents()
+        .chooser
+        .as_ref()
+        .unwrap()
+        .templates
+        .iter()
+        .position(|t| t.label == "Clone researcher")
+        .unwrap();
+    for _ in 0..at {
+        dash.handle_key(key(KeyCode::Down));
+    }
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(dash.agents().editor.as_ref().unwrap().name, "my-researcher");
+    dash.handle_key(ctrl('s'));
+    assert!(
+        root.join("agents")
+            .join("my-researcher")
+            .join("tools")
+            .join("web_search.rhai")
+            .exists()
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── the editor ──────────────────────────────────────────────────────────────
+
+#[test]
+fn the_canvas_adds_connects_selects_and_deletes_with_undo_behind_it() {
+    let (mut dash, root) = dashboard("canvas");
+    open_editor_on(&mut dash, "own");
+    let screen = text(&mut dash);
+    assert!(screen.contains("Agent editor · own"), "{screen}");
+    assert!(screen.contains("This agent"), "{screen}");
+    assert!(screen.contains("[hint]"), "the path is labelled: {screen}");
+    assert!(
+        screen.contains("no problems") || screen.contains("warning"),
+        "{screen}"
+    );
+    // Select the entry stage with the arrows; Enter opens the inspector.
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage {
+            name: "work".into(),
+            tab: StageTab::Behaviour
+        }
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().focus,
+        Focus::Inspector
+    );
+    assert!(text(&mut dash).contains("Stage · work · Behaviour"));
+    dash.handle_key(key(KeyCode::Esc));
+    assert_eq!(dash.agents().editor.as_ref().unwrap().focus, Focus::Canvas);
+    // Add a stage after work.
+    dash.handle_key(key(KeyCode::Char('a')));
+    assert!(dash.agents().editor.as_ref().unwrap().add_stage.is_some());
+    assert!(text(&mut dash).contains("New stage"));
+    type_str(&mut dash, "review");
+    dash.handle_key(key(KeyCode::Enter));
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert_eq!(editor.doc.stage_names(), ["work", "review", "finish"]);
+    assert_eq!(
+        editor.panel,
+        Panel::Stage {
+            name: "review".into(),
+            tab: StageTab::Behaviour
+        }
+    );
+    assert_eq!(editor.focus, Focus::Inspector);
+    assert!(editor.dirty);
+    // An empty name is ignored; Esc cancels the prompt; a taken name is
+    // refused with a message.
+    dash.handle_key(key(KeyCode::Esc));
+    dash.handle_key(key(KeyCode::Char('a')));
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage_names()
+            .len(),
+        3
+    );
+    dash.handle_key(key(KeyCode::Char('a')));
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agents().editor.as_ref().unwrap().add_stage.is_none());
+    dash.handle_key(key(KeyCode::Char('a')));
+    type_str(&mut dash, "work");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(text(&mut dash).contains("already taken"));
+    // Connect review to finish through the chooser (typing narrows it).
+    dash.handle_key(key(KeyCode::Char('c')));
+    assert!(text(&mut dash).contains("Connect review to"));
+    type_str(&mut dash, "fin");
+    dash.handle_key(key(KeyCode::Enter));
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert!(editor.doc.edge("review", "finish").is_some());
+    assert_eq!(
+        editor.panel,
+        Panel::Edge {
+            from: "review".into(),
+            to: "finish".into()
+        }
+    );
+    assert!(text(&mut dash).contains("Path · review → finish"));
+    // A loop to itself.
+    dash.handle_key(key(KeyCode::Esc));
+    dash.handle_key(key(KeyCode::Char('[')));
+    dash.handle_key(key(KeyCode::Char(']')));
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("review");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.handle_key(key(KeyCode::Char('c')));
+    type_str(&mut dash, "review");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("review", "review")
+            .is_some()
+    );
+    assert!(text(&mut dash).contains("↺ loops"));
+    // Connect from nothing selected: a message.
+    dash.handle_key(key(KeyCode::Esc));
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .clear_selection();
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.handle_key(key(KeyCode::Char('c')));
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_none());
+    assert!(text(&mut dash).contains("Select a stage to connect from"));
+    dash.handle_key(key(KeyCode::Char('x')));
+    assert!(text(&mut dash).contains("Select a stage or a path to delete"));
+    // Delete the path with x, then undo and redo it.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_edge("review", "finish");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.handle_key(key(KeyCode::Char('x')));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("review", "finish")
+            .is_none()
+    );
+    dash.handle_key(key(KeyCode::Char('u')));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("review", "finish")
+            .is_some()
+    );
+    dash.handle_key(ctrl('r'));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("review", "finish")
+            .is_none()
+    );
+    dash.handle_key(ctrl('r'));
+    assert!(text(&mut dash).contains("Nothing to redo"));
+    // Delete a stage: asks; No keeps it, Yes removes it and its paths.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("review");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.handle_key(key(KeyCode::Delete));
+    assert!(matches!(
+        dash.pending_confirm,
+        Some((ConfirmAction::StageDelete { .. }, _))
+    ));
+    dash.handle_key(key(KeyCode::Char('n')));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .has_stage("review")
+    );
+    dash.handle_key(key(KeyCode::Char('x')));
+    dash.handle_key(key(KeyCode::Char('y')));
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert!(!editor.doc.has_stage("review"));
+    assert_eq!(editor.panel, Panel::Agent);
+    // Undo everything: the file is what it was, and one more undo says so.
+    while dash.agents().editor.as_mut().unwrap().undo() {}
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().doc.stage_names(),
+        ["work", "finish"]
+    );
+    dash.handle_key(key(KeyCode::Char('u')));
+    assert!(text(&mut dash).contains("Nothing to undo"));
+    // The rest of the canvas keys: rotate, fit, zoom, and a key nobody has.
+    for code in [
+        KeyCode::Char('r'),
+        KeyCode::Char('f'),
+        KeyCode::Char('+'),
+        KeyCode::Char('-'),
+        KeyCode::Char('0'),
+        KeyCode::Char('z'),
+    ] {
+        dash.handle_key(key(code));
+    }
+    assert!(dash.agents().editor.is_some());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_inspector_edits_every_kind_of_field() {
+    let (mut dash, root) = dashboard("inspector");
+    open_editor_on(&mut dash, "own");
+    // The agent panel: description (text), starts at (choice), model.
+    dash.handle_key(key(KeyCode::Tab));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().focus,
+        Focus::Inspector
+    );
+    dash.handle_key(key(KeyCode::Enter)); // description
+    assert!(dash.agents().editor.as_ref().unwrap().line.is_some());
+    for _ in 0..40 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    type_str(&mut dash, "Builds things");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .agent()
+            .description,
+        "Builds things"
+    );
+    dash.handle_key(key(KeyCode::Down)); // starts at
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .agent()
+            .entry_stage
+            .as_deref(),
+        Some("finish")
+    );
+    dash.handle_key(key(KeyCode::Left));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .agent()
+            .entry_stage
+            .as_deref(),
+        Some("work")
+    );
+    dash.handle_key(key(KeyCode::Enter)); // the chooser
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_some());
+    assert!(text(&mut dash).contains("Starts at"));
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .agent()
+            .entry_stage
+            .as_deref(),
+        Some("finish")
+    );
+    dash.handle_key(key(KeyCode::Down)); // default model
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(text(&mut dash).contains("Default model"));
+    type_str(&mut dash, "claude");
+    dash.handle_key(key(KeyCode::Enter));
+    let model = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .agent()
+        .default_model
+        .clone();
+    assert!(
+        model.as_deref().is_some_and(|m| m.contains("claude")),
+        "{model:?}"
+    );
+    // Left/right on the model cycles the catalog too; Esc in a chooser
+    // cancels; a region row is inert.
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_none());
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .add_region(&crate::blueprint_edit::RegionScope::Shared, "notes")
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.handle_key(key(KeyCode::End));
+    let field = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .current_field()
+        .unwrap();
+    assert_eq!(field.id, FieldId::RegionRow("notes".into()));
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Right));
+    assert!(text(&mut dash).contains("Shared region"));
+    dash.handle_key(key(KeyCode::Home));
+    // The stage panel.
+    dash.handle_key(key(KeyCode::Tab));
+    dash.handle_key(key(KeyCode::Right)); // work
+    dash.handle_key(key(KeyCode::Enter));
+    let fields = dash.agents().editor.as_ref().unwrap().fields();
+    let at = |id: FieldId| fields.iter().position(|f| f.id == id).unwrap();
+    // Rename.
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "2");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .has_stage("work2")
+    );
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage {
+            name: "work2".into(),
+            tab: StageTab::Behaviour
+        }
+    );
+    // Mode: cycle with the arrows, then through the chooser to fan-out.
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::StageMode);
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .mode,
+        crate::blueprint_edit::StageModeView::InteractivePoints
+    );
+    dash.handle_key(key(KeyCode::Left));
+    dash.handle_key(key(KeyCode::Left));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .mode,
+        crate::blueprint_edit::StageModeView::Output
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "fan");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .mode,
+        crate::blueprint_edit::StageModeView::FanOut
+    );
+    // The fan-out rows are live now: worker kind, worker, merge, caps, policy.
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::WorkerKind);
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Enter));
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::WorkerRef);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "finish");
+    dash.handle_key(key(KeyCode::Enter));
+    let fan = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .stage("work2")
+        .unwrap()
+        .fan_out;
+    assert_eq!(fan.worker.as_ref().map(|(_, v)| v.as_str()), Some("finish"));
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MergeStage);
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .fan_out
+            .merge_stage
+            .as_deref(),
+        Some("finish")
+    );
+    dash.handle_key(key(KeyCode::Left));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .fan_out
+            .merge_stage,
+        None
+    );
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MaxWorkers);
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .fan_out
+            .max_workers,
+        Some(2)
+    );
+    dash.handle_key(key(KeyCode::Left));
+    dash.handle_key(key(KeyCode::Left));
+    dash.handle_key(key(KeyCode::Left));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .fan_out
+            .max_workers,
+        None
+    );
+    dash.handle_key(key(KeyCode::Left));
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MaxItems);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "7");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .fan_out
+            .max_items,
+        Some(7)
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "x");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(text(&mut dash).contains("is not a whole number"));
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::OnWorkerFailure);
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .fan_out
+            .on_worker_failure
+            .as_deref(),
+        Some("fail_all")
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Enter));
+    // Clearing the worker.
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::WorkerRef);
+    dash.handle_key(key(KeyCode::Enter));
+    for _ in 0..8 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .fan_out
+            .worker,
+        None
+    );
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::WorkerKind);
+    dash.handle_key(key(KeyCode::Right));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .fan_out
+            .worker
+            .is_some()
+    );
+    // Back to autonomous: the fan-out rows are disabled and inert.
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::StageMode);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Home));
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .mode,
+        crate::blueprint_edit::StageModeView::Autonomous
+    );
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MaxWorkers);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Right));
+    assert!(dash.agents().editor.as_ref().unwrap().line.is_none());
+    // Description, tries, revisits, allow complete.
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::StageDescription);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "!");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .description
+            .ends_with('!')
+    );
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MaxIterations);
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .max_iterations,
+        Some(26)
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Backspace));
+    dash.handle_key(key(KeyCode::Backspace));
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .max_iterations,
+        None
+    );
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MaxRevisits);
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .max_revisits,
+        Some(2)
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "0");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .max_revisits,
+        Some(20)
+    );
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::AllowComplete);
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .allow_complete,
+        Some(true)
+    );
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work2")
+            .unwrap()
+            .allow_complete,
+        None
+    );
+    // Move down, then up; the tabs; the delete button (asks).
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MoveDown);
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().doc.stage_names(),
+        ["finish", "work2"]
+    );
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MoveUp);
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().doc.stage_names(),
+        ["work2", "finish"]
+    );
+    dash.handle_key(key(KeyCode::Char('2')));
+    assert!(text(&mut dash).contains("Model & tools"));
+    dash.handle_key(key(KeyCode::Char('3')));
+    dash.handle_key(key(KeyCode::Char('1')));
+    dash.handle_key(key(KeyCode::Char('j')));
+    dash.handle_key(key(KeyCode::Char('k')));
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::DeleteStage);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        dash.pending_confirm,
+        Some((ConfirmAction::StageDelete { .. }, _))
+    ));
+    dash.handle_key(key(KeyCode::Char('n')));
+    // The path panel: kind, hint, gate, delete.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_edge("work2", "finish");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.agents().editor.as_mut().unwrap().cursor = 0;
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("work2", "finish")
+            .unwrap()
+            .kind,
+        crate::blueprint_edit::EdgeKind::LlmChoice
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "always");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("work2", "finish")
+            .unwrap()
+            .kind,
+        crate::blueprint_edit::EdgeKind::Always
+    );
+    // The hint row is disabled under a condition; back to hint it edits.
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().line.is_none());
+    dash.handle_key(key(KeyCode::Up));
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "!");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("work2", "finish")
+            .unwrap()
+            .hint
+            .as_deref()
+            .unwrap()
+            .ends_with('!')
+    );
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("work2", "finish")
+            .unwrap()
+            .gated
+    );
+    dash.handle_key(key(KeyCode::Left));
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("work2", "finish")
+            .unwrap()
+            .gated
+    );
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("work2", "finish")
+            .is_none()
+    );
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage {
+            name: "work2".into(),
+            tab: StageTab::Behaviour
+        }
+    );
+    // The delete-stage button on the last stage is disabled.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .delete_stage("finish")
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("work2");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    let fields = dash.agents().editor.as_ref().unwrap().fields();
+    assert!(
+        !fields
+            .iter()
+            .find(|f| f.id == FieldId::DeleteStage)
+            .unwrap()
+            .enabled
+    );
+    dash.editor_request_delete_stage("work2");
+    assert!(dash.pending_confirm.is_none());
+    assert!(text(&mut dash).contains("only stage"));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn saving_checks_first_and_writes_the_file_and_the_layout() {
+    let (mut dash, root) = dashboard("save");
+    open_editor_on(&mut dash, "own");
+    // A tool nobody has is a lint error: the save is refused and the
+    // problems open.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_tools("work", &["no_such_tool".into()])
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.handle_key(ctrl('s'));
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert!(
+        editor.dirty
+            || editor
+                .message
+                .as_deref()
+                .is_some_and(|m| m.contains("Not saved"))
+    );
+    assert!(editor.problems_open);
+    let screen = text(&mut dash);
+    assert!(screen.contains("Not saved: 1 problem"), "{screen}");
+    assert!(
+        screen.contains("unknown-tool") || screen.contains("no_such_tool"),
+        "{screen}"
+    );
+    assert!(
+        screen.contains("! ") && screen.contains("error"),
+        "the box is flagged: {screen}"
+    );
+    // `p` folds the list; fix it; save writes.
+    dash.handle_key(key(KeyCode::Char('p')));
+    assert!(!dash.agents().editor.as_ref().unwrap().problems_open);
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_tools("work", &["read_file".into()])
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    // Move a box so the layout has something to remember.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("work");
+    dash.handle_key(ctrl('s'));
+    let text_on_disk =
+        std::fs::read_to_string(root.join("agents").join("own").join("agent.leviath")).unwrap();
+    assert!(
+        text_on_disk.contains("available_tools = [\"read_file\"]"),
+        "{text_on_disk}"
+    );
+    assert!(root.join("dash").join("graph-layouts.json").exists());
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert!(!editor.dirty);
+    assert!(dash.toasts.iter().any(|t| t.message == "Saved own"));
+    // A save into a directory that cannot be written says so.
+    dash.agents().editor.as_mut().unwrap().dir = root
+        .join("agents")
+        .join("own")
+        .join("agent.leviath")
+        .join("x");
+    dash.handle_key(ctrl('s'));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .unwrap()
+            .contains("Could not write")
+    );
+    // Not dirty: Esc closes without asking, and the catalog is back.
+    dash.agents().editor.as_mut().unwrap().dirty = false;
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agent_builder.as_ref().unwrap().editor.is_none());
+    assert!(text(&mut dash).contains("Agents ("));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_definition_overlay_scrolls_and_copies() {
+    let (mut dash, root) = dashboard("definition");
+    open_editor_on(&mut dash, "coder");
+    dash.handle_key(key(KeyCode::Char('v')));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Definition { scroll: 0 })
+    );
+    let screen = text(&mut dash);
+    assert!(screen.contains("Definition"), "{screen}");
+    assert!(screen.contains("name = \"coder\""), "{screen}");
+    for code in [
+        KeyCode::Down,
+        KeyCode::PageDown,
+        KeyCode::Up,
+        KeyCode::PageUp,
+        KeyCode::End,
+        KeyCode::Home,
+        KeyCode::Char('j'),
+        KeyCode::Char('k'),
+        KeyCode::Char('z'),
+    ] {
+        dash.handle_key(key(code));
+    }
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Definition { scroll: 0 })
+    );
+    dash.handle_key(key(KeyCode::End));
+    let screen = text(&mut dash);
+    assert!(
+        !screen.contains("name = \"coder\""),
+        "scrolled to the end: {screen}"
+    );
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(text(&mut dash).contains("Could not reach a clipboard"));
+    dash.yank_fn = |_| true;
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(text(&mut dash).contains("Copied the definition"));
+    dash.handle_key(key(KeyCode::Char('v')));
+    assert!(dash.agents().editor.as_ref().unwrap().overlay.is_none());
+    // Help from the editor names its sections; F1 too.
+    dash.handle_key(key(KeyCode::F(1)));
+    assert!(text(&mut dash).contains("Agent editor: canvas"));
+    dash.handle_key(key(KeyCode::Esc));
+    // A narrow terminal shows one pane at a time.
+    let narrow = rendered_buffer(&draw(&mut dash, 100, 40));
+    assert!(narrow.contains("Graph ·"), "{narrow}");
+    assert!(!narrow.contains("This agent"), "{narrow}");
+    dash.handle_key(key(KeyCode::Tab));
+    let narrow = rendered_buffer(&draw(&mut dash, 100, 40));
+    assert!(narrow.contains("This agent"), "{narrow}");
+    assert!(!narrow.contains("Graph ·"), "{narrow}");
+    // A worker blueprint's node has a panel that says where to edit it.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_stage_mode("plan", &crate::blueprint_edit::StageModeView::FanOut)
+        .unwrap();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_fan_out(
+            "plan",
+            crate::blueprint_edit::FanOutField::Worker(Some((
+                crate::blueprint_edit::WorkerKind::Agent,
+                "researcher".into(),
+            ))),
+        )
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("ext:researcher");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::External("researcher".into())
+    );
+    let screen = text(&mut dash);
+    assert!(screen.contains("Worker blueprint · researcher"), "{screen}");
+    assert!(screen.contains("is a separate agent"), "{screen}");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_mouse_selects_connects_and_moves_on_the_editor_canvas() {
+    let (mut dash, root) = dashboard("mouse");
+    open_editor_on(&mut dash, "own");
+    draw(&mut dash, 160, 50);
+    // A click on the finish box selects it and the panel follows.
+    let (x, y, _, _) = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .view
+        .node_rect("finish")
+        .expect("drawn");
+    let (x, y) = (x as u16 + 2, y as u16 + 1);
+    dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+    dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x, y));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage {
+            name: "finish".into(),
+            tab: StageTab::Behaviour
+        }
+    );
+    // Drag it: the arrangement is remembered in the layout store.
+    dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+    dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x + 6, y + 3));
+    dash.handle_mouse(mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        x + 12,
+        y + 6,
+    ));
+    dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x + 12, y + 6));
+    let positions = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .layout
+        .positions("own")
+        .cloned();
+    assert!(
+        positions.is_some_and(|p| p.contains_key("finish")),
+        "moved and remembered"
+    );
+    // Drag from finish's source handle onto work: a new path.
+    draw(&mut dash, 160, 50);
+    let (fx, fy, fr, fb) = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .view
+        .node_rect("finish")
+        .unwrap();
+    let (wx, wy, _, _) = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .view
+        .node_rect("work")
+        .unwrap();
+    let (_, _, _, wb) = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .view
+        .node_rect("work")
+        .unwrap();
+    // The source handle sits on the right border, the target on the left.
+    let handle = ((fr - 1) as u16, ((fy + fb) / 2) as u16);
+    let target = (wx as u16, ((wy + wb) / 2) as u16);
+    let _ = fx;
+    dash.handle_mouse(mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        handle.0,
+        handle.1,
+    ));
+    dash.handle_mouse(mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        target.0 + 4,
+        target.1,
+    ));
+    dash.handle_mouse(mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        target.0,
+        target.1,
+    ));
+    dash.handle_mouse(mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        target.0,
+        target.1,
+    ));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("finish", "work")
+            .is_some(),
+        "connected by drag"
+    );
+    // A wheel over the canvas zooms; a chooser open takes the mouse.
+    dash.handle_mouse(mouse(MouseEventKind::ScrollDown, x, y));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().focus,
+        Focus::Inspector,
+        "a new path opens its panel"
+    );
+    dash.handle_key(key(KeyCode::Esc));
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("finish");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.handle_key(key(KeyCode::Char('c')));
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_some());
+    dash.handle_mouse(mouse(MouseEventKind::ScrollDown, 5, 5));
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_some());
+    dash.handle_key(key(KeyCode::Esc));
+    // The catalog preview pans too, and a click elsewhere is a text
+    // selection as everywhere.
+    dash.handle_key(key(KeyCode::Esc));
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(dash.agent_builder.as_ref().unwrap().editor.is_none());
+    draw(&mut dash, 160, 50);
+    let preview = dash
+        .pane_rects
+        .iter()
+        .find(|(id, _)| *id == PaneId::AgentsPreview)
+        .map(|(_, r)| *r)
+        .expect("preview registered");
+    dash.handle_mouse(mouse(
+        MouseEventKind::ScrollDown,
+        preview.x + 5,
+        preview.y + 3,
+    ));
+    dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 2, 3));
+    assert!(dash.selection.is_some() || dash.mouse_capture.is_none());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn opening_targets_and_edge_cases_of_the_editor() {
+    let (mut dash, root) = dashboard("targets");
+    dash.handle_key(key(KeyCode::Char('a')));
+    // A manifest the editor cannot hold is a toast.
+    dash.open_editor(
+        EditTarget::New {
+            name: "x".into(),
+            bundled_from: None,
+        },
+        "not = [toml",
+    );
+    assert!(dash.agents().editor.is_none());
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("Cannot edit that manifest"))
+    );
+    // An existing agent with no directory saves under the agents dir.
+    dash.open_editor(
+        EditTarget::Existing {
+            name: "fresh".into(),
+            dir: None,
+            bundled_from: None,
+        },
+        &templates::empty_blueprint("fresh").unwrap(),
+    );
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().dir,
+        root.join("agents").join("fresh")
+    );
+    // Ticks animate it; the mouse drain with nothing pending is nothing.
+    dash.tick_graphs(std::time::Duration::from_millis(100));
+    dash.editor_drain_canvas();
+    // Enter on a chooser with an empty filter chooses nothing.
+    dash.handle_key(key(KeyCode::Char('c')));
+    assert!(
+        dash.agents().editor.as_ref().unwrap().picker.is_none(),
+        "nothing selected yet"
+    );
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Char('c')));
+    type_str(&mut dash, "zzz");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_none());
+    assert_eq!(dash.agents().editor.as_ref().unwrap().doc.edges().len(), 1);
+    // The catalog refresh keeps the cursor on the same agent.
+    dash.close_editor();
+    let name = dash.agents().catalog.selected_entry().unwrap().name.clone();
+    dash.refresh_catalog();
+    assert_eq!(dash.agents().catalog.selected_entry().unwrap().name, name);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── the corners ─────────────────────────────────────────────────────────────
+
+#[test]
+fn the_corners_of_the_editor() {
+    use crate::blueprint_edit::check::{Problem, Problems, Severity};
+    let (mut dash, root) = dashboard("corners");
+    // A single-stage agent for the catalog's singular, and one whose
+    // manifest names no entry stage.
+    catalog::write_agent(
+        &root.join("agents"),
+        "solo",
+        "[agent]\nname = \"solo\"\n[stages.only]\nmode = \"autonomous\"\n",
+    )
+    .unwrap();
+    // A clone template whose manifest will not parse is a toast.
+    dash.handle_key(key(KeyCode::Char('a')));
+    let solo = dash
+        .agents()
+        .catalog
+        .visible()
+        .into_iter()
+        .position(|i| dash.agents().catalog.entries[i].name == "solo")
+        .unwrap();
+    dash.agents().catalog.selected = solo;
+    let screen = text(&mut dash);
+    assert!(screen.contains("solo · v0.1.0 · 1 stage "), "{screen}");
+    dash.agents().catalog.entries.push(catalog::CatalogEntry {
+        name: "junk".into(),
+        version: "0".into(),
+        description: String::new(),
+        source: catalog::Source::Installed,
+        dir: None,
+        manifest: Some("not = [".into()),
+        stages: vec![],
+        bundled: false,
+        differs_from_bundled: false,
+    });
+    dash.handle_key(key(KeyCode::Char('n')));
+    let last = dash.agents().chooser.as_ref().unwrap().templates.len() - 1;
+    for _ in 0..last {
+        dash.handle_key(key(KeyCode::Down));
+    }
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.is_none());
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("Could not start from that template"))
+    );
+    // The editor on solo: no entry stage reads as "(first stage)"; ticking
+    // and a confirm drawn over the screen.
+    dash.agents().catalog.selected = solo;
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(text(&mut dash).contains("(first stage)"));
+    dash.tick_graphs(std::time::Duration::from_millis(100));
+    dash.editor_request_delete_stage("only");
+    assert!(dash.pending_confirm.is_none(), "the only stage");
+    // Enter and the arrows on a panel with no rows (a worker blueprint's).
+    dash.agents().editor.as_mut().unwrap().panel = Panel::External("x".into());
+    dash.agents().editor.as_mut().unwrap().focus = Focus::Inspector;
+    dash.editor_activate();
+    dash.editor_adjust(1);
+    dash.handle_key(key(KeyCode::Char('2')));
+    dash.handle_key(key(KeyCode::Char('z')));
+    assert_eq!(dash.agents().editor.as_ref().unwrap().panel_edge(), None);
+    // The arms only tests reach: a toggle, number, choice, button or line
+    // committed for a field of another kind does nothing.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("only");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.editor_set_toggle(&FieldId::StageName, true);
+    dash.editor_set_number(&FieldId::StageName, Some(1));
+    assert_eq!(
+        dash.editor_choice_options(&FieldId::StageName),
+        (Vec::new(), None)
+    );
+    dash.editor_open_choice(&FieldId::StageName);
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_none());
+    dash.editor_pick(&FieldId::StageName, "x");
+    dash.editor_button(&FieldId::StageName);
+    dash.editor_commit_line(&FieldId::StageMode, "x");
+    // A choice with nothing to offer: the default model when the catalog is
+    // empty.
+    dash.agents().editor.as_mut().unwrap().models.clear();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .clear_selection();
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.agents().editor.as_mut().unwrap().cursor = 2;
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_none());
+    // Failed mutations through the helpers.
+    dash.editor_delete_stage("ghost");
+    dash.editor_delete_edge("only", "ghost");
+    dash.editor_connect("only", "ghost");
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .unwrap()
+            .contains("ghost")
+    );
+    // Renaming to a taken name is refused with the reason.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .add_stage("other", None)
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("only");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.agents().editor.as_mut().unwrap().focus = Focus::Inspector;
+    dash.agents().editor.as_mut().unwrap().cursor = 0;
+    dash.handle_key(key(KeyCode::Enter));
+    for _ in 0..4 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    type_str(&mut dash, "other");
+    let screen = text(&mut dash);
+    assert!(
+        screen.contains("Name"),
+        "the line editor is on screen: {screen}"
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(text(&mut dash).contains("already taken"));
+    // Esc while typing a field drops the edit.
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "zz");
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agents().editor.as_ref().unwrap().doc.has_stage("only"));
+    // The merge-stage chooser opens; a max-iterations path is labelled.
+    let fields = dash.agents().editor.as_ref().unwrap().fields();
+    let at = |id: FieldId| fields.iter().position(|f| f.id == id).unwrap();
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::StageMode);
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Right));
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::MergeStage);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(text(&mut dash).contains("Merge stage"));
+    dash.handle_key(key(KeyCode::Esc));
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .add_edge("only", "other")
+        .unwrap();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_edge_kind(
+            "only",
+            "other",
+            crate::blueprint_edit::EdgeKind::MaxIterations,
+        )
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    assert!(text(&mut dash).contains("[too many tries]"));
+    // Toggle rows and typing render; problems in every shape render.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_allow_complete("only", Some(true))
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.agents().editor.as_mut().unwrap().cursor = at(FieldId::StageDescription);
+    dash.handle_key(key(KeyCode::Enter));
+    let screen = text(&mut dash);
+    assert!(screen.contains("[x] on"), "{screen}");
+    dash.handle_key(key(KeyCode::Esc));
+    dash.agents().editor.as_mut().unwrap().problems = Problems::default();
+    assert!(text(&mut dash).contains("✓ no problems"));
+    dash.agents().editor.as_mut().unwrap().problems = Problems {
+        items: vec![
+            Problem {
+                severity: Severity::Error,
+                code: "e",
+                stage: None,
+                message: "broken".into(),
+                fix: None,
+            },
+            Problem {
+                severity: Severity::Note,
+                code: "n",
+                stage: Some("only".into()),
+                message: "noted".into(),
+                fix: Some("do".into()),
+            },
+        ],
+    };
+    dash.agents().editor.as_mut().unwrap().problems_open = true;
+    let screen = text(&mut dash);
+    assert!(
+        screen.contains("1 error") && screen.contains("noted") && screen.contains("(do)"),
+        "{screen}"
+    );
+    // Two errors pluralise the save message.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_stage_mode("only", &crate::blueprint_edit::StageModeView::Autonomous)
+        .unwrap();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_tools("only", &["nope1".into()])
+        .unwrap();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_tools("other", &["nope2".into()])
+        .unwrap();
+    dash.handle_key(ctrl('s'));
+    let screen = text(&mut dash);
+    assert!(screen.contains("2 problems to fix"), "{screen}");
+    // A hundred and one edits: the undo stack stays at a hundred.
+    for i in 0..101 {
+        dash.agents()
+            .editor
+            .as_mut()
+            .unwrap()
+            .mutate(|d| {
+                d.set_description(&format!("d{i}"));
+                Ok(())
+            })
+            .unwrap();
+    }
+    assert_eq!(dash.agents().editor.as_ref().unwrap().undo.len(), 100);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_dashboard_without_a_layout_path_keeps_arrangements_in_memory() {
+    let mut dash = make_test_dashboard();
+    let root =
+        std::env::temp_dir().join(format!("lev-agents-screen-memory-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(root.join("agents")).unwrap();
+    dash.new_run_ctx.agents_dir = root.join("agents");
+    dash.new_run_ctx.workdir = root.clone();
+    dash.new_run_ctx.config_path = root.join("config.toml");
+    catalog::write_agent(
+        &root.join("agents"),
+        "own",
+        &templates::empty_blueprint("own").unwrap(),
+    )
+    .unwrap();
+    open_editor_on(&mut dash, "own");
+    assert_eq!(dash.agents().editor.as_ref().unwrap().layout.path(), None);
+    dash.handle_key(ctrl('s'));
+    assert!(!root.join("dash").exists());
+    // Delete from the catalog forgets the arrangement in memory too.
+    dash.close_editor();
+    dash.perform_agent_delete("own");
+    // The inspector for a stage or path that is gone has no rows.
+    let doc = crate::blueprint_edit::ManifestDoc::parse(&templates::empty_blueprint("x").unwrap())
+        .unwrap();
+    assert!(
+        super::inspector::fields(
+            &doc,
+            &Panel::Stage {
+                name: "ghost".into(),
+                tab: StageTab::Behaviour
+            }
+        )
+        .is_empty()
+    );
+    assert!(
+        super::inspector::fields(
+            &doc,
+            &Panel::Edge {
+                from: "work".into(),
+                to: "ghost".into()
+            }
+        )
+        .is_empty()
+    );
+    assert!(
+        super::inspector::fields(
+            &doc,
+            &Panel::Stage {
+                name: "work".into(),
+                tab: StageTab::Model
+            }
+        )
+        .is_empty()
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -168,6 +168,8 @@ impl Dashboard {
             new_run_yolo: false,
             yolo_warning_silenced: false,
             new_run_ctx,
+            agent_builder: None,
+            layout_store_path: None,
             spawn_cmd_tx,
             spawn_outcome_rx,
             spawn_bg_ends: Some((spawn_cmd_rx, spawn_outcome_tx)),

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -75,6 +75,14 @@ impl Dashboard {
         if let Some(Ok(view)) = self.new_run_preview.as_mut().map(|p| p.view.as_mut()) {
             view.tick(elapsed);
         }
+        if let Some(screen) = self.agent_builder.as_deref_mut() {
+            if let Some((_, Ok(view))) = screen.catalog.preview.as_mut() {
+                view.tick(elapsed);
+            }
+            if let Some(editor) = screen.editor.as_mut() {
+                editor.view.tick(elapsed);
+            }
+        }
     }
 
     /// Keys while the full-screen stage explorer is open. The explorer owns
@@ -296,6 +304,16 @@ impl Dashboard {
                     .filter(|_| open)
                     .and_then(|p| p.view.as_mut().ok())
             }
+            PaneId::AgentsPreview => self
+                .agent_builder
+                .as_deref_mut()
+                .and_then(|s| s.catalog.preview.as_mut())
+                .and_then(|(_, view)| view.as_mut().ok()),
+            PaneId::AgentEditorGraph => self
+                .agent_builder
+                .as_deref_mut()
+                .and_then(|s| s.editor.as_mut())
+                .map(|e| &mut e.view),
             PaneId::RunTable | PaneId::LogPanel => None,
         }
     }

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -37,6 +37,12 @@ impl Dashboard {
             return;
         }
 
+        // The Agents screen (catalog, chooser, editor) is modal too.
+        if self.agent_builder.is_some() {
+            self.handle_agents_key(key);
+            return;
+        }
+
         // MCP management screen is modal: it owns all keys while open.
         if self.mcp_screen {
             self.handle_mcp_screen_key(key_code);
@@ -151,6 +157,10 @@ impl Dashboard {
                 // outcome: whether to ask again is a note about future
                 // questions, not a third answer to this one.
                 ConfirmAction::EnableYolo => self.accept_yolo_warning(dialog.remembered()),
+                ConfirmAction::AgentDelete { name } => self.perform_agent_delete(&name),
+                ConfirmAction::AgentReset { name } => self.perform_agent_reset(&name),
+                ConfirmAction::StageDelete { name } => self.editor_delete_stage(&name),
+                ConfirmAction::EditorDiscard => self.close_editor(),
             },
         }
     }
@@ -745,6 +755,7 @@ impl Dashboard {
                 self.refresh_mcp_rows();
             }
             KeyCode::Char('n') => self.open_new_run_screen(),
+            KeyCode::Char('a') => self.open_agents_screen(),
             _ => {}
         }
     }

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -1,5 +1,6 @@
 //! `lev dash` - Interactive terminal UI for managing concurrent agents.
 
+mod agents;
 mod construct;
 mod context_tree;
 mod detail_band;
@@ -12,6 +13,7 @@ mod mcp;
 mod new_run;
 mod new_run_preview;
 mod render;
+mod run_actions;
 mod selection;
 mod state;
 #[cfg(test)]
@@ -240,6 +242,8 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
         mcp_ctx,
         new_run::production_new_run_context(),
     );
+    // The agent editor keeps its canvas arrangements under the data dir.
+    dashboard.layout_store_path = crate::blueprint_edit::LayoutStore::default_path();
 
     // Forward the dashboard's control commands to the daemon, and report each
     // result back so a refused command is surfaced rather than swallowed. A

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -30,6 +30,20 @@ impl Dashboard {
         // registers where it actually drew.
         self.pane_rects.clear();
 
+        if self.agent_builder.is_some() {
+            self.draw_agents_screen(frame, frame.area());
+            self.apply_selection_overlay(frame);
+            self.draw_toasts(frame);
+            if self.show_help {
+                self.draw_help_overlay(frame);
+            }
+            // Delete, reset, discard and stage-delete confirmations open
+            // over this screen.
+            if let Some((_, dialog)) = &self.pending_confirm {
+                dialog.draw(frame, frame.area());
+            }
+            return;
+        }
         if self.mcp_screen {
             self.draw_mcp_screen(frame, frame.area());
             self.apply_selection_overlay(frame);

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -69,7 +69,13 @@ impl Dashboard {
     /// works in all of them, which is worth saying where somebody is looking
     /// rather than only where it happens to have been listed.
     pub(in crate::commands::dashboard) fn draw_help_overlay(&self, frame: &mut Frame) {
-        let mut sections: Vec<HelpSection> = if self.new_run_screen {
+        let mut sections: Vec<HelpSection> = if let Some(screen) = self.agent_builder.as_deref() {
+            if screen.editor.is_some() {
+                agent_editor_sections()
+            } else {
+                agents_sections()
+            }
+        } else if self.new_run_screen {
             new_run_sections()
         } else if self.mcp_screen {
             mcp_sections()
@@ -83,6 +89,99 @@ impl Dashboard {
         sections.extend(shared_sections());
         draw_help(frame, frame.area(), &sections, &self.help_scroll);
     }
+}
+
+/// The Agents screen's catalog.
+fn agents_sections() -> Vec<HelpSection> {
+    vec![
+        HelpSection {
+            title: "Agents (a)",
+            entries: vec![
+                ("↑ ↓ / k j", "select an agent"),
+                ("enter / e", "edit it (a bundled one installs when saved)"),
+                ("n", "new agent: start simple, or clone one"),
+                ("l", "launch it: the new-run screen with it picked"),
+                ("d", "delete an installed agent (asks first)"),
+                (
+                    "r",
+                    "reset an edited bundled agent to the bundled copy (asks first)",
+                ),
+                (
+                    "/",
+                    "filter by name or description; enter keeps it, esc clears it",
+                ),
+                ("esc / q", "back to the run list"),
+            ],
+        },
+        HelpSection {
+            title: "New agent (n)",
+            entries: vec![
+                (
+                    "↑ ↓",
+                    "pick the template; the name follows until you type one",
+                ),
+                ("enter", "open the editor on it (not saved until you save)"),
+                ("esc", "back to the catalog"),
+            ],
+        },
+    ]
+}
+
+/// The agent editor.
+fn agent_editor_sections() -> Vec<HelpSection> {
+    vec![
+        HelpSection {
+            title: "Agent editor: everywhere",
+            entries: vec![
+                (
+                    "ctrl-s",
+                    "save (checks first; errors block it and open the problems)",
+                ),
+                ("tab", "move the keys between the canvas and the inspector"),
+                ("u / ctrl-r", "undo / redo an edit"),
+                (
+                    "v",
+                    "the definition: the exact file that will be saved (y copies it)",
+                ),
+                ("p", "open / close the problems list under the canvas"),
+                (
+                    "esc",
+                    "on the canvas: close (asks when there are unsaved edits)",
+                ),
+            ],
+        },
+        HelpSection {
+            title: "Agent editor: canvas",
+            entries: vec![
+                ("↑ ↓ ← → / h j k l", "select a stage in that direction"),
+                ("[ / ]", "previous / next stage in file order"),
+                ("enter", "edit the selected stage or path in the inspector"),
+                ("a", "add a stage after the selected one (asks its name)"),
+                ("c", "connect the selected stage to another (or to itself)"),
+                ("x / delete", "delete the selected stage (asks) or path"),
+                ("+ / - / 0, f, r", "zoom, fit, turn the graph"),
+                ("drag a box", "move it (the arrangement is kept per agent)"),
+                ("drag a ●", "connect two stages with the mouse"),
+                ("click", "select a stage or a path"),
+            ],
+        },
+        HelpSection {
+            title: "Agent editor: inspector",
+            entries: vec![
+                ("↑ ↓ / k j", "move between rows"),
+                (
+                    "enter",
+                    "edit the row: type, choose, flip, or press the button",
+                ),
+                (
+                    "← → / h l",
+                    "change the row in place: cycle a choice, step a number, flip a toggle",
+                ),
+                ("1 2 3", "a stage's tabs: behaviour, model & tools, context"),
+                ("esc", "back to the canvas"),
+            ],
+        },
+    ]
 }
 
 /// The run list: the screen `lev dash` opens on.
@@ -105,6 +204,7 @@ fn run_list_sections() -> Vec<HelpSection> {
                 "mark/unmark the run, then move down (marked runs are killed/deleted together)",
             ),
             ("m", "manage MCP servers"),
+            ("a", "agents: the catalog and the editor"),
             ("esc", "clear the filter, then the marks"),
             ("q", "quit"),
         ],

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -585,6 +585,8 @@ impl Dashboard {
             Span::raw(" mark  "),
             Span::styled("[m]", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" mcp  "),
+            Span::styled("[a]", Style::default().add_modifier(Modifier::BOLD)),
+            Span::raw(" agents  "),
         ];
         if can_kill {
             spans.push(Span::styled(

--- a/crates/leviath-cli/src/commands/dashboard/run_actions.rs
+++ b/crates/leviath-cli/src/commands/dashboard/run_actions.rs
@@ -1,0 +1,172 @@
+//! Killing and deleting runs from the dashboard: the confirmations, and
+//! what runs when they are answered.
+
+use super::helpers::truncate;
+use super::state::Dashboard;
+use super::types::*;
+use crate::runstate;
+use ratatui_textarea::TextArea;
+
+impl Dashboard {
+    /// Open the kill confirmation. Acts on every marked run that is killable
+    /// when any are marked, else on the selected run if it is killable.
+    pub(super) fn request_kill(&mut self) {
+        use crate::tui::widgets::confirm::Confirm;
+        use ratatui::text::Line;
+        if !self.marked.is_empty() {
+            // Marked but already-finished runs are skipped, the same way `x`
+            // on a finished run does nothing.
+            let run_ids: Vec<String> = self
+                .agents
+                .iter()
+                .filter(|a| self.marked.contains(&a.id) && a.status.is_killable())
+                .map(|a| a.id.clone())
+                .collect();
+            if run_ids.is_empty() {
+                return;
+            }
+            let body = if run_ids.len() == 1 {
+                "Cancel 1 run? Its state stays on disk.".to_string()
+            } else {
+                format!("Cancel {} runs? Their state stays on disk.", run_ids.len())
+            };
+            let dialog =
+                Confirm::new("Kill runs?", vec![Line::from(body)], "Kill", "Cancel").danger();
+            self.pending_confirm = Some((ConfirmAction::Kill { run_ids }, dialog));
+            return;
+        }
+        let Some(agent) = self.selected_agent() else {
+            return;
+        };
+        if !agent.status.is_killable() {
+            return;
+        }
+        let run_id = agent.id.clone();
+        let name = agent
+            .title
+            .clone()
+            .unwrap_or_else(|| truncate(&agent.blueprint_name, 24));
+        let dialog = Confirm::new(
+            "Kill run?",
+            vec![Line::from(format!(
+                "Cancel '{name}' ({})? Its state stays on disk.",
+                truncate(&run_id, 20)
+            ))],
+            "Kill",
+            "Cancel",
+        )
+        .danger();
+        self.pending_confirm = Some((
+            ConfirmAction::Kill {
+                run_ids: vec![run_id],
+            },
+            dialog,
+        ));
+    }
+
+    /// Open the delete confirmation. Acts on every marked run when any are
+    /// marked, else on the selected run.
+    pub(super) fn request_delete(&mut self) {
+        use crate::tui::widgets::confirm::Confirm;
+        use ratatui::text::Line;
+        if !self.marked.is_empty() {
+            // Every marked id names a live run: `update_display_indices` prunes
+            // marks whenever the agent list changes, so no emptiness check is
+            // needed here.
+            let run_ids: Vec<String> = self
+                .agents
+                .iter()
+                .filter(|a| self.marked.contains(&a.id))
+                .map(|a| a.id.clone())
+                .collect();
+            let body = if run_ids.len() == 1 {
+                "Delete 1 run and its on-disk state? This is permanent.".to_string()
+            } else {
+                format!(
+                    "Delete {} runs and their on-disk state? This is permanent.",
+                    run_ids.len()
+                )
+            };
+            let dialog =
+                Confirm::new("Delete runs?", vec![Line::from(body)], "Delete", "Cancel").danger();
+            self.pending_confirm = Some((ConfirmAction::Delete { run_ids }, dialog));
+            return;
+        }
+        let Some(agent) = self.selected_agent() else {
+            return;
+        };
+        let run_id = agent.id.clone();
+        let dialog = Confirm::new(
+            "Delete run?",
+            vec![Line::from(format!(
+                "Delete '{}' and all of its on-disk state? This is permanent.",
+                truncate(&run_id, 24)
+            ))],
+            "Delete",
+            "Cancel",
+        )
+        .danger();
+        self.pending_confirm = Some((
+            ConfirmAction::Delete {
+                run_ids: vec![run_id],
+            },
+            dialog,
+        ));
+    }
+
+    /// Ask the daemon to cancel `run_id` and mark the row cancelled. The one
+    /// implementation behind the list's and the detail view's kill key.
+    pub(super) fn perform_kill(&mut self, run_id: &str) {
+        let _ = self.cmd_tx.send(DaemonCommand::Cancel {
+            run_id: run_id.to_string(),
+        });
+        if let Some(a) = self.agents.iter_mut().find(|a| a.id == run_id) {
+            a.status = AgentDisplayStatus::Cancelled;
+            a.waiting_prompt = None;
+            a.pending_request = None;
+        }
+        // Any half-typed response to the killed run is moot.
+        self.input_mode = false;
+        self.input_textarea = TextArea::default();
+        self.add_log(format!("{run_id}: kill requested"));
+    }
+
+    /// Cancel (via the daemon) then delete all on-disk state for `run_id`.
+    /// Keyed by id rather than the current selection so the action confirmed
+    /// in the dialog is the one that runs, whatever the list did since.
+    pub(super) fn perform_delete(&mut self, run_id: &str) {
+        let Some(raw_idx) = self.agents.iter().position(|a| a.id == run_id) else {
+            return;
+        };
+        let id = run_id.to_string();
+        // Record the run terminal on disk *before* removing it, and ask the
+        // daemon to cancel it too.
+        //
+        // The daemon command is asynchronous while the removal below is not, so
+        // an in-flight persist job can `create_dir_all` the directory straight
+        // back. Writing the terminal status first means that if it does
+        // reappear, it reappears as a finished run rather than as a live one the
+        // user just tried to delete. (The daemon cancel is what actually stops
+        // it writing; this only bounds what a lost race looks like.)
+        let _ = crate::runstate::force_cancel(&id);
+        let _ = self
+            .cmd_tx
+            .send(DaemonCommand::Cancel { run_id: id.clone() });
+        // Remove run directory
+        let run_dir = runstate::run_dir(&id);
+        if let Err(e) = std::fs::remove_dir_all(&run_dir) {
+            self.add_log(format!("Delete failed: {}", e));
+        } else {
+            self.add_log(format!("Deleted run {}", id));
+        }
+        // Remove saved context state if present. Resolved through the shared
+        // LEVIATH_HOME-aware helper so the delete hits the same data root the
+        // run wrote to; map() avoids a dead None branch.
+        let _ = leviath_core::paths::data_dir()
+            .map(|d| std::fs::remove_dir_all(d.join("state").join(&id)));
+        // Remove agent from self.agents using the raw index (always valid because
+        // selected_agent_raw_idx() succeeded above and agents hasn't changed).
+        self.agents.remove(raw_idx);
+        self.update_display_indices();
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/selection.rs
+++ b/crates/leviath-cli/src/commands/dashboard/selection.rs
@@ -136,6 +136,10 @@ impl Dashboard {
     /// cursor, hit-tested against the rects each renderer registered this
     /// frame - not whichever pane the keyboard last touched.
     pub(super) fn handle_mouse(&mut self, event: MouseEvent) {
+        // The Agents screen's chooser and canvas take the mouse first.
+        if self.agent_builder.is_some() && self.handle_agents_mouse(event) {
+            return;
+        }
         // A graph canvas takes the mouse before the selection machinery: a
         // pan is not a copy highlight.
         if self.route_mouse_to_graph(event) {

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -203,6 +203,12 @@ pub(crate) struct Dashboard {
     pub(super) yolo_warning_silenced: bool,
     /// Paths the screen reads its agents and file candidates from.
     pub(super) new_run_ctx: NewRunContext,
+    /// The Agents screen (`a`): catalog and editor. Boxed: it carries a
+    /// canvas and a document.
+    pub(super) agent_builder: Option<Box<super::agents::AgentsScreen>>,
+    /// Where the editor keeps canvas arrangements; `None` keeps them in
+    /// memory (tests).
+    pub(super) layout_store_path: Option<std::path::PathBuf>,
     /// Sends resolve-and-spawn work to the background lane.
     pub(super) spawn_cmd_tx: mpsc::UnboundedSender<SpawnCommand>,
     /// Receives spawn results, drained into toasts each tick.
@@ -939,168 +945,6 @@ impl Dashboard {
     pub(super) fn cycle_sort_mode(&mut self) {
         self.sort_mode = self.sort_mode.next();
         self.add_log(format!("Sort: {}", self.sort_mode.label()));
-        self.update_display_indices();
-    }
-
-    /// Open the kill confirmation. Acts on every marked run that is killable
-    /// when any are marked, else on the selected run if it is killable.
-    pub(super) fn request_kill(&mut self) {
-        use crate::tui::widgets::confirm::Confirm;
-        use ratatui::text::Line;
-        if !self.marked.is_empty() {
-            // Marked but already-finished runs are skipped, the same way `x`
-            // on a finished run does nothing.
-            let run_ids: Vec<String> = self
-                .agents
-                .iter()
-                .filter(|a| self.marked.contains(&a.id) && a.status.is_killable())
-                .map(|a| a.id.clone())
-                .collect();
-            if run_ids.is_empty() {
-                return;
-            }
-            let body = if run_ids.len() == 1 {
-                "Cancel 1 run? Its state stays on disk.".to_string()
-            } else {
-                format!("Cancel {} runs? Their state stays on disk.", run_ids.len())
-            };
-            let dialog =
-                Confirm::new("Kill runs?", vec![Line::from(body)], "Kill", "Cancel").danger();
-            self.pending_confirm = Some((ConfirmAction::Kill { run_ids }, dialog));
-            return;
-        }
-        let Some(agent) = self.selected_agent() else {
-            return;
-        };
-        if !agent.status.is_killable() {
-            return;
-        }
-        let run_id = agent.id.clone();
-        let name = agent
-            .title
-            .clone()
-            .unwrap_or_else(|| truncate(&agent.blueprint_name, 24));
-        let dialog = Confirm::new(
-            "Kill run?",
-            vec![Line::from(format!(
-                "Cancel '{name}' ({})? Its state stays on disk.",
-                truncate(&run_id, 20)
-            ))],
-            "Kill",
-            "Cancel",
-        )
-        .danger();
-        self.pending_confirm = Some((
-            ConfirmAction::Kill {
-                run_ids: vec![run_id],
-            },
-            dialog,
-        ));
-    }
-
-    /// Open the delete confirmation. Acts on every marked run when any are
-    /// marked, else on the selected run.
-    pub(super) fn request_delete(&mut self) {
-        use crate::tui::widgets::confirm::Confirm;
-        use ratatui::text::Line;
-        if !self.marked.is_empty() {
-            // Every marked id names a live run: `update_display_indices` prunes
-            // marks whenever the agent list changes, so no emptiness check is
-            // needed here.
-            let run_ids: Vec<String> = self
-                .agents
-                .iter()
-                .filter(|a| self.marked.contains(&a.id))
-                .map(|a| a.id.clone())
-                .collect();
-            let body = if run_ids.len() == 1 {
-                "Delete 1 run and its on-disk state? This is permanent.".to_string()
-            } else {
-                format!(
-                    "Delete {} runs and their on-disk state? This is permanent.",
-                    run_ids.len()
-                )
-            };
-            let dialog =
-                Confirm::new("Delete runs?", vec![Line::from(body)], "Delete", "Cancel").danger();
-            self.pending_confirm = Some((ConfirmAction::Delete { run_ids }, dialog));
-            return;
-        }
-        let Some(agent) = self.selected_agent() else {
-            return;
-        };
-        let run_id = agent.id.clone();
-        let dialog = Confirm::new(
-            "Delete run?",
-            vec![Line::from(format!(
-                "Delete '{}' and all of its on-disk state? This is permanent.",
-                truncate(&run_id, 24)
-            ))],
-            "Delete",
-            "Cancel",
-        )
-        .danger();
-        self.pending_confirm = Some((
-            ConfirmAction::Delete {
-                run_ids: vec![run_id],
-            },
-            dialog,
-        ));
-    }
-
-    /// Ask the daemon to cancel `run_id` and mark the row cancelled. The one
-    /// implementation behind the list's and the detail view's kill key.
-    pub(super) fn perform_kill(&mut self, run_id: &str) {
-        let _ = self.cmd_tx.send(DaemonCommand::Cancel {
-            run_id: run_id.to_string(),
-        });
-        if let Some(a) = self.agents.iter_mut().find(|a| a.id == run_id) {
-            a.status = AgentDisplayStatus::Cancelled;
-            a.waiting_prompt = None;
-            a.pending_request = None;
-        }
-        // Any half-typed response to the killed run is moot.
-        self.input_mode = false;
-        self.input_textarea = TextArea::default();
-        self.add_log(format!("{run_id}: kill requested"));
-    }
-
-    /// Cancel (via the daemon) then delete all on-disk state for `run_id`.
-    /// Keyed by id rather than the current selection so the action confirmed
-    /// in the dialog is the one that runs, whatever the list did since.
-    pub(super) fn perform_delete(&mut self, run_id: &str) {
-        let Some(raw_idx) = self.agents.iter().position(|a| a.id == run_id) else {
-            return;
-        };
-        let id = run_id.to_string();
-        // Record the run terminal on disk *before* removing it, and ask the
-        // daemon to cancel it too.
-        //
-        // The daemon command is asynchronous while the removal below is not, so
-        // an in-flight persist job can `create_dir_all` the directory straight
-        // back. Writing the terminal status first means that if it does
-        // reappear, it reappears as a finished run rather than as a live one the
-        // user just tried to delete. (The daemon cancel is what actually stops
-        // it writing; this only bounds what a lost race looks like.)
-        let _ = crate::runstate::force_cancel(&id);
-        let _ = self
-            .cmd_tx
-            .send(DaemonCommand::Cancel { run_id: id.clone() });
-        // Remove run directory
-        let run_dir = runstate::run_dir(&id);
-        if let Err(e) = std::fs::remove_dir_all(&run_dir) {
-            self.add_log(format!("Delete failed: {}", e));
-        } else {
-            self.add_log(format!("Deleted run {}", id));
-        }
-        // Remove saved context state if present. Resolved through the shared
-        // LEVIATH_HOME-aware helper so the delete hits the same data root the
-        // run wrote to; map() avoids a dead None branch.
-        let _ = leviath_core::paths::data_dir()
-            .map(|d| std::fs::remove_dir_all(d.join("state").join(&id)));
-        // Remove agent from self.agents using the raw index (always valid because
-        // selected_agent_raw_idx() succeeded above and agents hasn't changed).
-        self.agents.remove(raw_idx);
         self.update_display_indices();
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -77,6 +77,10 @@ pub(super) enum PaneId {
     DetailBand,
     /// The new-run screen's blueprint preview: a drag pans.
     NewRunPreview,
+    /// The Agents screen's preview of the selected agent: a drag pans.
+    AgentsPreview,
+    /// The agent editor's canvas: boxes drag, handles connect.
+    AgentEditorGraph,
 }
 
 impl PaneId {
@@ -85,7 +89,11 @@ impl PaneId {
     pub(super) fn is_graph(self) -> bool {
         matches!(
             self,
-            PaneId::ExplorerGraph | PaneId::DetailBand | PaneId::NewRunPreview
+            PaneId::ExplorerGraph
+                | PaneId::DetailBand
+                | PaneId::NewRunPreview
+                | PaneId::AgentsPreview
+                | PaneId::AgentEditorGraph
         )
     }
 }
@@ -155,6 +163,14 @@ pub(super) enum ConfirmAction {
     McpRemove { name: String },
     /// Turn on unattended runs for the new-run screen.
     EnableYolo,
+    /// Delete an installed agent's directory (the Agents screen).
+    AgentDelete { name: String },
+    /// Put a bundled agent's embedded copy back (the Agents screen).
+    AgentReset { name: String },
+    /// Delete a stage in the agent editor, with its paths.
+    StageDelete { name: String },
+    /// Close the agent editor and lose its unsaved edits.
+    EditorDiscard,
 }
 
 /// Display status for agents in the dashboard.

--- a/crates/leviath-cli/src/tui/flowgraph/content.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/content.rs
@@ -125,6 +125,11 @@ pub(crate) struct StageNodeContent {
     pub(crate) is_entry: bool,
     pub(crate) is_terminal: bool,
     pub(crate) self_loop: bool,
+    // ── editor ──
+    /// The editor's problems list names this stage.
+    pub(crate) problem: bool,
+    /// The stage has a context layout of its own.
+    pub(crate) own_layout: bool,
     // ── live ──
     pub(crate) status: NodeStatus,
     /// The run's iteration count, when this is the current stage. It counts
@@ -147,6 +152,8 @@ impl StageNodeContent {
             is_entry: node.is_entry,
             is_terminal: node.is_terminal || node.allow_complete,
             self_loop: node.self_loop,
+            problem: false,
+            own_layout: false,
             status: NodeStatus::Pending,
             iteration: None,
             last_seen: None,
@@ -176,6 +183,9 @@ impl StageNodeContent {
         let mut prefix = String::new();
         if self.is_entry {
             prefix.push_str("▶ ");
+        }
+        if self.problem {
+            prefix.push_str("! ");
         }
         prefix.push_str(glyph);
         prefix.push(' ');
@@ -220,6 +230,9 @@ impl StageNodeContent {
         }
         if self.is_terminal {
             parts.push("⏹ can end".to_string());
+        }
+        if self.own_layout {
+            parts.push("▣ own context".to_string());
         }
         if let Some(seen) = &self.last_seen {
             parts.push(seen.clone());

--- a/crates/leviath-cli/src/tui/flowgraph/mod.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/mod.rs
@@ -23,4 +23,4 @@ pub(crate) mod view;
 pub(crate) use content::{RunPhase, WorkerCounts};
 pub(crate) use layout::Direction;
 pub(crate) use model::StageGraph;
-pub(crate) use view::{FlowView, LiveOverlay, Selection, StageLive};
+pub(crate) use view::{CanvasEvent, FlowView, LiveOverlay, Selection, StageLive};

--- a/crates/leviath-cli/src/tui/flowgraph/model.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/model.rs
@@ -153,6 +153,23 @@ fn transform_label(transform: &EdgeTransform) -> &'static str {
 
 impl StageEdge {
     /// The `[condition]` label an edge shows, empty for `always`.
+    /// The word the editor puts on every edge: what makes it fire.
+    pub(crate) fn editor_label(&self) -> &'static str {
+        match self.condition {
+            // A hint is a `hint = "..."` key; the parser leaves the
+            // condition at its default under it.
+            TransitionCondition::Always | TransitionCondition::LlmChoice if self.hint.is_some() => {
+                "hint"
+            }
+            TransitionCondition::Always => "always",
+            TransitionCondition::LlmChoice => "model's choice",
+            TransitionCondition::Error => "on error",
+            TransitionCondition::MaxIterations => "too many tries",
+            TransitionCondition::Stuck => "when stuck",
+            TransitionCondition::DeadEnd => "dead end",
+        }
+    }
+
     pub(crate) fn condition_label(&self) -> &'static str {
         match self.condition {
             TransitionCondition::Always => "",

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -20,6 +20,7 @@ use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::widgets::Block;
 
+use crate::blueprint_edit::Positions;
 use crate::tui::theme::C_ACCENT;
 
 use super::content::{
@@ -71,6 +72,15 @@ pub(crate) enum Selection {
     Nothing,
 }
 
+/// What the canvas did with the mouse that the editor has to act on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CanvasEvent {
+    /// A handle was dragged onto another box: a path to add.
+    Connected { from: String, to: String },
+    /// A box was dropped somewhere new: positions to remember.
+    Moved,
+}
+
 /// One drawn edge, remembered so live restyling can find it.
 #[derive(Debug, Clone)]
 struct EdgeMeta {
@@ -91,6 +101,13 @@ pub(crate) struct FlowView {
     layout: GraphLayout,
     edges: Vec<EdgeMeta>,
     locked: bool,
+    /// An editor: handles show and connect, and the mouse's connections and
+    /// drops are reported through [`FlowView::take_events`].
+    edit: bool,
+    /// Where dragged boxes were left (an editor); empty means the layered
+    /// layout places every box.
+    positions: Positions,
+    events: Vec<CanvasEvent>,
     direction: Direction,
     /// Until the user turns the graph by hand, the first draw picks the
     /// direction that fits.
@@ -122,6 +139,39 @@ pub(crate) struct FlowView {
 /// Box size and gaps: `(node_w, node_h, gap_x, gap_y)`.
 fn metrics(longest_id: usize) -> (f64, f64, f64, f64) {
     (node_width(longest_id), NODE_HEIGHT, 8.0, 1.0)
+}
+
+/// Put saved positions on the boxes, and any box without one to the right
+/// of the rightmost saved box (the way The Lair appends a new stage), so an
+/// arrangement survives a stage being added.
+fn apply_positions(
+    flow: &mut Flow<StageNodeContent, StepEdge>,
+    positions: &Positions,
+    node_w: f64,
+    node_h: f64,
+    gap_x: f64,
+    gap_y: f64,
+) {
+    if positions.is_empty() {
+        return;
+    }
+    let mut right = f64::MIN;
+    let mut top = f64::MAX;
+    for (x, y) in positions.values() {
+        right = right.max(x + node_w);
+        top = top.min(*y);
+    }
+    let ids: Vec<String> = flow.nodes().map(|n| n.id.clone()).collect();
+    let mut appended = 0.0;
+    for id in ids {
+        match positions.get(&id) {
+            Some((x, y)) => flow.set_node_position(&id, (*x, *y)),
+            None => {
+                flow.set_node_position(&id, (right + gap_x, top + appended));
+                appended += node_h + gap_y;
+            }
+        }
+    }
 }
 
 /// Which sides an edge leaves and enters on, and how far it travels before
@@ -183,9 +233,10 @@ impl std::fmt::Debug for FlowView {
 /// attaches. The forward sides (out along the flow, in against it) sit at
 /// the middle of their edge; the lane sides carry the source a little past
 /// the middle and the target a little before it, so a loop leaves and
-/// re-enters at different cells. Hidden: the canvas is not an editor, and
-/// handle glyphs read as ports.
-fn handles(direction: Direction) -> Vec<Handle> {
+/// re-enters at different cells. Hidden on a viewer, where handle glyphs
+/// would read as ports; on an editor the flow-side pair shows and connects,
+/// and the lanes stay hidden (routing, not ports).
+fn handles(direction: Direction, edit: bool) -> Vec<Handle> {
     let (out, back, lane_a, lane_b) = match direction {
         Direction::LeftToRight => (
             HandlePosition::Right,
@@ -203,25 +254,29 @@ fn handles(direction: Direction) -> Vec<Handle> {
     vec![
         Handle::source(out)
             .with_id(out.side_name())
-            .with_hidden(true),
+            .with_hidden(!edit),
         Handle::source(lane_a)
             .with_id(lane_a.side_name())
             .with_offset(0.7)
+            .with_connectable(false)
             .with_hidden(true),
         Handle::source(lane_b)
             .with_id(lane_b.side_name())
             .with_offset(0.7)
+            .with_connectable(false)
             .with_hidden(true),
         Handle::target(back)
             .with_id(back.side_name())
-            .with_hidden(true),
+            .with_hidden(!edit),
         Handle::target(lane_a)
             .with_id(lane_a.side_name())
             .with_offset(0.3)
+            .with_connectable(false)
             .with_hidden(true),
         Handle::target(lane_b)
             .with_id(lane_b.side_name())
             .with_offset(0.3)
+            .with_connectable(false)
             .with_hidden(true),
     ]
 }
@@ -233,6 +288,8 @@ fn build(
     layout: &GraphLayout,
     locked: bool,
     direction: Direction,
+    edit: bool,
+    positions: &Positions,
 ) -> (Flow<StageNodeContent, StepEdge>, Vec<EdgeMeta>, f64) {
     let longest = graph
         .nodes
@@ -252,11 +309,13 @@ fn build(
                 (node_w, node_h),
                 StageNodeContent::from_node(n),
             )
-            .with_handles(handles(direction))
-            .with_connectable(false)
+            .with_handles(handles(direction, edit))
+            // An external blueprint is drawn, not edited: nothing connects to
+            // it and it cannot be moved.
+            .with_connectable(edit && n.kind != super::model::NodeKind::ExternalBlueprint)
             .with_deletable(false)
             .with_resizable(false)
-            .with_draggable(!locked)
+            .with_draggable(!locked && n.kind != super::model::NodeKind::ExternalBlueprint)
         })
         .collect();
 
@@ -286,7 +345,11 @@ fn build(
                 .with_target_side(tgt)
                 .with_deletable(false)
                 .with_hidden(e.class == EdgeClass::Escape);
-            let label = e.condition_label();
+            let label = if edit {
+                e.editor_label()
+            } else {
+                e.condition_label()
+            };
             if !label.is_empty() {
                 edge = edge.with_label(format!("[{label}]"));
             }
@@ -308,6 +371,20 @@ fn build(
         .with_deselect_on_pane_click(false)
         .with_locked(locked);
     flow.set_node_positions(layout.positions(direction, node_w, node_h, gap_x, gap_y));
+    apply_positions(&mut flow, positions, node_w, node_h, gap_x, gap_y);
+    if edit {
+        // A path that exists is not drawn twice, whichever handles a drag
+        // would route it through; and a box cannot be wired to itself on
+        // the canvas (rataflow refuses), so a self-loop is added by key.
+        let pairs: HashSet<(String, String)> = graph
+            .edges
+            .iter()
+            .map(|e| (e.from.clone(), e.to.clone()))
+            .collect();
+        flow.set_connection_validator(move |c| {
+            !pairs.contains(&(c.source.clone(), c.target.clone()))
+        });
+    }
     // No fit here: the first `render` settles the viewport for the area it
     // gets. A fit requested now would land after that and undo it.
     (flow, metas, max_stem)
@@ -319,14 +396,39 @@ impl FlowView {
     /// explorer is unlocked, so boxes can be dragged into a better
     /// arrangement and clicked to select.
     pub(crate) fn new(graph: Arc<StageGraph>, locked: bool) -> Self {
+        Self::build_view(graph, locked, false, Positions::new())
+    }
+
+    /// Build the canvas as an editor: handles show and connect, boxes drag,
+    /// every edge is drawn, and `positions` (from an earlier session) place
+    /// the boxes.
+    pub(crate) fn new_editor(graph: Arc<StageGraph>, positions: Positions) -> Self {
+        let mut view = Self::build_view(graph, false, true, positions);
+        view.show_all = true;
+        view.show_escape = true;
+        view.sync_visibility();
+        view
+    }
+
+    fn build_view(graph: Arc<StageGraph>, locked: bool, edit: bool, positions: Positions) -> Self {
         let layout = layout::layout(&graph);
-        let (flow, edges, max_stem) = build(&graph, &layout, locked, Direction::LeftToRight);
+        let (flow, edges, max_stem) = build(
+            &graph,
+            &layout,
+            locked,
+            Direction::LeftToRight,
+            edit,
+            &positions,
+        );
         Self {
             flow,
             graph,
             layout,
             edges,
             locked,
+            edit,
+            positions,
+            events: Vec::new(),
             direction: Direction::LeftToRight,
             auto_direction: true,
             show_escape: false,
@@ -347,7 +449,68 @@ impl FlowView {
     /// overlay carry over.
     pub(crate) fn rotate(&mut self) {
         self.auto_direction = false;
+        // Turning the graph is asking for the layout's arrangement.
+        self.positions.clear();
         self.rebuild(self.direction.rotated());
+    }
+
+    /// Draw a different graph on the same canvas (the editor after an edit):
+    /// selection by id, viewport, direction and toggles carry over;
+    /// `positions` place the boxes.
+    pub(crate) fn replace_graph(&mut self, graph: Arc<StageGraph>, positions: Positions) {
+        self.graph = graph;
+        self.layout = layout::layout(&self.graph);
+        self.positions = positions;
+        let area = self.last_area;
+        self.rebuild(self.direction);
+        // Same area, same camera: a rebuild here is an edit, not a resize.
+        self.last_area = area;
+    }
+
+    /// Where every stage box sits now, for the layout store.
+    pub(crate) fn positions(&self) -> Positions {
+        self.flow
+            .nodes()
+            .filter(|n| !n.id.starts_with("ext:"))
+            .map(|n| (n.id.clone(), (n.position.x, n.position.y)))
+            .collect()
+    }
+
+    /// The mouse's connections and drops since the last call.
+    pub(crate) fn take_events(&mut self) -> Vec<CanvasEvent> {
+        std::mem::take(&mut self.events)
+    }
+
+    /// Mark a stage as named by the problems list, and as having its own
+    /// context layout: the box shows a `!` and a `▣ own context` badge.
+    pub(crate) fn set_flags(&mut self, id: &str, problem: bool, own_layout: bool) {
+        if let Some(content) = self.flow.node_content_mut(id) {
+            content.problem = problem;
+            content.own_layout = own_layout;
+        }
+    }
+
+    /// Bring a stage on screen at the next draw.
+    pub(crate) fn reveal(&mut self, id: &str) {
+        self.reveal = Some(id.to_string());
+    }
+
+    /// Nothing selected: the inspector falls back to the agent.
+    pub(crate) fn clear_selection(&mut self) {
+        self.flow.clear_selection();
+    }
+
+    /// Select the path from one stage to another.
+    pub(crate) fn select_edge(&mut self, from: &str, to: &str) {
+        if let Some(meta) = self
+            .edges
+            .iter()
+            .find(|m| m.edge.from == from && m.edge.to == to)
+        {
+            let id = meta.id.clone();
+            self.flow.clear_selection();
+            self.flow.select_edge(&id);
+        }
     }
 
     /// Which way the layers run.
@@ -357,7 +520,19 @@ impl FlowView {
 
     fn rebuild(&mut self, direction: Direction) {
         let selected = self.flow.first_selected_node_id();
-        let (flow, edges, max_stem) = build(&self.graph, &self.layout, self.locked, direction);
+        let selected_edge = match self.selection() {
+            Selection::Edge(e) => Some((e.from, e.to)),
+            _ => None,
+        };
+        let viewport = self.flow.viewport;
+        let (flow, edges, max_stem) = build(
+            &self.graph,
+            &self.layout,
+            self.locked,
+            direction,
+            self.edit,
+            &self.positions,
+        );
         self.flow = flow;
         self.edges = edges;
         self.max_stem = max_stem;
@@ -368,9 +543,16 @@ impl FlowView {
         self.sync_visibility();
         if let Some(id) = selected {
             self.flow.select_node(&id);
+        } else if let Some((from, to)) = selected_edge {
+            self.select_edge(&from, &to);
         }
-        // Settle again for the current area at the next draw.
-        self.last_area = Rect::default();
+        // An editor keeps its camera across an edit; a rebuild from a turn
+        // settles again for the current area at the next draw.
+        if self.edit {
+            self.flow.viewport = viewport;
+        } else {
+            self.last_area = Rect::default();
+        }
     }
 
     /// The longest edge lane, in rows above or below the nodes.
@@ -564,7 +746,23 @@ impl FlowView {
                 | MouseEventKind::ScrollDown
         );
         if forward {
-            let _ = self.flow.handle_mouse_event(event);
+            let response = self.flow.handle_mouse_event(event);
+            if self.edit {
+                for ev in response.events() {
+                    match ev {
+                        rataflow::FlowEvent::ConnectionCompleted(c) => {
+                            self.events.push(CanvasEvent::Connected {
+                                from: c.source.clone(),
+                                to: c.target.clone(),
+                            });
+                        }
+                        rataflow::FlowEvent::NodeDragEnded { .. } => {
+                            self.events.push(CanvasEvent::Moved);
+                        }
+                        _ => {}
+                    }
+                }
+            }
         }
         forward
     }
@@ -1268,5 +1466,118 @@ merge_stage = "merge"
         // New size: fit again.
         draw(&mut v, 60, 20);
         assert_ne!(v.zoom(), zoomed);
+    }
+
+    #[test]
+    fn an_editor_shows_every_edge_connects_by_mouse_and_reports_it() {
+        let mut v = FlowView::new_editor(graph(), Positions::new());
+        assert!(v.show_all() && v.show_escape());
+        assert!(
+            !v.edge_hidden("implement", "recover"),
+            "escapes show on an editor"
+        );
+        let (_, text) = draw(&mut v, 220, 50);
+        assert!(
+            text.contains("[hint]") || text.contains("[always]"),
+            "{text}"
+        );
+        assert!(text.contains("●"), "handles show: {text}");
+        // Drag from done's source handle onto plan's target handle: a new
+        // connection, reported once and not drawn (the editor adds it).
+        let (_, dy, dr, db) = v.node_rect("done").expect("drawn");
+        let (px, py, _, pb) = v.node_rect("plan").expect("drawn");
+        let from = ((dr - 1) as u16, ((dy + db) / 2) as u16);
+        let to = (px as u16, ((py + pb) / 2) as u16);
+        v.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            from.0,
+            from.1,
+        ));
+        v.handle_mouse(mouse(
+            MouseEventKind::Drag(MouseButton::Left),
+            to.0 + 5,
+            to.1,
+        ));
+        v.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), to.0, to.1));
+        v.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), to.0, to.1));
+        assert_eq!(
+            v.take_events(),
+            vec![CanvasEvent::Connected {
+                from: "done".into(),
+                to: "plan".into()
+            }]
+        );
+        assert!(v.take_events().is_empty(), "taken once");
+        // A pair that already exists is refused by the validator: no event.
+        let (_, py2, pr, pb2) = v.node_rect("plan").expect("drawn");
+        let (ix, iy, _, ib) = v.node_rect("implement").expect("drawn");
+        let from = ((pr - 1) as u16, ((py2 + pb2) / 2) as u16);
+        let to = (ix as u16, ((iy + ib) / 2) as u16);
+        v.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            from.0,
+            from.1,
+        ));
+        v.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), to.0, to.1));
+        v.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), to.0, to.1));
+        assert!(v.take_events().is_empty(), "plan → implement exists");
+        // Dragging a box reports a move, and the positions read back.
+        let (x, y, _, _) = v.node_rect("review").expect("drawn");
+        let (x, y) = (x as u16 + 2, y as u16 + 1);
+        v.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+        v.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x + 8, y + 4));
+        v.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x + 8, y + 4));
+        assert_eq!(v.take_events(), vec![CanvasEvent::Moved]);
+        let positions = v.positions();
+        assert_eq!(positions.len(), 5, "every stage, no ext: nodes");
+        // Flags and selection helpers.
+        v.set_flags("plan", true, true);
+        v.set_flags("ghost", true, true);
+        v.select_stage("plan");
+        let (_, text) = draw(&mut v, 220, 50);
+        assert!(text.contains("! ○ plan"), "{text}");
+        assert!(text.contains("▣ own context"), "{text}");
+        v.clear_selection();
+        assert_eq!(v.selection(), Selection::Nothing);
+        let plan_implement = v
+            .graph()
+            .edges
+            .iter()
+            .find(|e| e.from == "plan" && e.to == "implement")
+            .cloned()
+            .expect("in the graph");
+        v.select_edge("plan", "implement");
+        assert_eq!(v.selection(), Selection::Edge(plan_implement.clone()));
+        v.select_edge("plan", "nowhere");
+        assert_eq!(
+            v.selection(),
+            Selection::Edge(plan_implement.clone()),
+            "an unknown path leaves the selection"
+        );
+        v.reveal("done");
+        draw(&mut v, 220, 50);
+        // Replace the graph: the moved box keeps its place, the camera stays,
+        // the selected edge is selected again.
+        let camera = v.pan();
+        let mut positions = v.positions();
+        let review = positions["review"];
+        // A stage the positions do not know lands right of the rightmost.
+        positions.remove("done");
+        v.replace_graph(graph(), positions.clone());
+        assert_eq!(v.positions()["review"], review);
+        assert_eq!(v.pan(), camera);
+        assert_eq!(v.selection(), Selection::Edge(plan_implement));
+        let done = v.positions()["done"];
+        assert!(
+            done.0 > review.0,
+            "appended to the right: {done:?} vs {review:?}"
+        );
+        // Turning the graph forgets the arrangement.
+        v.rotate();
+        assert_ne!(v.positions()["review"], review);
+        // A rebuild with a stage node selected keeps it.
+        v.select_stage("plan");
+        v.replace_graph(graph(), Positions::new());
+        assert_eq!(v.selection(), Selection::Node("plan".into()));
     }
 }

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -41,6 +41,9 @@ panel and answer. `lev respond` does the same from the shell.
   **Logs**, and **Context** (JSON). Markdown is rendered. `g` opens the graph full screen.
 - **Interactions**: answer an agent's question (free-text, edit, multiple-choice, tool-approval, or
   confirm) or send it a mid-run message.
+- **Agents**: the catalog of agents this machine can run (`a`), and an editor that builds one on
+  the same graph canvas: stages as boxes, paths drawn between them, an inspector for whatever is
+  selected. The same editor The Lair has, in the terminal.
 - **Mouse support**: wheel scroll, click-drag select with copy-on-release, OSC52 copy over SSH,
   `y` to yank a pane, Shift+drag for native selection.
 - **`m`** opens the MCP management screen without leaving the dashboard.
@@ -57,7 +60,8 @@ where `?` would be typed as text: on the new-run screen every printable characte
 filter or the task.
 
 Besides the main list and the detail view below, there is a screen for starting a run (`n`), one for
-MCP servers (`m`), and the stage explorer (`g`, from the detail view).
+your agents and the agent editor (`a`), one for MCP servers (`m`), and the stage explorer (`g`, from
+the detail view).
 
 ### Main list
 
@@ -220,6 +224,78 @@ the cursor, click a stage to select it. While the explorer is open the detail vi
 what the table above says rather than what they mean underneath.
 
 `lev validate --graph <agent>` prints the same picture as plain text.
+
+### Agents (`a`)
+
+The catalog: every agent `lev run` can resolve (installed under `~/.leviath/agents`, configured in
+`agent_paths`, the working directory's own) and the ones bundled in the binary and not installed
+yet. The right half shows the selected agent's graph, what it does, where it lives and its stages.
+An installed bundled agent that has been edited says `edited`, and `r` puts the bundled copy back.
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` (or `k` / `j`), `Home` / `End`, `PgUp` / `PgDn` | Move |
+| `Enter` / `e` | Open the agent in the editor. A bundled agent not installed yet opens from its embedded copy and is installed when saved |
+| `n` | New agent: start from the two-stage starter, or clone any agent in the catalog, under a name you type |
+| `l` | Launch it: the new-run screen with this agent picked |
+| `d` | Delete an installed agent and its directory. Asks first. Agents that live elsewhere are edited in place but deleted where they are |
+| `r` | Reset an edited bundled agent to the copy bundled in the binary. Asks first |
+| `/` | Filter by name or description; `Enter` keeps the filter, `Esc` clears it |
+| `?` / `F1` | Help |
+| `Esc` / `q` | Back to the run list |
+
+### Agent editor
+
+The editor is one screen: the graph on the left, an inspector on the right showing whatever is
+selected on the graph, a problems line under the graph, and a hint bar. Nothing is written until you
+save. The inspector shows one thing at a time: **This agent** when nothing is selected (description,
+which stage a run starts at, the model every stage tries first, the shared context regions), a
+**Stage** (its behaviour: how it works, description, tries, revisits, whether it may finish the run,
+the fan-out settings when it fans out; move it in the file; delete it), or a **Path** (when it is
+taken, the hint the model routes on, whether it needs your approval; delete it). A field that does
+not apply is greyed rather than hidden, so the panel never reflows under the cursor.
+
+Every edit is checked as you make it, the way `lev validate` checks a file: the line under the graph
+says how many errors and warnings there are (`p` opens the list), a stage an error names carries a
+`!` on its box, and saving is refused while there are errors. `u` undoes the last edit, `Ctrl-R`
+redoes it. `v` shows the exact `agent.leviath` that will be saved, comments and all: the editor keeps
+your file's comments, key order and formatting, and only writes the keys it knows.
+
+An arrangement dragged into shape is kept per agent (in `dash/graph-layouts.json` under the data
+directory), so a graph opens the way you left it; it is never part of the manifest.
+
+| Key | Action |
+|---|---|
+| `Ctrl-S` | Save (checks first; errors block it and open the problems list) |
+| `Tab` | Move the keys between the graph and the inspector |
+| `u` / `Ctrl-R` | Undo / redo |
+| `v` | The definition; `y` copies it, `Esc` closes it |
+| `p` | Open or close the problems list under the graph |
+| `?` / `F1` | Help |
+| `Esc` | On the graph: close the editor (asks when there are unsaved edits). On the inspector: back to the graph |
+
+On the graph:
+
+| Key | Action |
+|---|---|
+| `←` `→` `↑` `↓` (or `h` `j` `k` `l`) | Select a stage in that direction; `[` / `]` the previous / next in file order |
+| `Enter` | Edit the selected stage or path in the inspector |
+| `a` | Add a stage after the selected one (asks its name) |
+| `c` | Connect the selected stage to another, picked from a list (or to itself: a loop) |
+| `x` / `Delete` | Delete the selected stage (asks first) or path |
+| `+` / `-` , `0`, `f`, `r` | Zoom, fit, turn the graph |
+| mouse | Click a box or a path to select it, drag a box to move it, drag a `●` handle onto another box to connect them, drag empty canvas to pan, wheel to zoom |
+
+On the inspector:
+
+| Key | Action |
+|---|---|
+| `↑` / `↓` (or `k` / `j`), `Home` / `End` | Move between rows |
+| `Enter` | Edit the row: type into it, choose from a list, flip it, or press the button |
+| `←` / `→` (or `h` / `l`) | Change the row in place: cycle a choice, step a number, flip a toggle |
+| `1` `2` `3` | A stage's tabs: behaviour, model & tools, context |
+
+On a terminal under 110 columns the graph and the inspector take turns; `Tab` swaps them.
 
 ### MCP servers (`m`)
 

--- a/docs/content/first-agent.md
+++ b/docs/content/first-agent.md
@@ -36,7 +36,9 @@ cd release-notes
 
 That writes a directory with an `agent.leviath` file in it, plus a `.gitignore` and a
 `.env.example`. The blueprint it generates is a working one-stage agent. You are going to replace
-it, so open it and delete everything.
+it, so open it and delete everything. (There is also a graph editor for this in the
+[dashboard](/docs/dashboard#agent-editor): `lev dash`, then `a`, then `n`. This page writes the file
+by hand so every key is explained.)
 
 Every agent needs a name and an entry stage. Start there:
 


### PR DESCRIPTION
## What

The Agents screen and the agent editor in `lev dash` (the second of three PRs; #512 was the model underneath). Feature parity with The Lair's blueprint editor is the target; this PR ships the screen, the canvas as an editor, and the This agent / Stage (behaviour) / Path panels; the model & tools and context tabs, the region panel and the prompts editor follow in the third.

- **`a` on the run list opens the Agents screen**: the catalog `lev list` shows (installed, configured, local, bundled-not-installed), with the selected agent's graph, description, location and stages on the right. `Enter` edits, `n` starts a new agent (the two-stage starter, or a clone of any agent, under a name you type, checked as you type), `l` launches it through the new-run screen, `d` deletes an installed one and `r` resets an edited bundled one to the bundle (both ask first), `/` filters.
- **The editor**: the graph on the left, an inspector on the right showing whatever is selected. Boxes are added (`a`), connected (`c` picks a target from a list, or drag a `●` handle onto another box; a loop to itself is a pick), selected (arrows, click), deleted (`x`; a stage asks). The inspector edits fields in place: `Enter` types into a text row, opens the chooser on a choice, flips a toggle, presses a button; `←`/`→` cycle a choice, step a number, flip a toggle without opening anything. Fields that do not apply are greyed, not hidden, so the panel never reflows. Every edit is checked as `lev validate` checks a file: a problems line under the graph (`p` expands it), a `!` on a stage an error names, and saving refused while there are errors. `u`/`Ctrl-R` undo and redo, `v` shows the exact file that will be saved (`y` copies it), `Ctrl-S` saves, `Esc` closes (asks when dirty). Arrangements are kept per agent in `dash/graph-layouts.json`.
- **The canvas as an editor** (`FlowView::new_editor`): handles show and connect, every edge is drawn and labelled with what fires it, saved positions place the boxes (a stage without one lands right of the rightmost), the camera survives an edit, and the mouse's connections and drops come back through `take_events`.

Live at 200x50 (mock provider, real daemon), after `a`, `n`, "Start simple" as `demo`, `a review`, `c finish`:

```
 Agent editor · demo*  (not saved yet)
╭ Graph · a add · c connect · x delete · drag a ● to connect ────────────╮╭ Path · review → finish ───────────────╮
│  ╭ ▶ ○ work ────────────────╮      ╭ ○ finish ──────────╮   ┏ ○ review ┓ ││› When to take it   ‹ model decides (hi… │
│  ●                          ●[hint]● ⏹ can end          ●   ● ⏹ can end ● ││  Hint the model routes on  Continue here… │
│  ╰──────────────────────────╯      ╰────────────────────╯   ┗━━━━━━━━━━┛ ││  Needs your approval  [ ] off            │
 ! 0 errors · 4 warnings · review: cannot be reached from entry stage 'work'    ││  Delete path          ▸                  │
^s save · tab inspector · a add stage · c connect · x delete · enter edit · u undo · ^r redo · v definition · p problems …
```

The saved file passes `lev validate` and runs.

## How

- `commands/dashboard/agents/{mod,catalog,chooser,editor,editor_keys,inspector,render_catalog,render_editor}.rs`, tests in `tests.rs`. `Dashboard.agent_builder: Option<Box<AgentsScreen>>`; the screen is modal like the new-run screen; `PaneId::{AgentsPreview, AgentEditorGraph}`; `ConfirmAction::{AgentDelete, AgentReset, StageDelete, EditorDiscard}`.
- `tui/flowgraph/view.rs`: `new_editor`, `replace_graph`, `positions`, `take_events`, `set_flags`, `reveal`, `select_edge`, `clear_selection`; `build` takes `edit` and positions; handles connectable on an editor; a connection validator refuses a pair that exists. `content.rs`: `problem`/`own_layout` badges. `model.rs`: `editor_label`.
- `blueprint_edit/edges.rs`: a headed `transitions` table turns implicit once it has paths and back when the last goes, so a saved file has no stray empty header.
- `dashboard/run_actions.rs`: kill/delete moved out of `state.rs` for the file ratchet.
- Docs: `dashboard.md` "Agents (a)" and "Agent editor"; `first-agent.md` points at it; help overlay sections; the main list's bar; CHANGELOG.

## Checks

- `cargo xtask coverage --package leviath-cli` 100%; `cargo xtask docs`; clippy `-D warnings`.
- Live pty walkthrough at 200x50 (catalog, chooser, editor: add, connect, inspector edits, problems, definition, undo/redo, save; `lev validate` on the result) and 100x30.
