### PR TITLE
feat(dash): the rest of the agent editor's inspector, prompts, and $EDITOR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ same list.
 
 ## Unreleased
 
-<<<<<<< Updated upstream
 - New: the scripts API manages Rhai model providers. `provider` joins `tool`,
   `region_hook`, `stage_hook` and `output_validator` as a `kind` on
   `GET /api/scripts`, `GET/PUT/DELETE /api/scripts/{kind}/{name}` and
@@ -38,23 +37,29 @@ same list.
   script's `initialize` were printable, where the first-party provider config
   had been careful not to be; the two now agree, reporting whether the key is
   set and the names in the extra table and nothing more.
-=======
 - New: `lev dash` has an Agents screen (`a`): the catalog of agents this
   machine can run, with each one's graph, and an editor that builds one on
   the same canvas the explorer draws. Stages are boxes you add (`a`),
   connect (`c`, or drag a handle), select and delete; an inspector edits
-  whatever is selected (the agent's description, entry stage and default
-  model; a stage's mode, description, tries, revisits, allow-complete and
-  fan-out settings; a path's kind, hint and approval gate). Every edit is
-  checked as `lev validate` would check the file, with the problems on a
-  line under the graph and a `!` on the stage they name; saving is refused
-  while there are errors. Undo and redo, a view of the exact file that
-  will be saved, and arrangements kept per agent. New agents start from a
-  two-stage starter or as a copy of any agent in the catalog; a bundled
-  agent opens from its embedded copy and installs when saved; an edited
-  bundled agent can be reset to the bundle. The editor keeps a file's
-  comments, order and formatting: it edits the manifest as a document.
->>>>>>> Stashed changes
+  whatever is selected: the agent's description, entry stage, default
+  model and shared context regions; a stage's behaviour (mode, description,
+  tries, revisits, allow-complete, fan-out settings, its loop back to
+  itself), its model chain and tools (the models every configured provider
+  reports, on top of the built-in catalog; the tools this install has), and
+  its context (the regions it sees, a layout of its own or the shared one,
+  where tool results land, per-tool routing); a path's kind, hint, approval
+  gate and what context crosses it (everything, pinned only, summarized, or
+  per-region rules with the summary instructions); a context region's every
+  setting. Prompts open full screen, and `Ctrl-E` hands one to `$EDITOR`
+  and takes it back. Every edit is checked as `lev validate` would check
+  the file, with the problems on a line under the graph and a `!` on the
+  stage they name; saving is refused while there are errors. Undo and redo,
+  a view of the exact file that will be saved, and arrangements kept per
+  agent. New agents start from a two-stage starter or as a copy of any
+  agent in the catalog; a bundled agent opens from its embedded copy and
+  installs when saved, scripts and all; an edited bundled agent can be
+  reset to the bundle. The editor keeps a file's comments, order and
+  formatting: it edits the manifest as a document.
 - Fixed: `lev serve`, `lev dash`, and `lev agent-client` ride out a daemon
   restart instead of breaking. A request that lands while the daemon is down
   (a `lev daemon restart`, a supervisor relaunch, or the restart that follows

--- a/crates/leviath-cli/src/blueprint_edit/regions.rs
+++ b/crates/leviath-cli/src/blueprint_edit/regions.rs
@@ -9,7 +9,7 @@ use toml_edit::{InlineTable, Item, Value};
 use super::doc::ManifestDoc;
 use super::stages::set_or_remove_int;
 use super::tables::{
-    child_mut, ensure_child, get_str, remove_and_report_empty, rename_key, set_bool,
+    child_mut, ensure_child, ensure_parent, get_str, remove_and_report_empty, rename_key, set_bool,
     set_or_remove_str, set_str,
 };
 use super::{EditError, require_name};
@@ -218,7 +218,7 @@ impl ManifestDoc {
         }
         let shared: Option<Item> = self.regions_item(None).cloned();
         let stage_item = self.stage_item_mut(stage).expect("require_stage checked");
-        let context = ensure_child(stage_item, "context")?;
+        let context = ensure_parent(stage_item, "context")?;
         let inline = context.is_inline_table();
         let regions = match shared {
             Some(item) if !inline => item,
@@ -304,7 +304,7 @@ impl ManifestDoc {
             }
             return Ok(());
         }
-        let routing = ensure_child(stage_item, "tool_routing")?;
+        let routing = ensure_parent(stage_item, "tool_routing")?;
         let overrides = ensure_child(routing, "overrides")?;
         set_str(
             overrides.as_table_like_mut().expect("ensure_child checked"),
@@ -332,7 +332,7 @@ impl ManifestDoc {
                 .stage_item_mut(name)
                 .ok_or_else(|| EditError::NoSuchStage(name.clone()))?,
         };
-        let context = ensure_child(parent, "context")?;
+        let context = ensure_parent(parent, "context")?;
         ensure_child(context, "regions")
     }
 

--- a/crates/leviath-cli/src/blueprint_edit/tables.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tables.rs
@@ -48,6 +48,22 @@ pub(super) fn ensure_child<'a>(item: &'a mut Item, key: &str) -> Result<&'a mut 
     Ok(child)
 }
 
