### PR TITLE
fix: stop agents reading context regions as files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,48 @@ same list.
 
 ## Unreleased
 
+- Fixed: agents no longer waste turns calling `read_file` on a context region.
+  A stage that routes tool output into a region left a pointer in the
+  conversation ending "read that region for the full result" - an instruction
+  with no tool behind it, since the region is rendered into the system prompt
+  already and most stages that route did not grant `context_read`. Models did
+  the only thing left and aimed `read_file` at the region name. Across 152 local
+  runs, 168 of 299 `read_file` calls failed and 90 of those were a region name
+  where a path belongs, spread over 32 of the 46 runs that used the tool; one
+  run spent five turns on five spellings of `raw_findings` across three stages
+  and finished reporting that it had found nothing. The pointer now names the
+  heading the region is rendered under and says no tool call is needed, a path
+  tool aimed at a region says so in its error (as does one handed a directory
+  instead of a file), every bundled stage that routes and reads files grants
+  `context_read`, and `lev validate` warns
+  (`routing-without-region-read`) when a blueprint has the shape that caused it.
+- Fixed: a routed tool result that does not fit its region is no longer
+  described as though it did. The pointer promised the full result whatever the
+  region had actually kept, so a full region silently turned a fetched source
+  into `[result omitted]` while the model went on reasoning as if it were there
+  - three of thirty-five entries in one run, two of them dropped outright.
+- Fixed: `admission = "evict"` evicts. It is the default and has always been
+  documented as "make room for the write - roll off the oldest entry", but a
+  write that did not fit was refused exactly as under `admission = "reject"`;
+  only a sliding window's *count* limit ever dropped anything. A working region
+  now rolls its oldest entries off to admit a new write, which is what stops the
+  newest material being the thing that gets lost. Regions that own their own
+  retention are untouched: `pinned` and persistent custom regions are meant to
+  survive the run, a `hashmap` already evicts by LRU, and a custom region's
+  `on_overflow` script is the author's policy and is not overridden. An entry
+  larger than the whole region still fails without emptying it, since evicting
+  for it would destroy what is held and fail anyway.
+- Fixed: region budgets scale with the model again. Every bundled region paired
+  `budget = "N%"` with an absolute `max_tokens`, and the cap is the smaller of
+  the two above roughly a 167k window - `researcher` ran on a 1,048,576-token
+  model with `raw_findings` asking for 30%, or 314,573 tokens, and getting
+  40,000. Resolving each bundled layout at 200k and at 1M produced almost
+  identical numbers, a growth of 1.03x across a 5.24x difference in window. The
+  guard-rails are gone, along with the `threshold_tokens` that independently
+  capped compaction triggers, so the percentage decides. `lev create`'s
+  templates and the blueprint editor's new-region defaults lose their caps too,
+  and the editor can now see and set `min_tokens`, which it never modelled.
+
 - New: the scripts API manages Rhai model providers. `provider` joins `tool`,
   `region_hook`, `stage_hook` and `output_validator` as a `kind` on
   `GET /api/scripts`, `GET/PUT/DELETE /api/scripts/{kind}/{name}` and

--- a/crates/leviath-cli/agents/coder/agent.leviath
+++ b/crates/leviath-cli/agents/coder/agent.leviath
@@ -654,8 +654,14 @@ provider = "anthropic"
 model    = "claude-sonnet-5"
 
 # ─── Context layout ──────────────────────────────────────────────────────────
-# Budgets are a percentage of the model's context window (issue #100) with an
-# absolute `max_tokens`/`threshold_tokens` guard-rail. Percentages are ceilings.
+# Budgets are a percentage of the model's context window (issue #100), and the
+# percentage is the whole answer: every region scales with whatever model the
+# stage runs on. No absolute `max_tokens`/`threshold_tokens` guard-rails - a cap
+# below the percentage silently wins on every window worth having, which is how
+# a 1M-context run ended up with a 40k findings region. Percentages are ceilings,
+# not reservations: a region costs only what is stored in it, so a ceiling it
+# never reaches is free, and they may sum past 100% because regions rarely fill
+# together.
 
 # ─── Final output ────────────────────────────────────────────────────────────
 # Terminal. `mode = "output"` grants `submit_output`, requires the call, and
@@ -681,60 +687,60 @@ why you did it this way.
 
 [context.regions]
 # ── Inputs (pinned, stable, cacheable) ──
-task         = { kind = "pinned", budget = "2%", max_tokens = 4000, required = true, required_message = "Describe the task via --task (or the API/ACP task field).", volatility = "stable" }
+task         = { kind = "pinned", budget = "2%", required = true, required_message = "Describe the task via --task (or the API/ACP task field).", volatility = "stable" }
 # Optional caller limits: --constraints "must stay on Node 18, no new deps".
-constraints  = { kind = "pinned", budget = "1%", max_tokens = 2000, seed = "constraints", volatility = "stable" }
+constraints  = { kind = "pinned", budget = "1%", seed = "constraints", volatility = "stable" }
 # Pre-loaded on startup: architecture / design docs (missing files skipped).
 # Pre-loaded on startup: coding style, lint rules, contribution guide (missing files skipped).
-conventions  = { kind = "pinned", budget = "2%", max_tokens = 3000, seed = { files = ["CONVENTIONS.md", "CONTRIBUTING.md", "STYLEGUIDE.md", "STYLE.md", ".editorconfig", "rustfmt.toml", ".rustfmt.toml", ".prettierrc", ".eslintrc.json", "ruff.toml", "pyproject.toml"] }, volatility = "stable" }
-architecture = { kind = "pinned", budget = "3%", max_tokens = 6000, seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "docs/architecture.md", "README.md"] }, volatility = "stable" }
-plan         = { kind = "pinned", budget = "5%", max_tokens = 6000 }
+conventions  = { kind = "pinned", budget = "2%", seed = { files = ["CONVENTIONS.md", "CONTRIBUTING.md", "STYLEGUIDE.md", "STYLE.md", ".editorconfig", "rustfmt.toml", ".rustfmt.toml", ".prettierrc", ".eslintrc.json", "ruff.toml", "pyproject.toml"] }, volatility = "stable" }
+architecture = { kind = "pinned", budget = "3%", seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "docs/architecture.md", "README.md"] }, volatility = "stable" }
+plan         = { kind = "pinned", budget = "5%" }
 # Verified findings from a `prototype` spike: the assumption, the verdict, and
 # the command that settled it - including what was RULED OUT. Pinned so neither
 # implement nor reassess redoes the spike.
-prototypes   = { kind = "pinned", budget = "4%", max_tokens = 6000, volatility = "grows" }
+prototypes   = { kind = "pinned", budget = "4%", volatility = "grows" }
 # Written by the RUNTIME when a `stuck` edge fires (issue #106): which threshold
 # tripped and why. Pinned so it survives the edge transform into `reassess`.
-stuck_report = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+stuck_report = { kind = "pinned", budget = "1%" }
 # Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
 # inference call's error text, or a note that a stage hit its iteration cap.
 # Pinned so it survives the edge transform into `error_recovery` or `review`.
-error_report = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+error_report = { kind = "pinned", budget = "1%" }
 # Deterministic repo scan, run once at spawn - the discover stage starts from
 # facts instead of burning iterations on `ls`. `git ls-files` behaves identically
 # on POSIX and Windows shells; outside a git repo it fails and this is simply
 # left empty (non-fatal), and oversized output is trimmed to the budget.
 # Refuse it with `--no-seed-commands` or `[security] allow_seed_commands = false`.
-repo_files   = { kind = "pinned", budget = "3%", max_tokens = 4000, seed = { command = "git ls-files" }, volatility = "stable" }
+repo_files   = { kind = "pinned", budget = "3%", seed = { command = "git ls-files" }, volatility = "stable" }
 
 # ── Discovery (issue #108): written by the discover stage, read by every later
 # stage. Pinned, so no edge transform can clear or compact them. `required` puts
 # the runtime's own gate behind them (`require_context_regions`): the discover
 # stage is re-run with a nudge until it actually fills them, so the synthesized
 # workflow is a commitment the review stage can hold the run to, not a suggestion.
-discovery    = { kind = "pinned", budget = "4%", max_tokens = 6000, required = true, required_message = "Populate `discovery` (context_write) with this project's build system, test runner, layout and conventions before leaving the discover stage.", volatility = "grows" }
-workflow     = { kind = "pinned", budget = "2%", max_tokens = 3000, required = true, required_message = "Populate `workflow` (context_write) with the tier and the literal BASELINE / VERIFY / DONE WHEN lines before leaving the discover stage.", volatility = "grows" }
+discovery    = { kind = "pinned", budget = "4%", required = true, required_message = "Populate `discovery` (context_write) with this project's build system, test runner, layout and conventions before leaving the discover stage.", volatility = "grows" }
+workflow     = { kind = "pinned", budget = "2%", required = true, required_message = "Populate `workflow` (context_write) with the tier and the literal BASELINE / VERIFY / DONE WHEN lines before leaving the discover stage.", volatility = "grows" }
 # Pre-change test state, captured by implement before its first edit. Without it
 # a regression is indistinguishable from a pre-existing failure.
-baseline     = { kind = "pinned", budget = "3%", max_tokens = 4000 }
+baseline     = { kind = "pinned", budget = "3%" }
 
 # ── Knowledge (non-volatile; compacts to *_history) ──
-codebase         = { kind = "compacting",      budget = "25%", compact_at = "80%", threshold_tokens = 25000, max_tokens = 40000, volatility = "grows" }
-codebase_history = { kind = "compact_history", source_region = "codebase",      budget = "2%", max_tokens = 8000, volatility = "grows" }
-implementation   = { kind = "compacting",      budget = "35%", compact_at = "80%", threshold_tokens = 32000, max_tokens = 40000 }
-impl_history     = { kind = "compact_history", source_region = "implementation", budget = "2%", max_tokens = 8000, volatility = "grows" }
+codebase         = { kind = "compacting",      budget = "25%", compact_at = "80%", volatility = "grows" }
+codebase_history = { kind = "compact_history", source_region = "codebase",      budget = "2%", volatility = "grows" }
+implementation   = { kind = "compacting",      budget = "35%", compact_at = "80%" }
+impl_history     = { kind = "compact_history", source_region = "implementation", budget = "2%", volatility = "grows" }
 
 # ── Working records (sliding windows) + test feedback ──
 # decisions: WHY choices were made. changelog: which files changed.
-decisions    = { kind = "sliding_window", max_items = 10, budget = "3%", max_tokens = 4000 }
-changelog    = { kind = "sliding_window", max_items = 20, budget = "2%", max_tokens = 3000 }
-test_results = { kind = "clearable",      budget = "4%", max_tokens = 5000 }
+decisions    = { kind = "sliding_window", max_items = 10, budget = "3%" }
+changelog    = { kind = "sliding_window", max_items = 20, budget = "2%" }
+test_results = { kind = "clearable",      budget = "4%" }
 # A small sliding window so a repeating failure is visible as a pattern rather
 # than a one-off. Written explicitly via context_append by error_recovery and
 # reassess - never by tool routing (only `conversation` may hold routed tool
 # results; a second sliding_window desyncs them from their tool_use → API 400).
-errors       = { kind = "sliding_window", max_items = 5, budget = "2%", max_tokens = 3000 }
+errors       = { kind = "sliding_window", max_items = 5, budget = "2%" }
 
 # ── Conversation (bulk eviction for caching) + working memory ──
-conversation = { kind = "sliding_window", max_items = 40, budget = "20%", max_tokens = 30000, strategy = "bulk", overflow = 20 }
-scratch      = { kind = "clearable",      budget = "8%", max_tokens = 10000 }
+conversation = { kind = "sliding_window", max_items = 40, budget = "20%", strategy = "bulk", overflow = 20 }
+scratch      = { kind = "clearable",      budget = "8%" }

--- a/crates/leviath-cli/agents/coder/agent.leviath
+++ b/crates/leviath-cli/agents/coder/agent.leviath
@@ -22,7 +22,7 @@ bash       = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Map the codebase and synthesize a verification workflow"
-available_tools = ["read_file", "list_dir", "bash", "context_write"]
+available_tools = ["read_file", "list_dir", "bash", "context_write", "context_read"]
 max_iterations = 8
 max_revisits = 2
 system_prompt = """
@@ -108,7 +108,7 @@ condition = "dead_end"
 mode = "interactive_points"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Explore the codebase and produce a step-by-step implementation plan"
-available_tools = ["read_file", "list_dir", "ask_user_text", "ask_user_choice", "edit_document"]
+available_tools = ["read_file", "list_dir", "ask_user_text", "ask_user_choice", "edit_document", "context_read"]
 # Attended, planning is where this agent most wants its user, and all three of
 # these are available above. They are deliberately NOT in required_tools: an
 # unattended run drops them with the rest of the blocking tools, so `--yolo`
@@ -262,7 +262,7 @@ edit_options = ["Add detail - expand a section"]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Spike the riskiest assumption in the approved plan before executing it"
-available_tools = ["read_file", "list_dir", "write_file", "edit_file", "bash", "context_write", "context_append"]
+available_tools = ["read_file", "list_dir", "write_file", "edit_file", "bash", "context_write", "context_append", "context_read"]
 max_iterations = 15
 max_revisits = 2
 transition_prompt = """
@@ -338,7 +338,7 @@ condition = "dead_end"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Write code according to the approved plan"
-available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "ask_user_text", "ask_user_confirm", "context_append"]
+available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "ask_user_text", "ask_user_confirm", "context_append", "context_read"]
 max_iterations = 50
 max_revisits = 5
 # The ask_user_* tools suspend the run until a person answers, which is
@@ -465,7 +465,7 @@ condition = "dead_end"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Review the implementation and evaluate code quality"
-available_tools = ["read_file", "list_dir", "bash"]
+available_tools = ["read_file", "list_dir", "bash", "context_read"]
 max_iterations = 20
 max_revisits = 3
 # Lets the run end here (via "DONE") when the review approves the work,
