### PR TITLE
fix(research): a search that cannot reach an engine now says so

### DIFF
--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "data-analyst"
-version = "0.0.3"
+version = "0.0.4"
 description = "Data analyst - searches the web for data on a subject, builds a clean CSV of it, and hands back a ready-to-use summary of what the numbers say"
 entry_stage = "scope"
 
@@ -23,13 +23,16 @@ bash       = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Decide the table's columns before gathering anything"
-available_tools = ["web_search", "context_write"]
+available_tools = ["web_search", "context_write", "current_time"]
 max_iterations = 8
 system_prompt = """
 Decide what table would answer the question in the `subject` region, honouring
 anything in `constraints`.
 
 Run two or three searches to learn what data actually exists on this subject.
+Today's date is in the `environment` region - treat it as authoritative over
+anything you remember, and let it decide what "current" or "latest" means for
+this table. Pass `freshness` to web_search when currency matters.
 Then write the schema to the `schema` region with context_write, as one line per
 column:
 
@@ -119,7 +122,7 @@ transform = "direct"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather the rows for one slice of the subject"
-available_tools = ["web_search", "web_fetch", "submit_output"]
+available_tools = ["web_search", "web_fetch", "submit_output", "current_time"]
 allow_as_worker = true
 require_output = true
 max_iterations = 25
@@ -136,7 +139,11 @@ every worker is using - it is all the context you get, so work from it.
 
 Record what you find, not what you expect. A value you could not source is an
 empty field, never an estimate: an invented number is worse than a missing one,
-because nobody downstream can tell which it was.
+because nobody downstream can tell which it was. The same goes for the whole
+slice: if web_search hands back a diagnostic instead of results - no engine
+configured, an engine error, or an encyclopedia fallback - then you cannot see
+the web, and every field you cannot source stays empty. Say so in `source_ref`
+rather than filling the table from memory. Call current_time for the date.
 
 Only your submitted rows reach the merge. Anything else you write is lost.
 """
@@ -252,6 +259,10 @@ model = "claude-sonnet-5"
 subject       = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "Say what to gather data on via --task.", volatility = "stable" }
 # Optional caller bounds: --constraints "US only, since 2015".
 constraints   = { kind = "pinned", budget = "1%", seed = "constraints", volatility = "stable" }
+# The clock. This agent gathers data off the live web, so "latest", "current"
+# and "as of" are load-bearing, and the model's own sense of the date is its
+# training cutoff. The three researcher blueprints seed this the same way.
+environment   = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
 # The table's columns, decided in scope and followed by every later stage.
 schema        = { kind = "pinned", budget = "2%", required = true, required_message = "Write the table's columns to `schema` (context_write) before gathering: one line per column, as name | type | meaning | unit.", volatility = "grows" }
 # Bibliography, one line per source actually used.

--- a/crates/leviath-cli/agents/data-analyst/tools/web_fetch.rhai
+++ b/crates/leviath-cli/agents/data-analyst/tools/web_fetch.rhai
@@ -1,7 +1,13 @@
 // @tool web_fetch
-// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized, blocked, or client-side-rendered pages return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
+
+// Below this many characters, an HTML page that stripped to prose gave us a
+// shell, not an article: the text lives in client-side JS that never ran here.
+// Reddit strips to the single word "Reddit", and a model handed that will
+// happily cite the discussion it remembers being there.
+let MIN_HTML_PROSE = 200;
 
 let out = "";
 try {
@@ -12,12 +18,18 @@ try {
     // prose instead of markup. (Content injected by client-side JS isn't in the
     // source and can't be recovered here.)
     let lo = body.to_lower();
-    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+    let was_html = lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>");
+    if was_html {
         body = html_to_text(body);
     }
 
-    // Cap very large content so a single fetch can't blow the context budget.
-    if body.len() > 12000 {
+    if was_html && body.trim().len() < MIN_HTML_PROSE {
+        // Name it rather than returning the husk. A few words of navigation
+        // chrome is indistinguishable from real content once it is sitting in
+        // the sources region next to everything else.
+        out = `[web_fetch got no readable content from ${params.url}: the page is HTML but strips to only ${body.trim().len()} characters, so its text is rendered client-side by JavaScript that does not run here. Whatever it says, this fetch did not read it - do not cite this URL or reconstruct its contents from memory. Try an API endpoint, an RSS/JSON feed, or a static mirror instead.]`;
+    } else if body.len() > 12000 {
+        // Cap very large content so a single fetch can't blow the context budget.
         out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;

--- a/crates/leviath-cli/agents/data-analyst/tools/web_search.rhai
+++ b/crates/leviath-cli/agents/data-analyst/tools/web_search.rhai
@@ -1,51 +1,108 @@
 // @tool web_search
-// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @description Search the web and return a JSON list of {title, url, snippet, date} results. Uses Brave Search when BRAVE_API_KEY is readable. Without it there is no search engine: the call falls back to a keyless Wikipedia lookup and says so in its result.
 // @param query string required "The search query"
 // @param count integer optional "Maximum number of results to return (default 5)"
+// @param freshness string optional "Restrict results by age: pd (past day), pw (past week), pm (past month), py (past year), or YYYY-MM-DDtoYYYY-MM-DD. Use this whenever 'latest' or 'current' matters."
 // @requires network
 
 let n = if params.count == () { 5 } else { params.count };
 let results = [];
 
-// Prefer Brave Search when an API key is configured. env_var throws when the
-// variable is unset, so probe it inside try/catch and fall back to keyless search.
+// Probe BRAVE_API_KEY. env_var throws for two very different reasons and the
+// caller has to tell them apart: the variable is genuinely unset, or it is set
+// and the security layer refused it because the name looks like a credential
+// (`[security] allow_env_vars`). Collapsing both into "" is what let this tool
+// degrade to Wikipedia for a whole run without anyone noticing.
 let key = "";
-try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+let key_state = "unset";
+try {
+    key = env_var("BRAVE_API_KEY");
+    key_state = if key == "" { "unset" } else { "ok" };
+} catch(e) {
+    let msg = `${e}`;
+    key_state = if msg.contains("[denied]") { "denied" } else { "unset" };
+    key = "";
+}
 
-let got = false;
-if key != "" {
+// Why no engine ran, phrased as the fix rather than the symptom. Empty when one did.
+let engine_problem = "";
+
+if key_state == "ok" {
     try {
         let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        if params.freshness != () && params.freshness != "" {
+            url += `&freshness=${encode_uri(params.freshness)}`;
+        }
         let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
         if data.web != () && data.web.results != () {
             for r in data.web.results {
                 if results.len() >= n { break; }
-                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+                // Brave dates the page two ways: `page_age` is an ISO timestamp,
+                // `age` a human string ("3 days ago"). Either one lets the agent
+                // judge recency against the run's date instead of guessing, and
+                // gives `sources_index` a real date to cite.
+                let when = "undated";
+                if r.page_age != () && r.page_age != "" {
+                    when = r.page_age;
+                } else if r.age != () && r.age != "" {
+                    when = r.age;
+                }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description, date: when });
             }
-            got = true;
+        } else {
+            engine_problem = "Brave Search answered without a result set (the response carried no `web.results`).";
         }
     } catch(e) {
-        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
-        got = false;
+        engine_problem = `Brave Search failed: ${e}. The key may be invalid or rate limited, or the network is blocked.`;
     }
+} else if key_state == "denied" {
+    engine_problem = "BRAVE_API_KEY is set but the security layer refused to hand it to this script, because the name looks like a credential. Fix: add `allow_env_vars = [\"BRAVE_API_KEY\"]` under `[security]` in ~/.leviath/config.toml, then restart the daemon.";
+} else {
+    engine_problem = "BRAVE_API_KEY is not set, so no search engine is configured. Fix: get a key from https://brave.com/search/api/, put it in the daemon's environment, and add `allow_env_vars = [\"BRAVE_API_KEY\"]` under `[security]` in ~/.leviath/config.toml.";
 }
 
-if !got {
-    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
-    // queries (no key required). Each page becomes a {title, url, snippet} result.
-    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
-    // Wikipedia requires a descriptive User-Agent (403 otherwise).
-    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
-    if data.pages != () {
-        for p in data.pages {
-            if results.len() >= n { break; }
-            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
-            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
-            snippet.replace("<span class=\"searchmatch\">", "");
-            snippet.replace("</span>", "");
-            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+let out = "";
+
+if engine_problem == "" {
+    if results.len() == 0 {
+        // A real search that found nothing is still worth saying out loud - a
+        // bare empty array reads as "nothing has been written about this topic".
+        out = `[web_search found no results for "${params.query}". The search engine ran and came back empty, so try different wording or a narrower claim. Do not fill the gap from memory.]`;
+    } else {
+        out = results;
+    }
+} else {
+    // No engine. Wikipedia's search API needs no key and returns clean JSON, so
+    // it beats nothing - but it is an encyclopedia, it is undated, and it cannot
+    // answer "what is the latest X". Say all of that, every time.
+    let wiki = [];
+    try {
+        let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+        // Wikipedia requires a descriptive User-Agent (403 otherwise).
+        let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+        if data.pages != () {
+            for p in data.pages {
+                if wiki.len() >= n { break; }
+                let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+                // Wikipedia wraps matched terms in <span class="searchmatch"> tags - strip them.
+                snippet.replace("<span class=\"searchmatch\">", "");
+                snippet.replace("</span>", "");
+                wiki.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet, date: "undated" });
+            }
         }
+    } catch(e) {
+        // The fallback failed too. The engine problem is the one worth reporting.
+    }
+
+    if wiki.len() == 0 {
+        out = `[web_search could not search the web. ${engine_problem}
+The keyless Wikipedia fallback found nothing for "${params.query}", which is normal - an encyclopedia cannot answer this kind of question.
+Treat this topic as UNRESEARCHED. Do not answer it from memory and do not invent sources: report that web search was unavailable, in your findings and in any report you write.]`;
+    } else {
+        out = `[web_search could not search the web. ${engine_problem}
+What follows came from a keyless Wikipedia lookup instead. These are undated encyclopedia articles, NOT web search results, and they are no evidence at all about what is current, recent, or state of the art. Cite them as Wikipedia, and report that web search was unavailable.]
+${to_json(wiki)}`;
     }
 }
 
-results
+out

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.2.1"
+version = "0.2.2"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
@@ -28,6 +28,12 @@ You are investigating the topic in the `query` region in DEPTH, within any bound
 in `scope`. This is a single-topic deep dive - go for primary sources and
 authoritative references, not a broad skim.
 
+- START by establishing what exists NOW, before you name a single candidate.
+  Search for the current state of the field as of the date in `environment`, and
+  web_fetch the authoritative index for the domain (the registry, the leaderboard,
+  the release feed, the standards list). Only then narrow. Skipping this step is
+  how an investigation ends up thoroughly researching the answer from two years
+  ago: every name you can recall is, by construction, older than your cutoff.
 - Run a focused first round of web_search calls across the distinct facets of the
   question, then web_fetch the most authoritative results for detail. Prefer
   primary sources (papers, standards, official docs) over summaries. read_file for
@@ -36,6 +42,14 @@ authoritative references, not a broad skim.
   anything you remember: your training has a cutoff and this run does not. Judge
   "recent", "current" and "latest" against it, and say how old a source is when
   its age bears on the claim. Call current_time if you need the clock again.
+  Pass `freshness` to web_search whenever "latest" or "current" is part of the
+  question, and record each source's date in `sources_index`.
+- If web_search hands back a diagnostic instead of results - no engine
+  configured, an engine error, or an encyclopedia fallback - then this run cannot
+  see the web. Say so in `sources_index` immediately, and do NOT close the gap
+  from memory. An unresearched topic reported as unresearched is a usable
+  result; a confident answer assembled from recall is not, and there is no way
+  for a reader to tell the two apart after the fact.
 - For every source you actually use, append one bibliography line to
   `sources_index` (context_append): `[n] <title> - <url/path> - <date> -
   credibility: <high/med/low + why>`.
@@ -116,6 +130,19 @@ markdown fences. Each item:
 Every item MUST carry enough to work from alone: a worker is a separate agent
 and does not share this run's context, so the work item is all it gets. Name the
 question precisely enough that two workers cannot answer the same one.
+
+GROUND EVERY NAME IN `sources`. A proper noun in a sub-question - a product,
+model, version, company, standard - must already appear in `sources`. If you
+cannot name the candidates from what was gathered, then finding them IS the
+sub-question ("which X exist as of the date in `environment`, and which are
+current"), not evaluating a list you remember.
+
+This is not style. A worker starts from a clean context and cannot question your
+premise: it will faithfully research whatever you named. A list you recalled
+instead of gathered therefore comes back as several workers' worth of
+independent-looking confirmation for candidates that may be years stale or may
+not exist at all, and the analysis stage has no way to tell that apart from
+evidence. The fan-out multiplies whatever you put in, including the mistake.
 
 Prefer a handful of substantial questions over many thin ones. One question is
 fine for a narrow topic.
@@ -247,6 +274,23 @@ following the citation/confidence rules in `format`. Structure:
 - References - the numbered bibliography from `sources_index`
 
 Write for a technical audience. Be precise. Distinguish evidence from inference.
+
+Citations are load-bearing, so two rules bind absolutely:
+
+1. Every `[n]` must resolve to a line already in `sources_index`. A reference is
+   a pointer to something this run actually read - never a reconstructed URL,
+   a remembered paper or discussion thread, or a plausible-looking title. Never
+   invent the details that make a citation look checked: no vote counts, no
+   comment counts, no dates you did not read off the source.
+2. If `sources_index` is empty, you have no bibliography and therefore no
+   evidence. Do not write one. Say at the top of the report that the
+   investigation could not reach its sources, drop the `[n]` markers, mark every
+   finding low confidence, and describe what you have as background knowledge
+   rather than findings.
+
+Confidence is a claim about the evidence, not about how sure the prose sounds.
+A finding resting on sources you could not fetch is low confidence however
+familiar it feels.
 """
 
 [stages.synthesize.transitions.summary]
@@ -308,7 +352,12 @@ is worse than no summary.
 query          = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the research topic via --task.", volatility = "stable" }
 scope          = { kind = "pinned", budget = "1%", seed = "scope", volatility = "stable" }
 environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
-sources_index  = { kind = "pinned", budget = "4%", volatility = "grows" }
+# `required`: the whole report is built from this, and a stage that gathered
+# nothing used to hand an empty bibliography to `synthesize`, which wrote the
+# references from memory rather than reporting that it had none. The gate binds
+# the stages that can write context (gather, analyze, follow_citations) and
+# no-ops for the ones that cannot, so it can never deadlock the deliverable.
+sources_index  = { kind = "pinned", budget = "4%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url/path> - <date> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
 format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Mark each key finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
 
 sources        = { kind = "temporary",      budget = "30%" }

--- a/crates/leviath-cli/agents/deep-researcher/tools/web_fetch.rhai
+++ b/crates/leviath-cli/agents/deep-researcher/tools/web_fetch.rhai
@@ -1,7 +1,13 @@
 // @tool web_fetch
-// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized, blocked, or client-side-rendered pages return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
+
+// Below this many characters, an HTML page that stripped to prose gave us a
+// shell, not an article: the text lives in client-side JS that never ran here.
+// Reddit strips to the single word "Reddit", and a model handed that will
+// happily cite the discussion it remembers being there.
+let MIN_HTML_PROSE = 200;
 
 let out = "";
 try {
@@ -12,12 +18,18 @@ try {
     // prose instead of markup. (Content injected by client-side JS isn't in the
     // source and can't be recovered here.)
     let lo = body.to_lower();
-    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+    let was_html = lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>");
+    if was_html {
         body = html_to_text(body);
     }
 
-    // Cap very large content so a single fetch can't blow the context budget.
-    if body.len() > 12000 {
+    if was_html && body.trim().len() < MIN_HTML_PROSE {
+        // Name it rather than returning the husk. A few words of navigation
+        // chrome is indistinguishable from real content once it is sitting in
+        // the sources region next to everything else.
+        out = `[web_fetch got no readable content from ${params.url}: the page is HTML but strips to only ${body.trim().len()} characters, so its text is rendered client-side by JavaScript that does not run here. Whatever it says, this fetch did not read it - do not cite this URL or reconstruct its contents from memory. Try an API endpoint, an RSS/JSON feed, or a static mirror instead.]`;
+    } else if body.len() > 12000 {
+        // Cap very large content so a single fetch can't blow the context budget.
         out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;

--- a/crates/leviath-cli/agents/deep-researcher/tools/web_search.rhai
+++ b/crates/leviath-cli/agents/deep-researcher/tools/web_search.rhai
@@ -1,51 +1,108 @@
 // @tool web_search
-// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @description Search the web and return a JSON list of {title, url, snippet, date} results. Uses Brave Search when BRAVE_API_KEY is readable. Without it there is no search engine: the call falls back to a keyless Wikipedia lookup and says so in its result.
 // @param query string required "The search query"
 // @param count integer optional "Maximum number of results to return (default 5)"
+// @param freshness string optional "Restrict results by age: pd (past day), pw (past week), pm (past month), py (past year), or YYYY-MM-DDtoYYYY-MM-DD. Use this whenever 'latest' or 'current' matters."
 // @requires network
 
 let n = if params.count == () { 5 } else { params.count };
 let results = [];
 
-// Prefer Brave Search when an API key is configured. env_var throws when the
-// variable is unset, so probe it inside try/catch and fall back to keyless search.
+// Probe BRAVE_API_KEY. env_var throws for two very different reasons and the
+// caller has to tell them apart: the variable is genuinely unset, or it is set
+// and the security layer refused it because the name looks like a credential
+// (`[security] allow_env_vars`). Collapsing both into "" is what let this tool
+// degrade to Wikipedia for a whole run without anyone noticing.
 let key = "";
-try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+let key_state = "unset";
+try {
+    key = env_var("BRAVE_API_KEY");
+    key_state = if key == "" { "unset" } else { "ok" };
+} catch(e) {
+    let msg = `${e}`;
+    key_state = if msg.contains("[denied]") { "denied" } else { "unset" };
+    key = "";
+}
 
-let got = false;
-if key != "" {
+// Why no engine ran, phrased as the fix rather than the symptom. Empty when one did.
+let engine_problem = "";
+
+if key_state == "ok" {
     try {
         let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        if params.freshness != () && params.freshness != "" {
+            url += `&freshness=${encode_uri(params.freshness)}`;
+        }
         let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
         if data.web != () && data.web.results != () {
             for r in data.web.results {
                 if results.len() >= n { break; }
-                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+                // Brave dates the page two ways: `page_age` is an ISO timestamp,
+                // `age` a human string ("3 days ago"). Either one lets the agent
+                // judge recency against the run's date instead of guessing, and
+                // gives `sources_index` a real date to cite.
+                let when = "undated";
+                if r.page_age != () && r.page_age != "" {
+                    when = r.page_age;
+                } else if r.age != () && r.age != "" {
+                    when = r.age;
+                }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description, date: when });
             }
-            got = true;
+        } else {
+            engine_problem = "Brave Search answered without a result set (the response carried no `web.results`).";
         }
     } catch(e) {
-        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
-        got = false;
+        engine_problem = `Brave Search failed: ${e}. The key may be invalid or rate limited, or the network is blocked.`;
     }
+} else if key_state == "denied" {
+    engine_problem = "BRAVE_API_KEY is set but the security layer refused to hand it to this script, because the name looks like a credential. Fix: add `allow_env_vars = [\"BRAVE_API_KEY\"]` under `[security]` in ~/.leviath/config.toml, then restart the daemon.";
+} else {
+    engine_problem = "BRAVE_API_KEY is not set, so no search engine is configured. Fix: get a key from https://brave.com/search/api/, put it in the daemon's environment, and add `allow_env_vars = [\"BRAVE_API_KEY\"]` under `[security]` in ~/.leviath/config.toml.";
 }
 
-if !got {
-    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
-    // queries (no key required). Each page becomes a {title, url, snippet} result.
-    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
-    // Wikipedia requires a descriptive User-Agent (403 otherwise).
-    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
-    if data.pages != () {
-        for p in data.pages {
-            if results.len() >= n { break; }
-            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
-            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
-            snippet.replace("<span class=\"searchmatch\">", "");
-            snippet.replace("</span>", "");
-            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+let out = "";
+
+if engine_problem == "" {
+    if results.len() == 0 {
+        // A real search that found nothing is still worth saying out loud - a
+        // bare empty array reads as "nothing has been written about this topic".
+        out = `[web_search found no results for "${params.query}". The search engine ran and came back empty, so try different wording or a narrower claim. Do not fill the gap from memory.]`;
+    } else {
+        out = results;
+    }
+} else {
+    // No engine. Wikipedia's search API needs no key and returns clean JSON, so
+    // it beats nothing - but it is an encyclopedia, it is undated, and it cannot
+    // answer "what is the latest X". Say all of that, every time.
+    let wiki = [];
+    try {
+        let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+        // Wikipedia requires a descriptive User-Agent (403 otherwise).
+        let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+        if data.pages != () {
+            for p in data.pages {
+                if wiki.len() >= n { break; }
+                let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+                // Wikipedia wraps matched terms in <span class="searchmatch"> tags - strip them.
+                snippet.replace("<span class=\"searchmatch\">", "");
+                snippet.replace("</span>", "");
+                wiki.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet, date: "undated" });
+            }
         }
+    } catch(e) {
+        // The fallback failed too. The engine problem is the one worth reporting.
+    }
+
+    if wiki.len() == 0 {
+        out = `[web_search could not search the web. ${engine_problem}
+The keyless Wikipedia fallback found nothing for "${params.query}", which is normal - an encyclopedia cannot answer this kind of question.
+Treat this topic as UNRESEARCHED. Do not answer it from memory and do not invent sources: report that web search was unavailable, in your findings and in any report you write.]`;
+    } else {
+        out = `[web_search could not search the web. ${engine_problem}
+What follows came from a keyless Wikipedia lookup instead. These are undated encyclopedia articles, NOT web search results, and they are no evidence at all about what is current, recent, or state of the art. Cite them as Wikipedia, and report that web search was unavailable.]
+${to_json(wiki)}`;
     }
 }
 
-results
+out

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.1.1"
+version = "0.1.2"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
@@ -28,6 +28,11 @@ You are gathering source material on the topic in the `query` region, within any
 bounds set in `scope`.
 
 Be efficient - do not search exhaustively:
+0. If the question turns on what is current, latest, or state of the art,
+   establish what exists NOW before naming candidates: search the field as of
+   the date in `environment` and fetch the authoritative index for the domain
+   (registry, leaderboard, release feed). Every name you can recall is older
+   than your cutoff, so a list from memory is a list from the past.
 1. Run a FOCUSED first round of 3-5 web_search calls covering the distinct
    sub-topics of the question (not many rephrasings of the same query).
 2. web_fetch only the 2-3 most promising sources for detail; the search snippets
@@ -40,7 +45,14 @@ Be efficient - do not search exhaustively:
 Today's date is in the `environment` region. Treat it as authoritative over
 anything you remember: your training has a cutoff and this run does not. Judge
 "recent", "current" and "latest" against it, and note how old a source is when
-its age bears on the claim. Call current_time if you need the clock again.
+its age bears on the claim. Call current_time if you need the clock again. Pass
+`freshness` to web_search whenever "latest" or "current" is part of the question.
+
+If web_search hands back a diagnostic instead of results - no engine configured,
+an engine error, or an encyclopedia fallback - then this run cannot see the web.
+Record that in `sources_index` and do NOT close the gap from memory. Reporting a
+topic as unresearched is a usable result; a confident answer assembled from
+recall is not, and a reader cannot tell the two apart after the fact.
 Prefer primary sources and well-established outlets; note when something is a blog,
 forum, or vendor claim. Once you have solid coverage of the sub-topics, transition
 to analyze - don't keep searching for marginal additions. The analyze stage will
@@ -133,6 +145,20 @@ Structure:
 - Sources - the numbered bibliography from `sources_index`.
 
 Keep it tight and skimmable. Every non-obvious claim must carry a [n] citation.
+
+Citations are load-bearing, so two rules bind absolutely:
+
+1. Every `[n]` must resolve to a line already in `sources_index`. A reference
+   points at something this run actually read - never a reconstructed URL, a
+   remembered paper or discussion thread, or a plausible-looking title. Never
+   invent the details that make a citation look checked: no vote counts, no
+   comment counts, no dates you did not read off the source.
+2. If `sources_index` is empty, you have no bibliography and therefore no
+   evidence. Do not write one. Say up front that the research could not reach
+   its sources, drop the `[n]` markers, mark every finding low confidence, and
+   present what you have as background knowledge rather than findings.
+
+Confidence describes the evidence, not how sure the prose sounds.
 """
 
 [stages.summarize.transitions.summary]
@@ -206,7 +232,12 @@ query          = { kind = "pinned", budget = "1%", required = true, seed = "task
 scope          = { kind = "pinned", budget = "1%", seed = "scope", volatility = "stable" }
 # Growing bibliography with credibility notes (curated by the agent).
 environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
-sources_index  = { kind = "pinned", budget = "3%", volatility = "grows" }
+# `required`: the report is built from this, and a stage that gathered nothing
+# used to hand an empty bibliography to `summarize`, which wrote the references
+# from memory rather than reporting that it had none. The gate binds the stages
+# that can write context and no-ops for the ones that cannot, so it can never
+# deadlock the deliverable.
+sources_index  = { kind = "pinned", budget = "3%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url or path> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
 # Citation/confidence rules (seeded with a sensible default the agent follows).
 format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Mark each finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
 

--- a/crates/leviath-cli/agents/researcher/tools/web_fetch.rhai
+++ b/crates/leviath-cli/agents/researcher/tools/web_fetch.rhai
@@ -1,7 +1,13 @@
 // @tool web_fetch
-// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized, blocked, or client-side-rendered pages return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
+
+// Below this many characters, an HTML page that stripped to prose gave us a
+// shell, not an article: the text lives in client-side JS that never ran here.
+// Reddit strips to the single word "Reddit", and a model handed that will
+// happily cite the discussion it remembers being there.
+let MIN_HTML_PROSE = 200;
 
 let out = "";
 try {
@@ -12,12 +18,18 @@ try {
     // prose instead of markup. (Content injected by client-side JS isn't in the
     // source and can't be recovered here.)
     let lo = body.to_lower();
-    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+    let was_html = lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>");
+    if was_html {
         body = html_to_text(body);
     }
 
-    // Cap very large content so a single fetch can't blow the context budget.
-    if body.len() > 12000 {
+    if was_html && body.trim().len() < MIN_HTML_PROSE {
+        // Name it rather than returning the husk. A few words of navigation
+        // chrome is indistinguishable from real content once it is sitting in
+        // the sources region next to everything else.
+        out = `[web_fetch got no readable content from ${params.url}: the page is HTML but strips to only ${body.trim().len()} characters, so its text is rendered client-side by JavaScript that does not run here. Whatever it says, this fetch did not read it - do not cite this URL or reconstruct its contents from memory. Try an API endpoint, an RSS/JSON feed, or a static mirror instead.]`;
+    } else if body.len() > 12000 {
+        // Cap very large content so a single fetch can't blow the context budget.
         out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;

--- a/crates/leviath-cli/agents/researcher/tools/web_search.rhai
+++ b/crates/leviath-cli/agents/researcher/tools/web_search.rhai
@@ -1,51 +1,108 @@
 // @tool web_search
-// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @description Search the web and return a JSON list of {title, url, snippet, date} results. Uses Brave Search when BRAVE_API_KEY is readable. Without it there is no search engine: the call falls back to a keyless Wikipedia lookup and says so in its result.
 // @param query string required "The search query"
 // @param count integer optional "Maximum number of results to return (default 5)"
+// @param freshness string optional "Restrict results by age: pd (past day), pw (past week), pm (past month), py (past year), or YYYY-MM-DDtoYYYY-MM-DD. Use this whenever 'latest' or 'current' matters."
 // @requires network
 
 let n = if params.count == () { 5 } else { params.count };
 let results = [];
 
-// Prefer Brave Search when an API key is configured. env_var throws when the
-// variable is unset, so probe it inside try/catch and fall back to keyless search.
+// Probe BRAVE_API_KEY. env_var throws for two very different reasons and the
+// caller has to tell them apart: the variable is genuinely unset, or it is set
+// and the security layer refused it because the name looks like a credential
+// (`[security] allow_env_vars`). Collapsing both into "" is what let this tool
+// degrade to Wikipedia for a whole run without anyone noticing.
 let key = "";
-try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+let key_state = "unset";
+try {
+    key = env_var("BRAVE_API_KEY");
+    key_state = if key == "" { "unset" } else { "ok" };
+} catch(e) {
+    let msg = `${e}`;
+    key_state = if msg.contains("[denied]") { "denied" } else { "unset" };
+    key = "";
+}
 
-let got = false;
-if key != "" {
+// Why no engine ran, phrased as the fix rather than the symptom. Empty when one did.
+let engine_problem = "";
+
+if key_state == "ok" {
     try {
         let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        if params.freshness != () && params.freshness != "" {
+            url += `&freshness=${encode_uri(params.freshness)}`;
+        }
         let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
         if data.web != () && data.web.results != () {
             for r in data.web.results {
                 if results.len() >= n { break; }
-                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+                // Brave dates the page two ways: `page_age` is an ISO timestamp,
+                // `age` a human string ("3 days ago"). Either one lets the agent
+                // judge recency against the run's date instead of guessing, and
+                // gives `sources_index` a real date to cite.
+                let when = "undated";
+                if r.page_age != () && r.page_age != "" {
+                    when = r.page_age;
+                } else if r.age != () && r.age != "" {
+                    when = r.age;
+                }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description, date: when });
             }
-            got = true;
+        } else {
+            engine_problem = "Brave Search answered without a result set (the response carried no `web.results`).";
         }
     } catch(e) {
-        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
-        got = false;
+        engine_problem = `Brave Search failed: ${e}. The key may be invalid or rate limited, or the network is blocked.`;
     }
+} else if key_state == "denied" {
+    engine_problem = "BRAVE_API_KEY is set but the security layer refused to hand it to this script, because the name looks like a credential. Fix: add `allow_env_vars = [\"BRAVE_API_KEY\"]` under `[security]` in ~/.leviath/config.toml, then restart the daemon.";
+} else {
+    engine_problem = "BRAVE_API_KEY is not set, so no search engine is configured. Fix: get a key from https://brave.com/search/api/, put it in the daemon's environment, and add `allow_env_vars = [\"BRAVE_API_KEY\"]` under `[security]` in ~/.leviath/config.toml.";
 }
 
-if !got {
-    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
-    // queries (no key required). Each page becomes a {title, url, snippet} result.
-    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
-    // Wikipedia requires a descriptive User-Agent (403 otherwise).
-    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
-    if data.pages != () {
-        for p in data.pages {
-            if results.len() >= n { break; }
-            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
-            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
-            snippet.replace("<span class=\"searchmatch\">", "");
-            snippet.replace("</span>", "");
-            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+let out = "";
+
+if engine_problem == "" {
+    if results.len() == 0 {
+        // A real search that found nothing is still worth saying out loud - a
+        // bare empty array reads as "nothing has been written about this topic".
+        out = `[web_search found no results for "${params.query}". The search engine ran and came back empty, so try different wording or a narrower claim. Do not fill the gap from memory.]`;
+    } else {
+        out = results;
+    }
+} else {
+    // No engine. Wikipedia's search API needs no key and returns clean JSON, so
+    // it beats nothing - but it is an encyclopedia, it is undated, and it cannot
+    // answer "what is the latest X". Say all of that, every time.
+    let wiki = [];
+    try {
+        let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+        // Wikipedia requires a descriptive User-Agent (403 otherwise).
+        let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+        if data.pages != () {
+            for p in data.pages {
+                if wiki.len() >= n { break; }
+                let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+                // Wikipedia wraps matched terms in <span class="searchmatch"> tags - strip them.
+                snippet.replace("<span class=\"searchmatch\">", "");
+                snippet.replace("</span>", "");
+                wiki.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet, date: "undated" });
+            }
         }
+    } catch(e) {
+        // The fallback failed too. The engine problem is the one worth reporting.
+    }
+
+    if wiki.len() == 0 {
+        out = `[web_search could not search the web. ${engine_problem}
+The keyless Wikipedia fallback found nothing for "${params.query}", which is normal - an encyclopedia cannot answer this kind of question.
+Treat this topic as UNRESEARCHED. Do not answer it from memory and do not invent sources: report that web search was unavailable, in your findings and in any report you write.]`;
+    } else {
+        out = `[web_search could not search the web. ${engine_problem}
+What follows came from a keyless Wikipedia lookup instead. These are undated encyclopedia articles, NOT web search results, and they are no evidence at all about what is current, recent, or state of the art. Cite them as Wikipedia, and report that web search was unavailable.]
+${to_json(wiki)}`;
     }
 }
 
-results
+out

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.2.1"
+version = "0.2.2"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 
@@ -34,10 +34,23 @@ For each source you use, append a bibliography line to `sources_index`
 Note interesting threads worth pulling on later. If sent back, focus on the named
 coverage gap.
 
+Establish what exists NOW before naming players. Search the field as of the date
+in `environment` and fetch the authoritative index for the domain (registry,
+leaderboard, release feed) before you settle the list of threads. A landscape
+recalled rather than gathered is by construction the landscape from before your
+cutoff, and this stage decides what the whole fan-out investigates.
+
 Today's date is in the `environment` region. Treat it as authoritative over
 anything you remember: your training has a cutoff and this run does not. Judge
 "recent", "current", "active" and "state of the art" against it, and note how
 old a source is when its age bears on the claim. Call current_time for the clock.
+Pass `freshness` to web_search whenever currency is part of the question.
+
+If web_search hands back a diagnostic instead of results - no engine configured,
+an engine error, or an encyclopedia fallback - then this run cannot see the web.
+Record that in `sources_index` and do NOT close the gap from memory. A landscape
+reported as unmapped is a usable result; one assembled from recall is not, and a
+reader cannot tell the two apart after the fact.
 """
 
 [stages.survey.tool_routing]
@@ -111,6 +124,19 @@ markdown fences. Each item:
 
 Every item MUST carry enough to work from alone: a worker is a separate agent
 and does not share this run's context, so the work item is all it gets.
+
+GROUND EVERY NAME IN `landscape`. A proper noun in a thread - a product, model,
+version, company, standard - must already appear there. If you cannot name the
+players from what the survey gathered, then finding them IS the thread ("which X
+exist as of the date in `environment`, and which are current"), not comparing a
+list you remember.
+
+This is not style. A worker starts from a clean context and cannot question your
+premise: it will faithfully research whatever you named. A list you recalled
+instead of surveyed therefore comes back as several workers' worth of
+independent-looking confirmation for candidates that may be years stale or may
+not exist at all, and the compare stage has no way to tell that apart from
+evidence. The fan-out multiplies whatever you put in, including the mistake.
 
 Prefer a handful of substantial threads over many thin ones. One thread is fine
 for a narrow area.
@@ -237,6 +263,20 @@ citing `sources_index` per the rules in `format`. Include:
 
 Write concisely - the reader wants the lay of the land quickly. Cite sources for
 non-obvious claims.
+
+Citations are load-bearing, so two rules bind absolutely:
+
+1. Every `[n]` must resolve to a line already in `sources_index`. A reference
+   points at something this run actually read - never a reconstructed URL, a
+   remembered paper or discussion thread, or a plausible-looking title. Never
+   invent the details that make a citation look checked: no vote counts, no
+   comment counts, no dates you did not read off the source.
+2. If `sources_index` is empty, you have no bibliography and therefore no
+   evidence. Do not write one. Say up front that the survey could not reach its
+   sources, drop the `[n]` markers, mark every finding low confidence, and
+   present what you have as background knowledge rather than findings.
+
+Confidence describes the evidence, not how sure the prose sounds.
 """
 
 [stages.summarize.transitions.summary]
@@ -295,7 +335,12 @@ file you wrote.
 query              = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the survey topic/area via --task.", volatility = "stable" }
 scope              = { kind = "pinned", budget = "1%", seed = "scope", volatility = "stable" }
 environment        = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
-sources_index      = { kind = "pinned", budget = "3%", volatility = "grows" }
+# `required`: the overview is built from this, and a stage that gathered nothing
+# used to hand an empty bibliography to `summarize`, which wrote the references
+# from memory rather than reporting that it had none. The gate binds the stages
+# that can write context and no-ops for the ones that cannot, so it can never
+# deadlock the deliverable.
+sources_index      = { kind = "pinned", budget = "3%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url or path> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
 format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Prefer comparison tables where they clarify tradeoffs." }, volatility = "stable" }
 
 landscape          = { kind = "temporary",      budget = "30%" }

--- a/crates/leviath-cli/agents/wide-researcher/tools/web_fetch.rhai
+++ b/crates/leviath-cli/agents/wide-researcher/tools/web_fetch.rhai
@@ -1,7 +1,13 @@
 // @tool web_fetch
-// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized/blocked requests return a diagnostic instead of failing the run.
+// @description Fetch a URL over HTTP(S) and return its readable text. HTML pages are stripped to prose (scripts/styles/tags removed, entities decoded); other content is returned as-is. Large pages are truncated; oversized, blocked, or client-side-rendered pages return a diagnostic instead of failing the run.
 // @param url string required "The URL to fetch (http or https)"
 // @requires network
+
+// Below this many characters, an HTML page that stripped to prose gave us a
+// shell, not an article: the text lives in client-side JS that never ran here.
+// Reddit strips to the single word "Reddit", and a model handed that will
+// happily cite the discussion it remembers being there.
+let MIN_HTML_PROSE = 200;
 
 let out = "";
 try {
@@ -12,12 +18,18 @@ try {
     // prose instead of markup. (Content injected by client-side JS isn't in the
     // source and can't be recovered here.)
     let lo = body.to_lower();
-    if lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>") {
+    let was_html = lo.contains("<html") || lo.contains("<!doctype html") || lo.contains("<body") || lo.contains("<div") || lo.contains("</p>") || lo.contains("</a>");
+    if was_html {
         body = html_to_text(body);
     }
 
-    // Cap very large content so a single fetch can't blow the context budget.
-    if body.len() > 12000 {
+    if was_html && body.trim().len() < MIN_HTML_PROSE {
+        // Name it rather than returning the husk. A few words of navigation
+        // chrome is indistinguishable from real content once it is sitting in
+        // the sources region next to everything else.
+        out = `[web_fetch got no readable content from ${params.url}: the page is HTML but strips to only ${body.trim().len()} characters, so its text is rendered client-side by JavaScript that does not run here. Whatever it says, this fetch did not read it - do not cite this URL or reconstruct its contents from memory. Try an API endpoint, an RSS/JSON feed, or a static mirror instead.]`;
+    } else if body.len() > 12000 {
+        // Cap very large content so a single fetch can't blow the context budget.
         out = body.sub_string(0, 12000) + "\n\n...[truncated — content was " + body.len() + " chars]";
     } else {
         out = body;

--- a/crates/leviath-cli/agents/wide-researcher/tools/web_search.rhai
+++ b/crates/leviath-cli/agents/wide-researcher/tools/web_search.rhai
@@ -1,51 +1,108 @@
 // @tool web_search
-// @description Search the web and return a JSON list of {title, url, snippet} results. Uses Brave Search when BRAVE_API_KEY is set in the environment, otherwise a keyless Wikipedia search (works out of the box for any query).
+// @description Search the web and return a JSON list of {title, url, snippet, date} results. Uses Brave Search when BRAVE_API_KEY is readable. Without it there is no search engine: the call falls back to a keyless Wikipedia lookup and says so in its result.
 // @param query string required "The search query"
 // @param count integer optional "Maximum number of results to return (default 5)"
+// @param freshness string optional "Restrict results by age: pd (past day), pw (past week), pm (past month), py (past year), or YYYY-MM-DDtoYYYY-MM-DD. Use this whenever 'latest' or 'current' matters."
 // @requires network
 
 let n = if params.count == () { 5 } else { params.count };
 let results = [];
 
-// Prefer Brave Search when an API key is configured. env_var throws when the
-// variable is unset, so probe it inside try/catch and fall back to keyless search.
+// Probe BRAVE_API_KEY. env_var throws for two very different reasons and the
+// caller has to tell them apart: the variable is genuinely unset, or it is set
+// and the security layer refused it because the name looks like a credential
+// (`[security] allow_env_vars`). Collapsing both into "" is what let this tool
+// degrade to Wikipedia for a whole run without anyone noticing.
 let key = "";
-try { key = env_var("BRAVE_API_KEY"); } catch(e) { key = ""; }
+let key_state = "unset";
+try {
+    key = env_var("BRAVE_API_KEY");
+    key_state = if key == "" { "unset" } else { "ok" };
+} catch(e) {
+    let msg = `${e}`;
+    key_state = if msg.contains("[denied]") { "denied" } else { "unset" };
+    key = "";
+}
 
-let got = false;
-if key != "" {
+// Why no engine ran, phrased as the fix rather than the symptom. Empty when one did.
+let engine_problem = "";
+
+if key_state == "ok" {
     try {
         let url = `https://api.search.brave.com/res/v1/web/search?q=${encode_uri(params.query)}&count=${n}`;
+        if params.freshness != () && params.freshness != "" {
+            url += `&freshness=${encode_uri(params.freshness)}`;
+        }
         let data = parse_json(http_get(url, #{ "X-Subscription-Token": key, "Accept": "application/json" }));
         if data.web != () && data.web.results != () {
             for r in data.web.results {
                 if results.len() >= n { break; }
-                results.push(#{ title: r.title, url: r.url, snippet: r.description });
+                // Brave dates the page two ways: `page_age` is an ISO timestamp,
+                // `age` a human string ("3 days ago"). Either one lets the agent
+                // judge recency against the run's date instead of guessing, and
+                // gives `sources_index` a real date to cite.
+                let when = "undated";
+                if r.page_age != () && r.page_age != "" {
+                    when = r.page_age;
+                } else if r.age != () && r.age != "" {
+                    when = r.age;
+                }
+                results.push(#{ title: r.title, url: r.url, snippet: r.description, date: when });
             }
-            got = true;
+        } else {
+            engine_problem = "Brave Search answered without a result set (the response carried no `web.results`).";
         }
     } catch(e) {
-        // Brave failed (bad key, rate limit, network) — fall through to keyless search.
-        got = false;
+        engine_problem = `Brave Search failed: ${e}. The key may be invalid or rate limited, or the network is blocked.`;
     }
+} else if key_state == "denied" {
+    engine_problem = "BRAVE_API_KEY is set but the security layer refused to hand it to this script, because the name looks like a credential. Fix: add `allow_env_vars = [\"BRAVE_API_KEY\"]` under `[security]` in ~/.leviath/config.toml, then restart the daemon.";
+} else {
+    engine_problem = "BRAVE_API_KEY is not set, so no search engine is configured. Fix: get a key from https://brave.com/search/api/, put it in the daemon's environment, and add `allow_env_vars = [\"BRAVE_API_KEY\"]` under `[security]` in ~/.leviath/config.toml.";
 }
 
-if !got {
-    // Keyless fallback: Wikipedia's search API returns clean JSON for arbitrary
-    // queries (no key required). Each page becomes a {title, url, snippet} result.
-    let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
-    // Wikipedia requires a descriptive User-Agent (403 otherwise).
-    let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
-    if data.pages != () {
-        for p in data.pages {
-            if results.len() >= n { break; }
-            let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
-            // Wikipedia wraps matched terms in <span class="searchmatch"> tags — strip them.
-            snippet.replace("<span class=\"searchmatch\">", "");
-            snippet.replace("</span>", "");
-            results.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet });
+let out = "";
+
+if engine_problem == "" {
+    if results.len() == 0 {
+        // A real search that found nothing is still worth saying out loud - a
+        // bare empty array reads as "nothing has been written about this topic".
+        out = `[web_search found no results for "${params.query}". The search engine ran and came back empty, so try different wording or a narrower claim. Do not fill the gap from memory.]`;
+    } else {
+        out = results;
+    }
+} else {
+    // No engine. Wikipedia's search API needs no key and returns clean JSON, so
+    // it beats nothing - but it is an encyclopedia, it is undated, and it cannot
+    // answer "what is the latest X". Say all of that, every time.
+    let wiki = [];
+    try {
+        let url = `https://en.wikipedia.org/w/rest.php/v1/search/page?q=${encode_uri(params.query)}&limit=${n}`;
+        // Wikipedia requires a descriptive User-Agent (403 otherwise).
+        let data = parse_json(http_get(url, #{ "User-Agent": "Leviath-Researcher/0.3 (+https://leviath.dev)", "Accept": "application/json" }));
+        if data.pages != () {
+            for p in data.pages {
+                if wiki.len() >= n { break; }
+                let snippet = if p.excerpt != () && p.excerpt != "" { p.excerpt } else if p.description != () { p.description } else { "" };
+                // Wikipedia wraps matched terms in <span class="searchmatch"> tags - strip them.
+                snippet.replace("<span class=\"searchmatch\">", "");
+                snippet.replace("</span>", "");
+                wiki.push(#{ title: p.title, url: `https://en.wikipedia.org/wiki/${p.key}`, snippet: snippet, date: "undated" });
+            }
         }
+    } catch(e) {
+        // The fallback failed too. The engine problem is the one worth reporting.
+    }
+
+    if wiki.len() == 0 {
+        out = `[web_search could not search the web. ${engine_problem}
+The keyless Wikipedia fallback found nothing for "${params.query}", which is normal - an encyclopedia cannot answer this kind of question.
+Treat this topic as UNRESEARCHED. Do not answer it from memory and do not invent sources: report that web search was unavailable, in your findings and in any report you write.]`;
+    } else {
+        out = `[web_search could not search the web. ${engine_problem}
+What follows came from a keyless Wikipedia lookup instead. These are undated encyclopedia articles, NOT web search results, and they are no evidence at all about what is current, recent, or state of the art. Cite them as Wikipedia, and report that web search was unavailable.]
+${to_json(wiki)}`;
     }
 }
 
-results
+out

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -1,20 +1,24 @@
 //! `lev doctor` - prove the provider wiring works, one layer at a time.
 //!
-//! Four checks run in order and each one is reported, so a failure names the
+//! Five checks run in order and each one is reported, so a failure names the
 //! layer that broke instead of leaving the caller to guess:
 //!
 //! 1. `config` - the config file parses and a provider registry can be built.
-//! 2. `resolve` - the user's defaults pick a provider that is actually
+//! 2. `search` - the bundled research agents can reach a search engine. The odd
+//!    one out: it warns rather than fails, and it asks the *daemon* what it can
+//!    see rather than inspecting this process, because the daemon's environment
+//!    is fixed at exec time and is not the shell `doctor` was typed in.
+//! 3. `resolve` - the user's defaults pick a provider that is actually
 //!    registered. This is the check that catches a stage resolving to
 //!    `anthropic/claude-sonnet-4-6` (the hard-coded last resort in
 //!    [`ModelConfig::provider`](leviath_core::blueprint::ModelConfig::provider))
 //!    on a machine with no Anthropic key - the root cause of a fleet of runs
 //!    that spawned, sat at iteration 0, and never took a turn.
-//! 3. `inference` - one real call to that provider, straight through
+//! 4. `inference` - one real call to that provider, straight through
 //!    [`Provider::infer`]. No world, no run, nothing on disk.
-//! 4. `daemon` - a throwaway one-stage agent spawned over the control socket
+//! 5. `daemon` - a throwaway one-stage agent spawned over the control socket
 //!    and waited on, then deleted. This is the only check that exercises the
-//!    handoff, which is why it is worth the second billed call: checks 1-3
+//!    handoff, which is why it is worth the second billed call: checks 1-4
 //!    passing while this one fails is exactly the "credentials are fine, the
 //!    daemon is wedged" verdict that used to take a hand-built canary agent to
 //!    establish.
@@ -32,7 +36,9 @@ use anyhow::bail;
 use leviath_core::blueprint::ModelConfig;
 use leviath_providers::{InferenceRequest, Message, Provider};
 use leviath_runtime::ProviderRegistry;
-use leviath_runtime::control_socket::{ControlClient, ControlResponse};
+use leviath_runtime::control_socket::{
+    ControlClient, ControlRequest, ControlResponse, DaemonIdentity,
+};
 use leviath_runtime::pipeline::{bare_default_model, providers_tried, resolve_stage_model};
 
 use crate::commands::run::session::build_provider_registry_from_config;
@@ -48,10 +54,12 @@ fails is the diagnosis:
 
   config     the config file parses and a provider registry can be built.
              Fails on a malformed config.toml.
-  search     the bundled research agents can reach a search engine. Warns
-             (never fails) when BRAVE_API_KEY is unset, or is set but missing
-             from [security] allow_env_vars - which silently downgrades every
-             web_search to a keyless Wikipedia lookup.
+  search     the bundled research agents can reach a search engine. Asks the
+             daemon what it can see, not this shell, since only the daemon's
+             environment decides. Warns (never fails) when BRAVE_API_KEY is
+             unset, when the daemon was started before it existed, or when it
+             is missing from [security] allow_env_vars - each of which silently
+             downgrades every web_search to a keyless Wikipedia lookup.
   resolve    your default provider/model picks a provider that is actually
              registered. Fails when a key is missing or misspelled - and
              catches the case where a blueprint with no model falls back to
@@ -241,8 +249,8 @@ const SEARCH_KEY: &str = "BRAVE_API_KEY";
 
 /// Whether the bundled research agents can actually search the web.
 ///
-/// Two independent things have to be true, and getting one of them wrong is
-/// silent: the key has to be in the daemon's environment, *and* `[security]
+/// Two independent things have to be true, and getting either wrong is silent:
+/// the key has to be in **the daemon's** environment, *and* `[security]
 /// allow_env_vars` has to list it. The name ends in `KEY`, so the script host
 /// classes it as a credential and refuses to hand it to a Rhai tool that was
 /// not explicitly granted it - which means a user who exports the key and
@@ -252,30 +260,70 @@ const SEARCH_KEY: &str = "BRAVE_API_KEY";
 /// which still wrote a confident, fully cited report. Worth a line in `doctor`
 /// precisely because nothing else in the system says it out loud.
 ///
+/// `daemon` is the identity from the control handshake, and the key half of
+/// this check: a daemon's environment is fixed at exec time and is not this
+/// process's, so asking `std::env` answers for the shell `doctor` was typed in.
+/// The two disagree exactly when the bug is present - a key exported now,
+/// against a daemon started before it - so the daemon's answer wins whenever
+/// there is one, and the fallback says whose environment it is describing.
+///
+/// The allowlist half needs no such care: it comes from `config.toml`, which
+/// both processes read, and which the daemon re-reads per spawn.
+///
 /// Warns rather than fails: an install with no search key is perfectly good for
 /// everyone not running a research agent.
-fn search_check(config: &Config) -> Check {
+fn search_check(config: &Config, daemon: Option<&DaemonIdentity>) -> Check {
     let allowlisted = leviath_core::script_env_allowed(SEARCH_KEY, &config.security.allow_env_vars);
-    match (std::env::var(SEARCH_KEY), allowlisted) {
-        (Ok(key), true) if !key.is_empty() => Check::ok(
-            "search",
-            format!("brave ({SEARCH_KEY} is set and allowlisted)"),
+    let grant_fix = format!(
+        "Add `allow_env_vars = [\"{SEARCH_KEY}\"]` under `[security]` in ~/.leviath/config.toml"
+    );
+
+    // Whose environment we are describing, and what it holds. A daemon that did
+    // not report (older build, or an embedder) leaves `None` and we fall back to
+    // this process, saying so.
+    let in_env = daemon.and_then(|d| d.sees_tool_env(SEARCH_KEY));
+    let (present, whose) = match in_env {
+        Some(seen) => (seen, "the daemon"),
+        None => (
+            std::env::var_os(SEARCH_KEY).is_some_and(|v| !v.is_empty()),
+            "this shell (the daemon did not report; it may differ)",
         ),
-        (Ok(key), false) if !key.is_empty() => Check::warn(
+    };
+
+    match (present, allowlisted) {
+        (true, true) => Check::ok(
+            "search",
+            format!("brave ({SEARCH_KEY} readable by {whose})"),
+        ),
+        (true, false) => Check::warn(
             "search",
             format!(
-                "{SEARCH_KEY} is set but not granted, so every web_search falls back to \
-                 Wikipedia. Add `allow_env_vars = [\"{SEARCH_KEY}\"]` under `[security]` in \
-                 ~/.leviath/config.toml, then restart the daemon"
+                "{SEARCH_KEY} is readable by {whose} but not granted to script tools, so every \
+                 web_search falls back to Wikipedia. {grant_fix} - the daemon re-reads it, so no \
+                 restart is needed"
             ),
         ),
-        _ => Check::warn(
+        // The case a CLI-only check could never see: the key exists here, the
+        // grant exists, and the process that will run the tool still cannot
+        // read it. Naming the restart is the whole value of asking the daemon.
+        (false, _) if in_env == Some(false) && std::env::var_os(SEARCH_KEY).is_some() => {
+            Check::warn(
+                "search",
+                format!(
+                    "{SEARCH_KEY} is set in this shell but the daemon cannot see it - it was \
+                     started before the key existed, and a process does not inherit an \
+                     environment it already has. Run `lev daemon restart` from a shell that \
+                     exports {SEARCH_KEY}; until then every web_search falls back to Wikipedia"
+                ),
+            )
+        }
+        (false, _) => Check::warn(
             "search",
             format!(
-                "no search engine configured: {SEARCH_KEY} is unset, so research agents fall \
-                 back to a keyless Wikipedia lookup. Get a key from \
-                 https://brave.com/search/api/, put it in the daemon's environment, and add \
-                 `allow_env_vars = [\"{SEARCH_KEY}\"]` under `[security]`"
+                "no search engine configured: {SEARCH_KEY} is not readable by {whose}, so \
+                 research agents fall back to a keyless Wikipedia lookup. Get a key from \
+                 https://brave.com/search/api/ and export it in the shell the daemon starts \
+                 from. {grant_fix}"
             ),
         ),
     }
@@ -819,9 +867,21 @@ pub async fn run_checks(
         }
     };
     checks.push(config_check(&config, &registry));
-    // Offline and cheap, so it runs early enough to be seen even when a later
-    // network check fails. It only ever warns, so it never cuts the run short.
-    checks.push(search_check(&config));
+    // Ask the daemon who it is before judging its environment. `List` is
+    // idempotent and local, and it is only sent to force the handshake that
+    // fills `link().daemon` - the reply itself is not the point, and a daemon
+    // that will not answer just leaves the identity unknown, which the check
+    // reports as such rather than guessing.
+    let identity = match &daemon {
+        DaemonTarget::Client(client) => {
+            let _ = client.request(&ControlRequest::List).await;
+            client.link().daemon
+        }
+        DaemonTarget::Skip | DaemonTarget::Unavailable(_) => None,
+    };
+    // Runs early enough to be seen even when a later network check fails, and
+    // only ever warns, so it never cuts the run short.
+    checks.push(search_check(&config, identity.as_ref()));
 
     let (check, resolved) = resolve_check(&config, args.model.as_deref(), &registry);
     checks.push(check);

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -43,11 +43,15 @@ use crate::daemon::spawn::model_defaults;
 pub const DOCTOR_LONG_ABOUT: &str = "\
 Check that provider wiring works, end to end.
 
-Four checks run in order, and the first failure stops the rest. The check that
+Five checks run in order, and the first failure stops the rest. The check that
 fails is the diagnosis:
 
   config     the config file parses and a provider registry can be built.
              Fails on a malformed config.toml.
+  search     the bundled research agents can reach a search engine. Warns
+             (never fails) when BRAVE_API_KEY is unset, or is set but missing
+             from [security] allow_env_vars - which silently downgrades every
+             web_search to a keyless Wikipedia lookup.
   resolve    your default provider/model picks a provider that is actually
              registered. Fails when a key is missing or misspelled - and
              catches the case where a blueprint with no model falls back to
@@ -118,6 +122,13 @@ const PROBE_EXPECTED: &str = "PONG";
 pub enum CheckStatus {
     /// The layer works.
     Ok,
+    /// The layer works, in a degraded way the user should know about.
+    ///
+    /// Distinct from [`Self::Fail`] because it neither stops the checks after
+    /// it nor fails the command: a machine with no search key is a working
+    /// install for everyone not running a research agent, and turning that into
+    /// a red CI gate would teach people to ignore `doctor`.
+    Warn,
     /// The layer is broken; nothing after it ran.
     Fail,
 }
@@ -127,6 +138,7 @@ impl CheckStatus {
     fn label(&self) -> &'static str {
         match self {
             Self::Ok => "OK",
+            Self::Warn => "WARN",
             Self::Fail => "FAIL",
         }
     }
@@ -152,6 +164,16 @@ impl Check {
         Self {
             name,
             status: CheckStatus::Ok,
+            detail: detail.into(),
+            elapsed_ms: None,
+        }
+    }
+
+    /// A check that passed in a degraded state worth naming.
+    fn warn(name: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            name,
+            status: CheckStatus::Warn,
             detail: detail.into(),
             elapsed_ms: None,
         }
@@ -202,10 +224,61 @@ pub fn format_report(checks: &[Check]) -> String {
         }
         out.push('\n');
     }
-    if checks.iter().all(|c| c.status == CheckStatus::Ok) {
+    // Keyed on "nothing failed", to agree with the exit code and the `passed`
+    // field in --json. A warning is a note about a degraded layer, not a verdict
+    // on the run, and a table that withheld "doctor passed" over one would read
+    // as a failure the exit code disagreed with.
+    if !checks.iter().any(|c| c.status == CheckStatus::Fail) {
         out.push_str("\ndoctor passed\n");
     }
     out
+}
+
+// ─── Check 2: search ──────────────────────────────────────────────────────────
+
+/// The environment variable the bundled `web_search` script reads.
+const SEARCH_KEY: &str = "BRAVE_API_KEY";
+
+/// Whether the bundled research agents can actually search the web.
+///
+/// Two independent things have to be true, and getting one of them wrong is
+/// silent: the key has to be in the daemon's environment, *and* `[security]
+/// allow_env_vars` has to list it. The name ends in `KEY`, so the script host
+/// classes it as a credential and refuses to hand it to a Rhai tool that was
+/// not explicitly granted it - which means a user who exports the key and
+/// nothing else gets the keyless Wikipedia fallback with no error anywhere.
+///
+/// That combination produced a run whose 47 searches all came back empty and
+/// which still wrote a confident, fully cited report. Worth a line in `doctor`
+/// precisely because nothing else in the system says it out loud.
+///
+/// Warns rather than fails: an install with no search key is perfectly good for
+/// everyone not running a research agent.
+fn search_check(config: &Config) -> Check {
+    let allowlisted = leviath_core::script_env_allowed(SEARCH_KEY, &config.security.allow_env_vars);
+    match (std::env::var(SEARCH_KEY), allowlisted) {
+        (Ok(key), true) if !key.is_empty() => Check::ok(
+            "search",
+            format!("brave ({SEARCH_KEY} is set and allowlisted)"),
+        ),
+        (Ok(key), false) if !key.is_empty() => Check::warn(
+            "search",
+            format!(
+                "{SEARCH_KEY} is set but not granted, so every web_search falls back to \
+                 Wikipedia. Add `allow_env_vars = [\"{SEARCH_KEY}\"]` under `[security]` in \
+                 ~/.leviath/config.toml, then restart the daemon"
+            ),
+        ),
+        _ => Check::warn(
+            "search",
+            format!(
+                "no search engine configured: {SEARCH_KEY} is unset, so research agents fall \
+                 back to a keyless Wikipedia lookup. Get a key from \
+                 https://brave.com/search/api/, put it in the daemon's environment, and add \
+                 `allow_env_vars = [\"{SEARCH_KEY}\"]` under `[security]`"
+            ),
+        ),
+    }
 }
 
 // ─── Check 1: config ──────────────────────────────────────────────────────────
@@ -746,6 +819,9 @@ pub async fn run_checks(
         }
     };
     checks.push(config_check(&config, &registry));
+    // Offline and cheap, so it runs early enough to be seen even when a later
+    // network check fails. It only ever warns, so it never cuts the run short.
+    checks.push(search_check(&config));
 
     let (check, resolved) = resolve_check(&config, args.model.as_deref(), &registry);
     checks.push(check);

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -127,6 +127,10 @@ fn scripted_daemon(dir: &Path, responses: Vec<String>) -> (ControlId, JoinHandle
     (id, handle)
 }
 
+/// The reply to the `List` the search check sends to force a handshake. Its
+/// contents are discarded - only the identity the handshake carries is wanted -
+/// but the daemon still has to answer it, so a scripted daemon must queue one.
+const LISTING: &str = r#"{"result":"list","runs":[],"finished":[]}"#;
 const SPAWNED: &str = r#"{"result":"spawned","run_id":"doctor-1-abc"}"#;
 const COMPLETE: &str = r#"{"result":"status","status":"Complete"}"#;
 const ACTIVE: &str = r#"{"result":"status","status":"Active"}"#;
@@ -208,12 +212,28 @@ fn format_report_of_a_warning_still_passes() {
 
 // ─── search_check ─────────────────────────────────────────────────────────────
 
-/// Run `search_check` with `BRAVE_API_KEY` set to `key` and the allowlist set
-/// to `allowed`.
-fn search_with(key: Option<&str>, allowed: &[&str]) -> Check {
+/// A daemon that reports seeing exactly `names`.
+fn daemon_seeing(names: &[&str]) -> DaemonIdentity {
+    DaemonIdentity::this_process("test")
+        .with_tool_env(names.iter().map(|s| (*s).to_string()).collect())
+}
+
+/// Run `search_check` against `daemon`, with `BRAVE_API_KEY` set to `key` in
+/// *this* process and the allowlist set to `allowed`.
+fn search_with_daemon(
+    key: Option<&str>,
+    allowed: &[&str],
+    daemon: Option<&DaemonIdentity>,
+) -> Check {
     let mut config = Config::default();
     config.security.allow_env_vars = allowed.iter().map(|s| (*s).to_string()).collect();
-    temp_env::with_var("BRAVE_API_KEY", key, || search_check(&config))
+    temp_env::with_var("BRAVE_API_KEY", key, || search_check(&config, daemon))
+}
+
+/// The common case: no daemon reported, so the check falls back to this
+/// process's own environment.
+fn search_with(key: Option<&str>, allowed: &[&str]) -> Check {
+    search_with_daemon(key, allowed, None)
 }
 
 #[test]
@@ -234,6 +254,13 @@ fn search_check_warns_when_the_key_is_set_but_not_allowlisted() {
         "names the fix: {}",
         check.detail
     );
+    // The grant is config, which the daemon re-reads per spawn - telling the
+    // user to restart here would be busywork.
+    assert!(
+        check.detail.contains("no restart is needed"),
+        "{}",
+        check.detail
+    );
 }
 
 #[test]
@@ -252,7 +279,73 @@ fn search_check_treats_an_empty_key_as_no_key() {
     // An exported-but-empty variable reads as configured and is not.
     let check = search_with(Some(""), &["BRAVE_API_KEY"]);
     assert_eq!(check.status, CheckStatus::Warn);
-    assert!(check.detail.contains("unset"), "{}", check.detail);
+    assert!(check.detail.contains("not readable"), "{}", check.detail);
+}
+
+#[test]
+fn search_check_without_a_daemon_says_whose_environment_it_read() {
+    // Answering for the wrong process silently is the bug this check exists to
+    // catch, so when it cannot reach the right one it must say so.
+    let check = search_with(Some("sk-brave"), &["BRAVE_API_KEY"]);
+    assert!(
+        check.detail.contains("the daemon did not report"),
+        "{}",
+        check.detail
+    );
+}
+
+#[test]
+fn search_check_believes_the_daemon_over_this_process() {
+    // The daemon has the key and this shell does not. Nothing is wrong: the
+    // process that runs the tool is the one that matters.
+    let check = search_with_daemon(
+        None,
+        &["BRAVE_API_KEY"],
+        Some(&daemon_seeing(&["BRAVE_API_KEY"])),
+    );
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(check.detail.contains("the daemon"), "{}", check.detail);
+}
+
+#[test]
+fn search_check_catches_a_daemon_started_before_the_key_existed() {
+    // The false negative a CLI-only check could never see: key here, grant in
+    // place, and the daemon still blind to it. This is the whole reason the
+    // daemon is asked.
+    let check = search_with_daemon(
+        Some("sk-brave"),
+        &["BRAVE_API_KEY"],
+        Some(&daemon_seeing(&[])),
+    );
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(
+        check.detail.contains("the daemon cannot see it"),
+        "names the real problem: {}",
+        check.detail
+    );
+    assert!(
+        check.detail.contains("lev daemon restart"),
+        "names the remedy: {}",
+        check.detail
+    );
+}
+
+#[test]
+fn search_check_reports_a_key_nobody_has_as_unconfigured() {
+    // Neither side has it: that is not a restart problem, it is a setup one,
+    // and pointing at `lev daemon restart` would send the user in circles.
+    let check = search_with_daemon(None, &["BRAVE_API_KEY"], Some(&daemon_seeing(&[])));
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(
+        check.detail.contains("brave.com/search/api"),
+        "{}",
+        check.detail
+    );
+    assert!(
+        !check.detail.contains("lev daemon restart"),
+        "no restart advice when there is no key to load: {}",
+        check.detail
+    );
 }
 
 // ─── config_check ─────────────────────────────────────────────────────────────
@@ -1054,7 +1147,14 @@ async fn run_checks_runs_all_five_against_a_healthy_daemon() {
             "anthropic_api_key = \"not-a-real-shape\"\n",
         );
         let build = always(registry_with("stub", StubProvider::replying("PONG")));
-        let (id, _server) = scripted_daemon(&root, vec![SPAWNED.to_string(), COMPLETE.to_string()]);
+        let (id, _server) = scripted_daemon(
+            &root,
+            vec![
+                LISTING.to_string(),
+                SPAWNED.to_string(),
+                COMPLETE.to_string(),
+            ],
+        );
         let client = ControlClient::new(id);
         run_checks(
             &DoctorArgs::default(),

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -33,6 +33,9 @@ where
     let mut vars = crate::config::config_isolation_vars(&root);
     vars.push(("LEVIATH_HOME", Some(root.clone().into_os_string())));
     vars.push(("LEVIATH_RUNS_DIR", Some(root.join("runs").into_os_string())));
+    // The search check reads this, so a developer who has one exported would
+    // otherwise see a different check list than CI does.
+    vars.push(("BRAVE_API_KEY", None));
     temp_env::async_with_vars(vars, f(root)).await
 }
 
@@ -188,6 +191,68 @@ fn format_report_of_a_failure_has_no_pass_line() {
     let out = format_report(&checks);
     assert!(out.contains("FAIL"), "{out}");
     assert!(!out.contains("doctor passed"), "{out}");
+}
+
+#[test]
+fn format_report_of_a_warning_still_passes() {
+    // A degraded layer is a note, not a verdict: the exit code and the `passed`
+    // field both say this run is fine, and the table has to agree with them.
+    let checks = vec![
+        Check::ok("config", "fine"),
+        Check::warn("search", "no search engine configured"),
+    ];
+    let out = format_report(&checks);
+    assert!(out.contains("search  WARN"), "columns pad: {out}");
+    assert!(out.ends_with("doctor passed\n"), "{out}");
+}
+
+// ─── search_check ─────────────────────────────────────────────────────────────
+
+/// Run `search_check` with `BRAVE_API_KEY` set to `key` and the allowlist set
+/// to `allowed`.
+fn search_with(key: Option<&str>, allowed: &[&str]) -> Check {
+    let mut config = Config::default();
+    config.security.allow_env_vars = allowed.iter().map(|s| (*s).to_string()).collect();
+    temp_env::with_var("BRAVE_API_KEY", key, || search_check(&config))
+}
+
+#[test]
+fn search_check_passes_when_the_key_is_set_and_allowlisted() {
+    let check = search_with(Some("sk-brave"), &["BRAVE_API_KEY"]);
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert!(check.detail.contains("brave"), "{}", check.detail);
+}
+
+#[test]
+fn search_check_warns_when_the_key_is_set_but_not_allowlisted() {
+    // The trap this check exists for: the name ends in KEY, so the script host
+    // refuses it and every search silently becomes a Wikipedia lookup.
+    let check = search_with(Some("sk-brave"), &[]);
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(
+        check.detail.contains("allow_env_vars"),
+        "names the fix: {}",
+        check.detail
+    );
+}
+
+#[test]
+fn search_check_warns_when_there_is_no_key_at_all() {
+    let check = search_with(None, &["BRAVE_API_KEY"]);
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(
+        check.detail.contains("Wikipedia"),
+        "says what happens instead: {}",
+        check.detail
+    );
+}
+
+#[test]
+fn search_check_treats_an_empty_key_as_no_key() {
+    // An exported-but-empty variable reads as configured and is not.
+    let check = search_with(Some(""), &["BRAVE_API_KEY"]);
+    assert_eq!(check.status, CheckStatus::Warn);
+    assert!(check.detail.contains("unset"), "{}", check.detail);
 }
 
 // ─── config_check ─────────────────────────────────────────────────────────────
@@ -931,9 +996,9 @@ async fn run_checks_stops_at_an_unconfigured_provider() {
         run_checks(&DoctorArgs::default(), &build, DaemonTarget::Skip).await
     })
     .await;
-    assert_eq!(checks.len(), 2, "no inference is attempted: {checks:?}");
-    assert_eq!(checks[1].name, "resolve");
-    assert_eq!(checks[1].status, CheckStatus::Fail);
+    assert_eq!(checks.len(), 3, "no inference is attempted: {checks:?}");
+    assert_eq!(checks[2].name, "resolve");
+    assert_eq!(checks[2].status, CheckStatus::Fail);
 }
 
 #[tokio::test]
@@ -944,8 +1009,8 @@ async fn run_checks_stops_at_a_failing_inference() {
         run_checks(&DoctorArgs::default(), &build, DaemonTarget::Skip).await
     })
     .await;
-    assert_eq!(checks.len(), 3, "the daemon is never contacted: {checks:?}");
-    assert_eq!(checks[2].status, CheckStatus::Fail);
+    assert_eq!(checks.len(), 4, "the daemon is never contacted: {checks:?}");
+    assert_eq!(checks[3].status, CheckStatus::Fail);
 }
 
 #[tokio::test]
@@ -956,8 +1021,8 @@ async fn run_checks_skips_the_daemon_when_asked_to() {
         run_checks(&DoctorArgs::default(), &build, DaemonTarget::Skip).await
     })
     .await;
-    assert_eq!(checks.len(), 3, "--no-daemon stops after the inference");
-    assert!(checks.iter().all(|c| c.status == CheckStatus::Ok));
+    assert_eq!(checks.len(), 4, "--no-daemon stops after the inference");
+    assert!(checks.iter().all(|c| c.status != CheckStatus::Fail));
 }
 
 #[tokio::test]
@@ -972,14 +1037,14 @@ async fn run_checks_reports_a_daemon_that_would_not_start() {
         run_checks(&DoctorArgs::default(), &build, target).await
     })
     .await;
-    assert_eq!(checks.len(), 4, "{checks:?}");
-    assert!(checks[..3].iter().all(|c| c.status == CheckStatus::Ok));
-    assert_eq!(checks[3].status, CheckStatus::Fail);
-    assert!(checks[3].detail.contains("did not start"), "{checks:?}");
+    assert_eq!(checks.len(), 5, "{checks:?}");
+    assert!(checks[..4].iter().all(|c| c.status != CheckStatus::Fail));
+    assert_eq!(checks[4].status, CheckStatus::Fail);
+    assert!(checks[4].detail.contains("did not start"), "{checks:?}");
 }
 
 #[tokio::test]
-async fn run_checks_runs_all_four_against_a_healthy_daemon() {
+async fn run_checks_runs_all_five_against_a_healthy_daemon() {
     let checks = with_env(|root| async move {
         // A key of the wrong shape, so the warning branch runs too.
         write_config(
@@ -999,9 +1064,9 @@ async fn run_checks_runs_all_four_against_a_healthy_daemon() {
         .await
     })
     .await;
-    assert_eq!(checks.len(), 4, "{checks:?}");
+    assert_eq!(checks.len(), 5, "{checks:?}");
     assert!(
-        checks.iter().all(|c| c.status == CheckStatus::Ok),
+        checks.iter().all(|c| c.status != CheckStatus::Fail),
         "{checks:?}"
     );
 }

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -36,7 +36,10 @@ pub(super) async fn run_doctor(State(state): State<AppState>) -> Json<DoctorResp
             .into_iter()
             .map(|c| DoctorCheck {
                 name: c.name.to_string(),
-                ok: c.status == CheckStatus::Ok,
+                // Keyed on "did not fail", so a degraded-but-working layer
+                // reports the same verdict here as the CLI's exit code gives
+                // it. The detail carries what is degraded.
+                ok: c.status != CheckStatus::Fail,
                 detail: c.detail,
                 elapsed_ms: c.elapsed_ms,
             })
@@ -73,6 +76,9 @@ mod tests {
         let mut vars = crate::config::config_isolation_vars(&root);
         vars.push(("LEVIATH_HOME", Some(root.clone().into_os_string())));
         vars.push(("LEVIATH_RUNS_DIR", Some(root.join("runs").into_os_string())));
+        // The search check reads this, so a developer who has one exported
+        // would otherwise see a different check list than CI does.
+        vars.push(("BRAVE_API_KEY", None));
         temp_env::async_with_vars(vars, f(root)).await
     }
 
@@ -92,7 +98,8 @@ mod tests {
     }
 
     /// The endpoint over the shared production route table, against an empty
-    /// isolated config: `config` parses (ok), `resolve` fails (nothing
+    /// isolated config: `config` parses (ok), `search` warns (no key in the
+    /// isolated environment), `resolve` fails (nothing
     /// registered answers to the default provider), and the chain stops there -
     /// before any billed call. The failure arrives as an `ok: false` entry in
     /// a 200, which is the endpoint's whole contract.
@@ -112,11 +119,19 @@ mod tests {
                 .unwrap();
             let report: DoctorResp = serde_json::from_slice(&body).unwrap();
 
-            assert_eq!(report.checks.len(), 2, "config ok, resolve fail, stop");
+            assert_eq!(
+                report.checks.len(),
+                3,
+                "config ok, search warn, resolve fail, stop"
+            );
             let config_check = &report.checks[0];
             assert_eq!(config_check.name, "config");
             assert!(config_check.ok, "{}", config_check.detail);
-            let resolve_check = &report.checks[1];
+            // A warning is not a failure over the API either.
+            let search_check = &report.checks[1];
+            assert_eq!(search_check.name, "search");
+            assert!(search_check.ok, "{}", search_check.detail);
+            let resolve_check = &report.checks[2];
             assert_eq!(resolve_check.name, "resolve");
             assert!(!resolve_check.ok);
             assert!(

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -45,6 +45,32 @@ pub fn control_dir() -> Option<std::path::PathBuf> {
 /// binary is newer and the daemon is running stale code.
 pub const CURRENT_BUILD: &str = env!("LEVIATH_BUILD");
 
+/// Environment variables that a bundled script tool needs and that only the
+/// daemon's own process can be asked about.
+///
+/// A daemon inherits its environment at exec time from whatever started it, and
+/// no client shares it. So `lev doctor` inspecting its own environment answers
+/// for the shell it was typed in, not for the process that will actually run
+/// the tool - which is how a working key and a daemon that could not see it
+/// reported as healthy while every search fell back to Wikipedia.
+///
+/// Kept to credentials a *bundled* tool reads, so the reported set is a fixed
+/// list in the source rather than anything scraped from the environment.
+pub const TOOL_ENV_PROBE: &[&str] = &["BRAVE_API_KEY"];
+
+/// Which of [`TOOL_ENV_PROBE`] this process can actually read, by name.
+///
+/// Presence only - the value is never read here and never leaves the process.
+/// An empty vec is the real answer "asked, saw none", which the identity type
+/// keeps distinct from "did not say".
+pub fn visible_tool_env() -> Vec<String> {
+    TOOL_ENV_PROBE
+        .iter()
+        .filter(|name| std::env::var_os(name).is_some_and(|v| !v.is_empty()))
+        .map(|name| (*name).to_string())
+        .collect()
+}
+
 /// Path to the file where a running daemon records its build id
 /// (`<leviath-home>/.leviath/daemon.build`).
 pub fn build_marker_path() -> Option<std::path::PathBuf> {
@@ -1677,6 +1703,31 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             reply,
         });
         assert!(rx.await.unwrap());
+    }
+
+    /// Presence only, and only for the names the binary asks about - so this
+    /// can never become a way to read a daemon's environment.
+    #[test]
+    fn visible_tool_env_reports_the_probed_names_it_can_read() {
+        temp_env::with_var("BRAVE_API_KEY", Some("sk-brave"), || {
+            assert_eq!(visible_tool_env(), vec!["BRAVE_API_KEY".to_string()]);
+        });
+    }
+
+    #[test]
+    fn visible_tool_env_is_empty_when_nothing_probed_is_set() {
+        temp_env::with_var("BRAVE_API_KEY", None::<&str>, || {
+            assert!(visible_tool_env().is_empty());
+        });
+    }
+
+    /// An exported-but-empty variable reads as configured and is not: the
+    /// script that would use it gets an empty key and falls back anyway.
+    #[test]
+    fn visible_tool_env_treats_an_empty_value_as_absent() {
+        temp_env::with_var("BRAVE_API_KEY", Some(""), || {
+            assert!(visible_tool_env().is_empty());
+        });
     }
 
     #[test]

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -638,6 +638,84 @@ pub(super) fn lint_compacted_deliverables(blueprint: &Blueprint) -> Vec<LintFind
         .collect()
 }
 
+/// A `required` region no stage is able to populate, so nothing enforces it.
+///
+/// `required` reads as a guarantee: a stage may not complete while the region is
+/// empty. The runtime gate that provides it
+/// (`leviath_runtime::pipeline::unmet_required_regions`) opens with an escape -
+/// a stage granting neither `context_write` nor `context_append` is skipped
+/// entirely, because gating a stage that could never populate the region would
+/// loop until the re-entry cap and then proceed anyway.
+///
+/// That escape is right per stage and wrong per blueprint. If *no* stage using
+/// the layout grants a context-writing tool, the flag is inert everywhere: it
+/// looks like the deliverable is protected, and it is not. The failure it hides
+/// is quiet - `sources_index` stayed empty through all seven stages of a
+/// research run and the report stage invented a bibliography rather than
+/// reporting it had none.
+///
+/// Caller-seeded regions are exempt for the same reason the runtime exempts
+/// them: the caller owns those, and they are validated at spawn.
+pub(super) fn lint_required_regions_enforceable(blueprint: &Blueprint) -> Vec<LintFinding> {
+    let writes_context = |stage: &leviath_core::Stage| {
+        stage
+            .available_tools
+            .iter()
+            .any(|t| t == "context_write" || t == "context_append")
+    };
+
+    let mut findings = Vec::new();
+    let mut named: Vec<&str> = Vec::new();
+    for stage in &blueprint.stages {
+        let layout = stage
+            .context_layout
+            .as_ref()
+            .unwrap_or(&blueprint.context_layout);
+        for region in &layout.regions {
+            if !region.required
+                || matches!(
+                    region.seed,
+                    Some(leviath_core::layout::RegionSeed::CallerInput { .. })
+                )
+                || named.contains(&region.name.as_str())
+            {
+                continue;
+            }
+            // Any stage sharing this region's layout and able to write context
+            // is enough: that stage is where the gate binds.
+            let enforceable = blueprint.stages.iter().any(|s| {
+                let l = s
+                    .context_layout
+                    .as_ref()
+                    .unwrap_or(&blueprint.context_layout);
+                writes_context(s) && l.regions.iter().any(|r| r.name == region.name)
+            });
+            if enforceable {
+                continue;
+            }
+            named.push(region.name.as_str());
+            findings.push(
+                LintFinding::new(
+                    LintSeverity::Warning,
+                    "required-region-unenforceable",
+                    format!(
+                        "region '{}' is declared required, but no stage that uses it grants \
+                         context_write or context_append - so nothing can populate it and the \
+                         gate that would hold a stage for it is skipped. The flag has no effect",
+                        region.name
+                    ),
+                )
+                .with_fix(format!(
+                    "add context_write or context_append to available_tools on the stage that \
+                     owes '{}', or drop required = true",
+                    region.name
+                )),
+            );
+        }
+    }
+    findings
+}
+
 /// A region that evicts, bounded by a share of a window nobody has measured.
 ///
 /// Percentage budgets exist so an author's intent survives a change of model:

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -273,6 +273,7 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
     findings.extend(lint_output_reachable(blueprint));
     findings.extend(lint_dead_end_possible(blueprint));
     findings.extend(lint_compacted_deliverables(blueprint));
+    findings.extend(lint_required_regions_enforceable(blueprint));
     findings.extend(lint_unbounded_percentage(blueprint, env));
 
     let agent_permissions = blueprint.agent_tool_permissions();

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -2153,3 +2153,87 @@ conversation = { kind = "sliding_window", max_items = 20, budget = "12%" }
         );
     }
 }
+
+// ─── required-region-unenforceable ───────────────────────────────────────────
+
+/// The shape that made `required` inert: the flag is set, and every stage that
+/// could satisfy it lacks the tool to write context. The runtime gate skips
+/// such a stage by design, so nothing anywhere enforces the region - and the
+/// stage downstream, told to build its deliverable from it, invents one instead.
+#[test]
+fn a_required_region_no_stage_can_write_is_warned_about() {
+    let toml = manifest_with_regions(
+        r#"sources_index = { kind = "pinned", max_tokens = 2000, required = true }"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    let found = with_code(&findings, "required-region-unenforceable");
+    assert_eq!(found.len(), 1, "{:?}", codes(&findings));
+    assert_eq!(found[0].severity, LintSeverity::Warning);
+    assert!(
+        found[0].message.contains("sources_index"),
+        "{}",
+        found[0].message
+    );
+    assert!(
+        found[0]
+            .fix
+            .as_deref()
+            .is_some_and(|f| f.contains("context_append")),
+        "{:?}",
+        found[0].fix
+    );
+}
+
+/// One stage able to write context is enough: that is where the gate binds.
+#[test]
+fn a_required_region_some_stage_can_write_is_not_warned_about() {
+    let toml = manifest_with_regions(
+        r#"sources_index = { kind = "pinned", max_tokens = 2000, required = true }"#,
+    )
+    .replace(
+        "allow_complete = true",
+        "allow_complete = true\navailable_tools = [\"context_append\"]",
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(
+        with_code(&findings, "required-region-unenforceable").is_empty(),
+        "{:?}",
+        codes(&findings)
+    );
+}
+
+/// Caller-seeded regions are exempt, the same exemption the runtime gate makes:
+/// the caller owns them and they are validated at spawn, so no stage ever owed
+/// one. Without this every bundled agent's `query` region would warn.
+#[test]
+fn a_required_caller_seeded_region_is_not_warned_about() {
+    let toml = manifest_with_regions(
+        r#"query = { kind = "pinned", max_tokens = 2000, required = true, seed = "task" }"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(
+        with_code(&findings, "required-region-unenforceable").is_empty(),
+        "{:?}",
+        codes(&findings)
+    );
+}
+
+/// Named once per region however many stages share the layout: the fix is on
+/// the declaration, so repeating it per stage is noise.
+#[test]
+fn an_unenforceable_required_region_is_named_once_across_stages() {
+    let toml = manifest_with_regions(
+        r#"sources_index = { kind = "pinned", max_tokens = 2000, required = true }"#,
+    )
+    .replace(
+        "[context.regions]",
+        "[stages.second]\nmode = \"autonomous\"\n\
+         model = { models = [{ provider = \"anthropic\", model = \"claude-sonnet-5\" }] }\n\
+         max_iterations = 10\nallow_complete = true\n\n[context.regions]",
+    );
+    let hits = codes(&lint(&toml, &LintEnv::default()))
+        .into_iter()
+        .filter(|c| *c == "required-region-unenforceable")
+        .count();
+    assert_eq!(hits, 1);
+}

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -663,7 +663,11 @@ async fn real_daemon(args: commands::daemon::DaemonArgs) -> anyhow::Result<()> {
     // Who this daemon is, told to every client that asks in its handshake. A
     // long-lived client (`lev serve`, `lev dash`, the ACP bridge) compares it
     // against its own build to tell a restart from an update.
-    let identity = DaemonIdentity::this_process(leviath_cli::daemon::setup::CURRENT_BUILD);
+    // It also reports which tool credentials this process can see, because that
+    // is a fact only this process holds: a client asking its own environment is
+    // answering for a different one.
+    let identity = DaemonIdentity::this_process(leviath_cli::daemon::setup::CURRENT_BUILD)
+        .with_tool_env(leviath_cli::daemon::setup::visible_tool_env());
     tokio::spawn(async move {
         // `Ok(None)` means someone connected but is not this user: the listener
         // has already closed that connection and logged it. Skip and keep

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -493,6 +493,26 @@ pub struct RunFlags {
     /// before this field had.
     #[serde(default)]
     pub no_output_tools: bool,
+    /// `web_search` calls this run made, across every stage.
+    ///
+    /// Zero for an agent that never had the tool, which is most of them - the
+    /// pair says nothing about a run that could not have searched, the same
+    /// escape [`Self::no_output_tools`] applies to file modifications.
+    #[serde(default)]
+    pub searches_run: usize,
+    /// Of those, how many came back with nothing usable: no results, or a
+    /// diagnostic saying the search could not run.
+    ///
+    /// A research run whose searches all came back empty still finishes
+    /// `complete` and still writes a confident, fully cited report, because a
+    /// model handed an empty result set fills the gap from its training data
+    /// and cites what it remembers. One did exactly that across 47 consecutive
+    /// failed searches - no engine was configured - and nothing on disk
+    /// recorded that the report rested on nothing.
+    ///
+    /// `searches_empty == searches_run` with `searches_run > 0` is that run.
+    #[serde(default)]
+    pub searches_empty: usize,
     /// How many stages exhausted their `max_iterations`.
     #[serde(default)]
     pub max_iterations_hit: usize,

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -355,6 +355,24 @@ pub struct DaemonIdentity {
     pub build: String,
     /// The daemon's process id.
     pub pid: u32,
+    /// Names - never values - of the tool credentials this process can see in
+    /// its own environment, out of the fixed set its binary asked about.
+    ///
+    /// A daemon's environment is fixed at exec time and no client shares it, so
+    /// a tool that reads a key from the environment can be misconfigured in a
+    /// way only the daemon can observe: a CLI inspecting *its own* environment
+    /// reports the shell it was typed in, which is a different process. That is
+    /// how `lev doctor` came to report a working search key while every run
+    /// still fell back to Wikipedia, because the daemon had been started from a
+    /// shell that did not export it.
+    ///
+    /// `None` means the process did not say (an older daemon, or an embedder
+    /// driving the runtime directly) - which a caller must report as "unknown",
+    /// never as "sees nothing". Names only: the value never crosses the wire,
+    /// and the set is chosen by the binary rather than scraped, so this cannot
+    /// become a way to enumerate a daemon's secrets.
+    #[serde(default)]
+    pub tool_env: Option<Vec<String>>,
 }
 
 impl DaemonIdentity {
@@ -364,12 +382,36 @@ impl DaemonIdentity {
     /// every client of it are built from the same tree, so comparing versions
     /// across the wire compares releases. The build id lives with the binary
     /// (it hashes the working tree), so the binary passes it in.
+    ///
+    /// Reports no [`tool_env`](Self::tool_env): which credentials are worth
+    /// probing is the binary's business, not the runtime's, so a process that
+    /// cares adds them with [`with_tool_env`](Self::with_tool_env).
     pub fn this_process(build: impl Into<String>) -> Self {
         Self {
             version: env!("CARGO_PKG_VERSION").to_string(),
             build: build.into(),
             pid: std::process::id(),
+            tool_env: None,
         }
+    }
+
+    /// Report which tool credentials this process can see, by name.
+    ///
+    /// An empty list is a real answer ("asked, saw none") and is kept as one -
+    /// distinct from the `None` of a process that never said.
+    pub fn with_tool_env(mut self, names: Vec<String>) -> Self {
+        self.tool_env = Some(names);
+        self
+    }
+
+    /// Whether this process reported seeing the environment variable `name`.
+    ///
+    /// `None` when it did not report at all, so a caller can say "unknown"
+    /// rather than guess in either direction.
+    pub fn sees_tool_env(&self, name: &str) -> Option<bool> {
+        self.tool_env
+            .as_ref()
+            .map(|seen| seen.iter().any(|n| n == name))
     }
 
     /// The build to record when a process does not say. Named rather than a
@@ -2177,6 +2219,63 @@ mod tests {
                 std::process::id()
             )
         );
+    }
+
+    /// A process that never said which credentials it can see is "unknown", not
+    /// "sees nothing" - the distinction a caller needs to avoid reporting a
+    /// missing key against a daemon that simply predates the field.
+    #[test]
+    fn an_identity_that_did_not_report_tool_env_answers_unknown() {
+        let me = DaemonIdentity::this_process("abc123");
+        assert_eq!(me.tool_env, None);
+        assert_eq!(me.sees_tool_env("BRAVE_API_KEY"), None);
+    }
+
+    /// Reporting an empty list is a real answer - "asked, saw none" - and stays
+    /// distinguishable from having said nothing at all.
+    #[test]
+    fn reporting_no_tool_env_is_different_from_not_reporting() {
+        let blind = DaemonIdentity::this_process("abc123").with_tool_env(Vec::new());
+        assert_eq!(blind.tool_env, Some(Vec::new()));
+        assert_eq!(blind.sees_tool_env("BRAVE_API_KEY"), Some(false));
+    }
+
+    #[test]
+    fn a_reported_tool_env_answers_by_name() {
+        let seeing =
+            DaemonIdentity::this_process("abc123").with_tool_env(vec!["BRAVE_API_KEY".to_string()]);
+        assert_eq!(seeing.sees_tool_env("BRAVE_API_KEY"), Some(true));
+        assert_eq!(seeing.sees_tool_env("OTHER_KEY"), Some(false));
+    }
+
+    /// The names travel; nothing else does. A client on an older build reads
+    /// the rest of the identity and treats the field as absent.
+    #[test]
+    fn tool_env_round_trips_and_is_optional_on_the_wire() {
+        let seeing =
+            DaemonIdentity::this_process("abc123").with_tool_env(vec!["BRAVE_API_KEY".to_string()]);
+        let json = serde_json::to_string(&seeing).expect("an identity serializes");
+        assert_eq!(
+            serde_json::from_str::<DaemonIdentity>(&json).expect("and parses back"),
+            seeing
+        );
+        let older = format!(
+            r#"{{"version":"{}","build":"abc123","pid":{}}}"#,
+            env!("CARGO_PKG_VERSION"),
+            std::process::id()
+        );
+        let parsed: DaemonIdentity = serde_json::from_str(&older).expect("an older reply parses");
+        assert_eq!(parsed.sees_tool_env("BRAVE_API_KEY"), None);
+    }
+
+    /// Which credentials a process can see says nothing about which code it
+    /// runs, so it must not make two identities look like different builds.
+    #[test]
+    fn tool_env_does_not_affect_the_code_comparison() {
+        let blind = same_code(1);
+        let seeing = same_code(1).with_tool_env(vec!["BRAVE_API_KEY".to_string()]);
+        assert!(blind.same_code_as(&seeing));
+        assert!(!seeing.to_string().contains("BRAVE"), "{seeing}");
     }
 
     /// Versions must match; builds must match when both are known; a side that

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -15076,3 +15076,68 @@ fn the_prefix_hash_tracks_the_prefix() {
     assert_eq!(a.system_hash, b.system_hash);
     assert_ne!(a.system_hash, c.system_hash);
 }
+
+// ── search accounting ──
+
+/// A search that came back with hits is counted, and counted as not-empty.
+///
+/// The result shape is what the bundled `web_search` returns on success: a JSON
+/// array of objects.
+#[test]
+fn collect_tools_counts_a_search_that_found_results() {
+    let (_, flags) = count_modifications(
+        &[(
+            "web_search",
+            serde_json::json!({"query": "gpt-oss-20b vram"}),
+            r#"[{"title":"t","url":"u","snippet":"s","date":"2026-08-01"}]"#,
+        )],
+        &[],
+    );
+    assert_eq!(flags.searches_run, 1);
+    assert_eq!(flags.searches_empty, 0);
+}
+
+/// The three shapes that mean "this search did not see the web": a bare empty
+/// array, an empty result, and the bracketed diagnostic `web_search` returns
+/// when it has no engine, when the engine errored, or when it fell back to an
+/// encyclopedia. All three counted, because the model cannot act on any of them
+/// and the run needs to record that its evidence is missing.
+#[test]
+fn collect_tools_counts_every_shape_of_empty_search() {
+    let (_, flags) = count_modifications(
+        &[
+            ("web_search", serde_json::json!({"query": "a"}), "[]"),
+            ("web_search", serde_json::json!({"query": "b"}), "  "),
+            (
+                "web_search",
+                serde_json::json!({"query": "c"}),
+                "[web_search could not search the web. BRAVE_API_KEY is not set…]",
+            ),
+            (
+                "web_search",
+                serde_json::json!({"query": "d"}),
+                "[error] web_search: something broke",
+            ),
+        ],
+        &[],
+    );
+    assert_eq!(flags.searches_run, 4);
+    assert_eq!(flags.searches_empty, 4, "every one saw nothing");
+}
+
+/// A run whose agent never searched says nothing about searching - the same
+/// escape `no_output_tools` applies to file modifications. Zero and zero is not
+/// a diagnosis, and a reader must not be able to mistake it for one.
+#[test]
+fn collect_tools_counts_no_searches_when_none_were_made() {
+    let (_, flags) = count_modifications(
+        &[(
+            "read_file",
+            serde_json::json!({"path": "a.rs"}),
+            "fn main() {}",
+        )],
+        &[],
+    );
+    assert_eq!(flags.searches_run, 0);
+    assert_eq!(flags.searches_empty, 0);
+}

--- a/crates/leviath-runtime/src/pipeline/tool_results.rs
+++ b/crates/leviath-runtime/src/pipeline/tool_results.rs
@@ -433,6 +433,50 @@ pub(crate) fn stage_modifying_tools(
     names
 }
 
+/// Tally this batch's `web_search` calls onto the run's outcome flags, counting
+/// how many came back with nothing usable.
+///
+/// "Nothing usable" is an empty JSON array, an empty result, or a bracketed
+/// diagnostic - the shape `web_search` returns when it has no engine configured,
+/// when the engine errored, or when it fell back to an encyclopedia. All three
+/// mean the same thing to the run: this search did not see the web.
+///
+/// Worth persisting because the failure is otherwise invisible. A model handed
+/// an empty result set does not stop; it fills the gap from training data and
+/// cites what it remembers, so the run finishes `complete` with a fully cited
+/// report resting on nothing. One did that across 47 consecutive failed
+/// searches. `searches_empty == searches_run` is the only trace that survives.
+pub(crate) fn record_searches(
+    tool_calls: &[crate::components::ToolCall],
+    merged: &[(String, String)],
+    flags: Option<bevy_ecs::prelude::Mut<'_, crate::persistence::RunOutcomeFlags>>,
+) {
+    let Some(mut flags) = flags else { return };
+    for (call, (_id, result)) in tool_calls.iter().zip(merged.iter()) {
+        if leviath_tools::canonical_tool_name(&call.name) != "web_search" {
+            continue;
+        }
+        flags.0.searches_run += 1;
+        if search_found_nothing(result) {
+            flags.0.searches_empty += 1;
+        }
+    }
+}
+
+/// Whether a `web_search` result carries no usable hits.
+///
+/// Kept separate from [`record_searches`] because "what an empty search looks
+/// like" is the part that changes when the tool script does.
+fn search_found_nothing(result: &str) -> bool {
+    let trimmed = result.trim();
+    // A bracketed opener is the convention every script tool uses for a
+    // diagnostic ([error], [denied], and web_search's own prose), and no result
+    // set starts that way - a list of hits starts with `[{`.
+    trimmed.is_empty()
+        || trimmed == "[]"
+        || (trimmed.starts_with('[') && !trimmed.starts_with("[{"))
+}
+
 /// Tally this batch's file-modifying tool calls onto the stage's progress and the
 /// run's outcome flags. A result prefixed `[denied]` (permission layer) counts as
 /// *blocked* rather than successful - the agent tried and was refused, which a
@@ -546,7 +590,7 @@ pub fn collect_tools(
             blueprint,
             repetition,
             progress,
-            flags,
+            mut flags,
             activity,
             (metadata, agent_state),
         )) = agents.get_mut(outcome.entity)
@@ -586,6 +630,13 @@ pub fn collect_tools(
         // stage actually landed, so a `require_modifications` transition gate can
         // tell "analyzed the code and wrote nothing" from "made the change".
         // Done before file tracking, which rewrites successful results.
+        // Search accounting: a research run whose every search came back empty
+        // still writes a confident report, so the count has to survive the run.
+        record_searches(
+            &infer.tool_calls,
+            &merged,
+            flags.as_mut().map(bevy_ecs::prelude::Mut::reborrow),
+        );
         record_modifications(
             &infer.tool_calls,
             &merged,

--- a/crates/leviath-scripting/tests/bundled_web_tools_compile.rs
+++ b/crates/leviath-scripting/tests/bundled_web_tools_compile.rs
@@ -1,0 +1,36 @@
+//! The bundled `web_search` / `web_fetch` scripts must compile.
+//!
+//! They ship inside four agents and are only ever exercised by a live run, so a
+//! syntax slip in one of them is invisible until an agent's search silently
+//! stops working - which is exactly the failure this pair was rewritten to make
+//! impossible.
+
+use std::path::Path;
+
+/// Every bundled copy of the two web tools parses its annotations and compiles.
+#[test]
+fn the_bundled_web_tools_compile() {
+    let agents = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("crates/")
+        .join("leviath-cli")
+        .join("agents");
+
+    let mut checked = 0;
+    for agent in [
+        "researcher",
+        "deep-researcher",
+        "wide-researcher",
+        "data-analyst",
+    ] {
+        for tool in ["web_search.rhai", "web_fetch.rhai"] {
+            let path = agents.join(agent).join("tools").join(tool);
+            let src = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+            leviath_scripting::tool::check_source(&format!("{agent}/{tool}"), &src)
+                .unwrap_or_else(|e| panic!("{}: {e}", path.display()));
+            checked += 1;
+        }
+    }
+    assert_eq!(checked, 8, "four agents ship two web tools each");
+}

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -248,12 +248,19 @@ network at all.
 
 | Tool | Purpose | Arguments |
 | --- | --- | --- |
-| `web_search` | Search the web and return a JSON list of `{title, url, snippet}`. See below | `query`, `count` (optional, default 5) |
+| `web_search` | Search the web and return a JSON list of `{title, url, snippet, date}`. See below | `query`, `count` (optional, default 5), `freshness` (optional) |
 | `web_fetch` | Fetch a URL and return its readable text, with HTML stripped to prose. See below | `url` |
 
-`web_search` uses Brave Search when `BRAVE_API_KEY` is readable. Otherwise it falls back to a
-keyless Wikipedia search that needs no configuration. `web_fetch` truncates large pages, and a
-blocked or oversized request comes back as a diagnostic rather than failing the run.
+`web_search` uses Brave Search when `BRAVE_API_KEY` is readable. Otherwise there is no search
+engine, and the call falls back to a keyless Wikipedia lookup. Pass `freshness` to bound results by
+age, as `pd` / `pw` / `pm` / `py` (past day, week, month, year) or `YYYY-MM-DDtoYYYY-MM-DD`; each
+result carries the page's `date` when Brave knows it, which is what lets an agent judge "latest"
+against the run's own clock rather than its training cutoff.
+
+`web_fetch` truncates large pages, and a blocked or oversized request comes back as a diagnostic
+rather than failing the run. So does a page whose text is rendered client-side: fetching a Reddit
+thread returns HTML that strips to the single word "Reddit", so the tool names that instead of
+handing back the husk as if it were the discussion.
 
 Both ship with `data-analyst`, `researcher`, `deep-researcher`, and `wide-researcher`. To give
 another agent web access, copy them into that agent's `tools/`
@@ -268,9 +275,18 @@ directory, or drop them in `~/.leviath/tools/` to offer them to every agent.
 > allow_env_vars = ["BRAVE_API_KEY"]
 > ```
 >
-> Without that line the tool falls back to Wikipedia and says nothing about why. If your searches
-> come back looking like encyclopedia entries, this is usually the reason. See
+> Without that line the tool falls back to Wikipedia. It now says so in every result rather than
+> returning a bare empty list, and `lev doctor` reports it as a `search` warning, but the searches
+> still find nothing until you add the line. See
 > [environment variables](/docs/configuration#environment-variables).
+
+A search that cannot reach an engine is the quietest failure a research agent has. The model is
+handed an empty result set, cannot tell it apart from "nobody has written about this", and closes
+the gap from its training data, citing what it remembers. The report comes out confident and
+fully referenced. Three things make that visible now: `web_search` returns prose naming the
+problem instead of `[]`, `lev doctor` runs a `search` check, and every run records `searches_run`
+and `searches_empty` in its `meta.json` - equal counts, with a non-zero total, mean the run saw
+nothing and wrote a report anyway.
 
 > [!WARNING]
 > Fetches cannot reach loopback, private, or link-local addresses unless you set

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -277,8 +277,20 @@ directory, or drop them in `~/.leviath/tools/` to offer them to every agent.
 >
 > Without that line the tool falls back to Wikipedia. It now says so in every result rather than
 > returning a bare empty list, and `lev doctor` reports it as a `search` warning, but the searches
-> still find nothing until you add the line. See
+> still find nothing until you add the line. The grant is config, which the daemon re-reads before
+> every run, so adding it needs no restart. See
 > [environment variables](/docs/configuration#environment-variables).
+
+> [!IMPORTANT]
+> The key itself is different: it has to be in **the daemon's** environment, not just the shell you
+> type `lev` in. A process inherits its environment when it starts, so a daemon that was already
+> running when you exported the key cannot see it, and every search falls back to Wikipedia while
+> your own shell looks correctly configured.
+>
+> `lev doctor` asks the daemon rather than itself, so it catches exactly this and tells you to
+> `lev daemon restart` from a shell that exports the key. (A daemon started from a desktop session
+> or a service manager inherits that environment, not your shell's - export the key where the
+> daemon actually starts.)
 
 A search that cannot reach an engine is the quietest failure a research agent has. The model is
 handed an empty result set, cannot tell it apart from "nobody has written about this", and closes


### PR DESCRIPTION
A `deep-researcher` run asked which local LLM suits a 16GB GPU and produced a confident, fully cited report recommending models from years ago. The models were the symptom.

**Every one of its 47 `web_search` calls — 30 in the parent, 17 in a single worker — returned `[]`.** The run had no live search at all, and nothing anywhere said so.

## Why

`web_search` falls back to a keyless Wikipedia lookup when `BRAVE_API_KEY` is not readable. Two things stacked:

1. No key was set, and
2. the name ends in `KEY`, so `is_sensitive_env_name` classes it a credential and `ScriptHost::env_var` refuses it unless `[security] allow_env_vars` lists it. **Exporting the key alone changes nothing** — and the script's `try { env_var(..) } catch { key = "" }` swallowed `[denied]` and "not set" identically.

Wikipedia has nothing for `"best quantized LLM 16GB VRAM coding agent function calling 2026"`, so the tool returned a bare `[]` — which a model cannot distinguish from "nobody has written about this". It closed the gap from training data and cited what it remembered.

Three consequences, all visible in the run's own files:

- **The fan-out laundered one stale recollection into four independent-looking confirmations.** `split_prompt` baked remembered names straight into the work items (*"BFCL scores for Qwen3-14B, Qwen2.5-14B, Llama-3.1-8B, Mistral-Nemo-12B, Phi-4-14B"*). A worker starts from a clean context and cannot question the premise, so three of four went off to deep-research a stale list.
- **The rigor apparatus never ran.** `sources_index`, `claims` and `contradictions` were **0 tokens across all 7 stages**; `context_append` was never called once. `synthesize` is told to build from them, found them empty, and wrote a 14-entry bibliography anyway — including Reddit threads with invented upvote counts, for pages that were never fetched (every Reddit fetch returned the 6-character JS shell `"Reddit"`).
- **Knowing the date did not help.** The correct date reached the parent and all four children, and both prompts say to treat it as authoritative. Date awareness without a recency *mechanism* is inert.

## What this changes

Make each layer say what it is doing:

- **`web_search`** returns prose naming the problem instead of an empty array, and tells a missing key apart from a refused one so the message is the fix. Wikipedia results are labelled as undated encyclopedia articles rather than passed off as search hits. A new `freshness` argument bounds results by age, and each hit carries the page's date — which is what makes "judge latest against the run's clock" actionable.
- **`web_fetch`** names a page whose text is rendered client-side instead of returning the husk.
- **`lev doctor`** grows a `search` check. It asks **the daemon** what it can see rather than inspecting itself: a daemon's environment is fixed at exec time and is not the shell `doctor` was typed in, so a CLI-only check reports healthy against a daemon started before the key existed. `DaemonIdentity` — already on the authentication handshake — now also carries `tool_env`, the names (never values) of tool credentials the process can read, out of a fixed list in the source. `CheckStatus` gains `Warn`: an install with no search key is fine for anyone not running a research agent.
- **Runs record `searches_run` / `searches_empty`** in `meta.json`. Equal counts with a non-zero total is the run above, and it left no other trace.
- **The fan-out prompts** must ground every proper noun in what was actually gathered.
- **`sources_index` is `required`** on the four web agents, and the synthesis prompts refuse to cite what the run did not read. An empty bibliography is now reported as one.
- **A new `required-region-unenforceable` lint.** The runtime gate skips any stage without a context-writing tool, so a `required` region no stage can write is guaranteed nothing — the flag looks load-bearing and is inert.

`data-analyst` also gains the `environment` region and `current_time`; it gathers live data and had no idea what "current" meant.

## Verification

Beyond the suite: two isolated daemons, same question, same model, same config.

| | with key | without key |
|---|---|---|
| searches | 6 run, **0 empty** | 3 run, **3 empty** |
| `sources_index` | real dated URLs | *"web_search unavailable — topic is unresearched"* |
| report | names GPT-OSS 20B, Qwen3-Coder 32B, Qwen3.6, Gemma 4 12B with resolvable citations | **"Status: UNRESEARCHED"**, every finding low confidence, zero invented sources |

The no-key run is the original failure reproduced — and it now reports honestly instead of fabricating.

The `doctor` check was verified against three daemons in turn: blind daemon with the key exported in the shell warns and names `lev daemon restart`; the same daemon restarted with the key reports `readable by the daemon`; dropping the grant from config warns about `allow_env_vars` and says no restart is needed (config is re-read per spawn).

Blueprint versions bumped on all four changed agents, per #6716b360 — without it the edits never reach anyone who already installed one.

Workspace suite green, coverage 100% on all 13 packages, clippy and `cargo xtask docs` clean.
