### PR TITLE
fix(serve): give the WebSocket pong its own deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ same list.
 
 ## Unreleased
 
+- Fixed: a WebSocket subscriber that drops a single pong is no longer
+  disconnected. The server's liveness check had no deadline of its own - a ping
+  left unanswered by the time the *next* ping was due meant a dead peer, so at
+  the 20-second cadence one lost packet or one tab that resumed a moment late
+  cost the client its stream. The pong deadline is now its own value (60
+  seconds, three cadences), so a peer gets three chances to answer, and the
+  test that covers a ponging client no longer has to win a 60 ms round trip on
+  a loaded CI runner to pass.
+
 - Fixed: agents no longer waste turns calling `read_file` on a context region.
   A stage that routes tool output into a region left a pointer in the
   conversation ending "read that region for the full result" - an instruction

--- a/crates/leviath-cli/src/commands/serve/testutil.rs
+++ b/crates/leviath-cli/src/commands/serve/testutil.rs
@@ -163,23 +163,39 @@ impl WsTestClient {
     }
 
     /// Read one server frame (unmasked) and return (opcode, payload).
+    ///
+    /// Each read names the frame part it was after, so a server that hung up
+    /// mid-stream fails with "the server closed the connection before ..."
+    /// rather than a bare `Os { code: 54 }` from an anonymous `unwrap`.
     pub(super) async fn recv_frame(&mut self) -> (u8, Vec<u8>) {
         let mut header = [0u8; 2];
-        self.stream.read_exact(&mut header).await.unwrap();
+        self.stream
+            .read_exact(&mut header)
+            .await
+            .expect("the server closed the connection before the frame header");
         let opcode = header[0] & 0x0f;
         let mut len = (header[1] & 0x7f) as usize;
         if len == 126 {
             let mut ext = [0u8; 2];
-            self.stream.read_exact(&mut ext).await.unwrap();
+            self.stream
+                .read_exact(&mut ext)
+                .await
+                .expect("the server closed the connection before the 16-bit length");
             len = u16::from_be_bytes(ext) as usize;
         } else if len == 127 {
             let mut ext = [0u8; 8];
-            self.stream.read_exact(&mut ext).await.unwrap();
+            self.stream
+                .read_exact(&mut ext)
+                .await
+                .expect("the server closed the connection before the 64-bit length");
             len = u64::from_be_bytes(ext) as usize;
         }
         let mut payload = vec![0u8; len];
         if len > 0 {
-            self.stream.read_exact(&mut payload).await.unwrap();
+            self.stream
+                .read_exact(&mut payload)
+                .await
+                .expect("the server closed the connection before the frame payload");
         }
         (opcode, payload)
     }

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -8,10 +8,20 @@ use tokio::sync::broadcast;
 use super::events::ServerEvent;
 use super::types::*;
 
-/// How often the server pings an idle-or-not connection. A peer that has not
-/// ponged by the NEXT ping is declared dead. Browsers answer pings
-/// automatically, so a live client never trips this.
+/// How often the server pings an idle-or-not connection. Browsers answer pings
+/// automatically, so a live client never trips the deadline below.
 const WS_PING_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// How long the oldest unanswered ping may stay unanswered before the peer is
+/// declared dead.
+///
+/// Deliberately a separate knob from [`WS_PING_INTERVAL`] rather than "gone by
+/// the next ping": the cadence answers "how often do we check", the deadline
+/// answers "how long do we wait", and conflating them meant a single dropped
+/// pong - one lost packet, one paused tab that resumed a moment late -
+/// disconnected an otherwise healthy client. At three times the cadence a peer
+/// gets three chances to answer before it is dropped.
+const WS_PONG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// How long one outbound frame may take to send+flush before the peer is
 /// declared dead. A peer that stopped reading without closing (a backgrounded
@@ -83,14 +93,16 @@ async fn handle_ws(
         rx,
         filter_run_id,
         WS_PING_INTERVAL,
+        WS_PONG_TIMEOUT,
         WS_SEND_TIMEOUT,
         greeting,
     )
     .await
 }
 
-/// Core of the WS relay, with the ping cadence and send deadline injected so
-/// tests can drive the dead-peer branches without real multi-second waits.
+/// Core of the WS relay, with the ping cadence, pong deadline and send
+/// deadline injected so tests can drive the dead-peer branches without real
+/// multi-second waits.
 ///
 /// The `select!` is deliberately **unbiased**: the old `biased;` variant
 /// polled the event branch first every iteration, so under a busy run the