@@ -551,7 +551,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Step back after no progress: diagnose the dead end and re-plan"
-available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append"]
+available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append", "context_read"]
 max_iterations = 8
 max_revisits = 2
 system_prompt = """

--- a/crates/leviath-cli/agents/coder/agent.leviath
+++ b/crates/leviath-cli/agents/coder/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "coder"
-version = "0.1.0"
+version = "0.1.1"
 description = "Coding agent: discover the repo, plan with your sign-off, optionally spike, implement, and review, with stuck detection and graph-based recovery"
 entry_stage = "discover"
 

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "data-analyst"
-version = "0.0.2"
+version = "0.0.3"
 description = "Data analyst - searches the web for data on a subject, builds a clean CSV of it, and hands back a ready-to-use summary of what the numbers say"
 entry_stage = "scope"
 

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -249,25 +249,25 @@ model = "claude-sonnet-5"
 # ─── Context layout ───────────────────────────────────────────────────────────
 [context.regions]
 # The subject - required. Supplied via --task (or the API/ACP task field).
-subject       = { kind = "pinned", budget = "1%", max_tokens = 1000, required = true, seed = "task", required_message = "Say what to gather data on via --task.", volatility = "stable" }
+subject       = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "Say what to gather data on via --task.", volatility = "stable" }
 # Optional caller bounds: --constraints "US only, since 2015".
-constraints   = { kind = "pinned", budget = "1%", max_tokens = 1000, seed = "constraints", volatility = "stable" }
+constraints   = { kind = "pinned", budget = "1%", seed = "constraints", volatility = "stable" }
 # The table's columns, decided in scope and followed by every later stage.
-schema        = { kind = "pinned", budget = "2%", max_tokens = 2000, required = true, required_message = "Write the table's columns to `schema` (context_write) before gathering: one line per column, as name | type | meaning | unit.", volatility = "grows" }
+schema        = { kind = "pinned", budget = "2%", required = true, required_message = "Write the table's columns to `schema` (context_write) before gathering: one line per column, as name | type | meaning | unit.", volatility = "grows" }
 # Bibliography, one line per source actually used.
-sources_index = { kind = "pinned", budget = "3%", max_tokens = 3000, volatility = "grows" }
+sources_index = { kind = "pinned", budget = "3%", volatility = "grows" }
 # What to distrust in the result. Read by the present stage.
-caveats       = { kind = "pinned", budget = "2%", max_tokens = 2000, volatility = "grows" }
+caveats       = { kind = "pinned", budget = "2%", volatility = "grows" }
 
 # Raw pages and search results (bulk, evictable).
-raw_sources   = { kind = "temporary", budget = "25%", max_tokens = 30000 }
+raw_sources   = { kind = "temporary", budget = "25%" }
 # The workers' consolidated rows, on the way into the merge. Its budget is what
 # each worker's share is divided from, so it gets the largest slice here.
-worker_rows   = { kind = "clearable", budget = "40%", max_tokens = 45000 }
+worker_rows   = { kind = "clearable", budget = "40%" }
 
-conversation  = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+conversation  = { kind = "sliding_window", max_items = 30, budget = "12%", strategy = "bulk", overflow = 10 }
 
 # Written by the runtime on an abnormal stage ending: the failed inference's
 # error text, or a note that a stage hit its iteration cap. Pinned so it
 # survives the edge transform into the stage that acts on it.
-error_report  = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+error_report  = { kind = "pinned", budget = "1%" }

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -305,24 +305,24 @@ is worse than no summary.
 # ─── Context layout ───────────────────────────────────────────────────────────
 # Percentage budgets (issue #100) with absolute guard-rails.
 [context.regions]
-query          = { kind = "pinned", budget = "1%", max_tokens = 1500, required = true, seed = "task", required_message = "State the research topic via --task.", volatility = "stable" }
-scope          = { kind = "pinned", budget = "1%", max_tokens = 1500, seed = "scope", volatility = "stable" }
-environment    = { kind = "pinned", budget = "1%", max_tokens = 600, seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
-sources_index  = { kind = "pinned", budget = "4%", max_tokens = 4000, volatility = "grows" }
-format         = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Mark each key finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
+query          = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the research topic via --task.", volatility = "stable" }
+scope          = { kind = "pinned", budget = "1%", seed = "scope", volatility = "stable" }
+environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
+sources_index  = { kind = "pinned", budget = "4%", volatility = "grows" }
+format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Mark each key finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
 
-sources        = { kind = "temporary",      budget = "30%", max_tokens = 50000 }
-claims         = { kind = "sliding_window", max_items = 40, budget = "8%", max_tokens = 9000 }
-contradictions = { kind = "clearable",      budget = "3%", max_tokens = 3000 }
+sources        = { kind = "temporary",      budget = "30%" }
+claims         = { kind = "sliding_window", max_items = 40, budget = "8%" }
+contradictions = { kind = "clearable",      budget = "3%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: the
 # analysis stage reads it directly and it is the point of the fan-out.
-sub_findings   = { kind = "pinned", budget = "20%", max_tokens = 30000, volatility = "grows" }
-analysis         = { kind = "compacting",      budget = "30%", compact_at = "80%", threshold_tokens = 30000, max_tokens = 40000 }
-analysis_history = { kind = "compact_history", source_region = "analysis", budget = "3%", max_tokens = 15000, volatility = "grows" }
+sub_findings   = { kind = "pinned", budget = "20%", volatility = "grows" }
+analysis         = { kind = "compacting",      budget = "30%", compact_at = "80%" }
+analysis_history = { kind = "compact_history", source_region = "analysis", budget = "3%", volatility = "grows" }
 
-conversation   = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+conversation   = { kind = "sliding_window", max_items = 30, budget = "12%", strategy = "bulk", overflow = 10 }
 
 # Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
 # inference call's error text, or a note that a stage hit its iteration cap.
 # Pinned so it survives the edge transform into the stage that acts on it.
-error_report   = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+error_report   = { kind = "pinned", budget = "1%" }

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -20,7 +20,7 @@ mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather primary sources and key references on the topic"
 # web_search / web_fetch are provided by this agent's tools/ (issue #97).
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read"]
 max_iterations = 25
 max_revisits = 3
 system_prompt = """
@@ -191,7 +191,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Pull and read specific cited sources flagged during analysis"
-available_tools = ["web_fetch", "web_search", "read_file", "context_append", "current_time"]
+available_tools = ["web_fetch", "web_search", "read_file", "context_append", "current_time", "context_read"]
 max_iterations = 12
 max_revisits = 3
 system_prompt = """

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.2.0"
+version = "0.2.1"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "log-analyzer"
-version = "0.1.1"
+version = "0.1.2"
 description = "Analyzes log files - sweeps many files or time windows in parallel, then identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
 entry_stage = "ingest"
 

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -339,23 +339,23 @@ guess.
 
 # ─── Context layout ───────────────────────────────────────────────────────────
 [context.regions]
-task            = { kind = "pinned", budget = "2%", max_tokens = 3000, required = true, seed = "task", required_message = "Name the log file(s)/dir and what to look for via --task.", volatility = "stable" }
-severity_index  = { kind = "pinned", budget = "2%", max_tokens = 2000 }
-findings        = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+task            = { kind = "pinned", budget = "2%", required = true, seed = "task", required_message = "Name the log file(s)/dir and what to look for via --task.", volatility = "stable" }
+severity_index  = { kind = "pinned", budget = "2%" }
+findings        = { kind = "sliding_window", max_items = 30, budget = "12%", strategy = "bulk", overflow = 10 }
 # The sweepers' submitted findings, on the way into the analyze stage. Its budget
 # is what each worker's share is divided from, so it matches the findings region
 # it feeds. Clearable: once analyze has folded the findings in, the raw worker
 # report is safe to drop.
-worker_findings = { kind = "clearable", budget = "12%", max_tokens = 15000 }
+worker_findings = { kind = "clearable", budget = "12%" }
 
-logs            = { kind = "temporary",       budget = "30%", max_tokens = 50000 }
-scripts         = { kind = "compacting",      budget = "20%", compact_at = "80%", threshold_tokens = 20000, max_tokens = 30000, volatility = "grows" }
-scripts_history = { kind = "compact_history", source_region = "scripts", budget = "3%", max_tokens = 10000, volatility = "grows" }
+logs            = { kind = "temporary",       budget = "30%" }
+scripts         = { kind = "compacting",      budget = "20%", compact_at = "80%", volatility = "grows" }
+scripts_history = { kind = "compact_history", source_region = "scripts", budget = "3%", volatility = "grows" }
 
-conversation    = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
-scratch         = { kind = "clearable", budget = "6%", max_tokens = 6000 }
+conversation    = { kind = "sliding_window", max_items = 30, budget = "12%", strategy = "bulk", overflow = 10 }
+scratch         = { kind = "clearable", budget = "6%" }
 
 # Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
 # inference call's error text, or a note that a stage hit its iteration cap.
 # Pinned so it survives the edge transform into the stage that acts on it.
-error_report    = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+error_report    = { kind = "pinned", budget = "1%" }

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -15,7 +15,7 @@ write_file = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Read log files, identify format and structure"
-available_tools = ["read_file", "list_dir", "bash", "context_write"]
+available_tools = ["read_file", "list_dir", "bash", "context_write", "context_read"]
 max_iterations = 15
 system_prompt = """
 Ingest the log files named in `task`. Determine:
@@ -157,7 +157,7 @@ instructions = "One finding per line, as `<severity> | <finding> | <evidence: co
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Identify anomalies, trends, and error patterns"
-available_tools = ["read_file", "bash", "context_write", "context_append"]
+available_tools = ["read_file", "bash", "context_write", "context_append", "context_read"]
 max_iterations = 25
 max_revisits = 3
 transition_prompt = """
@@ -212,7 +212,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Write and execute scripts to parse, filter, and aggregate log data"
-available_tools = ["read_file", "bash"]
+available_tools = ["read_file", "bash", "context_read"]
 max_iterations = 20
 max_revisits = 5
 transition_prompt = """

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -191,35 +191,41 @@ reads instead of the report, not a second copy of it.
 [stages.summary.transitions]
 
 # ─── Context layout ───────────────────────────────────────────────────────────
-# Budgets are a percentage of the model's context window (issue #100) with an
-# absolute `max_tokens`/`threshold_tokens` guard-rail. Percentages are ceilings.
+# Budgets are a percentage of the model's context window (issue #100), and the
+# percentage is the whole answer: every region scales with whatever model the
+# stage runs on. No absolute `max_tokens`/`threshold_tokens` guard-rails - a cap
+# below the percentage silently wins on every window worth having, which is how
+# a 1M-context run ended up with a 40k findings region. Percentages are ceilings,
+# not reservations: a region costs only what is stored in it, so a ceiling it
+# never reaches is free, and they may sum past 100% because regions rarely fill
+# together.
 [context.regions]
 # The research question - required. Supplied via --task (or the API/ACP task field).
-query          = { kind = "pinned", budget = "1%", max_tokens = 1000, required = true, seed = "task", required_message = "State the research question via --task.", volatility = "stable" }
+query          = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the research question via --task.", volatility = "stable" }
 # Optional caller bounds: --scope "peer-reviewed sources since 2020 only".
-scope          = { kind = "pinned", budget = "1%", max_tokens = 1000, seed = "scope", volatility = "stable" }
+scope          = { kind = "pinned", budget = "1%", seed = "scope", volatility = "stable" }
 # Growing bibliography with credibility notes (curated by the agent).
-environment    = { kind = "pinned", budget = "1%", max_tokens = 600, seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
-sources_index  = { kind = "pinned", budget = "3%", max_tokens = 3000, volatility = "grows" }
+environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
+sources_index  = { kind = "pinned", budget = "3%", volatility = "grows" }
 # Citation/confidence rules (seeded with a sensible default the agent follows).
-format         = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Mark each finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
+format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Mark each finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
 
 # Raw source material (bulk, evictable).
-raw_findings   = { kind = "temporary", budget = "30%", max_tokens = 40000 }
+raw_findings   = { kind = "temporary", budget = "30%" }
 # Extracted claims (with source refs) and cross-source conflicts.
-claims         = { kind = "sliding_window", max_items = 30, budget = "7%", max_tokens = 8000 }
-contradictions = { kind = "clearable",      budget = "3%", max_tokens = 3000 }
+claims         = { kind = "sliding_window", max_items = 30, budget = "7%" }
+contradictions = { kind = "clearable",      budget = "3%" }
 
 # Synthesis workspace (compacts to a running history when it grows).
-synthesis         = { kind = "compacting",      budget = "40%", compact_at = "80%", threshold_tokens = 30000, max_tokens = 50000 }
-synthesis_history = { kind = "compact_history", source_region = "synthesis", budget = "3%", max_tokens = 10000, volatility = "grows" }
+synthesis         = { kind = "compacting",      budget = "40%", compact_at = "80%" }
+synthesis_history = { kind = "compact_history", source_region = "synthesis", budget = "3%", volatility = "grows" }
 
 # The message stream. An explicit sliding_window `conversation` region is required -
 # the per-stage layout is rebuilt from this table on each transition, so an
 # auto-added one would be dropped after the first stage.
-conversation      = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+conversation      = { kind = "sliding_window", max_items = 30, budget = "12%", strategy = "bulk", overflow = 10 }
 
 # Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
 # inference call's error text, or a note that a stage hit its iteration cap.
 # Pinned so it survives the edge transform into the stage that acts on it.
-error_report      = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+error_report      = { kind = "pinned", budget = "1%" }

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.1.0"
+version = "0.1.1"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -20,7 +20,7 @@ mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather relevant information on the topic"
 # web_search / web_fetch are provided by the agent's script tools (issue #97).
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "context_read", "current_time"]
 max_iterations = 8
 max_revisits = 2
 system_prompt = """
@@ -73,7 +73,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Analyze and synthesize findings"
-available_tools = ["read_file", "web_fetch", "context_write", "context_append", "current_time"]
+available_tools = ["read_file", "web_fetch", "context_write", "context_append", "context_read", "current_time"]
 max_iterations = 20
 max_revisits = 3
 transition_prompt = """

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -59,7 +59,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Fast first pass for obvious issues"
-available_tools = ["read_file", "list_dir", "context_append"]
+available_tools = ["read_file", "list_dir", "context_append", "context_read"]
 max_iterations = 12
 system_prompt = """
 Do a fast first pass over the code in the `diff` region (and read_file for
@@ -203,7 +203,7 @@ instructions = "One finding per line, most severe first, as `severity | file:lin
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "In-depth analysis of correctness, security, and architecture"
-available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append"]
+available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append", "context_read"]
 max_iterations = 25
 max_revisits = 2
 system_prompt = """

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "reviewer"
-version = "0.1.1"
+version = "0.1.2"
 description = "Code review agent - discover, scan, review the areas in parallel, then deep review and report, with error recovery and multi-provider fallback"
 entry_stage = "discover"
 

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -330,47 +330,53 @@ If nothing blocking turned up, say so plainly - a clean review is a result.
 [stages.summary.transitions]
 
 # ─── Context layout ───────────────────────────────────────────────────────────
-# Budgets are a percentage of the model's context window (issue #100) with an
-# absolute `max_tokens` guard-rail. Percentages are ceilings, not reservations.
+# Budgets are a percentage of the model's context window (issue #100), and the
+# percentage is the whole answer: every region scales with whatever model the
+# stage runs on. No absolute `max_tokens`/`threshold_tokens` guard-rails - a cap
+# below the percentage silently wins on every window worth having, which is how
+# a 1M-context run ended up with a 40k findings region. Percentages are ceilings,
+# not reservations: a region costs only what is stored in it, so a ceiling it
+# never reaches is free, and they may sum past 100% because regions rarely fill
+# together.
 [context.regions]
 # The code/diff to review - required. Supply via `--diff <text|@file>` (CLI),
 # a ---region:diff--- block (ACP), or the API `regions` field.
