### PR TITLE
fix: read script-provider and config state live rather than at boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,38 @@ same list.
 
 ## Unreleased
 
+- Fixed: `GET /api/models` now reports a Rhai script provider's models, so The
+  Lair offers them on the new-run page, in the agent editor and in settings.
+  `ProviderRegistry::provider_names()` returns natively registered providers
+  only and the script layer is reachable through `get()`, so an enumeration
+  built on it skipped script providers entirely - the same defect fixed for
+  `lev models list --provider` in the previous release, in a sibling surface.
+  The registry now answers `resolvable_names()` for callers that are
+  enumerating, and both the API path and `lev models list --remote` use it.
+  Until now the provider showed under Custom Gateways while none of its models
+  existed anywhere.
+
+- Fixed: `lev serve` no longer answers `GET /api/config` from a snapshot taken
+  at start-up. An edit saved through `PUT /api/config` was written to disk and
+  never read back, so reloading the page showed the old value and the save read
+  as lost; an edit made anywhere else was invisible for the life of the process,
+  and since `lev serve` is a separate process from `lev daemon`, restarting the
+  daemon did not help. Every handler now reads the file through the same
+  mtime-checked reloader the daemon uses, so a change - from this API or from
+  outside - is visible to the next request.
+
+- Fixed: `[model_providers.<name>]` is now as hot as the `.rhai` file it
+  configures. A provider script has always been re-read when its file changes,
+  but the table feeding its `initialize(config)` was captured at daemon boot, so
+  editing the script's code took effect on the next run while editing the config
+  it receives silently did nothing until `lev daemon restart`. Setting a
+  `base_url` and watching it have no effect was indistinguishable from having
+  typed the key wrong. The layer now reads that config on every load, and its
+  compiled-script cache is invalidated by a config change as well as by the
+  file's mtime. `[model_capabilities]`, `request_timeout_secs` and `[security]
+  allow_env_vars` reload with it; the shared HTTP client still does not, since
+  it holds a connection pool.
+
 - Fixed: a network blip no longer ends a run. `Response::json` does two things -
   read the body off the socket, then parse it - and every provider mapped both
   failures to "invalid response", which the retry policy treats as permanent. So

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -508,30 +508,38 @@ async fn list_with_registry(
         entries.retain(|e| available.contains(&e.provider));
     }
 
+    // The one name the script path below owns outright, so the sweep does not
+    // also query it: it reports a failure differently (fatal there, a warning
+    // here) and querying it twice would be a wasted round trip.
+    let script_target = args.provider.as_deref().filter(|name| {
+        !available.contains(*name) && !builtin_table().iter().any(|e| e.provider == *name)
+    });
+
     // --remote: fetch live model lists and merge (remote wins on same ID).
     if args.remote {
-        for provider_name in registry.provider_names() {
+        // `resolvable_names`, not `provider_names`: a script provider is
+        // reachable only through `get`, so a sweep built on the registered
+        // names alone silently omitted every one of them - the same shape as
+        // issues #523 and #531.
+        for provider_name in registry.resolvable_names() {
             // If the caller filtered to a specific provider, skip others.
             if let Some(ref filter) = args.provider
-                && filter != provider_name
+                && filter != &provider_name
             {
                 continue;
             }
+            if script_target == Some(provider_name.as_str()) {
+                continue; // asked for, and answered for, below
+            }
 
-            // `registry.get(provider_name)` is structurally guaranteed
-            // `Some` here - `provider_name` comes from
-            // `registry.provider_names()` just above, and both methods read
-            // the same underlying map (see `leviath-runtime/src/providers.rs`'s
-            // `ProviderRegistry`). There is no way to construct a registry
-            // where a name from `provider_names()` isn't `get()`-able, so
-            // `.expect()` documents that invariant instead of leaving a
-            // defensive-but-unreachable `if let` branch permanently
-            // uncovered - the same choice already made by
-            // `commands/serve/config.rs`'s `get_models` for this identical
-            // pattern.
-            let provider = registry
-                .get(provider_name)
-                .expect("provider_names returns registered names");
+            // A script name is a candidate until it compiles, so this cannot
+            // assume the lookup succeeds the way the old `provider_names` loop
+            // could. One that will not load is skipped here - the layer has
+            // already logged why - and is only ever fatal when the caller named
+            // it with `--provider`, which is `script_target` above.
+            let Some(provider) = registry.get(&provider_name) else {
+                continue;
+            };
             match provider.list_models().await {
                 Ok(remote_models) => {
                     for rm in remote_models {
@@ -561,10 +569,7 @@ async fn list_with_registry(
     // - `--provider openai` with no OpenAI key is an empty table, exactly as it
     // has always been.
     let mut script_provider_answered = false;
-    if let Some(ref name) = args.provider
-        && !available.contains(name)
-        && !builtin_table().iter().any(|e| e.provider == name.as_str())
-    {
+    if let Some(name) = script_target {
         merge_script_provider(&registry, name, &mut entries).await?;
         script_provider_answered = true;
     }
@@ -2003,6 +2008,72 @@ mod tests {
                 let args = ListArgs {
                     remote: false,
                     provider: Some("scripted".to_string()),
+                    all: false,
+                    json: true,
+                };
+                let result = list_with_registry(args, &script_registry(dir)).await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
+    /// `--remote` sweeps every provider it can resolve, script providers now
+    /// included - the sweep used to be built on `provider_names`, which names
+    /// only the natively registered ones (issues #523, #531).
+    #[tokio::test]
+    async fn list_remote_sweeps_script_providers_too() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        std::fs::write(
+            dir.path().join("swept.rhai"),
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { [ #{ id: \"swept-large\" } ] }",
+        )
+        .expect("the temp dir is writable");
+        // A second script that will not compile: the sweep skips it rather
+        // than failing, which is only fatal when `--provider` named it.
+        std::fs::write(
+            dir.path().join("wont-compile.rhai"),
+            "fn initialize(config) { #{",
+        )
+        .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-list_remote_sweeps_script_providers_too",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: true,
+                    provider: None,
+                    all: false,
+                    json: true,
+                };
+                let result = list_with_registry(args, &script_registry(dir)).await;
+                assert!(result.is_ok(), "one broken script does not fail the sweep");
+            },
+        )
+        .await;
+    }
+
+    /// A `--provider` naming a script provider is answered once, by the path
+    /// that reports its failures properly - not twice, once by each.
+    #[tokio::test]
+    async fn a_named_script_provider_is_not_also_swept() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        std::fs::write(
+            dir.path().join("once.rhai"),
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { [ #{ id: \"once-large\" } ] }",
+        )
+        .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-a_named_script_provider_is_not_also_swept",
+            |_fake_dir| async move {
+                let args = ListArgs {
+                    remote: true,
+                    provider: Some("once".to_string()),
                     all: false,
                     json: true,
                 };

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -172,6 +172,52 @@ pub fn build_provider_registry_from_config_with(
     ))
 }
 
+/// [`build_provider_registry_from_config_with`], with the script-provider
+/// layer reading `reloader` on every load rather than a snapshot of `config`.
+///
+/// The daemon builds its registry this way so an edit to
+/// `[model_providers.<name>]` reaches the next provider load with no restart,
+/// matching the `.rhai` file's own hot-reload (issue #533). Short-lived
+/// processes keep the snapshot: there is nothing to reload inside one command.
+pub fn build_provider_registry_live(
+    config: &Config,
+    reloader: std::sync::Arc<crate::daemon::config_reload::ConfigReloader>,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    let registry = leviath_runtime::provider_creds::build_provider_registry_with(
+        &provider_creds_from_config(config),
+        build_client,
+    )?;
+    Ok(attach_live_script_layer(
+        registry,
+        crate::config::providers_dir(),
+        config,
+        reloader,
+    ))
+}
+
+/// [`attach_script_layer`], with the layer reading `reloader` on every load.
+/// Split out for the same reason: both the with-dir and no-home paths are then
+/// unit-testable.
+fn attach_live_script_layer(
+    registry: ProviderRegistry,
+    dir: Option<std::path::PathBuf>,
+    config: &Config,
+    reloader: std::sync::Arc<crate::daemon::config_reload::ConfigReloader>,
+) -> ProviderRegistry {
+    let Some(dir) = dir else {
+        return registry;
+    };
+    let layer = leviath_runtime::script_provider::ScriptProviderLayer::with_config_source(
+        dir,
+        script_provider_config_source(reloader),
+        leviath_runtime::script_provider::ScriptProviderLayer::build_executor(
+            config.request_timeout_secs,
+        ),
+    );
+    registry.with_script_layer(std::sync::Arc::new(layer))
+}
+
 /// Attach a [`ScriptProviderLayer`](leviath_runtime::script_provider::ScriptProviderLayer)
 /// over `dir` (the providers directory) when one is available; otherwise return
 /// the registry unchanged. Split out so both the with-dir and no-home paths are
@@ -184,19 +230,69 @@ fn attach_script_layer(
     let Some(dir) = dir else {
         return registry;
     };
-    let overrides = config
-        .model_providers
-        .iter()
-        .map(|(name, mp)| (name.clone(), script_provider_spec(mp)))
-        .collect();
     let layer = leviath_runtime::script_provider::ScriptProviderLayer::new(
         dir,
-        overrides,
+        script_provider_config(config).overrides,
         config.model_capabilities.clone(),
         config.request_timeout_secs,
         config.security.allow_env_vars.clone(),
     );
     registry.with_script_layer(std::sync::Arc::new(layer))
+}
+
+/// The [`ScriptProviderConfig`](leviath_runtime::script_provider::ScriptProviderConfig)
+/// a script-provider load reads out of `config`.
+pub fn script_provider_config(
+    config: &Config,
+) -> leviath_runtime::script_provider::ScriptProviderConfig {
+    leviath_runtime::script_provider::ScriptProviderConfig {
+        overrides: config
+            .model_providers
+            .iter()
+            .map(|(name, mp)| (name.clone(), script_provider_spec(mp)))
+            .collect(),
+        default_caps: config.model_capabilities.clone(),
+        request_timeout_secs: config.request_timeout_secs,
+        env_allowlist: std::sync::Arc::new(config.security.allow_env_vars.clone()),
+    }
+}
+
+/// A script-provider config source that follows `reloader`, so an edit to
+/// `[model_providers.<name>]` reaches the next provider load without a daemon
+/// restart - the same way an edit to the `.rhai` file beside it already did
+/// (issue #533).
+///
+/// Memoised on the identity of the config the reloader hands back, which is a
+/// requirement rather than an optimisation: the layer's cache compares its
+/// stored config by pointer, so deriving a fresh one per call would recompile
+/// every script on every lookup.
+pub fn script_provider_config_source(
+    reloader: std::sync::Arc<crate::daemon::config_reload::ConfigReloader>,
+) -> Box<
+    dyn Fn() -> std::sync::Arc<leviath_runtime::script_provider::ScriptProviderConfig>
+        + Send
+        + Sync,
+> {
+    use std::sync::{Arc, Mutex, PoisonError};
+    type Memo = Mutex<
+        Option<(
+            Arc<Config>,
+            Arc<leviath_runtime::script_provider::ScriptProviderConfig>,
+        )>,
+    >;
+    let memo: Memo = Mutex::new(None);
+    Box::new(move || {
+        let current = reloader.current();
+        let mut memo = memo.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some((from, derived)) = memo.as_ref()
+            && Arc::ptr_eq(from, &current)
+        {
+            return derived.clone();
+        }
+        let derived = Arc::new(script_provider_config(&current));
+        *memo = Some((current, derived.clone()));
+        derived
+    })
 }
 
 /// Translate a CLI [`ModelProviderConfig`](crate::config::ModelProviderConfig)
@@ -377,6 +473,56 @@ mod tests {
         assert!(registry.has("ollama"));
     }
 
+    /// The memo is a requirement, not an optimisation: the layer compares its
+    /// cached config by pointer, so a source that derived a fresh one per call
+    /// would recompile every script on every lookup.
+    #[test]
+    fn the_script_config_source_is_stable_until_the_config_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+        let reloader = std::sync::Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+            path.clone(),
+            Config::default(),
+        ));
+        let source = script_provider_config_source(reloader);
+
+        let first = source();
+        assert!(
+            std::sync::Arc::ptr_eq(&first, &source()),
+            "an unchanged config must hand back the very same value"
+        );
+        assert!(first.overrides.is_empty());
+
+        let mut edited = Config::default();
+        edited.model_providers.insert(
+            "cerebras".to_string(),
+            crate::config::ModelProviderConfig {
+                base_url: Some("https://api.cerebras.ai/v1".to_string()),
+                ..Default::default()
+            },
+        );
+        edited.save_to_path_public(&path).unwrap();
+        // Strictly newer, so the reload is observable even in the same tick.
+        let later = std::time::SystemTime::now() + std::time::Duration::from_secs(5);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(later)
+            .unwrap();
+
+        let after = source();
+        assert!(
+            !std::sync::Arc::ptr_eq(&first, &after),
+            "a change is a new value"
+        );
+        assert_eq!(
+            after.overrides["cerebras"].init_config["base_url"],
+            "https://api.cerebras.ai/v1"
+        );
+    }
+
     #[test]
     fn script_provider_spec_assembles_init_config() {
         let mut extra = std::collections::HashMap::new();
@@ -397,6 +543,22 @@ mod tests {
         assert_eq!(spec.init_config["base_url"], "http://api");
         assert_eq!(spec.init_config["api_key"], "k");
         assert_eq!(spec.init_config["region"], "us");
+    }
+
+    #[test]
+    fn attach_live_script_layer_without_home_is_a_noop() {
+        let registry = attach_live_script_layer(
+            ProviderRegistry::new(),
+            None,
+            &Config::default(),
+            std::sync::Arc::new(crate::daemon::config_reload::ConfigReloader::fixed(
+                Config::default(),
+            )),
+        );
+        assert!(
+            registry.resolvable_names().is_empty(),
+            "no providers directory means no script layer to enumerate"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -47,7 +47,7 @@ pub(super) async fn spawn_agent(
     State(state): State<AppState>,
     Json(body): Json<SpawnAgentReq>,
 ) -> Result<Json<SpawnAgentResp>, (StatusCode, Json<ErrorResponse>)> {
-    let blueprints = discover_blueprints(&state.config);
+    let blueprints = discover_blueprints(&state.current_config());
     let bp_info = blueprints
         .iter()
         .find(|b| b.name == body.blueprint)
@@ -844,7 +844,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
@@ -870,7 +870,7 @@ mod tests {
 
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
-            config: Arc::new(Config {
+            config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![agents.path().to_path_buf()],
                 ..Default::default()
             }),
@@ -1140,7 +1140,7 @@ mod tests {
     fn test_state_with_agent_paths(paths: Vec<PathBuf>, control: ControlClient) -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
-            config: Arc::new(Config {
+            config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: paths,
                 ..Default::default()
             }),
@@ -2963,7 +2963,7 @@ system_prompt = "Plan the work"
         use axum::routing::delete;
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
@@ -3019,7 +3019,7 @@ system_prompt = "Plan the work"
         use axum::routing::post;
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,
             mcp: crate::commands::serve::mcp::McpAdmin::default(),

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -203,7 +203,7 @@ pub(super) async fn list_blueprints(
         ),
     };
 
-    let mut found = discover_blueprints(&state.config);
+    let mut found = discover_blueprints(&state.current_config());
 
     // `q` shares the search primitive but not the framework: three in-memory
     // string fields do not need sources, phases or highlights.
@@ -291,7 +291,7 @@ pub(super) async fn get_blueprint(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
 ) -> Result<Json<BlueprintDetail>, StatusCode> {
-    let blueprints = discover_blueprints(&state.config);
+    let blueprints = discover_blueprints(&state.current_config());
     let mut info = blueprints
         .into_iter()
         .find(|b| b.name == name)
@@ -592,7 +592,7 @@ system_prompt = "do it"
     async fn page(dir: &tempfile::TempDir, extra: &str) -> (StatusCode, serde_json::Value) {
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
-            config: Arc::new(Config {
+            config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![dir.path().to_path_buf()],
                 ..Default::default()
             }),
@@ -816,7 +816,6 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use axum::routing::{get, post};
-    use std::sync::Arc;
     use tokio::sync::broadcast;
     use tower::ServiceExt;
 
@@ -825,7 +824,7 @@ mod tests {
     fn test_state_with_path(path: PathBuf) -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
-            config: Arc::new(Config {
+            config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![path],
                 ..Default::default()
             }),

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -52,8 +52,11 @@ fn redact(c: &Config) -> RedactedConfig {
     }
 }
 
+/// `GET /api/config`. Reads the file rather than a start-up copy, so an edit
+/// made through [`put_config`] - or by anything else on the machine - is
+/// visible to the very next request (issue #532).
 pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedConfig> {
-    Json(redact(&state.config))
+    Json(redact(&state.current_config()))
 }
 
 /// `PUT /api/config` (admin-only). Loads the on-disk config, applies every
@@ -204,7 +207,7 @@ pub(super) async fn models_with(
     state: &AppState,
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
 ) -> Json<Vec<ModelEntry>> {
-    Json(list_models_from_config(&state.config, build_client).await)
+    Json(list_models_from_config(&state.current_config(), build_client).await)
 }
 
 /// Every model every configured provider reports, as `provider/id`: what the
@@ -222,6 +225,14 @@ pub(crate) async fn list_model_ids(
 
 /// Every model every configured provider reports, for `GET /api/models` and
 /// the dashboard's agent editor alike.
+///
+/// Iterates `resolvable_names` rather than `provider_names`, so a Rhai script
+/// provider is asked too. It used to be skipped here: `provider_names` returns
+/// natively registered providers only, and a script provider is reachable only
+/// through `get`. The result was that The Lair listed a script provider under
+/// its gateways while offering none of its models, on the new-run page, in the
+/// agent editor and in settings alike (issue #531 - the same defect #523 fixed
+/// for the CLI).
 pub(super) async fn list_models_from_config(
     config: &crate::config::Config,
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
@@ -237,10 +248,15 @@ pub(super) async fn list_models_from_config(
     };
     let mut models = Vec::new();
 
-    for provider_name in registry.provider_names() {
-        let provider = registry
-            .get(provider_name)
-            .expect("provider_names returns registered names");
+    for provider_name in registry.resolvable_names() {
+        // A script name is a candidate until it compiles, so unlike the old
+        // `provider_names` loop this cannot assume the lookup succeeds. A
+        // script that will not load is skipped with its own log line already
+        // written by the layer, exactly as a provider whose `list_models`
+        // errors is skipped below.
+        let Some(provider) = registry.get(&provider_name) else {
+            continue;
+        };
         if let Ok(list) = provider.list_models().await {
             for m in list {
                 models.push(ModelEntry {
@@ -283,7 +299,7 @@ mod tests {
     fn state_without_a_reachable_ollama() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
-            config: Arc::new(Config {
+            config: crate::commands::serve::testutil::fixed_config(Config {
                 ollama_base_url: Some("http://127.0.0.1:1".to_string()),
                 ..Config::default()
             }),
@@ -297,7 +313,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
@@ -308,7 +324,7 @@ mod tests {
     fn test_state_with_keys() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
-            config: Arc::new(Config {
+            config: crate::commands::serve::testutil::fixed_config(Config {
                 providers: crate::config::ProviderConfig {
                     anthropic_api_key: Some("sk-ant-test".to_string()),
                     openai_api_key: Some("sk-openai-test".to_string()),
@@ -441,7 +457,7 @@ mod tests {
     async fn get_config_agent_paths_included() {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         let state = AppState {
-            config: Arc::new(Config {
+            config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![
                     std::path::PathBuf::from("/my/agents"),
                     std::path::PathBuf::from("/other/agents"),
@@ -476,7 +492,7 @@ mod tests {
     fn test_state_listing_models() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
-            config: Arc::new(Config {
+            config: crate::commands::serve::testutil::fixed_config(Config {
                 providers: crate::config::ProviderConfig {
                     anthropic_base_url: None,
                     openai_base_url: None,
@@ -538,12 +554,56 @@ mod tests {
         assert!(models.iter().all(|m| m["id"].is_string()));
     }
 
+    /// A script provider's models must reach `GET /api/models`, or The Lair
+    /// lists the gateway under settings while offering none of its models on
+    /// the new-run page or in the agent editor (issue #531).
+    ///
+    /// A real `.rhai` on disk under an isolated `LEVIATH_HOME`, not a mock:
+    /// the endpoint builds its own registry, so the only way to put a script
+    /// provider in front of it is to put one where it looks.
+    #[tokio::test]
+    async fn api_models_includes_a_script_providers_models() {
+        let home = tempfile::tempdir().unwrap();
+        let providers = home.path().join(".leviath").join("providers");
+        std::fs::create_dir_all(&providers).unwrap();
+        std::fs::write(
+            providers.join("scripted.rhai"),
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { [ #{ id: \"scripted-large\", \
+             max_context_tokens: 32768 } ] }",
+        )
+        .unwrap();
+        // A second script that will not compile: it must be skipped rather
+        // than take the endpoint down with it.
+        std::fs::write(providers.join("broken.rhai"), "fn initialize(config) { #{").unwrap();
+
+        let models = temp_env::async_with_vars(
+            [("LEVIATH_HOME", Some(home.path()))],
+            list_models_from_config(
+                &Config::default(),
+                &leviath_providers::provider::build_http_client,
+            ),
+        )
+        .await;
+
+        let scripted: Vec<_> = models.iter().filter(|m| m.provider == "scripted").collect();
+        let named: Vec<&str> = models.iter().map(|m| m.provider.as_str()).collect();
+        assert_eq!(scripted.len(), 1, "the script provider answered: {named:?}");
+        assert_eq!(scripted[0].id, "scripted-large");
+        assert_eq!(scripted[0].max_context_tokens, 32768);
+        assert!(
+            !models.iter().any(|m| m.provider == "broken"),
+            "a script that will not compile is skipped, not fatal"
+        );
+    }
+
     /// The dashboard's flat `provider/id` list is the same enumeration.
     #[tokio::test]
     async fn list_model_ids_flattens_to_provider_slash_id() {
         let state = test_state_listing_models();
         let ids = super::list_model_ids(
-            &state.config,
+            &state.current_config(),
             &leviath_providers::provider::build_http_client,
         )
         .await;
@@ -603,7 +663,7 @@ mod tests {
     fn state_with_config_path(path: std::path::PathBuf) -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin {
@@ -612,6 +672,111 @@ mod tests {
             },
             limits: Default::default(),
         }
+    }
+
+    /// [`state_with_config_path`], but its config source *watches* that file
+    /// rather than holding a copy - the way `lev serve` builds one. What the
+    /// handlers see is then whatever is on disk, which is the whole point of
+    /// issue #532.
+    fn state_watching_config_path(path: std::path::PathBuf) -> AppState {
+        let (tx, _) = broadcast::channel::<ServerEvent>(64);
+        AppState {
+            config: Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+                path.clone(),
+                Config::default(),
+            )),
+            event_tx: tx,
+            control: crate::commands::serve::testutil::no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin {
+                config_path: path,
+                ..Default::default()
+            },
+            limits: Default::default(),
+        }
+    }
+
+    /// Force a file's mtime strictly newer, so the reload is observable even
+    /// when the write lands in the same clock tick as the last one (mirrors
+    /// `config_reload`'s own test helper).
+    fn bump_mtime(path: &std::path::Path) {
+        let later = std::time::SystemTime::now() + std::time::Duration::from_secs(5);
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(later).unwrap();
+    }
+
+    /// The endpoint's answer as JSON rather than as `RedactedConfig`: a
+    /// gateway serializes with `skip_serializing_if` fields that its own
+    /// `Deserialize` requires, so the wire form is the only faithful reading.
+    async fn get_config_request(state: AppState) -> serde_json::Value {
+        let app = Router::new()
+            .route("/api/config", get(get_config))
+            .with_state(state);
+        let req = Request::builder()
+            .uri("/api/config")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).expect("the endpoint answers with JSON")
+    }
+
+    /// The round trip issue #532 is about: save an edit, reload the page, and
+    /// the edit is still there. `put_config` writes the file and `get_config`
+    /// used to answer from a start-up copy, so the second half showed the old
+    /// value and the save read as lost.
+    #[tokio::test]
+    async fn an_edit_through_put_is_visible_to_the_next_get() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+        let state = state_watching_config_path(path.clone());
+
+        let before = get_config_request(state.clone()).await;
+        assert_ne!(before["default_provider"], "openai");
+
+        let body = serde_json::json!({ "default_provider": "openai" }).to_string();
+        let resp = put_config_request(state.clone(), &body).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        bump_mtime(&path);
+
+        let after = get_config_request(state).await;
+        assert_eq!(
+            after["default_provider"], "openai",
+            "the edit this server just wrote must be what it reports"
+        );
+    }
+
+    /// And an edit made by anything else on the machine - `lev setup`, an
+    /// editor, the daemon - is picked up the same way. `lev serve` is a
+    /// separate process, so a daemon restart never fixed this one.
+    #[tokio::test]
+    async fn an_edit_made_outside_the_api_is_picked_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+        let state = state_watching_config_path(path.clone());
+        let before = get_config_request(state.clone()).await;
+        assert_eq!(before["gateways"].as_array().map(Vec::len), Some(0));
+
+        let mut edited = Config::default();
+        edited.model_providers.insert(
+            "cerebras".to_string(),
+            crate::config::ModelProviderConfig {
+                base_url: Some("https://api.cerebras.ai/v1".to_string()),
+                ..Default::default()
+            },
+        );
+        edited.save_to_path_public(&path).unwrap();
+        bump_mtime(&path);
+
+        let after = get_config_request(state).await;
+        let gateways = after["gateways"].as_array().expect("a gateway array");
+        assert_eq!(gateways.len(), 1, "the new gateway is reported");
+        assert_eq!(gateways[0]["name"], "cerebras");
+        assert_eq!(gateways[0]["base_url"], "https://api.cerebras.ai/v1");
     }
 
     async fn put_config_request(state: AppState, body: &str) -> axum::http::Response<Body> {

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -54,7 +54,6 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use std::path::PathBuf;
-    use std::sync::Arc;
     use tokio::sync::broadcast;
     use tower::ServiceExt;
 
@@ -85,7 +84,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: leviath_runtime::control_socket::ControlClient::new(
                 leviath_runtime::control_socket::control_id(std::path::Path::new(

--- a/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
@@ -137,6 +137,7 @@ async fn stand_up(runs_dir: &std::path::Path) -> Seam {
         runtime: tokio::runtime::Handle::current(),
         // A fixed clock, so nothing here is a function of how long CI took.
         now_secs: || 1_700_000_000,
+        reloader: None,
     });
 
     // The daemon half: the host's own event sender served over a real control
@@ -168,7 +169,7 @@ async fn stand_up(runs_dir: &std::path::Path) -> Seam {
         ControlClient::for_home(id, dir.path()).with_build(crate::test_support::TEST_BUILD);
     let (event_tx, _) = broadcast::channel(256);
     let state = AppState {
-        config: Arc::new(Config::default()),
+        config: crate::commands::serve::testutil::fixed_config(Config::default()),
         event_tx,
         control: control.clone(),
         mcp: super::mcp::McpAdmin::default(),

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -164,7 +164,7 @@ mod tests {
     fn app_with_root(workdir_root: Option<PathBuf>) -> Router {
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -128,7 +128,6 @@ mod tests {
     use axum::routing::{get, post};
     use leviath_core::interaction::InteractionRequest;
     use leviath_runtime::control_socket::ControlClient;
-    use std::sync::Arc;
     use tokio::sync::broadcast;
     use tower::ServiceExt;
 
@@ -136,7 +135,7 @@ mod tests {
     fn app_with(control: ControlClient) -> Router {
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,
             mcp: crate::commands::serve::mcp::McpAdmin::default(),

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -362,7 +362,7 @@ mod tests {
     ) -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: McpAdmin {
@@ -756,7 +756,7 @@ for line in sys.stdin:
         std::fs::create_dir(&store).unwrap();
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: McpAdmin {
@@ -810,7 +810,7 @@ for line in sys.stdin:
         std::fs::write(&file, b"x").unwrap();
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         let state = AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: McpAdmin {

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -266,7 +266,10 @@ async fn execute_with_shutdown(
     let (event_tx, _) = broadcast::channel::<ServerEvent>(256);
 
     let state = AppState {
-        config: Arc::new(cfg),
+        config: Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+            Config::config_path(),
+            cfg,
+        )),
         event_tx: event_tx.clone(),
         control,
         mcp: mcp::McpAdmin::default(),
@@ -701,7 +704,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon_control(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
@@ -1183,7 +1186,7 @@ system_prompt = "Run"
         let state = test_state();
         let cloned = state.clone();
         // Both should work (no panic)
-        let _ = cloned.config.default_provider.clone();
+        let _ = cloned.current_config().default_provider.clone();
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -138,7 +138,7 @@ fn handle_event(state: &AppState, client: &reqwest::Client, event: WorldEvent) {
     {
         fire_completion_webhook(
             client,
-            &state.config.webhook,
+            &state.current_config().webhook,
             run_id,
             status,
             final_output.as_ref(),
@@ -458,7 +458,6 @@ mod tests {
     use leviath_core::interaction::InteractionRequest;
     use leviath_core::run_meta::WaitReason;
     use leviath_runtime::control_socket::{ControlClient, bind_control_listener, control_id};
-    use std::sync::Arc;
     use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
     use tokio::sync::broadcast;
 
@@ -466,7 +465,7 @@ mod tests {
         let (tx, rx) = broadcast::channel(64);
         (
             AppState {
-                config: Arc::new(Config::default()),
+                config: crate::commands::serve::testutil::fixed_config(Config::default()),
                 event_tx: tx,
                 control,
                 mcp: crate::commands::serve::mcp::McpAdmin::default(),

--- a/crates/leviath-cli/src/commands/serve/testutil.rs
+++ b/crates/leviath-cli/src/commands/serve/testutil.rs
@@ -9,6 +9,15 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 
+/// A config source that never re-reads anything, for a test with no file to
+/// watch. Production watches [`crate::config::Config::config_path`] - see
+/// [`AppState::current_config`](super::types::AppState::current_config).
+pub(super) fn fixed_config(
+    config: crate::config::Config,
+) -> Arc<crate::daemon::config_reload::ConfigReloader> {
+    Arc::new(crate::daemon::config_reload::ConfigReloader::fixed(config))
+}
+
 /// Run `f` with `LEVIATH_HOME` redirected at a fresh scratch root, handing it
 /// that root.
 ///

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -10,6 +10,7 @@ use tokio::sync::broadcast;
 
 use super::events::ServerEvent;
 use crate::config::Config;
+use crate::daemon::config_reload::ConfigReloader;
 
 // ─── CLI ─────────────────────────────────────────────────────────────────────
 
@@ -97,7 +98,20 @@ pub struct ServeArgs {
 /// control-socket client that reaches the daemon.
 #[derive(Clone)]
 pub struct AppState {
-    pub(super) config: Arc<Config>,
+    /// Where the config comes from, rather than a copy of it.
+    ///
+    /// A snapshot taken at start-up was wrong in both directions: an edit made
+    /// through `PUT /api/config` was written to disk and never read back, so
+    /// reloading the page showed the old value and the edit read as lost; and
+    /// an edit made anywhere else - `lev setup`, an editor, the daemon's own
+    /// config - was invisible for the life of the process. `lev serve` is a
+    /// separate process from `lev daemon`, so restarting the daemon did not
+    /// help either (issue #532).
+    ///
+    /// This is the same [`ConfigReloader`] the daemon uses for its spawn-time
+    /// config: mtime-checked, last-good on a parse failure. Read it through
+    /// [`AppState::current_config`].
+    pub(super) config: Arc<ConfigReloader>,
     pub(super) event_tx: broadcast::Sender<ServerEvent>,
     /// Client for the shared-world daemon's control socket. Agent actions
     /// (spawn/cancel/message/interactions) go through this; read endpoints still
@@ -108,6 +122,16 @@ pub struct AppState {
     /// The spawn-request restrictions from [`ServeArgs`], resolved once at
     /// startup so every handler reads the same decision.
     pub(super) limits: Arc<ServeLimits>,
+}
+
+impl AppState {
+    /// The config as it is on disk right now.
+    ///
+    /// Every handler reads it through here rather than holding one, so an edit
+    /// - through this API or from outside - is visible to the next request.
+    pub(super) fn current_config(&self) -> Arc<Config> {
+        self.config.current()
+    }
 }
 
 /// What this server refuses regardless of who is asking.

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -208,7 +208,6 @@ mod tests {
 
     use axum::Router;
     use axum::routing::get;
-    use std::sync::Arc;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
@@ -219,7 +218,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
@@ -664,7 +663,7 @@ mod tests {
         daemon.client.list().await.expect("served, and introduced");
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: daemon.client.clone(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
@@ -818,7 +817,7 @@ mod tests {
         // `handle_ws` without needing to fabricate the error directly.
         let (tx, _) = broadcast::channel::<ServerEvent>(2);
         let state = AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx.clone(),
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),
@@ -945,7 +944,7 @@ mod tests {
     async fn handle_ws_breaks_on_closed_channel_via_server_shutdown() {
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         let state = AppState {
-            config: Arc::new(Config::default()),
+            config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx.clone(),
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: crate::commands::serve::mcp::McpAdmin::default(),

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -140,8 +140,17 @@ pub async fn setup_daemon_host_with(
     // redirect policy has no per-agent context to consult; see
     // `script_host::set_local_network_allowed`.
     crate::daemon::script_host::set_local_network_allowed(config.security.allow_local_network);
-    let providers = crate::commands::run::session::build_provider_registry_from_config_with(
+    // Built before the registry, and shared with it: a script provider's
+    // `[model_providers.<name>]` table is read through this, so editing it
+    // takes effect on the next load exactly as editing the `.rhai` beside it
+    // already did (issue #533).
+    let reloader = Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+        Config::config_path(),
+        config.clone(),
+    ));
+    let providers = crate::commands::run::session::build_provider_registry_live(
         &config,
+        reloader.clone(),
         build_client,
     )?;
     // Ask each provider what its models are before anything runs on one.
@@ -180,6 +189,7 @@ pub async fn setup_daemon_host_with(
         mcp_pool,
         runtime,
         now_secs: || chrono::Utc::now().timestamp(),
+        reloader: Some(reloader),
     }))
 }
 
@@ -230,6 +240,10 @@ pub struct HostParts {
     pub runtime: Handle,
     /// The clock, injected so a test does not depend on the wall clock.
     pub now_secs: fn() -> i64,
+    /// The daemon's config source. Built before the provider registry so the
+    /// script-provider layer can follow it too (issue #533); `None` builds a
+    /// fixed one from `config`, for a caller with nothing to watch.
+    pub reloader: Option<Arc<crate::daemon::config_reload::ConfigReloader>>,
 }
 
 /// Build the daemon's [`WorldHost`]: one world hosting every agent, its tool
@@ -330,14 +344,20 @@ pub fn build_host(parts: HostParts) -> WorldHost {
 
     // Config hot-reload: after boot, spawn-time parts.config (permissions,
     // `[read_paths]`, sandbox, limits, taint) is served from here, reloaded
-    // when `parts.config.toml` changes on disk. The boot infrastructure (provider
-    // registry, MCP pool, network policy, telemetry) keeps the boot snapshot -
-    // those hold live connections and need a restart - so the reloader takes a
-    // clone and the boot snapshot stays usable below.
-    let reloader = std::sync::Arc::new(crate::daemon::config_reload::ConfigReloader::new(
-        Config::config_path(),
-        parts.config.clone(),
-    ));
+    // when `parts.config.toml` changes on disk. The boot infrastructure that
+    // holds live connections - the MCP pool, the network policy, the telemetry
+    // sink - keeps the boot snapshot and needs a restart, so the reloader takes
+    // a clone and the boot snapshot stays usable below.
+    //
+    // Normally handed in: `setup_daemon_host_with` builds it before the
+    // provider registry so the script-provider layer can follow it as well
+    // (issue #533). A caller that did not gets a fixed one over its own config.
+    let reloader = parts.reloader.clone().unwrap_or_else(|| {
+        std::sync::Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+            Config::config_path(),
+            parts.config.clone(),
+        ))
+    });
 
     // Install the fan-out spawner as a world resource so the parts.runtime's fan-out
     // systems can start workers (it captures the same context as the spawner
@@ -1313,6 +1333,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             ),
             runtime: Handle::current(),
             now_secs: || 0,
+            reloader: None,
         });
     }
 
@@ -1342,6 +1363,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             ),
             runtime: Handle::current(),
             now_secs: || 0,
+            reloader: None,
         });
         assert!(
             host.world_mut()
@@ -1381,6 +1403,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             ),
             runtime: Handle::current(),
             now_secs: || 0,
+            reloader: None,
         });
         assert!(
             host.world_mut()
@@ -1415,6 +1438,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             ),
             runtime: Handle::current(),
             now_secs: || 0,
+            reloader: None,
         });
         let (ctl_tx, ctl_rx) = tokio::sync::mpsc::unbounded_channel();
         let (reply, reply_rx) = oneshot::channel();
@@ -1494,6 +1518,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             ),
             runtime: Handle::current(),
             now_secs: || 100,
+            reloader: None,
         });
 
         // Drive a Spawn control op through the host.
@@ -1600,6 +1625,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             ),
             runtime: Handle::current(),
             now_secs: || 100,
+            reloader: None,
         });
 
         // The reloaded run is registered → Status resolves it.
@@ -1637,6 +1663,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             ),
             runtime: Handle::current(),
             now_secs: || 100,
+            reloader: None,
         });
 
         // Persist a running run only now - build_host's startup reload already ran,

--- a/crates/leviath-cli/tests/agent_end_to_end.rs
+++ b/crates/leviath-cli/tests/agent_end_to_end.rs
@@ -214,6 +214,7 @@ async fn an_agent_runs_a_tool_and_the_file_lands_on_disk() {
         runtime: Handle::current(),
         // A fixed clock, so nothing here is a function of how long CI took.
         now_secs: || 1_700_000_000,
+        reloader: None,
     });
 
     let (reply, spawned) = oneshot::channel();

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -94,9 +94,37 @@ impl ProviderRegistry {
     }
 
     /// Get all *natively-registered* provider names. Script providers are
-    /// resolved on demand and so are not enumerated here.
+    /// resolved on demand and so are not enumerated here - see
+    /// [`resolvable_names`](Self::resolvable_names) for the set that includes
+    /// them.
     pub fn provider_names(&self) -> Vec<&str> {
         self.providers.keys().map(|k| k.as_str()).collect()
+    }
+
+    /// Every provider name this registry could answer for right now: the
+    /// natively registered ones, then the script providers the layer can see.
+    ///
+    /// This is what an *enumeration* wants - "list every model I can reach" -
+    /// where [`provider_names`](Self::provider_names) answers "what is
+    /// registered". Building the list on `provider_names` alone is what hid
+    /// script providers from `lev models list` (#523) and then, in the same
+    /// shape, from `GET /api/models` (#531).
+    ///
+    /// A script name here is a candidate: [`get`](Self::get) compiles it on
+    /// demand and returns `None` if it will not load, so a caller iterating
+    /// this must handle a name it cannot resolve.
+    pub fn resolvable_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.providers.keys().cloned().collect();
+        if let Some(layer) = &self.script_layer {
+            for name in layer.candidate_names() {
+                // A native provider of the same name wins, exactly as `get`
+                // resolves it, so it is never listed twice.
+                if !names.iter().any(|n| n == &name) {
+                    names.push(name);
+                }
+            }
+        }
+        names
     }
 }
 
@@ -153,6 +181,53 @@ mod tests {
         fn capabilities(&self, _model: &str) -> ModelCapabilities {
             ModelCapabilities::default()
         }
+    }
+
+    /// What an *enumeration* needs, and what `provider_names` cannot give it:
+    /// the script providers too. Building `GET /api/models` and
+    /// `lev models list --remote` on `provider_names` is what hid them
+    /// (issues #523, #531).
+    #[test]
+    fn resolvable_names_adds_the_script_layer_without_duplicating_a_native() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("scripted.rhai"),
+            "fn initialize(c) { #{} }\nfn inference(s, r) { #{ content: \"x\" } }",
+        )
+        .unwrap();
+        // A script of the same name as a native provider: `get` prefers the
+        // native one, so it must be listed once.
+        std::fs::write(
+            dir.path().join("native.rhai"),
+            "fn initialize(c) { #{} }\nfn inference(s, r) { #{ content: \"x\" } }",
+        )
+        .unwrap();
+
+        let mut registry = ProviderRegistry::new();
+        registry.register("native".to_string(), mock());
+        assert_eq!(
+            registry.resolvable_names(),
+            vec!["native".to_string()],
+            "with no layer attached this is just the registered set"
+        );
+
+        let layer = crate::script_provider::ScriptProviderLayer::new(
+            dir.path().to_path_buf(),
+            HashMap::new(),
+            HashMap::new(),
+            None,
+            Vec::new(),
+        );
+        let registry = registry.with_script_layer(Arc::new(layer));
+
+        let mut names = registry.resolvable_names();
+        names.sort();
+        assert_eq!(names, vec!["native".to_string(), "scripted".to_string()]);
+        assert_eq!(
+            registry.provider_names(),
+            vec!["native"],
+            "provider_names keeps its own contract"
+        );
     }
 
     fn mock() -> Arc<dyn Provider> {

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -14,6 +14,13 @@
 //! - a deleted file → evicted, the provider disappears;
 //! - a broken script → not resolved (logged), so selection falls through.
 //!
+//! The `[model_providers.<name>]` table that feeds a script's `initialize` is
+//! read the same way, through a [`ScriptProviderConfig`] source the layer calls
+//! on every lookup rather than a copy taken at boot. It used to be a copy, so
+//! editing a provider's `base_url` did nothing until `lev daemon restart` while
+//! editing the script beside it took effect immediately - two halves of one
+//! feature disagreeing, silently (issue #533).
+//!
 //! [`ProviderRegistry`]: crate::ProviderRegistry
 
 use std::collections::HashMap;
@@ -38,25 +45,55 @@ pub struct ScriptProviderSpec {
     pub init_config: serde_json::Value,
 }
 
-/// A cached, compiled script provider plus the source mtime it was built from.
+/// Everything a script-provider load reads out of `config.toml`.
+///
+/// Grouped so the layer can take it from a *source* it calls per lookup - see
+/// [`ScriptProviderLayer::with_config_source`] - rather than holding a copy.
+#[derive(Clone, Debug, Default)]
+pub struct ScriptProviderConfig {
+    /// `[model_providers]`, keyed by provider name.
+    pub overrides: HashMap<String, ScriptProviderSpec>,
+    /// `[model_capabilities]`, applied to whatever a script reports.
+    pub default_caps: HashMap<String, ModelCapabilityOverride>,
+    /// The global request timeout a script's own calls are bounded by.
+    pub request_timeout_secs: Option<u64>,
+    /// `[security] allow_env_vars`: credential-shaped environment variables a
+    /// provider script may read. Empty by default - a provider script runs
+    /// during inference, not through a tool call, so nothing it does passes an
+    /// approval prompt.
+    pub env_allowlist: Arc<Vec<String>>,
+}
+
+/// A cached, compiled script provider, plus what it was built from.
+///
+/// Both halves matter. The mtime catches an edited script; the config catches
+/// an edited `[model_providers]` entry, which used to leave a stale provider
+/// cached under an unchanged file (issue #533). Compared by pointer, so a
+/// source that returns the same `Arc` while nothing has changed costs nothing.
 struct Cached {
     mtime: SystemTime,
+    config: Arc<ScriptProviderConfig>,
     provider: Arc<dyn Provider>,
 }
 
 /// Lazy, hot-reloading resolver for script providers.
 pub struct ScriptProviderLayer {
     dir: PathBuf,
-    overrides: HashMap<String, ScriptProviderSpec>,
-    default_caps: HashMap<String, ModelCapabilityOverride>,
-    request_timeout_secs: Option<u64>,
-    /// `[security] allow_env_vars`: credential-shaped environment variables a
-    /// provider script may read. Empty by default - a provider script runs
-    /// during inference, not through a tool call, so nothing it does passes an
-    /// approval prompt.
-    env_allowlist: Arc<Vec<String>>,
+    /// Where the config comes from, called on every lookup.
+    ///
+    /// A boxed closure rather than a captured map so the daemon can hand in
+    /// one that reads its live config, while every other caller hands in a
+    /// constant. `Box<dyn Fn>` rather than a generic parameter deliberately:
+    /// one instantiation regardless of the caller, which keeps coverage
+    /// honest (see `run/task.rs`'s `resolve_task_with` for the same choice).
+    config: Box<dyn Fn() -> Arc<ScriptProviderConfig> + Send + Sync>,
     /// The HTTP executor every script provider shares, built once when the
     /// layer is created.
+    ///
+    /// This one really is fixed at boot, and stays that way: it holds a
+    /// connection pool, which is the kind of live state the daemon's config
+    /// reload deliberately leaves alone. Its timeout is the client-level
+    /// default; the per-call bound in [`ScriptProviderConfig`] is live.
     ///
     /// Kept as the `Result` rather than unwrapped: constructing it reads the
     /// machine's root certificate store and can fail, and a layer is built
@@ -77,8 +114,7 @@ impl ScriptProviderLayer {
         request_timeout_secs: Option<u64>,
         env_allowlist: Vec<String>,
     ) -> Self {
-        let executor = leviath_providers::provider::build_http_client(request_timeout_secs)
-            .map(|client| Arc::new(ReqwestExecutor::new(client)) as Arc<dyn HttpExecutor>);
+        let executor = Self::build_executor(request_timeout_secs);
         Self::with_executor(
             dir,
             overrides,
@@ -105,15 +141,45 @@ impl ScriptProviderLayer {
             leviath_providers::provider::HttpError,
         >,
     ) -> Self {
-        Self {
-            dir,
+        let config = Arc::new(ScriptProviderConfig {
             overrides,
             default_caps,
             request_timeout_secs,
             env_allowlist: Arc::new(env_allowlist),
+        });
+        Self::with_config_source(dir, Box::new(move || config.clone()), executor)
+    }
+
+    /// A layer whose config is read from `config` on every lookup rather than
+    /// captured once.
+    ///
+    /// This is what makes `[model_providers.<name>]` as hot as the `.rhai`
+    /// file beside it. The source must return the *same* `Arc` while nothing
+    /// has changed - the cache compares by pointer, so a source that rebuilds
+    /// its answer every call recompiles every script on every lookup.
+    pub fn with_config_source(
+        dir: PathBuf,
+        config: Box<dyn Fn() -> Arc<ScriptProviderConfig> + Send + Sync>,
+        executor: std::result::Result<
+            Arc<dyn HttpExecutor>,
+            leviath_providers::provider::HttpError,
+        >,
+    ) -> Self {
+        Self {
+            dir,
+            config,
             executor,
             cache: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Build the shared HTTP executor a layer runs its scripts through. Its
+    /// timeout is fixed for the life of the layer; see the field's note.
+    pub fn build_executor(
+        request_timeout_secs: Option<u64>,
+    ) -> std::result::Result<Arc<dyn HttpExecutor>, leviath_providers::provider::HttpError> {
+        leviath_providers::provider::build_http_client(request_timeout_secs)
+            .map(|client| Arc::new(ReqwestExecutor::new(client)) as Arc<dyn HttpExecutor>)
     }
 
     /// Resolve `<name>` to its script path: an explicit `script` override
@@ -128,8 +194,8 @@ impl ScriptProviderLayer {
     /// and it can only come from the user's own config, not from a blueprint.
     ///
     /// `None` when the override escapes; the caller reports it and loads nothing.
-    fn resolve_path(&self, name: &str) -> Option<PathBuf> {
-        let stem = self
+    fn resolve_path(&self, name: &str, config: &ScriptProviderConfig) -> Option<PathBuf> {
+        let stem = config
             .overrides
             .get(name)
             .and_then(|s| s.script.as_deref())
@@ -155,6 +221,36 @@ impl ScriptProviderLayer {
         Some(self.dir.join(joined))
     }
 
+    /// Every script provider this layer could resolve right now, in no
+    /// particular order: the `.rhai` files sitting in its directory, plus any
+    /// name with a `[model_providers]` entry (which may point its `script` at a
+    /// file kept elsewhere).
+    ///
+    /// A name here is a *candidate*, not a promise - it still has to compile.
+    /// Callers that enumerate providers resolve each through
+    /// [`get_or_load`](Self::get_or_load) and skip what does not load.
+    ///
+    /// Deliberately not folded into `ProviderRegistry::provider_names`, whose
+    /// contract is "registered natively" and whose callers rely on every name
+    /// it returns being `get`-able without compiling anything.
+    pub fn candidate_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = (self.config)().overrides.keys().cloned().collect();
+        // A directory that cannot be read is not an error here: it means no
+        // convention-named scripts, which is the same answer as an empty one.
+        if let Ok(entries) = std::fs::read_dir(&self.dir) {
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "rhai")
+                    && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+                    && !names.iter().any(|n| n == stem)
+                {
+                    names.push(stem.to_string());
+                }
+            }
+        }
+        names
+    }
+
     /// Get (or lazily load / reload) the provider named `name`, or `None` when
     /// there is no such script or it fails to load.
     ///
@@ -171,7 +267,11 @@ impl ScriptProviderLayer {
     /// wasted work, never a wrong answer, and it self-corrects on the next
     /// lookup because entries are validated by mtime.
     pub fn get_or_load(&self, name: &str) -> Option<Arc<dyn Provider>> {
-        let Some(path) = self.resolve_path(name) else {
+        // One read per lookup, used for both the path and the settings, so a
+        // config that changes mid-load cannot resolve one file and configure
+        // another.
+        let config = (self.config)();
+        let Some(path) = self.resolve_path(name, &config) else {
             tracing::warn!(
                 provider = %name,
                 "script provider path escapes the providers directory - refusing to load"
@@ -184,11 +284,11 @@ impl ScriptProviderLayer {
             self.evict(name);
             return None;
         };
-        if let Some(cached) = self.cached_fresh(name, mtime) {
+        if let Some(cached) = self.cached_fresh(name, mtime, &config) {
             return Some(cached);
         }
 
-        let spec = self.overrides.get(name);
+        let spec = config.overrides.get(name);
         let init_config = spec
             .map(|s| s.init_config.clone())
             .unwrap_or_else(|| serde_json::json!({}));
@@ -212,10 +312,10 @@ impl ScriptProviderLayer {
             leviath_providers::rhai_provider::ScriptProviderSettings {
                 name: name.to_string(),
                 init_config,
-                caps: self.default_caps.clone(),
+                caps: config.default_caps.clone(),
                 rate_limit,
-                request_timeout_secs: self.request_timeout_secs,
-                env_allowlist: self.env_allowlist.clone(),
+                request_timeout_secs: config.request_timeout_secs,
+                env_allowlist: config.env_allowlist.clone(),
             },
         ) {
             Ok(p) => {
@@ -227,6 +327,7 @@ impl ScriptProviderLayer {
                         name.to_string(),
                         Cached {
                             mtime,
+                            config: config.clone(),
                             provider: provider.clone(),
                         },
                     );
@@ -241,12 +342,17 @@ impl ScriptProviderLayer {
     }
 
     /// The cached provider for `name`, but only if it was built from the script
-    /// as it is on disk right now. Holds the lock just long enough to clone an
-    /// `Arc`.
-    fn cached_fresh(&self, name: &str, mtime: SystemTime) -> Option<Arc<dyn Provider>> {
+    /// as it is on disk right now **and** from the config in force right now.
+    /// Holds the lock just long enough to clone an `Arc`.
+    fn cached_fresh(
+        &self,
+        name: &str,
+        mtime: SystemTime,
+        config: &Arc<ScriptProviderConfig>,
+    ) -> Option<Arc<dyn Provider>> {
         let cache = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
         let cached = cache.get(name)?;
-        if cached.mtime == mtime {
+        if cached.mtime == mtime && Arc::ptr_eq(&cached.config, config) {
             Some(cached.provider.clone())
         } else {
             None
@@ -284,8 +390,122 @@ mod tests {
         f.set_modified(later).unwrap();
     }
 
+    /// The config a layer is holding, for the tests that call `resolve_path`
+    /// directly - the lookup path reads it once and threads it through, so the
+    /// method takes it rather than reading it a second time.
+    fn cfg(l: &ScriptProviderLayer) -> Arc<ScriptProviderConfig> {
+        (l.config)()
+    }
+
     fn layer(dir: PathBuf) -> ScriptProviderLayer {
         ScriptProviderLayer::new(dir, HashMap::new(), HashMap::new(), None, Vec::new())
+    }
+
+    /// The half of the feature that was frozen: the script file hot-reloads,
+    /// but its `[model_providers.<name>]` table was captured at boot, so
+    /// changing a `base_url` did nothing until a daemon restart - silently,
+    /// with the run using the old value (issue #533).
+    ///
+    /// The script here reports its `base_url` as a model id, so what the
+    /// provider was initialized with is directly observable.
+    #[tokio::test]
+    async fn a_config_change_reaches_the_next_load_without_touching_the_script() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "hot.rhai",
+            "fn initialize(config) { #{ base: config.base_url } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { [ #{ id: state.base } ] }",
+        );
+
+        // A source the test moves forward by hand, exactly as the daemon's
+        // reloader does when `config.toml`'s mtime changes.
+        let live: Arc<Mutex<Arc<ScriptProviderConfig>>> =
+            Arc::new(Mutex::new(Arc::new(spec_config("hot", "http://first"))));
+        let handle = live.clone();
+        let l = ScriptProviderLayer::with_config_source(
+            dir.path().to_path_buf(),
+            Box::new(move || handle.lock().unwrap().clone()),
+            ScriptProviderLayer::build_executor(None),
+        );
+
+        assert_eq!(first_model(&l).await, "http://first");
+        // Same `Arc` back on every call: an unchanged config must be a cache
+        // hit, not a recompile.
+        assert!(Arc::ptr_eq(
+            &l.get_or_load("hot").unwrap(),
+            &l.get_or_load("hot").unwrap()
+        ));
+
+        *live.lock().unwrap() = Arc::new(spec_config("hot", "http://second"));
+        assert_eq!(
+            first_model(&l).await,
+            "http://second",
+            "the edited config must reach the next load, with the file untouched"
+        );
+    }
+
+    /// One `ScriptProviderConfig` naming `provider`'s `base_url`.
+    fn spec_config(provider: &str, base_url: &str) -> ScriptProviderConfig {
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            provider.to_string(),
+            ScriptProviderSpec {
+                init_config: serde_json::json!({ "base_url": base_url }),
+                ..Default::default()
+            },
+        );
+        ScriptProviderConfig {
+            overrides,
+            ..Default::default()
+        }
+    }
+
+    /// The id of the first model `hot` reports - which this script sets to
+    /// whatever `initialize` was handed.
+    async fn first_model(l: &ScriptProviderLayer) -> String {
+        let provider = l.get_or_load("hot").expect("the script loads");
+        provider.list_models().await.unwrap()[0].id.clone()
+    }
+
+    #[test]
+    fn candidate_names_are_the_files_on_disk_and_the_configured_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        write(dir.path(), "groq.rhai", GOOD);
+        write(dir.path(), "notes.txt", "not a provider");
+        let mut overrides = HashMap::new();
+        // Configured, and its script lives outside the directory - so only the
+        // config half can name it.
+        overrides.insert(
+            "elsewhere".to_string(),
+            ScriptProviderSpec {
+                script: Some("/somewhere/else.rhai".to_string()),
+                ..Default::default()
+            },
+        );
+        // Configured *and* present by convention: named once, not twice.
+        overrides.insert("groq".to_string(), ScriptProviderSpec::default());
+        let l = ScriptProviderLayer::new(
+            dir.path().to_path_buf(),
+            overrides,
+            HashMap::new(),
+            None,
+            Vec::new(),
+        );
+
+        let mut names = l.candidate_names();
+        names.sort();
+        assert_eq!(names, vec!["elsewhere".to_string(), "groq".to_string()]);
+    }
+
+    #[test]
+    fn candidate_names_of_a_missing_directory_is_the_configured_set() {
+        let l = layer(PathBuf::from("/no/such/providers/dir"));
+        assert!(
+            l.candidate_names().is_empty(),
+            "an unreadable directory names nothing, the same as an empty one"
+        );
     }
 
     #[test]
@@ -388,10 +608,19 @@ mod tests {
             None,
             Vec::new(),
         );
-        assert_eq!(l.resolve_path("a"), Some(dir.path().join("custom.rhai")));
-        assert_eq!(l.resolve_path("b"), Some(dir.path().join("custom.rhai")));
-        assert_eq!(l.resolve_path("c"), Some(abs));
-        assert_eq!(l.resolve_path("z"), Some(dir.path().join("z.rhai")));
+        assert_eq!(
+            l.resolve_path("a", &cfg(&l)),
+            Some(dir.path().join("custom.rhai"))
+        );
+        assert_eq!(
+            l.resolve_path("b", &cfg(&l)),
+            Some(dir.path().join("custom.rhai"))
+        );
+        assert_eq!(l.resolve_path("c", &cfg(&l)), Some(abs));
+        assert_eq!(
+            l.resolve_path("z", &cfg(&l)),
+            Some(dir.path().join("z.rhai"))
+        );
     }
 
     /// A relative `script` override may not climb out of the providers
@@ -423,7 +652,11 @@ mod tests {
             Vec::new(),
         );
         for name in ["a", "b", "c"] {
-            assert_eq!(l.resolve_path(name), None, "{name} should be refused");
+            assert_eq!(
+                l.resolve_path(name, &cfg(&l)),
+                None,
+                "{name} should be refused"
+            );
             assert!(l.get_or_load(name).is_none(), "{name} must not load");
         }
     }
@@ -448,7 +681,7 @@ mod tests {
             Vec::new(),
         );
         assert_eq!(
-            l.resolve_path("a"),
+            l.resolve_path("a", &cfg(&l)),
             Some(dir.path().join("vendor/custom.rhai"))
         );
     }

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -18,8 +18,10 @@ where you look up the exact name, type, and default. The same contract ships mac
 
 > [!NOTE]
 > The daemon watches this file and reloads it when it changes, so an edit takes effect on the
-> **next** `lev run` with no restart. Boot-time wiring (providers, MCP connections, telemetry
-> exporters) still needs `lev daemon restart`. See [the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run).
+> **next** `lev run` with no restart. `lev serve` reads it per request, so an edit - through
+> `PUT /api/config` or from anywhere else - is on the next page load. Boot-time wiring (native
+> provider keys, MCP connections, telemetry exporters) still needs `lev daemon restart`. See
+> [the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run).
 
 ## Top level
 

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -157,10 +157,17 @@ If a save leaves the file briefly unparseable, which happens while you are halfw
 edit, the daemon keeps serving the last version that worked. It reloads on your next clean save, so
 an in-progress edit never breaks a spawn.
 
-Two kinds of change do need `lev daemon restart`. Both set up connections and process-wide state
+`[model_providers.<name>]` reloads too, as of this release. A script provider's own `.rhai` file
+has always been re-read on each use, so a table beside it that needed a restart made two halves of
+one feature disagree in silence - setting a `base_url` and watching it do nothing looked exactly
+like having typed the key wrong. Both halves are now live: edit the script, the table, or
+`[security] allow_env_vars`, and the next provider load uses it.
+
+Some changes do still need `lev daemon restart`. They set up connections and process-wide state
 once at startup rather than per run:
 
-- Provider keys and `[model_providers]`, which build the provider registry.
+- **Native** provider keys (`[providers]`, `openrouter_api_key`, `ollama_base_url`), which build the
+  provider registry at boot.
 - `[[mcp_servers]]` (live MCP connections), `[observability]` (the telemetry pipeline), and
   `[security] allow_local_network` (the outbound-network policy).
 - The `[limits]` the world itself is built with: `stall_timeout_secs`, `wedge_timeout_secs`,

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -33,7 +33,8 @@ Four things about the lifecycle:
 - **Nothing runs until it is named.** The daemon does not scan and execute every file it finds at
   startup, only the ones an agent actually asks for.
 - **Edits apply on the next run.** The file's modification time is checked on each use, so a change
-  is picked up with no daemon restart.
+  is picked up with no daemon restart. Its `[model_providers.<name>]` table is read the same way, so
+  changing a `base_url` or an `api_key` needs no restart either.
 - **A broken script is skipped, not fatal.** It logs a warning, and starts working again as soon as
   you fix the file.
 


### PR DESCRIPTION
Closes #531. Closes #532. Closes #533.

Three issues with one shape: state captured once at start-up while the thing it
described kept changing underneath. They land together because two of them meet
in the same file — the script-provider layer needed the live-config change
before it could enumerate names honestly.

---

## #531 — `GET /api/models` omits script providers

`provider_names()` returns natively registered providers only; the script layer
is reachable through `get()`. Anything built on the former skips script
providers, which is exactly what #523 fixed for `lev models list --provider` and
exactly what `list_models_from_config` still did. The Lair therefore listed a
gateway under settings while offering none of its models on the new-run page or
in the agent editor.

The registry now answers **`resolvable_names()`** — natives, then the script
names the layer can see, deduped with the native winning as `get()` resolves it.
The layer enumerates by reading its directory *and* the `[model_providers]`
keys, so a convention-named `.rhai` with no config entry counts too (it is
already runnable — #533 demonstrates a run against one).

Both enumerating call sites use it: the API path, and `lev models list --remote`,
which had the identical hole. A name the layer offers is a candidate until it
compiles, so both loops skip one that will not load instead of assuming the
lookup succeeds. `--provider <script> --remote` is answered once, by the path
that reports failures properly, not twice.

`provider_names()` keeps its contract and its callers.

## #532 — `GET /api/config` serves a start-up snapshot

`put_config` re-read the file, applied the patch and wrote it back; `get_config`
answered from `AppState.config`, an `Arc<Config>` built once at boot. So the two
handlers disagreed about where the truth lived: a save came back with the new
value, and reloading the page showed the old one.

`AppState` now holds the same mtime-checked `ConfigReloader` the daemon uses,
and every handler reads through `current_config()` — not just `get_config`, but
`/api/models`, blueprint discovery and the webhook config too, all of which were
equally stale. That fixes external edits as well, which matters because
`lev serve` is a separate process from `lev daemon`: restarting the daemon never
helped.

## #533 — `[model_providers.<name>]` frozen while the script hot-reloads

Two halves of one feature disagreeing in silence. The `.rhai` file is re-read on
every use; the table feeding its `initialize(config)` was captured at boot. So
setting a `base_url` and watching it do nothing was indistinguishable from
having typed the key wrong.

`ScriptProviderLayer` now takes a **config source** it calls per load rather
than owned maps. `new()` keeps its signature and builds a constant source, so
every short-lived command keeps its snapshot; the daemon builds its
`ConfigReloader` *before* the provider registry and hands in a source that
follows it.

The second half matters as much as the first: the compiled-script cache is
keyed on the config as well as the file's mtime, or the stale provider stays
cached under an unchanged file. Verified — dropping the `Arc::ptr_eq` makes the
test fail with `left: "http://first", right: "http://second"`.

The source memoises on the identity of the config the reloader returns. That is
a requirement, not an optimisation: the cache compares by pointer, so a source
that derived a fresh value per call would recompile every script on every
lookup. There is a test pinning it.

`[model_capabilities]`, `request_timeout_secs` and `[security] allow_env_vars`
reload with it — the last one is the issue's footnote, and it was the same
silent failure on a path that already fails silently by design. The shared HTTP
client still does **not** reload: it holds a connection pool, which is the live
state `ConfigReloader` deliberately leaves alone. That is stated on the field.

---

## Tests

- `api_models_includes_a_script_providers_models` — a real `.rhai` under an
  isolated `LEVIATH_HOME`, not a mock, since the endpoint builds its own
  registry. A second uncompilable script alongside it must be skipped, not fatal.
- `resolvable_names_adds_the_script_layer_without_duplicating_a_native`, and
  `candidate_names_*` for the directory and the configured set.
- `list_remote_sweeps_script_providers_too` and
  `a_named_script_provider_is_not_also_swept`.
- `an_edit_through_put_is_visible_to_the_next_get` and
  `an_edit_made_outside_the_api_is_picked_up`.
- `a_config_change_reaches_the_next_load_without_touching_the_script` — the
  script reports its `base_url` as a model id, so what `initialize` was handed is
  directly observable; also asserts an unchanged config is a cache hit.
- `the_script_config_source_is_stable_until_the_config_changes`.

## Docs

`daemon.md`'s restart list no longer names `[model_providers]` and now
distinguishes native provider keys, which genuinely are boot-time.
`rhai-providers.md`'s "edits apply on the next run" bullet says the table beside
the script behaves the same way. `configuration.md` notes that `lev serve` reads
per request.

## Checks

Full workspace suite green; `cargo xtask coverage` at 100% for both
`leviath-runtime` and `leviath-cli`; `cargo xtask docs` clean.
