### PR TITLE
fix: a network blip no longer kills a run, and a paused run stays paused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ same list.
 
 ## Unreleased
 
+- Fixed: a network blip no longer ends a run. `Response::json` does two things -
+  read the body off the socket, then parse it - and every provider mapped both
+  failures to "invalid response", which the retry policy treats as permanent. So
+  a dead socket got no retry, no failover and no circuit-breaker record: it went
+  straight to the terminal error arm and took the run's work with it. Measured on
+  a laptop that slept for 31 minutes and woke onto a different network: three
+  runs with 35-38 iterations of completed work each died with `Invalid response:
+  error decoding response body` twenty seconds after the lid opened, and a fourth
+  died the same way on an ordinary blip with no sleep involved. A body that never
+  finished arriving is now reported as the transport failure it is - retried,
+  counted against the provider, eligible for failover - while bytes that arrived
+  and did not fit the schema stay permanent. If the provider still cannot be
+  reached once the retries are spent, the run parks with a remedy instead of
+  failing, so `lev resume` gets the work back.
+
+- Fixed: a paused run is no longer walked forward, or killed, by the inference
+  that was already in flight when it paused. Pause lets the outstanding step
+  finish, but its result was applied unconditionally: a success carried the run
+  on through its tool calls and stage transitions while it still displayed
+  `paused`, and a failure overwrote the pause with an error and discarded the
+  run. The outcome is now held and replayed on resume, so the response you have
+  already paid for is used rather than thrown away.
+
+- Fixed: pausing a fan-out parent now pauses the runs that are actually working.
+  A parent waiting on its children is not itself pausable - the merge poll reads
+  that status - so the request was refused while every child carried on. Pause
+  and resume now walk the whole sub-agent tree, as cancel already did, and a
+  paused fan-out stops starting the next queued worker instead of immediately
+  replacing the children it just paused. Resuming the parent releases them all.
+  `lev pause`/`lev resume`, the REST endpoints and the dashboard's `p`/`r` keys
+  all go through it.
+
 - Fixed: an inference-pool limit of `0` no longer parks every affected run for
   the life of the daemon. Waiting for a full pool is ordinary backpressure and
   is deliberately never failed or reported, so a pool of nothing was a wedge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,11 @@ same list.
   on through its tool calls and stage transitions while it still displayed
   `paused`, and a failure overwrote the pause with an error and discarded the
   run. The outcome is now held and replayed on resume, so the response you have
