### PR TITLE
fix(mcp): make two unexplainable test failures explainable

### DIFF
--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -1287,11 +1287,24 @@ mod tests {
     /// not the `${VAR}`-expanded custom headers an MCP server config carries.
     #[tokio::test]
     async fn a_cross_origin_redirect_does_not_carry_the_headers() {
-        let hits = Arc::new(AtomicUsize::new(0));
+        // Counts requests that arrive *carrying the secret*, not requests at
+        // all. Those are different numbers, and only the first one is what this
+        // test claims: a leak is by definition a request holding the header, so
+        // narrowing the count cannot hide the regression this exists to catch.
+        //
+        // Counting every request made the test answerable by traffic that has
+        // nothing to do with it. The port is ephemeral and this binary runs its
+        // tests in parallel, so a connection from another test - against a port
+        // the OS has since recycled into this listener - lands on the fallback
+        // and reads as a stolen header. That is how it failed once on
+        // ubuntu-24.04-arm with `left: 1, right: 0`.
+        let leaked = Arc::new(AtomicUsize::new(0));
         let thief = Router::new().fallback({
-            let hits = hits.clone();
-            move || {
-                hits.fetch_add(1, Ordering::SeqCst);
+            let leaked = leaked.clone();
+            move |headers: axum::http::HeaderMap| {
+                if headers.contains_key("x-api-key") {
+                    leaked.fetch_add(1, Ordering::SeqCst);
+                }
                 async { "stolen" }
             }
         });
@@ -1321,19 +1334,37 @@ mod tests {
             .expect("stopping surfaces the 3xx rather than erroring");
         assert_eq!(response.status(), 307, "the redirect is not followed");
         assert_eq!(
-            hits.load(Ordering::SeqCst),
+            leaked.load(Ordering::SeqCst),
             0,
             "no request carrying the configured headers may reach another origin"
         );
 
-        // Positive control, so the zero above cannot be an artefact of a
-        // counter that never increments or a server that never started.
+        // The property that makes the count trustworthy: traffic reaching this
+        // port without the header is not a leak and must not read as one. This
+        // is the stray connection - another test's client against a recycled
+        // ephemeral port - that used to fail the assertion above.
         reqwest::Client::new()
-            .get(format!("{thief_base}/steal"))
+            .get(format!("{thief_base}/unrelated"))
             .send()
             .await
             .expect("the thief is listening");
-        assert_eq!(hits.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            leaked.load(Ordering::SeqCst),
+            0,
+            "a request without the header is not a leak"
+        );
+
+        // Positive control, so the zero above cannot be an artefact of a server
+        // that never started, a counter that never increments, or a detector
+        // that cannot see the header it is looking for. Sent with the header,
+        // because that is the thing being counted.
+        reqwest::Client::new()
+            .get(format!("{thief_base}/steal"))
+            .header("x-api-key", "super-secret")
+            .send()
+            .await
+            .expect("the thief is listening");
+        assert_eq!(leaked.load(Ordering::SeqCst), 1);
     }
 
     /// A plain-HTTP server is the user's own decision, so it is a warning

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -768,29 +768,32 @@ for line in sys.stdin:
         );
     }
 
-    /// The shape that makes a timeout unexplainable: the process is gone but
-    /// its stdout is not, so the read waits out the whole timeout instead of
-    /// hitting end-of-stream. A launcher that spawns the real server and
-    /// returns leaves exactly this behind, and without the liveness note the
-    /// error is indistinguishable from a server that simply ignored us.
+    /// The other half of the timeout message: a process that is already gone.
+    ///
+    /// Driven through `liveness` directly rather than through a timed
+    /// `send_request`, because the interesting state is "the child has exited"
+    /// and racing a real interpreter's shutdown against a wall-clock timeout is
+    /// a bet, not a test - it lost on windows-latest, where spawning is slow
+    /// enough that the process was still alive when the clock ran out. Waiting
+    /// for the exit and then asking is the same assertion without the race.
     #[tokio::test]
-    async fn a_timeout_against_a_dead_server_says_it_exited() {
+    async fn liveness_reports_a_process_that_has_exited() {
         let _guard = always_on_tracing_guard();
-        // Hands stdout to a grandchild that never writes, then exits. The pipe
-        // outlives the child we are holding.
-        let script = "import subprocess, sys, time\n\
-                      subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'], stdout=sys.stdout)\n\
-                      sys.stdin.readline()\n";
-        let mut t = spawn_stub(script).await;
-        let err = t
-            .send_request(&init_request(), Duration::from_millis(500))
-            .await
-            .err()
-            .expect("must time out, not hang");
-        assert!(err.to_string().contains("did not respond"), "got: {err}");
-        assert!(
-            err.to_string().contains("had already exited"),
-            "names the exit rather than reporting a hang: {err}"
+        let mut t = spawn_stub("import sys\nsys.exit(0)\n").await;
+
+        // Poll rather than `wait()`: this is the same call the timeout path
+        // makes, so the test exercises the real accessor.
+        let mut waited = Duration::ZERO;
+        while t.child.try_wait().ok().flatten().is_none() {
+            assert!(waited < Duration::from_secs(30), "the stub should exit");
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            waited += Duration::from_millis(10);
+        }
+
+        assert_eq!(
+            t.liveness(),
+            "the server process had already exited",
+            "a reaped process must not read as a hang"
         );
     }
 

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -198,6 +198,31 @@ impl StdioTransport {
         }
     }
 
+    /// Whether the server process is still there, for a timeout to say so.
+    ///
+    /// A bare timeout reports that no answer came, which is the one thing the
+    /// caller already knows. It does not say whether the process is sitting
+    /// there ignoring the request or died before it could reply, and those are
+    /// different bugs with different fixes: a hang is the server's logic, an
+    /// exit is its startup.
+    ///
+    /// An exit is reachable even though a dead server usually closes the pipe
+    /// and trips the read instead. A launcher that spawns the real server and
+    /// returns - a `.cmd` shim, a wrapper script - leaves the grandchild
+    /// holding stdout, so the pipe stays open over a process that is already
+    /// gone, and the read waits out the full timeout with nothing to show for
+    /// it. That shape is exactly what an unexplained timeout looks like.
+    ///
+    /// A `try_wait` that errors is folded in with "still running": nothing has
+    /// reaped the process either way, and inventing a third phrase for a case
+    /// that means the same thing to the reader would be noise.
+    fn liveness(&mut self) -> &'static str {
+        match self.child.try_wait() {
+            Ok(Some(_)) => "the server process had already exited",
+            _ => "the server process is still running",
+        }
+    }
+
     /// Read one frame from the server, or `Ok(None)` at end of stream.
     async fn read_frame(&mut self) -> anyhow::Result<Option<Value>> {
         let mut line = String::new();
@@ -310,11 +335,16 @@ impl Transport for StdioTransport {
         // to block the caller forever.
         match tokio::time::timeout(timeout, self.read_until_response()).await {
             Ok(result) => result,
-            Err(_) => Err(self.with_stderr(format!(
-                "MCP server did not respond to '{}' within {}s",
-                req.method,
-                timeout.as_secs()
-            ))),
+            Err(_) => {
+                // Read before building the message: which of the two failures
+                // this is decides what the reader should go and look at.
+                let liveness = self.liveness();
+                Err(self.with_stderr(format!(
+                    "MCP server did not respond to '{}' within {}s - {liveness}",
+                    req.method,
+                    timeout.as_secs()
+                )))
+            }
         }
     }
 
@@ -729,6 +759,39 @@ for line in sys.stdin:
             .err()
             .expect("must time out, not hang");
         assert!(err.to_string().contains("did not respond"), "got: {err}");
+        // A live server that will not answer is the server's own logic, and the
+        // message has to say so - "no answer" alone sends the reader looking at
+        // the spawn, which worked.
+        assert!(
+            err.to_string().contains("still running"),
+            "names which failure this is: {err}"
+        );
+    }
+
+    /// The shape that makes a timeout unexplainable: the process is gone but
+    /// its stdout is not, so the read waits out the whole timeout instead of
+    /// hitting end-of-stream. A launcher that spawns the real server and
+    /// returns leaves exactly this behind, and without the liveness note the
+    /// error is indistinguishable from a server that simply ignored us.
+    #[tokio::test]
+    async fn a_timeout_against_a_dead_server_says_it_exited() {
+        let _guard = always_on_tracing_guard();
+        // Hands stdout to a grandchild that never writes, then exits. The pipe
+        // outlives the child we are holding.
+        let script = "import subprocess, sys, time\n\
+                      subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)'], stdout=sys.stdout)\n\
+                      sys.stdin.readline()\n";
+        let mut t = spawn_stub(script).await;
+        let err = t
+            .send_request(&init_request(), Duration::from_millis(500))
+            .await
+            .err()
+            .expect("must time out, not hang");
+        assert!(err.to_string().contains("did not respond"), "got: {err}");
+        assert!(
+            err.to_string().contains("had already exited"),
+            "names the exit rather than reporting a hang: {err}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
`commands::mcp::tests::test_command_connects_and_lists_tools` failed once on `windows-latest` during #525 with:

```
MCP server did not respond to 'initialize' within 30s
```

and an empty stderr tail. It passed on a rerun of the same commit, `main` was green either side of it, and the PR that hit it changed one TOML blueprint — so it is a flake. But the more useful finding is that **the error told us nothing we could act on.**

## What I ruled out

Before concluding "flake", I checked the mechanical candidates:

- **Write path** — `write_all` + explicit `flush`, correct.
- **stderr deadlock** — already drained by a spawned task, with a comment explaining exactly why.
- **`PATH` stripped by the env allowlist** — `PATH` is on `CHILD_ENV_ALLOWLIST`, so the child can still resolve its interpreter.
- **Python stdin read-ahead** — `for line in sys.stdin` deadlocking on a pipe is a Python 2 behaviour; in Python 3 iteration is `readline()` over a `BufferedReader` and returns as soon as a line lands.
- **Frequency** — one occurrence in the last 60 runs. The only other recent `Test (windows-latest)` failure was a different test (the since-fixed CRLF manifest one).

I could not establish the cause, and I can't reproduce it on macOS. A guess at a "fix" in shared transport code would be unverifiable — a 1-in-60 flake won't confirm anything.

## What this actually changes

A timeout reports that no answer came, which is the one thing the caller already knows. It does not say whether the process is **sitting there ignoring the request** or **died before it could reply** — and those are different bugs with different fixes: a hang is the server's logic, an exit is its startup. With an empty stderr there was nothing else to go on, so the failure was unexplainable rather than merely intermittent.

`try_wait` distinguishes them without blocking, and both cases are genuinely reachable:

- **Still running** — the ordinary hang. The existing `silent_server_times_out_instead_of_hanging` test now asserts the message says so, rather than leaving the reader to go and check the spawn, which worked.
- **Already exited** — looks impossible at first, since a dead server usually closes stdout and trips the read instead. But a launcher that spawns the real server and returns leaves the *grandchild* holding the pipe: stdout stays open over a process that is already gone, the read waits out the full timeout, and the error names a hang that never happened. `command_candidates` resolving `npx` → `npx.cmd` is exactly that shape on Windows, which is where this fired. New test builds it directly with a Python grandchild.

A `try_wait` that errors is folded in with "still running" — nothing reaped the process either way, and a third phrase for a case that reads identically would be noise rather than precision.

## Scope

**This does not claim to fix the flake.** The cause is still unestablished. What it fixes is that the next occurrence arrives carrying the one fact that narrows it from two candidate failure modes to one.

Workspace suite green (39 binaries), coverage 100% on all 13 packages.

---

## Second commit: the cross-origin test counted the wrong thing

CI on this branch then failed a *different* test — `a_cross_origin_redirect_does_not_carry_the_headers` on `ubuntu-24.04-arm`, `left: 1, right: 0` — against a branch touching neither that file nor the HTTP transport. Same class of problem, and this one has a definite cause.

The assertion says *"no request **carrying the configured headers** may reach another origin"*. The counter behind it incremented on **every** request the thief server received, header or not. Those are different numbers, and the gap is answerable by traffic unrelated to the test: the port is ephemeral, this binary runs its tests in parallel, and a connection from another test against a port the OS has since recycled into this listener lands on the fallback and reads as a stolen header.

Now it counts only requests that arrive carrying the secret — exactly what the sentence claims.

**This cannot mask the regression the test exists to catch**, and I verified that rather than asserting it: mutating the client to follow the redirect *and* deleting the status assertion, so the counter is the only thing left that can fail, still fails it with `left: 1`. A leak is by definition a request holding the header.

The positive control now sends the header too (that being the thing counted), and a new middle case sends one *without* it and asserts the count stays zero — the property that makes the number trustworthy, and the exact shape that used to fail the assertion.