@@ -101,6 +113,7 @@ async fn handle_ws_with(
     mut rx: broadcast::Receiver<ServerEvent>,
     filter_run_id: Option<String>,
     ping_every: std::time::Duration,
+    pong_timeout: std::time::Duration,
     send_timeout: std::time::Duration,
     greeting: Option<ServerEvent>,
 ) {
@@ -116,13 +129,17 @@ async fn handle_ws_with(
     // live, and pinging in the handshake's shadow confuses simple clients.
     let mut ping = tokio::time::interval_at(tokio::time::Instant::now() + ping_every, ping_every);
     ping.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-    let mut awaiting_pong = false;
+    // When the oldest still-unanswered ping went out, or `None` when every
+    // ping so far has been answered. A pong clears it; the deadline is
+    // measured from it, so answering late still costs nothing as long as it
+    // arrives inside `pong_timeout`.
+    let mut unanswered_since: Option<tokio::time::Instant> = None;
     loop {
         tokio::select! {
             msg = socket.recv() => {
                 match msg {
                     Some(Ok(Message::Close(_))) | None => break,
-                    Some(Ok(Message::Pong(_))) => awaiting_pong = false,
+                    Some(Ok(Message::Pong(_))) => unanswered_since = None,
                     Some(Err(_)) => break,
                     _ => {} // Ignore other client messages
                 }
@@ -153,10 +170,14 @@ async fn handle_ws_with(
                 }
             }
             _ = ping.tick() => {
-                // An unanswered previous ping, and a ping that cannot be
-                // sent, both mean the peer is gone without a Close (sleep,
-                // kill, dropped NAT mapping).
-                if awaiting_pong
+                // A ping left unanswered past the deadline, and a ping that
+                // cannot be sent, both mean the peer is gone without a Close
+                // (sleep, kill, dropped NAT mapping). Anything short of the
+                // deadline just gets another ping: a peer that missed one and
+                // answers the next is a live peer.
+                let overdue = unanswered_since
+                    .is_some_and(|since| since.elapsed() >= pong_timeout);
+                if overdue
                     || !send_within(
                         &mut socket,
                         send_timeout,
@@ -166,7 +187,7 @@ async fn handle_ws_with(
                 {
                     break;
                 }
-                awaiting_pong = true;
+                unanswered_since.get_or_insert_with(tokio::time::Instant::now);
             }
         }
     }
@@ -264,7 +285,7 @@ mod tests {
         assert_text_frame(0x2);
     }
 
-    /// A server whose WS route uses injected ping/send deadlines, so the
+    /// A server whose WS route uses injected ping/pong/send deadlines, so the
     /// dead-peer branches can be driven in tens of milliseconds. Shares the
     /// graceful-shutdown server plumbing with `spawn_test_server_with_shutdown`
     /// (whose shutdown path a dedicated test exercises); the shutdown sender
@@ -272,6 +293,7 @@ mod tests {
     async fn spawn_ping_test_server(
         state: AppState,
         ping_every: std::time::Duration,
+        pong_timeout: std::time::Duration,
         send_timeout: std::time::Duration,
     ) -> std::net::SocketAddr {
         let app = Router::new()
@@ -282,7 +304,15 @@ mod tests {
                         let rx = state.event_tx.subscribe();
                         let greeting = link_greeting(&state);
                         ws.on_upgrade(move |socket| {
-                            handle_ws_with(socket, rx, None, ping_every, send_timeout, greeting)
+                            handle_ws_with(
+                                socket,
+                                rx,
+                                None,
+                                ping_every,
+                                pong_timeout,
+                                send_timeout,
+                                greeting,
+                            )
                         })
                     },
                 ),
@@ -330,6 +360,9 @@ mod tests {
         let addr = spawn_ping_test_server(
             state,
             std::time::Duration::from_millis(80),
+            // Shorter than the cadence, so the tick after the first ping is
+            // already past the deadline: two ticks, not two seconds.
+            std::time::Duration::from_millis(1),
             std::time::Duration::from_secs(5),
         )
         .await;
@@ -342,6 +375,13 @@ mod tests {
     }
 
     /// A peer that answers pings stays connected across many intervals.
+    ///
+    /// This depends on the *pong deadline*, not on wall-clock scheduling: the
+    /// cadence is fast so the test is quick, but the deadline is 30 s, so the
+    /// client may be descheduled for an age between receiving a ping and
+    /// answering it and still be a live peer. The exchange count is fixed
+    /// rather than bounded by a wall clock for the same reason - a loaded
+    /// runner makes the test slower, never redder.
     #[tokio::test]
     async fn ws_stays_alive_when_client_pongs() {
         let state = test_state();
@@ -349,6 +389,7 @@ mod tests {
         let addr = spawn_ping_test_server(
             state,
             std::time::Duration::from_millis(60),
+            std::time::Duration::from_secs(30),
             std::time::Duration::from_secs(5),
         )
         .await;
@@ -356,14 +397,13 @@ mod tests {
         let mut client = WsTestClient::connect(addr, "/ws").await;
         wait_for_receiver_count(&tx, 1).await;
 
-        // Answer pings for ~5 intervals. Nothing else is broadcast on this
+        // Answer five consecutive pings. Nothing else is broadcast on this
         // channel, so every inbound frame is a ping.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(400);
-        while std::time::Instant::now() < deadline {
+        for _ in 0..5 {
             let (opcode, payload) =
-                tokio::time::timeout(std::time::Duration::from_secs(5), client.recv_frame())
+                tokio::time::timeout(std::time::Duration::from_secs(30), client.recv_frame())
                     .await
-                    .expect("expected a ping before the deadline");
+                    .expect("the server keeps pinging a peer that answers");
             assert_eq!(opcode, 0x9, "only pings flow on an idle channel");
             client.send_frame(0xA, &payload).await; // masked pong
         }
@@ -371,6 +411,48 @@ mod tests {
             tx.receiver_count(),
             1,
             "a ponging client must not be disconnected"
+        );
+        client.send_close().await;
+        wait_for_receiver_count(&tx, 0).await;
+    }
+
+    /// One dropped pong is not a dead peer: the client ignores the first ping
+    /// and answers the second, and the connection survives. Before the pong
+    /// deadline was split from the ping cadence this was fatal - the tick that
+    /// sent the second ping found the first unanswered and closed the socket.
+    #[tokio::test]
+    async fn ws_survives_a_missed_pong_when_the_next_one_answers() {
+        let state = test_state();
+        let tx = state.event_tx.clone();
+        let addr = spawn_ping_test_server(
+            state,
+            std::time::Duration::from_millis(40),
+            std::time::Duration::from_secs(30),
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+
+        let mut client = WsTestClient::connect(addr, "/ws").await;
+        wait_for_receiver_count(&tx, 1).await;
+
+        let (first, _) =
+            tokio::time::timeout(std::time::Duration::from_secs(30), client.recv_frame())
+                .await
+                .expect("the first ping arrives");
+        assert_eq!(first, 0x9, "only pings flow on an idle channel");
+        // ...and goes unanswered. Reaching a second ping at all is the
+        // assertion: the old code broke the loop instead of sending it.
+        let (second, payload) =
+            tokio::time::timeout(std::time::Duration::from_secs(30), client.recv_frame())
+                .await
+                .expect("a missed pong still earns another ping");
+        assert_eq!(second, 0x9);
+        client.send_frame(0xA, &payload).await; // masked pong, late but in time
+
+        assert_eq!(
+            tx.receiver_count(),
+            1,
+            "a peer that answers the second ping is alive"
         );
         client.send_close().await;
         wait_for_receiver_count(&tx, 0).await;
@@ -385,6 +467,7 @@ mod tests {
         let addr = spawn_ping_test_server(
             state,
             std::time::Duration::from_secs(3600), // pings out of the picture
+            std::time::Duration::from_secs(3600),
             std::time::Duration::from_millis(100),
         )
         .await;


### PR DESCRIPTION
Closes #521.

## The bug

`handle_ws_with` had no pong deadline. It declared a peer dead when the *next*
ping tick found the previous ping unanswered, so the ping cadence silently
doubled as the deadline:

```rust
_ = ping.tick() => {
    if awaiting_pong || !send_within(..., Message::Ping(...)).await { break; }
    awaiting_pong = true;
}
```

Two consequences:

- **In production**, at `WS_PING_INTERVAL` = 20 s, a single dropped pong
  disconnected a healthy client. One lost packet, one backgrounded tab that
  resumed a moment late, and the subscriber lost its stream.
- **In tests**, `ws_stays_alive_when_client_pongs` set a 60 ms cadence, so its
  client had to receive a ping and get a pong back within 60 ms, about six
  times in a row, through a shared current-thread runtime on a runner running
  the whole 3600-test suite. Miss one window and the server dropped the socket;
  the client's next `read_exact` panicked with `Os { code: 54 }`.

## The fix (option 1 from the issue)

`WS_PONG_TIMEOUT` is now its own constant - 60 s against the 20 s cadence, so a
peer gets three chances to answer - and the handler tracks *when* the oldest
still-unanswered ping went out rather than a bare "one is outstanding" flag. A
pong clears it; the deadline is measured from it.

The cadence now answers "how often do we check" and the deadline answers "how
long do we wait", which is what makes a fast test cadence stop implying a tight
test deadline.

## Tests

- `ws_stays_alive_when_client_pongs` keeps the 60 ms cadence but takes a 30 s
  pong deadline and a **fixed** five exchanges instead of a 400 ms wall-clock
  loop. A loaded runner now makes it slower, never redder. The comment says
  what it depends on.
- New: `ws_survives_a_missed_pong_when_the_next_one_answers` - the client
  ignores the first ping and answers the second. Verified it discriminates:
  with the deadline set to 1 ms it fails with "the server closed the connection
  before the frame header".
- `ws_closes_a_client_that_never_pongs` still drives the dead-peer branch, in
  two ticks (~160 ms), by taking a deadline shorter than its cadence.
- `WsTestClient::recv_frame`'s four bare `.unwrap()`s now `.expect()` with the
  frame part each read was after, so a mid-stream hangup says so instead of
  surfacing an anonymous `Os { code: 54 }`.

No behaviour change for a peer that answers within a minute, and no config
surface added.