-  already paid for is used rather than thrown away.
+  already paid for is used rather than thrown away. Relatedly, a paused run with
+  a call still outstanding is no longer paged out of memory while it waits: an
+  in-flight inference is a live continuation like a blocked prompt, and parking
+  the run meant the answer arrived at a despawned entity and was dropped, so the
+  resume quietly paid for the same turn twice.
 
 - Fixed: pausing a fan-out parent now pauses the runs that are actually working.
   A parent waiting on its children is not itself pausable - the merge poll reads

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -620,13 +620,23 @@ impl Dashboard {
     /// will actually pause, so an ineligible row sends nothing instead of
     /// producing a guaranteed refusal toast.
     fn handle_pause(&mut self) {
+        // `Waiting` is included because the daemon pauses the whole sub-agent
+        // tree: a fan-out parent sits here while its children do the work, so
+        // refusing the key would leave the only row a user thinks to press it on
+        // doing nothing at all.
         if let Some(agent) = self.selected_agent()
             && matches!(
                 agent.status,
-                AgentDisplayStatus::Active | AgentDisplayStatus::Idle | AgentDisplayStatus::Stale
+                AgentDisplayStatus::Active
+                    | AgentDisplayStatus::Idle
+                    | AgentDisplayStatus::Stale
+                    | AgentDisplayStatus::Waiting
             )
         {
             let agent_id = agent.id.clone();
+            // Snapshotted before the send, which is what the optimistic flip
+            // below keys on.
+            let waiting = agent.status == AgentDisplayStatus::Waiting;
             let _ = self.cmd_tx.send(DaemonCommand::Pause {
                 run_id: agent_id.clone(),
             });
@@ -640,17 +650,29 @@ impl Dashboard {
                 .agents
                 .get_mut(idx)
                 .expect("index snapshotted from the still-unchanged display_indices/agents above");
-            a.status = AgentDisplayStatus::Paused;
+            // A waiting parent keeps its own status - the merge poll depends on
+            // it, so the daemon pauses the children instead. Flipping this row
+            // would be a claim the next poll contradicts; the children's rows
+            // are where the pause shows up.
+            if !waiting {
+                a.status = AgentDisplayStatus::Paused;
+            }
             self.add_log(format!("{}: pause requested", agent_id));
         }
     }
 
     /// Resume the selected agent if it is paused.
     fn handle_resume(&mut self) {
+        // `Waiting` for the same reason as the pause key: that is the row a
+        // fan-out parent occupies while its paused children wait to be let go.
         if let Some(agent) = self.selected_agent()
-            && agent.status == AgentDisplayStatus::Paused
+            && matches!(
+                agent.status,
+                AgentDisplayStatus::Paused | AgentDisplayStatus::Waiting
+            )
         {
             let agent_id = agent.id.clone();
+            let waiting = agent.status == AgentDisplayStatus::Waiting;
             let _ = self.cmd_tx.send(DaemonCommand::Resume {
                 run_id: agent_id.clone(),
             });
@@ -664,7 +686,9 @@ impl Dashboard {
                 .agents
                 .get_mut(idx)
                 .expect("index snapshotted from the still-unchanged display_indices/agents above");
-            a.status = AgentDisplayStatus::Active;
+            if !waiting {
+                a.status = AgentDisplayStatus::Active;
+            }
             self.add_log(format!("{}: resume requested", agent_id));
         }
     }
@@ -1791,12 +1815,12 @@ mod tests {
         }
     }
 
-    /// Waiting and finished runs are not pausable: nothing is sent, so the user
-    /// never sees a guaranteed refusal toast.
+    /// Finished runs are not pausable: nothing is sent, so the user never sees a
+    /// guaranteed refusal toast. `Waiting` is deliberately absent - see
+    /// `pause_and_resume_reach_a_waiting_parents_children`.
     #[test]
     fn pause_is_a_no_op_for_unpausable_states() {
         for status in [
-            AgentDisplayStatus::Waiting,
             AgentDisplayStatus::Paused,
             AgentDisplayStatus::Complete,
             AgentDisplayStatus::Cancelled,
@@ -1829,6 +1853,44 @@ mod tests {
             })
         );
         assert_eq!(dash.agents[0].status, AgentDisplayStatus::Active);
+    }
+
+    /// A fan-out parent sits at `Waiting` while its children do the work, and it
+    /// is the row a user actually presses `p` on. The daemon pauses the whole
+    /// sub-agent tree, so the key has to reach it - but the parent keeps its own
+    /// status, because the merge poll reads it, so this row must not flip.
+    /// Claiming otherwise would be undone by the very next poll.
+    #[test]
+    fn pause_and_resume_reach_a_waiting_parents_children() {
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.agents
+            .push(make_test_agent("parent", AgentDisplayStatus::Waiting));
+        dash.update_display_indices();
+
+        dash.handle_key(key(KeyCode::Char('p')));
+        assert_eq!(
+            cmd_rx.try_recv().ok(),
+            Some(DaemonCommand::Pause {
+                run_id: "parent".to_string()
+            }),
+            "the request has to get through; the children are what pauses"
+        );
+        assert_eq!(
+            dash.agents[0].status,
+            AgentDisplayStatus::Waiting,
+            "the parent's own row does not lie about a status it keeps"
+        );
+
+        dash.handle_key(key(KeyCode::Char('r')));
+        assert_eq!(
+            cmd_rx.try_recv().ok(),
+            Some(DaemonCommand::Resume {
+                run_id: "parent".to_string()
+            }),
+            "and resuming through the parent is how the children are let go"
+        );
+        assert_eq!(dash.agents[0].status, AgentDisplayStatus::Waiting);
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -1717,6 +1717,7 @@ mod tests {
             active: vec![("item-1".to_string(), "worker-fo".to_string())],
             summaries: vec![],
             failures: vec![],
+            paused: false,
         };
         std::fs::write(
             runs.path().join("parent-fo").join("fanout.json"),

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -472,10 +472,7 @@ impl AnthropicProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
         let response = crate::provider::check_http_response(response, None).await?;
-        let value: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let value: serde_json::Value = crate::provider::decode_json(response).await?;
         value
             .get("input_tokens")
             .and_then(|v| v.as_u64())
@@ -763,10 +760,7 @@ impl Provider for AnthropicProvider {
         )
         .await?;
 
-        let response_body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let response_body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         let result = self.parse_response(&response_body)?;
 

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -208,10 +208,7 @@ impl GeminiProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
         let response = crate::provider::check_http_response(response, None).await?;
-        let value: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let value: serde_json::Value = crate::provider::decode_json(response).await?;
         value
             .get("totalTokens")
             .and_then(|v| v.as_u64())
@@ -248,10 +245,7 @@ impl Provider for GeminiProvider {
         )
         .await?;
 
-        let response_body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let response_body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         let result = parse_openai_response(&response_body)?;
 
@@ -351,10 +345,7 @@ impl GeminiProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
         let response = crate::provider::check_http_response(response, None).await?;
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         let models = body
             .get("models")
@@ -405,10 +396,7 @@ impl GeminiProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
         let response = crate::provider::check_http_response(response, None).await?;
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         let models = body
             .get("data")

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -275,10 +275,7 @@ impl OllamaProvider {
             .await
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
         let tags = crate::provider::check_http_response(tags, None).await?;
-        let tags: serde_json::Value = tags
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let tags: serde_json::Value = crate::provider::decode_json(tags).await?;
 
         let names: Vec<String> = tags
             .get("models")
@@ -301,10 +298,7 @@ impl OllamaProvider {
                 .await
                 .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
             let show = crate::provider::check_http_response(show, None).await?;
-            let show: serde_json::Value = show
-                .json()
-                .await
-                .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+            let show: serde_json::Value = crate::provider::decode_json(show).await?;
             if let Some(window) = effective_window(&show) {
                 windows.insert(name, window);
             }
@@ -561,10 +555,7 @@ impl Provider for OllamaProvider {
         .await
         .map_err(|e| self.explain_truncation(e, request))?;
 
-        let response_body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let response_body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         self.parse_response(&response_body)
     }
@@ -658,10 +649,7 @@ impl Provider for OllamaProvider {
         // retrying can help.
         let response = crate::provider::check_http_response(response, None).await?;
 
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         let models = body
             .get("models")

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -261,10 +261,7 @@ impl Provider for OpenAIProvider {
         let body = build_openai_request_body_with(request, TokenLimitField::MaxCompletionTokens);
         let response = self.post_chat(request, body).await?;
 
-        let response_body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let response_body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         let result = parse_openai_response(&response_body)?;
 
@@ -339,10 +336,7 @@ impl Provider for OpenAIProvider {
             )));
         }
 
-        let body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         let models = body
             .get("data")

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -444,10 +444,7 @@ impl OpenRouterProvider {
             )));
         }
 
-        response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))
+        crate::provider::decode_json(response).await
     }
 
     fn warn_if_unknown(&self, model: &str, resolved: &ModelCapabilities) {
@@ -507,10 +504,7 @@ impl Provider for OpenRouterProvider {
         )
         .await?;
 
-        let response_body: serde_json::Value = response
-            .json()
-            .await
-            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+        let response_body: serde_json::Value = crate::provider::decode_json(response).await?;
 
         let result = parse_openai_response(&response_body)?;
 

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -1063,6 +1063,32 @@ pub async fn check_http_response(
     Ok(response)
 }
 
+/// Read a response body to completion and parse it as JSON.
+///
+/// The two halves fail for entirely different reasons and must not share an
+/// error variant. Bytes that never arrived - a reset connection, a socket that
+/// died while the machine was asleep, a truncated body - are a *transport*
+/// failure: [`ProviderError::RequestFailed`], which is transient, gets retried,
+/// counts against the provider's circuit breaker and is eligible for failover.
+/// Bytes that arrived and did not fit the schema are the provider's own fault:
+/// [`ProviderError::InvalidResponse`], which is permanent, because sending the
+/// same request again produces the same unusable answer.
+///
+/// `reqwest`'s own `Response::json` collapses both into one `Decode` error whose
+/// message is the famously unhelpful "error decoding response body". Routing
+/// that through `InvalidResponse` made every network blip permanent: a run with
+/// dozens of iterations of completed work died outright rather than retrying,
+/// because a dead socket was being reported as malformed JSON. The streaming
+/// path already drew this line correctly (see `openai_compat::stream_chat`);
+/// this is the buffered path drawing the same one.
+pub async fn decode_json<T: serde::de::DeserializeOwned>(response: reqwest::Response) -> Result<T> {
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|e| ProviderError::RequestFailed(format!("reading response body: {e}")))?;
+    serde_json::from_slice(&bytes).map_err(|e| ProviderError::InvalidResponse(e.to_string()))
+}
+
 // Helper module for single-item streams
 mod stream_once {
     use futures_core::Stream;
@@ -2207,5 +2233,93 @@ mod tests {
     fn finish_reason_different_variants_not_eq() {
         assert_ne!(FinishReason::Stop, FinishReason::Complete);
         assert_ne!(FinishReason::TokenLimit, FinishReason::ToolCall);
+    }
+
+    // ─── decode_json: transport failure vs schema failure ──────────────────
+
+    /// Serve one HTTP response over a raw socket, then close it.
+    ///
+    /// Takes the literal bytes so a test can send a deliberately malformed or
+    /// truncated response, which the higher-level test servers go out of their
+    /// way to make impossible.
+    async fn serve_raw(raw: &'static [u8]) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.expect("accept succeeds");
+            let mut buf = [0u8; 4096];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock.write_all(raw).await;
+            let _ = sock.shutdown().await;
+        });
+        format!("http://{addr}/")
+    }
+
+    /// A body that stops early is a *transport* failure, not a parse failure.
+    ///
+    /// This is the regression the whole split exists for: a socket that dies
+    /// mid-body (a reset, or a machine that slept through the response) used to
+    /// surface as `InvalidResponse`, which `is_transient` calls permanent - so a
+    /// run with dozens of iterations of work behind it died without one retry.
+    #[tokio::test]
+    async fn decode_json_reports_a_truncated_body_as_a_transport_failure() {
+        // Declares 200 bytes, sends 9, then hangs up.
+        let url = serve_raw(b"HTTP/1.1 200 OK\r\nContent-Length: 200\r\n\r\n{\"a\": 1}\n").await;
+        let client = build_http_client(None).expect("an HTTPS client builds in tests");
+        let response = client.get(url).send().await.expect("headers arrive");
+
+        let err = decode_json::<serde_json::Value>(response)
+            .await
+            .expect_err("a truncated body cannot decode");
+
+        assert_eq!(
+            std::mem::discriminant(&err),
+            std::mem::discriminant(&ProviderError::RequestFailed(String::new())),
+            "a body that never finished arriving is a transport failure: {err}"
+        );
+        assert!(err.is_transient(), "it must be retried: {err}");
+        assert_eq!(
+            err.unavailable_reason(),
+            Some(UnavailableReason::Unreachable),
+            "it must count against the provider and allow failover: {err}"
+        );
+    }
+
+    /// Bytes that all arrived and did not fit the schema stay permanent: the
+    /// same request would produce the same unusable answer, so retrying it only
+    /// spends the attempts.
+    #[tokio::test]
+    async fn decode_json_reports_a_complete_but_unparseable_body_as_invalid() {
+        let url = serve_raw(b"HTTP/1.1 200 OK\r\nContent-Length: 8\r\n\r\nnot json").await;
+        let client = build_http_client(None).expect("an HTTPS client builds in tests");
+        let response = client.get(url).send().await.expect("headers arrive");
+
+        let err = decode_json::<serde_json::Value>(response)
+            .await
+            .expect_err("`not json` cannot parse");
+
+        assert_eq!(
+            std::mem::discriminant(&err),
+            std::mem::discriminant(&ProviderError::InvalidResponse(String::new())),
+            "a fully delivered body that does not parse is the provider's fault: {err}"
+        );
+        assert!(!err.is_transient(), "retrying cannot help: {err}");
+        assert_eq!(
+            err.unavailable_reason(),
+            None,
+            "the provider is fine: {err}"
+        );
+    }
+
+    /// The happy path, so the success arm is not carried by the failure tests.
+    #[tokio::test]
+    async fn decode_json_parses_a_well_formed_body() {
+        let url = serve_raw(b"HTTP/1.1 200 OK\r\nContent-Length: 12\r\n\r\n{\"ok\":true}\n").await;
+        let client = build_http_client(None).expect("an HTTPS client builds in tests");
+        let response = client.get(url).send().await.expect("headers arrive");
+
+        let body: serde_json::Value = decode_json(response).await.expect("it parses");
+        assert_eq!(body["ok"], serde_json::json!(true));
     }
 }

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -154,6 +154,12 @@ pub struct FanOutWaiting {
     active: Vec<ActiveWorker>,
     summaries: Vec<(String, String)>,
     failures: Vec<(String, String)>,
+    /// Set when the user pauses this parent. Its own status has to stay
+    /// `Waiting` - the merge poll reads it - so the pause lives here instead,
+    /// and holds back the one thing a parked parent still does on its own:
+    /// starting the next queued worker. Without it, pausing a fan-out would
+    /// pause the running children and immediately launch their replacements.
+    paused: bool,
 }
 
 /// The serializable form of [`FanOutWaiting`], written to `<run_dir>/fanout.json`
@@ -174,6 +180,10 @@ pub struct FanOutState {
     pub summaries: Vec<(String, String)>,
     /// Failed worker results as `(item_id, message)`.
     pub failures: Vec<(String, String)>,
+    /// Whether the fan-out was paused. `default` so a state written by an older
+    /// build still loads, as an un-paused one.
+    #[serde(default)]
+    pub paused: bool,
 }
 
 impl FanOutWaiting {
@@ -183,6 +193,19 @@ impl FanOutWaiting {
     /// against a known denominator rather than an unexplained stall.
     pub fn outstanding(&self) -> usize {
         self.active.len() + self.pending.len()
+    }
+
+    /// Whether this parent's fan-out is paused (see the field).
+    pub fn is_paused(&self) -> bool {
+        self.paused
+    }
+
+    /// Latch or release the fan-out. Returns whether this changed anything, so
+    /// a caller can tell a real pause from a repeat.
+    pub fn set_paused(&mut self, paused: bool) -> bool {
+        let changed = self.paused != paused;
+        self.paused = paused;
+        changed
     }
 
     /// Project to the serializable [`FanOutState`] (workers by run-id).
@@ -198,6 +221,7 @@ impl FanOutWaiting {
                 .collect(),
             summaries: self.summaries.clone(),
             failures: self.failures.clone(),
+            paused: self.paused,
         }
     }
 }
@@ -232,6 +256,7 @@ pub fn restore_fan_out_waiting(
         active,
         summaries: state.summaries,
         failures,
+        paused: state.paused,
     });
 }
 