+/// Like [`ensure_child`], for a table that only exists to hold other
+/// tables (`context` over `regions`, `tool_routing` over `overrides`): a new
+/// one is implicit, so the file does not get an empty `[stages.x.context]`
+/// header above `[stages.x.context.regions]`.
+pub(super) fn ensure_parent<'a>(item: &'a mut Item, key: &str) -> Result<&'a mut Item, EditError> {
+    let fresh = !item
+        .as_table_like()
+        .expect("callers pass a table")
+        .contains_key(key);
+    let child = ensure_child(item, key)?;
+    if fresh && let Some(table) = child.as_table_mut() {
+        table.set_implicit(true);
+    }
+    Ok(child)
+}
+
 /// An empty table of the shape a parent uses.
 pub(super) fn new_table(inline: bool) -> Item {
     if inline {

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
@@ -11,7 +11,8 @@ use super::super::types::*;
 use super::inspector::{self, Field, FieldId, FieldValue, Panel, StageTab};
 use crate::blueprint_edit::check::{Problems, check};
 use crate::blueprint_edit::{
-    EdgeKind, EditError, LayoutStore, ManifestDoc, StageModeView, WorkerKind, catalog,
+    EdgeKind, EditError, LayoutStore, ManifestDoc, StageModeView, TransformKind, WorkerKind,
+    catalog,
 };
 use crate::tui::flowgraph::{FlowView, Selection, StageGraph};
 use crate::tui::widgets::confirm::Confirm;
@@ -34,13 +35,25 @@ pub(in crate::commands::dashboard) enum PickerFor {
     Field(FieldId),
     /// The other end of a new path from this stage.
     ConnectFrom(String),
+    /// A model to append to the chain.
+    AddModel,
+    /// A model to put in place of the chain's `n`th.
+    ReplaceModel(usize),
+    /// The stage's tools (many).
+    Tools,
+    /// Which tool to route.
+    RoutingTool,
+    /// Where a tool's results land.
+    RoutingRegion(String),
 }
 
 /// A full-screen overlay over the editor.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(in crate::commands::dashboard) enum Overlay {
     /// The exact manifest that will be saved, scrolled by `scroll` lines.
     Definition { scroll: usize },
+    /// A stage's prompts.
+    Prompts(Box<super::prompts::PromptsEditor>),
 }
 
 /// What is being opened.
@@ -66,6 +79,9 @@ pub(in crate::commands::dashboard) struct Editor {
     pub(in crate::commands::dashboard) name: String,
     /// Not saved anywhere yet.
     pub(in crate::commands::dashboard) is_new: bool,
+    /// The directory was made at open, only so the lint could see a
+    /// bundled agent's scripts; closing without a save removes it again.
+    pub(in crate::commands::dashboard) scratch_dir: bool,
     /// Where `agent.leviath` is written.
     pub(in crate::commands::dashboard) dir: PathBuf,
     pub(in crate::commands::dashboard) doc: ManifestDoc,
@@ -84,6 +100,11 @@ pub(in crate::commands::dashboard) struct Editor {
     pub(in crate::commands::dashboard) picker: Option<(PickerFor, Picker)>,
     /// The name of a stage about to be added.
     pub(in crate::commands::dashboard) add_stage: Option<LineEdit>,
+    /// The name of a region about to be added.
+    pub(in crate::commands::dashboard) add_region: Option<LineEdit>,
+    /// The canvas selection a pushed panel (a region, a stage's loop back
+    /// to itself) was opened from: the panel stays while it holds.
+    pub(in crate::commands::dashboard) panel_anchor: Option<Selection>,
     pub(in crate::commands::dashboard) overlay: Option<Overlay>,
     pub(in crate::commands::dashboard) problems: Problems,
     /// The problems list expanded under the canvas.
@@ -94,6 +115,23 @@ pub(in crate::commands::dashboard) struct Editor {
     pub(in crate::commands::dashboard) message: Option<String>,
     /// `provider/model` ids the model chooser offers.
     pub(in crate::commands::dashboard) models: Vec<String>,
+    /// Tool names the tools chooser offers.
+    pub(in crate::commands::dashboard) tools: Vec<String>,
+    /// Where the last frame put the inspector's rows: the screen row of
+    /// each field, and the column span of each stage tab, so a click lands
+    /// on the right one.
+    pub(in crate::commands::dashboard) hit: InspectorHits,
+}
+
+/// What the inspector drew last, for the mouse.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(in crate::commands::dashboard) struct InspectorHits {
+    /// The inspector's area (border included).
+    pub(in crate::commands::dashboard) area: ratatui::layout::Rect,
+    /// The screen row each field sits on, in field order.
+    pub(in crate::commands::dashboard) rows: Vec<u16>,
+    /// The screen row of the stage tab bar, and each tab's `[x0, x1)`.
+    pub(in crate::commands::dashboard) tabs: Option<(u16, Vec<(u16, u16)>)>,
 }
 
 /// Snapshots kept for undo.
@@ -139,6 +177,17 @@ impl Editor {
     /// Bring the panel in line with the canvas selection, keeping a stage
     /// panel's tab across stages.
     pub(in crate::commands::dashboard) fn sync_panel(&mut self) {
+        // A pushed panel (a region, a loop back to the same stage) stays
+        // while the selection that opened it holds and what it shows exists.
+        let pushed = match &self.panel {
+            Panel::Region { scope, name, .. } => self.doc.region(scope.stage(), name).is_some(),
+            Panel::Edge { from, to } if from == to => self.doc.edge(from, to).is_some(),
+            _ => false,
+        };
+        if pushed && self.panel_anchor.as_ref() == Some(&self.view.selection()) {
+            return;
+        }
+        self.panel_anchor = None;
         let tab = match &self.panel {
             Panel::Stage { tab, .. } => *tab,
             _ => StageTab::Behaviour,
@@ -285,14 +334,16 @@ impl Dashboard {
                 (name, true, dir, bundled_from)
             }
         };
-        // A copy of a bundled agent brings its scripts along now, so the
-        // lint sees the tools they define; an unsaved new agent's directory
-        // is removed again when the editor closes without saving.
-        if is_new
-            && !dir.exists()
+        // A bundled agent not installed yet (edited as itself, or as the
+        // start of a new one) brings its scripts along now, so the lint sees
+        // the tools they define and a save leaves a complete install; the
+        // directory is removed again when the editor closes without saving.
+        let mut scratch_dir = false;
+        if !dir.exists()
             && let Some(from) = bundled_from.as_deref().and_then(catalog::bundled)
         {
             let _ = catalog::copy_bundled_extras(&self.new_run_ctx.agents_dir, &name, from);
+            scratch_dir = true;
         }
         let layout = self.layout_store();
         let positions = layout.positions(&name).cloned().unwrap_or_default();
@@ -304,11 +355,28 @@ impl Dashboard {
             .map(|(p, m)| format!("{p}/{m}"))
             .collect();
         models.extend(doc.known_models());
+        models.extend(
+            self.agent_builder
+                .as_deref()
+                .map(|s| s.model_catalog.clone())
+                .unwrap_or_default(),
+        );
         models.sort();
         models.dedup();
+        // The tools this install has: built in, plus scripts under the
+        // agent's directory and the ones the manifest already names.
+        let mut tools: Vec<String> =
+            crate::tool_inventory::ToolInventory::discover(Some(&dir), Some(&name))
+                .names()
+                .into_iter()
+                .collect();
+        tools.extend(doc.known_tools());
+        tools.sort();
+        tools.dedup();
         let mut editor = Editor {
             name,
             is_new,
+            scratch_dir,
             dir,
             doc,
             undo: Vec::new(),
@@ -321,6 +389,8 @@ impl Dashboard {
             line: None,
             picker: None,
             add_stage: None,
+            add_region: None,
+            panel_anchor: None,
             overlay: None,
             problems,
             problems_open: false,
@@ -328,6 +398,8 @@ impl Dashboard {
             dirty: is_new,
             message: None,
             models,
+            tools,
+            hit: InspectorHits::default(),
         };
         editor.apply_flags();
         self.agents().editor = Some(editor);
@@ -421,7 +493,7 @@ impl Dashboard {
             (
                 editor.name.clone(),
                 editor.view.positions(),
-                editor.is_new.then(|| editor.dir.clone()),
+                editor.scratch_dir.then(|| editor.dir.clone()),
             )
         };
         {
@@ -429,7 +501,7 @@ impl Dashboard {
             editor.layout.set(&name, positions);
             let _ = editor.layout.save();
         }
-        // A new agent never saved leaves nothing behind (its scripts were
+        // An agent never saved leaves nothing behind (its scripts were
         // materialised for the lint's sake).
         if let Some(dir) = unsaved_dir
             && !dir.join("agent.leviath").exists()
@@ -458,8 +530,9 @@ impl Dashboard {
             }
             FieldValue::Toggle(on) => self.editor_set_toggle(&field.id, !on),
             FieldValue::Choice(_) => self.editor_open_choice(&field.id),
-            FieldValue::Row(_) => {}
+            FieldValue::Row(_) => self.editor_open_row(&field.id),
             FieldValue::Button => self.editor_button(&field.id),
+            FieldValue::Segment { .. } => self.editor_cycle_segment(&field.id, 1),
         }
     }
 
@@ -492,7 +565,13 @@ impl Dashboard {
                 let at = at.rem_euclid(options.len() as isize) as usize;
                 self.editor_pick(&field.id, &options[at]);
             }
-            FieldValue::Text(_) | FieldValue::Row(_) | FieldValue::Button => {}
+            FieldValue::Segment { .. } => self.editor_cycle_segment(&field.id, delta),
+            FieldValue::Row(_) => {
+                if let FieldId::ModelEntry(i) = field.id {
+                    self.editor_move_model(i, delta);
+                }
+            }
+            FieldValue::Text(_) | FieldValue::Button => {}
         }
     }
 
@@ -506,7 +585,7 @@ impl Dashboard {
                 let (from, to) = self.editor().panel_edge().expect("a path field");
                 self.editor_mutate(|d| d.set_edge_gate(&from, &to, on));
             }
-            _ => {}
+            _ => self.editor_set_toggle_more(id, on),
         }
     }
 
@@ -515,6 +594,9 @@ impl Dashboard {
         id: &FieldId,
         value: Option<u64>,
     ) {
+        if self.editor_set_number_more(id, value) {
+            return;
+        }
         let stage = self.editor().panel_stage().expect("a stage field");
         match id {
             FieldId::MaxIterations => {
@@ -622,7 +704,7 @@ impl Dashboard {
                     .and_then(|e| EdgeKind::CHOICES.iter().position(|k| *k == e.kind));
                 (options, current)
             }
-            _ => (Vec::new(), None),
+            _ => self.editor_choice_options_more(id),
         }
     }
 
@@ -633,6 +715,27 @@ impl Dashboard {
             return;
         }
         let (title, explain, details): (&str, &str, Vec<String>) = match id {
+            FieldId::RoutingDefault => (
+                "Tool results land in",
+                "Where a tool's output goes unless a row says otherwise.",
+                vec![],
+            ),
+            FieldId::EdgeTransform => (
+                "Context carried over",
+                "What crosses the path with the run. Pinned regions always do.",
+                TransformKind::CHOICES
+                    .iter()
+                    .map(|t| t.label().to_string())
+                    .collect(),
+            ),
+            FieldId::RegionKind => (
+                "How the region behaves",
+                "What the runtime does with it as the window fills.",
+                inspector::REGION_KINDS
+                    .iter()
+                    .map(|(_, h)| h.to_string())
+                    .collect(),
+            ),
             FieldId::EntryStage => ("Starts at", "The stage a run begins in.", vec![]),
             FieldId::DefaultModel => (
                 "Default model",
@@ -750,7 +853,7 @@ impl Dashboard {
                     .expect("an offered kind");
                 self.editor_mutate(|d| d.set_edge_kind(&from, &to, kind));
             }
-            _ => {}
+            _ => self.editor_pick_more(id, &value),
         }
     }
 
@@ -770,7 +873,7 @@ impl Dashboard {
                 let (from, to) = self.editor().panel_edge().expect("a path field");
                 self.editor_delete_edge(&from, &to);
             }
-            _ => {}
+            _ => self.editor_button_more(id),
         }
     }
 
@@ -829,9 +932,20 @@ impl Dashboard {
             }
             FieldId::StageName => {
                 let stage = self.editor().panel_stage().expect("a stage field");
+                // The box keeps its place under the new name.
+                let positions = self
+                    .editor()
+                    .view
+                    .positions()
+                    .into_iter()
+                    .map(|(id, at)| (if id == stage { text.clone() } else { id }, at))
+                    .collect();
                 if self.editor_mutate(|d| d.rename_stage(&stage, &text)) {
-                    self.editor().view.select_stage(&text);
-                    self.editor().sync_panel();
+                    let editor = self.editor();
+                    let graph = editor.graph.clone();
+                    editor.view.replace_graph(graph, positions);
+                    editor.view.select_stage(&text);
+                    editor.sync_panel();
                 }
             }
             FieldId::StageDescription => {
@@ -843,7 +957,11 @@ impl Dashboard {
             FieldId::MaxIterations
             | FieldId::MaxRevisits
             | FieldId::MaxWorkers
-            | FieldId::MaxItems => {
+            | FieldId::MaxItems
+            | FieldId::RegionBudget
+            | FieldId::RegionMaxTokens
+            | FieldId::RegionMaxItems
+            | FieldId::RegionOverflow => {
                 let value = match text.parse::<u64>() {
                     Ok(n) => Some(n),
                     Err(_) if text.is_empty() => None,
@@ -871,7 +989,7 @@ impl Dashboard {
                 let (from, to) = self.editor().panel_edge().expect("a path field");
                 self.editor_mutate(|d| d.set_edge_hint(&from, &to, &text));
             }
-            _ => {}
+            _ => self.editor_commit_line_more(id, &text),
         }
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_keys.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_keys.rs
@@ -2,7 +2,7 @@
 //! an overlay, the canvas, the inspector), and the canvas operations that
 //! change the graph.
 
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
 use ratatui::layout::Rect;
 
 use super::super::state::Dashboard;
@@ -16,10 +16,17 @@ impl Dashboard {
     /// Keys while the editor is open.
     pub(in crate::commands::dashboard) fn handle_editor_key(&mut self, key: KeyEvent) {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        // A message answers one key; the next key clears it.
+        self.editor().message = None;
         // Save works from anywhere in the editor, chooser and all: what is
-        // in the document is what is saved.
+        // in the document is what is saved. The prompts overlay is the one
+        // place it means "apply these": its text is not in the document yet.
         if ctrl && key.code == KeyCode::Char('s') {
-            self.editor_save();
+            if matches!(self.editor().overlay, Some(Overlay::Prompts(_))) {
+                self.editor_prompts_key(&key);
+            } else {
+                self.editor_save();
+            }
             return;
         }
         if self.editor().picker.is_some() {
@@ -28,6 +35,10 @@ impl Dashboard {
         }
         if self.editor().add_stage.is_some() {
             self.editor_add_stage_key(&key);
+            return;
+        }
+        if self.editor().add_region.is_some() {
+            self.editor_add_region_key(&key);
             return;
         }
         if self.editor().line.is_some() {
@@ -103,7 +114,14 @@ impl Dashboard {
     /// Keys on the inspector.
     fn editor_inspector_key(&mut self, code: KeyCode) {
         match code {
-            KeyCode::Esc => self.editor().focus = Focus::Canvas,
+            KeyCode::Esc => {
+                if self.editor().panel_anchor.is_some() {
+                    self.editor_leave_region();
+                } else {
+                    self.editor().focus = Focus::Canvas;
+                }
+            }
+            KeyCode::Char('x') | KeyCode::Delete => self.editor_remove_row(),
             KeyCode::Up | KeyCode::Char('k') => {
                 let editor = self.editor();
                 editor.cursor = editor.cursor.saturating_sub(1);
@@ -172,6 +190,21 @@ impl Dashboard {
         }
     }
 
+    /// Keys while the name of a new region is being typed.
+    fn editor_add_region_key(&mut self, key: &KeyEvent) {
+        let mut line = self.editor().add_region.take().expect("callers check");
+        match line.handle_key(key) {
+            EditOutcome::Pending => self.editor().add_region = Some(line),
+            EditOutcome::Cancel => {}
+            EditOutcome::Commit => {
+                let name = line.value().trim().to_string();
+                if !name.is_empty() {
+                    self.editor_add_region(&name);
+                }
+            }
+        }
+    }
+
     /// Keys on the chooser.
     fn editor_picker_key(&mut self, key: &KeyEvent) {
         let (purpose, mut picker) = self.editor().picker.take().expect("callers check");
@@ -196,24 +229,80 @@ impl Dashboard {
         true
     }
 
+    /// A click on the inspector: the row under it takes the cursor and the
+    /// keys; a click on a stage tab switches to it; a second click on the
+    /// row the cursor is on opens it, like Enter.
+    pub(in crate::commands::dashboard) fn editor_inspector_mouse(
+        &mut self,
+        event: MouseEvent,
+    ) -> bool {
+        let Some(editor) = self.agents().editor.as_mut() else {
+            return false;
+        };
+        if editor.overlay.is_some() || editor.line.is_some() || editor.add_stage.is_some() {
+            return false;
+        }
+        if event.kind != MouseEventKind::Down(MouseButton::Left) {
+            return false;
+        }
+        let hit = editor.hit.clone();
+        let inside = event.column >= hit.area.x
+            && event.column < hit.area.x + hit.area.width
+            && event.row >= hit.area.y
+            && event.row < hit.area.y + hit.area.height;
+        if !inside {
+            return false;
+        }
+        if let Some((tab_row, tabs)) = &hit.tabs
+            && event.row == *tab_row
+            && let Some(i) = tabs
+                .iter()
+                .position(|(x0, x1)| event.column >= *x0 && event.column < *x1)
+            && let Panel::Stage { name, .. } = &editor.panel
+        {
+            editor.panel = Panel::Stage {
+                name: name.clone(),
+                tab: StageTab::ALL[i],
+            };
+            editor.cursor = 0;
+            editor.focus = Focus::Inspector;
+            return true;
+        }
+        let was = (editor.focus, editor.cursor);
+        editor.focus = Focus::Inspector;
+        if let Some(i) = hit.rows.iter().position(|y| *y == event.row) {
+            editor.cursor = i;
+            if was == (Focus::Inspector, i) {
+                self.editor_activate();
+            }
+        }
+        true
+    }
+
     fn editor_settle_picker(&mut self, purpose: PickerFor, picker: Picker, outcome: PickerOutcome) {
         match outcome {
             PickerOutcome::Pending => self.editor().picker = Some((purpose, picker)),
-            PickerOutcome::Cancelled | PickerOutcome::ChosenMany(_) => {}
+            PickerOutcome::Cancelled => {}
+            PickerOutcome::ChosenMany(chosen) => self.editor_settle_tools(&chosen),
             PickerOutcome::Chosen(index) => {
                 let value = picker.options[index].value.clone();
                 match purpose {
                     PickerFor::Field(id) => self.editor_pick(&id, &value),
                     PickerFor::ConnectFrom(from) => self.editor_connect(&from, &value),
+                    other => self.editor_settle_more(other, &value),
                 }
             }
         }
     }
 
-    /// Keys on an overlay: the definition scrolls and closes.
+    /// Keys on an overlay: the prompts edit, the definition scrolls and
+    /// closes.
     fn editor_overlay_key(&mut self, key: &KeyEvent) {
         let editor = self.editor();
-        let Overlay::Definition { scroll } = editor.overlay.as_mut().expect("callers check");
+        let Some(Overlay::Definition { scroll }) = editor.overlay.as_mut() else {
+            self.editor_prompts_key(key);
+            return;
+        };
         match key.code {
             KeyCode::Esc | KeyCode::Char('v') | KeyCode::Char('q') => editor.overlay = None,
             KeyCode::Up | KeyCode::Char('k') => *scroll = scroll.saturating_sub(1),
@@ -282,12 +371,12 @@ impl Dashboard {
     pub(in crate::commands::dashboard) fn editor_connect(&mut self, from: &str, to: &str) {
         let (from, to) = (from.to_string(), to.to_string());
         if self.editor_mutate(|d| d.add_edge(&from, &to)) {
-            let editor = self.editor();
             if from == to {
-                editor.view.select_stage(&from);
-            } else {
-                editor.view.select_edge(&from, &to);
+                self.editor_open_self_loop(&from);
+                return;
             }
+            let editor = self.editor();
+            editor.view.select_edge(&from, &to);
             editor.sync_panel();
             editor.focus = Focus::Inspector;
         }
@@ -298,7 +387,7 @@ impl Dashboard {
         match self.editor().panel.clone() {
             Panel::Stage { name, .. } => self.editor_request_delete_stage(&name),
             Panel::Edge { from, to } => self.editor_delete_edge(&from, &to),
-            Panel::Agent | Panel::External(_) => {
+            Panel::Agent | Panel::External(_) | Panel::Region { .. } => {
                 self.editor().message = Some("Select a stage or a path to delete".to_string());
             }
         }

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
@@ -1,0 +1,621 @@
+//! The inspector's other panels: a stage's model chain and tools, its
+//! context layout and tool routing, a region, and a path's transform. The
+//! core (`editor.rs`) hands a field it does not know to the `*_more`
+//! functions here.
+
+use std::collections::BTreeSet;
+
+use super::super::state::Dashboard;
+use super::super::types::ConfirmAction;
+use super::editor::PickerFor;
+use super::inspector::{FieldId, Panel, REGION_KINDS};
+use crate::blueprint_edit::{RegionField, RegionScope, RegionValue, Rule, TransformKind};
+use crate::tui::widgets::confirm::Confirm;
+use crate::tui::widgets::line_edit::LineEdit;
+use crate::tui::widgets::picker::{Picker, PickerOption};
+use ratatui::text::Line;
+
+/// `200k`, `1M`, `1.5M`: a context window as the picker shows it.
+pub(super) fn window_label(tokens: usize) -> String {
+    if tokens >= 1_000_000 {
+        let m = tokens as f64 / 1_000_000.0;
+        let text = format!("{m:.1}");
+        format!("{}M", text.trim_end_matches(".0"))
+    } else {
+        format!("{}k", tokens / 1000)
+    }
+}
+
+/// The regions a stage's tool routing may name: its effective layout plus
+/// the regions the runtime always provides.
+const ALWAYS_VISIBLE: [&str; 4] = [
+    "conversation",
+    "tool_results",
+    "final_output",
+    "stage_instructions",
+];
+
+impl Dashboard {
+    /// The scope of the region panel, when the inspector is on one.
+    fn panel_region(&mut self) -> Option<(RegionScope, String)> {
+        match &self.editor().panel {
+            Panel::Region { scope, name, .. } => Some((scope.clone(), name.clone())),
+            _ => None,
+        }
+    }
+
+    /// A toggle the core does not know: the region's `required`.
+    pub(super) fn editor_set_toggle_more(&mut self, id: &FieldId, on: bool) {
+        if *id == FieldId::RegionRequired
+            && let Some((scope, name)) = self.panel_region()
+        {
+            self.editor_mutate(|d| {
+                d.set_region_field(&scope, &name, RegionField::Required, RegionValue::Flag(on))
+            });
+        }
+    }
+
+    /// A number the core does not know: the region's sizes.
+    pub(super) fn editor_set_number_more(&mut self, id: &FieldId, value: Option<u64>) -> bool {
+        let field = match id {
+            FieldId::RegionBudget => RegionField::BudgetPercent,
+            FieldId::RegionMaxTokens => RegionField::MaxTokens,
+            FieldId::RegionMaxItems => RegionField::MaxItems,
+            FieldId::RegionOverflow => RegionField::Overflow,
+            _ => return false,
+        };
+        if let Some((scope, name)) = self.panel_region() {
+            self.editor_mutate(|d| {
+                d.set_region_field(&scope, &name, field, RegionValue::Number(value))
+            });
+        }
+        true
+    }
+
+    /// Choices the core does not know: the routing default, the transform,
+    /// the region kind.
+    pub(super) fn editor_choice_options_more(
+        &mut self,
+        id: &FieldId,
+    ) -> (Vec<String>, Option<usize>) {
+        match id {
+            FieldId::RoutingDefault => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let options = self.routing_regions(&stage);
+                let current = self
+                    .editor()
+                    .doc
+                    .tool_routing(&stage)
+                    .default_region
+                    .and_then(|r| options.iter().position(|o| *o == r))
+                    .or(Some(0));
+                (options, current)
+            }
+            FieldId::EdgeTransform => {
+                let (from, to) = self.editor().panel_edge().expect("a path field");
+                let options: Vec<String> = TransformKind::CHOICES
+                    .iter()
+                    .map(|t| t.as_str().to_string())
+                    .collect();
+                let current = self.editor().doc.edge(&from, &to).and_then(|e| {
+                    TransformKind::CHOICES
+                        .iter()
+                        .position(|t| *t == e.transform)
+                });
+                (options, current)
+            }
+            FieldId::RegionKind => {
+                let options: Vec<String> =
+                    REGION_KINDS.iter().map(|(k, _)| k.to_string()).collect();
+                let current = self
+                    .panel_region()
+                    .and_then(|(scope, name)| self.editor().doc.region(scope.stage(), &name))
+                    .and_then(|r| options.iter().position(|o| *o == r.kind));
+                (options, current)
+            }
+            _ => (Vec::new(), None),
+        }
+    }
+
+    /// `(default)` then every region the stage's routing may name.
+    fn routing_regions(&mut self, stage: &str) -> Vec<String> {
+        let mut options = vec!["(default)".to_string()];
+        options.extend(
+            self.editor()
+                .doc
+                .effective_regions(Some(stage))
+                .regions
+                .into_iter()
+                .map(|r| r.name),
+        );
+        for always in ALWAYS_VISIBLE {
+            if !options.iter().any(|o| o == always) {
+                options.push(always.to_string());
+            }
+        }
+        options
+    }
+
+    /// A pick the core does not know.
+    pub(super) fn editor_pick_more(&mut self, id: &FieldId, value: &str) {
+        let value = value.to_string();
+        match id {
+            FieldId::RoutingDefault => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let region = if value == "(default)" {
+                    String::new()
+                } else {
+                    value
+                };
+                self.editor_mutate(|d| d.set_tool_routing_default(&stage, &region));
+            }
+            FieldId::EdgeTransform => {
+                let (from, to) = self.editor().panel_edge().expect("a path field");
+                let kind = TransformKind::parse(&value);
+                self.editor_mutate(|d| d.set_transform(&from, &to, &kind));
+            }
+            FieldId::RegionKind => {
+                if let Some((scope, name)) = self.panel_region() {
+                    self.editor_mutate(|d| {
+                        d.set_region_field(
+                            &scope,
+                            &name,
+                            RegionField::Kind,
+                            RegionValue::Text(value),
+                        )
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// A button the core does not know.
+    pub(super) fn editor_button_more(&mut self, id: &FieldId) {
+        match id {
+            FieldId::EditPrompts => self.editor_open_prompts(),
+            FieldId::AddModel => self.editor_open_model_picker(PickerFor::AddModel),
+            FieldId::AddRegion => {
+                self.editor().add_region = Some(LineEdit::new(String::new(), false));
+            }
+            FieldId::OwnLayout => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                if self.editor().doc.effective_regions(Some(&stage)).inherited {
+                    self.editor_mutate(|d| d.create_stage_override(&stage));
+                } else {
+                    let dialog = Confirm::new(
+                        "Remove its own layout?",
+                        vec![Line::from(format!(
+                            "Drop {stage}'s own context regions and go back to the shared layout?"
+                        ))],
+                        "Remove",
+                        "Keep",
+                    )
+                    .danger();
+                    self.pending_confirm = Some((ConfirmAction::OverrideRemove { stage }, dialog));
+                }
+            }
+            FieldId::AddRouting => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let routed = self.editor().doc.tool_routing(&stage);
+                let tools: Vec<String> = self
+                    .editor()
+                    .doc
+                    .stage(&stage)
+                    .map(|s| s.tools)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .filter(|t| !routed.overrides.iter().any(|(r, _)| r == t))
+                    .collect();
+                if tools.is_empty() {
+                    self.editor().message = Some(
+                        "Every tool this stage has is routed already; give it a tool first"
+                            .to_string(),
+                    );
+                    return;
+                }
+                let rows = tools
+                    .into_iter()
+                    .map(|value| PickerOption {
+                        value,
+                        detail: String::new(),
+                    })
+                    .collect();
+                let picker = Picker::new(
+                    "Route which tool?",
+                    vec!["Its results will land in a region of their own.".to_string()],
+                    rows,
+                    0,
+                );
+                self.editor().picker = Some((PickerFor::RoutingTool, picker));
+            }
+            FieldId::DeleteRegion => {
+                let Some((scope, name)) = self.panel_region() else {
+                    return;
+                };
+                let routed = self.editor().doc.stages_routing_into(&name);
+                let mut lines = vec![Line::from(format!("Delete the region '{name}'?"))];
+                if !routed.is_empty() {
+                    lines.push(Line::from(format!(
+                        "Tool results of {} land in it; that routing goes too.",
+                        routed.join(", ")
+                    )));
+                }
+                let dialog = Confirm::new("Delete region?", lines, "Delete", "Cancel").danger();
+                self.pending_confirm = Some((ConfirmAction::RegionDelete { scope, name }, dialog));
+            }
+            _ => {}
+        }
+    }
+
+    /// The confirmed region delete.
+    pub(in crate::commands::dashboard) fn editor_delete_region(
+        &mut self,
+        scope: &RegionScope,
+        name: &str,
+    ) {
+        let (scope, name) = (scope.clone(), name.to_string());
+        // Where the panel came from, taken before the refresh forgets it.
+        let back = match &self.editor().panel {
+            Panel::Region { back, .. } => Some((**back).clone()),
+            _ => None,
+        };
+        if self.editor_mutate(|d| d.delete_region(&scope, &name))
+            && let Some(back) = back
+        {
+            let editor = self.editor();
+            editor.panel = back;
+            editor.panel_anchor = None;
+            editor.cursor = 0;
+        }
+    }
+
+    /// The confirmed removal of a stage's own layout.
+    pub(in crate::commands::dashboard) fn editor_remove_override(&mut self, stage: &str) {
+        let stage = stage.to_string();
+        self.editor_mutate(|d| d.remove_stage_override(&stage));
+    }
+
+    /// A typed line the core does not know.
+    pub(super) fn editor_commit_line_more(&mut self, id: &FieldId, text: &str) {
+        let text = text.to_string();
+        match id {
+            FieldId::CompactPrompt => {
+                let (from, to) = self.editor().panel_edge().expect("a path field");
+                self.editor_mutate(|d| d.set_compact_prompt(&from, &to, &text));
+            }
+            FieldId::RegionName => {
+                let Some((scope, name)) = self.panel_region() else {
+                    return;
+                };
+                // The panel follows the new name before the document changes,
+                // so the refresh finds the region it shows; a refusal puts
+                // the old name back.
+                self.set_region_panel_name(&text);
+                if !self.editor_mutate(|d| d.rename_region(&scope, &name, &text)) {
+                    self.set_region_panel_name(&name);
+                }
+            }
+            FieldId::RegionStrategy
+            | FieldId::RegionMessage
+            | FieldId::RegionSeed
+            | FieldId::RegionDescription => {
+                let field = match id {
+                    FieldId::RegionStrategy => RegionField::Strategy,
+                    FieldId::RegionMessage => RegionField::RequiredMessage,
+                    FieldId::RegionSeed => RegionField::Seed,
+                    _ => RegionField::Description,
+                };
+                if let Some((scope, name)) = self.panel_region() {
+                    self.editor_mutate(|d| {
+                        d.set_region_field(&scope, &name, field, RegionValue::Text(text))
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// The name the region panel shows.
+    pub(super) fn set_region_panel_name(&mut self, name: &str) {
+        if let Panel::Region { name: shown, .. } = &mut self.editor().panel {
+            *shown = name.to_string();
+        }
+    }
+
+    /// Enter on a row: a region opens its panel, a model entry swaps it, the
+    /// tools open the multi-chooser, a routing row changes its region.
+    pub(super) fn editor_open_row(&mut self, id: &FieldId) {
+        match id {
+            FieldId::RegionRow(name) => {
+                self.editor_open_region(RegionScope::Shared, name);
+            }
+            FieldId::StageRegionRow(name) => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let scope = if self.editor().doc.effective_regions(Some(&stage)).inherited {
+                    RegionScope::Shared
+                } else {
+                    RegionScope::Stage(stage)
+                };
+                self.editor_open_region(scope, name);
+            }
+            FieldId::ModelEntry(i) => self.editor_open_model_picker(PickerFor::ReplaceModel(*i)),
+            // The empty chain reads as a model row; Enter still adds.
+            FieldId::AddModel => self.editor_open_model_picker(PickerFor::AddModel),
+            FieldId::ToolSet => self.editor_open_tools_picker(),
+            FieldId::RoutingRow(tool) => self.editor_open_routing_region_picker(tool),
+            FieldId::SelfLoop => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                self.editor_open_self_loop(&stage);
+            }
+            _ => {}
+        }
+    }
+
+    /// `x` on a row: drop a model from the chain, stop routing a tool.
+    pub(super) fn editor_remove_row(&mut self) {
+        let Some(field) = self.editor().current_field() else {
+            return;
+        };
+        match field.id {
+            FieldId::ModelEntry(i) => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let chain: Vec<String> = self
+                    .editor()
+                    .doc
+                    .stage(&stage)
+                    .map(|s| s.models)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .enumerate()
+                    .filter(|(j, _)| *j != i)
+                    .map(|(_, m)| m)
+                    .collect();
+                self.editor_mutate(|d| d.set_models(&stage, &chain));
+            }
+            FieldId::RoutingRow(tool) => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                self.editor_mutate(|d| d.set_tool_routing_override(&stage, &tool, ""));
+            }
+            _ => {}
+        }
+    }
+
+    /// `←`/`→` on a model entry: move it in the chain.
+    pub(super) fn editor_move_model(&mut self, index: usize, delta: isize) {
+        let stage = self.editor().panel_stage().expect("a stage field");
+        let mut chain = self
+            .editor()
+            .doc
+            .stage(&stage)
+            .map(|s| s.models)
+            .unwrap_or_default();
+        let to = index as isize + delta;
+        if index >= chain.len() || to < 0 || to as usize >= chain.len() {
+            return;
+        }
+        chain.swap(index, to as usize);
+        // The stage is the one the panel shows, so the write cannot be
+        // refused; the cursor follows the entry.
+        self.editor_mutate(|d| d.set_models(&stage, &chain));
+        let editor = self.editor();
+        editor.cursor = (editor.cursor as isize + delta) as usize;
+    }
+
+    /// `←`/`→`/Enter on a segment: the next rule for the region.
+    pub(super) fn editor_cycle_segment(&mut self, id: &FieldId, delta: isize) {
+        let FieldId::TransformRule(region) = id else {
+            return;
+        };
+        let (from, to) = self.editor().panel_edge().expect("a path field");
+        let Some(edge) = self.editor().doc.edge(&from, &to) else {
+            return;
+        };
+        let current = Rule::ALL.iter().position(|r| match r {
+            Rule::Carry => edge.rules.carry.contains(region),
+            Rule::Compact => edge.rules.compact.contains(region),
+            Rule::Clear => edge.rules.clear.contains(region),
+        });
+        let next = match current {
+            Some(i) => (i as isize + delta).rem_euclid(Rule::ALL.len() as isize) as usize,
+            None if delta < 0 => Rule::ALL.len() - 1,
+            None => 0,
+        };
+        let rule = Rule::ALL[next];
+        let region = region.clone();
+        self.editor_mutate(|d| d.set_transform_rule(&from, &to, &region, rule));
+    }
+
+    /// Open the region panel, remembering where to go back to.
+    pub(super) fn editor_open_region(&mut self, scope: RegionScope, name: &str) {
+        let editor = self.editor();
+        let back = Box::new(editor.panel.clone());
+        editor.panel_anchor = Some(editor.view.selection());
+        editor.panel = Panel::Region {
+            scope,
+            name: name.to_string(),
+            back,
+        };
+        editor.cursor = 0;
+    }
+
+    /// Open the path panel on a stage's loop back to itself. A loop is not
+    /// a line on the canvas (the box wears a badge instead), so this is how
+    /// it is reached: from the stage's behaviour tab, or right after `c`
+    /// connects a stage to itself.
+    pub(super) fn editor_open_self_loop(&mut self, stage: &str) {
+        let editor = self.editor();
+        editor.view.select_stage(stage);
+        editor.panel_anchor = Some(editor.view.selection());
+        editor.panel = Panel::Edge {
+            from: stage.to_string(),
+            to: stage.to_string(),
+        };
+        editor.cursor = 0;
+        editor.focus = super::editor::Focus::Inspector;
+    }
+
+    /// Esc on a pushed panel: back to what opened it.
+    pub(super) fn editor_leave_region(&mut self) {
+        let editor = self.editor();
+        if let Panel::Edge { from, .. } = &editor.panel {
+            let name = from.clone();
+            editor.panel = Panel::Stage {
+                name,
+                tab: super::inspector::StageTab::Behaviour,
+            };
+            editor.panel_anchor = None;
+            editor.cursor = 0;
+            return;
+        }
+        if let Panel::Region { back, .. } = &editor.panel {
+            editor.panel = (**back).clone();
+            editor.panel_anchor = None;
+            editor.cursor = 0;
+            let count = editor.fields().len();
+            editor.cursor = editor.cursor.min(count.saturating_sub(1));
+        }
+    }
+
+    /// The model chooser: every model this install knows, live ones first.
+    fn editor_open_model_picker(&mut self, purpose: PickerFor) {
+        let windows = crate::commands::models::builtin_model_windows();
+        let live: BTreeSet<String> = self.agents().model_catalog.iter().cloned().collect();
+        let named: BTreeSet<String> = self.editor().doc.known_models().into_iter().collect();
+        let rows: Vec<PickerOption> = self
+            .editor()
+            .models
+            .iter()
+            .map(|m| {
+                let (provider, id) = m.split_once('/').unwrap_or(("", m.as_str()));
+                let mut detail: Vec<String> = Vec::new();
+                if live.contains(m) {
+                    detail.push("your provider lists it".to_string());
+                }
+                if named.contains(m) {
+                    detail.push("already in this agent".to_string());
+                }
+                if let Some(window) = windows.get(&(provider.to_string(), id.to_string())) {
+                    detail.push(format!("{} context", window_label(*window)));
+                }
+                PickerOption {
+                    value: m.clone(),
+                    detail: detail.join(" · "),
+                }
+            })
+            .collect();
+        let picker = Picker::new(
+            "Which model?",
+            vec![
+                "Written as provider/model. A run uses the first one in the chain that a configured \
+                 provider can serve."
+                    .to_string(),
+            ],
+            rows,
+            0,
+        );
+        self.editor().picker = Some((purpose, picker));
+    }
+
+    /// The tools multi-chooser, preselected with the stage's tools.
+    fn editor_open_tools_picker(&mut self) {
+        let stage = self.editor().panel_stage().expect("a stage field");
+        let have = self
+            .editor()
+            .doc
+            .stage(&stage)
+            .map(|s| s.tools)
+            .unwrap_or_default();
+        let all = self.editor().tools.clone();
+        let rows: Vec<PickerOption> = all
+            .iter()
+            .map(|t| PickerOption {
+                value: t.clone(),
+                detail: String::new(),
+            })
+            .collect();
+        let chosen: Vec<usize> = all
+            .iter()
+            .enumerate()
+            .filter(|(_, t)| have.contains(t))
+            .map(|(i, _)| i)
+            .collect();
+        let mut picker = Picker::new(
+            format!("Tools {stage} may use"),
+            vec!["Every tool this install has: built in, and scripts under the agent.".to_string()],
+            rows,
+            0,
+        );
+        picker.multi = Some(chosen.into_iter().collect());
+        self.editor().picker = Some((PickerFor::Tools, picker));
+    }
+
+    /// The region chooser for a routing row, or for a tool just picked.
+    fn editor_open_routing_region_picker(&mut self, tool: &str) {
+        let stage = self.editor().panel_stage().expect("a stage field");
+        let options = self.routing_regions(&stage);
+        let rows: Vec<PickerOption> = options
+            .into_iter()
+            .skip(1)
+            .map(|value| PickerOption {
+                value,
+                detail: String::new(),
+            })
+            .collect();
+        let picker = Picker::new(
+            format!("{tool}'s results land in"),
+            vec!["A region the stage sees.".to_string()],
+            rows,
+            0,
+        );
+        self.editor().picker = Some((PickerFor::RoutingRegion(tool.to_string()), picker));
+    }
+
+    /// A pick from the choosers the core does not settle itself.
+    pub(super) fn editor_settle_more(&mut self, purpose: PickerFor, value: &str) {
+        match purpose {
+            PickerFor::AddModel | PickerFor::ReplaceModel(_) => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let mut chain = self
+                    .editor()
+                    .doc
+                    .stage(&stage)
+                    .map(|s| s.models)
+                    .unwrap_or_default();
+                match purpose {
+                    PickerFor::ReplaceModel(i) if i < chain.len() => chain[i] = value.to_string(),
+                    _ => chain.push(value.to_string()),
+                }
+                self.editor_mutate(|d| d.set_models(&stage, &chain));
+            }
+            PickerFor::RoutingTool => self.editor_open_routing_region_picker(value),
+            PickerFor::RoutingRegion(tool) => {
+                let stage = self.editor().panel_stage().expect("a stage field");
+                let region = value.to_string();
+                self.editor_mutate(|d| d.set_tool_routing_override(&stage, &tool, &region));
+            }
+            PickerFor::Tools | PickerFor::Field(_) | PickerFor::ConnectFrom(_) => {}
+        }
+    }
+
+    /// The tools chosen in the multi-chooser.
+    pub(super) fn editor_settle_tools(&mut self, chosen: &[usize]) {
+        let stage = self.editor().panel_stage().expect("a stage field");
+        let all = self.editor().tools.clone();
+        let tools: Vec<String> = chosen.iter().filter_map(|i| all.get(*i).cloned()).collect();
+        self.editor_mutate(|d| d.set_tools(&stage, &tools));
+    }
+
+    /// Enter on the add-region prompt: a new region in the stage's own
+    /// layout (or the agent's, from the agent panel).
+    pub(super) fn editor_add_region(&mut self, name: &str) {
+        let scope = match self.editor().panel_stage() {
+            Some(stage) => RegionScope::Stage(stage),
+            None => RegionScope::Shared,
+        };
+        let name = name.to_string();
+        if self.editor_mutate(|d| d.add_region(&scope, &name)) {
+            self.editor_open_region(scope, &name);
+        }
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
@@ -8,7 +8,9 @@
 //! stage and greyed until the mode is `fan_out`; the hint row is there on
 //! every path and greyed unless the path is a hint.
 
-use crate::blueprint_edit::{EdgeKind, ManifestDoc, StageModeView, WorkerKind};
+use crate::blueprint_edit::{
+    EdgeKind, ManifestDoc, RegionScope, Rule, StageModeView, TransformKind, WorkerKind,
+};
 
 /// Which tab of the stage panel is open.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,6 +49,13 @@ pub(in crate::commands::dashboard) enum Panel {
     Edge { from: String, to: String },
     /// A worker blueprint drawn on the canvas, which is edited elsewhere.
     External(String),
+    /// A context region of a layout, opened from a region row; `back` is the
+    /// panel to return to.
+    Region {
+        scope: RegionScope,
+        name: String,
+        back: Box<Panel>,
+    },
 }
 
 /// One thing the inspector can edit.
@@ -62,6 +71,8 @@ pub(in crate::commands::dashboard) enum FieldId {
     StageDescription,
     MaxIterations,
     MaxRevisits,
+    /// The stage's path back to itself (a row on its behaviour tab).
+    SelfLoop,
     AllowComplete,
     WorkerKind,
     WorkerRef,
@@ -75,7 +86,43 @@ pub(in crate::commands::dashboard) enum FieldId {
     EdgeKind,
     EdgeHint,
     EdgeGate,
+    /// How context crosses the path.
+    EdgeTransform,
+    /// One region's rule under a custom transform.
+    TransformRule(String),
+    CompactPrompt,
     DeletePath,
+    /// The stage's own prompts, in the overlay.
+    EditPrompts,
+    /// One entry of the model chain (its index).
+    ModelEntry(usize),
+    AddModel,
+    /// The tools the stage may use.
+    ToolSet,
+    /// Inherits the shared layout, or has its own: a status row.
+    ContextStatus,
+    /// A region of the stage's effective layout, by name.
+    StageRegionRow(String),
+    AddRegion,
+    /// Give the stage its own layout, or drop it.
+    OwnLayout,
+    /// `tool_routing.default_region`.
+    RoutingDefault,
+    /// One `tool_routing.overrides` entry, by tool.
+    RoutingRow(String),
+    AddRouting,
+    RegionName,
+    RegionKind,
+    RegionBudget,
+    RegionMaxTokens,
+    RegionMaxItems,
+    RegionStrategy,
+    RegionOverflow,
+    RegionRequired,
+    RegionMessage,
+    RegionSeed,
+    RegionDescription,
+    DeleteRegion,
 }
 
 /// What a field holds and how it edits.
@@ -89,17 +136,22 @@ pub(in crate::commands::dashboard) enum FieldValue {
     Toggle(bool),
     /// One of a list: Enter opens the chooser, `←`/`→` cycle.
     Choice(String),
-    /// A row that opens something (a region).
+    /// A row that opens something (a region), or is removed with `x`.
     Row(String),
     /// Enter does the thing.
     Button,
+    /// One of a few words, cycled in place with `←`/`→` or Enter.
+    Segment {
+        options: Vec<&'static str>,
+        index: Option<usize>,
+    },
 }
 
 /// One row of the inspector.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(in crate::commands::dashboard) struct Field {
     pub(in crate::commands::dashboard) id: FieldId,
-    pub(in crate::commands::dashboard) label: &'static str,
+    pub(in crate::commands::dashboard) label: String,
     pub(in crate::commands::dashboard) value: FieldValue,
     /// One line under the panel while the cursor is on the row.
     pub(in crate::commands::dashboard) help: &'static str,
@@ -108,10 +160,10 @@ pub(in crate::commands::dashboard) struct Field {
 }
 
 impl Field {
-    fn new(id: FieldId, label: &'static str, value: FieldValue, help: &'static str) -> Self {
+    fn new(id: FieldId, label: impl Into<String>, value: FieldValue, help: &'static str) -> Self {
         Self {
             id,
-            label,
+            label: label.into(),
             value,
             help,
             enabled: true,
@@ -131,6 +183,7 @@ pub(in crate::commands::dashboard) fn fields(doc: &ManifestDoc, panel: &Panel) -
         Panel::Stage { name, tab } => stage_fields(doc, name, *tab),
         Panel::Edge { from, to } => edge_fields(doc, from, to),
         Panel::External(_) => Vec::new(),
+        Panel::Region { scope, name, .. } => region_fields(doc, scope, name),
     }
 }
 
@@ -139,8 +192,13 @@ pub(in crate::commands::dashboard) fn panel_title(panel: &Panel) -> String {
     match panel {
         Panel::Agent => "This agent".to_string(),
         Panel::Stage { name, tab } => format!("Stage · {name} · {}", tab.title()),
+        Panel::Edge { from, to } if from == to => format!("Path · {from} ↺ back to itself"),
         Panel::Edge { from, to } => format!("Path · {from} → {to}"),
         Panel::External(name) => format!("Worker blueprint · {name}"),
+        Panel::Region { scope, name, .. } => match scope {
+            RegionScope::Shared => format!("Context region · {name} · shared layout"),
+            RegionScope::Stage(stage) => format!("Context region · {name} · {stage}'s own layout"),
+        },
     }
 }
 
@@ -209,7 +267,8 @@ fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
             };
             let names = doc.stage_names();
             let index = names.iter().position(|n| n == name).unwrap_or(0);
-            vec![
+            let own_loop = doc.edge(name, name);
+            let mut out = vec![
                 Field::new(
                     FieldId::StageName,
                     "Name",
@@ -246,6 +305,16 @@ fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
                     FieldValue::Toggle(stage.allow_complete.unwrap_or(false)),
                     "The stage can call the run complete from inside, without a path out.",
                 ),
+            ];
+            if let Some(edge) = own_loop {
+                out.push(Field::new(
+                    FieldId::SelfLoop,
+                    "Loops back to itself",
+                    FieldValue::Row(edge.kind.short().to_string()),
+                    "A path from the stage to itself. Enter edits it like any other path.",
+                ));
+            }
+            out.extend([
                 Field::new(
                     FieldId::WorkerKind,
                     "Workers come from",
@@ -301,6 +370,12 @@ fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
                 )
                 .enabled(fan_out),
                 Field::new(
+                    FieldId::EditPrompts,
+                    "Edit prompts",
+                    FieldValue::Button,
+                    "What the stage is told to do, and how it decides where to go next.",
+                ),
+                Field::new(
                     FieldId::MoveUp,
                     "Move up in the file",
                     FieldValue::Button,
@@ -321,10 +396,252 @@ fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
                     "Removes the stage and every path in or out of it.",
                 )
                 .enabled(names.len() > 1),
-            ]
+            ]);
+            out
         }
-        StageTab::Model | StageTab::Context => Vec::new(),
+        StageTab::Model => {
+            let mut out: Vec<Field> = stage
+                .models
+                .iter()
+                .enumerate()
+                .map(|(i, m)| {
+                    Field::new(
+                        FieldId::ModelEntry(i),
+                        if i == 0 { "Model" } else { "then" },
+                        FieldValue::Row(m.clone()),
+                        "The chain is tried in order. Enter swaps this one, x drops it, ←/→ move it.",
+                    )
+                })
+                .collect();
+            if out.is_empty() {
+                out.push(Field::new(
+                    FieldId::AddModel,
+                    "Model",
+                    FieldValue::Row("(not set · runs on your default provider)".into()),
+                    "Choose the model this stage runs on; Enter opens the list.",
+                ));
+            } else {
+                out.push(Field::new(
+                    FieldId::AddModel,
+                    "Add a fallback model",
+                    FieldValue::Button,
+                    "Append a model to try when the ones above are not available.",
+                ));
+            }
+            let tools = if stage.tools.is_empty() {
+                "(none)".to_string()
+            } else {
+                stage.tools.join(", ")
+            };
+            out.push(Field::new(
+                FieldId::ToolSet,
+                "Tools it may use",
+                FieldValue::Row(tools),
+                "Enter picks from every tool this install has; Space toggles one.",
+            ));
+            out
+        }
+        StageTab::Context => {
+            let layout = doc.effective_regions(Some(name));
+            let status = if layout.inherited {
+                "shared with the agent"
+            } else {
+                "its own layout"
+            };
+            let mut out = vec![Field::new(
+                FieldId::ContextStatus,
+                "Context",
+                FieldValue::Row(status.to_string()),
+                if layout.inherited {
+                    "The stage sees the agent's shared regions, listed below."
+                } else {
+                    "The stage has regions of its own, listed below; the agent's shared ones are not seen here."
+                },
+            )];
+            for region in &layout.regions {
+                out.push(Field::new(
+                    FieldId::StageRegionRow(region.name.clone()),
+                    if layout.inherited { "  shared" } else { "  own" },
+                    FieldValue::Row(format!("{}  {}{}", region.name, region.kind, region_size(region))),
+                    if layout.inherited {
+                        "Part of the shared layout; a change here is seen by every stage that inherits it."
+                    } else {
+                        "A region of this stage's own layout."
+                    },
+                ));
+            }
+            out.push(
+                Field::new(
+                    FieldId::AddRegion,
+                    "Add a region",
+                    FieldValue::Button,
+                    "A new pinned region in this stage's own layout (asks its name).",
+                )
+                .enabled(!layout.inherited),
+            );
+            out.push(Field::new(
+                FieldId::OwnLayout,
+                if layout.inherited {
+                    "Give this stage its own layout"
+                } else {
+                    "Back to the shared layout"
+                },
+                FieldValue::Button,
+                if layout.inherited {
+                    "A copy of the shared regions the stage can change without touching the others."
+                } else {
+                    "Back to inheriting the shared regions; the stage's own regions go."
+                },
+            ));
+            let routing = doc.tool_routing(name);
+            out.push(Field::new(
+                FieldId::RoutingDefault,
+                "Tool results land in",
+                FieldValue::Choice(
+                    routing
+                        .default_region
+                        .clone()
+                        .unwrap_or_else(|| "(default)".to_string()),
+                ),
+                "Where a tool's output goes unless a row below says otherwise.",
+            ));
+            for (tool, region) in &routing.overrides {
+                out.push(Field::new(
+                    FieldId::RoutingRow(tool.clone()),
+                    "  tool",
+                    FieldValue::Row(format!("{tool} → {region}")),
+                    "This tool's results land here. Enter changes the region, x stops routing it.",
+                ));
+            }
+            out.push(Field::new(
+                FieldId::AddRouting,
+                "Route a tool",
+                FieldValue::Button,
+                "Send one tool's results to a region of their own.",
+            ));
+            out
+        }
     }
+}
+
+/// `· 5% · 4000 tokens`, whichever a region has.
+fn region_size(region: &crate::blueprint_edit::RegionView) -> String {
+    let mut s = String::new();
+    if let Some(p) = region.budget_percent {
+        s.push_str(&format!(" · {p}%"));
+    }
+    if let Some(t) = region.max_tokens {
+        s.push_str(&format!(" · {t} tokens"));
+    }
+    s
+}
+
+/// What the editor calls each region kind, and the line under it.
+pub(in crate::commands::dashboard) const REGION_KINDS: [(&str, &str); 6] = [
+    ("pinned", "Always kept, never evicted."),
+    ("temporary", "Cleared when the stage hands off."),
+    ("clearable", "The agent may wipe it when done with it."),
+    ("sliding_window", "Keeps only the newest items."),
+    ("compacting", "Summarizes itself when it fills up."),
+    (
+        "compact_history",
+        "Stores the summaries squeezed out of a compacting region.",
+    ),
+];
+
+fn region_fields(doc: &ManifestDoc, scope: &RegionScope, name: &str) -> Vec<Field> {
+    let Some(region) = doc.region(scope.stage(), name) else {
+        return Vec::new();
+    };
+    let sliding = region.kind == "sliding_window";
+    let kind_help = REGION_KINDS
+        .iter()
+        .find(|(k, _)| *k == region.kind)
+        .map(|(_, h)| *h)
+        .unwrap_or("A kind this editor does not know; kept as written.");
+    vec![
+        Field::new(
+            FieldId::RegionName,
+            "Name",
+            FieldValue::Text(region.name.clone()),
+            "Renaming rewrites the tool routing that names it.",
+        ),
+        Field::new(
+            FieldId::RegionKind,
+            "How it behaves",
+            FieldValue::Choice(region.kind.clone()),
+            kind_help,
+        ),
+        Field::new(
+            FieldId::RegionBudget,
+            "Share of context (%)",
+            FieldValue::Number(region.budget_percent.map(|p| p as u64)),
+            "Give it a % of the window, a token cap, or both.",
+        ),
+        Field::new(
+            FieldId::RegionMaxTokens,
+            "Token cap",
+            FieldValue::Number(region.max_tokens),
+            "Give it a % of the window, a token cap, or both.",
+        ),
+        Field::new(
+            FieldId::RegionMaxItems,
+            "Window: keeps at most",
+            FieldValue::Number(region.max_items),
+            "How many items the window keeps.",
+        )
+        .enabled(sliding),
+        Field::new(
+            FieldId::RegionStrategy,
+            "Window: strategy",
+            FieldValue::Text(region.strategy.clone()),
+            "per_item, bulk or compact.",
+        )
+        .enabled(sliding),
+        Field::new(
+            FieldId::RegionOverflow,
+            "Window: overflow",
+            FieldValue::Number(region.overflow),
+            "How many items over the limit before it evicts.",
+        )
+        .enabled(sliding),
+        Field::new(
+            FieldId::RegionRequired,
+            "Must be filled first",
+            FieldValue::Toggle(region.required),
+            "The agent cannot move on while this region is empty.",
+        ),
+        Field::new(
+            FieldId::RegionMessage,
+            "Reminder if empty",
+            FieldValue::Text(region.required_message.clone()),
+            "What the run says when it is stopped by an empty required region.",
+        )
+        .enabled(region.required),
+        Field::new(
+            FieldId::RegionSeed,
+            "Seeded with",
+            FieldValue::Text(if region.seed_is_table {
+                "(files, a command or a script: edit the file)".to_string()
+            } else {
+                region.seed.clone()
+            }),
+            "`task` means the user's request; another name, that caller input.",
+        )
+        .enabled(!region.seed_is_table),
+        Field::new(
+            FieldId::RegionDescription,
+            "Description",
+            FieldValue::Text(region.description.clone()),
+            "What the region holds, for anyone reading the file.",
+        ),
+        Field::new(
+            FieldId::DeleteRegion,
+            "Delete region",
+            FieldValue::Button,
+            "Removes the region and stops routing tool results into it.",
+        ),
+    ]
 }
 
 fn edge_fields(doc: &ManifestDoc, from: &str, to: &str) -> Vec<Field> {
@@ -340,7 +657,7 @@ fn edge_fields(doc: &ManifestDoc, from: &str, to: &str) -> Vec<Field> {
         ),
         Field::new(
             FieldId::EdgeHint,
-            "Hint the model routes on",
+            "Hint for the model",
             FieldValue::Text(edge.hint.clone().unwrap_or_default()),
             "e.g. The work is done and verified",
         )
@@ -352,12 +669,71 @@ fn edge_fields(doc: &ManifestDoc, from: &str, to: &str) -> Vec<Field> {
             "The run pauses on this path until you approve it.",
         ),
         Field::new(
+            FieldId::EdgeTransform,
+            "Context carried over",
+            FieldValue::Choice(edge.transform.label().to_string()),
+            "Pinned regions always survive an edge.",
+        ),
+    ]
+    .into_iter()
+    .chain(transform_rule_fields(doc, from, &edge))
+    .chain([
+        Field::new(
+            FieldId::CompactPrompt,
+            "How to summarize",
+            FieldValue::Text(edge.rules.compact_prompt.clone()),
+            "What the summary of the compacted regions should keep.",
+        )
+        .enabled(edge.transform == TransformKind::Custom),
+        Field::new(
             FieldId::DeletePath,
             "Delete path",
             FieldValue::Button,
             "Removes the path; the stages stay.",
         ),
-    ]
+    ])
+    .collect()
+}
+
+/// One segment row per region the leaving stage sees: carry / summarize /
+/// drop, live only under a custom transform; a pinned region is always
+/// carried and has no segment.
+fn transform_rule_fields(
+    doc: &ManifestDoc,
+    from: &str,
+    edge: &crate::blueprint_edit::EdgeView,
+) -> Vec<Field> {
+    let custom = edge.transform == TransformKind::Custom;
+    doc.effective_regions(Some(from))
+        .regions
+        .into_iter()
+        .map(|region| {
+            if region.kind == "pinned" {
+                return Field::new(
+                    FieldId::TransformRule(region.name.clone()),
+                    format!("  {}", region.name),
+                    FieldValue::Row("always carried".to_string()),
+                    "Pinned regions always survive an edge.",
+                )
+                .enabled(false);
+            }
+            let index = Rule::ALL.iter().position(|r| match r {
+                Rule::Carry => edge.rules.carry.contains(&region.name),
+                Rule::Compact => edge.rules.compact.contains(&region.name),
+                Rule::Clear => edge.rules.clear.contains(&region.name),
+            });
+            Field::new(
+                FieldId::TransformRule(region.name.clone()),
+                format!("  {}", region.name),
+                FieldValue::Segment {
+                    options: vec!["Carry", "Summarize", "Drop"],
+                    index,
+                },
+                "Carry it as it is, summarize it, or drop it on the way across.",
+            )
+            .enabled(custom)
+        })
+        .collect()
 }
 
 /// What the editor calls a worker source.

--- a/crates/leviath-cli/src/commands/dashboard/agents/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/mod.rs
@@ -13,9 +13,14 @@ mod catalog;
 mod chooser;
 mod editor;
 mod editor_keys;
+mod editor_panels;
 mod inspector;
+#[cfg(test)]
+mod panel_tests;
+mod prompts;
 mod render_catalog;
 mod render_editor;
+mod render_prompts;
 #[cfg(test)]
 mod tests;
 
@@ -24,6 +29,9 @@ use ratatui::layout::Rect;
 pub(in crate::commands::dashboard) use catalog::Catalog;
 pub(in crate::commands::dashboard) use chooser::Chooser;
 pub(in crate::commands::dashboard) use editor::Editor;
+pub(in crate::commands::dashboard) use prompts::ExternalEdit;
+#[cfg(test)]
+pub(in crate::commands::dashboard) use prompts::PromptFocus;
 
 use super::state::Dashboard;
 use crate::config::Config;
@@ -38,6 +46,12 @@ pub(in crate::commands::dashboard) struct AgentsScreen {
     pub(in crate::commands::dashboard) editor: Option<Editor>,
     /// The whole terminal at the last draw, for overlays that take the mouse.
     pub(in crate::commands::dashboard) last_area: Rect,
+    /// `provider/model` ids the providers reported, once the background
+    /// listing comes back; empty until then.
+    pub(in crate::commands::dashboard) model_catalog: Vec<String>,
+    /// The listing's channel, drained each tick.
+    pub(in crate::commands::dashboard) models_rx:
+        Option<tokio::sync::mpsc::UnboundedReceiver<Vec<String>>>,
 }
 
 impl Dashboard {
@@ -46,12 +60,56 @@ impl Dashboard {
         let mut catalog = Catalog::default();
         let config = self.agents_config();
         catalog.refresh(&self.new_run_ctx, &config);
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
         self.agent_builder = Some(Box::new(AgentsScreen {
             catalog,
             chooser: None,
             editor: None,
             last_area: Rect::default(),
+            model_catalog: Vec::new(),
+            models_rx: Some(rx),
         }));
+        // Ask every configured provider for its models, off the UI loop; the
+        // chooser offers the closed catalog until they land.
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            let config = self.agents_config();
+            handle.spawn(async move {
+                let models = crate::commands::serve::list_model_ids(
+                    &config,
+                    &leviath_providers::provider::build_http_client,
+                )
+                .await;
+                let _ = tx.send(models);
+            });
+        }
+    }
+
+    /// Take the models the providers reported, when they have.
+    pub(in crate::commands::dashboard) fn drain_agents_models(&mut self) {
+        let Some(screen) = self.agent_builder.as_deref_mut() else {
+            return;
+        };
+        let Some(rx) = screen.models_rx.as_mut() else {
+            return;
+        };
+        loop {
+            match rx.try_recv() {
+                Ok(models) => {
+                    screen.model_catalog = models;
+                    if let Some(editor) = screen.editor.as_mut() {
+                        editor.models.extend(screen.model_catalog.iter().cloned());
+                        editor.models.sort();
+                        editor.models.dedup();
+                    }
+                }
+                Err(tokio::sync::mpsc::error::TryRecvError::Empty) => return,
+                // The task has answered and gone: nothing more will come.
+                Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => {
+                    screen.models_rx = None;
+                    return;
+                }
+            }
+        }
     }
 
     /// Close the Agents screen, whatever it was showing.
@@ -96,6 +154,9 @@ impl Dashboard {
     ) -> bool {
         let area = self.agents().last_area;
         if self.editor_picker_mouse(event, area) {
+            return true;
+        }
+        if self.editor_inspector_mouse(event) {
             return true;
         }
         if self.route_mouse_to_graph(event) {

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -1,0 +1,1558 @@
+//! The inspector's other panels and the prompts overlay, driven by keys and
+//! clicks: a stage's model chain and tools, its context layout and routing,
+//! a region, a path's transform, a loop back to the same stage, and the
+//! prompts with their round trip through `$EDITOR`.
+
+use crossterm::event::{KeyCode, MouseButton, MouseEventKind};
+
+use super::editor::{Focus, Overlay};
+use super::inspector::{FieldId, FieldValue, Panel, StageTab};
+use super::prompts::{ExternalEdit, PromptFocus};
+use super::tests::{ctrl, dashboard, draw, key, mouse, open_editor_on, text, type_str};
+use crate::blueprint_edit::{RegionScope, TransformKind};
+use crate::commands::dashboard::state::Dashboard;
+use crate::commands::dashboard::test_support::rendered_buffer;
+
+/// Put the inspector cursor on the row with `id` (the row must exist).
+fn goto(dash: &mut Dashboard, id: FieldId) {
+    let editor = dash.agents().editor.as_mut().unwrap();
+    let at = editor
+        .fields()
+        .iter()
+        .position(|f| f.id == id)
+        .unwrap_or_else(|| panic!("no row {id:?} on {:?}", editor.panel));
+    editor.cursor = at;
+    editor.focus = Focus::Inspector;
+}
+
+/// Open the editor on `agent`, select `stage` and land on its `tab`.
+fn open_stage(dash: &mut Dashboard, agent: &str, stage: &str, tab: StageTab) {
+    open_editor_on(dash, agent);
+    let editor = dash.agents().editor.as_mut().unwrap();
+    editor.view.select_stage(stage);
+    editor.sync_panel();
+    editor.panel = Panel::Stage {
+        name: stage.to_string(),
+        tab,
+    };
+    editor.cursor = 0;
+    editor.focus = Focus::Inspector;
+}
+
+fn models_of(dash: &mut Dashboard, stage: &str) -> Vec<String> {
+    dash.agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .stage(stage)
+        .unwrap()
+        .models
+}
+
+fn picker_open(dash: &mut Dashboard) -> bool {
+    dash.agents().editor.as_ref().unwrap().picker.is_some()
+}
+
+// ─── model & tools ───────────────────────────────────────────────────────────
+
+#[test]
+fn the_model_tab_builds_a_chain_and_picks_tools() {
+    let (mut dash, root) = dashboard("model_tab");
+    open_stage(&mut dash, "own", "work", StageTab::Model);
+    // No model yet: one row says so, and Enter on it opens the chooser.
+    let fields = dash.agents().editor.as_ref().unwrap().fields();
+    assert_eq!(fields[0].id, FieldId::AddModel);
+    assert!(matches!(&fields[0].value, FieldValue::Row(r) if r.contains("not set")));
+    let screen = text(&mut dash);
+    assert!(screen.contains("not set"), "{screen}");
+    // ←/→ on that row do nothing (it is not a chain entry).
+    dash.handle_key(key(KeyCode::Right));
+    assert!(models_of(&mut dash, "work").is_empty());
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(picker_open(&mut dash));
+    let screen = text(&mut dash);
+    assert!(screen.contains("Which model?"), "{screen}");
+    assert!(screen.contains("context"), "{screen}");
+    // Letters go to the search, never to the editor's own keys.
+    type_str(&mut dash, "haiku");
+    assert!(picker_open(&mut dash));
+    dash.handle_key(key(KeyCode::Enter));
+    let chain = models_of(&mut dash, "work");
+    assert_eq!(chain.len(), 1);
+    assert!(chain[0].contains("haiku"), "{chain:?}");
+    // Add a fallback, then replace the first entry.
+    goto(&mut dash, FieldId::AddModel);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "sonnet-5");
+    dash.handle_key(key(KeyCode::Enter));
+    let chain = models_of(&mut dash, "work");
+    assert_eq!(chain.len(), 2, "{chain:?}");
+    assert!(chain[1].contains("sonnet-5"), "{chain:?}");
+    goto(&mut dash, FieldId::ModelEntry(0));
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "opus-5");
+    dash.handle_key(key(KeyCode::Enter));
+    let chain = models_of(&mut dash, "work");
+    assert!(chain[0].contains("opus-5"), "{chain:?}");
+    // Move the second one first with ←, and back with →; the cursor follows.
+    goto(&mut dash, FieldId::ModelEntry(1));
+    dash.handle_key(key(KeyCode::Left));
+    let chain = models_of(&mut dash, "work");
+    assert!(chain[0].contains("sonnet-5"), "{chain:?}");
+    assert_eq!(dash.agents().editor.as_ref().unwrap().cursor, 0);
+    dash.handle_key(key(KeyCode::Right));
+    let chain = models_of(&mut dash, "work");
+    assert!(chain[1].contains("sonnet-5"), "{chain:?}");
+    // Off the ends nothing moves.
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(models_of(&mut dash, "work"), chain);
+    goto(&mut dash, FieldId::ModelEntry(0));
+    dash.handle_key(key(KeyCode::Left));
+    assert_eq!(models_of(&mut dash, "work"), chain);
+    // Esc in the chooser leaves the chain alone; a replace on a stale index
+    // appends instead of panicking.
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Esc));
+    assert_eq!(models_of(&mut dash, "work"), chain);
+    dash.editor_settle_more(super::editor::PickerFor::ReplaceModel(9), "x/y");
+    assert_eq!(models_of(&mut dash, "work").len(), 3);
+    // x drops entries until the row reads "not set" again.
+    goto(&mut dash, FieldId::ModelEntry(2));
+    dash.handle_key(key(KeyCode::Char('x')));
+    goto(&mut dash, FieldId::ModelEntry(1));
+    dash.handle_key(key(KeyCode::Delete));
+    goto(&mut dash, FieldId::ModelEntry(0));
+    dash.handle_key(key(KeyCode::Char('x')));
+    assert!(models_of(&mut dash, "work").is_empty());
+    // x on a row that is not removable does nothing.
+    goto(&mut dash, FieldId::ToolSet);
+    dash.handle_key(key(KeyCode::Char('x')));
+    // Tools: a multi-chooser; Space toggles, Enter keeps.
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(picker_open(&mut dash));
+    let screen = text(&mut dash);
+    assert!(screen.contains("Tools work may use"), "{screen}");
+    dash.handle_key(key(KeyCode::Char(' ')));
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Char(' ')));
+    dash.handle_key(key(KeyCode::Enter));
+    let tools = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .stage("work")
+        .unwrap()
+        .tools;
+    assert_eq!(tools.len(), 2, "{tools:?}");
+    let screen = text(&mut dash);
+    assert!(screen.contains(&tools[0]), "{screen}");
+    // Reopen: the chosen ones are preselected; clearing them removes the key.
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Char(' ')));
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Char(' ')));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .stage("work")
+            .unwrap()
+            .tools
+            .is_empty()
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[tokio::test]
+async fn the_model_chooser_grows_when_the_providers_answer() {
+    let (mut dash, root) = dashboard("models_arrive");
+    // Opening the screen asks the providers off the loop; with none
+    // configured the answer is empty and arrives at once.
+    dash.handle_key(key(KeyCode::Char('a')));
+    assert!(dash.agents().models_rx.is_some());
+    // The answer lands when the task is done, however long the providers
+    // take to say no; the channel closing behind it is what says so.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+    while dash.agents().models_rx.is_some() {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the providers never answered"
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        dash.drain_agents_models();
+    }
+    // A catalog that names models feeds the editor's chooser when one is
+    // open, and the chooser at open when one is not.
+    dash.agents().model_catalog = vec!["zeta/live-model".to_string()];
+    open_editor_on(&mut dash, "own");
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .models
+            .contains(&"zeta/live-model".to_string())
+    );
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    dash.agents().models_rx = Some(rx);
+    tx.send(vec!["zeta/later-model".to_string()]).unwrap();
+    dash.drain_agents_models();
+    let models = dash.agents().editor.as_ref().unwrap().models.clone();
+    assert!(
+        models.contains(&"zeta/later-model".to_string()),
+        "{models:?}"
+    );
+    // The chooser marks what came from the providers and what the agent
+    // already names.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_models("work", &["zeta/later-model".to_string()])
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.agents().editor.as_mut().unwrap().panel = Panel::Stage {
+        name: "work".into(),
+        tab: StageTab::Model,
+    };
+    goto(&mut dash, FieldId::AddModel);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "zeta/later");
+    let screen = text(&mut dash);
+    assert!(screen.contains("your provider lists it"), "{screen}");
+    assert!(screen.contains("already in this agent"), "{screen}");
+    // Draining with no channel, or no screen, is a no-op; a sender still
+    // alive but silent leaves the channel in place.
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<Vec<String>>();
+    dash.agents().models_rx = Some(rx);
+    dash.drain_agents_models();
+    assert!(dash.agents().models_rx.is_some());
+    drop(tx);
+    dash.drain_agents_models();
+    assert!(dash.agents().models_rx.is_none());
+    dash.drain_agents_models();
+    dash.agent_builder = None;
+    dash.drain_agents_models();
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn context_windows_read_as_k_or_m() {
+    assert_eq!(super::editor_panels::window_label(200_000), "200k");
+    assert_eq!(super::editor_panels::window_label(1_000_000), "1M");
+    assert_eq!(super::editor_panels::window_label(1_500_000), "1.5M");
+}
+
+// ─── context ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_context_tab_owns_a_layout_adds_regions_and_routes_tools() {
+    let (mut dash, root) = dashboard("context_tab");
+    open_stage(&mut dash, "own", "work", StageTab::Context);
+    let screen = text(&mut dash);
+    assert!(screen.contains("shared with the agent"), "{screen}");
+    // Adding a region is off while the layout is inherited.
+    goto(&mut dash, FieldId::AddRegion);
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .current_field()
+            .unwrap()
+            .enabled
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().add_region.is_none());
+    // Give the stage its own layout.
+    goto(&mut dash, FieldId::OwnLayout);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .effective_regions(Some("work"))
+            .inherited
+    );
+    let screen = text(&mut dash);
+    assert!(screen.contains("its own layout"), "{screen}");
+    assert!(screen.contains("own context"), "{screen}");
+    // Add a region: the popup, Esc cancels, an empty name is ignored, a
+    // name adds it and opens its panel.
+    goto(&mut dash, FieldId::AddRegion);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().add_region.is_some());
+    let screen = text(&mut dash);
+    assert!(screen.contains("New region"), "{screen}");
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agents().editor.as_ref().unwrap().add_region.is_none());
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().add_region.is_none());
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage { .. }
+    ));
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "notes");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { scope: RegionScope::Stage(s), name, .. } if s == "work" && name == "notes"
+    ));
+    let screen = text(&mut dash);
+    assert!(screen.contains("work's own layout"), "{screen}");
+    // A bad name is refused with a message and no panel change.
+    dash.handle_key(key(KeyCode::Esc));
+    goto(&mut dash, FieldId::AddRegion);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "notes");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("notes"))
+    );
+    // The region row opens the panel too; Esc comes back to the tab.
+    goto(&mut dash, FieldId::StageRegionRow("notes".into()));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { .. }
+    ));
+    dash.handle_key(key(KeyCode::Esc));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage {
+            name: "work".into(),
+            tab: StageTab::Context
+        }
+    );
+    // Routing: no tools yet, so "route a tool" says so.
+    goto(&mut dash, FieldId::AddRouting);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(!picker_open(&mut dash));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("give it a tool first"))
+    );
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_tools("work", &["bash".to_string(), "read_file".to_string()])
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    // The default region cycles with ←/→ through the stage's regions and
+    // the ones every stage has.
+    goto(&mut dash, FieldId::RoutingDefault);
+    dash.handle_key(key(KeyCode::Right));
+    let routing = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .tool_routing("work");
+    assert_eq!(routing.default_region.as_deref(), Some("notes"));
+    dash.handle_key(key(KeyCode::Left));
+    let routing = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .tool_routing("work");
+    assert_eq!(routing.default_region, None);
+    // Enter opens a chooser for it.
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(picker_open(&mut dash));
+    type_str(&mut dash, "conversation");
+    dash.handle_key(key(KeyCode::Enter));
+    let routing = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .tool_routing("work");
+    assert_eq!(routing.default_region.as_deref(), Some("conversation"));
+    // Route one tool: tool chooser, then region chooser.
+    goto(&mut dash, FieldId::AddRouting);
+    dash.handle_key(key(KeyCode::Enter));
+    let screen = text(&mut dash);
+    assert!(screen.contains("Route which tool?"), "{screen}");
+    type_str(&mut dash, "bash");
+    dash.handle_key(key(KeyCode::Enter));
+    let screen = text(&mut dash);
+    assert!(screen.contains("bash's results land in"), "{screen}");
+    type_str(&mut dash, "notes");
+    dash.handle_key(key(KeyCode::Enter));
+    let routing = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .tool_routing("work");
+    assert_eq!(
+        routing.overrides,
+        vec![("bash".to_string(), "notes".to_string())]
+    );
+    let screen = text(&mut dash);
+    assert!(screen.contains("bash → notes"), "{screen}");
+    // The routed tool is not offered again; Enter on its row changes the
+    // region; x stops routing it.
+    goto(&mut dash, FieldId::AddRouting);
+    dash.handle_key(key(KeyCode::Enter));
+    let offered: Vec<String> = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .picker
+        .as_ref()
+        .unwrap()
+        .1
+        .options
+        .iter()
+        .map(|o| o.value.clone())
+        .collect();
+    assert_eq!(offered, vec!["read_file".to_string()]);
+    dash.handle_key(key(KeyCode::Esc));
+    goto(&mut dash, FieldId::RoutingRow("bash".into()));
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "tool_results");
+    dash.handle_key(key(KeyCode::Enter));
+    let routing = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .tool_routing("work");
+    assert_eq!(routing.overrides[0].1, "tool_results");
+    goto(&mut dash, FieldId::RoutingRow("bash".into()));
+    dash.handle_key(key(KeyCode::Char('x')));
+    let routing = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .tool_routing("work");
+    assert!(routing.overrides.is_empty());
+    // Back to the shared layout asks first; No keeps it, Yes drops it.
+    goto(&mut dash, FieldId::OwnLayout);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.pending_confirm.is_some());
+    dash.handle_key(key(KeyCode::Char('n')));
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .effective_regions(Some("work"))
+            .inherited
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .effective_regions(Some("work"))
+            .inherited
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_agent_panel_opens_a_shared_region_and_adds_one() {
+    let (mut dash, root) = dashboard("agent_regions");
+    open_editor_on(&mut dash, "coder");
+    dash.handle_key(key(KeyCode::Tab));
+    assert_eq!(dash.agents().editor.as_ref().unwrap().panel, Panel::Agent);
+    let first = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .regions(None)
+        .first()
+        .map(|r| r.name.clone())
+        .expect("coder has shared regions");
+    goto(&mut dash, FieldId::RegionRow(first.clone()));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { scope: RegionScope::Shared, name, .. } if *name == first
+    ));
+    let screen = text(&mut dash);
+    assert!(screen.contains("shared layout"), "{screen}");
+    // A region added from the agent panel lands in the shared layout.
+    dash.handle_key(key(KeyCode::Esc));
+    dash.editor_add_region("fresh");
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { scope: RegionScope::Shared, name, .. } if name == "fresh"
+    ));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .region(None, "fresh")
+            .is_some()
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── a region ────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_region_panel_edits_every_field_and_deletes() {
+    let (mut dash, root) = dashboard("region_panel");
+    open_stage(&mut dash, "own", "work", StageTab::Context);
+    goto(&mut dash, FieldId::OwnLayout);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.editor_add_region("notes");
+    let region = |dash: &mut Dashboard| {
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .region(Some("work"), "notes")
+            .unwrap()
+    };
+    // Kind: ←/→ cycle, Enter opens a chooser with the help line per kind.
+    goto(&mut dash, FieldId::RegionKind);
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(region(&mut dash).kind, "temporary");
+    dash.handle_key(key(KeyCode::Left));
+    assert_eq!(region(&mut dash).kind, "pinned");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(picker_open(&mut dash));
+    let screen = text(&mut dash);
+    assert!(screen.contains("Keeps only the newest items"), "{screen}");
+    type_str(&mut dash, "sliding");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).kind, "sliding_window");
+    // The sliding-window knobs are live now.
+    goto(&mut dash, FieldId::RegionMaxItems);
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .current_field()
+            .unwrap()
+            .enabled
+    );
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(region(&mut dash).max_items, Some(1));
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "2");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).max_items, Some(12));
+    goto(&mut dash, FieldId::RegionStrategy);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "oldest");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).strategy, "oldest");
+    goto(&mut dash, FieldId::RegionOverflow);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "3");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).overflow, Some(3));
+    // Budget and cap: typed and stepped; a word is refused with a message.
+    goto(&mut dash, FieldId::RegionBudget);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Backspace));
+    type_str(&mut dash, "20");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).budget_percent, Some(20.0));
+    dash.handle_key(key(KeyCode::Left));
+    assert_eq!(region(&mut dash).budget_percent, Some(19.0));
+    goto(&mut dash, FieldId::RegionMaxTokens);
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(region(&mut dash).max_tokens, Some(4001));
+    dash.handle_key(key(KeyCode::Left));
+    dash.handle_key(key(KeyCode::Enter));
+    for _ in 0..4 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    type_str(&mut dash, "lots");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).max_tokens, Some(4000));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("whole number"))
+    );
+    // Required: off → on enables the reminder; typing it; off again.
+    goto(&mut dash, FieldId::RegionMessage);
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .current_field()
+            .unwrap()
+            .enabled
+    );
+    goto(&mut dash, FieldId::RegionRequired);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(region(&mut dash).required);
+    goto(&mut dash, FieldId::RegionMessage);
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .current_field()
+            .unwrap()
+            .enabled
+    );
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "Fill me");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).required_message, "Fill me");
+    goto(&mut dash, FieldId::RegionRequired);
+    dash.handle_key(key(KeyCode::Left));
+    assert!(!region(&mut dash).required);
+    // Seed and description.
+    goto(&mut dash, FieldId::RegionSeed);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "task");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).seed, "task");
+    goto(&mut dash, FieldId::RegionDescription);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "Working notes");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).description, "Working notes");
+    // Rename: the panel follows the new name; a taken name is refused.
+    goto(&mut dash, FieldId::RegionName);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "2");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { name, .. } if name == "notes2"
+    ));
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, " two");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { name, .. } if name == "notes2"
+    ));
+    assert!(dash.agents().editor.as_ref().unwrap().message.is_some());
+    // The panel survives a refresh while its region exists.
+    dash.agents().editor.as_mut().unwrap().refresh();
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { .. }
+    ));
+    // A second region of the stage's own, opened from its row.
+    dash.handle_key(key(KeyCode::Esc));
+    goto(&mut dash, FieldId::AddRegion);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "other");
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Esc));
+    // Delete: the dialog names routing that goes with it; Yes removes it
+    // and returns to the tab the panel was opened from.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_tools("work", &["bash".to_string()])
+        .unwrap();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_tool_routing_override("work", "bash", "other")
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    goto(&mut dash, FieldId::StageRegionRow("other".into()));
+    dash.handle_key(key(KeyCode::Enter));
+    goto(&mut dash, FieldId::DeleteRegion);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.pending_confirm.is_some());
+    let screen = text(&mut dash);
+    assert!(screen.contains("land in it"), "{screen}");
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .region(Some("work"), "other")
+            .is_none()
+    );
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage {
+            name: "work".into(),
+            tab: StageTab::Context
+        }
+    );
+    // A region panel whose region is gone underneath it has no rows.
+    assert!(
+        super::inspector::fields(
+            &dash.agents().editor.as_ref().unwrap().doc,
+            &Panel::Region {
+                scope: RegionScope::Stage("work".into()),
+                name: "ghost".into(),
+                back: Box::new(Panel::Agent),
+            }
+        )
+        .is_empty()
+    );
+    // The region-scoped helpers are inert off a region panel.
+    dash.editor_set_toggle_more(&FieldId::RegionRequired, true);
+    assert!(!dash.editor_set_number_more(&FieldId::StageName, None));
+    dash.editor_pick_more(&FieldId::RegionKind, "pinned");
+    dash.editor_commit_line_more(&FieldId::RegionName, "x");
+    dash.editor_commit_line_more(&FieldId::RegionSeed, "x");
+    dash.editor_button_more(&FieldId::DeleteRegion);
+    assert!(dash.pending_confirm.is_none());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── a path's transform, and a loop ──────────────────────────────────────────
+
+#[test]
+fn the_path_panel_sets_the_transform_its_rules_and_the_summary_prompt() {
+    let (mut dash, root) = dashboard("path_transform");
+    open_editor_on(&mut dash, "coder");
+    // Pick the first path the coder has.
+    let edge = dash.agents().editor.as_ref().unwrap().doc.edges()[0].clone();
+    let editor = dash.agents().editor.as_mut().unwrap();
+    editor.view.select_edge(&edge.from, &edge.to);
+    editor.sync_panel();
+    editor.focus = Focus::Inspector;
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Edge { .. }
+    ));
+    let transform = |dash: &mut Dashboard| {
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge(&edge.from, &edge.to)
+            .unwrap()
+            .transform
+    };
+    // → cycles through every kind and wraps; the per-region rows only
+    // wake up on custom.
+    goto(&mut dash, FieldId::EdgeTransform);
+    let start = transform(&mut dash);
+    let mut seen = vec![start.clone()];
+    for _ in 0..TransformKind::CHOICES.len() {
+        dash.handle_key(key(KeyCode::Right));
+        seen.push(transform(&mut dash));
+    }
+    assert_eq!(seen.last(), Some(&start), "{seen:?}");
+    assert!(seen.contains(&TransformKind::Custom), "{seen:?}");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(picker_open(&mut dash));
+    type_str(&mut dash, "custom");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(transform(&mut dash), TransformKind::Custom);
+    let fields = dash.agents().editor.as_ref().unwrap().fields();
+    let rule = fields
+        .iter()
+        .find(|f| matches!(f.id, FieldId::TransformRule(_)) && f.enabled)
+        .cloned()
+        .expect("a non-pinned region has a live rule row");
+    let FieldId::TransformRule(region) = rule.id.clone() else {
+        unreachable!()
+    };
+    let rules = |dash: &mut Dashboard| {
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge(&edge.from, &edge.to)
+            .unwrap()
+            .rules
+    };
+    goto(&mut dash, rule.id.clone());
+    // Enter, → and ← all step the segment; the screen shows the bracketed
+    // choice.
+    dash.handle_key(key(KeyCode::Right));
+    let after_right = rules(&mut dash);
+    dash.handle_key(key(KeyCode::Enter));
+    let after_enter = rules(&mut dash);
+    assert_ne!(after_right, after_enter);
+    dash.handle_key(key(KeyCode::Left));
+    assert_eq!(rules(&mut dash), after_right);
+    let screen = text(&mut dash);
+    assert!(screen.contains('['), "{screen}");
+    // A region in the clear list, then stepping from it.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_transform_rule(
+            &edge.from,
+            &edge.to,
+            &region,
+            crate::blueprint_edit::Rule::Clear,
+        )
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    goto(&mut dash, rule.id.clone());
+    dash.handle_key(key(KeyCode::Right));
+    assert!(!rules(&mut dash).clear.contains(&region));
+    // The summary prompt: a typed line.
+    goto(&mut dash, FieldId::CompactPrompt);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "Keep the decisions");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(rules(&mut dash).compact_prompt, "Keep the decisions");
+    // Segment cycling on something that is not a rule row is a no-op.
+    dash.editor_cycle_segment(&FieldId::EdgeHint, 1);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_loop_back_to_the_same_stage_has_its_own_path_panel() {
+    let (mut dash, root) = dashboard("self_loop");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    // No loop yet: no row for it.
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .fields()
+            .iter()
+            .any(|f| f.id == FieldId::SelfLoop)
+    );
+    // `c` → itself opens the loop's panel straight away.
+    dash.agents().editor.as_mut().unwrap().focus = Focus::Canvas;
+    dash.handle_key(key(KeyCode::Char('c')));
+    type_str(&mut dash, "itself");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Edge {
+            from: "work".into(),
+            to: "work".into()
+        }
+    );
+    let screen = text(&mut dash);
+    assert!(screen.contains("back to itself"), "{screen}");
+    // The panel stays across refreshes while the loop exists.
+    dash.agents().editor.as_mut().unwrap().refresh();
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Edge { .. }
+    ));
+    // Esc returns to the stage; the behaviour tab now lists the loop, and
+    // Enter on that row reopens the panel.
+    dash.handle_key(key(KeyCode::Esc));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage {
+            name: "work".into(),
+            tab: StageTab::Behaviour
+        }
+    );
+    goto(&mut dash, FieldId::SelfLoop);
+    let screen = text(&mut dash);
+    assert!(screen.contains("Loops back to itself"), "{screen}");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Edge { .. }
+    ));
+    // Deleting the loop from its panel drops back to what the canvas shows.
+    goto(&mut dash, FieldId::DeletePath);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("work", "work")
+            .is_none()
+    );
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage { .. }
+    ));
+    // Leaving from a stage panel with no anchor is the plain Esc: canvas.
+    dash.handle_key(key(KeyCode::Esc));
+    assert_eq!(dash.agents().editor.as_ref().unwrap().focus, Focus::Canvas);
+    // A leave with a stale anchor and a plain panel changes nothing.
+    dash.editor_leave_region();
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── the prompts overlay and $EDITOR ─────────────────────────────────────────
+
+#[test]
+fn the_prompts_overlay_edits_applies_and_discards() {
+    let (mut dash, root) = dashboard("prompts_overlay");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(_))
+    ));
+    let screen = text(&mut dash);
+    assert!(screen.contains("Prompts · work"), "{screen}");
+    assert!(screen.contains("System prompt"), "{screen}");
+    assert!(screen.contains("Transition prompt"), "{screen}");
+    assert!(screen.contains("^e $EDITOR"), "{screen}");
+    // Typing lands in the focused box; Tab moves to the other; the keys on
+    // the editor underneath (v, u, p) are letters here.
+    type_str(&mut dash, " vup");
+    dash.handle_key(key(KeyCode::Tab));
+    type_str(&mut dash, "Go to finish.");
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "Second line.");
+    let prompts = match &dash.agents().editor.as_ref().unwrap().overlay {
+        Some(Overlay::Prompts(p)) => (*p).clone(),
+        _ => unreachable!(),
+    };
+    assert_eq!(prompts.focus, PromptFocus::Transition);
+    assert!(prompts.system.lines().join("\n").ends_with(" vup"));
+    dash.handle_key(key(KeyCode::BackTab));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(p)) if p.focus == PromptFocus::System
+    ));
+    // Ctrl-S applies both and closes; a multi-line prompt ends in a newline.
+    dash.handle_key(ctrl('s'));
+    assert!(dash.agents().editor.as_ref().unwrap().overlay.is_none());
+    let stage = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .stage("work")
+        .unwrap();
+    assert!(
+        stage.system_prompt.ends_with(" vup"),
+        "{:?}",
+        stage.system_prompt
+    );
+    assert_eq!(stage.transition_prompt, "Go to finish.\nSecond line.\n");
+    // Ctrl-Q discards.
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "lost");
+    dash.handle_key(ctrl('q'));
+    assert!(dash.agents().editor.as_ref().unwrap().overlay.is_none());
+    let stage = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .stage("work")
+        .unwrap();
+    assert!(!stage.system_prompt.contains("lost"));
+    // Esc applies too.
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, " kept");
+    dash.handle_key(key(KeyCode::Esc));
+    let stage = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .stage("work")
+        .unwrap();
+    assert!(
+        stage.system_prompt.ends_with(" kept"),
+        "{:?}",
+        stage.system_prompt
+    );
+    // Opening prompts on a stage that is gone is a no-op.
+    dash.agents().editor.as_mut().unwrap().panel = Panel::Stage {
+        name: "ghost".into(),
+        tab: StageTab::Behaviour,
+    };
+    dash.editor_open_prompts();
+    assert!(dash.agents().editor.as_ref().unwrap().overlay.is_none());
+    // The prompt keys do nothing with no overlay open.
+    dash.editor_prompts_key(&ctrl('s'));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
+    let (mut dash, root) = dashboard("prompts_external");
+    dash.external_edit_dir = root.join("scratch");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Tab));
+    type_str(&mut dash, "Before.");
+    assert!(!dash.has_external_edit());
+    dash.handle_key(ctrl('e'));
+    assert!(dash.has_external_edit());
+    let edit = dash.take_external_edit().expect("a file to open");
+    assert!(!dash.has_external_edit());
+    assert_eq!(edit.target, PromptFocus::Transition);
+    assert_eq!(std::fs::read_to_string(&edit.path).unwrap(), "Before.");
+    // The "editor" rewrites the file; the text comes back into the box and
+    // the file is gone.
+    std::fs::write(&edit.path, "After.\n").unwrap();
+    let path = edit.path.clone();
+    dash.finish_external_edit(edit, Ok(()));
+    assert!(!path.exists());
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(p)) if p.transition.lines() == ["After."]
+    ));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("updated"))
+    );
+    // An editor that failed leaves the box alone and says so.
+    dash.handle_key(ctrl('e'));
+    let edit = dash.take_external_edit().unwrap();
+    dash.finish_external_edit(edit, Err(std::io::Error::other("no editor")));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(p)) if p.transition.lines() == ["After."]
+    ));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("no editor"))
+    );
+    // A file that vanished reads the same way.
+    dash.handle_key(ctrl('e'));
+    let edit = dash.take_external_edit().unwrap();
+    std::fs::remove_file(&edit.path).unwrap();
+    dash.finish_external_edit(edit, Ok(()));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("did not hand"))
+    );
+    // Coming back with the overlay closed, or the editor closed, or the
+    // screen closed, drops the text quietly.
+    dash.handle_key(ctrl('e'));
+    let edit = dash.take_external_edit().unwrap();
+    dash.handle_key(ctrl('q'));
+    dash.finish_external_edit(edit.clone(), Ok(()));
+    dash.handle_key(key(KeyCode::Esc));
+    dash.handle_key(key(KeyCode::Esc));
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(dash.agents().editor.is_none());
+    dash.finish_external_edit(edit.clone(), Ok(()));
+    dash.agent_builder = None;
+    dash.finish_external_edit(edit, Ok(()));
+    // A scratch directory that cannot be made: a message, nothing pending.
+    std::fs::write(root.join("blocked"), "not a dir").unwrap();
+    dash.external_edit_dir = root.join("blocked");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(ctrl('e'));
+    assert!(!dash.has_external_edit());
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("Could not hand"))
+    );
+    // Ctrl-E with no overlay is a no-op.
+    dash.handle_key(ctrl('q'));
+    dash.editor_request_external_edit();
+    assert!(!dash.has_external_edit());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_external_edit_shape_is_plain_data() {
+    let edit = ExternalEdit {
+        path: "/tmp/x".into(),
+        target: PromptFocus::System,
+    };
+    assert_eq!(edit.clone(), edit);
+    assert!(format!("{edit:?}").contains("System"));
+}
+
+// ─── the mouse on the inspector ──────────────────────────────────────────────
+
+#[test]
+fn a_click_on_the_inspector_picks_rows_and_tabs() {
+    let (mut dash, root) = dashboard("inspector_mouse");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    let _ = draw(&mut dash, 160, 50);
+    let hit = dash.agents().editor.as_ref().unwrap().hit.clone();
+    assert!(!hit.rows.is_empty());
+    let (tab_row, tabs) = hit.tabs.clone().expect("a stage panel has tabs");
+    // A click on the third tab switches to it.
+    let press = |col: u16, row: u16| mouse(MouseEventKind::Down(MouseButton::Left), col, row);
+    assert!(dash.handle_agents_mouse(press(tabs[2].0 + 1, tab_row)));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage {
+            name: "work".into(),
+            tab: StageTab::Context
+        }
+    );
+    let _ = draw(&mut dash, 160, 50);
+    let hit = dash.agents().editor.as_ref().unwrap().hit.clone();
+    // A click on a row moves the cursor there; a second click opens it
+    // (the own-layout button acts).
+    let own = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .fields()
+        .iter()
+        .position(|f| f.id == FieldId::OwnLayout)
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().focus = Focus::Canvas;
+    assert!(dash.handle_agents_mouse(press(hit.area.x + 4, hit.rows[own])));
+    assert_eq!(dash.agents().editor.as_ref().unwrap().cursor, own);
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().focus,
+        Focus::Inspector
+    );
+    assert!(dash.handle_agents_mouse(press(hit.area.x + 4, hit.rows[own])));
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .effective_regions(Some("work"))
+            .inherited
+    );
+    // A click on the inspector's empty space only takes the focus; outside
+    // it, on the canvas, the click is the canvas's; other buttons and
+    // drags are not clicks; a line being typed keeps the mouse out.
+    dash.agents().editor.as_mut().unwrap().focus = Focus::Canvas;
+    assert!(dash.handle_agents_mouse(press(hit.area.x + 4, hit.area.y + hit.area.height - 2)));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().focus,
+        Focus::Inspector
+    );
+    assert!(!dash.editor_inspector_mouse(press(2, hit.rows[own])));
+    assert!(!dash.editor_inspector_mouse(mouse(
+        MouseEventKind::Down(MouseButton::Right),
+        hit.area.x + 4,
+        hit.rows[own]
+    )));
+    goto(&mut dash, FieldId::RoutingDefault);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(picker_open(&mut dash));
+    dash.handle_key(key(KeyCode::Esc));
+    dash.agents().editor.as_mut().unwrap().line = Some((
+        FieldId::StageName,
+        crate::tui::widgets::line_edit::LineEdit::new(String::new(), false),
+    ));
+    assert!(!dash.editor_inspector_mouse(press(hit.area.x + 4, hit.rows[own])));
+    dash.agents().editor.as_mut().unwrap().line = None;
+    // A tab click on a panel without tabs is a row click.
+    dash.handle_key(key(KeyCode::Tab));
+    dash.handle_key(key(KeyCode::Tab));
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .clear_selection();
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    let _ = draw(&mut dash, 160, 50);
+    let hit = dash.agents().editor.as_ref().unwrap().hit.clone();
+    assert!(hit.tabs.is_none());
+    assert!(dash.handle_agents_mouse(press(hit.area.x + 4, hit.rows[0])));
+    assert_eq!(dash.agents().editor.as_ref().unwrap().cursor, 0);
+    // No editor: not handled.
+    dash.close_editor();
+    assert!(!dash.editor_inspector_mouse(press(1, 1)));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── drawing ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn segments_buttons_and_name_popups_draw() {
+    let (mut dash, root) = dashboard("panel_drawing");
+    open_stage(&mut dash, "own", "work", StageTab::Context);
+    goto(&mut dash, FieldId::OwnLayout);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.editor_add_region("scratch");
+    dash.handle_key(key(KeyCode::Esc));
+    // A button row is its label, arrowed.
+    let screen = text(&mut dash);
+    assert!(screen.contains("▸ Add a region"), "{screen}");
+    assert!(screen.contains("▸ Back to the shared layout"), "{screen}");
+    // The add-stage popup and the add-region popup share a frame.
+    dash.agents().editor.as_mut().unwrap().focus = Focus::Canvas;
+    dash.handle_key(key(KeyCode::Char('a')));
+    let screen = text(&mut dash);
+    assert!(screen.contains("New stage"), "{screen}");
+    assert!(screen.contains("enter apply"), "{screen}");
+    dash.handle_key(key(KeyCode::Esc));
+    // A path with custom rules draws the segment with the choice bracketed.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_transform("work", "finish", &TransformKind::Custom)
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    let editor = dash.agents().editor.as_mut().unwrap();
+    editor.view.select_edge("work", "finish");
+    editor.sync_panel();
+    editor.focus = Focus::Inspector;
+    let screen = text(&mut dash);
+    assert!(screen.contains("Per-region rules"), "{screen}");
+    assert!(
+        screen.contains("[carry]") || screen.contains("[Carry]") || screen.contains("carried"),
+        "{screen}"
+    );
+    // The overlay's hint bar and the picker's hint bar.
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_prompts_overlay_draws_on_a_small_terminal_too() {
+    let (mut dash, root) = dashboard("prompts_small");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    let screen = rendered_buffer(&draw(&mut dash, 80, 20));
+    assert!(screen.contains("System prompt"), "{screen}");
+    assert!(screen.contains("tab other prompt"), "{screen}");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+// ─── the corners ─────────────────────────────────────────────────────────────
+
+#[test]
+fn a_bundled_agent_opened_for_editing_brings_its_scripts_and_takes_them_back() {
+    let (mut dash, root) = dashboard("bundled_scratch");
+    // The data analyst is bundled, not installed, and ships scripts:
+    // editing it materialises its directory so the lint can see them.
+    open_editor_on(&mut dash, "data-analyst");
+    let dir = dash.agents().editor.as_ref().unwrap().dir.clone();
+    assert!(dash.agents().editor.as_ref().unwrap().scratch_dir);
+    assert!(dir.exists(), "{}", dir.display());
+    assert!(!dir.join("agent.leviath").exists());
+    // Closing without saving leaves nothing behind.
+    dash.close_editor();
+    assert!(!dir.exists());
+    // Saved, it stays: a complete install.
+    open_editor_on(&mut dash, "data-analyst");
+    dash.handle_key(ctrl('s'));
+    assert!(dir.join("agent.leviath").exists());
+    dash.close_editor();
+    assert!(dir.join("agent.leviath").exists());
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_helpers_are_inert_off_their_panels_and_rows() {
+    let (mut dash, root) = dashboard("panel_corners");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    // ←/→ on a text row or a button change nothing.
+    goto(&mut dash, FieldId::StageDescription);
+    dash.handle_key(key(KeyCode::Right));
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Left));
+    assert!(dash.agents().editor.as_ref().unwrap().overlay.is_none());
+    // Enter on a plain status row opens nothing.
+    dash.handle_key(key(KeyCode::Char('3')));
+    goto(&mut dash, FieldId::ContextStatus);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(!picker_open(&mut dash));
+    // The region-scoped number helper answers "mine" for a region field
+    // even off a region panel, and does nothing.
+    assert!(dash.editor_set_number_more(&FieldId::RegionBudget, None));
+    dash.set_region_panel_name("x");
+    // A settle for a chooser purpose that is not a pick is a no-op.
+    dash.editor_settle_more(super::editor::PickerFor::Tools, "x");
+    dash.editor_settle_more(super::editor::PickerFor::Field(FieldId::StageMode), "x");
+    // x with no row under the cursor.
+    dash.agents().editor.as_mut().unwrap().panel = Panel::Stage {
+        name: "ghost".into(),
+        tab: StageTab::Model,
+    };
+    dash.editor_remove_row();
+    // A delete-region off a region panel still deletes, with nowhere to
+    // go back to; a cycle on a path that is gone does nothing.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .add_region(&RegionScope::Shared, "loose")
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.agents().editor.as_mut().unwrap().panel = Panel::Agent;
+    dash.editor_delete_region(&RegionScope::Shared, "loose");
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .region(None, "loose")
+            .is_none()
+    );
+    dash.agents().editor.as_mut().unwrap().panel = Panel::Edge {
+        from: "work".into(),
+        to: "ghost".into(),
+    };
+    dash.editor_cycle_segment(&FieldId::TransformRule("x".into()), 1);
+    // A rule row for a region in no list steps to the first rule going
+    // forward and the last going back.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_transform("work", "finish", &TransformKind::Custom)
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    let editor = dash.agents().editor.as_mut().unwrap();
+    editor.view.select_edge("work", "finish");
+    editor.sync_panel();
+    dash.editor_cycle_segment(&FieldId::TransformRule("nowhere".into()), -1);
+    dash.editor_cycle_segment(&FieldId::TransformRule("elsewhere".into()), 1);
+    let rules = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .edge("work", "finish")
+        .unwrap()
+        .rules;
+    assert!(rules.clear.contains(&"nowhere".to_string()), "{rules:?}");
+    assert!(rules.carry.contains(&"elsewhere".to_string()), "{rules:?}");
+    // Applying prompts with no overlay open does nothing.
+    dash.editor_apply_prompts();
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_stage_that_inherits_lists_the_shared_regions_and_a_table_seed_reads_as_such() {
+    let (mut dash, root) = dashboard("coder_context");
+    let stage = {
+        let (mut d, _) = (dashboard("coder_context_probe").0, ());
+        open_editor_on(&mut d, "coder");
+        d.agents().editor.as_ref().unwrap().doc.stage_names()[0].clone()
+    };
+    open_stage(&mut dash, "coder", &stage, StageTab::Context);
+    let screen = text(&mut dash);
+    assert!(screen.contains("shared with the agent"), "{screen}");
+    assert!(screen.contains("  shared"), "{screen}");
+    // A shared region row opened from the stage's tab is the shared region.
+    let first = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .doc
+        .regions(None)
+        .first()
+        .map(|r| r.name.clone())
+        .unwrap();
+    goto(&mut dash, FieldId::StageRegionRow(first.clone()));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { scope: RegionScope::Shared, name, .. } if *name == first
+    ));
+    dash.handle_key(key(KeyCode::Esc));
+    // The routing chooser lists the stage's regions once even when one of
+    // them is a name every stage has.
+    let (options, _) = dash.editor_choice_options_more(&FieldId::RoutingDefault);
+    let mut sorted = options.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(options.len(), sorted.len(), "{options:?}");
+    assert!(options.contains(&"conversation".to_string()), "{options:?}");
+    // A region seeded from files says so, and the seed is not editable.
+    dash.handle_key(key(KeyCode::Tab));
+    dash.handle_key(key(KeyCode::Tab));
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .clear_selection();
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    goto(&mut dash, FieldId::RegionRow("conventions".into()));
+    dash.handle_key(key(KeyCode::Enter));
+    goto(&mut dash, FieldId::RegionSeed);
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .current_field()
+            .unwrap()
+            .enabled
+    );
+    let screen = text(&mut dash);
+    assert!(screen.contains("(files, a command"), "{screen}");
+    // A region with neither budget nor cap shows neither.
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_region_field(
+            &RegionScope::Shared,
+            "conventions",
+            crate::blueprint_edit::RegionField::BudgetPercent,
+            crate::blueprint_edit::RegionValue::Number(None),
+        )
+        .unwrap();
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .doc
+        .set_region_field(
+            &RegionScope::Shared,
+            "conventions",
+            crate::blueprint_edit::RegionField::MaxTokens,
+            crate::blueprint_edit::RegionValue::Number(None),
+        )
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().refresh();
+    dash.handle_key(key(KeyCode::Esc));
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage(&stage);
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.agents().editor.as_mut().unwrap().panel = Panel::Stage {
+        name: stage.clone(),
+        tab: StageTab::Context,
+    };
+    let rows = dash.agents().editor.as_ref().unwrap().fields();
+    let conventions = rows
+        .iter()
+        .find(|f| f.id == FieldId::StageRegionRow("conventions".into()))
+        .unwrap();
+    assert!(
+        matches!(&conventions.value, FieldValue::Row(r) if !r.contains('%') && !r.contains("tokens"))
+    );
+    // Delete a region nothing routes into: the dialog is one line.
+    goto(&mut dash, FieldId::StageRegionRow("conventions".into()));
+    dash.handle_key(key(KeyCode::Enter));
+    goto(&mut dash, FieldId::DeleteRegion);
+    dash.handle_key(key(KeyCode::Enter));
+    let screen = text(&mut dash);
+    assert!(!screen.contains("land in it"), "{screen}");
+    dash.handle_key(key(KeyCode::Char('y')));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .region(None, "conventions")
+            .is_none()
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_system_prompt_comes_back_from_the_editor_too() {
+    let (mut dash, root) = dashboard("prompts_system_back");
+    dash.external_edit_dir = root.join("scratch");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(ctrl('e'));
+    let edit = dash.take_external_edit().unwrap();
+    assert_eq!(edit.target, PromptFocus::System);
+    std::fs::write(&edit.path, "Rewritten.").unwrap();
+    dash.finish_external_edit(edit, Ok(()));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(p)) if p.system.lines() == ["Rewritten."]
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/prompts.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/prompts.rs
@@ -1,0 +1,205 @@
+//! A stage's prompts, edited full screen: what the stage is told to do
+//! (`system_prompt`) and how it decides where to go next
+//! (`transition_prompt`). `Tab` moves between the two, `Ctrl-S` or `Esc`
+//! applies and closes, `Ctrl-Q` closes without applying, and `Ctrl-E` hands
+//! the focused text to `$EDITOR`: the dashboard leaves the terminal, the
+//! editor runs, and the text comes back into the box.
+
+use std::path::PathBuf;
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui_textarea::TextArea;
+
+use super::super::state::Dashboard;
+use super::editor::Overlay;
+use crate::blueprint_edit::StageText;
+
+/// Which of the two prompts has the keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands::dashboard) enum PromptFocus {
+    /// `system_prompt`.
+    System,
+    /// `transition_prompt`.
+    Transition,
+}
+
+/// The overlay's state.
+#[derive(Debug, Clone)]
+pub(in crate::commands::dashboard) struct PromptsEditor {
+    /// The stage whose prompts these are.
+    pub(in crate::commands::dashboard) stage: String,
+    pub(in crate::commands::dashboard) system: TextArea<'static>,
+    pub(in crate::commands::dashboard) transition: TextArea<'static>,
+    pub(in crate::commands::dashboard) focus: PromptFocus,
+}
+
+impl PromptsEditor {
+    fn new(stage: &str, system: &str, transition: &str) -> Self {
+        Self {
+            stage: stage.to_string(),
+            system: textarea(system),
+            transition: textarea(transition),
+            focus: PromptFocus::System,
+        }
+    }
+
+    /// The focused box.
+    fn focused_mut(&mut self) -> &mut TextArea<'static> {
+        match self.focus {
+            PromptFocus::System => &mut self.system,
+            PromptFocus::Transition => &mut self.transition,
+        }
+    }
+
+    /// The text of a box, without the trailing newline a textarea adds.
+    fn text_of(area: &TextArea<'static>) -> String {
+        let mut text = area.lines().join("\n");
+        // One trailing newline is how a multi-line prompt ends in the file;
+        // a single line has none.
+        if text.contains('\n') && !text.ends_with('\n') {
+            text.push('\n');
+        }
+        text
+    }
+}
+
+fn textarea(text: &str) -> TextArea<'static> {
+    let mut area = TextArea::new(text.lines().map(str::to_string).collect());
+    area.move_cursor(ratatui_textarea::CursorMove::Bottom);
+    area.move_cursor(ratatui_textarea::CursorMove::End);
+    area
+}
+
+/// Text handed to `$EDITOR`, and where it goes when it comes back.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(in crate::commands::dashboard) struct ExternalEdit {
+    /// The temp file the editor opens.
+    pub(in crate::commands::dashboard) path: PathBuf,
+    /// Which prompt of the open overlay takes the text.
+    pub(in crate::commands::dashboard) target: PromptFocus,
+}
+
+impl Dashboard {
+    /// Open the prompts overlay on the panel's stage.
+    pub(super) fn editor_open_prompts(&mut self) {
+        let stage = self.editor().panel_stage().expect("a stage field");
+        let Some(view) = self.editor().doc.stage(&stage) else {
+            return;
+        };
+        self.editor().overlay = Some(Overlay::Prompts(Box::new(PromptsEditor::new(
+            &stage,
+            &view.system_prompt,
+            &view.transition_prompt,
+        ))));
+    }
+
+    /// Keys on the prompts overlay.
+    pub(super) fn editor_prompts_key(&mut self, key: &KeyEvent) {
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let Some(Overlay::Prompts(prompts)) = self.editor().overlay.as_mut() else {
+            return;
+        };
+        match (key.code, ctrl) {
+            (KeyCode::Tab, _) | (KeyCode::BackTab, _) => {
+                prompts.focus = match prompts.focus {
+                    PromptFocus::System => PromptFocus::Transition,
+                    PromptFocus::Transition => PromptFocus::System,
+                };
+            }
+            (KeyCode::Esc, _) | (KeyCode::Char('s'), true) => self.editor_apply_prompts(),
+            (KeyCode::Char('q'), true) => self.editor().overlay = None,
+            (KeyCode::Char('e'), true) => self.editor_request_external_edit(),
+            _ => {
+                prompts
+                    .focused_mut()
+                    .input(ratatui_textarea::Input::from(*key));
+            }
+        }
+    }
+
+    /// Write both prompts back and close the overlay.
+    pub(super) fn editor_apply_prompts(&mut self) {
+        let Some(Overlay::Prompts(prompts)) = self.editor().overlay.take() else {
+            return;
+        };
+        let stage = prompts.stage.clone();
+        let system = PromptsEditor::text_of(&prompts.system);
+        let transition = PromptsEditor::text_of(&prompts.transition);
+        self.editor_mutate(|d| {
+            d.set_stage_text(&stage, StageText::SystemPrompt, &system)
+                .and_then(|()| d.set_stage_text(&stage, StageText::TransitionPrompt, &transition))
+        });
+    }
+
+    /// Ctrl-E: write the focused text to a temp file and ask the loop to
+    /// run `$EDITOR` on it.
+    pub(super) fn editor_request_external_edit(&mut self) {
+        let Some(Overlay::Prompts(prompts)) = self.editor().overlay.as_mut() else {
+            return;
+        };
+        let target = prompts.focus;
+        let text = PromptsEditor::text_of(match target {
+            PromptFocus::System => &prompts.system,
+            PromptFocus::Transition => &prompts.transition,
+        });
+        let stage = prompts.stage.clone();
+        let dir = self.external_edit_dir.clone();
+        let path = dir.join(format!(
+            "{stage}-{}.md",
+            match target {
+                PromptFocus::System => "system",
+                PromptFocus::Transition => "transition",
+            }
+        ));
+        let written = std::fs::create_dir_all(&dir).and_then(|()| std::fs::write(&path, &text));
+        match written {
+            Ok(()) => self.pending_external_edit = Some(ExternalEdit { path, target }),
+            Err(e) => {
+                self.editor().message = Some(format!("Could not hand the prompt to an editor: {e}"))
+            }
+        }
+    }
+
+    /// Whether a prompt is waiting for `$EDITOR`: the loop hands the terminal
+    /// over when this is true.
+    pub(in crate::commands::dashboard) fn has_external_edit(&self) -> bool {
+        self.pending_external_edit.is_some()
+    }
+
+    /// The file waiting for `$EDITOR`, taken so the loop runs it once.
+    pub(in crate::commands::dashboard) fn take_external_edit(&mut self) -> Option<ExternalEdit> {
+        self.pending_external_edit.take()
+    }
+
+    /// The editor came back: read the file into the prompt it was for, or
+    /// say why the editor failed or the file could not be read.
+    pub(in crate::commands::dashboard) fn finish_external_edit(
+        &mut self,
+        edit: ExternalEdit,
+        ran: std::io::Result<()>,
+    ) {
+        let text = ran.and_then(|()| std::fs::read_to_string(&edit.path));
+        let _ = std::fs::remove_file(&edit.path);
+        let Some(screen) = self.agent_builder.as_deref_mut() else {
+            return;
+        };
+        let Some(editor) = screen.editor.as_mut() else {
+            return;
+        };
+        match text {
+            Ok(text) => {
+                if let Some(Overlay::Prompts(prompts)) = editor.overlay.as_mut() {
+                    let area = match edit.target {
+                        PromptFocus::System => &mut prompts.system,
+                        PromptFocus::Transition => &mut prompts.transition,
+                    };
+                    *area = textarea(&text);
+                }
+                editor.message = Some("Prompt updated from the editor".to_string());
+            }
+            Err(e) => {
+                editor.message = Some(format!("The editor did not hand the prompt back: {e}"));
+            }
+        }
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
@@ -13,8 +13,8 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
 use super::super::state::Dashboard;
 use super::super::theme::*;
 use super::super::types::PaneId;
-use super::editor::{Focus, Overlay};
-use super::inspector::{FieldValue, Panel, StageTab, panel_title};
+use super::editor::{Focus, InspectorHits, Overlay};
+use super::inspector::{Field, FieldValue, Panel, StageTab, panel_title};
 use crate::blueprint_edit::check::Severity;
 use crate::tui::widgets::footer::{draw_hint_bar, hint};
 use crate::tui::widgets::popup::{centered, popup_frame};
@@ -22,7 +22,7 @@ use crate::tui::widgets::popup::{centered, popup_frame};
 /// Under this many columns the panes take turns.
 const SIDE_BY_SIDE_MIN_WIDTH: u16 = 110;
 /// The inspector's width when both panes are on.
-const INSPECTOR_WIDTH: u16 = 54;
+const INSPECTOR_WIDTH: u16 = 58;
 /// Rows the expanded problems list takes.
 const PROBLEMS_ROWS: u16 = 6;
 
@@ -175,12 +175,22 @@ impl Dashboard {
         let inner = block.inner(area);
         frame.render_widget(block, area);
         let mut lines: Vec<Line> = Vec::new();
+        let mut hits = InspectorHits {
+            area,
+            ..InspectorHits::default()
+        };
         if let Panel::Stage { tab, .. } = &editor.panel {
             let mut spans = Vec::new();
+            let mut x = inner.x;
+            let mut tabs = Vec::new();
             for (i, t) in StageTab::ALL.iter().enumerate() {
                 let on = t == tab;
+                let text = format!(" {} {} ", i + 1, t.title());
+                let w = text.chars().count() as u16;
+                tabs.push((x, x + w));
+                x += w;
                 spans.push(Span::styled(
-                    format!(" {} {} ", i + 1, t.title()),
+                    text,
                     if on {
                         Style::default()
                             .fg(C_ACTIVE)
@@ -190,6 +200,7 @@ impl Dashboard {
                     },
                 ));
             }
+            hits.tabs = Some((inner.y, tabs));
             lines.push(Line::from(spans));
             lines.push(Line::from(""));
         }
@@ -200,9 +211,10 @@ impl Dashboard {
             )));
         }
         let fields = editor.fields();
-        let label_w = 26usize;
+        let label_w = 23usize;
         let value_w = (inner.width as usize).saturating_sub(label_w + 3);
         for (i, field) in fields.iter().enumerate() {
+            hits.rows.push(inner.y + lines.len() as u16);
             let on = focused && i == editor.cursor;
             let editing = editor.line.as_ref().filter(|(id, _)| *id == field.id);
             let label_style = if !field.enabled {
@@ -212,15 +224,29 @@ impl Dashboard {
             } else {
                 Style::default().fg(C_MUTED)
             };
-            let mut spans = vec![
-                Span::styled(if on { "› " } else { "  " }, Style::default().fg(C_ACCENT)),
-                Span::styled(format!("{:<label_w$}", field.label), label_style),
-            ];
+            let mut spans = vec![Span::styled(
+                if on { "› " } else { "  " },
+                Style::default().fg(C_ACCENT),
+            )];
+            // A button is its label: the whole row is the action, so it has
+            // no value column.
+            let is_button = matches!(field.value, FieldValue::Button);
+            if !is_button {
+                spans.push(Span::styled(
+                    format!("{:<label_w$}", field.label),
+                    label_style,
+                ));
+            }
             match editing {
                 Some((_, line)) => spans.extend(line.display_spans(true).spans),
                 None => {
-                    let (text, style) = value_text(&field.value, field.enabled, on);
-                    spans.push(Span::styled(fit(&text, value_w), style));
+                    let (text, style) = value_text(field, on);
+                    let room = if is_button {
+                        value_w + label_w
+                    } else {
+                        value_w
+                    };
+                    spans.push(Span::styled(fit(&text, room), style));
                 }
             }
             lines.push(Line::from(spans));
@@ -239,6 +265,9 @@ impl Dashboard {
                 }
             });
         let body_h = inner.height.saturating_sub(3);
+        // Rows under the help area are not drawn, so they are not clickable.
+        hits.rows.retain(|y| *y < inner.y + body_h);
+        editor.hit = hits;
         frame.render_widget(
             Paragraph::new(lines).wrap(Wrap { trim: false }),
             Rect {
@@ -267,8 +296,16 @@ impl Dashboard {
                 hint("enter", "choose"),
                 hint("esc", "cancel"),
             ]
-        } else if editor.line.is_some() || editor.add_stage.is_some() {
+        } else if editor.line.is_some() || editor.add_stage.is_some() || editor.add_region.is_some()
+        {
             vec![hint("enter", "apply"), hint("esc", "cancel")]
+        } else if matches!(editor.overlay, Some(Overlay::Prompts(_))) {
+            vec![
+                hint("tab", "other prompt"),
+                hint("^s/esc", "apply"),
+                hint("^q", "discard"),
+                hint("^e", "$EDITOR"),
+            ]
         } else if editor.overlay.is_some() {
             vec![
                 hint("↑↓", "scroll"),
@@ -309,34 +346,21 @@ impl Dashboard {
         draw_hint_bar(frame, area, None, &hints, false);
     }
 
-    /// The chooser, the add-stage prompt, and the definition, on top.
+    /// The picker, the name prompts, the prompts overlay, and the
+    /// definition, on top.
     fn draw_editor_overlays(&mut self, frame: &mut Frame, area: Rect) {
+        if self.draw_editor_prompts(frame, area) {
+            return;
+        }
         let editor = self.editor();
         if let Some((_, picker)) = &editor.picker {
             picker.draw(frame, area);
             return;
         }
-        if let Some(line) = &editor.add_stage {
-            let popup = centered(50, 20, area);
-            let popup = Rect {
-                height: popup.height.clamp(3, 5),
-                ..popup
-            };
-            let inner = popup_frame(frame, popup, "New stage", C_BORDER_FOCUS);
-            let mut spans = vec![Span::styled("Name  ", Style::default().fg(C_DIM))];
-            spans.extend(line.display_spans(true).spans);
-            frame.render_widget(
-                Paragraph::new(vec![
-                    Line::from(spans),
-                    Line::from(Span::styled(
-                        "Letters, digits, . _ - · Enter adds it after the selected stage",
-                        Style::default().fg(C_MUTED),
-                    )),
-                ]),
-                inner,
-            );
+        if self.draw_editor_name_popups(frame, area) {
             return;
         }
+        let editor = self.editor();
         if let Some(Overlay::Definition { scroll }) = &editor.overlay {
             let text = editor.doc.to_toml();
             let popup = centered(90, 90, area);
@@ -355,8 +379,9 @@ impl Dashboard {
     }
 }
 
-/// How a field's value reads on its row.
-fn value_text(value: &FieldValue, enabled: bool, on: bool) -> (String, Style) {
+/// How a field's value reads on its row (a button reads as its label).
+fn value_text(field: &Field, on: bool) -> (String, Style) {
+    let (value, enabled) = (&field.value, field.enabled);
     let base = if !enabled {
         Style::default().fg(C_DIM)
     } else if on {
@@ -375,9 +400,30 @@ fn value_text(value: &FieldValue, enabled: bool, on: bool) -> (String, Style) {
         FieldValue::Toggle(false) => ("[ ] off".to_string(), base),
         FieldValue::Choice(c) => (format!("‹ {c} ›"), base),
         FieldValue::Row(r) => (r.clone(), base),
+        FieldValue::Segment { options, index } => (
+            options
+                .iter()
+                .enumerate()
+                .map(|(i, o)| {
+                    if Some(i) == *index {
+                        format!("[{o}]")
+                    } else {
+                        format!(" {o} ")
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join(" "),
+            base,
+        ),
         FieldValue::Button => (
-            "▸".to_string(),
-            base.fg(if enabled { C_ACCENT } else { C_DIM }),
+            format!("▸ {}", field.label),
+            if !enabled {
+                Style::default().fg(C_DIM)
+            } else if on {
+                Style::default().fg(C_ACTIVE).add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(C_MUTED)
+            },
         ),
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_prompts.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_prompts.rs
@@ -1,0 +1,145 @@
+//! Drawing the prompts overlay: the two prompt boxes stacked full screen,
+//! the focused one framed in the focus colour, plus the small name popups
+//! (new stage, new region) the editor asks with.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
+use ratatui_textarea::TextArea;
+
+use super::super::state::Dashboard;
+use super::super::theme::*;
+use super::editor::Overlay;
+use super::prompts::PromptFocus;
+use crate::tui::widgets::line_edit::LineEdit;
+use crate::tui::widgets::popup::{centered, popup_frame};
+
+impl Dashboard {
+    /// The prompts overlay, if it is open. Returns whether it drew.
+    pub(super) fn draw_editor_prompts(&mut self, frame: &mut Frame, area: Rect) -> bool {
+        let Some(Overlay::Prompts(prompts)) = self.editor().overlay.as_mut() else {
+            return false;
+        };
+        // The hint bar on the last row stays: it says what the keys do here.
+        let area = Rect {
+            height: area.height.saturating_sub(1),
+            ..area
+        };
+        frame.render_widget(Clear, area);
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1),
+                Constraint::Percentage(60),
+                Constraint::Min(3),
+            ])
+            .split(area);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(
+                    format!(" Prompts · {}", prompts.stage),
+                    Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    " · what the stage is told, and how it decides where to go next",
+                    Style::default().fg(C_DIM),
+                ),
+            ])),
+            rows[0],
+        );
+        let focus = prompts.focus;
+        prompt_box(
+            frame,
+            rows[1],
+            &mut prompts.system,
+            " System prompt · what this stage does ",
+            focus == PromptFocus::System,
+        );
+        prompt_box(
+            frame,
+            rows[2],
+            &mut prompts.transition,
+            " Transition prompt · how it picks the next path (only read with more than one) ",
+            focus == PromptFocus::Transition,
+        );
+        true
+    }
+
+    /// The add-stage and add-region name prompts, if one is open. Returns
+    /// whether it drew.
+    pub(super) fn draw_editor_name_popups(&mut self, frame: &mut Frame, area: Rect) -> bool {
+        let editor = self.editor();
+        if let Some(line) = &editor.add_stage {
+            name_popup(
+                frame,
+                area,
+                line,
+                "New stage",
+                "Letters, digits, . _ - · Enter adds it after the selected stage",
+            );
+            return true;
+        }
+        if let Some(line) = &editor.add_region {
+            name_popup(
+                frame,
+                area,
+                line,
+                "New region",
+                "Letters, digits, . _ - · a pinned region with a 5% budget to start",
+            );
+            return true;
+        }
+        false
+    }
+}
+
+/// One prompt box: framed, the focused one in the focus colour with a
+/// visible cursor.
+fn prompt_box(
+    frame: &mut Frame,
+    area: Rect,
+    text: &mut TextArea<'static>,
+    title: &'static str,
+    focused: bool,
+) {
+    let colour = if focused { C_BORDER_FOCUS } else { C_BORDER };
+    text.set_block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(colour))
+            .title(Span::styled(
+                title,
+                Style::default().fg(colour).add_modifier(Modifier::BOLD),
+            )),
+    );
+    text.set_style(Style::default().fg(C_WHITE));
+    text.set_cursor_style(if focused {
+        Style::default().fg(Color::Black).bg(C_ACCENT)
+    } else {
+        Style::default()
+    });
+    text.set_cursor_line_style(Style::default());
+    frame.render_widget(&*text, area);
+}
+
+/// A one-line name prompt with a help line under it.
+fn name_popup(frame: &mut Frame, area: Rect, line: &LineEdit, title: &str, help: &str) {
+    let popup = centered(50, 20, area);
+    let popup = Rect {
+        height: popup.height.clamp(3, 5),
+        ..popup
+    };
+    let inner = popup_frame(frame, popup, title, C_BORDER_FOCUS);
+    let mut spans = vec![Span::styled("Name  ", Style::default().fg(C_DIM))];
+    spans.extend(line.display_spans(true).spans);
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(spans),
+            Line::from(Span::styled(help, Style::default().fg(C_MUTED))),
+        ]),
+        inner,
+    );
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
@@ -15,15 +15,15 @@ use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
 use crate::commands::dashboard::types::*;
 
-fn key(code: KeyCode) -> KeyEvent {
+pub(super) fn key(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::empty())
 }
 
-fn ctrl(c: char) -> KeyEvent {
+pub(super) fn ctrl(c: char) -> KeyEvent {
     KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
 }
 
-fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+pub(super) fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
     MouseEvent {
         kind,
         column,
@@ -32,7 +32,7 @@ fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
     }
 }
 
-fn type_str(dash: &mut Dashboard, text: &str) {
+pub(super) fn type_str(dash: &mut Dashboard, text: &str) {
     for c in text.chars() {
         dash.handle_key(key(KeyCode::Char(c)));
     }
@@ -40,7 +40,7 @@ fn type_str(dash: &mut Dashboard, text: &str) {
 
 /// A dashboard whose agents directory is a fresh temp tree holding one
 /// agent of our own (`own`, the starter) and the installed coder.
-fn dashboard(tag: &str) -> (Dashboard, PathBuf) {
+pub(super) fn dashboard(tag: &str) -> (Dashboard, PathBuf) {
     let root = std::env::temp_dir().join(format!("lev-agents-screen-{tag}-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&root);
     let agents = root.join("agents");
@@ -56,17 +56,17 @@ fn dashboard(tag: &str) -> (Dashboard, PathBuf) {
     (dash, root)
 }
 
-fn draw(dash: &mut Dashboard, w: u16, h: u16) -> Terminal<TestBackend> {
+pub(super) fn draw(dash: &mut Dashboard, w: u16, h: u16) -> Terminal<TestBackend> {
     let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
     terminal.draw(|f| dash.draw(f)).unwrap();
     terminal
 }
 
-fn text(dash: &mut Dashboard) -> String {
+pub(super) fn text(dash: &mut Dashboard) -> String {
     rendered_buffer(&draw(dash, 160, 50))
 }
 
-fn open_editor_on(dash: &mut Dashboard, name: &str) {
+pub(super) fn open_editor_on(dash: &mut Dashboard, name: &str) {
     dash.handle_key(key(KeyCode::Char('a')));
     let at = dash
         .agents()
@@ -574,6 +574,17 @@ fn the_canvas_adds_connects_selects_and_deletes_with_undo_behind_it() {
             .is_some()
     );
     assert!(text(&mut dash).contains("↺ loops"));
+    // The loop opened its own path panel; Esc goes back to the stage, a
+    // second Esc to the canvas.
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Edge { .. }
+    ));
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Stage { .. }
+    ));
     // Connect from nothing selected: a message.
     dash.handle_key(key(KeyCode::Esc));
     dash.agents()
@@ -787,8 +798,13 @@ fn the_inspector_edits_every_kind_of_field() {
         .current_field()
         .unwrap();
     assert_eq!(field.id, FieldId::RegionRow("notes".into()));
+    // Enter opens the region's own panel; Esc comes back to the agent.
     dash.handle_key(key(KeyCode::Enter));
-    dash.handle_key(key(KeyCode::Right));
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().panel,
+        Panel::Region { .. }
+    ));
+    dash.handle_key(key(KeyCode::Esc));
     assert!(text(&mut dash).contains("Shared region"));
     dash.handle_key(key(KeyCode::Home));
     // The stage panel.
@@ -1230,7 +1246,8 @@ fn the_inspector_edits_every_kind_of_field() {
             .unwrap()
             .gated
     );
-    dash.handle_key(key(KeyCode::Down));
+    // The last row is the delete button.
+    dash.handle_key(key(KeyCode::End));
     dash.handle_key(key(KeyCode::Enter));
     assert!(
         dash.agents()
@@ -1371,10 +1388,10 @@ fn the_definition_overlay_scrolls_and_copies() {
     let (mut dash, root) = dashboard("definition");
     open_editor_on(&mut dash, "coder");
     dash.handle_key(key(KeyCode::Char('v')));
-    assert_eq!(
+    assert!(matches!(
         dash.agents().editor.as_ref().unwrap().overlay,
         Some(Overlay::Definition { scroll: 0 })
-    );
+    ));
     let screen = text(&mut dash);
     assert!(screen.contains("Definition"), "{screen}");
     assert!(screen.contains("name = \"coder\""), "{screen}");
@@ -1391,10 +1408,10 @@ fn the_definition_overlay_scrolls_and_copies() {
     ] {
         dash.handle_key(key(code));
     }
-    assert_eq!(
+    assert!(matches!(
         dash.agents().editor.as_ref().unwrap().overlay,
         Some(Overlay::Definition { scroll: 0 })
-    );
+    ));
     dash.handle_key(key(KeyCode::End));
     let screen = text(&mut dash);
     assert!(
@@ -1965,15 +1982,21 @@ fn a_dashboard_without_a_layout_path_keeps_arrangements_in_memory() {
         )
         .is_empty()
     );
-    assert!(
-        super::inspector::fields(
-            &doc,
-            &Panel::Stage {
-                name: "work".into(),
-                tab: StageTab::Model
-            }
-        )
-        .is_empty()
-    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn typing_in_a_chooser_never_reaches_the_editor_keys() {
+    // `u` is undo on the editor; inside a chooser it is a letter.
+    let (mut dash, root) = dashboard("chooser_letters");
+    open_editor_on(&mut dash, "coder");
+    dash.handle_key(key(KeyCode::Right));
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Char('2')));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_some());
+    type_str(&mut dash, "haiku");
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_some());
+    assert_eq!(dash.agents().editor.as_ref().unwrap().message, None);
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -170,6 +170,8 @@ impl Dashboard {
             new_run_ctx,
             agent_builder: None,
             layout_store_path: None,
+            pending_external_edit: None,
+            external_edit_dir: std::env::temp_dir().join("leviath-dash-prompts"),
             spawn_cmd_tx,
             spawn_outcome_rx,
             spawn_bg_ends: Some((spawn_cmd_rx, spawn_outcome_tx)),

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -161,6 +161,10 @@ impl Dashboard {
                 ConfirmAction::AgentReset { name } => self.perform_agent_reset(&name),
                 ConfirmAction::StageDelete { name } => self.editor_delete_stage(&name),
                 ConfirmAction::EditorDiscard => self.close_editor(),
+                ConfirmAction::RegionDelete { scope, name } => {
+                    self.editor_delete_region(&scope, &name)
+                }
+                ConfirmAction::OverrideRemove { stage } => self.editor_remove_override(&stage),
             },
         }
     }

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -127,7 +127,20 @@ async fn execute_core<S: TerminalSetup, E: EventSource>(
     setup.enable()?;
     let mut terminal = setup.create_terminal()?;
     let tick_rate = Duration::from_millis(100);
-    run_dashboard_loop(dashboard, control, &mut terminal, events, tick_rate).await?;
+    loop {
+        run_dashboard_loop(dashboard, control, &mut terminal, events, tick_rate).await?;
+        // The loop also returns when the agent editor wants `$EDITOR` on a
+        // prompt: hand the terminal over, run it, take the terminal back and
+        // carry on where the dashboard left off.
+        let Some(edit) = dashboard.take_external_edit() else {
+            break;
+        };
+        setup.disable();
+        let ran = setup.run_editor(&edit.path);
+        setup.enable()?;
+        terminal = setup.create_terminal()?;
+        dashboard.finish_external_edit(edit, ran);
+    }
     setup.disable();
     setup.print_done();
     Ok(())
@@ -185,6 +198,7 @@ async fn run_dashboard_loop<B: ratatui::backend::Backend>(
 
         // …and any run the new-run screen asked for.
         dashboard.drain_spawn_outcomes();
+        dashboard.drain_agents_models();
         // A run started here opens its own page, once the daemon reports it.
         dashboard.open_pending_run();
 
@@ -215,7 +229,7 @@ async fn run_dashboard_loop<B: ratatui::backend::Backend>(
             }
         }
 
-        if dashboard.should_quit {
+        if dashboard.should_quit || dashboard.has_external_edit() {
             return Ok(());
         }
     }
@@ -935,6 +949,70 @@ mod tests {
         .await;
     }
 
+    /// A prompt handed to `$EDITOR`: the loop returns, the editor runs with
+    /// the terminal released, the dashboard takes it back and carries on.
+    #[tokio::test]
+    async fn execute_core_runs_the_editor_on_a_pending_prompt_and_carries_on() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "execute_core_external_edit",
+            |d| async move {
+                let control = no_daemon_control();
+                let mut dashboard = init_dashboard(control.clone(), |_| false);
+                let path = d.join("prompt.md");
+                std::fs::write(&path, "before").unwrap();
+                dashboard.pending_external_edit = Some(agents::ExternalEdit {
+                    path: path.clone(),
+                    target: agents::PromptFocus::System,
+                });
+                let mut setup = TestSetup {
+                    editor_writes: Some("after".to_string()),
+                    ..TestSetup::new()
+                };
+                let mut events = TestEventSource::new(vec![key(KeyCode::Char('q'))]);
+                let result = execute_core(&mut dashboard, &control, &mut setup, &mut events).await;
+                assert!(result.is_ok());
+                assert!(dashboard.should_quit);
+                assert_eq!(setup.edited, vec![path.clone()]);
+                // The file was read back (and removed) even with no editor
+                // open to receive it.
+                assert!(!path.exists());
+                assert!(!dashboard.has_external_edit());
+            },
+        )
+        .await;
+    }
+
+    /// Taking the terminal back after `$EDITOR` can fail like the first take.
+    #[tokio::test]
+    async fn execute_core_reports_a_failed_retake_after_the_editor() {
+        crate::runstate::with_isolated_runs_dir_async(
+            "execute_core_external_edit_retake",
+            |d| async move {
+                for (enable_on, create_on) in [(Some(2), None), (None, Some(2))] {
+                    let control = no_daemon_control();
+                    let mut dashboard = init_dashboard(control.clone(), |_| false);
+                    let path = d.join("prompt.md");
+                    std::fs::write(&path, "before").unwrap();
+                    dashboard.pending_external_edit = Some(agents::ExternalEdit {
+                        path: path.clone(),
+                        target: agents::PromptFocus::Transition,
+                    });
+                    let mut setup = TestSetup {
+                        enable_fails_on_call: enable_on,
+                        create_fails_on_call: create_on,
+                        ..TestSetup::new()
+                    };
+                    let mut events = TestEventSource::new(vec![key(KeyCode::Char('q'))]);
+                    let result =
+                        execute_core(&mut dashboard, &control, &mut setup, &mut events).await;
+                    assert!(result.is_err());
+                    assert_eq!(setup.edited.len(), 1);
+                }
+            },
+        )
+        .await;
+    }
+
     #[tokio::test]
     async fn execute_core_enable_error_propagates() {
         crate::runstate::with_isolated_runs_dir_async(
@@ -947,6 +1025,7 @@ mod tests {
                     enable_should_fail: true,
                     create_should_fail: false,
                     draw_should_fail: false,
+                    ..TestSetup::new()
                 };
                 let mut events = TestEventSource::new(vec![]);
                 let result = execute_core(&mut dashboard, &control, &mut setup, &mut events).await;
@@ -969,6 +1048,7 @@ mod tests {
                     enable_should_fail: false,
                     create_should_fail: true,
                     draw_should_fail: false,
+                    ..TestSetup::new()
                 };
                 let mut events = TestEventSource::new(vec![]);
                 let result = execute_core(&mut dashboard, &control, &mut setup, &mut events).await;

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -178,7 +178,30 @@ fn agent_editor_sections() -> Vec<HelpSection> {
                     "change the row in place: cycle a choice, step a number, flip a toggle",
                 ),
                 ("1 2 3", "a stage's tabs: behaviour, model & tools, context"),
-                ("esc", "back to the canvas"),
+                (
+                    "x / backspace",
+                    "remove the row: a model from the chain, a routing rule",
+                ),
+                ("← → on a model", "move it earlier or later in the chain"),
+                (
+                    "esc",
+                    "back: a region returns to where it was opened from, otherwise the canvas",
+                ),
+            ],
+        },
+        HelpSection {
+            title: "Agent editor: prompts",
+            entries: vec![
+                (
+                    "tab",
+                    "move between the system prompt and the transition prompt",
+                ),
+                ("ctrl-s / esc", "apply both and close"),
+                ("ctrl-q", "close without applying"),
+                (
+                    "ctrl-e",
+                    "open the focused prompt in $EDITOR (the dashboard waits for it)",
+                ),
             ],
         },
     ]

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -209,6 +209,11 @@ pub(crate) struct Dashboard {
     /// Where the editor keeps canvas arrangements; `None` keeps them in
     /// memory (tests).
     pub(super) layout_store_path: Option<std::path::PathBuf>,
+    /// A prompt handed to `$EDITOR`, waiting for the loop to leave the
+    /// terminal and run it.
+    pub(super) pending_external_edit: Option<super::agents::ExternalEdit>,
+    /// Where a prompt handed to `$EDITOR` is written while the editor runs.
+    pub(super) external_edit_dir: std::path::PathBuf,
     /// Sends resolve-and-spawn work to the background lane.
     pub(super) spawn_cmd_tx: mpsc::UnboundedSender<SpawnCommand>,
     /// Receives spawn results, drained into toasts each tick.

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -171,6 +171,13 @@ pub(super) enum ConfirmAction {
     StageDelete { name: String },
     /// Close the agent editor and lose its unsaved edits.
     EditorDiscard,
+    /// Delete a context region in the agent editor (and the routing into it).
+    RegionDelete {
+        scope: crate::blueprint_edit::RegionScope,
+        name: String,
+    },
+    /// Drop a stage's own context layout in the agent editor.
+    OverrideRemove { stage: String },
 }
 
 /// Display status for agents in the dashboard.

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -204,14 +204,36 @@ pub(super) async fn models_with(
     state: &AppState,
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
 ) -> Json<Vec<ModelEntry>> {
+    Json(list_models_from_config(&state.config, build_client).await)
+}
+
+/// Every model every configured provider reports, as `provider/id`: what the
+/// dashboard's agent editor offers once the providers have answered.
+pub(crate) async fn list_model_ids(
+    config: &crate::config::Config,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Vec<String> {
+    list_models_from_config(config, build_client)
+        .await
+        .into_iter()
+        .map(|m| format!("{}/{}", m.provider, m.id))
+        .collect()
+}
+
+/// Every model every configured provider reports, for `GET /api/models` and
+/// the dashboard's agent editor alike.
+pub(super) async fn list_models_from_config(
+    config: &crate::config::Config,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Vec<ModelEntry> {
     // Nothing to list if no client could be built; the endpoint answers with an
     // empty set rather than failing the request, matching how it treats a
     // provider whose `list_models` errors.
     let Ok(registry) = crate::commands::run::session::build_provider_registry_from_config_with(
-        &state.config,
+        config,
         build_client,
     ) else {
-        return Json(Vec::new());
+        return Vec::new();
     };
     let mut models = Vec::new();
 
@@ -233,7 +255,7 @@ pub(super) async fn models_with(
         }
     }
 
-    Json(models)
+    models
 }
 
 #[cfg(test)]
@@ -514,6 +536,22 @@ mod tests {
         assert!(!models.is_empty());
         assert!(models.iter().any(|m| m["provider"] == "claude-code"));
         assert!(models.iter().all(|m| m["id"].is_string()));
+    }
+
+    /// The dashboard's flat `provider/id` list is the same enumeration.
+    #[tokio::test]
+    async fn list_model_ids_flattens_to_provider_slash_id() {
+        let state = test_state_listing_models();
+        let ids = super::list_model_ids(
+            &state.config,
+            &leviath_providers::provider::build_http_client,
+        )
+        .await;
+        assert!(!ids.is_empty());
+        assert!(
+            ids.iter().any(|id| id.starts_with("claude-code/")),
+            "{ids:?}"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -25,6 +25,7 @@ mod tree;
 mod types;
 mod websocket;
 
+pub(crate) use config::list_model_ids;
 use types::ServeLimits;
 pub use types::{AppState, ServeArgs, ServerEvent};
 

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -989,6 +989,7 @@ mod tests {
             enable_should_fail: true,
             create_should_fail: false,
             draw_should_fail: false,
+            ..TestSetup::new()
         };
         assert!(
             execute_core(&mut wizard, &env, &mut enable_fails, &mut events)
@@ -1000,6 +1001,7 @@ mod tests {
             enable_should_fail: false,
             create_should_fail: true,
             draw_should_fail: false,
+            ..TestSetup::new()
         };
         assert!(
             execute_core(&mut wizard, &env, &mut create_fails, &mut events)

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -875,6 +875,10 @@ fn install_terminal_restore_panic_hook() {
 impl TerminalSetup for CrosstermSetup {
     type B = ratatui::backend::CrosstermBackend<io::Stdout>;
 
+    fn run_editor(&mut self, path: &std::path::Path) -> std::io::Result<()> {
+        leviath_sys::editor::launch(path)
+    }
+
     fn enable(&mut self) -> anyhow::Result<()> {
         install_terminal_restore_panic_hook();
         enable_raw_mode().map_err(anyhow::Error::from)?;

--- a/crates/leviath-cli/src/tui/mod.rs
+++ b/crates/leviath-cli/src/tui/mod.rs
@@ -96,6 +96,10 @@ pub trait TerminalSetup {
     fn disable(&mut self);
     /// Print whatever should remain on screen after the UI exits.
     fn print_done(&self);
+    /// Run the user's `$EDITOR` on `path` and wait for it to close. Called
+    /// between [`Self::disable`] and [`Self::enable`], so the editor has the
+    /// terminal to itself.
+    fn run_editor(&mut self, path: &std::path::Path) -> std::io::Result<()>;
 }
 
 // ─── Test doubles (shared crate-wide; see the module docs for why) ───────────
@@ -284,6 +288,18 @@ mod test_doubles {
         /// Hand back a backend whose every draw fails, so a loop's draw-error
         /// arm is reachable without a second `TerminalSetup` implementation.
         pub(crate) draw_should_fail: bool,
+        /// What `run_editor` writes into the file it is handed (`None` keeps
+        /// the file as it is).
+        pub(crate) editor_writes: Option<String>,
+        /// Every path `run_editor` was asked to open.
+        pub(crate) edited: Vec<std::path::PathBuf>,
+        /// Fail `enable` / `create_terminal` on this call (1-based) only:
+        /// the dashboard takes the terminal again after `$EDITOR`, and that
+        /// second take can fail too.
+        pub(crate) enable_fails_on_call: Option<usize>,
+        pub(crate) create_fails_on_call: Option<usize>,
+        pub(crate) enable_calls: usize,
+        pub(crate) create_calls: usize,
     }
 
     impl TestSetup {
@@ -292,6 +308,12 @@ mod test_doubles {
                 enable_should_fail: false,
                 create_should_fail: false,
                 draw_should_fail: false,
+                editor_writes: None,
+                edited: Vec::new(),
+                enable_fails_on_call: None,
+                create_fails_on_call: None,
+                enable_calls: 0,
+                create_calls: 0,
             }
         }
     }
@@ -300,14 +322,16 @@ mod test_doubles {
         type B = TestBackendHarness;
 
         fn enable(&mut self) -> anyhow::Result<()> {
-            if self.enable_should_fail {
+            self.enable_calls += 1;
+            if self.enable_should_fail || self.enable_fails_on_call == Some(self.enable_calls) {
                 anyhow::bail!("simulated enable failure");
             }
             Ok(())
         }
 
         fn create_terminal(&mut self) -> anyhow::Result<Terminal<Self::B>> {
-            if self.create_should_fail {
+            self.create_calls += 1;
+            if self.create_should_fail || self.create_fails_on_call == Some(self.create_calls) {
                 anyhow::bail!("simulated create_terminal failure");
             }
             let backend = match self.draw_should_fail {
@@ -320,6 +344,14 @@ mod test_doubles {
         fn disable(&mut self) {}
 
         fn print_done(&self) {}
+
+        fn run_editor(&mut self, path: &std::path::Path) -> std::io::Result<()> {
+            self.edited.push(path.to_path_buf());
+            match &self.editor_writes {
+                Some(text) => std::fs::write(path, text),
+                None => Ok(()),
+            }
+        }
     }
 }
 
@@ -513,6 +545,7 @@ mod tests {
             enable_should_fail: true,
             create_should_fail: false,
             draw_should_fail: false,
+            ..TestSetup::new()
         };
         assert!(enable_fails.enable().is_err());
 
@@ -520,6 +553,7 @@ mod tests {
             enable_should_fail: false,
             create_should_fail: true,
             draw_should_fail: false,
+            ..TestSetup::new()
         };
         assert!(create_fails.create_terminal().is_err());
     }

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -248,12 +248,35 @@ An installed bundled agent that has been edited says `edited`, and `r` puts the 
 
 The editor is one screen: the graph on the left, an inspector on the right showing whatever is
 selected on the graph, a problems line under the graph, and a hint bar. Nothing is written until you
-save. The inspector shows one thing at a time: **This agent** when nothing is selected (description,
-which stage a run starts at, the model every stage tries first, the shared context regions), a
-**Stage** (its behaviour: how it works, description, tries, revisits, whether it may finish the run,
-the fan-out settings when it fans out; move it in the file; delete it), or a **Path** (when it is
-taken, the hint the model routes on, whether it needs your approval; delete it). A field that does
-not apply is greyed rather than hidden, so the panel never reflows under the cursor.
+save. The inspector shows one thing at a time, and a field that does not apply is greyed rather than
+hidden, so the panel never reflows under the cursor:
+
+- **This agent**, when nothing is selected: description, which stage a run starts at, the model every
+  stage tries first, and the shared context regions (`Enter` on one opens it).
+- **A stage**, on three tabs (`1` `2` `3`). *Behaviour*: how it works, description, tries, revisits,
+  whether it may finish the run, the fan-out settings when it fans out, its loop back to itself when it
+  has one, the prompts, its place in the file, delete. *Model & tools*: the model chain (the first is
+  tried first; `Enter` swaps an entry, `x` drops it, `←` `→` move it, the last row adds a fallback)
+  and the tools it may use, picked from every tool this install has (`Space` toggles, `Enter` keeps).
+  *Context*: whether the stage sees the agent's shared regions or has a layout of its own, the regions
+  it sees (`Enter` opens one), a button to give it its own layout or go back to the shared one, where
+  tool results land by default, and per-tool routing (`Enter` on a row changes the region, `x` stops
+  routing the tool).
+- **A path**: when it is taken, the hint the model routes on, whether it needs your approval, what
+  context is carried across (everything, only pinned regions, everything summarized, or per-region
+  rules: carry, summarize or drop each one, with the instructions the summary follows), delete.
+- **A context region**, opened from a region row: name, kind (each kind says what it does), share of
+  the context window and token cap, the sliding-window knobs when it is one, whether it must be filled
+  before the run goes on and what to say if it is not, what seeds it, description, delete. `Esc` goes
+  back to where the region was opened from.
+
+The models the chooser offers come from every provider in your config (asked when the screen
+opens, so the list fills in a moment later) on top of the built-in catalog, marked with the context
+window when it is known. The prompts open full screen: the system prompt (what the stage is told)
+and the transition prompt (how it picks the next path; only read when there is more than one), with
+`Tab` between them, `Ctrl-S` or `Esc` to apply, `Ctrl-Q` to discard, and `Ctrl-E` to hand the
+focused prompt to `$EDITOR` (`$VISUAL` first): the dashboard steps aside while the editor runs and
+the text comes back into the box when it closes.
 
 Every edit is checked as you make it, the way `lev validate` checks a file: the line under the graph
 says how many errors and warnings there are (`p` opens the list), a stage an error names carries a
@@ -291,9 +314,21 @@ On the inspector:
 | Key | Action |
 |---|---|
 | `↑` / `↓` (or `k` / `j`), `Home` / `End` | Move between rows |
-| `Enter` | Edit the row: type into it, choose from a list, flip it, or press the button |
-| `←` / `→` (or `h` / `l`) | Change the row in place: cycle a choice, step a number, flip a toggle |
+| `Enter` | Edit the row: type into it, choose from a list, flip it, open it, or press the button |
+| `←` / `→` (or `h` / `l`) | Change the row in place: cycle a choice, step a number, flip a toggle, move a model in its chain |
+| `x` / `Backspace` | Remove the row: a model from the chain, a tool's routing |
 | `1` `2` `3` | A stage's tabs: behaviour, model & tools, context |
+| `Esc` | Back: a region or a loop's path returns to where it was opened from; otherwise to the graph |
+| mouse | Click a row to pick it (again to open it); click a tab to switch to it |
+
+In the prompts:
+
+| Key | Action |
+|---|---|
+| `Tab` | Move between the system prompt and the transition prompt |
+| `Ctrl-S` / `Esc` | Apply both and close |
+| `Ctrl-Q` | Close without applying |
+| `Ctrl-E` | Open the focused prompt in `$EDITOR`; the dashboard waits for it |
 
 On a terminal under 110 columns the graph and the inspector take turns; `Tab` swaps them.
 


### PR DESCRIPTION
Third and last part of the agent builder in `lev dash` (after #512 and #514): the rest of the inspector, the prompts overlay, and the `$EDITOR` hook.

## What it adds

- **Model & tools tab**: the model chain (Enter swaps an entry, `x` drops it, `←`/`→` move it, last row adds a fallback) and the tools a stage may use, picked in a multi-chooser from every tool this install has. The model chooser offers what every configured provider reports (asked off the UI loop when the screen opens) on top of the built-in catalog, with the context window when known.
- **Context tab**: inherits the shared regions or has its own layout (a button either way), the regions it sees, where tool results land, per-tool routing (`Enter` changes the region, `x` stops routing).
- **Region panel**: name, kind (each with a one-line meaning), share of the window and token cap, sliding-window knobs, required + reminder, seed, description, delete. `Esc` returns to where it was opened from.
- **Path**: what context crosses it (everything / pinned only / summarized / per-region rules as carry-summarize-drop segments) and the summary instructions.
- **A loop back to the same stage** has its own path panel (a row on the behaviour tab; opens after `c` → itself).
- **Prompts** full screen: `Tab` between system and transition prompt, `Ctrl-S`/`Esc` apply, `Ctrl-Q` discard, `Ctrl-E` hands the focused prompt to `$EDITOR` and takes it back (`TerminalSetup::run_editor`, the loop releases and retakes the terminal).
- Mouse on the inspector: click a row (again to open it), click a tab.

## Found live and fixed

- `Ctrl-S` inside the prompts overlay saved the file **without** the typed prompt; it now applies the prompts.
- A bundled agent edited before it was installed could not be saved when it shipped scripts (the lint could not see them); its directory is materialised at open and removed again if closed unsaved.
- Empty `[stages.x.context]` / `[stages.x.tool_routing]` headers above their children.
- A renamed stage lost its place on the canvas; a region rename/delete dropped its panel mid-refresh; the message line never cleared.
- **#514 left `<<<<<<<` conflict markers in CHANGELOG.md on main** (stash residue); resolved here.

## Verification

- `cargo xtask coverage --package leviath-cli` 100%, clippy clean, `cargo xtask docs` clean.
- Live (pty, mock home, fake `$EDITOR` script): start simple → model picker → fallback → tools → own layout → add region → route a tool → loop to itself → max revisits → transform cycling → prompts typed → `Ctrl-E` round trip → `Ctrl-S` → save → `lev validate` passes; the narrow layout and the inspector mouse clicks checked too.
