### PR TITLE
feat(limits): per-provider and per-model inference pool caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ same list.
 
 ## Unreleased
 
+- Added: `[limits.max_concurrent_inferences_by_provider]` caps in-flight
+  requests to one provider across every model it serves, and
+  `[limits.max_concurrent_inferences_by_model]` overrides the global cap for one
+  model id. `[limits] max_concurrent_inferences` was the only concurrency knob
+  and it applied to every model's pool, so bounding spend on one metered
+  provider also throttled Anthropic and OpenAI on the same machine - while
+  `configuration.md` and `engine.md` both described a per-model pool entry that
+  had no configuration surface at all. The provider cap is a second, coarser
+  pool in front of the per-model one: a request takes a slot in both and holds
+  both until it finishes. A provider nobody caps has no pool of its own, so
+  nothing an existing install runs is bounded any more tightly than before.
+  The daemon's health reading carries provider-pool occupancy alongside the
+  model pools (`lev ps --json` under `health`, and the lane heartbeat in the
+  log), because a run parked on a full provider pool sees every model pool with
+  room in it.
+
 - Fixed: a WebSocket subscriber that drops a single pong is no longer
   disconnected. The server's liveness check had no deadline of its own - a ping
   left unanswered by the time the *next* ping was due meant a dead peer, so at

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -6,6 +6,8 @@
 //! that drifts from the field it fills is invisible until someone reads a
 //! config that omits it.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 fn default_max_concurrent_inferences() -> Option<usize> {