@@ -297,6 +322,7 @@ pub fn fan_out_split(world: &mut World) {
                     active: Vec::new(),
                     summaries: Vec::new(),
                     failures: Vec::new(),
+                    paused: false,
                 });
                 set_status(world, parent, AgentStatus::Waiting);
             }
@@ -418,8 +444,11 @@ pub fn fan_out_collect(world: &mut World) {
         }
         w.active = still_active;
 
-        // 2. Start pending workers up to the concurrency cap.
-        while w.active.len() < w.max_workers {
+        // 2. Start pending workers up to the concurrency cap - unless the
+        // fan-out is paused, in which case the queue stays where it is. Reaping
+        // above still runs: a worker that finished before the pause landed has a
+        // result worth keeping.
+        while !w.paused && w.active.len() < w.max_workers {
             let Some(item) = w.pending.pop_front() else {
                 break;
             };
@@ -1334,6 +1363,93 @@ mod tests {
     }
 
     // ── fan_out_collect: worker lifecycle + merge ─────────────────────────────
+
+    /// A paused fan-out does not start the next queued worker.
+    ///
+    /// Without the latch, pausing a parent pauses the children that are running
+    /// and the collector immediately launches their replacements out of
+    /// `pending` - so the run keeps spending money and the pause achieves
+    /// nothing visible.
+    #[test]
+    fn a_paused_fan_out_starts_no_further_workers() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        // Cap of one against three items, so there is always something queued.
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(Some("merge"), 1, WorkerFailurePolicy::Continue)),
+            r#"[{"id":"a"},{"id":"b"},{"id":"c"}]"#,
+        );
+        fan_out_split(&mut world);
+        fan_out_collect(&mut world);
+        assert_eq!(
+            world.get::<SubAgentChildren>(e).unwrap().children.len(),
+            1,
+            "one worker runs under a cap of one"
+        );
+
+        world
+            .get_mut::<FanOutWaiting>(e)
+            .expect("parked")
+            .set_paused(true);
+        // Finish the running worker: its slot frees, which is exactly when the
+        // collector would otherwise reach into the queue.
+        let running = world.get::<SubAgentChildren>(e).unwrap().children[0];
+        complete_worker(&mut world, running, "done");
+        fan_out_collect(&mut world);
+
+        assert_eq!(
+            world.get::<SubAgentChildren>(e).unwrap().children.len(),
+            1,
+            "the freed slot stays empty while the fan-out is paused"
+        );
+        let w = world.get::<FanOutWaiting>(e).expect("still parked");
+        assert_eq!(w.pending.len(), 2, "the queue is held, not consumed");
+        assert_eq!(
+            w.summaries.len(),
+            1,
+            "the worker that finished before the pause is still reaped"
+        );
+
+        // Releasing the latch lets the queue move again.
+        world
+            .get_mut::<FanOutWaiting>(e)
+            .expect("parked")
+            .set_paused(false);
+        fan_out_collect(&mut world);
+        assert_eq!(
+            world.get::<SubAgentChildren>(e).unwrap().children.len(),
+            2,
+            "resuming starts the next queued worker"
+        );
+    }
+
+    /// The latch survives a daemon restart: it rides the persisted fan-out state
+    /// like everything else the parent is parked on.
+    #[test]
+    fn the_fan_out_pause_round_trips_through_its_persisted_state() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(Some("merge"), 1, WorkerFailurePolicy::Continue)),
+            r#"[{"id":"a"},{"id":"b"}]"#,
+        );
+        fan_out_split(&mut world);
+        world
+            .get_mut::<FanOutWaiting>(e)
+            .expect("parked")
+            .set_paused(true);
+
+        let state = world.get::<FanOutWaiting>(e).expect("parked").to_state();
+        assert!(state.paused, "the latch is written out");
+
+        restore_fan_out_waiting(&mut world, e, state, &|_| None);
+        assert!(
+            world.get::<FanOutWaiting>(e).expect("parked").is_paused(),
+            "and comes back paused, so a restart does not quietly resume the fan-out"
+        );
+    }
 
     #[test]
     fn collect_starts_workers_then_merges_on_completion() {

--- a/crates/leviath-runtime/src/host/mod.rs
+++ b/crates/leviath-runtime/src/host/mod.rs
@@ -428,16 +428,17 @@ impl WorldHost {
                     });
                 let _ = reply.send(status);
             }
