### PR TITLE
fix(models): let `lev models list --provider` reach a script provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ same list.
 
 ## Unreleased
 
+- Fixed: `lev models list --provider <name>` now reaches a Rhai script
+  provider. `ProviderRegistry::provider_names()` enumerates natively registered
+  providers only, and the script layer is consulted by `get()`, never by that -
+  so the one command `rhai-providers.md` prescribes for smoke-testing a
+  provider script answered "No models available." for a working provider and a
+  syntactically broken one alike. A `--provider` naming neither a registered
+  provider nor a row in the built-in table is now loaded through the script
+  layer and asked for its catalog, with or without `--remote` (a script names
+  its models at run time, so there is nothing local to read). A script that
+  will not load, and an error raised by its `list_models`, are each reported by
+  name instead of being folded into an empty table. `lev doctor --help` and the
+  CLI reference no longer say a script provider cannot be listed.
+
 - Added: `[limits.max_concurrent_inferences_by_provider]` caps in-flight
   requests to one provider across every model it serves, and
   `[limits.max_concurrent_inferences_by_model]` overrides the global cap for one

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -75,9 +75,9 @@ So config/resolve/inference OK with daemon FAIL means the daemon is the
 problem, not your keys - the distinction this command exists to make.
 
 `--model` takes the same forms `lev run --model` does: `provider/model` picks
-both (the way to reach a Rhai script provider, which cannot be listed), and a
-bare model id pairs with your default_provider. Use it to try a model string
-before wiring it into a blueprint.
+both (the way to reach a Rhai script provider by name), and a bare model id
+pairs with your default_provider. Use it to try a model string before wiring it
+into a blueprint.
 
 Two inferences are billed per run, capped at 64 output tokens each.
 `--no-daemon` stops after the third check and bills one.

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -2047,6 +2047,41 @@ mod tests {
         .await;
     }
 
+    /// A script provider that names a model the built-in table also carries
+    /// replaces that row rather than adding a second one, the same way a
+    /// `--remote` fetch does. `--all` is what keeps the built-in rows in the
+    /// table for it to collide with.
+    #[tokio::test]
+    async fn a_script_provider_overrides_a_builtin_row_with_the_same_id() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        let builtin_id = builtin_table()[0].model_id.to_string();
+        std::fs::write(
+            dir.path().join("mirror.rhai"),
+            format!(
+                "fn initialize(config) {{ #{{ ok: true }} }}\n\
+                 fn inference(state, request) {{ #{{ content: \"ok\" }} }}\n\
+                 fn list_models(state) {{ [ #{{ id: \"{builtin_id}\", \
+                 max_context_tokens: 4096 }} ] }}"
+            ),
+        )
+        .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-a_script_provider_overrides_a_builtin_row",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: Some("mirror".to_string()),
+                    all: true,
+                    json: true,
+                };
+                let result = list_with_registry(args, &script_registry(dir)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
     /// A built-in provider name is answered from the table, not by trying to
     /// load a script of that name - `--provider openai` with no OpenAI key is
     /// an empty table, exactly as it was before script providers were reached.

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -553,6 +553,19 @@ async fn list_with_registry(
         }
     }
 