-diff            = { kind = "pinned", budget = "20%", max_tokens = 20000, required = true, seed = "diff", required_message = "Provide the code or diff to review via --diff <text|@file>.", volatility = "stable" }
+diff            = { kind = "pinned", budget = "20%", required = true, seed = "diff", required_message = "Provide the code or diff to review via --diff <text|@file>.", volatility = "stable" }
 # Optional caller focus, e.g. --criteria "focus on security / backwards-compat".
-review_criteria = { kind = "pinned", budget = "2%",  max_tokens = 3000, seed = "criteria", volatility = "stable" }
+review_criteria = { kind = "pinned", budget = "2%", seed = "criteria", volatility = "stable" }
 # Pre-loaded on startup: architecture / conventions (missing files skipped).
-project_context = { kind = "pinned", budget = "4%",  max_tokens = 5000, seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "CONVENTIONS.md", "CONTRIBUTING.md", "README.md"] }, volatility = "stable" }
+project_context = { kind = "pinned", budget = "4%", seed = { files = ["ARCHITECTURE.md", "DESIGN.md", "docs/ARCHITECTURE.md", "CONVENTIONS.md", "CONTRIBUTING.md", "README.md"] }, volatility = "stable" }
 # Deterministic repo scan, run once at spawn (issue #108) - the discover stage
 # starts from facts instead of burning iterations on `ls`. `git ls-files` behaves
 # identically on POSIX and Windows shells; outside a git repo it fails and this is
 # simply left empty (non-fatal), and oversized output is trimmed to the budget.
 # Refuse it with `--no-seed-commands` or `[security] allow_seed_commands = false`.
-repo_files      = { kind = "pinned", budget = "3%",  max_tokens = 4000, seed = { command = "git ls-files" }, volatility = "stable" }
+repo_files      = { kind = "pinned", budget = "3%", seed = { command = "git ls-files" }, volatility = "stable" }
 
 # ── Discovery (issue #108): written by the discover stage, read by every later
 # stage. Pinned, so no edge transform can clear or compact them. `required` puts
 # the runtime's own gate behind them (`require_context_regions`): the discover
 # stage is re-run with a nudge until it actually fills them.
-discovery       = { kind = "pinned", budget = "4%",  max_tokens = 5000, required = true, required_message = "Populate `discovery` (context_write) with this project's build system, test runner, layout and conventions before leaving the discover stage.", volatility = "grows" }
-workflow        = { kind = "pinned", budget = "2%",  max_tokens = 2000, required = true, required_message = "Populate `workflow` (context_write) with the literal VERIFY / DONE WHEN lines before leaving the discover stage.", volatility = "grows" }
+discovery       = { kind = "pinned", budget = "4%", required = true, required_message = "Populate `discovery` (context_write) with this project's build system, test runner, layout and conventions before leaving the discover stage.", volatility = "grows" }
+workflow        = { kind = "pinned", budget = "2%", required = true, required_message = "Populate `workflow` (context_write) with the literal VERIFY / DONE WHEN lines before leaving the discover stage.", volatility = "grows" }
 
 # The area workers' submitted findings, on the way into the deep review. Its
 # budget is what each worker's share is divided from, so it gets a slice the size
 # of the findings region it feeds. Clearable: once the deep review has folded the
 # findings in, the raw worker report is safe to drop.
-worker_findings = { kind = "clearable", budget = "20%", max_tokens = 25000 }
+worker_findings = { kind = "clearable", budget = "20%" }
 
 # Accumulated review findings and the running severity tally.
-findings        = { kind = "temporary", budget = "20%", max_tokens = 25000 }
-severity_index  = { kind = "pinned",    budget = "2%",  max_tokens = 2000 }
-report          = { kind = "clearable", budget = "7%",  max_tokens = 8000 }
+findings        = { kind = "temporary", budget = "20%" }
+severity_index  = { kind = "pinned",    budget = "2%" }
+report          = { kind = "clearable", budget = "7%" }
 
 # The message stream. Every blueprint needs an explicit sliding_window
 # `conversation` region - the layout that replaces it on each stage transition is
 # rebuilt from this table, so an auto-added one would be dropped after stage 1.
-conversation    = { kind = "sliding_window", max_items = 30, budget = "15%", max_tokens = 18000, strategy = "bulk", overflow = 10 }
+conversation    = { kind = "sliding_window", max_items = 30, budget = "15%", strategy = "bulk", overflow = 10 }
 
 # Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
 # inference call's error text, or a note that a stage hit its iteration cap.
 # Pinned so it survives the edge transform into the stage that acts on it.
-error_report    = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+error_report    = { kind = "pinned", budget = "1%" }

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -292,23 +292,23 @@ file you wrote.
 
 # ─── Context layout ───────────────────────────────────────────────────────────
 [context.regions]