+            // Both walk the sub-agent tree. Pausing only the run that was named
+            // leaves a fan-out parent's children running - the parent is
+            // `Waiting`, which is not pausable, so the request would report
+            // failure while the work carried on - and resuming only the parent
+            // would strand every child the pause had stopped.
             ControlOp::Pause { run_id, reply } => {
-                let ok = self
-                    .resolve_or_reload(&run_id)
-                    .is_some_and(|e| self.world.pause(e));
+                let ok = self.pause_tree(&run_id);
                 let _ = reply.send(ok);
             }
             ControlOp::Resume { run_id, reply } => {
-                let ok = self
-                    .resolve_or_reload(&run_id)
-                    .is_some_and(|e| self.world.resume(e));
+                let ok = self.resume_tree(&run_id);
                 let _ = reply.send(ok);
             }
             ControlOp::Cancel { run_id, reply } => {

--- a/crates/leviath-runtime/src/host/mod.rs
+++ b/crates/leviath-runtime/src/host/mod.rs
@@ -262,6 +262,18 @@ impl WorldHost {
                 .get::<crate::interaction_points::AwaitingInteractionPoint>(entity)
                 .is_none()
             && world.get::<AwaitingInteraction>(entity).is_none()
+            // An outstanding provider call is a live, unpersisted continuation
+            // just like a blocked `ask`: parking despawns the entity, and the
+            // response then lands on a dead one and is dropped on the collect
+            // system's stale path. So pausing a run mid-inference used to throw
+            // the call away silently - the run came back from its page-in as
+            // `ReadyToInfer` and paid for the same turn twice.
+            //
+            // `InFlightWork` covers the call still being out; `HeldInference`
+            // covers it having landed and being kept for the resume to apply.
+            // Either one keeps the run resident until it is resumed.
+            && world.get::<crate::pipeline::InFlightWork>(entity).is_none()
+            && world.get::<crate::pipeline::HeldInference>(entity).is_none()
     }
 
     /// Whether a terminal agent is safe to unload: it has no **live** parent that

--- a/crates/leviath-runtime/src/host/subagents.rs
+++ b/crates/leviath-runtime/src/host/subagents.rs
@@ -7,6 +7,7 @@
 //! here too, so the sender and its only reader are in one file.
 
 use super::*;
+use crate::fanout::FanOutWaiting;
 
 impl WorldHost {
     /// Service one [`SubAgentOp`] from a tool lane, replying on its oneshot.
@@ -186,21 +187,71 @@ impl WorldHost {
         false
     }
 
-    pub(super) fn cancel_tree(&mut self, run_id: &str) -> bool {
-        let Some(root) = self.resolve_or_reload(run_id) else {
-            return false;
-        };
-        // Collect the subtree (parent before children), then cancel each.
-        let mut subtree = Vec::new();
-        let mut stack = vec![root.entity()];
+    /// Every entity in `root`'s sub-agent tree, parent before children.
+    fn subtree(&self, root: Entity) -> Vec<Entity> {
+        let mut out = Vec::new();
+        let mut stack = vec![root];
         while let Some(e) = stack.pop() {
-            subtree.push(e);
+            out.push(e);
             if let Some(kids) = self.world.world().get::<SubAgentChildren>(e) {
                 stack.extend(kids.children.iter().copied());
             }
         }
+        out
+    }
+
+    /// Pause a run and everything it spawned.
+    ///
+    /// Pausing a fan-out parent on its own does nothing a user would recognise
+    /// as a pause: the parent is `Waiting` - a status the merge poll depends on,
+    /// so `PipelineWorld::pause` rightly refuses to overwrite it - while the
+    /// children that are actually burning tokens run on. So the request is
+    /// applied to the whole tree, exactly as if each child had been paused by
+    /// hand, and each fan-out parent is latched so the collector does not start
+    /// the next queued worker behind the pause.
+    ///
+    /// Reports whether anything took, which is what tells a caller a
+    /// still-running tree apart from one that was already finished.
+    pub(super) fn pause_tree(&mut self, run_id: &str) -> bool {
+        let Some(root) = self.resolve_or_reload(run_id) else {
+            return false;
+        };
+        let mut acted = false;
+        for e in self.subtree(root.entity()) {
+            acted |= self.world.pause(self.world.own_agent(e));
+            if let Some(mut fan_out) = self.world.world_mut().get_mut::<FanOutWaiting>(e) {
+                acted |= fan_out.set_paused(true);
+            }
+        }
+        acted
+    }
+
+    /// Resume a run and everything it spawned.
+    ///
+    /// The mirror of [`Self::pause_tree`], and it must not give up on the root:
+    /// a fan-out parent is `Waiting`, which `PipelineWorld::resume` refuses, so
+    /// resuming the tree through the parent would otherwise report failure and
+    /// leave every paused child paused with nothing left to resume them.
+    pub(super) fn resume_tree(&mut self, run_id: &str) -> bool {
+        let Some(root) = self.resolve_or_reload(run_id) else {
+            return false;
+        };
+        let mut acted = false;
+        for e in self.subtree(root.entity()) {
+            acted |= self.world.resume(self.world.own_agent(e));
+            if let Some(mut fan_out) = self.world.world_mut().get_mut::<FanOutWaiting>(e) {
+                acted |= fan_out.set_paused(false);
+            }
+        }
+        acted
+    }
+
+    pub(super) fn cancel_tree(&mut self, run_id: &str) -> bool {
+        let Some(root) = self.resolve_or_reload(run_id) else {
+            return false;
+        };
         let mut cancelled = false;
-        for e in subtree {
+        for e in self.subtree(root.entity()) {
             // Read the agent id before cancelling - the entity stays valid until
             // it is reaped, but reading first keeps this independent of that.
             let agent_id = self

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -3303,6 +3303,90 @@ async fn a_gate_outranks_the_generic_interaction_marker() {
     assert_eq!(reason, Some(WaitReason::TaintGate));
 }
 
+/// Pausing a fan-out parent latches the fan-out itself, and resuming releases
+/// it.
+///
+/// The parent keeps its `Waiting` status either way - the merge poll reads it -
+/// so the latch is the only durable record that the queue is held. Without it,
+/// the pause would stop the running children and the collector would start
+/// their replacements out of `pending` on the very next tick.
+#[tokio::test]
+async fn pausing_a_fan_out_parent_holds_its_worker_queue() {
+    let mut host = host_with(vec![]);
+    let parent = spawn(&mut host, "parent-fo", "parent-fo");
+    let worker = spawn(&mut host, "worker-fo", "worker-fo");
+    {
+        let world = host.world_mut().world_mut();
+        world
+            .get_mut::<AgentState>(parent.entity())
+            .expect("parent has state")
+            .status = AgentStatus::Waiting;
+        crate::fanout::restore_fan_out_waiting(
+            world,
+            parent.entity(),
+            crate::fanout::FanOutState {
+                config: leviath_core::blueprint::FanOutConfig {
+                    worker_agent: None,
+                    worker_stage: Some("work".to_string()),
+                    worker_query: None,
+                    merge_stage: None,
+                    max_workers: 1,
+                    on_worker_failure: Default::default(),
+                    split_prompt: String::new(),
+                    results_region: None,
+                    max_items: None,
+                },
+                max_workers: 1,
+                pending: vec![crate::fanout::WorkItem::default()],
+                active: vec![("item-1".to_string(), "worker-fo".to_string())],
+                summaries: Vec::new(),
+                failures: Vec::new(),
+                paused: false,
+            },
+            &|run_id| (run_id == "worker-fo").then_some(worker.entity()),
+        );
+    }
+
+    assert!(
+        ask(&mut host, |reply| ControlOp::Pause {
+            run_id: "parent-fo".to_string(),
+            reply
+        })
+        .await,
+        "the request takes even though the parent's own status is not pausable"
+    );
+    assert!(
+        host.world_mut()
+            .world()
+            .get::<crate::fanout::FanOutWaiting>(parent.entity())
+            .expect("still parked")
+            .is_paused(),
+        "the fan-out is latched, so no replacement worker starts"
+    );
+    assert_eq!(
+        host.world.agent_status(parent),
+        Some(AgentStatus::Waiting),
+        "and the parent keeps the status its merge poll depends on"
+    );
+
+    assert!(
+        ask(&mut host, |reply| ControlOp::Resume {
+            run_id: "parent-fo".to_string(),
+            reply
+        })
+        .await
+    );
+    assert!(
+        !host
+            .world_mut()
+            .world()
+            .get::<crate::fanout::FanOutWaiting>(parent.entity())
+            .expect("still parked")
+            .is_paused(),
+        "resuming releases the queue"
+    );
+}
+
 /// A fan-out parent reports how many workers are left, so "waiting" reads as
 /// progress against a denominator rather than an unexplained stall.
 #[tokio::test]

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -1777,6 +1777,86 @@ async fn cancel_cascades_to_the_whole_tree() {
     );
 }
 
+/// Pausing a run pauses everything it spawned.
+///
+/// A fan-out parent is the case that matters: its own status is `Waiting`, which
+/// is not pausable, so before this the request reported failure while every
+/// child carried on burning tokens.
+#[tokio::test]
+async fn pause_cascades_to_the_whole_tree() {
+    let mut host = host_with(vec![]);
+    host.set_spawner(child_spawner());
+    spawn(&mut host, "parent", "parent");
+    ask_sub(&mut host, |reply| SubAgentOp::Spawn {
+        args: Box::new(SpawnArgs {
+            run_id: "child".to_string(),
+            ..Default::default()
+        }),
+        parent_run_id: "parent".to_string(),
+        max_depth: 3,
+        reply,
+    })
+    .await
+    .unwrap();
+
+    assert!(
+        ask(&mut host, |reply| ControlOp::Pause {
+            run_id: "parent".to_string(),
+            reply
+        })
+        .await
+    );
+    assert_eq!(
+        host.world.agent_status(host.by_run_id["child"]),
+        Some(AgentStatus::Paused),
+        "pausing the parent pauses its children"
+    );
+}
+
+/// And resuming it resumes them again.
+///
+/// The parent is `Waiting`, which `resume` refuses, so a cascade that gave up on
+/// the root would report failure and leave every child paused with nothing left
+/// to bring them back.
+#[tokio::test]
+async fn resume_cascades_to_the_whole_tree() {
+    let mut host = host_with(vec![]);
+    host.set_spawner(child_spawner());
+    spawn(&mut host, "parent", "parent");
+    ask_sub(&mut host, |reply| SubAgentOp::Spawn {
+        args: Box::new(SpawnArgs {
+            run_id: "child".to_string(),
+            ..Default::default()
+        }),
+        parent_run_id: "parent".to_string(),
+        max_depth: 3,
+        reply,
+    })
+    .await
+    .unwrap();
+    assert!(
+        ask(&mut host, |reply| ControlOp::Pause {
+            run_id: "parent".to_string(),
+            reply
+        })
+        .await
+    );
+
+    assert!(
+        ask(&mut host, |reply| ControlOp::Resume {
+            run_id: "parent".to_string(),
+            reply
+        })
+        .await,
+        "resuming the tree reports success even though the root itself was never paused"
+    );
+    assert_eq!(
+        host.world.agent_status(host.by_run_id["child"]),
+        Some(AgentStatus::Active),
+        "resuming the parent resumes the children the pause stopped"
+    );
+}
+
 /// A child that was already reaped is skipped rather than tripping the
 /// cancel: `SubAgentChildren` still names it, but the entity is gone, so
 /// there is no agent id to close interactions for.
@@ -3260,6 +3340,7 @@ async fn wait_reason_counts_outstanding_fan_out_workers() {
                 active: vec![("item-1".to_string(), "run-b".to_string())],
                 summaries: Vec::new(),
                 failures: Vec::new(),
+                paused: false,
             },
             &|run_id| (run_id == "run-b").then_some(worker.entity()),
         );

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -1122,6 +1122,85 @@ async fn result_reports_the_submitted_answer() {
     );
 }
 
+/// A paused run with a provider call still outstanding stays resident.
+///
+/// Parking despawns the entity. An in-flight inference is a live, unpersisted
+/// continuation exactly like a blocked `ask`: if the run is paged out while the
+/// call is still going, the response lands on a dead entity and is dropped on
+/// the collect system's stale path - so the pause silently threw the call away
+/// and the page-in paid for the same turn again.
+#[tokio::test]
+async fn a_paused_run_with_a_call_still_out_is_not_parked() {
+    let mut host = host_with(vec![]);
+    host.set_reloader(Box::new(|world, run_id| {
+        let mut state = agent_state(run_id);
+        state.status = AgentStatus::Paused;
+        Some(world.spawn_agent((state,)))
+    }));
+    let e = spawn(&mut host, "run-a", "agent-a");
+    assert!(
+        ask(&mut host, |reply| ControlOp::Pause {
+            run_id: "run-a".to_string(),
+            reply
+        })
+        .await
+    );
+    let mut wm = crate::pipeline::PersistWatermark::default();
+    wm.stamp_status(leviath_core::run_meta::RunStatus::Paused);
+    host.world_mut()
+        .world_mut()
+        .entity_mut(e.entity())
+        .insert((wm, crate::pipeline::InFlightWork(vec![])));
+
+    host.emit_events();
+
+    assert!(
+        host.world.world().get::<AgentState>(e.entity()).is_some(),
+        "the run stays in the world while its call is still out"
+    );
+    assert!(host.by_run_id.contains_key("run-a"));
+}
+
+/// And one holding a response that landed during the pause stays resident too,
+/// or the held outcome goes with the entity and the resume re-requests it.
+#[tokio::test]
+async fn a_paused_run_holding_a_landed_response_is_not_parked() {
+    let mut host = host_with(vec![]);
+    host.set_reloader(Box::new(|world, run_id| {
+        let mut state = agent_state(run_id);
+        state.status = AgentStatus::Paused;
+        Some(world.spawn_agent((state,)))
+    }));
+    let e = spawn(&mut host, "run-a", "agent-a");
+    assert!(
+        ask(&mut host, |reply| ControlOp::Pause {
+            run_id: "run-a".to_string(),
+            reply
+        })
+        .await
+    );
+    let mut wm = crate::pipeline::PersistWatermark::default();
+    wm.stamp_status(leviath_core::run_meta::RunStatus::Paused);
+    host.world_mut().world_mut().entity_mut(e.entity()).insert((
+        wm,
+        crate::pipeline::HeldInference {
+            outcome: crate::inference_bridge::InferenceOutcome {
+                entity: e.entity(),
+                latency: std::time::Duration::ZERO,
+                result: Err(leviath_providers::ProviderError::Other("held".to_string())),
+            },
+            lane: crate::pipeline::HeldLane::Stage,
+        },
+    ));
+
+    host.emit_events();
+
+    assert!(
+        host.world.world().get::<AgentState>(e.entity()).is_some(),
+        "the run stays in the world while it holds a response for the resume"
+    );
+}
+
 /// A paused standalone root whose paused snapshot has been dispatched is
 /// paged out of the world: the entity is gone, but the listing and the
 /// Status op still report it, and a Resume pages it back in.

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -34,6 +34,13 @@ pub(crate) fn to_inference_result(
     }
 }
 
+/// What a person has to do about a provider that could not be reached.
+///
+/// A separate constant rather than a line-continued literal inside the
+/// `format!`: rustfmt reflows those, and it silently baked the source's own
+/// indentation into the middle of the sentence a user reads.
+const UNREACHABLE_REMEDY: &str = "check the network connection, then `lev resume` this run";
+
 /// What `collect_inference` selects.
 ///
 /// `&'static` is bevy's `WorldQuery` convention, not a claim about
@@ -338,7 +345,7 @@ pub fn collect_inference(
                     == Some(leviath_providers::UnavailableReason::Unreachable)
                 {
                     let message = format!(
-                        "could not reach '{called_provider}' ({err}): check the                          network connection, then `lev resume` this run"
+                        "could not reach '{called_provider}' ({err}): {UNREACHABLE_REMEDY}"
                     );
                     tracing::warn!(
                         provider = %called_provider,

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -96,6 +96,22 @@ pub fn collect_inference(
                 .remove::<InFlightWork>();
             continue;
         }
+        // The user paused the run while this inference was in flight. Pause is
+        // documented as letting the in-flight step finish, so the outcome
+        // arriving is expected - but it must not *act*. Applying a success walks
+        // the run on through tool calls and stage changes while it still reads
+        // `paused`; applying a failure overwrites the deliberate pause with
+        // `Error` and throws away everything the run had done. Park the whole
+        // outcome and let `resume` replay it through this same system.
+        if state.status == AgentStatus::Paused {
+            commands
+                .entity(outcome.entity)
+                .insert(crate::pipeline::HeldInference {
+                    outcome,
+                    lane: crate::pipeline::HeldLane::Stage,
+                });
+            continue;
+        }
         let idx = cursor.map_or(0, |c| c.index);
         // Whoever we actually called. Read before the error arm below, which
         // may swap the component over to the next provider.
@@ -302,6 +318,48 @@ pub fn collect_inference(
                             blocker: leviath_core::run_meta::SetupBlocker::CreditsExhausted,
                             remedy: message,
                         })
+                        .insert(ReadyToInfer);
+                    continue;
+                }
+                // The provider could not be reached at all and there is no
+                // candidate left to try. That is the network being down, not the
+                // run being wrong: the request never got an answer, so nothing
+                // about this run is known to be bad. Failing here throws away
+                // every iteration it has completed for a condition that is
+                // usually over in seconds and is always somebody else's to fix,
+                // so it parks on the same terms as an empty account (issue
+                // #456) and `lev resume` picks it back up.
+                //
+                // Reachable only once the retry policy is spent - a transport
+                // failure is transient, so `run_inference_job` has already tried
+                // and backed off `inference_retry_attempts` times before the
+                // outcome gets here.
+                if err.unavailable_reason()
+                    == Some(leviath_providers::UnavailableReason::Unreachable)
+                {
+                    let message = format!(
+                        "could not reach '{called_provider}' ({err}): check the                          network connection, then `lev resume` this run"
+                    );
+                    tracing::warn!(
+                        provider = %called_provider,
+                        error = %err,
+                        "provider unreachable; pausing the run for a resume"
+                    );
+                    if let Some(mut buffer) = buffer {
+                        buffer.logs.push((idx, format!("[paused] {message}")));
+                    }
+                    state.status = AgentStatus::Paused;
+                    commands
+                        .entity(outcome.entity)
+                        .remove::<AwaitingInference>()
+                        .remove::<InFlightWork>()
+                        .insert(crate::pipeline::PausedForSetup {
+                            blocker: leviath_core::run_meta::SetupBlocker::ProvidersUnavailable,
+                            remedy: message,
+                        })
+                        // Kept on purpose, as the credits park does: the retry is
+                        // already staged, so a resume re-dispatches this same
+                        // inference rather than rebuilding anything.
                         .insert(ReadyToInfer);
                     continue;
                 }

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -201,6 +201,43 @@ pub struct PausedForSetup {
     pub remedy: String,
 }
 
+/// An inference outcome that landed while its agent was `Paused`, kept until
+/// the run resumes.
+///
+/// Pause is documented as "finishes any in-flight step, then stops before
+/// starting new work", so a call dispatched before the pause is expected to come
+/// back afterwards. What must not happen is that its result *acts*: applying a
+/// success walks the run on through `ProcessResponse`, its tool calls and its
+/// stage transitions, which is a resume nobody asked for; applying a failure
+/// overwrites the deliberate `Paused` with `Error` and throws the run away.
+///
+/// The outcome is therefore parked here, whole, and replayed by
+/// [`PipelineWorld::resume`](crate::world::PipelineWorld::resume) through the
+/// ordinary channel - so the response the user already paid for is not
+/// discarded, and no arm of the collect system has to be duplicated.
+///
+/// The agent keeps its `Awaiting*` marker while held: that is the query filter
+/// the collect system uses, and the run genuinely is still waiting on this
+/// result.
+#[derive(Component)]
+pub struct HeldInference {
+    /// The parked outcome, replayed verbatim on resume.
+    pub outcome: crate::inference_bridge::InferenceOutcome,
+    /// Which collect system is waiting for it. The two lanes have separate
+    /// channels on purpose - a routing decision is not an agent turn - so a
+    /// replay has to go back to the one it came from.
+    pub lane: HeldLane,
+}
+
+/// Which inference lane a [`HeldInference`] belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HeldLane {
+    /// An ordinary agent turn, collected by `collect_inference`.
+    Stage,
+    /// A stage-boundary routing call, collected by `collect_transition_choice`.
+    TransitionChoice,
+}
+
 /// Dispatch-stall watchdog: fail any agent whose dispatch has been declining for
 /// an unresolvable reason longer than [`StallTimeout`].
 ///

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -928,6 +928,13 @@ fn collect_parks_a_run_whose_provider_is_unreachable() {
         "the remedy must name the way back: {}",
         parked.remedy
     );
+    // A line-continued literal here once let rustfmt reflow the source's own
+    // indentation into the middle of the sentence a user reads.
+    assert!(
+        !parked.remedy.contains("  "),
+        "the remedy is one clean sentence: {:?}",
+        parked.remedy
+    );
     assert!(
         world.get::<ReadyToInfer>(e).is_some(),
         "the retry stays staged so a resume re-dispatches rather than rebuilding"

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -809,6 +809,133 @@ fn collect_applies_ok_and_advances_to_process_response() {
     assert_eq!(stored.tool_calls[0].name, "read_file");
 }
 
+// ─── a paused run is not walked forward by its own in-flight result ────────
+
+/// An agent paused mid-inference must not be advanced by the response landing.
+///
+/// This is the half of the bug that looked like a spontaneous resume: the run
+/// still read `paused` while its tool calls ran and its stage moved on.
+#[test]
+fn collect_holds_a_success_that_lands_on_a_paused_agent() {
+    let (mut world, tx) = world_with_results();
+    let mut state = agent_state();
+    state.status = AgentStatus::Paused;
+    let e = world.spawn((state, AwaitingInference)).id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Ok(resp("hi")),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused,
+        "the pause is what the user asked for; a landing response must not undo it"
+    );
+    assert!(
+        world.get::<ProcessResponse>(e).is_none(),
+        "advancing to ProcessResponse is the resume nobody asked for"
+    );
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().iteration,
+        0,
+        "a held turn has not been taken"
+    );
+    assert!(
+        world.get::<AwaitingInference>(e).is_some(),
+        "the marker stays: the collect system's query needs it on replay"
+    );
+    let held = world
+        .get::<HeldInference>(e)
+        .expect("the outcome is parked");
+    assert_eq!(held.lane, HeldLane::Stage);
+    assert!(
+        held.outcome.result.is_ok(),
+        "the response is kept whole, not discarded - it is already paid for"
+    );
+}
+
+/// The half that actually destroyed runs: a failure landing on a paused agent
+/// used to overwrite `Paused` with `Error`, ending a run with dozens of
+/// iterations of completed work behind it.
+#[test]
+fn collect_holds_a_failure_that_lands_on_a_paused_agent() {
+    let (mut world, tx) = world_with_results();
+    let mut state = agent_state();
+    state.status = AgentStatus::Paused;
+    let e = world.spawn((state, AwaitingInference)).id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(leviath_providers::ProviderError::RequestFailed(
+            "reading response body: error decoding response body".to_string(),
+        )),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused,
+        "a paused run stays paused and stays resumable"
+    );
+    assert!(
+        world.get::<ResolveTransition>(e).is_none(),
+        "the failure must not be routed into the stage's error edge either"
+    );
+    assert!(world.get::<HeldInference>(e).is_some());
+}
+
+// ─── an unreachable provider parks the run instead of ending it ────────────
+
+/// A provider that never answered says nothing about the run, so ending it
+/// throws away completed work for a condition that is usually over in seconds.
+#[test]
+fn collect_parks_a_run_whose_provider_is_unreachable() {
+    let (mut world, tx) = world_with_results();
+    let e = world.spawn((agent_state(), AwaitingInference)).id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(leviath_providers::ProviderError::RequestFailed(
+            "reading response body: error decoding response body".to_string(),
+        )),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused,
+        "a network failure parks the run; it does not end it"
+    );
+    let parked = world
+        .get::<crate::pipeline::PausedForSetup>(e)
+        .expect("it parks with a remedy a person can act on");
+    assert_eq!(
+        parked.blocker,
+        leviath_core::run_meta::SetupBlocker::ProvidersUnavailable
+    );
+    assert!(
+        parked.remedy.contains("lev resume"),
+        "the remedy must name the way back: {}",
+        parked.remedy
+    );
+    assert!(
+        world.get::<ReadyToInfer>(e).is_some(),
+        "the retry stays staged so a resume re-dispatches rather than rebuilding"
+    );
+    assert!(
+        world.get::<ResolveTransition>(e).is_none(),
+        "parking returns before the transition logic, so no error edge is taken"
+    );
+}
+
 #[test]
 fn collect_marks_error_on_failure() {
     let (mut world, tx) = world_with_results();

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -2352,6 +2352,7 @@ fn dispatch_persistence_serializes_fan_out_waiting() {
             active: vec![],
             summaries: vec![],
             failures: vec![],
+            paused: false,
         },
         &|_| None,
     );

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -897,7 +897,9 @@ fn collect_holds_a_failure_that_lands_on_a_paused_agent() {
 #[test]
 fn collect_parks_a_run_whose_provider_is_unreachable() {
     let (mut world, tx) = world_with_results();
-    let e = world.spawn((agent_state(), AwaitingInference)).id();
+    let e = world
+        .spawn((agent_state(), AwaitingInference, StageIoBuffer::default()))
+        .id();
     tx.send(InferenceOutcome {
         latency: std::time::Duration::ZERO,
         entity: e,
@@ -934,6 +936,37 @@ fn collect_parks_a_run_whose_provider_is_unreachable() {
         world.get::<ResolveTransition>(e).is_none(),
         "parking returns before the transition logic, so no error edge is taken"
     );
+    // The stage log says it parked, not that it failed - that log is what the
+    // run's own transcript shows a reader afterwards.
+    let logs = &world.get::<StageIoBuffer>(e).unwrap().logs;
+    assert!(
+        logs.iter().any(|(_, l)| l.starts_with("[paused]")),
+        "the stage log records a park: {logs:?}"
+    );
+}
+
+/// The same park with no stage log attached. Not every agent carries a
+/// `StageIoBuffer`, and the park must not depend on one being there.
+#[test]
+fn a_run_with_no_stage_log_still_parks_on_an_unreachable_provider() {
+    let (mut world, tx) = world_with_results();
+    let e = world.spawn((agent_state(), AwaitingInference)).id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(leviath_providers::ProviderError::RequestFailed(
+            "reading response body: error decoding response body".to_string(),
+        )),
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused
+    );
+    assert!(world.get::<crate::pipeline::PausedForSetup>(e).is_some());
 }
 
 #[test]
@@ -11375,6 +11408,53 @@ fn run_collect_transition(world: &mut World) {
     let mut s = Schedule::default();
     s.add_systems(collect_transition_choice);
     s.run(world);
+}
+
+/// A pause landing during a stage-boundary routing call gets the same
+/// protection as one landing during an ordinary turn. Every arm below the guard
+/// rewrites the status, so letting the outcome through would either route a
+/// paused run into its next stage or bury the pause under an error.
+#[test]
+fn collect_choice_holds_an_outcome_that_lands_on_a_paused_agent() {
+    let (mut world, tx) = world_with_transition_results();
+    let bp = blueprint(vec![
+        stage_named("a", None, false, None),
+        stage_named("b", None, false, None),
+    ]);
+    let e = spawn_responding_agent(
+        &mut world,
+        bp,
+        vec![si("m0"), si("m1")],
+        vec![plain_edge("b")],
+    );
+    world.get_mut::<AgentState>(e).unwrap().status = AgentStatus::Paused;
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Ok(resp("b")),
+    })
+    .unwrap();
+
+    run_collect_transition(&mut world);
+
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Paused
+    );
+    assert_eq!(
+        world.get::<StageCursor>(e).unwrap().index,
+        0,
+        "a paused run does not move to the stage the routing call chose"
+    );
+    assert!(world.get::<AwaitingTransitionResponse>(e).is_some());
+    let held = world
+        .get::<HeldInference>(e)
+        .expect("the outcome is parked");
+    assert_eq!(
+        held.lane,
+        HeldLane::TransitionChoice,
+        "the lane is recorded so resume replays it to the right collector"
+    );
 }
 
 #[test]

