### PR TITLE
fix(daemon): a run's model override reaches its workers and sub-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ same list.
 
 ## Unreleased
 
+- Fixed: a run's `--model` override now covers fan-out workers and sub-agents,
+  not just the parent blueprint. Both spawn paths passed `model: None` while
+  carrying every other field of the parent down - workdir, `--yolo`,
+  `--no-seed-commands`, the requested output shape - so
+  `lev run deep-researcher --model cerebras/gpt-oss-120b` sent the parent's
+  stages to Cerebras and all thirty workers to whatever the worker blueprint
+  listed. That is the large majority of a run's spend landing on providers the
+  operator explicitly overrode away from, with no warning and no log line, and
+  it made benchmarking a provider this way report a number that was mostly not
+  about that provider. `providers.md` called the override absolute already
+  ("overrides everything"); it now is. A run that names no model leaves every
+  child resolving against its own blueprint exactly as before.
+
 - Fixed: `GET /api/models` now reports a Rhai script provider's models, so The
   Lair offers them on the new-run page, in the agent editor and in settings.
   `ProviderRegistry::provider_names()` returns natively registered providers

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -104,18 +104,25 @@ impl FanOutSpawner for DaemonFanOutSpawner {
         // The requested output shape rides along too: a caller who asked the
         // parent for a2ui wants its workers' contributions in the same shape,
         // and the worker's answer is what the merge stage reads.
-        let (parent_path, workdir, parent_run_id, unattended, output_request) = world
-            .get::<RunMetadata>(parent)
-            .map(|md| {
-                (
-                    md.agent_path.clone(),
-                    md.workdir.clone(),
-                    md.run_id.clone(),
-                    md.unattended,
-                    md.output_request.clone(),
-                )
-            })
-            .ok_or_else(|| "fan-out parent has no run metadata".to_string())?;
+        // So does the run's `--model` override, which the docs call absolute
+        // ("overrides everything"). It used to stop at the run boundary, so a
+        // fan-out of thirty workers sent the large majority of a run's spend to
+        // whatever the worker blueprint listed - silently, and against an
+        // instruction the operator had typed for this run (issue #534).
+        let (parent_path, workdir, parent_run_id, unattended, output_request, model_override) =
+            world
+                .get::<RunMetadata>(parent)
+                .map(|md| {
+                    (
+                        md.agent_path.clone(),
+                        md.workdir.clone(),
+                        md.run_id.clone(),
+                        md.unattended,
+                        md.output_request.clone(),
+                        md.model_override.clone(),
+                    )
+                })
+                .ok_or_else(|| "fan-out parent has no run metadata".to_string())?;
 
         let (resolve_path, entry_stage) =
             resolve_worker_source(config, &parent_path, self.agents_dir.as_deref())?;
@@ -125,7 +132,7 @@ impl FanOutSpawner for DaemonFanOutSpawner {
             path: &resolve_path,
             task: Some(&task),
             stdin_is_terminal: &never_interactive,
-            model: None,
+            model: model_override,
             workdir: &workdir,
             yolo: unattended,
             allow: Vec::new(),
@@ -459,6 +466,22 @@ mod tests {
         manifest_path: &str,
         yolo: bool,
     ) -> (PipelineWorld, DaemonFanOutSpawner, Entity) {
+        world_with_parent_args(manifest_path, yolo, None)
+    }
+
+    /// [`world_with_parent_yolo`], with the run's `--model` override too.
+    fn world_with_parent_model(
+        manifest_path: &str,
+        model: &str,
+    ) -> (PipelineWorld, DaemonFanOutSpawner, Entity) {
+        world_with_parent_args(manifest_path, false, Some(model.to_string()))
+    }
+
+    fn world_with_parent_args(
+        manifest_path: &str,
+        yolo: bool,
+        model: Option<String>,
+    ) -> (PipelineWorld, DaemonFanOutSpawner, Entity) {
         let cli = Arc::new(CliToolService::new());
         let mut registry = leviath_runtime::ProviderRegistry::new();
         registry.register("anthropic".to_string(), Arc::new(FakeProvider));
@@ -476,7 +499,7 @@ mod tests {
             blueprint_path: manifest_path.to_string(),
             task: "parent task".to_string(),
             regions: HashMap::new(),
-            model: None,
+            model,
             workdir: std::env::temp_dir().to_string_lossy().to_string(),
             metadata: HashMap::new(),
             callback_url: None,
@@ -561,6 +584,86 @@ mod tests {
                 unattended
             );
         }
+    }
+
+    /// A run-level `--model` covers the whole run, workers included. It used to
+    /// stop at the run boundary, so a fan-out of thirty workers sent the large
+    /// majority of a run's spend to whatever the worker blueprint listed -
+    /// silently, and against an instruction typed for this run (issue #534).
+    ///
+    /// Asserts the worker's *resolved stage model*, not just the field: what
+    /// matters is which model the worker actually calls.
+    #[tokio::test]
+    async fn spawn_worker_inherits_the_parents_model_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(&manifest, two_stage_manifest()).unwrap();
+        // The blueprint says `anthropic/m` at every stage; the run says `m2`.
+        let (mut world, spawner, parent) =
+            world_with_parent_model(&manifest.to_string_lossy(), "anthropic/m2");
+
+        let child = spawner
+            .spawn_worker(
+                world.world_mut(),
+                parent,
+                &cfg(Some("second"), None, None),
+                "item-1",
+                &serde_json::json!({"k": "v"}),
+            )
+            .expect("worker spawns");
+
+        let inference = world
+            .world()
+            .get::<leviath_runtime::pipeline::StageInference>(child)
+            .expect("the worker resolved a stage model");
+        assert_eq!(
+            inference.model, "m2",
+            "the worker runs the overridden model"
+        );
+        assert_eq!(
+            world
+                .world()
+                .get::<RunMetadata>(child)
+                .expect("worker has run metadata")
+                .model_override
+                .as_deref(),
+            Some("anthropic/m2"),
+            "and carries it on, so its own children inherit it too"
+        );
+    }
+
+    /// No override on the run leaves every worker resolving against its own
+    /// blueprint, exactly as before.
+    #[tokio::test]
+    async fn spawn_worker_without_an_override_uses_the_blueprints_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = dir.path().join("agent.leviath");
+        std::fs::write(&manifest, two_stage_manifest()).unwrap();
+        let (mut world, spawner, parent) = world_with_parent(&manifest.to_string_lossy());
+
+        let child = spawner
+            .spawn_worker(
+                world.world_mut(),
+                parent,
+                &cfg(Some("second"), None, None),
+                "item-1",
+                &serde_json::json!({}),
+            )
+            .expect("worker spawns");
+
+        let inference = world
+            .world()
+            .get::<leviath_runtime::pipeline::StageInference>(child)
+            .expect("the worker resolved a stage model");
+        assert_eq!(inference.model, "m");
+        assert!(
+            world
+                .world()
+                .get::<RunMetadata>(child)
+                .unwrap()
+                .model_override
+                .is_none()
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -840,6 +840,7 @@ fn build_agent_inner(
         max_depth: max_child_depth,
         no_seed_commands: args.no_seed_commands,
         unattended: args.yolo,
+        model_override: args.model.clone(),
     };
     // Build the dynamic-tools re-resolution context (issue #97 escape hatch) and
     // tag the entity `DynamicTools` so the runtime polls it for mid-run re-scans.

--- a/crates/leviath-cli/src/daemon/subagent.rs
+++ b/crates/leviath-cli/src/daemon/subagent.rs
@@ -38,6 +38,14 @@ pub struct SubAgentHandle {
     /// with it whenever the parent is waiting on it. The operator asked for an
     /// unattended run; the tree is the run.
     pub unattended: bool,
+    /// The parent run's `--model` override, inherited by children.
+    ///
+    /// The docs call the override absolute - it "overrides everything" - and a
+    /// child named by the model at run time is part of the run, not a separate
+    /// one. Without this a spawned sub-agent quietly resolved against its own
+    /// blueprint's model list instead (issue #534). `None` when the run named
+    /// no model, which leaves every child resolving as it always has.
+    pub model_override: Option<String>,
 }
 
 // The sub-agent tool-name list lives in `leviath-tools` (next to the tool
@@ -150,7 +158,7 @@ async fn spawn(h: &SubAgentHandle, args: &serde_json::Value) -> String {
         path: blueprint,
         task: Some(&full_task),
         stdin_is_terminal: &never_interactive,
-        model: None,
+        model: h.model_override.clone(),
         workdir: &h.workdir,
         yolo: h.unattended,
         allow: Vec::new(),
@@ -388,6 +396,7 @@ mod tests {
             max_depth: 3,
             no_seed_commands: false,
             unattended: false,
+            model_override: None,
         };
 
         for bad in [
@@ -427,6 +436,7 @@ mod tests {
             max_depth: 3,
             no_seed_commands: false,
             unattended: false,
+            model_override: None,
         };
         let out = spawn(
             &h,
@@ -458,6 +468,7 @@ mod tests {
             max_depth: 3,
             no_seed_commands: false,
             unattended: false,
+            model_override: None,
         }
     }
 
@@ -705,6 +716,46 @@ task = { kind = "pinned", max_tokens = 1000 }
                 "a child inherits the parent's unattended setting"
             );
         }
+    }
+
+    /// A run's `--model` covers the children it spawns as well. The child is
+    /// named by the model at run time, so it is part of this run rather than a
+    /// separate one - and dropping the override there was silent (issue #534).
+    #[tokio::test]
+    async fn spawn_hands_the_parents_model_override_to_the_child() {
+        let bp = temp_blueprint();
+        let (mut h, seen, _t) = fake_host(Ok("child-1".to_string()), vec![], false);
+        h.model_override = Some("cerebras/gpt-oss-120b".to_string());
+        let out = handle(
+            &h,
+            &tc(
+                "spawn_agent",
+                json!({"blueprint": bp.path().to_str().unwrap(), "task": "go"}),
+            ),
+        )
+        .await;
+        assert!(out.contains("Spawned sub-agent"), "{out}");
+        assert_eq!(
+            seen.lock().unwrap()[0].model.as_deref(),
+            Some("cerebras/gpt-oss-120b")
+        );
+    }
+
+    /// A run with no override leaves the child on its own blueprint's models.
+    #[tokio::test]
+    async fn spawn_without_an_override_leaves_the_child_to_its_blueprint() {
+        let bp = temp_blueprint();
+        let (h, seen, _t) = fake_host(Ok("child-1".to_string()), vec![], false);
+        let out = handle(
+            &h,
+            &tc(
+                "spawn_agent",
+                json!({"blueprint": bp.path().to_str().unwrap(), "task": "go"}),
+            ),
+        )
+        .await;
+        assert!(out.contains("Spawned sub-agent"), "{out}");
+        assert!(seen.lock().unwrap()[0].model.is_none());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -2459,6 +2459,7 @@ mod tests {
             max_depth: 3,
             no_seed_commands: false,
             unattended: false,
+            model_override: None,
         };
         let builtins = Arc::new(leviath_tools::BuiltinTools::new(
             leviath_tools::ToolContext::new(std::env::temp_dir()),

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -35,7 +35,7 @@ Spawn an agent into the daemon. `PATH` is an installed agent name, a blueprint d
 | Flag | Purpose |
 |---|---|
 | `-t`, `--task <TEXT\|FILE>` | The task prompt, or the path of a file holding it. Left off, your editor opens |
-| `-m`, `--model <MODEL>` | Model override, as `provider/model` or a bare model name |
+| `-m`, `--model <MODEL>` | Model override for the whole run, as `provider/model` or a bare model name. Fan-out workers and sub-agents inherit it |
 | `--workdir <DIR>` | Working directory for the run, defaulting to where you ran the command. See below |
 | `--yolo` | Run unattended. See below |
 | `--allow <TOOL>` | Allow one tool outright. Repeatable |

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -156,6 +156,10 @@ In order:
 
 1. `lev run --model <provider>/<model>`, which overrides everything and skips the check entirely. A
    bare `--model <model>` replaces only the model name and keeps the provider resolved below.
+   "Everything" means the whole run: every stage of the blueprint, every
+   [fan-out](/docs/sub-agents#fan-out) worker, and every sub-agent spawned with `spawn_agent`. A
+   worker's own blueprint may list different models; they are its failover candidates when the run
+   names no model, and are not consulted when it does.
 2. Your `default_provider` / `default_model` from `config.toml`, when `default_model` is set, the
    provider is configured, and the stage did not set `allow_user_default = false`. It leads even
    when the blueprint lists that same provider with a different model: `default_provider = "ollama"`


### PR DESCRIPTION
Closes #534.

## The bug

Two independent spawn paths hardcoded `model: None` while carrying every other
field of the parent down — workdir, `--yolo`, `--no-seed-commands`, the
requested output shape — so a run-level `--model` covered the parent blueprint
and nothing below it.

`providers.md` already calls the override absolute ("overrides everything"), and
`resolve_stages` already applies it to every stage, so the promise held *within*
a run and broke only at the child spawn. Which made the failure invisible: the
parent obeyed, so nothing looked wrong.

The cost is lopsided. `lev run deep-researcher --model cerebras/gpt-oss-120b`
sent the parent's stages to Cerebras and all thirty workers to whatever
`researcher/agent.leviath` listed — the large majority of the run's spend
landing on providers the operator explicitly overrode away from, with no warning
and no log line. Benchmarking a provider that way reports a number that is
mostly not about that provider.

## The fix

Unconditional propagation, per the issue's open question. The parent's value was
already in hand at both sites:

- `fanout_spawner` destructures `md.model_override` off the same `RunMetadata` it
  already reads four other fields from, and passes it as the worker's `model`.
  Covers `worker_stage` *and* `worker_agent`/`worker_query`.
- `SubAgentHandle` gains `model_override`, carried from `args.model` where the
  handle is built, so `spawn_agent` hands it to the child.

Both are now commented like the inheritances around them, which is what the
issue notes was conspicuously missing.

A run that names no model is unchanged: every child resolves against its own
blueprint, and a worker blueprint's model list is still its failover set.

## Why unconditional

A child named by the model at run time, or by a `worker_agent` key, is part of
this run — not a separate one. A blueprint's own model list is what applies when
the run *doesn't* name a model; an explicit `--model` is a deliberate per-run
instruction, and there was no way to express "this run, strictly here" before
(`default_provider` is machine-wide and keeps the blueprint's models as
fallbacks).

## Verified live

A real daemon, a fan-out blueprint with `max_workers = 2`, and two script
providers pointed at separate mock endpoints:

| Run | `:19101` (blueprint's `alpha`) | `:19102` (`--model beta/beta-model`) |
|---|---|---|
| with the override | **0** | **3** |
| control, no `--model` | 3 | 0 |

Three calls either way — parent split plus both workers — so the same work
happened and only the destination moved. The two worker calls are the ones that
used to land on `alpha` regardless.

## Tests

- `spawn_worker_inherits_the_parents_model_override` asserts the worker's
  **resolved stage model** (`StageInference.model == "m2"`), not just that the
  field was copied, plus that the child carries it on so its own children
  inherit it. Verified it discriminates: reverting the one line fails it with
  `left: "m", right: "m2"`.
- `spawn_worker_without_an_override_uses_the_blueprints_model` pins the
  no-override path.
- `spawn_hands_the_parents_model_override_to_the_child` and
  `spawn_without_an_override_leaves_the_child_to_its_blueprint` for
  `spawn_agent`. Also verified to discriminate.

## Docs

`providers.md` spells out what "everything" covers; `cli.md`'s `--model` row
says workers and sub-agents inherit it.

Full workspace suite green, `cargo xtask coverage --package leviath-cli` at
100%, `cargo xtask docs` clean.
