### PR TITLE
feat(dash): rename an agent from the catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,9 @@ same list.
   right-click menu for the stage, path or empty canvas under the pointer,
   a click on empty canvas selects nothing, undo and redo are `Ctrl-Z` and
   `Ctrl-Y`, and every bar names its controls: the run list calls the
-  screen out next to "new run".
+  screen out next to "new run". `r` on the catalog renames an installed
+  agent (directory, manifest name and saved arrangement together); reset
+  to the bundled copy moved to `R`.
 - **Breaking (websocket):** stage transitions and tool calls are frames of
   their own. `stage_transition`, `tool_call_started` and `tool_call_finished`
   used to arrive wrapped as `{"type":"world","event":{...}}`, so a client had

--- a/crates/leviath-cli/src/blueprint_edit/catalog.rs
+++ b/crates/leviath-cli/src/blueprint_edit/catalog.rs
@@ -180,6 +180,48 @@ pub fn copy_bundled_extras(
     Ok(())
 }
 
+/// Rename an installed agent: its directory under the agents directory, and
+/// the `name` in its manifest (comments and all else kept). Refuses a name
+/// that will not do or is taken; an unreadable manifest is left as it is.
+pub fn rename_agent(agents_dir: &Path, from: &str, to: &str) -> Result<PathBuf, String> {
+    rename_agent_with(agents_dir, from, to, &mut |a, b| std::fs::rename(a, b))
+}
+
+/// [`rename_agent`] with the directory move injected, so a move the disk
+/// refuses can be exercised without a read-only filesystem.
+pub fn rename_agent_with(
+    agents_dir: &Path,
+    from: &str,
+    to: &str,
+    move_dir: &mut dyn FnMut(&Path, &Path) -> std::io::Result<()>,
+) -> Result<PathBuf, String> {
+    if !super::is_valid_name(to) {
+        return Err("Letters, digits, `.`, `_` and `-` only.".to_string());
+    }
+    let old = agents_dir.join(from);
+    let new = agents_dir.join(to);
+    if to == from {
+        return Ok(old);
+    }
+    if new.exists() {
+        return Err(format!("An agent named {to} already exists."));
+    }
+    let manifest_path = old.join("agent.leviath");
+    let text = std::fs::read_to_string(&manifest_path)
+        .map_err(|e| format!("Could not read {}: {e}", manifest_path.display()))?;
+    let mut doc = super::ManifestDoc::parse(&text).map_err(|e| e.to_string())?;
+    doc.set_agent_name(to)
+        .expect("the name passed the same check set_agent_name makes");
+    // The manifest first, in place: if the directory cannot move the agent
+    // is still whole, only under its old name with the new one inside,
+    // which the next open shows and the next save writes.
+    std::fs::write(&manifest_path, doc.to_toml())
+        .map_err(|e| format!("Could not write {}: {e}", manifest_path.display()))?;
+    move_dir(&old, &new)
+        .map_err(|e| format!("Could not move {} to {}: {e}", old.display(), new.display()))?;
+    Ok(new)
+}
+
 /// Delete an installed agent's directory.
 pub fn delete_agent(agents_dir: &Path, name: &str) -> std::io::Result<()> {
     std::fs::remove_dir_all(agents_dir.join(name))

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -1681,3 +1681,70 @@ fn the_written_order_walks_arrays_of_tables_and_renumbers_them() {
     );
     assert_eq!(written_order(&doc)[0], vec![Seg::Key("d".into())]);
 }