--- a/crates/leviath-runtime/src/pipeline/transition_choice.rs
+++ b/crates/leviath-runtime/src/pipeline/transition_choice.rs
@@ -302,6 +302,19 @@ pub fn collect_transition_choice(
                 .remove::<InFlightWork>();
             continue;
         }
+        // Paused mid-routing. Same hazard as the stage lane: every arm below
+        // rewrites the status, so letting a landing outcome through would either
+        // route a paused run into its next stage or bury the pause under an
+        // `Error`. Park it for `resume` to replay.
+        if state.status == AgentStatus::Paused {
+            commands
+                .entity(outcome.entity)
+                .insert(crate::pipeline::HeldInference {
+                    outcome,
+                    lane: crate::pipeline::HeldLane::TransitionChoice,
+                });
+            continue;
+        }
         let response = match outcome.result {
             Ok(response) => response,
             Err(err) => {

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -297,6 +297,10 @@ pub struct PipelineWorld {
     persist_task: Option<JoinHandle<()>>,
 }
 
+/// Agent status control: read a status, set one, and pause/resume/cancel.
+/// Split out to keep this file inside the workspace structure limit.
+mod control;
+
 impl PipelineWorld {
     /// Build a world: wire the pool/bridge resources, register the providers and
     /// tool service, spawn the tool worker onto `runtime`, and assemble the tick
@@ -793,126 +797,6 @@ impl PipelineWorld {
             world: self.id,
             entity,
         }
-    }
-
-    /// The status of an agent, if it still exists.
-    ///
-    /// An id another world minted reports `None` rather than this world's agent
-    /// of the same raw entity - see [`AgentId`]. `pause`, `resume` and `cancel`
-    /// all read status through here, so guarding it guards them.
-    pub fn agent_status(&self, agent: AgentId) -> Option<AgentStatus> {
-        if agent.world != self.id {
-            return None;
-        }
-        self.world
-            .get::<AgentState>(agent.entity)
-            .map(|s| s.status.clone())
-    }
-
-    /// Set an agent's status and wake the driver. Returns `false` if the agent no
-    /// longer exists. The async-starting dispatchers only act on `Active` agents,
-    /// so this is how the world pauses/resumes/cancels an agent - a non-`Active`
-    /// agent is simply data the systems skip until it is `Active` again.
-    pub fn set_status(&mut self, agent: AgentId, status: AgentStatus) -> bool {
-        // Every status mutation funnels through here, so this is the one place a
-        // foreign id has to be refused.
-        if agent.world != self.id {
-            return false;
-        }
-        let Some(mut state) = self.world.get_mut::<AgentState>(agent.entity) else {
-            return false;
-        };
-        state.status = status;
-        self.wake.notify_one();
-        true
-    }
-
-    /// Pause an agent (it finishes any in-flight step, then stops before starting
-    /// new work). Only `Active` and `Idle` agents can be paused: a `Waiting`
-    /// agent's status is the marker the fan-out merge poll and interaction
-    /// resolution depend on, so overwriting it would wedge the run, and pausing
-    /// a terminal agent is meaningless. Returns `false` if the agent no longer
-    /// exists or is not in a pausable state.
-    pub fn pause(&mut self, agent: AgentId) -> bool {
-        match self.agent_status(agent) {
-            Some(AgentStatus::Active | AgentStatus::Idle) => {
-                self.set_status(agent, AgentStatus::Paused)
-            }
-            _ => false,
-        }
-    }
-
-    /// Resume a paused agent. `Idle` is also accepted (resume-as-nudge for an
-    /// agent that has not ticked yet); anything else returns `false`.
-    pub fn resume(&mut self, agent: AgentId) -> bool {
-        // Resolved once, up front. Doing it again inside the arm below would
-        // be a second check that cannot fail - the status lookup already
-        // proved the entity is here - and an arm nothing can reach is an arm
-        // nothing can test.
-        let Some(entity) = agent.resolve_in(&self.world) else {
-            return false;
-        };
-        match self.agent_status(agent) {
-            Some(AgentStatus::Paused | AgentStatus::Idle) => {
-                // An explicit resume says conditions have changed - most often
-                // a top-up after a run paused on exhausted credits (issue
-                // #413). A tripped breaker would otherwise hold the retry
-                // until its cooldown lapses, making the resume look ignored.
-                if let Some(mut circuits) = self
-                    .world
-                    .get_resource_mut::<crate::pipeline::ProviderCircuits>()
-                {
-                    circuits.reset();
-                }
-                // The run no longer claims to need setup. If the machine was
-                // not actually fixed the watchdog re-parks it a minute later
-                // with a fresh message, which is better than carrying a stale
-                // one that describes a problem somebody may have just solved.
-                self.world
-                    .entity_mut(entity)
-                    .remove::<crate::pipeline::PausedForSetup>();
-                self.replay_held_inference(entity);
-                self.set_status(agent, AgentStatus::Active)
-            }
-            _ => false,
-        }
-    }
-
-    /// Put back an inference outcome that landed while the agent was paused.
-    ///
-    /// The result is sent to the same channel it originally came in on, so the
-    /// collect system applies it through its ordinary arms on the next tick -
-    /// no duplicated success/failure handling, and no wasted call: whatever the
-    /// provider already charged for is still used. The agent kept its
-    /// `Awaiting*` marker while held, which is what makes it visible to that
-    /// system's query.
-    ///
-    /// A no-op for the ordinary case of a run that was paused with nothing in
-    /// flight.
-    fn replay_held_inference(&mut self, entity: Entity) {
-        let Some(held) = self
-            .world
-            .entity_mut(entity)
-            .take::<crate::pipeline::HeldInference>()
-        else {
-            return;
-        };
-        // Installed unconditionally by `PipelineWorld::new`, which is the only
-        // way to get a world that can reach this at all.
-        let stage = self.world.resource::<crate::pipeline::InferenceStage>();
-        let channel = match held.lane {
-            crate::pipeline::HeldLane::Stage => &stage.outcomes,
-            crate::pipeline::HeldLane::TransitionChoice => &stage.transition_outcomes,
-        };
-        // A closed channel means the pipeline is shutting down; the run is being
-        // torn down with it, so there is nothing to salvage and nothing to warn
-        // about.
-        let _ = channel.send(held.outcome);
-    }
-
-    /// Cancel an agent (it stops starting new work; in-flight results still land).
-    pub fn cancel(&mut self, agent: AgentId) -> bool {
-        self.set_status(agent, AgentStatus::Cancelled)
     }
 
     /// Run one schedule tick over every agent, catching a panic from any system

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -871,10 +871,43 @@ impl PipelineWorld {
                 self.world
                     .entity_mut(entity)
                     .remove::<crate::pipeline::PausedForSetup>();
+                self.replay_held_inference(entity);
                 self.set_status(agent, AgentStatus::Active)
             }
             _ => false,
         }
+    }
+
+    /// Put back an inference outcome that landed while the agent was paused.
+    ///
+    /// The result is sent to the same channel it originally came in on, so the
+    /// collect system applies it through its ordinary arms on the next tick -
+    /// no duplicated success/failure handling, and no wasted call: whatever the
+    /// provider already charged for is still used. The agent kept its
+    /// `Awaiting*` marker while held, which is what makes it visible to that
+    /// system's query.
+    ///
+    /// A no-op for the ordinary case of a run that was paused with nothing in
+    /// flight.
+    fn replay_held_inference(&mut self, entity: Entity) {
+        let Some(held) = self
+            .world
+            .entity_mut(entity)
+            .take::<crate::pipeline::HeldInference>()
+        else {
+            return;
+        };
+        let Some(stage) = self.world.get_resource::<crate::pipeline::InferenceStage>() else {
+            return;
+        };
+        let channel = match held.lane {
+            crate::pipeline::HeldLane::Stage => &stage.outcomes,
+            crate::pipeline::HeldLane::TransitionChoice => &stage.transition_outcomes,
+        };
+        // A closed channel means the pipeline is shutting down; the run is being
+        // torn down with it, so there is nothing to salvage and nothing to warn
+        // about.
+        let _ = channel.send(held.outcome);
     }
 
     /// Cancel an agent (it stops starting new work; in-flight results still land).