@@ -72,8 +74,8 @@ fn default_inference_retry_base_ms() -> u64 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LimitsConfig {
     /// Global fallback cap on concurrent inference requests for any model
-    /// without its own per-model pool entry. Defaults to `Some(8)`; omit or set
-    /// a large number to effectively unbound it.
+    /// without its own entry in `max_concurrent_inferences_by_model`. Defaults
+    /// to `Some(8)`; omit or set a large number to effectively unbound it.
     ///
     /// One physical bound sits behind this for *script* providers: each of
     /// their in-flight calls occupies a blocking-pool thread, and the daemon's
@@ -294,9 +296,65 @@ pub struct LimitsConfig {
     /// unset in code, written by `lev setup`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_run_write_bytes: Option<u64>,
+
+    /// Per-model overrides of `max_concurrent_inferences`, keyed by model id.
+    ///
+    /// ```toml
+    /// [limits.max_concurrent_inferences_by_model]
+    /// "gpt-oss-120b" = 2
+    /// ```
+    ///
+    /// A model listed here uses its own number; every other model uses the
+    /// global one. This is the per-model pool the engine has always had - it
+    /// simply had no way to be configured.
+    ///
+    /// A `BTreeMap` so the file this is written back to keeps its order.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub max_concurrent_inferences_by_model: BTreeMap<String, usize>,
+
+    /// Caps on concurrent inference requests to one provider, across every
+    /// model it serves, keyed by provider name.
+    ///
+    /// ```toml
+    /// [limits.max_concurrent_inferences_by_provider]
+    /// cerebras = 1
+    /// ```
+    ///
+    /// A *second*, coarser bound than the per-model pool, not a replacement for
+    /// it: a request needs a slot in both. It exists because the per-model cap
+    /// cannot express "spend no more than one request at a time at this metered
+    /// third-party API", and because lowering the global number to get that
+    /// would throttle Anthropic and OpenAI on the same machine too.
+    ///
+    /// Distinct from `[rate_limits.<provider>]`, which shapes how *fast*
+    /// requests are sent. This bounds how many are in flight at once.
+    ///
+    /// A provider absent from here has no pool of its own. The global fallback
+    /// is deliberately not applied per provider: it is a per-model number, and
+    /// applying it twice would tighten every install that never asked for it.
+    ///
+    /// Read once at daemon start, so a change needs a daemon restart.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub max_concurrent_inferences_by_provider: BTreeMap<String, usize>,
 }
 
 impl LimitsConfig {
+    /// The inference pools these limits describe, for the engine: the global
+    /// fallback, the per-model overrides, and the per-provider caps.
+    pub fn inference_pools(&self) -> leviath_runtime::inference_pool::InferencePoolConfig {
+        let mut config = leviath_runtime::inference_pool::InferencePoolConfig::new()
+            .with_default(self.max_concurrent_inferences);
+        for (model, limit) in &self.max_concurrent_inferences_by_model {
+            config.set_limit(model, *limit);
+        }
+        for (provider, limit) in &self.max_concurrent_inferences_by_provider {
+            config.set_provider_limit(provider, *limit);
+        }
+        config
+    }
+
     /// The write ceilings in effect, for the engine.
     pub fn write_limits(&self) -> leviath_core::write_limits::WriteLimits {
         leviath_core::write_limits::WriteLimits {
@@ -324,6 +382,8 @@ impl Default for LimitsConfig {
             interaction_timeout_secs: default_interaction_timeout_secs(),
             inference_retry_attempts: default_inference_retry_attempts(),
             inference_retry_base_ms: default_inference_retry_base_ms(),
+            max_concurrent_inferences_by_model: BTreeMap::new(),
+            max_concurrent_inferences_by_provider: BTreeMap::new(),
             // Deliberately `None` here and concrete in `lev setup`: the code
             // imposes no ceiling on a user who never opened the config, and a
             // fresh install gets a number written where it can be seen and

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -1960,6 +1960,37 @@ some_custom_thing = \"forwarded to the script\"
         assert_eq!(Config::default().limits.max_concurrent_inferences, Some(8));
     }
 
+    /// The `[limits]` tables reach the engine's pools: the global fallback for
+    /// an unlisted model, a per-model override, and a per-provider cap that is
+    /// deliberately *not* filled in from the global number (issue #522).
+    #[test]
+    fn inference_pools_carries_every_limits_table_through() {
+        let mut limits = LimitsConfig {
+            max_concurrent_inferences: Some(8),
+            ..Default::default()
+        };
+        limits
+            .max_concurrent_inferences_by_model
+            .insert("gpt-oss-120b".to_string(), 2);
+        limits
+            .max_concurrent_inferences_by_provider
+            .insert("cerebras".to_string(), 1);
+
+        let pools = limits.inference_pools();
+        assert_eq!(pools.limit_for("gpt-oss-120b"), Some(2), "per-model wins");
+        assert_eq!(
+            pools.limit_for("claude-sonnet-5"),
+            Some(8),
+            "an unlisted model takes the global fallback"
+        );
+        assert_eq!(pools.provider_limit_for("cerebras"), Some(1));
+        assert_eq!(
+            pools.provider_limit_for("anthropic"),
+            None,
+            "a provider nobody capped has no pool of its own"
+        );
+    }
+
     /// A config written before the field existed still gets the hour, and an
     /// explicit `0` still means "wait for a person however long it takes".
     #[test]
@@ -3502,6 +3533,14 @@ enabled = false
                 interaction_timeout_secs: 120,
                 inference_retry_attempts: 6,
                 inference_retry_base_ms: 250,
+                max_concurrent_inferences_by_model: std::collections::BTreeMap::from([(
+                    "gpt-oss-120b".to_string(),
+                    2,
+                )]),
+                max_concurrent_inferences_by_provider: std::collections::BTreeMap::from([(
+                    "cerebras".to_string(),
+                    1,
+                )]),
             },
             batch_tool_hint: true,
             shell_hint: false,
@@ -3562,6 +3601,20 @@ enabled = false
 
         assert_eq!(deserialized.default_provider, "anthropic");
         assert_eq!(deserialized.limits.max_concurrent_inferences, Some(4));
+        assert_eq!(
+            deserialized
+                .limits
+                .max_concurrent_inferences_by_model
+                .get("gpt-oss-120b"),
+            Some(&2)
+        );
+        assert_eq!(
+            deserialized
+                .limits
+                .max_concurrent_inferences_by_provider
+                .get("cerebras"),
+            Some(&1)
+        );
         assert_eq!(deserialized.limits.max_concurrent_tools, 3);
         assert_eq!(deserialized.limits.script_shell_timeout_secs, 45);
         assert_eq!(deserialized.limits.dead_cycles_before_relief, 6);

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -10,7 +10,6 @@ use std::sync::Arc;
 use leviath_providers::Tool;
 use leviath_runtime::ProviderRegistry;
 use leviath_runtime::host::WorldHost;
-use leviath_runtime::inference_pool::InferencePoolConfig;
 use leviath_runtime::interaction_hub::InteractionHub;
 use leviath_runtime::world::PipelineWorld;
 use tokio::runtime::Handle;
@@ -246,9 +245,9 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let tool_service = Arc::new(CliToolService::new());
     // The configured global fallback bounds concurrent inference for any model
     // without its own per-model pool entry (defaults to a small cap so a fresh
-    // install can't fan out unbounded requests against provider rate limits).
-    let pool_config =
-        InferencePoolConfig::new().with_default(parts.config.limits.max_concurrent_inferences);
+    // install can't fan out unbounded requests against provider rate limits),
+    // alongside the per-model overrides and the per-provider caps.
+    let pool_config = parts.config.limits.inference_pools();
     let mut world = PipelineWorld::new(
         parts.providers,
         tool_service.clone(),
@@ -679,7 +678,7 @@ mod tests {
         let mut world = PipelineWorld::new(
             ProviderRegistry::new(),
             tool_service.clone(),
-            InferencePoolConfig::new(),
+            leviath_runtime::inference_pool::InferencePoolConfig::new(),
             1,
             None,
             Handle::current(),

--- a/crates/leviath-runtime/src/compaction_bridge.rs
+++ b/crates/leviath-runtime/src/compaction_bridge.rs
@@ -242,7 +242,7 @@ mod tests {
                 .into_iter()
                 .map(|r| (r.to_string(), request()))
                 .collect(),
-            permit: pools.try_acquire("m").expect("free"),
+            permit: pools.try_acquire("p", "m").expect("free"),
         }
     }
 

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -132,7 +132,7 @@ pub fn dispatch_content_summary(
             commands.entity(entity).remove::<PendingContentSummary>();
             continue;
         };
-        let Some(permit) = stage.pools.try_acquire(&config.model) else {
+        let Some(permit) = stage.pools.try_acquire(&config.provider, &config.model) else {
             continue; // pool full - retry next tick (keep the pending marker)
         };
         let requests = pending

--- a/crates/leviath-runtime/src/host/health.rs
+++ b/crates/leviath-runtime/src/host/health.rs
@@ -171,6 +171,7 @@ impl WorldHost {
         DaemonHealth {
             agents: snapshot.agents,
             inference: snapshot.inference,
+            inference_providers: snapshot.inference_providers,
             tools_busy: snapshot.tools_busy,
             tools_queued: snapshot.tools_queued,
             tools_parked: snapshot.tools_parked,

--- a/crates/leviath-runtime/src/host/types.rs
+++ b/crates/leviath-runtime/src/host/types.rs
@@ -200,6 +200,11 @@ pub struct DaemonHealth {
     pub agents: crate::world::AgentCounts,
     /// Inference-pool occupancy, one entry per model actually used.
     pub inference: Vec<crate::inference_pool::PoolOccupancy>,
+    /// Provider-pool occupancy, one entry per provider with a configured cap
+    /// that has been used. Empty unless `[limits]` caps a provider, which is
+    /// why it is `default`ed rather than required of an older client's payload.
+    #[serde(default)]
+    pub inference_providers: Vec<crate::inference_pool::ProviderPoolOccupancy>,
     /// Tool batches holding lane capacity and running.
     pub tools_busy: usize,
     /// Tool batches waiting for lane capacity.

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -545,6 +545,50 @@ async fn a_stage_boundary_is_crossed_without_waiting_for_the_redrive() {
     );
 }
 
+/// A host whose *provider* is capped rather than its model, so the only thing
+/// a second agent can be waiting on is the provider's pool.
+fn host_with_capped_provider(limit: usize) -> WorldHost {
+    let mut registry = crate::providers::ProviderRegistry::new();
+    registry.register("script".to_string(), Arc::new(Hangs { hang: true }));
+    let mut pools = InferencePoolConfig::new();
+    pools.set_provider_limit("script", limit);
+    WorldHost::new(PipelineWorld::new(
+        registry,
+        Arc::new(NoTools),
+        pools,
+        1,
+        None,
+        Handle::current(),
+    ))
+}
+
+/// A run parked on a full provider pool sees every model pool with room in it,
+/// so the heartbeat has to name the provider's own number or the line reads as
+/// "waiting on nothing" (issue #522).
+#[tokio::test]
+async fn the_heartbeat_names_a_full_provider_pool() {
+    leviath_testkit::with_tracing(|| async {
+        let mut host = host_with_capped_provider(1);
+        spawn(&mut host, "run-a", "agent-a");
+        spawn(&mut host, "run-b", "agent-b");
+        host.world_mut().run_to_fixed_point();
+
+        let busy = host.world_mut().lane_snapshot();
+        assert_eq!(busy.agents.active, 2);
+        assert_eq!(
+            busy.inference_summary(),
+            "m=1/unbounded provider:script=1/1",
+            "the model pool has room; the provider's is what everything is behind"
+        );
+        assert!(
+            busy.is_under_pressure(),
+            "a full provider pool with active agents is worth reporting"
+        );
+        host.log_lane_pressure(&busy);
+    })
+    .await;
+}
+
 /// The heartbeat's two levels. Under pressure it is worth an `info` line;
 /// idle it must not be, or a healthy daemon spams the log forever.
 #[tokio::test]

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -409,7 +409,7 @@ mod tests {
                 .expect("a small literal index is always a valid entity id"),
             provider,
             request: test_request(),
-            permit: pools.try_acquire("m").expect("free pool"),
+            permit: pools.try_acquire("p", "m").expect("free pool"),
             exact_token_counting: false,
         }
     }
@@ -422,8 +422,8 @@ mod tests {
         let mut cfg = InferencePoolConfig::new();
         cfg.set_limit("m", 1);
         let pools = InferencePools::new(cfg);
-        let permit = pools.try_acquire("m").expect("free pool");
-        assert!(pools.try_acquire("m").is_none(), "pool should be full");
+        let permit = pools.try_acquire("p", "m").expect("free pool");
+        assert!(pools.try_acquire("p", "m").is_none(), "pool should be full");
 
         // A provider that never answers - the stalled-call case a cancel exists
         // to escape.
@@ -461,7 +461,7 @@ mod tests {
             .expect("the cancel ended the job")
             .unwrap();
         assert!(
-            pools.try_acquire("m").is_some(),
+            pools.try_acquire("p", "m").is_some(),
             "the pool slot is free for the next agent"
         );
         assert!(
@@ -476,8 +476,8 @@ mod tests {
         let mut cfg = InferencePoolConfig::new();
         cfg.set_limit("m", 1);
         let pools = InferencePools::new(cfg);
-        let permit = pools.try_acquire("m").expect("free pool");
-        assert!(pools.try_acquire("m").is_none(), "pool should be full");
+        let permit = pools.try_acquire("p", "m").expect("free pool");
+        assert!(pools.try_acquire("p", "m").is_none(), "pool should be full");
 
         let provider = Arc::new(Scripted {
             steps: std::sync::Mutex::new(vec![Step::Hang].into()),
@@ -512,7 +512,7 @@ mod tests {
         assert!(err.to_string().contains("job timeout"), "got: {err}");
         // …and its pool slot is free again for the next agent.
         assert!(
-            pools.try_acquire("m").is_some(),
+            pools.try_acquire("p", "m").is_some(),
             "the slot must be released after the timeout"
         );
     }
@@ -594,7 +594,7 @@ mod tests {
                 .expect("a small literal index is always a valid entity id"),
             provider,
             request: test_request(), // max_tokens: 100
-            permit: pools.try_acquire("m").expect("free pool"),
+            permit: pools.try_acquire("p", "m").expect("free pool"),
             exact_token_counting: exact,
         }
     }

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -13,6 +13,13 @@
 //! pool is what keeps us from opening an unbounded number of simultaneous
 //! long-lived requests to a provider.
 //!
+//! A second, coarser pool sits in front of the per-model one: an optional cap
+//! *per provider*, across every model that provider serves. It exists for the
+//! metered third-party API where the point of a small pool is bounding spend,
+//! and where capping one experimental provider at 1 must not also throttle
+//! Anthropic and OpenAI on the same machine. A provider has no pool unless one
+//! is configured for it, so nothing is bounded twice by accident.
+//!
 //! Distinct from a blueprint's fan-out `max_workers` (which bounds a stage's
 //! sub-agent fan *width*); these pools bound total in-flight inferences *per
 //! model* across every agent in the world.
@@ -27,14 +34,16 @@ use tokio::sync::{AcquireError, Notify, OwnedSemaphorePermit, Semaphore};
 /// permits, so `acquire` never actually waits for it.
 const UNBOUNDED_PERMITS: usize = Semaphore::MAX_PERMITS;
 
-/// Configuration for the world's per-model inference concurrency limits.
+/// Configuration for the world's inference concurrency limits.
 ///
 /// A model listed in `per_model` uses that limit; any other model uses
-/// `default_limit` (or is unbounded when that is `None`). With a single world
-/// today this is just a global config table.
+/// `default_limit` (or is unbounded when that is `None`). A provider listed in
+/// `per_provider` additionally bounds every one of its models together.
+/// With a single world today this is just a global config table.
 #[derive(Debug, Clone, Default)]
 pub struct InferencePoolConfig {
     per_model: HashMap<String, usize>,
+    per_provider: HashMap<String, usize>,
     default_limit: Option<usize>,
 }
 
@@ -56,10 +65,24 @@ impl InferencePoolConfig {
         self.per_model.insert(model.into(), limit);
     }
 
+    /// Set the concurrency limit for every model one provider serves, together.
+    pub fn set_provider_limit(&mut self, provider: impl Into<String>, limit: usize) {
+        self.per_provider.insert(provider.into(), limit);
+    }
+
     /// The configured limit for `model`: its explicit entry if present, else the
     /// default. `None` means unbounded.
     pub fn limit_for(&self, model: &str) -> Option<usize> {
         self.per_model.get(model).copied().or(self.default_limit)
+    }
+
+    /// The configured limit for `provider` as a whole. `None` means the
+    /// provider has no pool of its own - deliberately *not* falling back to
+    /// `default_limit`, which is a per-model number: applying it per provider
+    /// as well would silently tighten every install that never asked for a
+    /// provider cap.
+    pub fn provider_limit_for(&self, provider: &str) -> Option<usize> {
+        self.per_provider.get(provider).copied()
     }
 }
 
@@ -69,6 +92,14 @@ impl InferencePoolConfig {
 pub struct InferencePools {
     config: InferencePoolConfig,
     semaphores: Mutex<HashMap<String, Arc<Semaphore>>>,
+    /// Per-provider semaphores and their caps, created lazily and only for a
+    /// provider that has a configured cap. A provider absent from here is
+    /// unbounded, and its models are bounded by their own pools alone.
+    ///
+    /// The cap is stored beside the semaphore rather than looked up again when
+    /// occupancy is read: an entry only exists because a cap did, so carrying
+    /// it removes an `Option` nothing could ever make `None`.
+    provider_semaphores: Mutex<HashMap<String, (usize, Arc<Semaphore>)>>,
     /// The tick-loop wake handle, handed to every permit so that releasing one
     /// re-drives dispatch. See [`InferencePools::with_wake`].
     wake: Option<Arc<Notify>>,
@@ -80,6 +111,7 @@ impl InferencePools {
         Self {
             config,
             semaphores: Mutex::new(HashMap::new()),
+            provider_semaphores: Mutex::new(HashMap::new()),
             wake: None,
         }
     }
@@ -103,30 +135,48 @@ impl InferencePools {
         self
     }
 
-    /// Acquire a permit for `model`, waiting for a free slot if the pool is
-    /// full. The returned [`InferencePermit`] releases the slot when dropped -
-    /// so the caller holds it for exactly the duration of the inference request.
-    pub async fn acquire(&self, model: &str) -> InferencePermit {
-        let semaphore = self.semaphore_for(model);
-        // The semaphore is never closed (we never call `.close()`), so
+    /// Acquire a permit for `provider`'s `model`, waiting for a free slot if
+    /// either pool is full. The returned [`InferencePermit`] releases both
+    /// slots when dropped - so the caller holds it for exactly the duration of
+    /// the inference request.
+    ///
+    /// The provider's slot is taken first and the model's second, here and in
+    /// [`try_acquire`](Self::try_acquire), so two callers can never each hold
+    /// half of what the other is waiting for.
+    pub async fn acquire(&self, provider: &str, model: &str) -> InferencePermit {
+        // The semaphores are never closed (we never call `.close()`), so
         // `acquire_owned` only ever returns `Ok`; `expect_permit` documents and
         // enforces that invariant.
+        let provider_permit = match self.provider_semaphore_for(provider) {
+            Some(semaphore) => Some(expect_permit(semaphore.acquire_owned().await)),
+            None => None,
+        };
+        let semaphore = self.semaphore_for(model);
         let permit = expect_permit(semaphore.acquire_owned().await);
-        self.issue(model, permit)
+        self.issue(provider, model, permit, provider_permit)
     }
 
-    /// Try to take a permit for `model` **without waiting**. Returns `None` if
-    /// the pool is currently full.
+    /// Take a permit for `provider`'s `model` **without waiting**. Returns
+    /// `None` if either pool is currently full.
     ///
     /// This is what the synchronous ECS inference-dispatch system calls: a
     /// system can't `.await`, so instead of blocking on a full pool it leaves
     /// the agent `ReadyToInfer` and retries on a later tick.
-    pub fn try_acquire(&self, model: &str) -> Option<InferencePermit> {
-        let semaphore = self.semaphore_for(model);
+    pub fn try_acquire(&self, provider: &str, model: &str) -> Option<InferencePermit> {
         // `try_acquire_owned` errors only on "no permits" (pool full) or
         // "closed" (never, since we never close) - both mean "no slot now".
+        let provider_permit = match self.provider_semaphore_for(provider) {
+            Some(semaphore) => match semaphore.try_acquire_owned() {
+                Ok(permit) => Some(permit),
+                Err(_) => return None,
+            },
+            None => None,
+        };
+        let semaphore = self.semaphore_for(model);
         match semaphore.try_acquire_owned() {
-            Ok(permit) => Some(self.issue(model, permit)),
+            Ok(permit) => Some(self.issue(provider, model, permit, provider_permit)),
+            // `provider_permit` is dropped here, handing that slot straight
+            // back: nothing was started, so nothing may stay held.
             Err(_) => None,
         }
     }
@@ -135,10 +185,17 @@ impl InferencePools {
     /// pool's wake handle, and trace the acquisition. Acquire and release are
     /// traced as a pair so a leaked or long-held slot can be read straight off
     /// the log.
-    fn issue(&self, model: &str, permit: OwnedSemaphorePermit) -> InferencePermit {
-        tracing::trace!(model = %model, "inference slot acquired");
+    fn issue(
+        &self,
+        provider: &str,
+        model: &str,
+        permit: OwnedSemaphorePermit,
+        provider_permit: Option<OwnedSemaphorePermit>,
+    ) -> InferencePermit {
+        tracing::trace!(provider = %provider, model = %model, "inference slot acquired");
         InferencePermit {
             permit: Some(permit),
+            provider_permit,
             model: model.to_string(),
             wake: self.wake.clone(),
         }
@@ -171,6 +228,47 @@ impl InferencePools {
             .collect();
         out.sort_by(|a, b| a.model.cmp(&b.model)); // stable output for logs and tests
         out
+    }
+
+    /// How many slots are in use per *provider*, against each provider's cap.
+    /// Only providers with a configured cap have a pool, so a provider absent
+    /// from this list is unbounded rather than idle.
+    ///
+    /// Reported separately from [`occupancy`](Self::occupancy) because a run
+    /// parked on a full provider pool sees every model pool with room in it,
+    /// and "waiting on nothing" is the one shape this reporting exists to
+    /// prevent.
+    pub fn provider_occupancy(&self) -> Vec<ProviderPoolOccupancy> {
+        let map = self
+            .provider_semaphores
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let mut out: Vec<ProviderPoolOccupancy> = map
+            .iter()
+            .map(|(provider, (cap, semaphore))| ProviderPoolOccupancy {
+                provider: provider.clone(),
+                in_use: cap.saturating_sub(semaphore.available_permits()),
+                cap: *cap,
+            })
+            .collect();
+        out.sort_by(|a, b| a.provider.cmp(&b.provider)); // stable output
+        out
+    }
+
+    /// Fetch (or lazily create) the semaphore bounding `provider` as a whole,
+    /// or `None` when that provider has no configured cap.
+    fn provider_semaphore_for(&self, provider: &str) -> Option<Arc<Semaphore>> {
+        let permits = self.config.provider_limit_for(provider)?;
+        let mut map = self
+            .provider_semaphores
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        if let Some((_, existing)) = map.get(provider) {
+            return Some(existing.clone());
+        }
+        let semaphore = Arc::new(Semaphore::new(permits));
+        map.insert(provider.to_string(), (permits, semaphore.clone()));
+        Some(semaphore)
     }
 
     /// Fetch (or lazily create) the semaphore for `model`.
@@ -217,6 +315,32 @@ impl std::fmt::Display for PoolOccupancy {
     }
 }
 
+/// How busy one provider's pool is. Only a provider with a configured cap has
+/// one, so unlike [`PoolOccupancy`] the cap is never absent.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProviderPoolOccupancy {
+    /// The provider the pool is scoped to.
+    pub provider: String,
+    /// Slots currently held, across every model this provider serves.
+    pub in_use: usize,
+    /// The configured limit.
+    pub cap: usize,
+}
+
+impl ProviderPoolOccupancy {
+    /// Whether every slot in this pool is taken.
+    #[must_use]
+    pub fn is_full(&self) -> bool {
+        self.in_use >= self.cap
+    }
+}
+
+impl std::fmt::Display for ProviderPoolOccupancy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}={}/{}", self.provider, self.in_use, self.cap)
+    }
+}
+
 /// Unwrap an `acquire_owned` result, panicking with a clear message if the
 /// semaphore was closed. Extracted as a free function (rather than an inline
 /// `.expect(...)`) so both arms - the ordinary `Ok` and the never-in-practice
@@ -238,6 +362,9 @@ pub struct InferencePermit {
     /// loop; a field would otherwise be dropped after the `Drop` body, and the
     /// woken tick could re-check the pool while this slot was still held.
     permit: Option<OwnedSemaphorePermit>,
+    /// The provider-wide slot, when that provider has a pool. Released with the
+    /// model's, in the reverse of the order they were taken.
+    provider_permit: Option<OwnedSemaphorePermit>,
     /// The model whose pool this slot belongs to; carried for the release trace.
     model: String,
     /// Present when the pools were built with [`InferencePools::with_wake`].
@@ -251,6 +378,7 @@ impl Drop for InferencePermit {
         // back, find the pool still full, and park again - with nothing left to
         // wake it. That is the exact failure this whole mechanism exists to stop.
         drop(self.permit.take());
+        drop(self.provider_permit.take());
         tracing::trace!(model = %self.model, "inference slot released");
         // `notify_one` stores a permit when nobody is parked yet, so a wake that
         // lands mid-tick is remembered rather than lost.
@@ -294,11 +422,11 @@ mod tests {
         cfg.set_limit("m", 1);
         let pools = Arc::new(InferencePools::new(cfg));
 
-        let permit = pools.acquire("m").await; // takes the only slot
+        let permit = pools.acquire("p", "m").await; // takes the only slot
 
         // A second acquire cannot complete while the permit is held.
         let pools2 = pools.clone();
-        let waiting = tokio::spawn(async move { pools2.acquire("m").await });
+        let waiting = tokio::spawn(async move { pools2.acquire("p", "m").await });
         // Give the task a chance to run and block on the full pool.
         tokio::task::yield_now().await;
         assert!(
@@ -317,10 +445,10 @@ mod tests {
         cfg.set_limit("m", 1);
         let pools = InferencePools::new(cfg);
 
-        let permit = pools.try_acquire("m").expect("first slot is free"); // Ok arm
-        assert!(pools.try_acquire("m").is_none()); // Err arm: pool full
+        let permit = pools.try_acquire("p", "m").expect("first slot is free"); // Ok arm
+        assert!(pools.try_acquire("p", "m").is_none()); // Err arm: pool full
         drop(permit);
-        assert!(pools.try_acquire("m").is_some()); // slot freed
+        assert!(pools.try_acquire("p", "m").is_some()); // slot freed
     }
 
     #[tokio::test]
@@ -330,9 +458,141 @@ mod tests {
         // acquire returns immediately without ever waiting for a slot.
         let mut permits = Vec::new();
         for _ in 0..64 {
-            permits.push(pools.acquire("free").await);
+            permits.push(pools.acquire("p", "free").await);
         }
         assert_eq!(permits.len(), 64);
+    }
+
+    #[test]
+    fn provider_limit_is_only_what_was_configured() {
+        let mut cfg = InferencePoolConfig::new().with_default(Some(8));
+        cfg.set_provider_limit("cerebras", 1);
+        assert_eq!(cfg.provider_limit_for("cerebras"), Some(1));
+        // The global fallback is a per-model number and is deliberately not
+        // applied a second time per provider - an install that caps nothing
+        // must keep the concurrency it had.
+        assert_eq!(cfg.provider_limit_for("anthropic"), None);
+    }
+
+    /// The motivating case in issue #522: one provider capped at 1 while every
+    /// other provider keeps the global cap.
+    #[test]
+    fn a_provider_cap_bounds_its_models_together_and_nobody_else() {
+        let mut cfg = InferencePoolConfig::new().with_default(Some(8));
+        cfg.set_provider_limit("cerebras", 1);
+        let pools = InferencePools::new(cfg);
+
+        // Two *different* models of the capped provider: the second waits, even
+        // though its own model pool is untouched.
+        let held = pools.try_acquire("cerebras", "gpt-oss-120b").expect("free");
+        assert!(
+            pools.try_acquire("cerebras", "llama-3.3-70b").is_none(),
+            "the provider's one slot is taken, whatever the model"
+        );
+        // An uncapped provider is unaffected by any of that.
+        let _elsewhere = pools
+            .try_acquire("anthropic", "claude-sonnet-5")
+            .expect("another provider has no pool of its own");
+
+        drop(held);
+        assert!(
+            pools.try_acquire("cerebras", "llama-3.3-70b").is_some(),
+            "the slot comes back when the request finishes"
+        );
+    }
+
+    /// A model pool that refuses must hand the provider slot straight back -
+    /// nothing was started, so nothing may stay held.
+    #[test]
+    fn a_full_model_pool_releases_the_provider_slot_it_just_took() {
+        let mut cfg = InferencePoolConfig::new();
+        cfg.set_limit("m", 1);
+        cfg.set_provider_limit("p", 4);
+        let pools = InferencePools::new(cfg);
+
+        let held = pools.try_acquire("p", "m").expect("the only model slot");
+        assert!(pools.try_acquire("p", "m").is_none(), "model pool is full");
+        // Three provider slots free, not two: the refused attempt kept none.
+        assert_eq!(
+            pools.provider_occupancy(),
+            vec![ProviderPoolOccupancy {
+                provider: "p".to_string(),
+                in_use: 1,
+                cap: 4,
+            }]
+        );
+        drop(held);
+    }
+
+    #[tokio::test]
+    async fn acquire_waits_for_a_provider_slot_and_takes_it_when_freed() {
+        let mut cfg = InferencePoolConfig::new();
+        cfg.set_provider_limit("p", 1);
+        let pools = Arc::new(InferencePools::new(cfg));
+
+        let held = pools.acquire("p", "one-model").await;
+        let pools2 = pools.clone();
+        // A different model, so only the provider pool can be what it waits on.
+        let waiting = tokio::spawn(async move { pools2.acquire("p", "other-model").await });
+        tokio::task::yield_now().await;
+        assert!(!waiting.is_finished(), "the provider's only slot is held");
+        drop(held);
+        let taken = waiting.await.expect("the waiter is handed the freed slot");
+        drop(taken);
+    }
+
+    #[test]
+    fn provider_occupancy_lists_only_capped_providers_that_have_run() {
+        let mut cfg = InferencePoolConfig::new().with_default(Some(4));
+        cfg.set_provider_limit("b", 2);
+        cfg.set_provider_limit("a", 1);
+        let pools = InferencePools::new(cfg);
+        assert!(
+            pools.provider_occupancy().is_empty(),
+            "pools are created lazily, so an unused cap has no entry"
+        );
+
+        let _a = pools.try_acquire("a", "m").expect("free");
+        let _b = pools.try_acquire("b", "m2").expect("free");
+        let _uncapped = pools.try_acquire("c", "m3").expect("free");
+        let occupancy = pools.provider_occupancy();
+        assert_eq!(
+            occupancy,
+            vec![
+                ProviderPoolOccupancy {
+                    provider: "a".to_string(),
+                    in_use: 1,
+                    cap: 1,
+                },
+                ProviderPoolOccupancy {
+                    provider: "b".to_string(),
+                    in_use: 1,
+                    cap: 2,
+                },
+            ],
+            "sorted, and the uncapped provider has no pool to report"
+        );
+        assert!(occupancy[0].is_full());
+        assert!(!occupancy[1].is_full());
+        assert_eq!(occupancy[0].to_string(), "a=1/1");
+        // The daemon's health payload carries these, so assert the wire form
+        // rather than assuming it.
+        let json = serde_json::to_string(&occupancy).expect("occupancy serializes");
+        assert_eq!(
+            serde_json::from_str::<Vec<ProviderPoolOccupancy>>(&json).expect("and reads back"),
+            occupancy
+        );
+    }
+
+    #[test]
+    fn provider_semaphore_is_cached_per_provider() {
+        let mut cfg = InferencePoolConfig::new();
+        cfg.set_provider_limit("p", 2);
+        let pools = InferencePools::new(cfg);
+        let first = pools.provider_semaphore_for("p").expect("configured");
+        let second = pools.provider_semaphore_for("p").expect("cache hit");
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(pools.provider_semaphore_for("other").is_none());
     }
 
     #[test]
@@ -366,8 +626,8 @@ mod tests {
             let wake = Arc::new(Notify::new());
             let pools = InferencePools::new(cfg).with_wake(wake.clone());
 
-            let permit = pools.try_acquire("m").expect("the only slot");
-            assert!(pools.try_acquire("m").is_none(), "pool full");
+            let permit = pools.try_acquire("p", "m").expect("the only slot");
+            assert!(pools.try_acquire("p", "m").is_none(), "pool full");
             // Nothing has released yet, so there is no wake to collect.
             assert!(
                 tokio::time::timeout(std::time::Duration::from_millis(20), wake.notified())
@@ -378,7 +638,7 @@ mod tests {
 
             drop(permit);
             // The slot is back...
-            assert!(pools.try_acquire("m").is_some(), "slot freed");
+            assert!(pools.try_acquire("p", "m").is_some(), "slot freed");
             // ...and the driver was told, so a parked loop re-drives dispatch.
             tokio::time::timeout(std::time::Duration::from_millis(20), wake.notified())
                 .await
@@ -394,10 +654,10 @@ mod tests {
         let mut cfg = InferencePoolConfig::new();
         cfg.set_limit("m", 1);
         let pools = InferencePools::new(cfg); // no `with_wake`
-        let permit = pools.try_acquire("m").expect("the only slot");
-        assert!(pools.try_acquire("m").is_none());
+        let permit = pools.try_acquire("p", "m").expect("the only slot");
+        assert!(pools.try_acquire("p", "m").is_none());
         drop(permit);
-        assert!(pools.try_acquire("m").is_some());
+        assert!(pools.try_acquire("p", "m").is_some());
     }
 
     /// The async `acquire` path carries the wake too, not just `try_acquire`.
@@ -405,7 +665,7 @@ mod tests {
     async fn the_awaiting_acquire_path_also_wakes_on_release() {
         let wake = Arc::new(Notify::new());
         let pools = InferencePools::new(InferencePoolConfig::new()).with_wake(wake.clone());
-        drop(pools.acquire("m").await);
+        drop(pools.acquire("p", "m").await);
         tokio::time::timeout(std::time::Duration::from_millis(20), wake.notified())
             .await
             .expect("an awaited permit wakes on release as well");
@@ -420,8 +680,10 @@ mod tests {
         // Untouched models don't appear: the semaphores are lazy.
         assert!(pools.occupancy().is_empty());
 
-        let held = pools.try_acquire("capped").expect("free");
-        let _unbounded = pools.try_acquire("free").expect("unbounded is always free");
+        let held = pools.try_acquire("p", "capped").expect("free");
+        let _unbounded = pools
+            .try_acquire("p", "free")
+            .expect("unbounded is always free");
         let occ = pools.occupancy();
         assert_eq!(
             occ,
@@ -445,7 +707,7 @@ mod tests {
         assert_eq!(occ[1].to_string(), "free=1/unbounded");
 
         // Fill the capped pool and it reads as full.
-        let _second = pools.try_acquire("capped").expect("second of two");
+        let _second = pools.try_acquire("p", "capped").expect("second of two");
         assert!(pools.occupancy()[0].is_full(), "2 of 2 is full");
         drop(held);
         assert!(!pools.occupancy()[0].is_full(), "and not full once freed");

--- a/crates/leviath-runtime/src/pipeline/compaction.rs
+++ b/crates/leviath-runtime/src/pipeline/compaction.rs
@@ -141,7 +141,7 @@ pub fn dispatch_compaction(
         let Some(provider) = providers.0.get(&config.provider) else {
             continue; // compaction provider not registered - skip, non-fatal
         };
-        let Some(permit) = stage.pools.try_acquire(&config.model) else {
+        let Some(permit) = stage.pools.try_acquire(&config.provider, &config.model) else {
             continue; // pool full - skip compaction this round
         };
 
@@ -441,7 +441,7 @@ pub fn dispatch_edge_compact(
                     );
                     return None;
                 };
-                let Some(permit) = stage.pools.try_acquire(&config.model) else {
+                let Some(permit) = stage.pools.try_acquire(&config.provider, &config.model) else {
                     tracing::warn!(
                         model = %config.model,
                         regions = ?pending.0,

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -394,7 +394,7 @@ pub fn dispatch_inference(
                     stall(StallReason::ProviderMissing);
                     return;
                 };
-                let Some(permit) = stage.pools.try_acquire(&si.model) else {
+                let Some(permit) = stage.pools.try_acquire(&si.provider_name, &si.model) else {
                     // Every in-flight call on this model holds a permit; if
                     // this repeats for minutes, one of them is stuck (see the
                     // default request timeout in leviath-providers).

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -532,7 +532,7 @@ async fn dispatch_skips_when_pool_full() {
     let mut cfg = InferencePoolConfig::new();
     cfg.set_limit("m", 1);
     let pools = InferencePools::new(cfg);
-    let _held = pools.try_acquire("m").unwrap(); // occupy the only slot
+    let _held = pools.try_acquire("p", "m").unwrap(); // occupy the only slot
     let (mut world, _rx) = build_world(pools);
     let e = world
         .spawn((

--- a/crates/leviath-runtime/src/pipeline/transition_choice.rs
+++ b/crates/leviath-runtime/src/pipeline/transition_choice.rs
@@ -165,7 +165,7 @@ pub fn dispatch_transition_choice(
                 .insert(note_stall(stalled, StallReason::ProviderMissing, now));
             continue; // provider not registered - retry later
         };
-        let Some(permit) = stage.pools.try_acquire(&si.model) else {
+        let Some(permit) = stage.pools.try_acquire(&si.provider_name, &si.model) else {
             commands
                 .entity(entity)
                 .insert(note_stall(stalled, StallReason::PoolFull, now));

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -258,7 +258,7 @@ pub fn dispatch_title(
             commands.entity(entity).remove::<PendingTitle>();
             continue;
         };
-        let Some(permit) = stage.pools.try_acquire(&model) else {
+        let Some(permit) = stage.pools.try_acquire(&provider_name, &model) else {
             continue; // pool full - retry next tick
         };
 
@@ -526,7 +526,7 @@ mod tests {
                 provider_name: "mock".to_string(),
                 model: "m".to_string(),
                 request: title_request("task", "mock", "m"),
-                permit: pools.try_acquire("m").expect("free"),
+                permit: pools.try_acquire("p", "m").expect("free"),
             },
             std::time::Duration::from_millis(5),
             tx,
@@ -710,7 +710,7 @@ mod tests {
         let mut cfg = crate::inference_pool::InferencePoolConfig::new();
         cfg.set_limit("m", 1);
         let pools = crate::inference_pool::InferencePools::new(cfg);
-        let held = pools.try_acquire("m").unwrap();
+        let held = pools.try_acquire("p", "m").unwrap();
         let (mut world, _title_rx) = build_world(Ok("t"), pools);
         world.insert_resource(TitleSettings(config(None, None)));
         let e = world.spawn((metadata(Some("mock/m")), PendingTitle)).id();

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -138,6 +138,9 @@ pub struct LaneSnapshot {
     pub agents: AgentCounts,
     /// Inference-pool occupancy, one entry per model actually used.
     pub inference: Vec<crate::inference_pool::PoolOccupancy>,
+    /// Provider-pool occupancy, one entry per provider that has a configured
+    /// cap and has been used. Empty on an install that caps no provider.
+    pub inference_providers: Vec<crate::inference_pool::ProviderPoolOccupancy>,
     /// Tool batches holding lane capacity and running.
     pub tools_busy: usize,
     /// Tool batches waiting for lane capacity.
@@ -156,20 +159,30 @@ impl LaneSnapshot {
     #[must_use]
     pub fn is_under_pressure(&self) -> bool {
         self.tools_saturated
-            || (self.agents.active > 0 && self.inference.iter().any(|p| p.is_full()))
+            || (self.agents.active > 0
+                && (self.inference.iter().any(|p| p.is_full())
+                    || self.inference_providers.iter().any(|p| p.is_full())))
     }
 
-    /// The per-model inference occupancy, rendered for a log line.
+    /// The inference occupancy, rendered for a log line: the per-model pools,
+    /// then the per-provider pools when any are configured.
+    ///
+    /// A provider pool is named rather than folded in with the models it
+    /// bounds, because "every model has room and nothing is dispatching" is
+    /// exactly the shape a provider cap produces, and it is unreadable unless
+    /// the provider's own number is on the line.
     #[must_use]
     pub fn inference_summary(&self) -> String {
-        if self.inference.is_empty() {
+        let models = self.inference.iter().map(ToString::to_string);
+        let providers = self
+            .inference_providers
+            .iter()
+            .map(|p| format!("provider:{p}"));
+        let parts: Vec<String> = models.chain(providers).collect();
+        if parts.is_empty() {
             return "none".to_string();
         }
-        self.inference
-            .iter()
-            .map(ToString::to_string)
-            .collect::<Vec<_>>()
-            .join(" ")
+        parts.join(" ")
     }
 }
 
@@ -731,6 +744,11 @@ impl PipelineWorld {
         LaneSnapshot {
             agents,
             inference: self.world.resource::<InferenceStage>().pools.occupancy(),
+            inference_providers: self
+                .world
+                .resource::<InferenceStage>()
+                .pools
+                .provider_occupancy(),
             tools_busy: tools.busy(),
             tools_queued: tools.queued(),
             tools_parked: tools.parked(),

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -150,6 +150,12 @@ inference_retry_attempts  = 4    # tries per inference, the first one included
 inference_retry_base_ms   = 1000 # first retry wait for an ordinary blip; it doubles
 max_tool_call_write_bytes = 2147483648   # 2 GiB; delete the line for no limit
 max_run_write_bytes       = 10737418240  # 10 GiB; delete the line for no limit
+
+[limits.max_concurrent_inferences_by_model]
+"gpt-oss-120b" = 2               # this model's pool; others use the number above
+
+[limits.max_concurrent_inferences_by_provider]
+cerebras = 1                     # every model this provider serves, together
 ```
 
 | Key | Default | Notes |
@@ -171,12 +177,33 @@ max_run_write_bytes       = 10737418240  # 10 GiB; delete the line for no limit
 | `inference_retry_base_ms` | `1000` | First retry wait for an ordinary blip, doubling each retry. See below |
 | `max_tool_call_write_bytes` | unset | Most one tool call may write. See below |
 | `max_run_write_bytes` | unset | Most a whole run may write. See below |
+| `max_concurrent_inferences_by_model` | empty | Per-model overrides of the cap above. See below |
+| `max_concurrent_inferences_by_provider` | empty | Per-provider caps across every model a provider serves. See below |
 
-Eight of those need more than a table cell.
+Nine of those need more than a table cell.
 
 **`exact_token_counting`** measures each assembled request before sending it and refuses one that
 would overflow the window. On providers with a remote counting endpoint that costs a network round
 trip per inference, so it is off by default.
+
+**`max_concurrent_inferences_by_model`** and **`max_concurrent_inferences_by_provider`** are the
+two ways to say "not this one". The first replaces the global cap for one model id. The second adds
+a *separate*, coarser pool in front of it, bounding every model one provider serves together - a
+request needs a slot in both, and holds both until it finishes:
+
+```toml
+[limits]
+max_concurrent_inferences = 8
+
+[limits.max_concurrent_inferences_by_provider]
+cerebras = 1
+```
+
+That is one request at a time to `cerebras`, whatever it is serving, while every other provider
+keeps the eight. A provider not named here has no pool of its own; the global number is a per-model
+one and is not applied per provider as well. See
+[inference pools](/docs/engine#inference-pools), and note that this bounds *concurrency* while
+[`[rate_limits.<provider>]`](#rate_limitsprovider) bounds *rate*.
 
 **`stall_timeout_secs`** only fires for something the runtime cannot resolve on its own. Today that
 means a stage whose provider is not configured: the run is ready to work and has nowhere to send the
@@ -510,8 +537,10 @@ requests_per_minute = 50
 tokens_per_minute   = 40000
 ```
 
-This shapes request *rate*. `[limits] max_concurrent_inferences` bounds *concurrency*. Both apply.
-Script providers configure theirs under `[model_providers.<name>.rate_limit]` instead.
+This shapes request *rate*. `[limits] max_concurrent_inferences` and
+`[limits.max_concurrent_inferences_by_provider]` bound *concurrency*. Both apply. Script providers
+configure their rate limit under `[model_providers.<name>.rate_limit]` instead; their concurrency
+cap goes in `[limits.max_concurrent_inferences_by_provider]` with everyone else's.
 
 ## Keys nothing reads
 

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -313,8 +313,15 @@ paused agents it holds.
 
 The world holds one pool per model that caps how many requests can be in flight at once. An agent
 takes a slot before calling the provider and holds it for the whole request. The default cap is
-`[limits] max_concurrent_inferences` in the [config](/docs/configuration); per-model limits
-override it.
+`[limits] max_concurrent_inferences` in the [config](/docs/configuration); a model named in
+`[limits.max_concurrent_inferences_by_model]` uses its own number instead.
+
+A provider named in `[limits.max_concurrent_inferences_by_provider]` gets a second, coarser pool in
+front of that one, bounding every model it serves together. A request takes a slot in both and
+holds both for its duration. It is for the metered API where the point of a small pool is bounding
+spend: capping one provider at 1 leaves every other provider's pool untouched, which lowering the
+global number cannot do. A provider that is not named there has no pool of its own - the global
+fallback is a per-model number and is not applied a second time per provider.
 
 Waiting for a slot is ordinary backpressure and is never treated as a failure, however long it
 lasts. Waiting for a provider that was never configured is different: that agent has nothing to
@@ -322,8 +329,12 @@ wait for, so it fails after `[limits] stall_timeout_secs` (60 seconds by default
 forever).
 
 This knob gets confused with two others. Fan-out's `max_workers` bounds how many *sub-agents* a
-stage spawns. `[rate_limits.<provider>]` shapes how fast requests are sent. The pool bounds how
-many run at once. All three apply independently.
+stage spawns. `[rate_limits.<provider>]` shapes how fast requests are sent. The pools bound how
+many run at once. All of them apply independently.
+
+The daemon's health reading carries each pool's occupancy, providers included - in `lev ps --json`
+under `health`, and in the lane heartbeat in the log - because a run parked on a full provider pool
+sees every model pool with room in it.
 
 ## The tool lane
 

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -161,12 +161,13 @@ in `lev validate` and not as a fan-out wider than the manifest appeared to allow
 
 ## `max_workers` is not the knob you might think
 
-Three different settings limit concurrency, and they are easy to confuse. All three apply at once:
+Four different settings limit concurrency, and they are easy to confuse. All four apply at once:
 
 | Setting | Bounds | Scope |
 |---|---|---|
 | `max_workers` | Sub-agents this stage spawns | One fan-out stage |
 | `[limits] max_concurrent_inferences` | Model requests in flight | Per model, daemon-wide |
+| `[limits.max_concurrent_inferences_by_provider]` | Model requests in flight | Per provider, daemon-wide |
 | `[rate_limits.<provider>]` | Requests per minute | Per provider |
 
 So `max_workers = 30` (the default) starts up to thirty sub-agents, but if the model pool only allows

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -54,6 +54,17 @@ inference_retry_base_ms = 1000
 max_tool_call_write_bytes = 2147483648
 max_run_write_bytes = 10737418240
 
+# Override the global cap for one model. Every model not listed uses
+# max_concurrent_inferences above.
+[limits.max_concurrent_inferences_by_model]
+"gpt-oss-120b" = 2
+
+# Bound one provider across every model it serves - a second cap on top of the
+# per-model pool, for a metered API where the point is bounding spend. Shapes
+# concurrency; [rate_limits.<provider>] shapes rate.
+[limits.max_concurrent_inferences_by_provider]
+cerebras = 1
+
 [security]
 allow_seed_commands = true
 allow_local_network = false

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -195,6 +195,22 @@
           "type": "integer",
           "minimum": 0,
           "description": "Most bytes a whole run may write to disk. Absent is unlimited. Catches what a per-call ceiling cannot: several individually plausible calls that together fill a disk. Same defaulting as max_tool_call_write_bytes."
+        },
+        "max_concurrent_inferences_by_model": {
+          "type": "object",
+          "description": "Per-model overrides of max_concurrent_inferences, keyed by model id. A model listed here uses its own number; every other model uses the global one.",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "max_concurrent_inferences_by_provider": {
+          "type": "object",
+          "description": "Caps on in-flight requests to one provider across every model it serves, keyed by provider name. A second, coarser bound than the per-model pool, not a replacement: a request needs a slot in both. Distinct from [rate_limits.<provider>], which shapes how fast requests are sent rather than how many run at once. A provider absent here has no pool of its own; the global fallback is not applied per provider.",
+          "additionalProperties": {
+            "type": "integer",
+            "minimum": 1
+          }
         }
       }
     },


### PR DESCRIPTION
Closes #522.

## The bug

`[limits] max_concurrent_inferences` was the only concurrency knob and it
applies to *every* model's pool. Capping a metered third-party provider at 1 to
bound spend therefore also throttled Anthropic and OpenAI on the same machine.

Meanwhile two doc lines promised a knob that did not exist:

- `docs/content/configuration.md:136` - "in-flight requests per model **without
  its own pool entry**"
- `docs/content/engine.md:317` - "**per-model limits override it**"

`InferencePoolConfig::per_model` and `set_limit` were real, and nothing ever
called them from config. So the engine had a per-model pool with no way to
configure it, and no per-provider pool at all.

## The fix

Two new `[limits]` tables:

```toml
[limits]
max_concurrent_inferences = 8

[limits.max_concurrent_inferences_by_model]
"gpt-oss-120b" = 2

[limits.max_concurrent_inferences_by_provider]
cerebras = 1
```

**By model** replaces the global cap for one model id - wiring up the pool that
was already there.

**By provider** is a *second, coarser* pool in front of the per-model one, not a
replacement for it. A request takes a slot in both and holds both until it
finishes. This is what the issue's motivating case actually needs: "one request
at a time to this provider, whatever it is serving" is not something a per-model
number can say, since the provider serves several models.

## Nothing existing gets tighter

A provider nobody names has **no pool of its own**, and the global fallback is
deliberately not applied per provider as well - it is a per-model number, and
applying it twice would silently tighten every install that never asked for a
provider cap. An install that adds neither table behaves exactly as before.

## Ordering and release

`try_acquire` takes the provider slot first and the model slot second, and
`acquire` waits in the same order, so two callers can never each hold half of
what the other needs. A model pool that refuses hands the provider slot straight
back - nothing was started, so nothing stays held. `InferencePermit` releases
both on drop, which is also what wakes the tick loop.

All six dispatch sites already had the provider name in scope
(`si.provider_name`, `config.provider`, the title job's `provider_name`).

## Observability

A run parked on a full provider pool sees every model pool with room in it, so
`inference` occupancy alone reads as "waiting on nothing". `LaneSnapshot` and
`DaemonHealth` gained `inference_providers` (`#[serde(default)]`, so an older
client's payload still parses), and the lane heartbeat renders it:

```
m=1/unbounded provider:script=1/1
```

That line is the assertion in `the_heartbeat_names_a_full_provider_pool`, which
runs two real agents against a provider capped at 1 with **no** model cap - so
the provider pool is the only thing the second agent can be behind.

## Tests

- `a_provider_cap_bounds_its_models_together_and_nobody_else` - two different
  models of the capped provider contend; an uncapped provider is unaffected.
- `a_full_model_pool_releases_the_provider_slot_it_just_took` - the refused
  attempt keeps nothing.
- `acquire_waits_for_a_provider_slot_and_takes_it_when_freed` - the async path.
- `provider_occupancy_lists_only_capped_providers_that_have_run` - lazy
  creation, sorting, `is_full`, `Display`, and a serde round trip of the wire
  form the health payload carries.
- `inference_pools_carries_every_limits_table_through` - config to engine.
- `the_heartbeat_names_a_full_provider_pool` - end to end through the world.
- The config round-trip test carries both new tables.

Docs: `engine.md`'s pool section describes both pools, `configuration.md` gains
both keys plus a worked example and the concurrency-vs-rate distinction,
`sub-agents.md`'s "three settings" table is now four, and the schema and example
config carry both.

`cargo xtask coverage --package leviath-runtime` and `--package leviath-cli`
both pass at 100%; the full suite is green (8040 tests).