+
+#[test]
+fn renaming_an_agent_moves_its_directory_and_the_name_in_its_manifest() {
+    let root =
+        std::env::temp_dir().join(format!("lev-blueprint-edit-rename-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&root);
+    let agents = root.join("agents");
+    std::fs::create_dir_all(&agents).unwrap();
+    let text = format!("# kept\n{}", templates::empty_blueprint("own").unwrap());
+    catalog::write_agent(&agents, "own", &text).unwrap();
+    catalog::write_agent(
+        &agents,
+        "taken",
+        &templates::empty_blueprint("taken").unwrap(),
+    )
+    .unwrap();
+    // Refusals leave everything alone.
+    assert!(catalog::rename_agent(&agents, "own", "bad name").is_err());
+    assert!(
+        catalog::rename_agent(&agents, "own", "taken")
+            .unwrap_err()
+            .contains("already exists")
+    );
+    assert!(
+        catalog::rename_agent(&agents, "ghost", "other")
+            .unwrap_err()
+            .contains("Could not read")
+    );
+    std::fs::create_dir_all(agents.join("junk")).unwrap();
+    std::fs::write(agents.join("junk").join("agent.leviath"), "= not toml").unwrap();
+    assert!(catalog::rename_agent(&agents, "junk", "other").is_err());
+    assert!(agents.join("own").exists());
+    // The same name is nothing to do.
+    assert_eq!(
+        catalog::rename_agent(&agents, "own", "own").unwrap(),
+        agents.join("own")
+    );
+    // A move the disk refuses: the manifest already carries the new name
+    // under the old directory, and says so.
+    let err = catalog::rename_agent_with(&agents, "own", "mine", &mut |_, _| {
+        Err(std::io::Error::other("disk says no"))
+    })
+    .unwrap_err();
+    assert!(err.contains("disk says no"), "{err}");
+    assert!(agents.join("own").exists());
+    let stuck = std::fs::read_to_string(agents.join("own").join("agent.leviath")).unwrap();
+    assert!(stuck.contains("name = \"mine\""));
+    std::fs::write(agents.join("own").join("agent.leviath"), &text).unwrap();
+    // A manifest that cannot be written: said, nothing moved.
+    let manifest = agents.join("own").join("agent.leviath");
+    let writable = std::fs::metadata(&manifest).unwrap().permissions();
+    let mut locked = writable.clone();
+    locked.set_readonly(true);
+    std::fs::set_permissions(&manifest, locked).unwrap();
+    let err = catalog::rename_agent(&agents, "own", "mine").unwrap_err();
+    assert!(err.contains("Could not write"), "{err}");
+    assert!(agents.join("own").exists());
+    std::fs::set_permissions(&manifest, writable).unwrap();
+    // The rename: the directory moves, the name changes, the comment stays.
+    let new = catalog::rename_agent(&agents, "own", "mine").unwrap();
+    assert_eq!(new, agents.join("mine"));
+    assert!(!agents.join("own").exists());
+    let moved = std::fs::read_to_string(new.join("agent.leviath")).unwrap();
+    assert!(moved.starts_with("# kept\n"), "{moved}");
+    assert!(moved.contains("name = \"mine\""), "{moved}");
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/crates/leviath-cli/src/commands/dashboard/agents/catalog.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/catalog.rs
@@ -12,6 +12,7 @@ use crate::blueprint_edit::catalog::{self, CatalogEntry, Source};
 use crate::config::Config;
 use crate::tui::flowgraph::{FlowView, StageGraph};
 use crate::tui::widgets::confirm::Confirm;
+use crate::tui::widgets::line_edit::{EditOutcome, LineEdit};
 
 /// The catalog's state.
 #[derive(Default)]
@@ -27,6 +28,33 @@ pub(in crate::commands::dashboard) struct Catalog {
     /// The graph of the entry the cursor is on, keyed by its name so it is
     /// rebuilt only when the cursor moves to another agent.
     pub(in crate::commands::dashboard) preview: Option<(String, Result<FlowView, String>)>,
+    /// `r` opened the rename prompt on an agent.
+    pub(in crate::commands::dashboard) renaming: Option<Rename>,
+}
+
+/// The rename prompt: the agent being renamed and the name being typed.
+#[derive(Debug, Clone)]
+pub(in crate::commands::dashboard) struct Rename {
+    pub(in crate::commands::dashboard) from: String,
+    pub(in crate::commands::dashboard) name: LineEdit,
+    /// Why the typed name will not do, once something was typed.
+    pub(in crate::commands::dashboard) problem: Option<String>,
+}
+
+impl Rename {
+    /// Whether the name will do, and if not why. `taken` are the names
+    /// already in the catalog (the agent's own is fine: nothing to do).
+    fn check(&mut self, taken: &[String]) -> bool {
+        let name = self.name.value().to_string();
+        self.problem = if !crate::blueprint_edit::is_valid_name(&name) {
+            Some("Letters, digits, `.`, `_` and `-` only.".to_string())
+        } else if name != self.from && taken.contains(&name) {
+            Some(format!("An agent named {name} already exists."))
+        } else {
+            None
+        };
+        self.problem.is_none()
+    }
 }
 
 impl Catalog {
@@ -110,6 +138,10 @@ impl Dashboard {
     /// Keys on the catalog.
     pub(in crate::commands::dashboard) fn handle_catalog_key(&mut self, key: KeyEvent) {
         let code = key.code;
+        if let Some(rename) = self.agents().catalog.renaming.take() {
+            self.catalog_rename_key(rename, &key);
+            return;
+        }
         let filtering = self.agents().catalog.filtering;
         if filtering {
             let catalog = &mut self.agents().catalog;
@@ -148,7 +180,8 @@ impl Dashboard {
             KeyCode::Enter | KeyCode::Char('e') => self.edit_selected_agent(),
             KeyCode::Char('n') => self.open_chooser(),
             KeyCode::Char('d') => self.request_agent_delete(),
-            KeyCode::Char('r') => self.request_agent_reset(),
+            KeyCode::Char('r') => self.start_agent_rename(),
+            KeyCode::Char('R') => self.request_agent_reset(),
             KeyCode::Char('l') => self.launch_selected_agent(),
             KeyCode::Char('?') | KeyCode::F(1) => self.show_help = true,
             _ => {}
@@ -201,6 +234,87 @@ impl Dashboard {
         }
         screen.catalog.move_by(delta);
         true
+    }
+
+    /// `r`: the rename prompt on the selected agent, when it lives under the
+    /// agents directory (a bundled agent not installed keeps its name: clone
+    /// it under another with `n`; a configured one is renamed where it is).
+    fn start_agent_rename(&mut self) {
+        let Some(entry) = self.agents().catalog.selected_entry().cloned() else {
+            return;
+        };
+        if !entry.deletable() {
+            let why = match entry.source {
+                Source::Bundled => "It is the bundled copy; `n` clones it under another name.",
+                _ => "It lives outside the agents directory; rename it where it is.",
+            };
+            self.toast(
+                format!("{} cannot be renamed from here. {why}", entry.name),
+                ToastLevel::Info,
+            );
+            return;
+        }
+        self.agents().catalog.renaming = Some(Rename {
+            from: entry.name.clone(),
+            name: LineEdit::new(entry.name, false),
+            problem: None,
+        });
+    }
+
+    /// Keys on the rename prompt: typing edits the name, Enter renames
+    /// (when the name will do), Esc leaves the agent as it is.
+    fn catalog_rename_key(&mut self, mut rename: Rename, key: &KeyEvent) {
+        let taken: Vec<String> = self
+            .agents()
+            .catalog
+            .entries
+            .iter()
+            .map(|e| e.name.clone())
+            .collect();
+        match rename.name.handle_key(key) {
+            EditOutcome::Cancel => {}
+            EditOutcome::Pending => {
+                rename.check(&taken);
+                self.agents().catalog.renaming = Some(rename);
+            }
+            EditOutcome::Commit => {
+                if !rename.check(&taken) {
+                    self.agents().catalog.renaming = Some(rename);
+                    return;
+                }
+                let to = rename.name.value().to_string();
+                self.perform_agent_rename(&rename.from, &to);
+            }
+        }
+    }
+
+    /// The rename itself: the directory and the manifest's name, the
+    /// arrangement carried over, the catalog re-read with the cursor on
+    /// the new name.
+    pub(in crate::commands::dashboard) fn perform_agent_rename(&mut self, from: &str, to: &str) {
+        if from == to {
+            return;
+        }
+        let agents_dir = self.new_run_ctx.agents_dir.clone();
+        match catalog::rename_agent(&agents_dir, from, to) {
+            Ok(_) => {
+                let mut layout = self.layout_store();
+                layout.copy(from, to);
+                layout.forget(from);
+                let _ = layout.save();
+                self.refresh_catalog();
+                let catalog = &mut self.agents().catalog;
+                if let Some(at) = catalog
+                    .visible()
+                    .into_iter()
+                    .position(|i| catalog.entries[i].name == to)
+                {
+                    catalog.selected = at;
+                }
+                self.toast(format!("Renamed {from} to {to}"), ToastLevel::Info);
+            }
+            Err(e) => self.toast(format!("Could not rename {from}: {e}"), ToastLevel::Error),
+        }
     }
 
     /// `d`: confirm deleting the selected agent, when it can be deleted from

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_catalog.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_catalog.rs
@@ -41,6 +41,40 @@ impl Dashboard {
         if self.agents().chooser.is_some() {
             self.draw_chooser(frame, area);
         }
+        self.draw_rename_prompt(frame, area);
+    }
+
+    /// The rename prompt, when `r` opened one: the name being typed, and
+    /// why it will not do when it will not.
+    fn draw_rename_prompt(&mut self, frame: &mut Frame, area: Rect) {
+        let Some(rename) = self.agents().catalog.renaming.clone() else {
+            return;
+        };
+        let popup = centered(50, 20, area);
+        let popup = Rect {
+            height: popup.height.clamp(4, 6),
+            ..popup
+        };
+        let inner = popup_frame(
+            frame,
+            popup,
+            &format!("Rename {}", rename.from),
+            C_BORDER_FOCUS,
+        );
+        let mut name = vec![Span::styled("Name  ", Style::default().fg(C_DIM))];
+        name.extend(rename.name.display_spans(true).spans);
+        let problem = rename.problem.clone().unwrap_or_default();
+        frame.render_widget(
+            Paragraph::new(vec![
+                Line::from(name),
+                Line::from(Span::styled(problem, Style::default().fg(C_WARN))),
+                Line::from(Span::styled(
+                    "The directory and the manifest's name change; its arrangement comes along.",
+                    Style::default().fg(C_MUTED),
+                )),
+            ]),
+            inner,
+        );
     }
 
     fn draw_catalog_list(&mut self, frame: &mut Frame, area: Rect) {
@@ -224,7 +258,13 @@ impl Dashboard {
         let screen = self.agent_builder.as_deref().expect("callers check");
         // Priority order: on a narrow terminal the tail falls off, and `?`
         // always has the full list.
-        let hints = if screen.chooser.is_some() {
+        let hints = if screen.catalog.renaming.is_some() {
+            vec![
+                hint("esc", "keep the name"),
+                hint("type", "the new name"),
+                hint("enter", "rename"),
+            ]
+        } else if screen.chooser.is_some() {
             vec![
                 hint("esc", "back"),
                 hint("↑↓", "template"),
@@ -246,8 +286,9 @@ impl Dashboard {
                 hint("n", "new"),
                 hint("l", "launch"),
                 hint("?", "help"),
+                hint("r", "rename"),
                 hint("d", "delete"),
-                hint("r", "reset"),
+                hint("R", "reset"),
                 hint("/", "filter"),
                 hint("wheel", "scroll"),
             ]

--- a/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/tests.rs
@@ -183,9 +183,11 @@ fn an_empty_home_says_so_and_a_broken_manifest_declines_the_preview() {
     // Actions on nothing do nothing.
     dash.handle_key(key(KeyCode::Enter));
     dash.handle_key(key(KeyCode::Char('d')));
+    dash.handle_key(key(KeyCode::Char('R')));
     dash.handle_key(key(KeyCode::Char('r')));
     dash.handle_key(key(KeyCode::Char('l')));
     assert!(dash.agent_builder.is_some() && dash.agents().editor.is_none());
+    assert!(dash.agents().catalog.renaming.is_none());
     // A preview that cannot be built says why (an unreadable manifest, a
     // manifest the runtime rejects); the second still opens in the editor,
     // which edits TOML, not the runtime's view of it.
@@ -242,7 +244,7 @@ fn delete_and_reset_ask_first_and_launch_goes_to_the_new_run_screen() {
     assert!(screen.contains("edited"), "{screen}");
     assert!(screen.contains("puts the bundled copy back"), "{screen}");
     // Reset: No keeps it, Yes restores it. The dialog draws over the screen.
-    dash.handle_key(key(KeyCode::Char('r')));
+    dash.handle_key(key(KeyCode::Char('R')));
     assert!(text(&mut dash).contains("Reset to original?"));
     dash.tick_graphs(std::time::Duration::from_millis(100));
     assert!(matches!(
@@ -251,7 +253,7 @@ fn delete_and_reset_ask_first_and_launch_goes_to_the_new_run_screen() {
     ));
     dash.handle_key(key(KeyCode::Char('n')));
     assert!(dash.pending_confirm.is_none());
-    dash.handle_key(key(KeyCode::Char('r')));
+    dash.handle_key(key(KeyCode::Char('R')));
     dash.handle_key(key(KeyCode::Char('y')));
     assert!(
         std::fs::read_to_string(&manifest)
@@ -264,7 +266,7 @@ fn delete_and_reset_ask_first_and_launch_goes_to_the_new_run_screen() {
             .any(|t| t.message.contains("Reset coder"))
     );
     // Reset on an agent that is not an edited bundled one is a toast.
-    dash.handle_key(key(KeyCode::Char('r')));
+    dash.handle_key(key(KeyCode::Char('R')));
     assert!(dash.pending_confirm.is_none());
     assert!(
         dash.toasts
@@ -2012,5 +2014,152 @@ fn typing_in_a_chooser_never_reaches_the_editor_keys() {
     type_str(&mut dash, "haiku");
     assert!(dash.agents().editor.as_ref().unwrap().picker.is_some());
     assert_eq!(dash.agents().editor.as_ref().unwrap().message, None);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn r_renames_an_installed_agent_directory_manifest_and_arrangement() {
+    let (mut dash, root) = dashboard("rename");
+    let agents = root.join("agents");
+    // An arrangement saved under the old name comes along.
+    {
+        let mut store =
+            crate::blueprint_edit::LayoutStore::open(root.join("dash").join("graph-layouts.json"));
+        store.set(
+            "own",
+            [("work".to_string(), (3.0, 4.0))].into_iter().collect(),
+        );
+        store.save().unwrap();
+    }
+    dash.handle_key(key(KeyCode::Char('a')));
+    let at = dash
+        .agents()
+        .catalog
+        .visible()
+        .into_iter()
+        .position(|i| dash.agents().catalog.entries[i].name == "own")
+        .unwrap();
+    dash.agents().catalog.selected = at;
+    dash.handle_key(key(KeyCode::Char('r')));
+    assert!(dash.agents().catalog.renaming.is_some());
+    let screen = text(&mut dash);
+    assert!(screen.contains("Rename own"), "{screen}");
+    assert!(screen.contains("esc keep the name"), "{screen}");
+    // The prompt starts on the current name; a bad name says why and Enter
+    // does not go through; Esc keeps everything.
+    type_str(&mut dash, " x");
+    let screen = text(&mut dash);
+    assert!(screen.contains("Letters, digits"), "{screen}");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().catalog.renaming.is_some());
+    dash.handle_key(key(KeyCode::Esc));
+    assert!(dash.agents().catalog.renaming.is_none());
+    assert!(agents.join("own").exists());
+    // A taken name says so; the agent's own name is fine and a no-op.
+    dash.handle_key(key(KeyCode::Char('r')));
+    for _ in 0..3 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    type_str(&mut dash, "coder");
+    assert!(
+        dash.agents()
+            .catalog
+            .renaming
+            .as_ref()
+            .unwrap()
+            .problem
+            .as_deref()
+            .is_some_and(|p| p.contains("already exists"))
+    );
+    for _ in 0..5 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    type_str(&mut dash, "own");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(dash.agents().catalog.renaming.is_none());
+    assert!(agents.join("own").exists());
+    // The rename: directory, manifest name, arrangement, cursor, toast.
+    dash.handle_key(key(KeyCode::Char('r')));
+    for _ in 0..3 {
+        dash.handle_key(key(KeyCode::Backspace));
+    }
+    type_str(&mut dash, "mine");
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(!agents.join("own").exists());
+    let manifest = std::fs::read_to_string(agents.join("mine").join("agent.leviath")).unwrap();
+    assert!(manifest.contains("name = \"mine\""), "{manifest}");
+    assert_eq!(
+        dash.agents()
+            .catalog
+            .selected_entry()
+            .map(|e| e.name.clone()),
+        Some("mine".to_string())
+    );
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("Renamed own to mine"))
+    );
+    let store =
+        crate::blueprint_edit::LayoutStore::open(root.join("dash").join("graph-layouts.json"));
+    assert!(store.positions("own").is_none());
+    assert_eq!(
+        store.positions("mine").and_then(|p| p.get("work").copied()),
+        Some((3.0, 4.0))
+    );
+    // The new-run picker knows the new name too.
+    assert!(dash.new_run_agents.iter().any(|a| a.name == "mine"));
+    // Not renamable from here: a bundled agent not installed.
+    let at = dash
+        .agents()
+        .catalog
+        .visible()
+        .into_iter()
+        .position(|i| dash.agents().catalog.entries[i].name == "reviewer")
+        .unwrap();
+    dash.agents().catalog.selected = at;
+    dash.handle_key(key(KeyCode::Char('r')));
+    assert!(dash.agents().catalog.renaming.is_none());
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("bundled copy"))
+    );
+    // Nor an agent that lives elsewhere (the working directory's own).
+    std::fs::write(
+        root.join("work").join("agent.leviath"),
+        templates::empty_blueprint("here").unwrap(),
+    )
+    .unwrap();
+    dash.refresh_catalog();
+    let at = dash
+        .agents()
+        .catalog
+        .visible()
+        .into_iter()
+        .position(|i| dash.agents().catalog.entries[i].name == "here")
+        .unwrap();
+    dash.agents().catalog.selected = at;
+    dash.handle_key(key(KeyCode::Char('r')));
+    assert!(dash.agents().catalog.renaming.is_none());
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("outside the agents directory"))
+    );
+    // A rename the disk refuses is a toast, nothing moved.
+    dash.perform_agent_rename("mine", "mine");
+    dash.perform_agent_rename("ghost", "other");
+    assert!(
+        dash.toasts
+            .iter()
+            .any(|t| t.message.contains("Could not rename ghost"))
+    );
+    // Renamed out of the filter, the cursor stays where it was.
+    dash.agents().catalog.filter = "mine".to_string();
+    dash.agents().catalog.clamp();
+    dash.perform_agent_rename("mine", "yours");
+    assert!(agents.join("yours").exists());
+    assert!(dash.agents().catalog.visible().is_empty());
     let _ = std::fs::remove_dir_all(&root);
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -103,9 +103,13 @@ fn agents_sections() -> Vec<HelpSection> {
                 ("enter / e", "edit it (a bundled one installs when saved)"),
                 ("n", "new agent: start simple, or clone one"),
                 ("l", "launch it: the new-run screen with it picked"),
-                ("d", "delete an installed agent (asks first)"),
                 (
                     "r",
+                    "rename an installed agent: its directory and its manifest's name",
+                ),
+                ("d", "delete an installed agent (asks first)"),
+                (
+                    "R",
                     "reset an edited bundled agent to the bundled copy (asks first)",
                 ),
                 (

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -238,8 +238,9 @@ An installed bundled agent that has been edited says `edited`, and `r` puts the 
 | `Enter` / `e` | Open the agent in the editor. A bundled agent not installed yet opens from its embedded copy and is installed when saved |
 | `n` | New agent: start from the two-stage starter, or clone any agent in the catalog, under a name you type |
 | `l` | Launch it: the new-run screen with this agent picked |
+| `r` | Rename an installed agent: type the new name, `Enter` renames its directory and the `name` in its manifest (its saved arrangement comes along), `Esc` keeps it. A bundled agent not installed keeps its name (clone it with `n`); agents that live elsewhere are renamed where they are |
 | `d` | Delete an installed agent and its directory. Asks first. Agents that live elsewhere are edited in place but deleted where they are |
-| `r` | Reset an edited bundled agent to the copy bundled in the binary. Asks first |
+| `R` | Reset an edited bundled agent to the copy bundled in the binary. Asks first |
 | `/` | Filter by name or description; `Enter` keeps the filter, `Esc` clears it |
 | `?` / `F1` | Help |
 | `Esc` / `q` | Back to the run list |


### PR DESCRIPTION
There was no way to rename an agent once created. Now `r` on the Agents catalog renames the selected one.

- A prompt starts on the current name; `Enter` renames the directory under the agents directory **and** the `name` in `agent.leviath` (comments, order, everything else kept), carries the saved canvas arrangement over, re-reads the catalog with the cursor on the new name, and refreshes the new-run picker. `Esc` keeps everything.
- A bad name or a taken one is said under the prompt and `Enter` does not go through; the agent's own name is a no-op.
- A bundled agent not installed keeps its name (clone it with `n`); one that lives outside the agents directory is renamed where it is; both say so in a toast.
- The manifest is rewritten first, in place, so a move the disk refuses leaves a whole agent under the old directory with the new name inside (tested through an injected move; the read-only-manifest case through `set_readonly`).
- Reset to the bundled copy moves to `R`. Hints, help and docs updated.

Verification: `cargo xtask coverage --package leviath-cli` 100%, clippy and docs clean; live in a pty: `r` on an installed agent → taken-name message → new name → directory and manifest renamed, cursor on it, toast.