+    // A `--provider` naming something neither registered natively nor present
+    // in the built-in table is a script provider (or a typo). Ask the script
+    // layer: it is the only thing that can answer for one. A name the built-in
+    // table knows is left alone - `--provider openai` with no OpenAI key is an
+    // empty table, exactly as it has always been.
+    let mut script_provider_answered = false;
+    if let Some(ref name) = args.provider
+        && !available.contains(name)
+        && !builtin_table().iter().any(|e| e.provider == name.as_str())
+    {
+        script_provider_answered = merge_script_provider(&registry, name, &mut entries).await;
+    }
+
     // Apply provider filter (after remote merge so we respect the filter).
     if let Some(ref filter) = args.provider {
         entries.retain(|e| &e.provider == filter);
@@ -590,14 +603,23 @@ async fn list_with_registry(
     }
 
     if entries.is_empty() {
-        // Reachable two ways now: a `--provider` filter that matches nothing,
-        // or no configured provider at all (a fresh install). Both want the
-        // same nudge, and the second is the one worth naming.
+        // Reachable three ways now: a `--provider` filter that matches nothing,
+        // no configured provider at all (a fresh install), or a script provider
+        // that loaded and named no models. The last one is not the same answer
+        // as the other two - the script compiled and its credentials were
+        // accepted - so it says so rather than reading as "nothing here".
         println!("No models available.");
-        println!(
-            "(configure a provider with `lev setup`, or pass --all to see every \
-             model Leviath knows about)"
-        );
+        if script_provider_answered {
+            println!(
+                "(the script provider loaded and listed no models - its script \
+                 may not define `list_models(state)`)"
+            );
+        } else {
+            println!(
+                "(configure a provider with `lev setup`, or pass --all to see every \
+                 model Leviath knows about)"
+            );
+        }
         return Ok(());
     }
 
@@ -634,6 +656,51 @@ async fn list_with_registry(
     }
 
     Ok(())
+}
+
+/// Load the script provider called `name` and merge whatever `list_models`
+/// answers into `entries`. Returns whether it answered at all.
+///
+/// A script provider defines its catalog at run time, so the built-in table
+/// has no rows for one and `lev models list --provider <name>` used to print
+/// "No models available." for a perfectly good provider. Loading it here is
+/// what makes that command the smoke test `rhai-providers.md` prescribes: it
+/// compiles the script, runs `initialize`, and calls `list_models`.
+///
+/// Both failure paths report and continue rather than erroring, matching what
+/// `--remote` has always done for a native provider that will not answer - the
+/// non-zero gate for a provider script is `lev doctor -m <provider>/<model>`.
+async fn merge_script_provider(
+    registry: &leviath_runtime::ProviderRegistry,
+    name: &str,
+    entries: &mut Vec<ModelInfo>,
+) -> bool {
+    let Some(provider) = registry.get(name) else {
+        // Either a name with nothing behind it, or a script that failed to
+        // compile - the script layer logged which as it happened. Say the part
+        // it cannot: that this is why the table below is empty.
+        eprintln!(
+            "Warning: no provider named '{}' is configured, and no script \
+             provider by that name loaded",
+            name
+        );
+        return false;
+    };
+    match provider.list_models().await {
+        Ok(models) => {
+            for rm in models {
+                match entries.iter_mut().find(|e| e.id == rm.id) {
+                    Some(existing) => *existing = rm,
+                    None => entries.push(rm),
+                }
+            }
+            true
+        }
+        Err(e) => {
+            eprintln!("Warning: could not fetch models from '{}': {}", name, e);
+            false
+        }
+    }
 }
 
 // ─── show ─────────────────────────────────────────────────────────────────────