-query              = { kind = "pinned", budget = "1%", max_tokens = 1000, required = true, seed = "task", required_message = "State the survey topic/area via --task.", volatility = "stable" }
-scope              = { kind = "pinned", budget = "1%", max_tokens = 1500, seed = "scope", volatility = "stable" }
-environment        = { kind = "pinned", budget = "1%", max_tokens = 600, seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
-sources_index      = { kind = "pinned", budget = "3%", max_tokens = 4000, volatility = "grows" }
-format             = { kind = "pinned", budget = "1%", max_tokens = 500, seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Prefer comparison tables where they clarify tradeoffs." }, volatility = "stable" }
+query              = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the survey topic/area via --task.", volatility = "stable" }
+scope              = { kind = "pinned", budget = "1%", seed = "scope", volatility = "stable" }
+environment        = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
+sources_index      = { kind = "pinned", budget = "3%", volatility = "grows" }
+format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Prefer comparison tables where they clarify tradeoffs." }, volatility = "stable" }
 
-landscape          = { kind = "temporary",      budget = "30%", max_tokens = 50000 }
-deep_dives         = { kind = "sliding_window", max_items = 15, budget = "8%", max_tokens = 9000 }
+landscape          = { kind = "temporary",      budget = "30%" }
+deep_dives         = { kind = "sliding_window", max_items = 15, budget = "8%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: it is
 # the whole point of the fan-out, and compare reads it directly.
-thread_findings    = { kind = "pinned", budget = "20%", max_tokens = 30000, volatility = "grows" }
-comparisons        = { kind = "compacting",      budget = "25%", compact_at = "80%", threshold_tokens = 25000, max_tokens = 35000, volatility = "grows" }
-comparison_history = { kind = "compact_history", source_region = "comparisons", budget = "3%", max_tokens = 10000, volatility = "grows" }
+thread_findings    = { kind = "pinned", budget = "20%", volatility = "grows" }
+comparisons        = { kind = "compacting",      budget = "25%", compact_at = "80%", volatility = "grows" }
+comparison_history = { kind = "compact_history", source_region = "comparisons", budget = "3%", volatility = "grows" }
 
-conversation       = { kind = "sliding_window", max_items = 30, budget = "12%", max_tokens = 15000, strategy = "bulk", overflow = 10 }
+conversation       = { kind = "sliding_window", max_items = 30, budget = "12%", strategy = "bulk", overflow = 10 }
 
 # Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
 # inference call's error text, or a note that a stage hit its iteration cap.
 # Pinned so it survives the edge transform into the stage that acts on it.
-error_report       = { kind = "pinned", budget = "1%", max_tokens = 2000 }
+error_report       = { kind = "pinned", budget = "1%" }

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -18,7 +18,7 @@ bash       = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Survey the landscape across multiple sub-topics"
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read"]
 max_iterations = 25
 max_revisits = 2
 system_prompt = """
@@ -181,7 +181,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Focused deep read on one interesting thread flagged during comparison"
-available_tools = ["web_search", "web_fetch", "read_file", "context_append", "current_time"]
+available_tools = ["web_search", "web_fetch", "read_file", "context_append", "current_time", "context_read"]
 max_iterations = 12
 max_revisits = 2
 system_prompt = """

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.2.0"
+version = "0.2.1"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 

--- a/crates/leviath-cli/src/blueprint_edit/doc.rs
+++ b/crates/leviath-cli/src/blueprint_edit/doc.rs
@@ -354,8 +354,18 @@ pub struct RegionView {
     pub kind: String,
     /// The `budget = "N%"` percentage, when it parses.
     pub budget_percent: Option<f64>,
-    /// `max_tokens`.
+    /// `max_tokens`, the absolute ceiling on a percentage budget.
+    ///
+    /// Usually absent: the percentage is what decides a region's size, and a
+    /// ceiling below it just clamps the region on every model large enough to
+    /// matter. Set it only where a region genuinely must not grow.
     pub max_tokens: Option<u64>,
+    /// `min_tokens`, the absolute floor under a percentage budget.
+    ///
+    /// The counterpart to `max_tokens`, and the one small pinned regions want:
+    /// a research question needs its ~1000 tokens whatever the model's window
+    /// is, and a percentage of a narrow window would not give it them.
+    pub min_tokens: Option<u64>,
     /// `required = true`.
     pub required: bool,
     /// `required_message`, or empty.
@@ -754,6 +764,7 @@ fn region_view(name: &str, table: &dyn TableLike) -> RegionView {
         kind: get_str(table, "kind").unwrap_or_default().to_string(),
         budget_percent: get_str(table, "budget").and_then(parse_percent),
         max_tokens: get_int(table, "max_tokens").and_then(|n| u64::try_from(n).ok()),
+        min_tokens: get_int(table, "min_tokens").and_then(|n| u64::try_from(n).ok()),
         required: get_bool(table, "required") == Some(true),
         required_message: get_str(table, "required_message")
             .unwrap_or_default()

--- a/crates/leviath-cli/src/blueprint_edit/regions.rs
+++ b/crates/leviath-cli/src/blueprint_edit/regions.rs
@@ -42,6 +42,8 @@ pub enum RegionField {
     BudgetPercent,
     /// `max_tokens`, at least 1.
     MaxTokens,
+    /// `min_tokens`, at least 1.
+    MinTokens,
     /// `required = true`; off deletes the key.
     Required,
     /// `required_message`.
@@ -70,8 +72,13 @@ pub enum RegionValue {
 }
 
 impl ManifestDoc {
-    /// Add a region to a layout with starter values (`pinned`, `5%`, `4000`
-    /// tokens), creating `[context.regions]` when the scope has none.
+    /// Add a region to a layout with starter values (`pinned`, `5%`), creating
+    /// `[context.regions]` when the scope has none.
+    ///
+    /// No `max_tokens`: a starter ceiling is the thing that quietly undoes the
+    /// percentage on every model with a window worth having, and a new region
+    /// has no reason to want one. The author can add a floor or a ceiling
+    /// deliberately.
     pub fn add_region(&mut self, scope: &RegionScope, name: &str) -> Result<(), EditError> {
         require_name(name)?;
         let regions = self.regions_item_ensure(scope)?;
@@ -84,7 +91,6 @@ impl ManifestDoc {
         let mut region = InlineTable::new();
         region.insert("kind", Value::from("pinned"));
         region.insert("budget", Value::from("5%"));
-        region.insert("max_tokens", Value::from(4000));
         // Inline whichever shape the parent has: a headed `[context.regions]`
         // lists its regions as one-line inline tables, the way every bundled
         // agent writes them.
@@ -166,6 +172,9 @@ impl ManifestDoc {
             }
             (RegionField::MaxTokens, RegionValue::Number(n)) => {
                 set_or_remove_int(table, "max_tokens", n.map(|n| n.max(1)));
+            }
+            (RegionField::MinTokens, RegionValue::Number(n)) => {
+                set_or_remove_int(table, "min_tokens", n.map(|n| n.max(1)));
             }
             (RegionField::MaxItems, RegionValue::Number(n)) => {
                 set_or_remove_int(table, "max_items", n.map(|n| n.max(1)));

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -138,12 +138,25 @@ fn parse_refuses_what_the_editor_cannot_stand_on() {
     assert!(err.starts_with("not valid TOML: "), "{err}");
 }
 
+/// The version the bundled table records for `name`, so a test can assert the
+/// view reports it without pinning the number.
+fn bundled_version(name: &str) -> &'static str {
+    crate::bundled::BUNDLED_AGENTS
+        .iter()
+        .find(|a| a.name == name)
+        .expect("a bundled agent by that name")
+        .version
+}
+
 #[test]
 fn the_views_read_the_coder_the_way_the_lair_does() {
     let doc = coder();
     let agent = doc.agent();
     assert_eq!(agent.name, "coder");
-    assert_eq!(agent.version, "0.1.0");
+    // Read from the bundled table rather than pinned here: the version moves
+    // whenever the blueprint's contents do, and a literal turns every such
+    // change into a test edit.
+    assert_eq!(agent.version, bundled_version("coder"));
     assert_eq!(agent.entry_stage.as_deref(), Some("discover"));
     assert!(agent.description.starts_with("Coding agent"));
     assert_eq!(

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -211,7 +211,10 @@ fn the_views_read_the_coder_the_way_the_lair_does() {
     let task = shared.regions.iter().find(|r| r.name == "task").unwrap();
     assert_eq!(task.kind, "pinned");
     assert_eq!(task.budget_percent, Some(2.0));
-    assert_eq!(task.max_tokens, Some(4000));
+    // Neither a ceiling nor a floor: the percentage decides the size, and both
+    // absolutes are the thing that stopped it deciding anything.
+    assert_eq!(task.max_tokens, None);
+    assert_eq!(task.min_tokens, None);
     assert!(task.required);
     assert!(task.required_message.starts_with("Describe the task"));
     let conventions = shared
@@ -957,9 +960,11 @@ fn regions_are_added_renamed_deleted_and_edited_in_both_scopes() {
     assert!(doc.regions(None).is_empty());
     doc.add_region(&RegionScope::Shared, "notes").unwrap();
     let notes = doc.region(None, "notes").unwrap();
+    // A starter region is a percentage and nothing else: a default ceiling is
+    // exactly what stops the percentage deciding anything on a real window.
     assert_eq!(
         (notes.kind.as_str(), notes.budget_percent, notes.max_tokens),
-        ("pinned", Some(5.0), Some(4000))
+        ("pinned", Some(5.0), None)
     );
     assert!(
         doc.to_toml().contains("[context.regions]"),

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -164,7 +164,13 @@ fn the_views_read_the_coder_the_way_the_lair_does() {
     assert_eq!(discover.models.len(), 5);
     assert_eq!(
         discover.tools,
-        ["read_file", "list_dir", "bash", "context_write"]
+        [
+            "read_file",
+            "list_dir",
+            "bash",
+            "context_write",
+            "context_read"
+        ]
     );
     assert!(discover.system_prompt.contains("Before any planning"));
     assert!(!discover.is_terminal);

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -377,6 +377,67 @@ mod tests {
         }
     }
 
+    /// A bundled stage that routes tool output into a region must be able to
+    /// read one.
+    ///
+    /// Routing leaves a pointer in the conversation saying where the output
+    /// went. If the stage also grants a file-reading tool and no
+    /// `context_read`, the only read verb the model has points at the
+    /// filesystem, and it aims it at the region name: 90 of 168 failed
+    /// `read_file` calls across 152 local runs were exactly that, one of them
+    /// spending five turns on five spellings of `raw_findings`.
+    ///
+    /// Asserted over whatever is bundled rather than a fixed list of stages, so
+    /// a new routed stage is held to it the day it lands.
+    #[test]
+    fn every_bundled_stage_that_routes_can_also_read_a_region() {
+        let mut routed = 0;
+        for agent in BUNDLED_AGENTS {
+            let manifest = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .map(|(_, c)| *c)
+                .expect("every bundled agent ships a manifest");
+            let parsed = leviath_core::manifest::parse_manifest(manifest);
+            assert!(
+                parsed.is_ok(),
+                "bundled agent {} does not parse",
+                agent.name
+            );
+            let blueprint = parsed.expect("asserted Ok just above");
+
+            for stage in &blueprint.stages {
+                let routes = stage.tool_result_routing.as_ref().is_some_and(|r| {
+                    r.default_region != "conversation"
+                        || r.tool_overrides.values().any(|v| v != "conversation")
+                });
+                let reads_files = stage
+                    .available_tools
+                    .iter()
+                    .any(|t| t == "read_file" || t == "read_files");
+                if !routes || !reads_files {
+                    continue;
+                }
+                routed += 1;
+                assert!(
+                    stage.available_tools.iter().any(|t| t == "context_read"),
+                    "{}'s stage '{}' routes tool output into a region and grants a \
+                     file-reading tool, but not 'context_read' - the only way the \
+                     model can act on the pointer is to aim read_file at the region \
+                     name",
+                    agent.name,
+                    stage.name
+                );
+            }
+        }
+        // A vacuous pass would be a bundled set that routes nowhere.
+        assert!(
+            routed > 0,
+            "no bundled stage routes tool output to a region"
+        );
+    }
+
     /// A bundled layout must actually grow with the model's context window.
     ///
     /// Every region was written as `budget = "N%"` *and* an absolute

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -494,22 +494,21 @@ mod tests {
             // work. Checked across the range a real model spans, because the
             // floors bind at the bottom of it and the percentages at the top.
             for window in [32_768, 128_000, NARROW, WIDE] {
-                let resolved = blueprint.context_layout.resolved(window);
-                assert!(
-                    resolved.validate().is_ok(),
-                    "{}'s layout does not validate at a {window}-token window",
-                    agent.name
+                // The shared layout plus any per-stage override, as one
+                // sequence: a bundled agent may declare either, and a branch
+                // for the per-stage case would sit unreached while none does.
+                let layouts = std::iter::once(&blueprint.context_layout).chain(
+                    blueprint
+                        .stages
+                        .iter()
+                        .filter_map(|s| s.context_layout.as_ref()),
                 );
-                for stage in &blueprint.stages {
-                    if let Some(layout) = &stage.context_layout {
-                        assert!(
-                            layout.resolved(window).validate().is_ok(),
-                            "{}'s stage '{}' layout does not validate at a \
-                             {window}-token window",
-                            agent.name,
-                            stage.name
-                        );
-                    }
+                for layout in layouts {
+                    assert!(
+                        layout.resolved(window).validate().is_ok(),
+                        "a layout of {} does not validate at a {window}-token window",
+                        agent.name
+                    );
                 }
             }
 

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -377,6 +377,98 @@ mod tests {
         }
     }
 
+    /// A bundled layout must actually grow with the model's context window.
+    ///
+    /// Every region was written as `budget = "N%"` *and* an absolute
+    /// `max_tokens`, and the cap is the smaller of the two on any window worth
+    /// having: `researcher` ran on a 1,048,576-token model with `raw_findings`
+    /// asking for 30% - 314,573 tokens - and getting the 40,000 its guard-rail
+    /// allowed. The percentages were decorative from about 167k upward.
+    ///
+    /// Stated as a ratio rather than a per-region ceiling so it holds whatever
+    /// the percentages are: resolve each layout against two windows a little
+    /// over 5x apart, and the room must scale with them. A layout clamped by
+    /// absolute caps scores 1.0 here, because both windows resolve to the same
+    /// fixed numbers.
+    ///
+    /// Asserted over whatever is bundled, so a new agent is held to it the day
+    /// it lands - and a deliberate ceiling on ONE region still passes, which is
+    /// the point: this forbids a clamped layout, not a considered cap.
+    #[test]
+    fn every_bundled_layout_scales_with_the_model_window() {
+        const NARROW: usize = 200_000;
+        const WIDE: usize = 1_048_576;
+        // The windows are 5.24x apart; require most of that to survive.
+        const MIN_GROWTH: f64 = 4.0;
+
+        let room = |layout: &leviath_core::ContextLayout, window: usize| -> usize {
+            layout
+                .resolved(window)
+                .regions
+                .iter()
+                .map(|r| r.max_tokens)
+                .sum()
+        };
+
+        let mut checked = 0;
+        for agent in BUNDLED_AGENTS {
+            let manifest = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .map(|(_, c)| *c)
+                .expect("every bundled agent ships a manifest");
+            let parsed = leviath_core::manifest::parse_manifest(manifest);
+            assert!(
+                parsed.is_ok(),
+                "bundled agent {} does not parse",
+                agent.name
+            );
+            let blueprint = parsed.expect("asserted Ok just above");
+
+            // Percentage ceilings may sum past 100% on purpose (regions rarely
+            // fill together), so the sum is not the thing to assert. What must
+            // hold at every window is the layout's own validation: the fixed
+            // pinned/hashmap/history regions have to leave the agent room to
+            // work. Checked across the range a real model spans, because the
+            // floors bind at the bottom of it and the percentages at the top.
+            for window in [32_768, 128_000, NARROW, WIDE] {
+                let resolved = blueprint.context_layout.resolved(window);
+                assert!(
+                    resolved.validate().is_ok(),
+                    "{}'s layout does not validate at a {window}-token window",
+                    agent.name
+                );
+                for stage in &blueprint.stages {
+                    if let Some(layout) = &stage.context_layout {
+                        assert!(
+                            layout.resolved(window).validate().is_ok(),
+                            "{}'s stage '{}' layout does not validate at a \
+                             {window}-token window",
+                            agent.name,
+                            stage.name
+                        );
+                    }
+                }
+            }
+
+            let narrow = room(&blueprint.context_layout, NARROW);
+            let wide = room(&blueprint.context_layout, WIDE);
+            let growth = wide as f64 / narrow as f64;
+            assert!(
+                growth >= MIN_GROWTH,
+                "{}'s context layout barely grows between a narrow window and a \
+                 wide one (growth {growth:.2}x, wanted at least {MIN_GROWTH}x, \
+                 {narrow} -> {wide} tokens of region room). An absolute \
+                 max_tokens is overriding the percentage budgets.",
+                agent.name
+            );
+            checked += 1;
+        }
+        // A vacuous pass would be a loop over nothing.
+        assert!(checked > 0, "no bundled agent was checked");
+    }
+
     /// Every bundled agent ends in a stage that hands something back, and
     /// nothing upstream can end the run before reaching it.
     ///

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -138,14 +138,17 @@ read_file = "codebase"
 list_dir = "codebase"
 
 # Region budgets are percentages of the model's context window (ceilings, may sum
-# past 100%); the absolute max_tokens is an optional guard-rail cap. Every
-# blueprint needs an explicit `conversation` sliding_window - it holds the message
-# stream and is carried across stage transitions.
+# past 100%), so a region scales with whatever model the stage runs. Add an
+# absolute max_tokens only where a region genuinely must not grow: a cap below
+# the percentage wins on every large window, which is how a 1M-context model
+# ends up with a 40k region. Every blueprint needs an explicit `conversation`
+# sliding_window - it holds the message stream and is carried across stage
+# transitions.
 [context.regions]
-task         = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000, required = true, seed = "task", required_message = "Describe the coding task via --task." }}
-codebase     = {{ kind = "temporary",       budget = "20%", max_tokens = 30000 }}
-conversation = {{ kind = "sliding_window",  max_items = 20, budget = "15%", max_tokens = 15000, strategy = "bulk", overflow = 10 }}
-scratch      = {{ kind = "clearable",       budget = "8%",  max_tokens = 10000 }}
+task         = {{ kind = "pinned",          budget = "2%", required = true, seed = "task", required_message = "Describe the coding task via --task." }}
+codebase     = {{ kind = "temporary",       budget = "20%" }}
+conversation = {{ kind = "sliding_window",  max_items = 20, budget = "15%", strategy = "bulk", overflow = 10 }}
+scratch      = {{ kind = "clearable",       budget = "8%" }}
 "#,
             name = name
         ),
@@ -195,15 +198,17 @@ well-supported vs speculative claims. Cite specific sources.
 """
 
 # Region budgets are percentages of the model's context window (ceilings, may sum
-# past 100%); absolute max_tokens / threshold_tokens are guard-rail caps. A
+# past 100%), so a region scales with whatever model the stage runs. Add an
+# absolute max_tokens / threshold_tokens only where a region must not grow: a cap
+# below the percentage wins on every large window. A
 # `compacting` region needs a paired `compact_history` region for its summaries.
 [context.regions]
-query           = {{ kind = "pinned",          budget = "2%",  max_tokens = 2000, required = true, seed = "task", required_message = "State the research question via --task." }}
-sources         = {{ kind = "temporary",       budget = "25%", max_tokens = 40000 }}
-findings        = {{ kind = "compacting",      budget = "12%", compact_at = "80%", threshold_tokens = 12000, max_tokens = 15000 }}
-findings_history = {{ kind = "compact_history", source_region = "findings", budget = "3%", max_tokens = 6000 }}
-conversation    = {{ kind = "sliding_window",  max_items = 15, budget = "12%", max_tokens = 12000, strategy = "bulk", overflow = 10 }}
-scratch         = {{ kind = "clearable",       budget = "6%",  max_tokens = 8000 }}
+query           = {{ kind = "pinned",          budget = "2%", required = true, seed = "task", required_message = "State the research question via --task." }}
+sources         = {{ kind = "temporary",       budget = "25%" }}
+findings        = {{ kind = "compacting",      budget = "12%", compact_at = "80%" }}
+findings_history = {{ kind = "compact_history", source_region = "findings", budget = "3%" }}
+conversation    = {{ kind = "sliding_window",  max_items = 15, budget = "12%", strategy = "bulk", overflow = 10 }}
+scratch         = {{ kind = "clearable",       budget = "6%" }}
 "#,
             name = name
         ),
@@ -232,12 +237,14 @@ thoroughly.
 """
 
 # Region budgets are percentages of the model's context window (ceilings, may sum
-# past 100%); the absolute max_tokens is an optional guard-rail cap. Every
+# past 100%), so a region scales with whatever model the stage runs. Add an
+# absolute max_tokens only where a region must not grow: a cap below the
+# percentage wins on every large window. Every
 # blueprint needs an explicit `conversation` sliding_window region.
 [context.regions]
-task         = {{ kind = "pinned",         budget = "2%",  max_tokens = 2000, required = true, seed = "task", required_message = "Describe the task via --task." }}
-conversation = {{ kind = "sliding_window", max_items = 10, budget = "12%", max_tokens = 10000, strategy = "bulk", overflow = 10 }}
-scratch      = {{ kind = "clearable",      budget = "6%",  max_tokens = 5000 }}
+task         = {{ kind = "pinned",         budget = "2%", required = true, seed = "task", required_message = "Describe the task via --task." }}
+conversation = {{ kind = "sliding_window", max_items = 10, budget = "12%", strategy = "bulk", overflow = 10 }}
+scratch      = {{ kind = "clearable",      budget = "6%" }}
 "#,
             name = name
         ),

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
@@ -967,6 +967,7 @@ impl Dashboard {
             | FieldId::MaxItems
             | FieldId::RegionBudget
             | FieldId::RegionMaxTokens
+            | FieldId::RegionMinTokens
             | FieldId::RegionMaxItems
             | FieldId::RegionOverflow => {
                 let value = match text.parse::<u64>() {

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
@@ -60,6 +60,7 @@ impl Dashboard {
         let field = match id {
             FieldId::RegionBudget => RegionField::BudgetPercent,
             FieldId::RegionMaxTokens => RegionField::MaxTokens,
+            FieldId::RegionMinTokens => RegionField::MinTokens,
             FieldId::RegionMaxItems => RegionField::MaxItems,
             FieldId::RegionOverflow => RegionField::Overflow,
             _ => return false,

--- a/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
@@ -115,6 +115,7 @@ pub(in crate::commands::dashboard) enum FieldId {
     RegionKind,
     RegionBudget,
     RegionMaxTokens,
+    RegionMinTokens,
     RegionMaxItems,
     RegionStrategy,
     RegionOverflow,
@@ -576,13 +577,22 @@ fn region_fields(doc: &ManifestDoc, scope: &RegionScope, name: &str) -> Vec<Fiel
             FieldId::RegionBudget,
             "Share of context (%)",
             FieldValue::Number(region.budget_percent.map(|p| p as u64)),
-            "Give it a % of the window, a token cap, or both.",
+            "The share of the model's window this region may use. On its own it \
+             scales with whatever model the stage runs.",
         ),
         Field::new(
             FieldId::RegionMaxTokens,
-            "Token cap",
+            "Token ceiling",
             FieldValue::Number(region.max_tokens),
-            "Give it a % of the window, a token cap, or both.",
+            "Hard cap on the share above. Usually leave empty - a ceiling below \
+             the percentage clamps the region on every large-window model.",
+        ),
+        Field::new(
+            FieldId::RegionMinTokens,
+            "Token floor",
+            FieldValue::Number(region.min_tokens),
+            "Floor under the share above, for a small region that needs its \
+             tokens whatever the window is.",
         ),
         Field::new(
             FieldId::RegionMaxItems,

--- a/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
@@ -234,20 +234,14 @@ fn agent_fields(doc: &ManifestDoc) -> Vec<Field> {
         ),
     ];
     for region in doc.regions(None) {
-        let budget = region
-            .budget_percent
-            .map(|p| format!("{p}%"))
-            .unwrap_or_default();
-        let tokens = region
-            .max_tokens
-            .map(|t| format!("{t} tokens"))
-            .unwrap_or_default();
         out.push(Field::new(
             FieldId::RegionRow(region.name.clone()),
             "Shared region",
             FieldValue::Row(format!(
-                "{}  {}  {budget} {tokens}",
-                region.name, region.kind
+                "{}  {}{}",
+                region.name,
+                region.kind,
+                region_size(&region)
             )),
             "A context region every stage sees unless it has a layout of its own.",
         ));
@@ -525,14 +519,20 @@ fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
     }
 }
 
-/// `· 5% · 4000 tokens`, whichever a region has.
+/// `· 5% · min 800 · max 4000`, whichever a region has.
+///
+/// Most regions now carry only the percentage - it is what decides the size,
+/// and an absolute beside it is the exception rather than the shape.
 fn region_size(region: &crate::blueprint_edit::RegionView) -> String {
     let mut s = String::new();
     if let Some(p) = region.budget_percent {
         s.push_str(&format!(" · {p}%"));
     }
+    if let Some(t) = region.min_tokens {
+        s.push_str(&format!(" · min {t}"));
+    }
     if let Some(t) = region.max_tokens {
-        s.push_str(&format!(" · {t} tokens"));
+        s.push_str(&format!(" · max {t}"));
     }
     s
 }

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -602,7 +602,14 @@ fn the_region_panel_edits_every_field_and_deletes() {
     assert_eq!(region(&mut dash).budget_percent, Some(20.0));
     dash.handle_key(key(KeyCode::Left));
     assert_eq!(region(&mut dash).budget_percent, Some(19.0));
+    // A new region carries no ceiling, so the field starts empty and the first
+    // step writes one rather than nudging a starter value.
     goto(&mut dash, FieldId::RegionMaxTokens);
+    assert_eq!(region(&mut dash).max_tokens, None);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "4000");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).max_tokens, Some(4000));
     dash.handle_key(key(KeyCode::Right));
     assert_eq!(region(&mut dash).max_tokens, Some(4001));
     dash.handle_key(key(KeyCode::Left));
@@ -622,6 +629,16 @@ fn the_region_panel_edits_every_field_and_deletes() {
             .as_deref()
             .is_some_and(|m| m.contains("whole number"))
     );
+    // The floor is the field that matters for a small pinned region, and it
+    // edits the same way.
+    goto(&mut dash, FieldId::RegionMinTokens);
+    assert_eq!(region(&mut dash).min_tokens, None);
+    dash.handle_key(key(KeyCode::Enter));
+    type_str(&mut dash, "800");
+    dash.handle_key(key(KeyCode::Enter));
+    assert_eq!(region(&mut dash).min_tokens, Some(800));
+    dash.handle_key(key(KeyCode::Right));
+    assert_eq!(region(&mut dash).min_tokens, Some(801));
     // Required: off → on enables the reminder; typing it; off again.
     goto(&mut dash, FieldId::RegionMessage);
     assert!(

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -639,6 +639,16 @@ fn the_region_panel_edits_every_field_and_deletes() {
     assert_eq!(region(&mut dash).min_tokens, Some(800));
     dash.handle_key(key(KeyCode::Right));
     assert_eq!(region(&mut dash).min_tokens, Some(801));
+    // Back out to the region list, which renders each row's size from whatever
+    // the region carries - the percentage, and either absolute when set, which
+    // now that the percentage decides is the exception.
+    dash.handle_key(key(KeyCode::Esc));
+    let listed = text(&mut dash);
+    assert!(listed.contains("notes  sliding_window"), "{listed}");
+    let row = region(&mut dash);
+    assert_eq!((row.min_tokens, row.max_tokens), (Some(801), Some(4000)));
+    goto(&mut dash, FieldId::StageRegionRow("notes".into()));
+    dash.handle_key(key(KeyCode::Enter));
     // Required: off → on enables the reminder; typing it; off again.
     goto(&mut dash, FieldId::RegionMessage);
     assert!(

--- a/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
@@ -98,7 +98,18 @@ fn a_opens_the_catalog_with_every_source_and_esc_closes_it() {
     assert!(screen.contains("installed"), "{screen}");
     assert!(screen.contains("bundled"), "{screen}");
     // The first entry (coder, sorted) previews its graph and its about box.
-    assert!(screen.contains("coder · v0.1.0 · 8 stages"), "{screen}");
+    // The version comes from the bundled table: it moves whenever the
+    // blueprint's contents do, and a literal would make every such change a
+    // test edit.
+    let coder_version = crate::bundled::BUNDLED_AGENTS
+        .iter()
+        .find(|a| a.name == "coder")
+        .expect("coder is bundled")
+        .version;
+    assert!(
+        screen.contains(&format!("coder · v{coder_version} · 8 stages")),
+        "{screen}"
+    );
     assert!(screen.contains("discover"), "{screen}");
     assert!(screen.contains("stages discover"), "{screen}");
     assert!(

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -123,6 +123,36 @@ pub(super) fn lint_tools(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lint
         );
     }
 
+    // A stage that routes tool output into a knowledge region tells the model,
+    // in the pointer left behind, that the output lives in that region. If it
+    // also hands the model a file-reading tool and no `context_read`, the only
+    // read verb in reach points at the filesystem - and models take it, aiming
+    // `read_file` at the region name. Measured over 152 local runs: 90 of 168
+    // failed `read_file` calls were a region name where a path belongs.
+    //
+    // A Warning rather than an Error: the runtime now names the region's
+    // heading in the pointer and corrects the mistake on the error, so this is
+    // an ergonomics gap and not a broken blueprint - and an Error would fail
+    // every user manifest written before it existed.
+    let routes_to_region = stage.tool_result_routing.as_ref().is_some_and(|r| {
+        r.default_region != "conversation" || r.tool_overrides.values().any(|v| v != "conversation")
+    });
+    let reads_files = granted.contains("read_file") || granted.contains("read_files");
+    if routes_to_region && reads_files && !granted.contains("context_read") {
+        findings.push(
+            LintFinding::new(
+                LintSeverity::Warning,
+                "routing-without-region-read",
+                "routes tool output into a context region and grants a file-reading \
+                 tool but not 'context_read', so the only way the model can act on \
+                 \"go and read that region\" is to aim read_file at the region name"
+                    .to_string(),
+            )
+            .in_stage(&stage.name)
+            .with_fix("add 'context_read' to available_tools".to_string()),
+        );
+    }
+
     findings
 }
 

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -2070,3 +2070,86 @@ raw_findings = { kind = "temporary", budget = "38%" }
         .count();
     assert_eq!(hits, 1);
 }
+
+/// A stage that routes tool output into a region and can read files, but has no
+/// `context_read`, leaves the model one read verb and it is the wrong one.
+///
+/// This is the authoring shape behind 90 of 168 failed `read_file` calls across
+/// 152 local runs: the pointer says the output is in `raw_findings`, the only
+/// tool that could act on that is not granted, and `read_file("raw_findings")`
+/// is what the model reaches for.
+#[test]
+fn routing_into_a_region_without_context_read_is_flagged() {
+    let manifest = r#"
+[agent]
+name = "router"
+version = "0.1.0"
+entry_stage = "gather"
+
+[stages.gather]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-5" }
+max_iterations = 5
+available_tools = ["read_file", "web_fetch"]
+system_prompt = "gather"
+
+[stages.gather.tool_routing]
+default_region = "raw_findings"
+
+[context.regions]
+raw_findings = { kind = "temporary", budget = "30%" }
+conversation = { kind = "sliding_window", max_items = 20, budget = "12%" }
+"#;
+    let findings = lint(manifest, &LintEnv::default());
+    assert!(
+        findings
+            .iter()
+            .any(|f| f.code == "routing-without-region-read"),
+        "expected the routing warning, got: {findings:?}"
+    );
+}
+
+/// Granting `context_read` settles it, and so does routing to `conversation`,
+/// where no pointer is written and there is nothing to go and read.
+#[test]
+fn routing_with_context_read_or_to_conversation_is_not_flagged() {
+    let with_grant = r#"
+[agent]
+name = "router"
+version = "0.1.0"
+entry_stage = "gather"
+
+[stages.gather]
+mode = "autonomous"
+model = { provider = "anthropic", model = "claude-sonnet-5" }
+max_iterations = 5
+available_tools = ["read_file", "context_read"]
+system_prompt = "gather"
+
+[stages.gather.tool_routing]
+default_region = "raw_findings"
+
+[context.regions]
+raw_findings = { kind = "temporary", budget = "30%" }
+conversation = { kind = "sliding_window", max_items = 20, budget = "12%" }
+"#;
+    let to_conversation = with_grant
+        .replace("\"read_file\", \"context_read\"", "\"read_file\"")
+        .replace(
+            "default_region = \"raw_findings\"",
+            "default_region = \"conversation\"",
+        );
+
+    for (label, manifest) in [
+        ("granted", with_grant),
+        ("conversation", to_conversation.as_str()),
+    ] {
+        let findings = lint(manifest, &LintEnv::default());
+        assert!(
+            !findings
+                .iter()
+                .any(|f| f.code == "routing-without-region-read"),
+            "{label}: unexpected warning in {findings:?}"
+        );
+    }
+}

--- a/crates/leviath-core/src/region/mod.rs
+++ b/crates/leviath-core/src/region/mod.rs
@@ -1156,7 +1156,10 @@ mod tests {
         region.add_entry("curated".to_string(), 80).unwrap();
 
         let err = region.add_entry("newest".to_string(), 40).unwrap_err();
-        assert!(matches!(err, crate::error::Error::RegionFull { .. }));
+        assert_eq!(
+            err.to_string(),
+            "Region 'sources' is full (80/100 tokens) and does not evict automatically - release an entry before adding another"
+        );
         assert_eq!(region.content.len(), 1);
         assert_eq!(region.current_tokens, 80);
     }
@@ -1171,10 +1174,7 @@ mod tests {
         region.add_entry("kept".to_string(), 50).unwrap();
 
         let err = region.add_entry("enormous".to_string(), 500).unwrap_err();
-        assert!(matches!(
-            err,
-            crate::error::Error::TokenBudgetExceeded { .. }
-        ));
+        assert_eq!(err.to_string(), "Content exceeds token budget: 550 > 100");
         assert_eq!(region.content.len(), 1, "the region was not emptied for it");
     }
 

--- a/crates/leviath-core/src/region/mod.rs
+++ b/crates/leviath-core/src/region/mod.rs
@@ -6,6 +6,10 @@
 
 use serde::{Deserialize, Serialize};
 
+pub mod policy;
+
+pub use policy::{Admission, EvictionStrategy, Volatility};
+
 /// The kind of content stored in a region entry.
 ///
 /// Entries carry typed metadata instead of relying on text-prefix parsing
@@ -54,34 +58,6 @@ pub struct SerializedToolCall {
     /// (Gemini's `thought_signature`). Persisted so it survives a restart.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thought_signature: Option<String>,
-}
-
-/// Eviction strategy for `SlidingWindow` regions.
-///
-/// Controls how entries are removed when the window exceeds its `max_items` limit.
-/// The choice of strategy affects prompt caching effectiveness: PerItem eviction
-/// shifts the message prefix every iteration (breaking cache), while Bulk and
-/// Compact keep the prefix stable between eviction events.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(tag = "strategy", rename_all = "snake_case")]
-pub enum EvictionStrategy {
-    /// Evict one turn group at a time (current behavior). Default.
-    #[default]
-    PerItem,
-    /// Evict in bulk when items exceed max + overflow.
-    /// Between bulk evictions, the prefix stays stable for caching.
-    Bulk {
-        /// How many items over max_items before triggering a bulk eviction.
-        /// When triggered, evicts items back down to max_items.
-        overflow: usize,
-    },
-    /// Summarize oldest entries when threshold is hit (requires external LLM call).
-    /// The region stores a `pending_compaction` flag; the runtime checks this
-    /// and performs compaction externally.
-    Compact {
-        /// Number of oldest entries to compact into a summary when triggered.
-        compact_count: usize,
-    },
 }
 
 /// A typed memory region within an agent's context window.
@@ -489,70 +465,6 @@ pub struct Region {
     pub describe_in_prompt: bool,
 }
 
-/// What a region does when a write does not fit.
-///
-/// The default is what every region did before this existed: make room. That
-/// is the right behaviour for a transcript, where the oldest turn is the least
-/// useful thing present and losing it costs nothing anyone will notice.
-///
-/// It is the wrong behaviour for a region holding material the agent chose to
-/// keep. There, silently dropping the oldest entry is a decision about what
-/// matters, taken by whichever write happened to arrive when the region was
-/// full - and the agent never learns it happened. [`Admission::Reject`] hands
-/// that decision back: the write fails, the agent is told the region is full,
-/// and it releases what it is finished with before adding more.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Admission {
-    /// Make room for the write - roll off the oldest entry, or let the
-    /// window-level cascade reclaim the region.
-    #[default]
-    Evict,
-    /// Refuse the write and say so. Nothing already in the region is lost to a
-    /// write the agent did not know would displace it.
-    Reject,
-}
-
-/// How much a region's contents move between requests.
-///
-/// This exists because a provider caches by *prefix*: an entry is readable next
-/// time only when every byte in front of it is unchanged, so a block that moves
-/// invalidates everything behind it however stable that later content is. The
-/// arrangement that pays is stable content first and churn last.
-///
-/// A region's [`RegionKind`] cannot answer this. A pinned region sounds
-/// immutable and is written constantly - `context_write` into a findings region
-/// is an ordinary move, and tool routing sends read results straight into one.
-/// A compact-history region sounds settled and gains an entry every time
-/// compaction fires. Inferring stability from the kind put churn at the front of
-/// the prefix and cost a measured 456,860 cache-write tokens against zero reads
-/// (issue #474).
-///
-/// So the blueprint says. The author knows whether a region is set once at spawn
-/// or written every turn, and nothing else does.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum Volatility {
-    /// Written rarely or never after setup: a task, a system prompt, a
-    /// convention the run does not revise. Sorted to the front, where it forms
-    /// the prefix everything else caches behind.
-    Stable,
-    /// Appended to, with existing entries left alone: a findings list, a
-    /// bibliography, a transcript of what has been read. Sorted after the stable
-    /// content, and split into chunks so the settled head of it can be cached
-    /// while only the tail is re-sent.
-    Grows,
-    /// Existing content changes in place: a scratchpad, a key-value store whose
-    /// keys are overwritten, anything rebuilt each turn. Sorted last, where it
-    /// invalidates nothing but itself.
-    ///
-    /// The default, and deliberately the pessimistic one: a blueprint that
-    /// declares nothing must never be made *worse* by this, and an optimistic
-    /// default is exactly how inferring stability from the kind went wrong.
-    #[default]
-    Rewritten,
-}
-
 mod schema;
 
 pub use schema::{ContentFormat, RegionSchema, Validator};
@@ -638,6 +550,19 @@ impl Region {
                     max: self.max_tokens,
                 });
             }
+            // `Evict` says it makes room, so it makes room. Until this existed
+            // the default admission refused the write exactly as `Reject` did,
+            // and the caller's fallback silently degraded the result to a
+            // truncation or to `[result omitted]` - losing the NEWEST material
+            // to protect the oldest, which is backwards for a working region.
+            if self.admission == Admission::Evict && self.kind.rolls_off_oldest() {
+                self.make_room(tokens);
+            }
+        }
+        // Still over after rolling off everything it could: one entry larger
+        // than the whole region. Nothing to drop that would help, so the caller
+        // gets the budget error and truncates.
+        if self.current_tokens + tokens > self.max_tokens {
             return Err(crate::error::Error::TokenBudgetExceeded {
                 used: self.current_tokens + tokens,
                 max: self.max_tokens,
@@ -674,6 +599,32 @@ impl Region {
         self.enforce_sliding_window();
 
         Ok(())
+    }
+
+    /// Roll off the oldest entries until `tokens` more would fit, and report
+    /// how many were dropped.
+    ///
+    /// This is what [`Admission::Evict`] has always claimed to do. Stops as
+    /// soon as the write fits, and does not start at all when it never can:
+    /// an entry larger than `max_tokens` does not fit an *empty* region either,
+    /// so evicting for it would destroy everything held and still fail. The
+    /// caller truncates instead, which is the right answer and needs the region
+    /// intact to have anywhere to put the truncation.
+    ///
+    /// Goes through [`remove_oldest`](Self::remove_oldest) rather than touching
+    /// `content` directly because that method is turn-group aware: an
+    /// `AssistantTurn` carrying tool calls leaves together with the
+    /// `ToolResult` entries that answer it, so eviction never strands a
+    /// `tool_use` that a provider would then reject.
+    pub fn make_room(&mut self, tokens: usize) -> usize {
+        if tokens > self.max_tokens {
+            return 0;
+        }
+        let mut evicted = 0;
+        while self.current_tokens + tokens > self.max_tokens && self.remove_oldest().is_some() {
+            evicted += 1;
+        }
+        evicted
     }
 
     /// Whether one more entry would push a sliding window past its item cap.
@@ -1159,6 +1110,149 @@ pub struct RegionEntry {
 ///
 #[cfg(test)]
 mod tests {
+
+    /// `Admission::Evict` evicts. It is the default, and its documentation has
+    /// always said "make room for the write - roll off the oldest entry", but
+    /// `push_entry` returned `TokenBudgetExceeded` for it exactly as it did for
+    /// `Reject`. Nothing ever rolled off by tokens; only a sliding window's
+    /// *count* limit did anything.
+    ///
+    /// What that cost was paid one region over: a full region refused the write,
+    /// and the tool-result caller degraded the result to a truncation or to
+    /// `[result omitted]` while still telling the model it had been stored.
+    #[test]
+    fn an_evicting_region_rolls_the_oldest_off_to_admit_a_write() {
+        let mut region = Region::new("findings".to_string(), RegionKind::Temporary, 100);
+        region.add_entry("oldest".to_string(), 40).unwrap();
+        region.add_entry("middle".to_string(), 40).unwrap();
+        assert_eq!(region.current_tokens, 80);
+
+        // Needs 40 of the 20 left: one entry has to go, and it is the oldest.
+        region.add_entry("newest".to_string(), 40).unwrap();
+
+        assert_eq!(region.current_tokens, 80);
+        let held: Vec<&str> = region.content.iter().map(|e| e.content.as_str()).collect();
+        assert_eq!(held, ["middle", "newest"]);
+    }
+
+    /// It rolls off only as far as it must - eviction is admission, not a purge.
+    #[test]
+    fn eviction_stops_as_soon_as_the_write_fits() {
+        let mut region = Region::new("findings".to_string(), RegionKind::Temporary, 100);
+        for i in 0..5 {
+            region.add_entry(format!("entry-{i}"), 20).unwrap();
+        }
+        region.add_entry("newest".to_string(), 20).unwrap();
+        let held: Vec<&str> = region.content.iter().map(|e| e.content.as_str()).collect();
+        assert_eq!(held, ["entry-1", "entry-2", "entry-3", "entry-4", "newest"]);
+    }
+
+    /// `Reject` still refuses, which is the entire reason an author sets it:
+    /// nothing curated is lost to a write they did not know would displace it.
+    #[test]
+    fn a_rejecting_region_still_refuses_rather_than_dropping_anything() {
+        let mut region = Region::new("sources".to_string(), RegionKind::Temporary, 100);
+        region.admission = Admission::Reject;
+        region.add_entry("curated".to_string(), 80).unwrap();
+
+        let err = region.add_entry("newest".to_string(), 40).unwrap_err();
+        assert!(matches!(err, crate::error::Error::RegionFull { .. }));
+        assert_eq!(region.content.len(), 1);
+        assert_eq!(region.current_tokens, 80);
+    }
+
+    /// An entry bigger than the whole region cannot be admitted by dropping
+    /// things, so the region keeps what it has and the caller truncates. The
+    /// failure mode this rules out is emptying a region for a write that was
+    /// never going to fit.
+    #[test]
+    fn an_entry_larger_than_the_region_does_not_empty_it() {
+        let mut region = Region::new("findings".to_string(), RegionKind::Temporary, 100);
+        region.add_entry("kept".to_string(), 50).unwrap();
+
+        let err = region.add_entry("enormous".to_string(), 500).unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::Error::TokenBudgetExceeded { .. }
+        ));
+        assert_eq!(region.content.len(), 1, "the region was not emptied for it");
+    }
+
+    /// Eviction takes a whole turn group, so an `AssistantTurn` never leaves its
+    /// `ToolResult` entries behind. An orphaned `tool_use` is a provider 400,
+    /// which is why this goes through `remove_oldest` rather than splicing.
+    #[test]
+    fn eviction_never_strands_a_tool_result_without_its_call() {
+        let mut region = Region::new(
+            "conversation".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: 100,
+                eviction_strategy: EvictionStrategy::PerItem,
+            },
+            100,
+        );
+        region
+            .add_typed_entry(
+                "call it".to_string(),
+                30,
+                EntryKind::AssistantTurn {
+                    tool_calls: vec![crate::SerializedToolCall {
+                        id: "t1".to_string(),
+                        name: "read_file".to_string(),
+                        arguments: serde_json::json!({}),
+                        thought_signature: None,
+                    }],
+                },
+            )
+            .unwrap();
+        region
+            .add_typed_entry(
+                "the answer".to_string(),
+                30,
+                EntryKind::ToolResult {
+                    tool_call_id: "t1".to_string(),
+                    tool_name: "read_file".to_string(),
+                    is_error: false,
+                },
+            )
+            .unwrap();
+
+        // Forces eviction: the pair together is 60 of the 100.
+        region.add_entry("next turn".to_string(), 60).unwrap();
+
+        assert!(
+            !region
+                .content
+                .iter()
+                .any(|e| matches!(e.kind, EntryKind::ToolResult { .. })),
+            "the result outlived the call that produced it"
+        );
+    }
+
+    /// A region whose kind owns its own retention is left to own it. A custom
+    /// region's `on_overflow` script IS the author's eviction policy, a pinned
+    /// region is meant to survive the run, and a HashMap already evicts by LRU.
+    #[test]
+    fn kinds_that_own_their_retention_do_not_roll_off() {
+        assert!(RegionKind::Temporary.rolls_off_oldest());
+        assert!(RegionKind::Clearable.rolls_off_oldest());
+        assert!(!RegionKind::Pinned.rolls_off_oldest());
+        assert!(
+            !RegionKind::Custom {
+                script: "r.rhai".to_string(),
+                persistent: false,
+            }
+            .rolls_off_oldest()
+        );
+        assert!(!RegionKind::HashMap { max_entries: None }.rolls_off_oldest());
+
+        // And a pinned region proves it in behaviour, not just in the predicate.
+        let mut pinned = Region::new("query".to_string(), RegionKind::Pinned, 100);
+        pinned.add_entry("the task".to_string(), 80).unwrap();
+        assert!(pinned.add_entry("more".to_string(), 40).is_err());
+        assert_eq!(pinned.content.len(), 1, "a pinned region kept its content");
+    }
+
     use super::*;
 
     // ─── Checklist items ────────────────────────────────────────────────────

--- a/crates/leviath-core/src/region/policy.rs
+++ b/crates/leviath-core/src/region/policy.rs
@@ -1,0 +1,130 @@
+//! What a region does under pressure, and how that shows up in the prompt.
+//!
+//! Three policies that travel together because they answer one question between
+//! them - a region that is full has to either drop something or refuse, and
+//! which it does decides whether the agent ever finds out. None of them touch
+//! `Region`'s state, which is why they are not in with it.
+
+use serde::{Deserialize, Serialize};
+
+use super::RegionKind;
+
+/// Eviction strategy for `SlidingWindow` regions.
+///
+/// Controls how entries are removed when the window exceeds its `max_items` limit.
+/// The choice of strategy affects prompt caching effectiveness: PerItem eviction
+/// shifts the message prefix every iteration (breaking cache), while Bulk and
+/// Compact keep the prefix stable between eviction events.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "strategy", rename_all = "snake_case")]
+pub enum EvictionStrategy {
+    /// Evict one turn group at a time (current behavior). Default.
+    #[default]
+    PerItem,
+    /// Evict in bulk when items exceed max + overflow.
+    /// Between bulk evictions, the prefix stays stable for caching.
+    Bulk {
+        /// How many items over max_items before triggering a bulk eviction.
+        /// When triggered, evicts items back down to max_items.
+        overflow: usize,
+    },
+    /// Summarize oldest entries when threshold is hit (requires external LLM call).
+    /// The region stores a `pending_compaction` flag; the runtime checks this
+    /// and performs compaction externally.
+    Compact {
+        /// Number of oldest entries to compact into a summary when triggered.
+        compact_count: usize,
+    },
+}
+
+impl RegionKind {
+    /// Whether a write that does not fit may roll the oldest entries off to
+    /// make room, given the region is under [`Admission::Evict`].
+    ///
+    /// Working regions say yes: they hold material whose oldest end is its
+    /// least useful, and refusing the newest write to protect it is backwards.
+    ///
+    /// The rest say no, each for its own reason. [`Pinned`](Self::Pinned) and a
+    /// persistent [`Custom`](Self::Custom) region are meant to survive the run,
+    /// so dropping the task to admit a tool result would be a strange trade.
+    /// [`HashMap`](Self::HashMap) already evicts by LRU on its own keyed path,
+    /// and oldest-first would fight it. [`CompactHistory`](Self::CompactHistory)
+    /// is the record of what was summarized away, and losing its front end
+    /// loses the only copy. A non-persistent [`Custom`](Self::Custom) region is
+    /// excluded too: its script's `on_overflow` hook IS the author's eviction
+    /// policy, and rolling off behind it would override the thing the region
+    /// exists to express.
+    pub fn rolls_off_oldest(&self) -> bool {
+        matches!(
+            self,
+            RegionKind::Temporary
+                | RegionKind::Clearable
+                | RegionKind::SlidingWindow { .. }
+                | RegionKind::Compacting { .. }
+        )
+    }
+}
+
+/// What a region does when a write does not fit.
+///
+/// The default is what every region did before this existed: make room. That
+/// is the right behaviour for a transcript, where the oldest turn is the least
+/// useful thing present and losing it costs nothing anyone will notice.
+///
+/// It is the wrong behaviour for a region holding material the agent chose to
+/// keep. There, silently dropping the oldest entry is a decision about what
+/// matters, taken by whichever write happened to arrive when the region was
+/// full - and the agent never learns it happened. [`Admission::Reject`] hands
+/// that decision back: the write fails, the agent is told the region is full,
+/// and it releases what it is finished with before adding more.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Admission {
+    /// Make room for the write - roll off the oldest entry, or let the
+    /// window-level cascade reclaim the region.
+    #[default]
+    Evict,
+    /// Refuse the write and say so. Nothing already in the region is lost to a
+    /// write the agent did not know would displace it.
+    Reject,
+}
+
+/// How much a region's contents move between requests.
+///
+/// This exists because a provider caches by *prefix*: an entry is readable next
+/// time only when every byte in front of it is unchanged, so a block that moves
+/// invalidates everything behind it however stable that later content is. The
+/// arrangement that pays is stable content first and churn last.
+///
+/// A region's [`RegionKind`] cannot answer this. A pinned region sounds
+/// immutable and is written constantly - `context_write` into a findings region
+/// is an ordinary move, and tool routing sends read results straight into one.
+/// A compact-history region sounds settled and gains an entry every time
+/// compaction fires. Inferring stability from the kind put churn at the front of
+/// the prefix and cost a measured 456,860 cache-write tokens against zero reads
+/// (issue #474).
+///
+/// So the blueprint says. The author knows whether a region is set once at spawn
+/// or written every turn, and nothing else does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Volatility {
+    /// Written rarely or never after setup: a task, a system prompt, a
+    /// convention the run does not revise. Sorted to the front, where it forms
+    /// the prefix everything else caches behind.
+    Stable,
+    /// Appended to, with existing entries left alone: a findings list, a
+    /// bibliography, a transcript of what has been read. Sorted after the stable
+    /// content, and split into chunks so the settled head of it can be cached
+    /// while only the tail is re-sent.
+    Grows,
+    /// Existing content changes in place: a scratchpad, a key-value store whose
+    /// keys are overwritten, anything rebuilt each turn. Sorted last, where it
+    /// invalidates nothing but itself.
+    ///
+    /// The default, and deliberately the pessimistic one: a blueprint that
+    /// declares nothing must never be made *worse* by this, and an optimistic
+    /// default is exactly how inferring stability from the kind went wrong.
+    #[default]
+    Rewritten,
+}

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -14339,6 +14339,87 @@ fn a_path_tool_aimed_at_a_region_is_told_it_is_a_region() {
     }
 }
 
+/// `read_files` takes `paths`, not `path`, and gets the same correction. The
+/// batch tool is the one an agent reaches for once the single read has failed a
+/// few times, so it is exactly where the hint must not go missing.
+#[test]
+fn the_batch_read_tool_gets_the_region_hint_too() {
+    let window = routed_window(&["raw_findings"], &[]);
+    let calls = vec![crate::components::ToolCall {
+        tool_id: "c1".to_string(),
+        name: "read_files".to_string(),
+        arguments: serde_json::json!({ "paths": ["raw_findings", "notes.md"] }),
+        thought_signature: None,
+    }];
+    let mut merged = vec![(
+        "c1".to_string(),
+        "[error] Failed to read 'raw_findings': No such file or directory (os error 2)".to_string(),
+    )];
+    crate::pipeline::annotate_path_errors(&window, &calls, &mut merged);
+    assert!(
+        merged[0].1.contains("is a context region, not a file"),
+        "{}",
+        merged[0].1
+    );
+}
+
+/// A region with room for some of the result keeps that much and the pointer
+/// says how much went missing.
+///
+/// The middle of the three outcomes, and the one that was silent longest: a
+/// region under `reject` with space left but not enough takes a prefix, and the
+/// old pointer described the whole result as stored either way.
+#[test]
+fn a_partly_stored_result_reports_what_was_dropped() {
+    let mut window = routed_window(&["data_preview"], &[]);
+    {
+        let region = window.get_region_mut("data_preview").expect("target");
+        region.admission = leviath_core::region::Admission::Reject;
+        // Room for a truncation (>100 tokens free) but not for the result.
+        region.max_tokens = 300;
+    }
+    let long = "x".repeat(8_000);
+    let calls = vec![crate::components::ToolCall {
+        tool_id: "call-1".to_string(),
+        name: "read_file".to_string(),
+        arguments: serde_json::json!({ "path": "manual.md" }),
+        thought_signature: None,
+    }];
+    let results = vec![("call-1".to_string(), long)];
+    apply_tool_results(
+        &mut window,
+        "",
+        &calls,
+        &results,
+        Some(&routed_to("data_preview")),
+        None,
+    );
+    let conversation = window.get_region("conversation").expect("conversation");
+    let text: String = conversation
+        .content
+        .iter()
+        .map(|e| e.content.clone())
+        .collect();
+    assert!(
+        text.contains("characters were dropped"),
+        "the pointer must quantify the loss: {text}"
+    );
+    assert!(
+        !text.contains("already in this prompt"),
+        "and must not describe a partial store as a whole one: {text}"
+    );
+    // The prefix really is there - a truncation that stored nothing would be
+    // the Dropped case wearing this message.
+    let stored = window.get_region("data_preview").expect("target region");
+    assert!(
+        stored
+            .content
+            .iter()
+            .any(|e| e.content.contains("truncated")),
+        "the region kept a marked prefix"
+    );
+}
+
 /// A directory handed to `read_file` is the same mistake with the right path:
 /// the OS error does not name the tool that would have worked.
 #[test]

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -14207,10 +14207,16 @@ fn one_read_call() -> (Vec<crate::components::ToolCall>, Vec<(String, String)>) 
     )
 }
 
-/// The pointer that reaches the model when the region *is* visible: go and read
-/// it, because it can.
+/// The pointer that reaches the model when the region *is* visible: it is
+/// already in the prompt, so say where, and do not ask for a tool call.
+///
+/// This used to read "read that region for the full result", which is an
+/// instruction with nothing behind it - the region renders into the system
+/// prompt, and the stages that route mostly do not grant `context_read`. What
+/// models did instead was aim `read_file` at the region name, and across 152
+/// local runs that was 90 of 168 failed `read_file` calls.
 #[test]
-fn a_pointer_to_a_visible_region_says_to_read_it() {
+fn a_pointer_to_a_visible_region_says_it_is_already_in_the_prompt() {
     let mut window = routed_window(&["data_preview"], &[]);
     let (calls, results) = one_read_call();
     apply_tool_results(
@@ -14227,9 +14233,190 @@ fn a_pointer_to_a_visible_region_says_to_read_it() {
         .iter()
         .map(|e| e.content.clone())
         .collect();
+    assert!(text.contains("already in this prompt"), "{text}");
+    assert!(text.contains("no tool call is needed"), "{text}");
     assert!(
-        text.contains("read that region for the full result"),
-        "{text}"
+        text.contains("'data_preview' heading"),
+        "the pointer must name the heading the assembler emits: {text}"
+    );
+    assert!(
+        !text.contains("read that region"),
+        "the instruction with no tool behind it must be gone: {text}"
+    );
+}
+
+/// A region too full to take the result must not be described as having taken
+/// it.
+///
+/// The old pointer promised "the full result" whatever the region had actually
+/// kept. In the run that prompted this, `raw_findings` sat pinned at its ceiling
+/// and three of its thirty-five entries were truncated or dropped - two of them
+/// whole `web_fetch` results the model had been told were stored, and went on
+/// to reason as though they were.
+#[test]
+fn a_pointer_says_when_the_region_could_not_take_the_whole_result() {
+    // Reject admission, and already full: the write cannot be made to fit by
+    // rolling anything off, so the fallbacks are the only path.
+    let mut window = routed_window(&["data_preview"], &[]);
+    {
+        let region = window.get_region_mut("data_preview").expect("target");
+        region.admission = leviath_core::region::Admission::Reject;
+        region.max_tokens = 12;
+        region
+            .add_entry("something already here".to_string(), 10)
+            .expect("seed fits");
+    }
+    let (calls, results) = one_read_call();
+    apply_tool_results(
+        &mut window,
+        "",
+        &calls,
+        &results,
+        Some(&routed_to("data_preview")),
+        None,
+    );
+    let conversation = window.get_region("conversation").expect("conversation");
+    let text: String = conversation
+        .content
+        .iter()
+        .map(|e| e.content.clone())
+        .collect();
+    assert!(
+        text.contains("could NOT be stored") || text.contains("characters were dropped"),
+        "a partial or refused write must say so: {text}"
+    );
+    assert!(
+        !text.contains("already in this prompt"),
+        "and must not claim the result is there to read: {text}"
+    );
+}
+
+/// A path tool aimed at a context region is told what it actually hit.
+///
+/// The model sees `## raw_findings` in its prompt and `read_file` in its tool
+/// list, and joins them. The tools crate cannot correct that - it resolves
+/// paths and has never seen the context window - so the correction is added
+/// here, and it names the heading the region is already rendered under.
+#[test]
+fn a_path_tool_aimed_at_a_region_is_told_it_is_a_region() {
+    let window = routed_window(&["raw_findings"], &[]);
+    // The five spellings one real run produced for the same region, across
+    // three stages, before giving up.
+    for path in [
+        "raw_findings",
+        "/context/raw_findings",
+        "/Users/someone/papers/raw_findings",
+        "context/raw_findings",
+        "./raw_findings",
+    ] {
+        let calls = vec![crate::components::ToolCall {
+            tool_id: "c1".to_string(),
+            name: "read_file".to_string(),
+            arguments: serde_json::json!({ "path": path }),
+            thought_signature: None,
+        }];
+        let mut merged = vec![(
+            "c1".to_string(),
+            "[error] Failed to read 'raw_findings': No such file or directory (os error 2)"
+                .to_string(),
+        )];
+        crate::pipeline::annotate_path_errors(&window, &calls, &mut merged);
+        assert!(
+            merged[0].1.contains("is a context region, not a file"),
+            "path {path} was not recognised as a region: {}",
+            merged[0].1
+        );
+        assert!(
+            merged[0].1.contains("already in this prompt"),
+            "the hint must say where to look instead: {}",
+            merged[0].1
+        );
+        assert!(
+            merged[0].1.starts_with("[error]"),
+            "the error prefix carries success/failure downstream and must survive: {}",
+            merged[0].1
+        );
+    }
+}
+
+/// A directory handed to `read_file` is the same mistake with the right path:
+/// the OS error does not name the tool that would have worked.
+#[test]
+fn a_directory_handed_to_read_file_names_list_dir() {
+    let window = routed_window(&["raw_findings"], &[]);
+    let calls = vec![crate::components::ToolCall {
+        tool_id: "c1".to_string(),
+        name: "read_file".to_string(),
+        arguments: serde_json::json!({ "path": "/Users/someone/papers" }),
+        thought_signature: None,
+    }];
+    let mut merged = vec![(
+        "c1".to_string(),
+        "[error] Failed to read '/Users/someone/papers': Is a directory (os error 21)".to_string(),
+    )];
+    crate::pipeline::annotate_path_errors(&window, &calls, &mut merged);
+    assert!(merged[0].1.contains("use list_dir"), "{}", merged[0].1);
+}
+
+/// An ordinary missing file is left exactly as it was: the hint is a correction
+/// for a specific confusion, not a decoration on every failure.
+#[test]
+fn an_ordinary_missing_file_error_is_not_annotated() {
+    let window = routed_window(&["raw_findings"], &[]);
+    let calls = vec![crate::components::ToolCall {
+        tool_id: "c1".to_string(),
+        name: "read_file".to_string(),
+        arguments: serde_json::json!({ "path": "notes.md" }),
+        thought_signature: None,
+    }];
+    let original =
+        "[error] Failed to read 'notes.md': No such file or directory (os error 2)".to_string();
+    let mut merged = vec![("c1".to_string(), original.clone())];
+    crate::pipeline::annotate_path_errors(&window, &calls, &mut merged);
+    assert_eq!(merged[0].1, original);
+}
+
+/// A successful call is never annotated either, however region-shaped its path
+/// looks - the hint keys off the failure, not the name.
+#[test]
+fn a_successful_path_call_is_left_alone() {
+    let window = routed_window(&["raw_findings"], &[]);
+    let calls = vec![crate::components::ToolCall {
+        tool_id: "c1".to_string(),
+        name: "read_file".to_string(),
+        arguments: serde_json::json!({ "path": "raw_findings" }),
+        thought_signature: None,
+    }];
+    let mut merged = vec![("c1".to_string(), "the file's contents".to_string())];
+    crate::pipeline::annotate_path_errors(&window, &calls, &mut merged);
+    assert_eq!(merged[0].1, "the file's contents");
+}
+
+/// A region the stage does not carry gets the honest version: it is a region,
+/// and there is nothing here to read.
+#[test]
+fn a_hidden_region_named_as_a_path_says_the_stage_does_not_carry_it() {
+    let window = routed_window(&["raw_findings"], &["raw_findings"]);
+    let calls = vec![crate::components::ToolCall {
+        tool_id: "c1".to_string(),
+        name: "read_file".to_string(),
+        arguments: serde_json::json!({ "path": "raw_findings" }),
+        thought_signature: None,
+    }];
+    let mut merged = vec![(
+        "c1".to_string(),
+        "[error] Failed to read 'raw_findings': No such file or directory (os error 2)".to_string(),
+    )];
+    crate::pipeline::annotate_path_errors(&window, &calls, &mut merged);
+    assert!(
+        merged[0].1.contains("this stage does not carry it"),
+        "{}",
+        merged[0].1
+    );
+    assert!(
+        !merged[0].1.contains("already in this prompt"),
+        "it is not in the prompt, and saying so is the bug this replaces: {}",
+        merged[0].1
     );
 }
 

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -6,6 +6,112 @@ use super::*;
 #[derive(Resource)]
 pub struct ToolResults(pub UnboundedReceiver<ToolOutcome>);
 
+/// What a region actually did with a tool result routed into it.
+///
+/// A routed result leaves a pointer in `conversation` describing where the
+/// output went, and the pointer is only worth anything if it is true: the
+/// region may have been too full to take the result whole, in which case
+/// "stored in region X" is a claim about tokens that are not there.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Stored {
+    /// The result went in as written.
+    Whole,
+    /// The region took a prefix; `omitted` characters did not fit.
+    Truncated { omitted: usize },
+    /// The region refused even a truncated entry; only a marker is there.
+    Dropped,
+}
+
+/// Tools whose first argument is a path into the workspace, and which therefore
+/// get the region hint below when that path is not one.
+const PATH_TOOLS: [&str; 5] = [
+    "read_file",
+    "read_files",
+    "list_dir",
+    "write_file",
+    "edit_file",
+];
+
+/// Append a corrective hint to a path tool's error when the path was never a
+/// path.
+///
+/// Models routinely aim `read_file` at a context region - `raw_findings`,
+/// `sources_index`, `claims` - because the region is a labelled block in their
+/// prompt and a file is the only thing they have a read verb for. The tools
+/// crate cannot tell them otherwise: it resolves paths and has no view of the
+/// context window. So the correction happens here, where the window is in
+/// scope, and it names the heading the region is already rendered under.
+///
+/// Measured on 152 local runs before this existed: 168 of 299 `read_file` calls
+/// failed, 90 of them on a region name, spread over 32 of the 46 runs that used
+/// the tool at all. One run spent five turns on five spellings of the same
+/// region across three stages. A quarter of those came from agents that route
+/// nothing and emit no pointer, which is why the fix has to live on the error
+/// rather than only on the routing pointer.
+pub(crate) fn annotate_path_errors(
+    window: &ContextWindow,
+    tool_calls: &[crate::components::ToolCall],
+    merged: &mut [(String, String)],
+) {
+    for (call, (_id, result)) in tool_calls.iter().zip(merged.iter_mut()) {
+        if !result.starts_with("[error]") || !PATH_TOOLS.contains(&call.name.as_str()) {
+            continue;
+        }
+        // `read_files` takes `paths`; everything else takes `path`. Either way
+        // the last segment is what identifies a region: the model reaches for
+        // `raw_findings`, `/context/raw_findings` and `<workdir>/raw_findings`
+        // in turn, and all three name the same thing.
+        let path = call
+            .arguments
+            .get("path")
+            .and_then(|v| v.as_str())
+            .map(str::to_string)
+            .or_else(|| {
+                call.arguments
+                    .get("paths")
+                    .and_then(|v| v.as_array())
+                    .and_then(|a| a.first())
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            });
+        let hint = match path.as_deref() {
+            Some(p) => region_hint(window, p),
+            None => None,
+        };
+        // "Is a directory" is the other half of the same problem: the model has
+        // the right path and the wrong tool, and the OS error does not say so.
+        let hint = hint.or_else(|| {
+            result.contains("Is a directory").then(|| {
+                "That path is a directory - use list_dir to see what is in it.".to_string()
+            })
+        });
+        if let Some(hint) = hint {
+            result.push(' ');
+            result.push_str(&hint);
+        }
+    }
+}
+
+/// The hint for a path whose last segment names a region this window holds.
+fn region_hint(window: &ContextWindow, path: &str) -> Option<String> {
+    let leaf = path
+        .rsplit(['/', '\\'])
+        .find(|s| !s.is_empty())
+        .unwrap_or(path);
+    let region = window.regions.iter().find(|r| r.name == leaf)?;
+    let name = &region.name;
+    match window.hidden.contains(name) {
+        false => Some(format!(
+            "'{name}' is a context region, not a file - its contents are already in this prompt, \
+             under the '{name}' heading. Read them there rather than through a tool."
+        )),
+        true => Some(format!(
+            "'{name}' is a context region rather than a file, and this stage does not carry it, \
+             so there is nothing to read here."
+        )),
+    }
+}
+
 /// Apply a completed tool batch to an agent's context window: add the assistant
 /// turn (with its tool calls) then each tool result, honoring the stage's
 /// tool-result routing (target region, `persist=false`→scratch, per-result
@@ -97,33 +203,47 @@ pub(crate) fn apply_tool_results(
         });
         // Add `content` (with entry `kind`) to `region`, honoring taint and falling
         // back to a truncated (then omitted) entry if the region is full.
+        //
+        // Reports which of the three happened, because the pointer left in the
+        // conversation describes this write and used to describe it wrongly:
+        // it promised the full result whatever the region had actually kept.
         let add_kind = |window: &mut ContextWindow,
                         region: &str,
                         kind: leviath_core::EntryKind,
                         content: String,
-                        tokens: usize| {
+                        tokens: usize|
+         -> Stored {
             let put = |w: &mut ContextWindow, c: String, t: usize| match taint_level {
                 Some(level) => w.add_typed_tainted_to_region(region, kind.clone(), c, t, level),
                 None => w.add_typed_entry(region, kind.clone(), c, t),
             };
-            if put(window, content.clone(), tokens).is_err() {
-                let available = window
-                    .get_region(region)
-                    .map(|r| r.max_tokens.saturating_sub(r.current_tokens))
-                    .unwrap_or(0);
-                let truncated = if available > 100 {
-                    let char_budget = (available - 10) * 4;
-                    let prefix = truncate_on_char_boundary(&content, char_budget);
-                    let omitted = content.len().saturating_sub(prefix.len());
-                    format!("{}... [truncated, {} chars omitted]", prefix, omitted)
-                } else {
-                    "[tool result truncated - context window full]".to_string()
-                };
-                let trunc_tokens = leviath_core::estimate_tokens(&truncated);
-                if put(window, truncated, trunc_tokens).is_err() {
-                    let _ = put(window, "[result omitted]".to_string(), 5);
-                }
+            if put(window, content.clone(), tokens).is_ok() {
+                return Stored::Whole;
             }
+            let available = window
+                .get_region(region)
+                .map(|r| r.max_tokens.saturating_sub(r.current_tokens))
+                .unwrap_or(0);
+            let (truncated, omitted) = if available > 100 {
+                let char_budget = (available - 10) * 4;
+                let prefix = truncate_on_char_boundary(&content, char_budget);
+                let omitted = content.len().saturating_sub(prefix.len());
+                (
+                    format!("{}... [truncated, {} chars omitted]", prefix, omitted),
+                    omitted,
+                )
+            } else {
+                (
+                    "[tool result truncated - context window full]".to_string(),
+                    content.len(),
+                )
+            };
+            let trunc_tokens = leviath_core::estimate_tokens(&truncated);
+            if put(window, truncated, trunc_tokens).is_ok() {
+                return Stored::Truncated { omitted };
+            }
+            let _ = put(window, "[result omitted]".to_string(), 5);
+            Stored::Dropped
         };
         let result_kind = || leviath_core::EntryKind::ToolResult {
             tool_call_id: tool_call_id.clone(),
@@ -156,19 +276,48 @@ pub(crate) fn apply_tool_results(
             } else {
                 ""
             };
-            // A region this stage does not render is one the model cannot go
-            // and read, so telling it to is worse than saying nothing: the
-            // instruction is unfollowable and the model spends turns trying
-            // (#370). `lev validate` refuses a blueprint that routes this way,
-            // so reaching here means a layout swapped underneath a routing rule
-            // rather than an author mistake - but the model still needs to be
-            // told the truth about where its output went.
-            let pointer = match window.hidden.contains(target_region) {
-                false => format!(
-                    "[output stored in context region '{target_region}' ({result_tokens} tokens) - read that region for the full result. Preview: {preview}{ellipsis}]"
-                ),
-                true => format!(
+            let hidden = window.hidden.contains(target_region);
+            // Stored FIRST, so the pointer can say what actually happened
+            // rather than what was intended. The two writes land in different
+            // regions, so the tool_use/tool_result adjacency Anthropic requires
+            // is unaffected by the order.
+            let stored = add_kind(
+                window,
+                target_region,
+                leviath_core::EntryKind::Text,
+                result_text,
+                result_tokens,
+            );
+            // What this text asks the model to do is the whole point of it.
+            //
+            // It used to say "read that region for the full result", which is
+            // an instruction with no tool behind it: the region is rendered
+            // into the system prompt already, and `context_read` is not granted
+            // by most stages that route. Models did the only thing left and
+            // pointed `read_file` at the region name - across 152 local runs,
+            // 90 of 168 failed `read_file` calls were a region name where a path
+            // belongs, one run spending five turns on five spellings of
+            // `raw_findings`. So the pointer now names the `## region` heading
+            // the assembler emits and says no call is needed.
+            //
+            // A region this stage does not render is the other half: the model
+            // cannot go and read it, so telling it to is worse than saying
+            // nothing (#370). `lev validate` refuses a blueprint that routes
+            // that way, so reaching here means a layout swapped underneath a
+            // routing rule rather than an author mistake - but the model still
+            // needs to be told the truth about where its output went.
+            let pointer = match (hidden, stored) {
+                (true, _) => format!(
                     "[output stored in context region '{target_region}' ({result_tokens} tokens), which this stage does not carry - it is kept for a later stage and cannot be read from here. Preview: {preview}{ellipsis}]"
+                ),
+                (false, Stored::Whole) => format!(
+                    "[output ({result_tokens} tokens) is in your context under the '{target_region}' heading - it is already in this prompt, so no tool call is needed to see it. Preview: {preview}{ellipsis}]"
+                ),
+                (false, Stored::Truncated { omitted }) => format!(
+                    "[output was too large for context region '{target_region}': the start of it is in this prompt under that heading and {omitted} characters were dropped. Release what you are finished with (context_delete) before fetching more this size. Preview: {preview}{ellipsis}]"
+                ),
+                (false, Stored::Dropped) => format!(
+                    "[output could NOT be stored - context region '{target_region}' is full and refused it, so only this preview survives. Release what you are finished with (context_delete) and fetch it again if you still need it. Preview: {preview}{ellipsis}]"
                 ),
             };
             let pointer_tokens = leviath_core::estimate_tokens(&pointer);
@@ -178,13 +327,6 @@ pub(crate) fn apply_tool_results(
                 result_kind(),
                 pointer,
                 pointer_tokens,
-            );
-            add_kind(
-                window,
-                target_region,
-                leviath_core::EntryKind::Text,
-                result_text,
-                result_tokens,
             );
         }
     }
@@ -464,6 +606,12 @@ pub fn collect_tools(
                 });
             }
         }
+        // A path tool aimed at a context region fails with an OS error that says
+        // nothing about why, and the model tries another spelling. Correct it
+        // here, before anything downstream reads the text: after the telemetry
+        // and modification passes above, which key off the `[error]` prefix the
+        // hint leaves in place, and before file tracking rewrites results.
+        annotate_path_errors(&window, &infer.tool_calls, &mut merged);
         // File tracking: sync read/write results into the configured HashMap
         // region and replace the inline result with a reference (de-dup context).
         if let Some(ft) = blueprint.and_then(|bp| bp.0.file_tracking.as_ref()) {

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -581,6 +581,24 @@ of its own `[context.regions]` writes it where that stage cannot read it back, s
 refuses the blueprint and says which region to add. The four the runtime always carries are always
 valid targets: `conversation`, `tool_results`, `final_output` and `stage_instructions`.
 
+### What the model is told about a routed result
+
+A routed result cannot sit in the message stream - a `tool_result` has to follow its `tool_use`
+immediately - so the full output goes to the region and a short pointer stays in the conversation in
+its place. The pointer names the region, and says the contents are already in the prompt under that
+heading, because they are: a region the stage carries is rendered into the system prompt every turn.
+
+That wording matters more than it looks. The pointer used to end "read that region for the full
+result", which is an instruction with no tool behind it - and the model, holding `read_file` and no
+`context_read`, would aim `read_file` at the region name and keep trying spellings. Grant
+`context_read` on a stage that routes and reads files; `lev validate` warns
+(`routing-without-region-read`) when one does not, and a path tool pointed at a region name now says
+so in its error.
+
+The pointer also says what actually happened rather than what was meant. A region too full to take
+the result whole reports the truncation or the refusal, instead of promising a full result that is
+not there.
+
 An override entry can also carry both answers at once, which is usually what you mean when a tool
 needs its own region *and* its own ceiling:
 

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -174,6 +174,14 @@ model resolves to 40,000 tokens. `compact_at = "80%"` then means 80% of *that*, 
 ceiling. Alongside `budget`, it caps the resolved percentage, so the region gets whichever is
 smaller.
 
+That last part is worth dwelling on, because it is easy to write a cap that quietly cancels the
+percentage. `budget = "30%", max_tokens = 40000` is 30% only below a 133k window; above that it is
+a flat 40,000 however large the model, and every bundled agent shipped that way until a 1M-context
+run held its findings to 40k while its own blueprint asked for 314k. If you mean the percentage,
+write the percentage on its own. Reach for `max_tokens` when a region genuinely must not grow, and
+`min_tokens` when a small one must not shrink on a narrow window - and check what the pair resolves
+to at the largest model you expect to run.
+
 A malformed `budget` or `compact_at` string is a hard error at load, so `lev validate` catches it
 instead of a run failing later.
 
@@ -600,5 +608,8 @@ token counts would need rewriting every time.
 
 > [!NOTE]
 > Percentages are ceilings, and they may add up to more than 100%. That is deliberate: regions
-> rarely fill at the same time, so reserving exact shares would waste most of the window. Use
-> `max_tokens` and `threshold_tokens` when you need a limit that really is hard.
+> rarely fill at the same time, so reserving exact shares would waste most of the window. A ceiling
+> also costs nothing until it is reached - a region is charged for what is stored in it, not for its
+> budget - which is why raising one is cheap and capping one is not. Use `max_tokens` and
+> `threshold_tokens` when you need a limit that really is hard, and remember they override the
+> percentage rather than sitting beside it.


### PR DESCRIPTION
## What was wrong

A stage that routes tool output into a context region leaves a pointer in the conversation in place of the result, and that pointer ended **"read that region for the full result"**. There is no tool behind that instruction. The region is rendered into the system prompt already, as a `## raw_findings` block the model reads every turn, and `context_read` — the one tool that would nominally answer it — was granted by exactly one bundled agent. So models did the only thing left and aimed `read_file` at the region name.

Measured across the 152 runs in a local `~/.leviath/runs`:

| | |
|---|---|
| `read_file` calls | 299 |
| …that failed | **168** |
| …whose path was a **context region name** | **90** |
| runs affected | 32 of the 46 that used `read_file` |

Every other tool over the same corpus is near-clean: `web_fetch` 0/1275, `web_search` 0/1371, `shell` 0/155.

One `researcher` run made 9 `read_file` calls and failed 9 — five of them the same region under five spellings (`/context/raw_findings`, `raw_findings`, `<workdir>/context/raw_findings`, `<workdir>/raw_findings`, `raw_findings`) across three stages. It burned 65 iterations and 4.38M prompt tokens, hit its iteration cap four times, and shipped a report whose headline finding was that it could not retrieve anything.

**Worth stating what this is not.** The obvious theory is that agents are re-reading files they think they wrote. I checked every run for a `read_file` error on a path written earlier in the same run: **zero**. Nothing is being lost.

## The fix

**The pointer** now names the heading the assembler emits and says no call is needed. That covers the 69 failures from the one bundled agent that routes.

**The error itself** now carries the correction, and this is the half that matters more than it looks: 21 of the 90 came from `deep-researcher`, `wide-researcher` and `coder`, which all route to `conversation` and emit no pointer at all — those models simply saw a labelled region in the prompt and guessed. A path tool that fails on a path whose last segment names a live region is told it is a region and where to read it instead; one handed a directory is pointed at `list_dir` (17 more failures). Matching the last segment catches all five spellings at once. This lives in `leviath-runtime` rather than `leviath-tools`, which resolves paths and has never seen a context window — so it also works for user-authored blueprints.

**Every bundled stage that routes and reads files** now grants `context_read`, and `lev validate` warns (`routing-without-region-read`) on the shape that caused this. A Warning, not an Error: with the two fixes above it is an ergonomics gap rather than a broken blueprint, and an Error would fail every manifest written before today. The bundled half is asserted as an invariant over discovered agents rather than a list of stage names — which is what caught six `coder` stages routing through `tool_overrides` while their `default_region` was `conversation`.

## Three more defects found in the same code path

**The pointer promised the full result whatever the region had actually kept.** `add_kind` silently degraded an over-budget write to a truncation or `[result omitted]` and said nothing — in the run above, `raw_findings` sat pinned at its ceiling with 3 of 35 entries degraded and 2 discarded outright, two whole `web_fetch` results the model was told it had, and went on reasoning as though they were there. The store now reports what it did and the pointer describes it, which is why the write to the region happens before the pointer rather than after.

**`Admission::Evict` never evicted.** It is the default and is documented as *"make room for the write — roll off the oldest entry"*, but `push_entry` returned `TokenBudgetExceeded` for it exactly as for `Reject`; only a sliding window's *count* limit ever dropped anything. A working region now rolls its oldest off through `remove_oldest`, which is turn-group aware, so eviction cannot strand a `tool_result` without the `tool_use` that produced it. Kinds that own their retention are excluded and say why in `RegionKind::rolls_off_oldest` — a custom region's `on_overflow` script is the author's policy, and overriding it would defeat the region.

**Region budgets stopped scaling with the model.** Every bundled region paired `budget = "N%"` with an absolute `max_tokens`, and `BudgetSpec::resolve` applies the percentage *then* the cap — so the cap wins above roughly a 167k window. `researcher` ran on a 1,048,576-token model with `raw_findings` asking for 30%, or 314,573 tokens, and getting 40,000. Resolving each bundled layout at 200k and at 1M produced almost identical numbers: **1.03x growth across a 5.24x difference in window.** That is also *why* the region was full enough for the silent drops above — the two are the same bug seen from opposite ends.

The guard-rails are gone, along with the `threshold_tokens` that independently capped compaction triggers (it would compact a 419k region at 30k). `lev create`'s templates and the editor's new-region defaults lose their caps too. Raising a ceiling costs nothing, which is what makes this safe: a region is charged for what is stored in it, not for its budget.

> One thing I tried and backed out: turning each small cap into a `min_tokens` floor. It looks conservative and is not — `coder` has twelve pinned regions, and twelve floors sum to 48k, larger than a 32k window, so the layout stops validating on exactly the small models a floor was meant to protect. Nothing is floored; percentages already do the right thing there. The new test caught it.

## Verification

Beyond the suite and the 100% gate, this was driven against a **running daemon** with a mock Rhai provider, because a green test would not have shown the strings a model actually receives:

- pointer → `[output (4 tokens) is in your context under the 'raw_findings' heading - it is already in this prompt, so no tool call is needed to see it. Preview: notes.md (7B)]`
- `read_file("raw_findings")` → `[error] Failed to read 'raw_findings': No such file or directory (os error 2) 'raw_findings' is a context region, not a file - its contents are already in this prompt, under the 'raw_findings' heading. Read them there rather than through a tool.`
- `read_file("sub")` → `[error] Failed to read 'sub': Is a directory (os error 21) That path is a directory - use list_dir to see what is in it.`
- `lev validate` → the new `routing-without-region-read` warning, with its fix line
- budgets, at a mock provider declaring the same 1,048,576-token window as the model that failed → `raw_findings` resolves to **314,573**, the number the blueprint had been asking for all along

**Limitation:** the eviction change is covered by unit tests but I did not stage a live full-region overflow. It is the one behaviour here proven only in tests.

## Notes for review

- The bundled blueprint versions are bumped because `plan_agent_actions` compares the recorded version *first* and only falls through to a byte comparison when versions match — so changed contents under an unchanged version read as `Modified` ("the user edited this themselves") and are deliberately never offered as an update.
- `region.rs` crossed the 1200-line structure limit, so the three policy enums move to `region/policy.rs` behind the same public paths.
- Two existing tests asserted the old pointer wording and are rewritten rather than deleted; the hidden-region case is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
