### PR TITLE
feat(dash): a right-click menu on the editor canvas, and every control named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,11 @@ same list.
   agent in the catalog; a bundled agent opens from its embedded copy and
   installs when saved, scripts and all; an edited bundled agent can be
   reset to the bundle. The editor keeps a file's comments, order and
-  formatting: it edits the manifest as a document.
+  formatting: it edits the manifest as a document. The canvas has a
+  right-click menu for the stage, path or empty canvas under the pointer,
+  a click on empty canvas selects nothing, undo and redo are `Ctrl-Z` and
+  `Ctrl-Y`, and every bar names its controls: the run list calls the
+  screen out next to "new run".
 - **Breaking (websocket):** stage transitions and tool calls are frames of
   their own. `stage_transition`, `tool_call_started` and `tool_call_finished`
   used to arrive wrapped as `{"type":"world","event":{...}}`, so a client had

--- a/crates/leviath-cli/src/commands/dashboard/agents/catalog.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/catalog.rs
@@ -175,6 +175,34 @@ impl Dashboard {
         );
     }
 
+    /// The wheel over the catalog list moves the cursor, as it does over the
+    /// run list. Returns whether the event was the wheel over the list.
+    pub(in crate::commands::dashboard) fn catalog_wheel(
+        &mut self,
+        event: crossterm::event::MouseEvent,
+    ) -> bool {
+        use crossterm::event::MouseEventKind;
+        let screen = self.agents();
+        if screen.editor.is_some() || screen.chooser.is_some() {
+            return false;
+        }
+        let delta = match event.kind {
+            MouseEventKind::ScrollUp => -1,
+            MouseEventKind::ScrollDown => 1,
+            _ => return false,
+        };
+        let area = screen.list_area;
+        let inside = event.column >= area.x
+            && event.column < area.x + area.width
+            && event.row >= area.y
+            && event.row < area.y + area.height;
+        if !inside {
+            return false;
+        }
+        screen.catalog.move_by(delta);
+        true
+    }
+
     /// `d`: confirm deleting the selected agent, when it can be deleted from
     /// here.
     fn request_agent_delete(&mut self) {

--- a/crates/leviath-cli/src/commands/dashboard/agents/context_menu.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/context_menu.rs
@@ -1,0 +1,385 @@
+//! The canvas's right-click menu: what can be done to the box, the path,
+//! or the empty canvas under the pointer. It is a small list drawn where
+//! the click landed; `↑`/`↓` and `Enter` work it, `Esc` or a click
+//! anywhere else closes it, and a click on a row picks it. Every row does
+//! what a key on the canvas does, so the menu discloses the keys rather
+//! than adding to them.
+
+use crossterm::event::{KeyCode, KeyEvent, MouseButton, MouseEvent, MouseEventKind};
+use ratatui::Frame;
+use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
+
+use super::super::state::Dashboard;
+use super::super::theme::*;
+use super::editor::Focus;
+use super::inspector::{FieldId, Panel, StageTab};
+use crate::tui::flowgraph::MenuTarget;
+use crate::tui::widgets::line_edit::LineEdit;
+
+/// What a menu row does.
+#[derive(Debug, Clone, PartialEq)]
+pub(in crate::commands::dashboard) enum MenuAction {
+    /// Select the stage and put the keys on its inspector.
+    EditStage(String),
+    /// Select the stage and open the connect chooser from it.
+    ConnectFrom(String),
+    /// Add a stage after this one (asks its name).
+    AddStageAfter(String),
+    /// Select the stage and start typing its new name.
+    RenameStage(String),
+    /// Select the stage and open its prompts.
+    EditPrompts(String),
+    /// Delete the stage (asks first).
+    DeleteStage(String),
+    /// Select the path and put the keys on its inspector.
+    EditPath(String, String),
+    /// Delete the path.
+    DeletePath(String, String),
+    /// Add a stage where the canvas was clicked (asks its name).
+    AddStageAt(f64, f64),
+    /// Fit the whole graph on screen.
+    Fit,
+    /// Turn the graph.
+    Rotate,
+    /// Show the file that will be saved.
+    Definition,
+}
+
+/// One row of the menu.
+#[derive(Debug, Clone, PartialEq)]
+pub(in crate::commands::dashboard) struct MenuItem {
+    pub(in crate::commands::dashboard) label: &'static str,
+    /// The key that does the same on the canvas, shown dim at the right.
+    pub(in crate::commands::dashboard) key: &'static str,
+    pub(in crate::commands::dashboard) action: MenuAction,
+}
+
+/// The open menu.
+#[derive(Debug, Clone, PartialEq)]
+pub(in crate::commands::dashboard) struct ContextMenu {
+    pub(in crate::commands::dashboard) title: String,
+    pub(in crate::commands::dashboard) items: Vec<MenuItem>,
+    pub(in crate::commands::dashboard) cursor: usize,
+    /// Where the click landed (screen cells); the menu opens there.
+    pub(in crate::commands::dashboard) at: (u16, u16),
+    /// Where the last frame drew it, for the mouse.
+    pub(in crate::commands::dashboard) drawn: Rect,
+}
+
+impl ContextMenu {
+    /// The menu for what a right click landed on, or `None` when nothing
+    /// can be done there (a worker box belongs to another agent).
+    pub(in crate::commands::dashboard) fn for_target(
+        target: &MenuTarget,
+        at: (u16, u16),
+    ) -> Option<Self> {
+        let (title, items) = match target {
+            MenuTarget::Node(id) if id.starts_with("ext:") => return None,
+            MenuTarget::Node(name) => (
+                format!("Stage · {name}"),
+                vec![
+                    MenuItem {
+                        label: "Edit",
+                        key: "enter",
+                        action: MenuAction::EditStage(name.clone()),
+                    },
+                    MenuItem {
+                        label: "Connect to…",
+                        key: "c",
+                        action: MenuAction::ConnectFrom(name.clone()),
+                    },
+                    MenuItem {
+                        label: "Add a stage after it",
+                        key: "a",
+                        action: MenuAction::AddStageAfter(name.clone()),
+                    },
+                    MenuItem {
+                        label: "Rename",
+                        key: "",
+                        action: MenuAction::RenameStage(name.clone()),
+                    },
+                    MenuItem {
+                        label: "Edit prompts",
+                        key: "",
+                        action: MenuAction::EditPrompts(name.clone()),
+                    },
+                    MenuItem {
+                        label: "Delete stage",
+                        key: "x",
+                        action: MenuAction::DeleteStage(name.clone()),
+                    },
+                ],
+            ),
+            MenuTarget::Edge(edge) => (
+                format!("Path · {} → {}", edge.from, edge.to),
+                vec![
+                    MenuItem {
+                        label: "Edit",
+                        key: "enter",
+                        action: MenuAction::EditPath(edge.from.clone(), edge.to.clone()),
+                    },
+                    MenuItem {
+                        label: "Delete path",
+                        key: "x",
+                        action: MenuAction::DeletePath(edge.from.clone(), edge.to.clone()),
+                    },
+                ],
+            ),
+            MenuTarget::Pane { x, y } => (
+                "Canvas".to_string(),
+                vec![
+                    MenuItem {
+                        label: "Add a stage here",
+                        key: "a",
+                        action: MenuAction::AddStageAt(*x, *y),
+                    },
+                    MenuItem {
+                        label: "Fit the graph",
+                        key: "f",
+                        action: MenuAction::Fit,
+                    },
+                    MenuItem {
+                        label: "Turn the graph",
+                        key: "r",
+                        action: MenuAction::Rotate,
+                    },
+                    MenuItem {
+                        label: "Show the definition",
+                        key: "v",
+                        action: MenuAction::Definition,
+                    },
+                ],
+            ),
+        };
+        Some(Self {
+            title,
+            items,
+            cursor: 0,
+            at,
+            drawn: Rect::default(),
+        })
+    }
+
+    /// The row under a screen position, if the menu was drawn there.
+    fn row_at(&self, column: u16, row: u16) -> Option<usize> {
+        let inner = Rect {
+            x: self.drawn.x + 1,
+            y: self.drawn.y + 1,
+            width: self.drawn.width.saturating_sub(2),
+            height: self.drawn.height.saturating_sub(2),
+        };
+        (column >= inner.x
+            && column < inner.x + inner.width
+            && row >= inner.y
+            && row < inner.y + inner.height)
+            .then(|| (row - inner.y) as usize)
+            .filter(|i| *i < self.items.len())
+    }
+
+    /// Draw the menu at its anchor, kept inside `area`.
+    pub(in crate::commands::dashboard) fn draw(&mut self, frame: &mut Frame, area: Rect) {
+        let widest = self
+            .items
+            .iter()
+            .map(|i| i.label.chars().count() + 2 + i.key.chars().count())
+            .max()
+            .unwrap_or(0)
+            .max(self.title.chars().count() + 2);
+        let width = (widest as u16 + 6).min(area.width);
+        let height = (self.items.len() as u16 + 2).min(area.height);
+        let x = self
+            .at
+            .0
+            .min(area.x + area.width.saturating_sub(width))
+            .max(area.x);
+        let y = self
+            .at
+            .1
+            .min(area.y + area.height.saturating_sub(height))
+            .max(area.y);
+        let rect = Rect {
+            x,
+            y,
+            width,
+            height,
+        };
+        self.drawn = rect;
+        frame.render_widget(Clear, rect);
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(C_BORDER_FOCUS))
+            .title(Span::styled(
+                format!(" {} ", self.title),
+                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+            ));
+        let inner = block.inner(rect);
+        frame.render_widget(block, rect);
+        let room = inner.width as usize;
+        let lines: Vec<Line> = self
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, item)| {
+                let on = i == self.cursor;
+                let label_w = room.saturating_sub(2 + item.key.chars().count());
+                let mut spans = vec![Span::styled(
+                    if on { "› " } else { "  " },
+                    Style::default().fg(C_ACCENT),
+                )];
+                spans.push(Span::styled(
+                    format!("{:<label_w$}", item.label),
+                    if on {
+                        Style::default().fg(C_ACTIVE).add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default().fg(C_WHITE)
+                    },
+                ));
+                spans.push(Span::styled(item.key, Style::default().fg(C_DIM)));
+                Line::from(spans)
+            })
+            .collect();
+        frame.render_widget(Paragraph::new(lines), inner);
+    }
+}
+
+impl Dashboard {
+    /// Open the menu for what a right click landed on; a worker box gets a
+    /// message instead, the same one its inspector panel shows.
+    pub(super) fn editor_open_menu(&mut self, target: &MenuTarget, at: (u16, u16)) {
+        match ContextMenu::for_target(target, at) {
+            Some(menu) => self.editor().menu = Some(menu),
+            None => {
+                self.editor().message =
+                    Some("That box is a separate agent; edit it from the catalog".to_string());
+            }
+        }
+    }
+
+    /// Keys while the menu is open.
+    pub(super) fn editor_menu_key(&mut self, key: &KeyEvent) {
+        let Some(menu) = self.editor().menu.as_mut() else {
+            return;
+        };
+        match key.code {
+            KeyCode::Esc => self.editor().menu = None,
+            KeyCode::Up | KeyCode::Char('k') => menu.cursor = menu.cursor.saturating_sub(1),
+            KeyCode::Down | KeyCode::Char('j') => {
+                menu.cursor = (menu.cursor + 1).min(menu.items.len().saturating_sub(1));
+            }
+            KeyCode::Enter => {
+                let action = menu.items[menu.cursor].action.clone();
+                self.editor().menu = None;
+                self.editor_menu_action(action);
+            }
+            _ => {}
+        }
+    }
+
+    /// The mouse while the menu is open: a press on a row picks it, a
+    /// press anywhere else closes the menu (and goes no further); the wheel
+    /// and moves are ignored. Returns whether the menu took the event.
+    pub(super) fn editor_menu_mouse(&mut self, event: MouseEvent) -> bool {
+        let Some(menu) = self
+            .agents()
+            .editor
+            .as_ref()
+            .and_then(|editor| editor.menu.as_ref())
+        else {
+            return false;
+        };
+        match event.kind {
+            MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Down(MouseButton::Right) => {
+                let hit = menu.row_at(event.column, event.row);
+                let action = hit.map(|i| menu.items[i].action.clone());
+                self.editor().menu = None;
+                if let Some(action) = action {
+                    self.editor_menu_action(action);
+                }
+                true
+            }
+            // Releases and drags belong to the press that opened or closed
+            // the menu; the wheel is swallowed so the canvas does not zoom
+            // under an open menu.
+            _ => true,
+        }
+    }
+
+    /// Run a menu row: each one is the key it names.
+    pub(super) fn editor_menu_action(&mut self, action: MenuAction) {
+        match action {
+            MenuAction::EditStage(name) => {
+                let editor = self.editor();
+                editor.view.select_stage(&name);
+                editor.sync_panel();
+                editor.focus = Focus::Inspector;
+            }
+            MenuAction::ConnectFrom(name) => {
+                let editor = self.editor();
+                editor.view.select_stage(&name);
+                editor.sync_panel();
+                self.editor_open_connect();
+            }
+            MenuAction::AddStageAfter(name) => {
+                let editor = self.editor();
+                editor.view.select_stage(&name);
+                editor.sync_panel();
+                editor.place_next = None;
+                editor.add_stage = Some(LineEdit::new(String::new(), false));
+            }
+            MenuAction::RenameStage(name) => {
+                let editor = self.editor();
+                editor.view.select_stage(&name);
+                editor.sync_panel();
+                editor.panel = Panel::Stage {
+                    name: name.clone(),
+                    tab: StageTab::Behaviour,
+                };
+                editor.focus = Focus::Inspector;
+                editor.cursor = editor
+                    .fields()
+                    .iter()
+                    .position(|f| f.id == FieldId::StageName)
+                    .unwrap_or(0);
+                self.editor_activate();
+            }
+            MenuAction::EditPrompts(name) => {
+                let editor = self.editor();
+                editor.view.select_stage(&name);
+                editor.sync_panel();
+                editor.panel = Panel::Stage {
+                    name,
+                    tab: StageTab::Behaviour,
+                };
+                editor.focus = Focus::Inspector;
+                self.editor_open_prompts();
+            }
+            MenuAction::DeleteStage(name) => {
+                let editor = self.editor();
+                editor.view.select_stage(&name);
+                editor.sync_panel();
+                self.editor_request_delete_stage(&name);
+            }
+            MenuAction::EditPath(from, to) => {
+                let editor = self.editor();
+                editor.view.select_edge(&from, &to);
+                editor.sync_panel();
+                editor.focus = Focus::Inspector;
+            }
+            MenuAction::DeletePath(from, to) => self.editor_delete_edge(&from, &to),
+            MenuAction::AddStageAt(x, y) => {
+                let editor = self.editor();
+                editor.place_next = Some((x, y));
+                editor.add_stage = Some(LineEdit::new(String::new(), false));
+            }
+            MenuAction::Fit => self.editor().view.fit(),
+            MenuAction::Rotate => self.editor().view.rotate(),
+            MenuAction::Definition => {
+                self.editor().overlay = Some(super::editor::Overlay::Definition { scroll: 0 });
+            }
+        }
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
@@ -106,6 +106,11 @@ pub(in crate::commands::dashboard) struct Editor {
     /// to itself) was opened from: the panel stays while it holds.
     pub(in crate::commands::dashboard) panel_anchor: Option<Selection>,
     pub(in crate::commands::dashboard) overlay: Option<Overlay>,
+    /// The right-click menu, while one is open.
+    pub(in crate::commands::dashboard) menu: Option<super::context_menu::ContextMenu>,
+    /// Where the next added stage goes on the canvas (a right click on empty
+    /// canvas); `None` places it after the rightmost box.
+    pub(in crate::commands::dashboard) place_next: Option<(f64, f64)>,
     pub(in crate::commands::dashboard) problems: Problems,
     /// The problems list expanded under the canvas.
     pub(in crate::commands::dashboard) problems_open: bool,
@@ -392,6 +397,8 @@ impl Dashboard {
             add_region: None,
             panel_anchor: None,
             overlay: None,
+            menu: None,
+            place_next: None,
             problems,
             problems_open: false,
             layout,

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_keys.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_keys.rs
@@ -29,6 +29,10 @@ impl Dashboard {
             }
             return;
         }
+        if self.editor().menu.is_some() {
+            self.editor_menu_key(&key);
+            return;
+        }
         if self.editor().picker.is_some() {
             self.editor_picker_key(&key);
             return;
@@ -51,12 +55,13 @@ impl Dashboard {
         }
         match key.code {
             KeyCode::Char('?') | KeyCode::F(1) => self.show_help = true,
-            KeyCode::Char('u') => {
+            KeyCode::Char('z') if ctrl && !key.modifiers.contains(KeyModifiers::SHIFT) => {
                 if !self.editor().undo() {
                     self.editor().message = Some("Nothing to undo".to_string());
                 }
             }
-            KeyCode::Char('r') if ctrl => {
+            // Ctrl-Y, and Ctrl-Shift-Z for those whose hands know that one.
+            KeyCode::Char('y') | KeyCode::Char('Z') | KeyCode::Char('z') if ctrl => {
                 if !self.editor().redo() {
                     self.editor().message = Some("Nothing to redo".to_string());
                 }
@@ -179,8 +184,16 @@ impl Dashboard {
                     return;
                 }
                 let after = self.editor().panel_stage();
+                let place = self.editor().place_next.take();
                 if self.editor_mutate(|d| d.add_stage(&name, after.as_deref())) {
                     let editor = self.editor();
+                    // A right click on empty canvas said where the box goes.
+                    if let Some(at) = place {
+                        let mut positions = editor.view.positions();
+                        positions.insert(name.clone(), at);
+                        let graph = editor.graph.clone();
+                        editor.view.replace_graph(graph, positions);
+                    }
                     editor.view.select_stage(&name);
                     editor.view.reveal(&name);
                     editor.sync_panel();
@@ -326,7 +339,7 @@ impl Dashboard {
 
     /// `c`: connect the selected stage to another, picked from a list (or
     /// to itself, which the canvas cannot draw as a drag).
-    fn editor_open_connect(&mut self) {
+    pub(super) fn editor_open_connect(&mut self) {
         let Some(from) = self.editor().panel_stage() else {
             self.editor().message = Some("Select a stage to connect from".to_string());
             return;
@@ -408,6 +421,7 @@ impl Dashboard {
                     let (name, positions) = (editor.name.clone(), editor.view.positions());
                     editor.layout.set(&name, positions);
                 }
+                CanvasEvent::ContextMenu { target, at } => self.editor_open_menu(&target, at),
             }
         }
         self.editor().sync_panel();

--- a/crates/leviath-cli/src/commands/dashboard/agents/menu_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/menu_tests.rs
@@ -1,0 +1,428 @@
+//! The canvas's right-click menu, a click off everything, and the hint
+//! bars that name every control: driven by mouse and keys, frames read
+//! back.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind};
+
+use super::context_menu::{ContextMenu, MenuAction};
+use super::editor::{Focus, Overlay};
+use super::inspector::{FieldId, Panel, StageTab};
+use super::tests::{dashboard, draw, key, mouse, open_editor_on, text, type_str};
+use crate::commands::dashboard::state::Dashboard;
+use crate::commands::dashboard::test_support::rendered_buffer;
+use crate::tui::flowgraph::MenuTarget;
+
+/// A press and release of `button` at a cell.
+fn click(dash: &mut Dashboard, button: MouseButton, x: u16, y: u16) {
+    dash.handle_mouse(mouse(MouseEventKind::Down(button), x, y));
+    dash.handle_mouse(mouse(MouseEventKind::Up(button), x, y));
+}
+
+/// A cell inside the box of `stage`, after a draw.
+fn inside(dash: &mut Dashboard, stage: &str) -> (u16, u16) {
+    let (x, y, _, _) = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .view
+        .node_rect(stage)
+        .expect("drawn");
+    (x as u16 + 2, y as u16 + 1)
+}
+
+/// An empty cell of the canvas: the bottom-left corner of the graph pane.
+fn empty_cell(dash: &mut Dashboard) -> (u16, u16) {
+    let rect = dash
+        .pane_rects
+        .iter()
+        .find(|(id, _)| *id == crate::commands::dashboard::types::PaneId::AgentEditorGraph)
+        .map(|(_, r)| *r)
+        .expect("the canvas is registered");
+    (rect.x + 2, rect.y + rect.height - 3)
+}
+
+fn menu(dash: &mut Dashboard) -> Option<ContextMenu> {
+    dash.agents().editor.as_ref().unwrap().menu.clone()
+}
+
+fn panel(dash: &mut Dashboard) -> Panel {
+    dash.agents().editor.as_ref().unwrap().panel.clone()
+}
+
+#[test]
+fn a_click_off_everything_clears_the_selection_but_a_pan_keeps_it() {
+    let (mut dash, root) = dashboard("click_off");
+    open_editor_on(&mut dash, "own");
+    draw(&mut dash, 160, 50);
+    let (x, y) = inside(&mut dash, "finish");
+    click(&mut dash, MouseButton::Left, x, y);
+    assert!(matches!(panel(&mut dash), Panel::Stage { .. }));
+    // A press and release on empty canvas: nothing selected, the agent panel.
+    let (ex, ey) = empty_cell(&mut dash);
+    click(&mut dash, MouseButton::Left, ex, ey);
+    assert_eq!(panel(&mut dash), Panel::Agent);
+    // Select again, then pan from empty canvas: the selection stays.
+    click(&mut dash, MouseButton::Left, x, y);
+    dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), ex, ey));
+    dash.handle_mouse(mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        ex + 4,
+        ey - 2,
+    ));
+    dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), ex + 4, ey - 2));
+    assert!(matches!(panel(&mut dash), Panel::Stage { .. }));
+    // A drag that goes nowhere is still a click.
+    dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), ex, ey));
+    dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), ex, ey));
+    dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), ex, ey));
+    assert_eq!(panel(&mut dash), Panel::Agent);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_right_click_opens_a_menu_for_what_is_under_it() {
+    let (mut dash, root) = dashboard("menus");
+    open_editor_on(&mut dash, "own");
+    draw(&mut dash, 160, 50);
+    // A stage: its menu, drawn where the click landed, with the keys named.
+    let (x, y) = inside(&mut dash, "work");
+    click(&mut dash, MouseButton::Right, x, y);
+    let m = menu(&mut dash).expect("a stage menu");
+    assert_eq!(m.title, "Stage · work");
+    assert_eq!(m.at, (x, y));
+    let screen = text(&mut dash);
+    assert!(screen.contains("Stage · work"), "{screen}");
+    assert!(screen.contains("Add a stage after it"), "{screen}");
+    assert!(
+        screen.contains("esc close · ↑↓ move · enter do it"),
+        "{screen}"
+    );
+    // Letters and the wheel do nothing to it; ↑↓ move, clamped.
+    dash.handle_key(key(KeyCode::Char('q')));
+    dash.handle_mouse(mouse(MouseEventKind::ScrollDown, x, y));
+    assert!(menu(&mut dash).is_some());
+    dash.handle_key(key(KeyCode::Up));
+    assert_eq!(menu(&mut dash).unwrap().cursor, 0);
+    for _ in 0..9 {
+        dash.handle_key(key(KeyCode::Down));
+    }
+    assert_eq!(menu(&mut dash).unwrap().cursor, 5);
+    dash.handle_key(key(KeyCode::Char('k')));
+    dash.handle_key(key(KeyCode::Char('j')));
+    assert_eq!(menu(&mut dash).unwrap().cursor, 5);
+    // Esc closes it; a click elsewhere closes it and goes no further (the
+    // stage selected with the left button stays selected).
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(menu(&mut dash).is_none());
+    click(&mut dash, MouseButton::Left, x, y);
+    click(&mut dash, MouseButton::Right, x, y);
+    let (ex, ey) = empty_cell(&mut dash);
+    dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), ex, ey));
+    assert!(menu(&mut dash).is_none());
+    assert!(
+        matches!(panel(&mut dash), Panel::Stage { .. }),
+        "the click only closed the menu"
+    );
+    dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), ex, ey));
+    // Empty canvas: the canvas menu; Enter on "fit" runs and closes.
+    click(&mut dash, MouseButton::Right, ex, ey);
+    let m = menu(&mut dash).expect("a canvas menu");
+    assert_eq!(m.title, "Canvas");
+    assert!(matches!(m.items[0].action, MenuAction::AddStageAt(..)));
+    dash.handle_key(key(KeyCode::Down));
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(menu(&mut dash).is_none());
+    // A path: its menu.
+    let (fx, fy, _, fb) = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .view
+        .node_rect("finish")
+        .unwrap();
+    let (wx, wy, wr, wb) = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .view
+        .node_rect("work")
+        .unwrap();
+    let _ = (wx, fb, wb);
+    // The path runs between the boxes at mid height (left-to-right).
+    let mid = ((wr + fx) / 2) as u16;
+    let row = ((wy + fy) / 2 + 1) as u16;
+    click(&mut dash, MouseButton::Right, mid, row);
+    let m = menu(&mut dash).expect("a path menu under the line");
+    assert_eq!(m.title, "Path · work → finish");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        panel(&mut dash),
+        Panel::Edge {
+            from: "work".into(),
+            to: "finish".into()
+        }
+    );
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().focus,
+        Focus::Inspector
+    );
+    // A worker box of another agent has no menu, only a message.
+    dash.editor_open_menu(&MenuTarget::Node("ext:researcher".into()), (1, 1));
+    assert!(menu(&mut dash).is_none());
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .message
+            .as_deref()
+            .is_some_and(|m| m.contains("separate agent"))
+    );
+    // A right drag is not the canvas's (it would box-select), nor is plain
+    // motion.
+    assert!(
+        !dash
+            .agents()
+            .editor
+            .as_mut()
+            .unwrap()
+            .view
+            .handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Right), x, y))
+    );
+    // The menu draws clamped inside a small area.
+    dash.editor_open_menu(&MenuTarget::Node("work".into()), (79, 23));
+    let screen = rendered_buffer(&draw(&mut dash, 80, 24));
+    assert!(screen.contains("Stage · work"), "{screen}");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn every_menu_row_does_what_its_key_does() {
+    let (mut dash, root) = dashboard("menu_rows");
+    open_editor_on(&mut dash, "own");
+    draw(&mut dash, 160, 50);
+    let (x, y) = inside(&mut dash, "work");
+    let pick = |dash: &mut Dashboard, row: usize| {
+        click(dash, MouseButton::Right, x, y);
+        let m = menu(dash).unwrap();
+        let drawn = {
+            draw(dash, 160, 50);
+            menu(dash).unwrap().drawn
+        };
+        assert_eq!(m.items.len(), 6);
+        // A click on the row picks it.
+        dash.handle_mouse(mouse(
+            MouseEventKind::Down(MouseButton::Left),
+            drawn.x + 2,
+            drawn.y + 1 + row as u16,
+        ));
+        assert!(menu(dash).is_none());
+    };
+    // Edit.
+    pick(&mut dash, 0);
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().focus,
+        Focus::Inspector
+    );
+    assert!(matches!(panel(&mut dash), Panel::Stage { name, .. } if name == "work"));
+    dash.handle_key(key(KeyCode::Esc));
+    // Connect to…: the chooser.
+    pick(&mut dash, 1);
+    assert!(dash.agents().editor.as_ref().unwrap().picker.is_some());
+    dash.handle_key(key(KeyCode::Esc));
+    // Add a stage after it: the name prompt, placed after the rightmost.
+    pick(&mut dash, 2);
+    assert!(dash.agents().editor.as_ref().unwrap().add_stage.is_some());
+    type_str(&mut dash, "next");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().doc.stage_names(),
+        ["work", "next", "finish"]
+    );
+    dash.handle_key(key(KeyCode::Esc));
+    draw(&mut dash, 160, 50);
+    // Rename: the name row is being typed.
+    pick(&mut dash, 3);
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().line,
+        Some((FieldId::StageName, _))
+    ));
+    dash.handle_key(key(KeyCode::Esc));
+    dash.handle_key(key(KeyCode::Esc));
+    draw(&mut dash, 160, 50);
+    // Edit prompts: the overlay.
+    pick(&mut dash, 4);
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(_))
+    ));
+    dash.handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL));
+    dash.handle_key(key(KeyCode::Esc));
+    draw(&mut dash, 160, 50);
+    // Delete stage: asks.
+    pick(&mut dash, 5);
+    assert!(dash.pending_confirm.is_some());
+    dash.handle_key(key(KeyCode::Char('n')));
+    // The canvas menu: add a stage at the click, turn, definition.
+    let (ex, ey) = empty_cell(&mut dash);
+    click(&mut dash, MouseButton::Right, ex, ey);
+    let MenuAction::AddStageAt(wx, wy) = menu(&mut dash).unwrap().items[0].action.clone() else {
+        panic!("the first row adds a stage");
+    };
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(
+        dash.agents().editor.as_ref().unwrap().place_next,
+        Some((wx, wy))
+    );
+    type_str(&mut dash, "here");
+    dash.handle_key(key(KeyCode::Enter));
+    let at = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .view
+        .positions()
+        .get("here")
+        .copied()
+        .expect("placed");
+    assert!(
+        (at.0 - wx).abs() < 1e-6 && (at.1 - wy).abs() < 1e-6,
+        "{at:?} vs {wx},{wy}"
+    );
+    assert!(dash.agents().editor.as_ref().unwrap().place_next.is_none());
+    // Esc on the prompt also forgets the spot.
+    dash.handle_key(key(KeyCode::Esc));
+    click(&mut dash, MouseButton::Right, ex, ey);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agents().editor.as_ref().unwrap().add_stage.is_none());
+    dash.editor_menu_action(MenuAction::Rotate);
+    dash.editor_menu_action(MenuAction::Definition);
+    assert!(matches!(
+        dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Definition { .. })
+    ));
+    dash.handle_key(key(KeyCode::Esc));
+    // A path row: delete it.
+    dash.editor_menu_action(MenuAction::DeletePath("work".into(), "finish".into()));
+    assert!(
+        dash.agents()
+            .editor
+            .as_ref()
+            .unwrap()
+            .doc
+            .edge("work", "finish")
+            .is_none()
+    );
+    // The menu helpers are inert with no menu, and with no editor.
+    assert!(!dash.editor_menu_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 1, 1)));
+    dash.editor_menu_key(&key(KeyCode::Enter));
+    dash.close_editor();
+    assert!(!dash.editor_menu_mouse(mouse(MouseEventKind::Down(MouseButton::Left), 1, 1)));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn the_bars_name_the_controls_on_every_screen() {
+    let (mut dash, root) = dashboard("bars");
+    // The run list calls the Agents screen out next to "new run", and the
+    // empty state too.
+    let screen = text(&mut dash);
+    assert!(screen.contains("[n] new run  [a] agents"), "{screen}");
+    assert!(screen.contains("`a` to build an agent"), "{screen}");
+    // The catalog, its filter, and the chooser.
+    dash.handle_key(key(KeyCode::Char('a')));
+    let screen = text(&mut dash);
+    assert!(
+        screen.contains("esc back · ↑↓ select · enter edit · n new"),
+        "{screen}"
+    );
+    dash.handle_key(key(KeyCode::Char('/')));
+    let screen = text(&mut dash);
+    assert!(
+        screen.contains("esc clear · type filter · enter keep"),
+        "{screen}"
+    );
+    dash.handle_key(key(KeyCode::Esc));
+    dash.handle_key(key(KeyCode::Char('n')));
+    let screen = text(&mut dash);
+    assert!(screen.contains("↑↓ template · type the name"), "{screen}");
+    dash.handle_key(key(KeyCode::Esc));
+    // The wheel over the catalog list moves the cursor; off it, or with the
+    // chooser open, it does not.
+    draw(&mut dash, 160, 50);
+    let list = dash.agents().list_area;
+    let before = dash.agents().catalog.selected;
+    dash.handle_mouse(mouse(MouseEventKind::ScrollDown, list.x + 2, list.y + 2));
+    assert_eq!(dash.agents().catalog.selected, before + 1);
+    dash.handle_mouse(mouse(MouseEventKind::ScrollUp, list.x + 2, list.y + 2));
+    assert_eq!(dash.agents().catalog.selected, before);
+    assert!(!dash.catalog_wheel(mouse(
+        MouseEventKind::ScrollDown,
+        list.x + list.width + 5,
+        list.y
+    )));
+    assert!(!dash.catalog_wheel(mouse(
+        MouseEventKind::Down(MouseButton::Left),
+        list.x + 2,
+        list.y + 2
+    )));
+    dash.handle_key(key(KeyCode::Char('n')));
+    assert!(!dash.catalog_wheel(mouse(MouseEventKind::ScrollDown, list.x + 2, list.y + 2)));
+    dash.handle_key(key(KeyCode::Esc));
+    // The editor: the canvas, the inspector (Esc says where it goes), a
+    // pushed panel, the choosers, the prompts.
+    open_editor_on(&mut dash, "own");
+    let screen = text(&mut dash);
+    assert!(screen.contains("esc close · ^s save · ? help"), "{screen}");
+    assert!(screen.contains("right-click menu"), "{screen}");
+    dash.handle_key(key(KeyCode::Tab));
+    let screen = text(&mut dash);
+    assert!(screen.contains("esc canvas · ^s save"), "{screen}");
+    assert!(screen.contains("x remove"), "{screen}");
+    dash.editor_add_region("r");
+    let screen = text(&mut dash);
+    assert!(screen.contains("esc back · ^s save"), "{screen}");
+    dash.handle_key(key(KeyCode::Esc));
+    dash.agents()
+        .editor
+        .as_mut()
+        .unwrap()
+        .view
+        .select_stage("work");
+    dash.agents().editor.as_mut().unwrap().sync_panel();
+    dash.agents().editor.as_mut().unwrap().panel = Panel::Stage {
+        name: "work".into(),
+        tab: StageTab::Model,
+    };
+    let at = dash
+        .agents()
+        .editor
+        .as_ref()
+        .unwrap()
+        .fields()
+        .iter()
+        .position(|f| f.id == FieldId::ToolSet)
+        .unwrap();
+    dash.agents().editor.as_mut().unwrap().cursor = at;
+    dash.handle_key(key(KeyCode::Enter));
+    let screen = text(&mut dash);
+    assert!(
+        screen.contains("space pick / drop · enter keep"),
+        "{screen}"
+    );
+    dash.handle_key(key(KeyCode::Esc));
+    dash.agents().editor.as_mut().unwrap().cursor = 0;
+    dash.handle_key(key(KeyCode::Enter));
+    let screen = text(&mut dash);
+    assert!(
+        screen.contains("esc cancel · type search · ↑↓ move · enter choose"),
+        "{screen}"
+    );
+    dash.handle_key(key(KeyCode::Esc));
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/mod.rs
@@ -11,10 +11,13 @@
 
 mod catalog;
 mod chooser;
+mod context_menu;
 mod editor;
 mod editor_keys;
 mod editor_panels;
 mod inspector;
+#[cfg(test)]
+mod menu_tests;
 #[cfg(test)]
 mod panel_tests;
 mod prompts;
@@ -46,6 +49,8 @@ pub(in crate::commands::dashboard) struct AgentsScreen {
     pub(in crate::commands::dashboard) editor: Option<Editor>,
     /// The whole terminal at the last draw, for overlays that take the mouse.
     pub(in crate::commands::dashboard) last_area: Rect,
+    /// Where the last frame drew the catalog list, for the wheel.
+    pub(in crate::commands::dashboard) list_area: Rect,
     /// `provider/model` ids the providers reported, once the background
     /// listing comes back; empty until then.
     pub(in crate::commands::dashboard) model_catalog: Vec<String>,
@@ -66,6 +71,7 @@ impl Dashboard {
             chooser: None,
             editor: None,
             last_area: Rect::default(),
+            list_area: Rect::default(),
             model_catalog: Vec::new(),
             models_rx: Some(rx),
         }));
