### PR TITLE
fix: follow-ups to the automate batch — exit codes and a zero-width pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ same list.
   provider nor a row in the built-in table is now loaded through the script
   layer and asked for its catalog, with or without `--remote` (a script names
   its models at run time, so there is nothing local to read). A script that
-  will not load, and an error raised by its `list_models`, are each reported by
-  name instead of being folded into an empty table. `lev doctor --help` and the
-  CLI reference no longer say a script provider cannot be listed.
+  will not load, and an error raised by its `list_models`, each now **fail the
+  command** rather than being folded into an empty table under an exit code of
+  0, so it works as the CI gate the docs send you to it for. A `--provider` the
+  built-in table knows but this install has no credential for is still an empty
+  table and still exits 0. `lev doctor --help` and the CLI reference no longer
+  say a script provider cannot be listed.
 
 - Added: `[limits.max_concurrent_inferences_by_provider]` caps in-flight
   requests to one provider across every model it serves, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ same list.
 
 ## Unreleased
 
+- Fixed: an inference-pool limit of `0` no longer parks every affected run for
+  the life of the daemon. Waiting for a full pool is ordinary backpressure and
+  is deliberately never failed or reported, so a pool of nothing was a wedge
+  with nothing said about it - and the schema's `minimum: 1` had nothing
+  enforcing it, since config values are not validated against the schema at run
+  time. `[limits] max_concurrent_inferences` and both of its per-model and
+  per-provider tables now read a `0` as `1` and say so in the log, matching the
+  tool lane, which has always clamped its own width. To lift a limit, delete
+  the key.
+
 - Fixed: `lev models list --provider <name>` now reaches a Rhai script
   provider. `ProviderRegistry::provider_names()` enumerates natively registered
   providers only, and the script layer is consulted by `get()`, never by that -

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -555,15 +555,18 @@ async fn list_with_registry(
 
     // A `--provider` naming something neither registered natively nor present
     // in the built-in table is a script provider (or a typo). Ask the script
-    // layer: it is the only thing that can answer for one. A name the built-in
-    // table knows is left alone - `--provider openai` with no OpenAI key is an
-    // empty table, exactly as it has always been.
+    // layer: it is the only thing that can answer for one, and a name it cannot
+    // answer for is an error rather than an empty table, since nothing else
+    // could have answered either. A name the built-in table knows is left alone
+    // - `--provider openai` with no OpenAI key is an empty table, exactly as it
+    // has always been.
     let mut script_provider_answered = false;
     if let Some(ref name) = args.provider
         && !available.contains(name)
         && !builtin_table().iter().any(|e| e.provider == name.as_str())
     {
-        script_provider_answered = merge_script_provider(&registry, name, &mut entries).await;
+        merge_script_provider(&registry, name, &mut entries).await?;
+        script_provider_answered = true;
     }
 
     // Apply provider filter (after remote merge so we respect the filter).
@@ -659,7 +662,7 @@ async fn list_with_registry(
 }
 
 /// Load the script provider called `name` and merge whatever `list_models`
-/// answers into `entries`. Returns whether it answered at all.
+/// answers into `entries`.
 ///
 /// A script provider defines its catalog at run time, so the built-in table
 /// has no rows for one and `lev models list --provider <name>` used to print
@@ -667,40 +670,40 @@ async fn list_with_registry(
 /// what makes that command the smoke test `rhai-providers.md` prescribes: it
 /// compiles the script, runs `initialize`, and calls `list_models`.
 ///
-/// Both failure paths report and continue rather than erroring, matching what
-/// `--remote` has always done for a native provider that will not answer - the
-/// non-zero gate for a provider script is `lev doctor -m <provider>/<model>`.
+/// **Errors rather than warning.** This is the command the Rhai docs send you
+/// to *because* a broken provider script is otherwise skipped silently at model
+/// selection, and an empty table under an exit code of 0 is that same silence
+/// one step earlier. A name reaching this function has nothing in the built-in
+/// table either, so there is no answer to fall back to and nothing an exit code
+/// of 0 could honestly mean.
 async fn merge_script_provider(
     registry: &leviath_runtime::ProviderRegistry,
     name: &str,
     entries: &mut Vec<ModelInfo>,
-) -> bool {
+) -> anyhow::Result<()> {
     let Some(provider) = registry.get(name) else {
         // Either a name with nothing behind it, or a script that failed to
-        // compile - the script layer logged which as it happened. Say the part
-        // it cannot: that this is why the table below is empty.
-        eprintln!(
-            "Warning: no provider named '{}' is configured, and no script \
-             provider by that name loaded",
-            name
+        // compile - the script layer logged which as it happened, so this says
+        // the part it cannot: that the command found nothing to ask.
+        anyhow::bail!(
+            "no provider named '{name}' is configured, and no script provider \
+             by that name loaded. Check the spelling, `[model_providers.{name}]` \
+             in {}, and that {name}.rhai compiles (a load failure is logged \
+             above with the line it failed on).",
+            Config::config_path().display()
         );
-        return false;
     };
-    match provider.list_models().await {
-        Ok(models) => {
-            for rm in models {
-                match entries.iter_mut().find(|e| e.id == rm.id) {
-                    Some(existing) => *existing = rm,
-                    None => entries.push(rm),
-                }
-            }
-            true
-        }
-        Err(e) => {
-            eprintln!("Warning: could not fetch models from '{}': {}", name, e);
-            false
+    let models = provider
+        .list_models()
+        .await
+        .map_err(|e| anyhow::anyhow!("provider '{name}' could not list its models: {e}"))?;
+    for rm in models {
+        match entries.iter_mut().find(|e| e.id == rm.id) {
+            Some(existing) => *existing = rm,
+            None => entries.push(rm),
         }
     }
+    Ok(())
 }
 
 // ─── show ─────────────────────────────────────────────────────────────────────
@@ -1171,7 +1174,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn execute_list_with_nonexistent_provider_filter() {
+    async fn execute_list_with_nonexistent_provider_filter_fails() {
         crate::config::with_isolated_config_path_async(
             "models-execute_list_with_nonexistent_provider_filter",
             |_fake_dir| async move {
@@ -1183,9 +1186,14 @@ mod tests {
                         json: false,
                     }),
                 };
-                // Should succeed but print "No models found."
-                let result = execute(args).await;
-                assert!(result.is_ok());
+                // Nothing registered, nothing in the built-in table, no script
+                // of that name: there is no answer, so this exits non-zero
+                // rather than printing an empty table.
+                let err = execute(args).await.expect_err("nothing can answer");
+                assert!(
+                    err.to_string().contains("nonexistent_provider"),
+                    "the message names the provider: {err}"
+                );
             },
         )
         .await;
@@ -1490,12 +1498,18 @@ mod tests {
     async fn list_json_with_no_configured_provider_is_an_empty_array() {
         // The prose report prints a nudge here. JSON must not: a caller reading
         // this branches on the array's length, and a sentence would not parse.
+        //
+        // `openai` rather than a made-up name: a provider the built-in table
+        // knows but this install has no credential for is the case that still
+        // has an honest empty answer. A name nothing can answer for is an error
+        // (see `execute_list_with_nonexistent_provider_filter_fails`), and an
+        // error has no array to print.
         crate::config::with_isolated_config_path_async(
             "models-list_json_empty",
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
-                    provider: Some("no-such-provider".to_string()),
+                    provider: Some("openai".to_string()),
                     all: false,
                     json: true,
                 };
@@ -1562,7 +1576,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_unknown_provider_filter_finds_nothing() {
+    async fn list_unknown_provider_filter_is_an_error_not_an_empty_table() {
         crate::config::with_isolated_config_path_async(
             "models-list_unknown_provider_filter_finds_nothing",
             |_fake_dir| async move {
@@ -1572,9 +1586,15 @@ mod tests {
                     all: false,
                     json: false,
                 };
-                // Should print "No models found." and still succeed, not error.
-                let result = list_with_registry(args, &build_provider_registry_from_config).await;
-                assert!(result.is_ok());
+                let err = list_with_registry(args, &build_provider_registry_from_config)
+                    .await
+                    .expect_err("a name nothing can answer for is an error");
+                let msg = err.to_string();
+                assert!(msg.contains("no-such-provider"), "{msg}");
+                assert!(
+                    msg.contains(".rhai"),
+                    "it says where a script would go: {msg}"
+                );
             },
         )
         .await;
@@ -1922,12 +1942,15 @@ mod tests {
         crate::config::with_isolated_config_path_async(
             "models-list_remote_skips_providers_not_matching_filter",
             |_fake_dir| async move {
-                // provider filter is "mock-other", but the registry only has "mock"
-                // registered -> the `if filter != provider_name { continue; }`
-                // branch is exercised, and the mock is never queried.
+                // The registry only has "mock" registered, so the filter never
+                // matches and the `if filter != provider_name { continue; }`
+                // branch is exercised without the mock ever being queried.
+                // `openai` rather than a made-up name so the filter is one the
+                // built-in table can still answer for - an unanswerable name is
+                // an error, which would end the command before this branch.
                 let args = ListArgs {
                     remote: true,
-                    provider: Some("mock-other".to_string()),
+                    provider: Some("openai".to_string()),
                     all: false,
                     json: false,
                 };
@@ -2019,7 +2042,8 @@ mod tests {
     }
 
     /// The auth failure the docs promise surfaces here: `list_models` threw, so
-    /// the command says so instead of printing an empty table and nothing else.
+    /// the command fails with what the provider said instead of printing an
+    /// empty table under an exit code of 0.
     #[tokio::test]
     async fn list_reports_a_script_provider_that_cannot_list() {
         let dir = tempfile::tempdir().expect("a temp providers dir");
@@ -2040,8 +2064,15 @@ mod tests {
                     all: false,
                     json: false,
                 };
-                let result = list_with_registry(args, &script_registry(dir)).await;
-                assert!(result.is_ok());
+                let err = list_with_registry(args, &script_registry(dir))
+                    .await
+                    .expect_err("a provider that cannot list is a failed smoke test");
+                let msg = err.to_string();
+                assert!(msg.contains("angry"), "{msg}");
+                assert!(
+                    msg.contains("401 Unauthorized"),
+                    "the provider's own words survive: {msg}"
+                );
             },
         )
         .await;

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -340,17 +340,63 @@ pub struct LimitsConfig {
     pub max_concurrent_inferences_by_provider: BTreeMap<String, usize>,
 }
 
+/// A pool of `0` would take no request ever, so every run needing it parks
+/// for the life of the daemon as *ordinary backpressure* - never failed, never
+/// reported as an error, because waiting for a busy pool is exactly what the
+/// engine is supposed to do. A wedge with no message is the worst answer
+/// available, so it is clamped to one and said out loud.
+///
+/// One rather than unbounded, deliberately: someone writing `0` in a table of
+/// ceilings meant "as little as possible", and the documented way to say "no
+/// limit" for these keys is to omit them. The schema declares `minimum: 1`;
+/// this is what enforces it, since nothing validates config values against the
+/// schema at run time.
+///
+/// Mirrors the tool lane, which clamps its own width the same way
+/// (`ToolLane::new`).
+fn usable_pool_limit(limit: usize, what: &str) -> usize {
+    if limit == 0 {
+        tracing::warn!(
+            limit = %what,
+            "a concurrency limit of 0 would park every request on this pool \
+             forever, so it is being treated as 1; omit the key entirely for \
+             no limit"
+        );
+        return 1;
+    }
+    limit
+}
+
 impl LimitsConfig {
     /// The inference pools these limits describe, for the engine: the global
     /// fallback, the per-model overrides, and the per-provider caps.
+    ///
+    /// A `0` anywhere here is read as `1`: a pool of nothing would park every
+    /// request on it for the life of the daemon, since waiting for a full pool
+    /// is backpressure the engine never fails. Deleting the key is how a limit
+    /// is lifted.
     pub fn inference_pools(&self) -> leviath_runtime::inference_pool::InferencePoolConfig {
-        let mut config = leviath_runtime::inference_pool::InferencePoolConfig::new()
-            .with_default(self.max_concurrent_inferences);
+        let mut config = leviath_runtime::inference_pool::InferencePoolConfig::new().with_default(
+            self.max_concurrent_inferences
+                .map(|limit| usable_pool_limit(limit, "[limits] max_concurrent_inferences")),
+        );
         for (model, limit) in &self.max_concurrent_inferences_by_model {
-            config.set_limit(model, *limit);
+            config.set_limit(
+                model,
+                usable_pool_limit(
+                    *limit,
+                    &format!("[limits.max_concurrent_inferences_by_model] {model}"),
+                ),
+            );
         }
         for (provider, limit) in &self.max_concurrent_inferences_by_provider {
-            config.set_provider_limit(provider, *limit);
+            config.set_provider_limit(
+                provider,
+                usable_pool_limit(
+                    *limit,
+                    &format!("[limits.max_concurrent_inferences_by_provider] {provider}"),
+                ),
+            );
         }
         config
     }

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -1960,6 +1960,35 @@ some_custom_thing = \"forwarded to the script\"
         assert_eq!(Config::default().limits.max_concurrent_inferences, Some(8));
     }
 
+    /// A pool of `0` takes no request ever, and waiting for a full pool is
+    /// ordinary backpressure the engine never fails - so a `0` left as written
+    /// parks every affected run for the life of the daemon with nothing said.
+    /// Every one of the three keys is clamped to 1 instead.
+    #[test]
+    fn a_zero_inference_pool_is_clamped_to_one() {
+        with_tracing(|| {
+            let mut limits = LimitsConfig {
+                max_concurrent_inferences: Some(0),
+                ..Default::default()
+            };
+            limits
+                .max_concurrent_inferences_by_model
+                .insert("stuck-model".to_string(), 0);
+            limits
+                .max_concurrent_inferences_by_provider
+                .insert("stuck-provider".to_string(), 0);
+
+            let pools = limits.inference_pools();
+            assert_eq!(pools.limit_for("stuck-model"), Some(1));
+            assert_eq!(
+                pools.limit_for("any-other-model"),
+                Some(1),
+                "the global fallback is clamped too"
+            );
+            assert_eq!(pools.provider_limit_for("stuck-provider"), Some(1));
+        });
+    }
+
     /// The `[limits]` tables reach the engine's pools: the global fallback for
     /// an unlisted model, a per-model override, and a per-provider cap that is
     /// deliberately *not* filled in from the global number (issue #522).

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -294,7 +294,11 @@ it returns `false`.
 
 `--provider` naming a [Rhai script provider](/docs/rhai-providers) loads that script and calls its
 `list_models`, with or without `--remote`: a script names its own catalog at run time, so there is
-no built-in table to read it from.
+no built-in table to read it from. A `--provider` that names nothing at all - no configured
+provider, no row in the built-in table, no script of that name that loads - **exits non-zero**
+rather than printing an empty table, since there is nothing an empty table could be reporting.
+A provider the built-in table knows but this install has no credential for is still an empty table
+and still exits 0.
 
 ### `lev agent-client`
 
@@ -593,8 +597,8 @@ the run. Nothing is left in `lev ps` or on disk.
 `--model` takes `provider/model` to pick both, and a bare model id pairs with your
 `default_provider`. `--model provider/model` is the way to reach a
 [Rhai script provider](/docs/rhai-providers), which is resolved by name. Use it to try a model
-string before wiring it into a blueprint - unlike `lev models list`, it exits non-zero when the
-model cannot be reached.
+string before wiring it into a blueprint: it goes further than `lev models list --provider`, which
+compiles the provider and reads its catalog but never sends an inference.
 
 `lev doctor` exits non-zero when a check fails, so it works as a CI gate. It bills two inferences
 per run, each capped at 64 output tokens; `--no-daemon` bills one.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -205,6 +205,11 @@ one and is not applied per provider as well. See
 [inference pools](/docs/engine#inference-pools), and note that this bounds *concurrency* while
 [`[rate_limits.<provider>]`](#rate_limitsprovider) bounds *rate*.
 
+`0` is not a way to say "no limit" in any of the three, and not a way to disable a provider either:
+a pool of nothing would park every request on it for the life of the daemon, and waiting for a full
+pool is ordinary backpressure that is never failed or reported. A `0` is therefore read as `1` and
+said so in the log. To lift a limit, delete the key.
+
 **`stall_timeout_secs`** only fires for something the runtime cannot resolve on its own. Today that
 means a stage whose provider is not configured: the run is ready to work and has nowhere to send the
 request. Waiting for a busy model's pool is ordinary backpressure and is never failed, however long

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -323,6 +323,10 @@ spend: capping one provider at 1 leaves every other provider's pool untouched, w
 global number cannot do. A provider that is not named there has no pool of its own - the global
 fallback is a per-model number and is not applied a second time per provider.
 
+The smallest a pool can be is 1. A configured `0` is read as `1`, since a pool of nothing would
+park every request on it forever under the backpressure rule below - which is exactly the shape
+nothing ever reports.
+
 Waiting for a slot is ordinary backpressure and is never treated as a failure, however long it
 lasts. Waiting for a provider that was never configured is different: that agent has nothing to
 wait for, so it fails after `[limits] stall_timeout_secs` (60 seconds by default; `0` waits

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -341,19 +341,22 @@ match its wire format.
 
 ```bash
 lev models list --provider groq   # compiles the script and calls list_models
-lev doctor -m groq/<model>        # the same, then a real inference; exits non-zero on failure
+lev doctor -m groq/<model>        # the same, then a real inference
 lev run <agent> --task "..."      # a live run through a stage that references the provider
 ```
 
 `lev models list --provider <name>` loads the script by name whether or not `--remote` is passed,
-since a script provider has no row in the built-in model table. A compile failure, and an error
-raised by `list_models` itself, are both reported by name.
+since a script provider has no row in the built-in model table. It **exits non-zero** when the
+script does not compile, when there is no script of that name, and when `list_models` itself
+raises - so it works as a CI gate, and a passing run means the script compiled, `initialize` ran,
+and the provider answered.
 
 > [!TIP]
 > A broken provider script is skipped and model selection falls through to the next configured model,
 > so a syntax error looks like "my agent quietly used the wrong model". Check it before you wire it
-> into a blueprint: `lev models list --provider <name>` shows the catalog and names any failure, and
-> `lev doctor -m <name>/<model>` does the same and exits non-zero, so it works as a CI gate.
+> into a blueprint: `lev models list --provider <name>` compiles it and shows the catalog, and
+> `lev doctor -m <name>/<model>` goes one step further and bills a real inference. Both exit
+> non-zero on failure.
 
 If `lev serve` is running, `POST /api/scripts/validate` with `kind: "provider"` answers the same
 question without a run and without a key: it compiles the text and checks that `initialize(config)`

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -174,7 +174,8 @@ pair with a provider that is named separately, so they take `qwen3.8:latest`; on
 `default_provider` is read bare and `lev doctor` says so; a blueprint entry is sent as written.
 
 Check the spelling against `lev models list --provider <name> --remote`, which asks the provider
-rather than Leviath's built-in table. Note that a valid dated identifier such as
+rather than Leviath's built-in table. A provider *name* it cannot reach at all fails the command
+outright, so a typo there is answered rather than shown as an empty table. Note that a valid dated identifier such as
 `deepseek/deepseek-v4-flash-0731` may be absent from the offline table while still working, so
 absence there is not proof of a bad name. See
 [model identifiers](/docs/providers#model-identifiers).


### PR DESCRIPTION
Two follow-ups to the `automate` batch (#521 / #522 / #523), one commit each.

## 1. `lev models list --provider` fails when nothing can answer

#523 made the command reach a script provider, but left both failure paths as a
warning and an exit code of 0. That kept the exact shape the tip in
`rhai-providers.md` exists to prevent - a broken provider script looking like a
working one with an empty catalog - just one step earlier than where #523 found
it.

A name that reaches the script layer at all has nothing in the built-in table
either, so there is no answer to fall back to and nothing an exit code of 0
could honestly report. Both paths now fail the command:

```
$ lev models list --provider cerebras
Error: no provider named 'cerebras' is configured, and no script provider by that name
loaded. Check the spelling, [model_providers.cerebras] in ~/.leviath/config.toml, and
that cerebras.rhai compiles (a load failure is logged above with the line it failed on).

$ lev models list --provider angry
Error: provider 'angry' could not list its models: 401 Unauthorized
```

**Unchanged**: a `--provider` the built-in table knows but this install has no
credential for is still an empty table and still exits 0 - `--provider openai`
with no OpenAI key behaves exactly as it always has. A script provider that
loads and lists nothing is also still a success; the smoke test passed.

Three tests pinned the old exit-0 contract for an unknown `--provider` and are
updated to assert the failure and its message. Two of them were also the only
coverage of paths that must still exit 0 (the empty-JSON array, and the remote
loop's filter-skip branch), so both now use `openai` - a name the built-in table
can still answer for - rather than a made-up one. That keeps what they were
really testing and stops them doubling as a contract for a case that has
changed.

`rhai-providers.md`, `cli.md` and `troubleshooting.md` now say the command is a
CI gate.

## 2. An inference pool of `0` is read as `1`

A pool of `0` takes no request ever, and waiting for a full pool is ordinary
backpressure the engine **deliberately never fails and never reports** - so
every run needing it parked for the life of the daemon with nothing said. The
schema declares `minimum: 1` for all three keys and nothing enforced it, since
config values are not validated against the schema at run time.

This predates #522 for `[limits] max_concurrent_inferences`; the two new tables
inherited it. All three now read a `0` as `1` and name the key in a warning:

```
WARN a concurrency limit of 0 would park every request on this pool forever, so it is
     being treated as 1; omit the key entirely for no limit
     limit=[limits.max_concurrent_inferences_by_provider] cerebras
```

One rather than unbounded, deliberately: someone writing `0` in a table of
ceilings meant "as little as possible", and the documented way to lift a limit
is to delete the key. Clamped at the config-to-engine boundary rather than
inside `InferencePoolConfig`, so the runtime keeps its zero-means-zero
semantics - `context_transform`'s tests use `with_default(Some(0))` to force a
full pool on purpose. This mirrors the tool lane, which has always clamped its
own width in `ToolLane::new`.

## Checks

Full workspace suite green, `cargo xtask coverage --package leviath-cli` at
100%, `cargo xtask docs` clean.