@@ -1995,6 +2028,71 @@ mod tests {
         assert!(world.resume(e));
         world.run_until_idle(30).await;
         assert_eq!(world.agent_status(e), Some(AgentStatus::Complete));
+    }
+
+    /// A response that landed during the pause is applied on resume, not thrown
+    /// away.
+    ///
+    /// The call was already made and already charged for. Dropping it would make
+    /// the model redo the turn, so the outcome is parked whole and replayed down
+    /// the channel it came in on - which also means the collect system's arms
+    /// are not duplicated anywhere.
+    #[tokio::test]
+    async fn resume_replays_an_inference_that_landed_while_paused() {
+        // Empty on purpose: nothing here can serve an inference, so any progress
+        // the agent makes has to have come from the parked outcome.
+        let mut world = build_world(registry_with(vec![]));
+        let e = spawn(&mut world);
+        assert!(world.pause(e));
+        // Put the agent where a pause-during-inference leaves it: the call is
+        // out, so it is awaiting a result rather than ready to dispatch one.
+        world
+            .world_mut()
+            .entity_mut(e.entity())
+            .remove::<crate::pipeline::ReadyToInfer>()
+            .insert(crate::pipeline::AwaitingInference);
+        world
+            .world_mut()
+            .entity_mut(e.entity())
+            .insert(crate::pipeline::HeldInference {
+                outcome: crate::inference_bridge::InferenceOutcome {
+                    entity: e.entity(),
+                    latency: std::time::Duration::ZERO,
+                    result: Ok(text("t1")),
+                },
+                lane: crate::pipeline::HeldLane::Stage,
+            });
+
+        assert!(world.resume(e));
+
+        assert!(
+            world
+                .world()
+                .get::<crate::pipeline::HeldInference>(e.entity())
+                .is_none(),
+            "the outcome is handed back to the pipeline, not left parked"
+        );
+        // One tick is all the replay needs: the outcome goes back down the
+        // channel and the ordinary collect system applies it.
+        world.tick();
+        assert_eq!(
+            world
+                .world()
+                .get::<AgentState>(e.entity())
+                .unwrap()
+                .iteration,
+            1,
+            "the held turn is taken on resume, not re-requested from the provider"
+        );
+        assert_eq!(
+            world
+                .world()
+                .get::<crate::components::InferenceResult>(e.entity())
+                .expect("the held response was applied")
+                .response,
+            "t1",
+            "the very response that landed during the pause is the one used"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -897,9 +897,9 @@ impl PipelineWorld {
         else {
             return;
         };
-        let Some(stage) = self.world.get_resource::<crate::pipeline::InferenceStage>() else {
-            return;
-        };
+        // Installed unconditionally by `PipelineWorld::new`, which is the only
+        // way to get a world that can reach this at all.
+        let stage = self.world.resource::<crate::pipeline::InferenceStage>();
         let channel = match held.lane {
             crate::pipeline::HeldLane::Stage => &stage.outcomes,
             crate::pipeline::HeldLane::TransitionChoice => &stage.transition_outcomes,
@@ -2092,6 +2092,50 @@ mod tests {
                 .response,
             "t1",
             "the very response that landed during the pause is the one used"
+        );
+    }
+
+    /// A held *routing* outcome goes back to the routing collector, not the
+    /// turn collector. The two lanes are separate on purpose - a stage-boundary
+    /// decision is not an agent turn - so replaying down the wrong one would
+    /// feed a routing answer into the run as if the model had spoken.
+    #[tokio::test]
+    async fn resume_replays_a_held_routing_call_on_its_own_lane() {
+        let mut world = build_world(registry_with(vec![]));
+        let e = spawn(&mut world);
+        assert!(world.pause(e));
+        world
+            .world_mut()
+            .entity_mut(e.entity())
+            .insert(crate::pipeline::HeldInference {
+                outcome: crate::inference_bridge::InferenceOutcome {
+                    entity: e.entity(),
+                    latency: std::time::Duration::ZERO,
+                    result: Ok(text("t1")),
+                },
+                lane: crate::pipeline::HeldLane::TransitionChoice,
+            });
+
+        assert!(world.resume(e));
+
+        assert!(
+            world
+                .world()
+                .get::<crate::pipeline::HeldInference>(e.entity())
+                .is_none(),
+            "the outcome is handed back rather than left parked"
+        );
+        // The turn lane must not have received it. Nothing consumed a turn, so
+        // the agent has still taken none.
+        world.tick();
+        assert_eq!(
+            world
+                .world()
+                .get::<AgentState>(e.entity())
+                .unwrap()
+                .iteration,
+            0,
+            "a routing answer replayed on the turn lane would have counted as a turn"
         );
     }
 

--- a/crates/leviath-runtime/src/world/control.rs
+++ b/crates/leviath-runtime/src/world/control.rs
@@ -1,0 +1,133 @@
+//! Agent status control on [`PipelineWorld`]: read a status, set one, and the
+//! three transitions a person can ask for.
+//!
+//! Split out of `world.rs` to keep that file inside the workspace's structure
+//! limit. It is one coherent unit rather than an arbitrary cut: every method
+//! here reads or writes `AgentState::status`, they share the foreign-id guard
+//! in [`PipelineWorld::agent_status`], and the guards they apply to each other
+//! (`pause` only from `Active`/`Idle`, `resume` only from `Paused`/`Idle`) only
+//! make sense side by side.
+
+use super::*;
+
+impl PipelineWorld {
+    /// The status of an agent, if it still exists.
+    ///
+    /// An id another world minted reports `None` rather than this world's agent
+    /// of the same raw entity - see [`AgentId`]. `pause`, `resume` and `cancel`
+    /// all read status through here, so guarding it guards them.
+    pub fn agent_status(&self, agent: AgentId) -> Option<AgentStatus> {
+        if agent.world != self.id {
+            return None;
+        }
+        self.world
+            .get::<AgentState>(agent.entity)
+            .map(|s| s.status.clone())
+    }
+
+    /// Set an agent's status and wake the driver. Returns `false` if the agent no
+    /// longer exists. The async-starting dispatchers only act on `Active` agents,
+    /// so this is how the world pauses/resumes/cancels an agent - a non-`Active`
+    /// agent is simply data the systems skip until it is `Active` again.
+    pub fn set_status(&mut self, agent: AgentId, status: AgentStatus) -> bool {
+        // Every status mutation funnels through here, so this is the one place a
+        // foreign id has to be refused.
+        if agent.world != self.id {
+            return false;
+        }
+        let Some(mut state) = self.world.get_mut::<AgentState>(agent.entity) else {
+            return false;
+        };
+        state.status = status;
+        self.wake.notify_one();
+        true
+    }
+
+    /// Pause an agent (it finishes any in-flight step, then stops before starting
+    /// new work). Only `Active` and `Idle` agents can be paused: a `Waiting`
+    /// agent's status is the marker the fan-out merge poll and interaction
+    /// resolution depend on, so overwriting it would wedge the run, and pausing
+    /// a terminal agent is meaningless. Returns `false` if the agent no longer
+    /// exists or is not in a pausable state.
+    pub fn pause(&mut self, agent: AgentId) -> bool {
+        match self.agent_status(agent) {
+            Some(AgentStatus::Active | AgentStatus::Idle) => {
+                self.set_status(agent, AgentStatus::Paused)
+            }
+            _ => false,
+        }
+    }
+
+    /// Resume a paused agent. `Idle` is also accepted (resume-as-nudge for an
+    /// agent that has not ticked yet); anything else returns `false`.
+    pub fn resume(&mut self, agent: AgentId) -> bool {
+        // Resolved once, up front. Doing it again inside the arm below would
+        // be a second check that cannot fail - the status lookup already
+        // proved the entity is here - and an arm nothing can reach is an arm
+        // nothing can test.
+        let Some(entity) = agent.resolve_in(&self.world) else {
+            return false;
+        };
+        match self.agent_status(agent) {
+            Some(AgentStatus::Paused | AgentStatus::Idle) => {
+                // An explicit resume says conditions have changed - most often
+                // a top-up after a run paused on exhausted credits (issue
+                // #413). A tripped breaker would otherwise hold the retry
+                // until its cooldown lapses, making the resume look ignored.
+                if let Some(mut circuits) = self
+                    .world
+                    .get_resource_mut::<crate::pipeline::ProviderCircuits>()
+                {
+                    circuits.reset();
+                }
+                // The run no longer claims to need setup. If the machine was
+                // not actually fixed the watchdog re-parks it a minute later
+                // with a fresh message, which is better than carrying a stale
+                // one that describes a problem somebody may have just solved.
+                self.world
+                    .entity_mut(entity)
+                    .remove::<crate::pipeline::PausedForSetup>();
+                self.replay_held_inference(entity);
+                self.set_status(agent, AgentStatus::Active)
+            }
+            _ => false,
+        }
+    }
+
+    /// Put back an inference outcome that landed while the agent was paused.
+    ///
+    /// The result is sent to the same channel it originally came in on, so the
+    /// collect system applies it through its ordinary arms on the next tick -
+    /// no duplicated success/failure handling, and no wasted call: whatever the
+    /// provider already charged for is still used. The agent kept its
+    /// `Awaiting*` marker while held, which is what makes it visible to that
+    /// system's query.
+    ///
+    /// A no-op for the ordinary case of a run that was paused with nothing in
+    /// flight.
+    fn replay_held_inference(&mut self, entity: Entity) {
+        let Some(held) = self
+            .world
+            .entity_mut(entity)
+            .take::<crate::pipeline::HeldInference>()
+        else {
+            return;
+        };
+        // Installed unconditionally by `PipelineWorld::new`, which is the only
+        // way to get a world that can reach this at all.
+        let stage = self.world.resource::<crate::pipeline::InferenceStage>();
+        let channel = match held.lane {
+            crate::pipeline::HeldLane::Stage => &stage.outcomes,
+            crate::pipeline::HeldLane::TransitionChoice => &stage.transition_outcomes,
+        };
+        // A closed channel means the pipeline is shutting down; the run is being
+        // torn down with it, so there is nothing to salvage and nothing to warn
+        // about.
+        let _ = channel.send(held.outcome);
+    }
+
+    /// Cancel an agent (it stops starting new work; in-flight results still land).
+    pub fn cancel(&mut self, agent: AgentId) -> bool {
+        self.set_status(agent, AgentStatus::Cancelled)
+    }
+}


### PR DESCRIPTION
Three runs were paused deliberately, then "resumed on their own" half an hour later and immediately failed. This is what actually happened, and the three bugs behind it.

## What the evidence says

Reconstructed from `~/.leviath/runs/*/run.lvr` and `pmset -g log`:

| time | event |
|---|---|
| 16:20:07 / 16:20:20 / 16:20:22 | three `researcher` children paused (`StatusChanged {paused}` in each journal) |
| 16:21:13 | macOS `Clamshell Sleep` - lid closed, on battery |
| 16:51:57 | wake; `en0: no SSID`, Wi-Fi returns on a **different** SSID |
| 16:52:10.6 | DHCP `publish success` - first usable network |
| 16:52:16 / :16 / :18 | all three paused runs go straight to `error` |

Every run's persist heartbeat froze at 16:20:5x and resumed at 16:51:56, to the second, across paused *and* unpaused runs - the process being suspended, not anything in the scheduler. Each died at 35-38 iterations of completed work with:

```
Invalid response: error decoding response body
```

**No run was actually resumed.** No journal shows a `StatusChanged` back to `running`; they went `paused` -> `error` directly. The perception was still right, for the reason in the first bug below.

The same failure then recurred on `deep-researcher-1787191745-7c71aad70ceb` with no sleep and no pause involved - an ordinary blip at 19:22:36, dead at iteration 10. This is not a sleep-specific bug.

## 1. A dead socket was reported as malformed JSON

`Response::json` does two things - read the body off the socket, then parse it - and all five providers mapped both failures to `ProviderError::InvalidResponse`, which `is_transient` calls permanent. So a transport failure got **no retry** (despite `inference_retry_attempts = 4`), no failover, and no circuit-breaker record; it fell to the terminal error arm and took the run with it.

A shared `decode_json` helper now splits the halves across all 14 call sites. Bytes that never arrived are `RequestFailed` - transient, retried, `Unreachable`, eligible for failover; bytes that arrived and did not fit the schema stay `InvalidResponse`. The streaming path already drew this line, so the buffered path now agrees with its own sibling.

## 2. A paused run was walked forward by its own in-flight result

Pause is documented as letting the outstanding step finish. Dispatch, the wedge detector and the transition resolver all honour `Paused`; the two inference collectors did not, guarding only on `is_terminal_status` - whose own doc comment states the invariant being broken: *"a run that reached a terminal state while its work was in flight must stay there, not be walked back by the result landing afterwards."*

So a landing result acted. A **success** carried the run through `ProcessResponse`, its tool calls and its stage transitions while it still displayed `paused` - the resume nobody asked for. A **failure** overwrote the pause with `Error`.

The outcome is now parked in `HeldInference`, tagged with its lane, and replayed from `resume` down the channel it came in on - so no collector arm is duplicated and the response already paid for is used rather than discarded.

Separately, a run whose provider could not be reached at all now **parks** with a remedy instead of failing, on the same terms as an empty account (#456), keeping `ReadyToInfer` staged so `lev resume` re-dispatches.

## 3. Pausing a fan-out parent did nothing

The parent sits at `Waiting` - a status the merge poll depends on, so `pause` rightly refuses to overwrite it - which meant the request reported failure while every child kept spending. Pause and resume now walk `SubAgentChildren` as `cancel_tree` already did. A latch on `FanOutWaiting` holds the worker queue, or the pause would stop the running children and immediately launch their replacements out of `pending`; it rides the persisted fan-out state, so a restart does not quietly resume the queue. Resume deliberately does not give up on the root - the parent is not itself `Paused`, so stopping there would strand every child.

`lev pause`/`lev resume`, the REST endpoints and the dashboard's `p`/`r` keys all reach this through one control op.

## 4. Pausing mid-inference threw the call away

Found by driving the real binaries; no test would have caught it, and it made the
fix above look like it was not working.

A paused run is **parked**: `emit.rs` runs the reap hook and **despawns the
entity**, and `resolve_or_reload` pages it back from disk on resume. `parkable`
already refused to do that for a run with a live, unpersisted continuation - a
blocked `ask`, a fan-out, tree links - and an outstanding provider call was
missing from that list. So the response landed on a despawned entity and was
dropped on the collect system's stale path, and the resume paid for the same turn
again twenty seconds later. `InFlightWork` and `HeldInference` now both hold the
run resident until it is resumed.

## Live verification

Against real binaries, with a fake provider wired in through
`[providers] openrouter_base_url` so the real `openrouter.rs` path runs:

- **Truncated body** (declares a Content-Length, hangs up mid-body - byte for
  byte the incident's failure): retried 3 times, then parked
  `paused: needs providers` with a remedy naming `lev resume`; fixing the
  endpoint and resuming ran the run to completion.
- **Pause mid-inference** against a provider that sleeps 20s: the run stayed
  `paused` at iteration 0 with the response landed, and `lev resume` applied the
  held response *instantly* - the journal records the turn at the resume instant
  rather than 20s later, so no second call was made.
- **Fan-out cascade**: parent with `max_workers = 1` and 4 items. Pausing the
  parent paused the running worker and, after 45s, still exactly one worker
  existed - the queue was held rather than replaced. Resuming the parent released
  the worker, started the remaining three, and the parent completed.

## Behaviour changes worth flagging

- Body-read failures become **transient**: they are now retried and count toward failover and the circuit breaker. This is what makes parking possible at all, and is the correct handling, but it is a default change.
- A run that cannot reach its provider now ends up `paused`, not `error`.

## Not in this PR

Widening the retry budget / detecting the wall-clock jump. Measured: wake at 16:51:57, DHCP bound at 16:52:10.6 - about 14 seconds unusable, against ~15s of total backoff. With the park in place this costs an operator a `lev resume` rather than the run. Worth its own issue.

## Verification

- `cargo xtask coverage`: all 13 packages at 100%.
- Full workspace suite green.
- New tests cover both collectors' pause guards, the replay on each lane, the transport park with and without a stage log, the fan-out latch (including its persistence round-trip), and pause/resume cascading through a real fan-out parent via the host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