@@ -153,7 +159,13 @@ impl Dashboard {
         event: crossterm::event::MouseEvent,
     ) -> bool {
         let area = self.agents().last_area;
+        if self.editor_menu_mouse(event) {
+            return true;
+        }
         if self.editor_picker_mouse(event, area) {
+            return true;
+        }
+        if self.catalog_wheel(event) {
             return true;
         }
         if self.editor_inspector_mouse(event) {

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_catalog.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_catalog.rs
@@ -34,6 +34,7 @@ impl Dashboard {
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(45), Constraint::Percentage(55)])
             .split(rows[0]);
+        self.agents().list_area = panes[0];
         self.draw_catalog_list(frame, panes[0]);
         self.draw_catalog_detail(frame, panes[1]);
         self.draw_catalog_hints(frame, rows[1]);
@@ -220,26 +221,35 @@ impl Dashboard {
     }
 
     fn draw_catalog_hints(&self, frame: &mut Frame, area: Rect) {
-        let filtering = self
-            .agent_builder
-            .as_ref()
-            .is_some_and(|s| s.catalog.filtering);
-        let hints = if filtering {
+        let screen = self.agent_builder.as_deref().expect("callers check");
+        // Priority order: on a narrow terminal the tail falls off, and `?`
+        // always has the full list.
+        let hints = if screen.chooser.is_some() {
             vec![
-                hint("type", "filter"),
-                hint("enter", "done"),
+                hint("esc", "back"),
+                hint("↑↓", "template"),
+                hint("type", "the name"),
+                hint("enter", "open the editor"),
+                hint("?", "help"),
+            ]
+        } else if screen.catalog.filtering {
+            vec![
                 hint("esc", "clear"),
+                hint("type", "filter"),
+                hint("enter", "keep"),
             ]
         } else {
             vec![
+                hint("esc", "back"),
+                hint("↑↓", "select"),
                 hint("enter", "edit"),
                 hint("n", "new"),
                 hint("l", "launch"),
+                hint("?", "help"),
                 hint("d", "delete"),
                 hint("r", "reset"),
                 hint("/", "filter"),
-                hint("?", "help"),
-                hint("esc", "back"),
+                hint("wheel", "scroll"),
             ]
         };
         draw_hint_bar(frame, area, None, &hints, false);

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
@@ -289,57 +289,90 @@ impl Dashboard {
 
     fn draw_editor_hints(&mut self, frame: &mut Frame, area: Rect) {
         let editor = self.editor();
-        let hints = if editor.picker.is_some() {
+        // Priority order: on a narrow terminal the tail falls off, and `?`
+        // always has the full list.
+        let hints = if editor.menu.is_some() {
             vec![
+                hint("esc", "close"),
+                hint("↑↓", "move"),
+                hint("enter", "do it"),
+                hint("click", "pick / close"),
+            ]
+        } else if let Some((_, picker)) = &editor.picker {
+            let mut hints = vec![
+                hint("esc", "cancel"),
                 hint("type", "search"),
                 hint("↑↓", "move"),
-                hint("enter", "choose"),
-                hint("esc", "cancel"),
-            ]
+            ];
+            if picker.multi.is_some() {
+                hints.push(hint("space", "pick / drop"));
+                hints.push(hint("enter", "keep"));
+            } else {
+                hints.push(hint("enter", "choose"));
+            }
+            hints
         } else if editor.line.is_some() || editor.add_stage.is_some() || editor.add_region.is_some()
         {
-            vec![hint("enter", "apply"), hint("esc", "cancel")]
+            vec![
+                hint("esc", "cancel"),
+                hint("type", "edit"),
+                hint("enter", "apply"),
+            ]
         } else if matches!(editor.overlay, Some(Overlay::Prompts(_))) {
             vec![
-                hint("tab", "other prompt"),
-                hint("^s/esc", "apply"),
+                hint("esc / ^s", "apply"),
                 hint("^q", "discard"),
+                hint("tab", "other prompt"),
                 hint("^e", "$EDITOR"),
+                hint("?", "help"),
             ]
         } else if editor.overlay.is_some() {
             vec![
+                hint("esc", "close"),
                 hint("↑↓", "scroll"),
                 hint("y", "copy"),
-                hint("esc", "close"),
             ]
         } else {
             match editor.focus {
                 Focus::Canvas => vec![
+                    hint("esc", "close"),
                     hint("^s", "save"),
+                    hint("?", "help"),
                     hint("tab", "inspector"),
+                    hint("←→↑↓", "select"),
+                    hint("enter", "edit"),
+                    hint("right-click", "menu"),
                     hint("a", "add stage"),
                     hint("c", "connect"),
                     hint("x", "delete"),
-                    hint("enter", "edit"),
-                    hint("u", "undo"),
-                    hint("^r", "redo"),
+                    hint("^z", "undo"),
+                    hint("^y", "redo"),
                     hint("v", "definition"),
                     hint("p", "problems"),
-                    hint("?", "help"),
                     hint("r", "rotate"),
                     hint("f", "fit"),
-                    hint("esc", "close"),
+                    hint("+ -", "zoom"),
+                    hint("drag", "move / connect"),
                 ],
                 Focus::Inspector => vec![
+                    hint(
+                        "esc",
+                        if editor.panel_anchor.is_some() {
+                            "back"
+                        } else {
+                            "canvas"
+                        },
+                    ),
                     hint("^s", "save"),
+                    hint("?", "help"),
                     hint("↑↓", "row"),
                     hint("enter", "edit"),
                     hint("←→", "change"),
+                    hint("x", "remove"),
                     hint("1-3", "tab"),
                     hint("tab", "canvas"),
-                    hint("u", "undo"),
-                    hint("?", "help"),
-                    hint("esc", "canvas"),
+                    hint("^z", "undo"),
+                    hint("click", "pick a row"),
                 ],
             }
         };
@@ -350,6 +383,10 @@ impl Dashboard {
     /// definition, on top.
     fn draw_editor_overlays(&mut self, frame: &mut Frame, area: Rect) {
         if self.draw_editor_prompts(frame, area) {
+            return;
+        }
+        if let Some(menu) = self.editor().menu.as_mut() {
+            menu.draw(frame, area);
             return;
         }
         let editor = self.editor();

--- a/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
@@ -617,7 +617,7 @@ fn the_canvas_adds_connects_selects_and_deletes_with_undo_behind_it() {
             .edge("review", "finish")
             .is_none()
     );
-    dash.handle_key(key(KeyCode::Char('u')));
+    dash.handle_key(ctrl('z'));
     assert!(
         dash.agents()
             .editor
@@ -627,7 +627,7 @@ fn the_canvas_adds_connects_selects_and_deletes_with_undo_behind_it() {
             .edge("review", "finish")
             .is_some()
     );
-    dash.handle_key(ctrl('r'));
+    dash.handle_key(ctrl('y'));
     assert!(
         dash.agents()
             .editor
@@ -637,7 +637,18 @@ fn the_canvas_adds_connects_selects_and_deletes_with_undo_behind_it() {
             .edge("review", "finish")
             .is_none()
     );
-    dash.handle_key(ctrl('r'));
+    // Ctrl-Shift-Z redoes too, however the terminal spells it.
+    dash.handle_key(KeyEvent::new(
+        KeyCode::Char('Z'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+    ));
+    assert!(text(&mut dash).contains("Nothing to redo"));
+    dash.handle_key(KeyEvent::new(
+        KeyCode::Char('z'),
+        KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+    ));
+    assert!(text(&mut dash).contains("Nothing to redo"));
+    dash.handle_key(ctrl('y'));
     assert!(text(&mut dash).contains("Nothing to redo"));
     // Delete a stage: asks; No keeps it, Yes removes it and its paths.
     dash.agents()
@@ -672,8 +683,11 @@ fn the_canvas_adds_connects_selects_and_deletes_with_undo_behind_it() {
         dash.agents().editor.as_ref().unwrap().doc.stage_names(),
         ["work", "finish"]
     );
-    dash.handle_key(key(KeyCode::Char('u')));
+    dash.handle_key(ctrl('z'));
     assert!(text(&mut dash).contains("Nothing to undo"));
+    // `u` is no longer a key: it is left for the canvas, which ignores it.
+    dash.handle_key(key(KeyCode::Char('u')));
+    assert!(!text(&mut dash).contains("Nothing to undo"));
     // The rest of the canvas keys: rotate, fit, zoom, and a key nobody has.
     for code in [
         KeyCode::Char('r'),

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -245,24 +245,27 @@ impl Dashboard {
     pub(super) fn route_mouse_to_graph(&mut self, event: MouseEvent) -> bool {
         let target = match event.kind {
             MouseEventKind::Down(MouseButton::Left)
+            | MouseEventKind::Down(MouseButton::Right)
             | MouseEventKind::ScrollUp
             | MouseEventKind::ScrollDown => self
                 .mouse_capture
                 .or_else(|| self.graph_pane_at(event.column, event.row)),
-            MouseEventKind::Drag(MouseButton::Left) | MouseEventKind::Up(MouseButton::Left) => {
-                self.mouse_capture
-            }
+            MouseEventKind::Drag(MouseButton::Left)
+            | MouseEventKind::Up(MouseButton::Left)
+            | MouseEventKind::Up(MouseButton::Right) => self.mouse_capture,
             _ => None,
         };
         let Some(id) = target else {
             return false;
         };
         match event.kind {
-            MouseEventKind::Down(MouseButton::Left) => {
+            MouseEventKind::Down(MouseButton::Left) | MouseEventKind::Down(MouseButton::Right) => {
                 self.mouse_capture = Some(id);
                 self.selection = None;
             }
-            MouseEventKind::Up(MouseButton::Left) => self.mouse_capture = None,
+            MouseEventKind::Up(MouseButton::Left) | MouseEventKind::Up(MouseButton::Right) => {
+                self.mouse_capture = None;
+            }
             _ => {}
         }
         // The pane may have closed between frames; the event is still ours
@@ -821,9 +824,17 @@ condition = "llm_choice"
         dash.handle_mouse(mouse(MouseEventKind::ScrollDown, inside.0, inside.1));
         assert!(dash.stage_explorer.as_ref().unwrap().view.zoom() < zoom);
 
-        // The right button and plain motion are not routed.
+        // The right button is the canvas's too (an editor opens a menu on
+        // it; the explorer ignores it), held until its release; plain
+        // motion is not routed.
         dash.handle_mouse(mouse(
             MouseEventKind::Down(MouseButton::Right),
+            inside.0,
+            inside.1,
+        ));
+        assert_ne!(dash.mouse_capture, None);
+        dash.handle_mouse(mouse(
+            MouseEventKind::Up(MouseButton::Right),
             inside.0,
             inside.1,
         ));

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -98,6 +98,8 @@ fn agents_sections() -> Vec<HelpSection> {
             title: "Agents (a)",
             entries: vec![
                 ("↑ ↓ / k j", "select an agent"),
+                ("home / end, pgup / pgdn", "first / last, a page at a time"),
+                ("wheel", "over the list: move; over the preview: zoom"),
                 ("enter / e", "edit it (a bundled one installs when saved)"),
                 ("n", "new agent: start simple, or clone one"),
                 ("l", "launch it: the new-run screen with it picked"),
@@ -111,6 +113,7 @@ fn agents_sections() -> Vec<HelpSection> {
                     "filter by name or description; enter keeps it, esc clears it",
                 ),
                 ("esc / q", "back to the run list"),
+                ("? / F1", "this help"),
             ],
         },
         HelpSection {
@@ -138,7 +141,10 @@ fn agent_editor_sections() -> Vec<HelpSection> {
                     "save (checks first; errors block it and open the problems)",
                 ),
                 ("tab", "move the keys between the canvas and the inspector"),
-                ("u / ctrl-r", "undo / redo an edit"),
+                (
+                    "ctrl-z / ctrl-y",
+                    "undo / redo an edit (ctrl-shift-z redoes too)",
+                ),
                 (
                     "v",
                     "the definition: the exact file that will be saved (y copies it)",
@@ -162,16 +168,23 @@ fn agent_editor_sections() -> Vec<HelpSection> {
                 ("+ / - / 0, f, r", "zoom, fit, turn the graph"),
                 ("drag a box", "move it (the arrangement is kept per agent)"),
                 ("drag a ●", "connect two stages with the mouse"),
-                ("click", "select a stage or a path"),
+                (
+                    "click",
+                    "select a stage or a path; on empty canvas, select nothing",
+                ),
+                (
+                    "right-click",
+                    "a menu for the stage, path or canvas under the pointer",
+                ),
             ],
         },
         HelpSection {
             title: "Agent editor: inspector",
             entries: vec![
-                ("↑ ↓ / k j", "move between rows"),
+                ("↑ ↓ / k j, home / end", "move between rows"),
                 (
                     "enter",
-                    "edit the row: type, choose, flip, or press the button",
+                    "edit the row: type, choose, flip, open, or press the button",
                 ),
                 (
                     "← → / h l",
@@ -185,8 +198,26 @@ fn agent_editor_sections() -> Vec<HelpSection> {
                 ("← → on a model", "move it earlier or later in the chain"),
                 (
                     "esc",
-                    "back: a region returns to where it was opened from, otherwise the canvas",
+                    "back: a region or a loop's path returns to where it was opened from, otherwise the canvas",
                 ),
+                (
+                    "click",
+                    "pick a row (again to open it); click a tab to switch",
+                ),
+            ],
+        },
+        HelpSection {
+            title: "Agent editor: choosers and the definition",
+            entries: vec![
+                (
+                    "type",
+                    "search the list; ↑ ↓ move; enter chooses, esc cancels",
+                ),
+                (
+                    "space",
+                    "in the tools chooser: pick or drop a row; enter keeps the picks",
+                ),
+                ("↑ ↓, y", "in the definition: scroll, copy it"),
             ],
         },
         HelpSection {

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -141,7 +141,10 @@ impl Dashboard {
             .collect();
 
         let empty_state_msg: Option<String> = if self.agents.is_empty() {
-            Some("  No agent runs yet. Press `n` to start one.".to_string())
+            Some(
+                "  No agent runs yet. Press `n` to start one, or `a` to build an agent."
+                    .to_string(),
+            )
         } else if self.display_indices.is_empty() {
             Some(format!(
                 "  No agent runs match \"{}\".",
@@ -568,6 +571,11 @@ impl Dashboard {
             ),
             Span::raw(" new run  "),
             Span::styled(
+                "[a]",
+                Style::default().fg(C_SUCCESS).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" agents  "),
+            Span::styled(
                 "[Tab]",
                 Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
             ),
@@ -585,8 +593,6 @@ impl Dashboard {
             Span::raw(" mark  "),
             Span::styled("[m]", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" mcp  "),
-            Span::styled("[a]", Style::default().add_modifier(Modifier::BOLD)),
-            Span::raw(" agents  "),
         ];
         if can_kill {
             spans.push(Span::styled(

--- a/crates/leviath-cli/src/tui/flowgraph/mod.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/mod.rs
@@ -23,4 +23,4 @@ pub(crate) mod view;
 pub(crate) use content::{RunPhase, WorkerCounts};
 pub(crate) use layout::Direction;
 pub(crate) use model::StageGraph;
-pub(crate) use view::{CanvasEvent, FlowView, LiveOverlay, Selection, StageLive};
+pub(crate) use view::{CanvasEvent, FlowView, LiveOverlay, MenuTarget, Selection, StageLive};

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -73,12 +73,25 @@ pub(crate) enum Selection {
 }
 
 /// What the canvas did with the mouse that the editor has to act on.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum CanvasEvent {
     /// A handle was dragged onto another box: a path to add.
     Connected { from: String, to: String },
     /// A box was dropped somewhere new: positions to remember.
     Moved,
+    /// A right click: what was under it, and where on screen it was.
+    ContextMenu { target: MenuTarget, at: (u16, u16) },
+}
+
+/// What a right click landed on.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum MenuTarget {
+    /// A stage box (an `ext:` worker box is reported as it is).
+    Node(String),
+    /// A path.
+    Edge(StageEdge),
+    /// Empty canvas, in world units (where a new box would go).
+    Pane { x: f64, y: f64 },
 }
 
 /// One drawn edge, remembered so live restyling can find it.
@@ -108,6 +121,11 @@ pub(crate) struct FlowView {
     /// layout places every box.
     positions: Positions,
     events: Vec<CanvasEvent>,
+    /// A left press on empty canvas that has not moved yet: its release
+    /// without a drag is a click off everything, which clears the selection.
+    /// (rataflow treats the press as the start of a pan, and a pan must keep
+    /// the selection, so the click is told apart here.)
+    pane_press: Option<(u16, u16)>,
     direction: Direction,
     /// Until the user turns the graph by hand, the first draw picks the
     /// direction that fits.
@@ -429,6 +447,7 @@ impl FlowView {
             edit,
             positions,
             events: Vec::new(),
+            pane_press: None,
             direction: Direction::LeftToRight,
             auto_direction: true,
             show_escape: false,
@@ -734,8 +753,8 @@ impl FlowView {
     }
 
     /// Mouse on the canvas: left button pans or selects, the wheel zooms at
-    /// the cursor. Anything else is left alone. Returns whether the event
-    /// was forwarded.
+    /// the cursor; in an editor the right button asks for a menu. Anything
+    /// else is left alone. Returns whether the event was forwarded.
     pub(crate) fn handle_mouse(&mut self, event: MouseEvent) -> bool {
         let forward = matches!(
             event.kind,
@@ -744,27 +763,68 @@ impl FlowView {
                 | MouseEventKind::Up(MouseButton::Left)
                 | MouseEventKind::ScrollUp
                 | MouseEventKind::ScrollDown
-        );
-        if forward {
-            let response = self.flow.handle_mouse_event(event);
-            if self.edit {
-                for ev in response.events() {
-                    match ev {
-                        rataflow::FlowEvent::ConnectionCompleted(c) => {
-                            self.events.push(CanvasEvent::Connected {
-                                from: c.source.clone(),
-                                to: c.target.clone(),
-                            });
-                        }
-                        rataflow::FlowEvent::NodeDragEnded { .. } => {
-                            self.events.push(CanvasEvent::Moved);
-                        }
-                        _ => {}
-                    }
+        ) || (self.edit
+            && matches!(
+                event.kind,
+                // The drag is left out on purpose: rataflow turns a right
+                // drag into a selection box, and the editor has no use for
+                // several boxes selected at once.
+                MouseEventKind::Down(MouseButton::Right) | MouseEventKind::Up(MouseButton::Right)
+            ));
+        if !forward {
+            return false;
+        }
+        let response = self.flow.handle_mouse_event(event);
+        if !self.edit {
+            return true;
+        }
+        let at = (event.column, event.row);
+        match event.kind {
+            MouseEventKind::Drag(MouseButton::Left) => {
+                if self.pane_press.is_some_and(|p| p != at) {
+                    self.pane_press = None;
                 }
             }
+            MouseEventKind::Up(MouseButton::Left) if self.pane_press.take().is_some() => {
+                self.flow.clear_selection();
+            }
+            _ => {}
         }
-        forward
+        for ev in response.events() {
+            match ev {
+                rataflow::FlowEvent::ConnectionCompleted(c) => {
+                    self.events.push(CanvasEvent::Connected {
+                        from: c.source.clone(),
+                        to: c.target.clone(),
+                    });
+                }
+                rataflow::FlowEvent::NodeDragEnded { .. } => {
+                    self.events.push(CanvasEvent::Moved);
+                }
+                rataflow::FlowEvent::PaneClicked { .. } => self.pane_press = Some(at),
+                rataflow::FlowEvent::NodeContextMenu { node_id } => {
+                    self.events.push(CanvasEvent::ContextMenu {
+                        target: MenuTarget::Node(node_id.clone()),
+                        at,
+                    });
+                }
+                rataflow::FlowEvent::EdgeContextMenu { edge_id } => {
+                    let hit = self.edges.iter().find(|m| m.id == *edge_id);
+                    self.events.extend(hit.map(|meta| CanvasEvent::ContextMenu {
+                        target: MenuTarget::Edge(meta.edge.clone()),
+                        at,
+                    }));
+                }
+                rataflow::FlowEvent::PaneContextMenu { x, y } => {
+                    self.events.push(CanvasEvent::ContextMenu {
+                        target: MenuTarget::Pane { x: *x, y: *y },
+                        at,
+                    });
+                }
+                _ => {}
+            }
+        }
+        true
     }
 
     /// Paint the run onto the blueprint. Cheap enough to call every draw:

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -243,6 +243,7 @@ An installed bundled agent that has been edited says `edited`, and `r` puts the 
 | `/` | Filter by name or description; `Enter` keeps the filter, `Esc` clears it |
 | `?` / `F1` | Help |
 | `Esc` / `q` | Back to the run list |
+| mouse | Wheel over the list to move; wheel and drag on the preview to zoom and pan |
 
 ### Agent editor
 
@@ -280,8 +281,8 @@ the text comes back into the box when it closes.
 
 Every edit is checked as you make it, the way `lev validate` checks a file: the line under the graph
 says how many errors and warnings there are (`p` opens the list), a stage an error names carries a
-`!` on its box, and saving is refused while there are errors. `u` undoes the last edit, `Ctrl-R`
-redoes it. `v` shows the exact `agent.leviath` that will be saved, comments and all: the editor keeps
+`!` on its box, and saving is refused while there are errors. `Ctrl-Z` undoes the last edit, `Ctrl-Y`
+(or `Ctrl-Shift-Z`) redoes it. `v` shows the exact `agent.leviath` that will be saved, comments and all: the editor keeps
 your file's comments, key order and formatting, and only writes the keys it knows.
 
 An arrangement dragged into shape is kept per agent (in `dash/graph-layouts.json` under the data
@@ -291,7 +292,7 @@ directory), so a graph opens the way you left it; it is never part of the manife
 |---|---|
 | `Ctrl-S` | Save (checks first; errors block it and open the problems list) |
 | `Tab` | Move the keys between the graph and the inspector |
-| `u` / `Ctrl-R` | Undo / redo |
+| `Ctrl-Z` / `Ctrl-Y` | Undo / redo (`Ctrl-Shift-Z` redoes too) |
 | `v` | The definition; `y` copies it, `Esc` closes it |
 | `p` | Open or close the problems list under the graph |
 | `?` / `F1` | Help |
@@ -307,7 +308,8 @@ On the graph:
 | `c` | Connect the selected stage to another, picked from a list (or to itself: a loop) |
 | `x` / `Delete` | Delete the selected stage (asks first) or path |
 | `+` / `-` , `0`, `f`, `r` | Zoom, fit, turn the graph |
-| mouse | Click a box or a path to select it, drag a box to move it, drag a `●` handle onto another box to connect them, drag empty canvas to pan, wheel to zoom |
+| mouse | Click a box or a path to select it; click empty canvas to select nothing (back to **This agent**); drag a box to move it, drag a `●` handle onto another box to connect them, drag empty canvas to pan, wheel to zoom |
+| right-click | A menu for what is under the pointer: a stage (edit, connect to, add a stage after it, rename, edit prompts, delete), a path (edit, delete), or the empty canvas (add a stage there, fit, turn, show the definition). `↑` `↓` and `Enter` work it, `Esc` or a click elsewhere closes it |
 
 On the inspector:
 


### PR DESCRIPTION
Follow-up to #515 from trying the editor: the controls were there but not all of them were said, and the canvas had no mouse menu.

## Called out
- The run list's bar put `[a] agents` last, where any terminal under ~150 columns cut it off, so the Agents screen looked like it did not exist. It now sits next to `[n] new run`, styled the same, and the empty state says "or `a` to build an agent".
- Every bar in the Agents screen and the editor is in priority order with `esc` and `?` first (they used to fall off first on a narrow terminal); the new-agent chooser has its own bar (it showed the catalog's); the inspector's `esc` says `back` on a region or loop panel and `canvas` otherwise; `x remove`, `space pick / drop`, `right-click menu`, `click pick a row` are named; the help overlay lists what the bars leave out (home/end, the wheel, the choosers, the definition).
- The wheel over the catalog list moves the cursor, as over the run list.

## Mouse on the canvas
- **Right-click menu**: on a stage (edit, connect to, add a stage after it, rename, edit prompts, delete), on a path (edit, delete), on empty canvas (add a stage there, fit, turn, definition). Opens at the pointer; `↑`/`↓` `Enter`, `Esc` or a click elsewhere closes it, a click on a row picks it. Every row is the key it names. A stage added from the canvas menu lands where the click was.
- **Click off**: a left click on empty canvas selects nothing (back to **This agent**); a pan still keeps the selection.
- **Undo/redo** are `Ctrl-Z` / `Ctrl-Y` (`Ctrl-Shift-Z` too) instead of `u` / `Ctrl-R`.

## Verification
- `cargo xtask coverage --package leviath-cli` 100%, clippy clean, `cargo xtask docs` clean; new `menu_tests.rs`.
- Live (pty): right-click on a box → menu → "Add a stage after it" → name → added; `Ctrl-Z` / `Ctrl-Y`; right-click on empty canvas → canvas menu; left click on empty canvas → agent panel; a pan keeps the selection; right-click on a path label → path menu.