@@ -1865,6 +1932,141 @@ mod tests {
                     json: false,
                 };
                 let result = list_with_registry(args, &mock_registry("mock", vec![], false)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
+    /// A registry whose only provider is a `.rhai` script in `dir`, exactly as
+    /// `lev models list` builds one for a real install. Not a mock: the script
+    /// is compiled, `initialize` runs, and `list_models` is dispatched, which
+    /// is the whole point of the command this covers.
+    fn script_registry(
+        dir: std::path::PathBuf,
+    ) -> impl Fn(&Config) -> Result<leviath_runtime::ProviderRegistry, leviath_providers::ProviderError>
+    {
+        move |_config: &Config| {
+            let layer = leviath_runtime::script_provider::ScriptProviderLayer::new(
+                dir.clone(),
+                std::collections::HashMap::new(),
+                std::collections::HashMap::new(),
+                None,
+                Vec::new(),
+            );
+            Ok(leviath_runtime::ProviderRegistry::new()
+                .with_script_layer(std::sync::Arc::new(layer)))
+        }
+    }
+
+    /// The command `rhai-providers.md` prescribes as a provider script's smoke
+    /// test: it has to reach the script layer, since the built-in table has no
+    /// row for a provider that names its own models at run time (issue #523).
+    #[tokio::test]
+    async fn list_provider_reaches_a_script_provider() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        std::fs::write(
+            dir.path().join("scripted.rhai"),
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { [ #{ id: \"scripted-large\", max_context_tokens: 32768 } ] }",
+        )
+        .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-list_provider_reaches_a_script_provider",
+            |_fake_dir| async move {
+                // JSON so the merged row is the whole output, not a table cell.
+                let args = ListArgs {
+                    remote: false,
+                    provider: Some("scripted".to_string()),
+                    all: false,
+                    json: true,
+                };
+                let result = list_with_registry(args, &script_registry(dir)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
+    /// A script provider that loads but names no models is not the same answer
+    /// as "nothing is configured", and does not print the `lev setup` nudge.
+    #[tokio::test]
+    async fn list_says_when_a_script_provider_loaded_and_listed_nothing() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        std::fs::write(
+            dir.path().join("quiet.rhai"),
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }",
+        )
+        .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-list_says_when_a_script_provider_listed_nothing",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: Some("quiet".to_string()),
+                    all: false,
+                    json: false,
+                };
+                let result = list_with_registry(args, &script_registry(dir)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
+    /// The auth failure the docs promise surfaces here: `list_models` threw, so
+    /// the command says so instead of printing an empty table and nothing else.
+    #[tokio::test]
+    async fn list_reports_a_script_provider_that_cannot_list() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        std::fs::write(
+            dir.path().join("angry.rhai"),
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { throw \"401 Unauthorized\" }",
+        )
+        .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-list_reports_a_script_provider_that_cannot_list",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: Some("angry".to_string()),
+                    all: false,
+                    json: false,
+                };
+                let result = list_with_registry(args, &script_registry(dir)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
+    /// A built-in provider name is answered from the table, not by trying to
+    /// load a script of that name - `--provider openai` with no OpenAI key is
+    /// an empty table, exactly as it was before script providers were reached.
+    #[tokio::test]
+    async fn list_provider_naming_a_builtin_does_not_reach_the_script_layer() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        // A script that would fail to compile if it were ever reached.
+        std::fs::write(dir.path().join("openai.rhai"), "this is not rhai (")
+            .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-list_provider_naming_a_builtin_skips_scripts",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: false,
+                    provider: Some("openai".to_string()),
+                    all: true,
+                    json: false,
+                };
+                let result = list_with_registry(args, &script_registry(dir)).await;
                 assert!(result.is_ok());
             },
         )

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -292,6 +292,10 @@ it returns `false`.
 | `lev models list` | `-p/--provider <NAME>`, `-r/--remote` (live from the provider APIs, slower), `-a/--all` (include providers with no credential here) |
 | `lev models show <MODEL>` | `-p/--provider <NAME>` (required for a remote lookup), `-r/--remote` |
 
+`--provider` naming a [Rhai script provider](/docs/rhai-providers) loads that script and calls its
+`list_models`, with or without `--remote`: a script names its own catalog at run time, so there is
+no built-in table to read it from.
+
 ### `lev agent-client`
 
 Serve an agent over the [Agent Client Protocol](/docs/agent-client-protocol) as JSON-RPC on stdio.
@@ -588,9 +592,9 @@ the run. Nothing is left in `lev ps` or on disk.
 
 `--model` takes `provider/model` to pick both, and a bare model id pairs with your
 `default_provider`. `--model provider/model` is the way to reach a
-[Rhai script provider](/docs/rhai-providers), which
-is resolved by name and so cannot be listed. Use it to try a model string before wiring it into a
-blueprint.
+[Rhai script provider](/docs/rhai-providers), which is resolved by name. Use it to try a model
+string before wiring it into a blueprint - unlike `lev models list`, it exits non-zero when the
+model cannot be reached.
 
 `lev doctor` exits non-zero when a check fails, so it works as a CI gate. It bills two inferences
 per run, each capped at 64 output tokens; `--no-daemon` bills one.

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -50,8 +50,9 @@ lev models list --all                        # every provider, even unconfigured
 ```
 
 > [!NOTE]
-> Without `--remote`, `lev models list` prints a built-in table of well-known models. It is a
-> convenience, not the catalog. A model absent from it is not necessarily invalid: `lev validate`
+> Without `--remote`, `lev models list` prints a built-in table of well-known models (the exception
+> is `--provider <name>` naming a [script provider](/docs/rhai-providers), which is always asked
+> directly - it has no row in that table). It is a convenience, not the catalog. A model absent from it is not necessarily invalid: `lev validate`
 > flags an unrecognized string with an `unknown-model` warning, never an error, and the string is
 > still sent to the provider exactly as written. Locally an unrecognized model gets conservative
 > capability assumptions: 128K context and 8192 output on OpenRouter, 8192 context and 4096 output

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -340,15 +340,20 @@ For an API that is not OpenAI-shaped, rewrite `build_body` and the response pars
 match its wire format.
 
 ```bash
-lev models list --provider groq   # calls list_models, exercising auth and parse_json end to end
+lev models list --provider groq   # compiles the script and calls list_models
+lev doctor -m groq/<model>        # the same, then a real inference; exits non-zero on failure
 lev run <agent> --task "..."      # a live run through a stage that references the provider
 ```
 
+`lev models list --provider <name>` loads the script by name whether or not `--remote` is passed,
+since a script provider has no row in the built-in model table. A compile failure, and an error
+raised by `list_models` itself, are both reported by name.
+
 > [!TIP]
 > A broken provider script is skipped and model selection falls through to the next configured model,
-> so a syntax error looks like "my agent quietly used the wrong model". Run
-> `lev models list --provider <name>` first; a compile or auth error surfaces there instead of
-> hiding behind a fallback.
+> so a syntax error looks like "my agent quietly used the wrong model". Check it before you wire it
+> into a blueprint: `lev models list --provider <name>` shows the catalog and names any failure, and
+> `lev doctor -m <name>/<model>` does the same and exits non-zero, so it works as a CI gate.
 
 If `lev serve` is running, `POST /api/scripts/validate` with `kind: "provider"` answers the same
 question without a run and without a key: it compiles the text and checks that `initialize(config)`


### PR DESCRIPTION
Closes #523.

## The bug

`ProviderRegistry::provider_names()` returns `self.providers.keys()` - natively
registered providers only. The script layer is consulted by `get()` and
`has()`, never by that. `list_with_registry` used `provider_names()` for both
the availability filter and the `--remote` fetch loop, so a script provider was
in neither set, and:

```
$ lev models list --provider cerebras
No models available.
(configure a provider with `lev setup`, or pass --all to see every model Leviath knows about)
```

...for a working provider and a syntactically broken one alike - which is the
exact failure mode the tip in `rhai-providers.md` exists to prevent, since that
page prescribes this command *because* a broken script otherwise falls through
to another model in silence.

## The fix

A `--provider` naming neither a registered provider nor any row in the built-in
table is now resolved through the script layer, which compiles the script, runs
`initialize`, and calls `list_models`. Its rows merge into the table the same
way `--remote` rows do.

That happens **with or without `--remote`**, deliberately: a script provider
names its catalog at run time, so there is no built-in row to show and no
useful non-remote answer. This is what makes the documented smoke test a smoke
test.

A name the built-in table already knows is left alone, so `--provider openai`
on a machine with no OpenAI key is the empty table it has always been, not an
attempt to load `openai.rhai`.

## Failures are named, exit codes are unchanged

- A script that will not load (compile error, missing file, path escaping the
  providers dir): `Warning: no provider named 'x' is configured, and no script
  provider by that name loaded`. The script layer already logs the compile
  error itself at `warn`, which the CLI prints by default.
- `list_models` raising: `Warning: could not fetch models from 'x': 401
  Unauthorized` - the same wording `--remote` has always used for a native
  provider that will not answer.
- A provider that loads and lists nothing says so, rather than printing the
  `lev setup` nudge meant for a fresh install.

Both failure paths report and continue, matching the existing `--remote`
contract and the three existing tests that pin "an unknown `--provider` exits
0". The non-zero gate for a provider script stays `lev doctor -m
<provider>/<model>`, which the docs now name alongside. Say the word if you'd
rather `models list` exit non-zero when a named provider cannot be reached -
it's a two-line change, but it flips behaviour those tests currently lock in.

## Docs

`lev doctor --help` and `cli.md` said a script provider "cannot be listed" -
the CLI and the Rhai docs contradicted each other, which the issue notes. Both
now describe what happens, `providers.md` notes the exception to "the built-in
table", and the `rhai-providers.md` testing section shows `models list` and
`lev doctor` side by side with what each one gives you.

## Tests

Four new tests build a real `ScriptProviderLayer` over a tempdir with an actual
`.rhai` file - the script is compiled, `initialize` runs, and `list_models` is
dispatched, so this is the path a real install takes and not a mock:

- a provider whose `list_models` returns a model - verified the row reaches the
  output (`--json`):
  `{"id": "scripted-large", "provider": "scripted", ... "max_context_tokens": 32768}`
- a provider with no `list_models` - prints the "loaded and listed no models" line
- a provider whose `list_models` throws - prints `could not fetch models from 'angry': 401 Unauthorized`
- `--provider openai --all` with an uncompilable `openai.rhai` sitting in the
  directory, which must never be reached

All 90 tests in `commands::models` pass, including the three that pin the
unknown-provider exit code.
