### PR TITLE
fix: a Rhai builtin was writing our request bodies, and not as JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ same list.
 
 ## Unreleased
 
+- Fixed: a Rhai script no longer builds a malformed request body when the
+  prompt contains an invisible character. Rhai's own standard library registers
+  `to_json(&mut Map)`, and an object map is exactly what a provider script
+  passes, so that more specific signature beat Leviath's serde encoder and every
+  request body went through Rhai's hand-rolled formatter instead. That formatter
+  writes strings with Rust's `Debug`, which spells a narrow no-break space
+  `\u{202f}`. JSON has no such escape, so a single invisible character anywhere
+  in the prompt made the whole request unparseable and the API answered `HTTP
+  400 ... invalid escape at line 1 column N`. The failure looked like a provider
+  outage rather than a client bug: runs worked for several turns, then every one
+  of them died at once, parent and fan-out workers together, as soon as a model
+  reply or a fetched page carried a narrow no-break space, a zero-width space, a
+  BOM, a bidi mark or a stray control byte. Printable characters were unaffected,
+  which is why quotes, dashes and box glyphs had passed for months. Both script
+  engines now register the encoder for an object map explicitly, so `to_json`
+  means serde in a provider script and in a tool script alike.
+- Fixed: `web_fetch` no longer returns a page of replacement characters when a
+  server answers compressed. The HTTP stack was built without `gzip`, `brotli`
+  and `zstd`, so it advertised no encoding, and a server that compressed anyway
+  had its bytes decoded lossily into mojibake that reached the model as though
+  it were the article. The three decoders are enabled, and a body that still
+  decodes mostly to replacement characters is refused with a message that says
+  so rather than handed on. The declared-content-type check was already there;
+  this catches the case that declares `text/html` and is not text.
+
 - Fixed: a run's `--model` override now covers fan-out workers and sub-agents,
   not just the parent blueprint. Both spawn paths passed `model: None` while
   carrying every other field of the parent down - workdir, `--yolo`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,6 +203,22 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+dependencies = [
+ "brotli",
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -712,6 +743,27 @@ name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "brotli"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bstr"
@@ -4857,12 +4909,17 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
+ "async-compression",
  "bitflags 2.13.1",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5872,6 +5929,34 @@ name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,11 @@ clap = { version = "4.6", features = ["derive"] }
 # `rustls-tls-native-roots` became `rustls` + `rustls-native-certs`, and
 # `macos-system-configuration` became `system-proxy`. `form` and `query`, which
 # used to be always-on, are now opt-in.
-reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "rustls-native-certs", "charset", "http2", "system-proxy", "blocking", "form", "query"] }
+# `gzip`/`brotli`/`zstd` are not optional niceties: without them reqwest sends no
+# `Accept-Encoding`, but a server can still answer compressed, and `Response::text`
+# then decodes the compressed bytes lossily into a page of replacement characters
+# that `web_fetch` hands to the model as if it were the article.
+reqwest = { version = "0.13", default-features = false, features = ["json", "stream", "rustls", "rustls-native-certs", "charset", "http2", "system-proxy", "blocking", "form", "query", "gzip", "brotli", "zstd"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # OpenTelemetry export ([observability] config, issue #73). OTLP goes over

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -590,7 +590,11 @@ impl RealScriptIo {
         if let Some(msg) = oversized_body_message(resp.content_length(), max) {
             return Err(msg);
         }
-        let text = cap_script_io(resp.text().map_err(|e| format!("read body: {e}"))?);
+        let text = resp.text().map_err(|e| format!("read body: {e}"))?;
+        if let Some(msg) = mojibake_message(&text) {
+            return Err(msg);
+        }
+        let text = cap_script_io(text);
         if status.is_success() {
             Ok(text)
         } else {
@@ -637,6 +641,39 @@ fn is_binary_content_type(content_type: &str) -> bool {
     BINARY_CONTENT_PREFIXES
         .iter()
         .any(|prefix| essence.starts_with(prefix))
+}
+
+/// Share of replacement characters above which a decoded body is mojibake
+/// rather than text. Real prose in any charset stays far under this; a body
+/// that was never text at all lands near 1.0, because every byte the decoder
+/// could not interpret becomes U+FFFD.
+const MOJIBAKE_REPLACEMENT_SHARE: f64 = 0.1;
+
+/// The refusal for a body that decoded into replacement characters, or `None`
+/// when the text is usable.
+///
+/// This is the case [`is_binary_content_type`] cannot catch: a response that
+/// declares `text/html` and answers with compressed or otherwise binary bytes.
+/// The decode does not fail, it succeeds lossily, so before this the agent
+/// received a page of U+FFFD and cited it as though it had read the article.
+/// The test is on the *decoded* text, never on raw UTF-8 validity, so a
+/// correctly decoded Shift-JIS or Windows-1252 page still passes.
+fn mojibake_message(text: &str) -> Option<String> {
+    let total = text.chars().count();
+    if total == 0 {
+        return None;
+    }
+    let replacements = text
+        .chars()
+        .filter(|c| *c == char::REPLACEMENT_CHARACTER)
+        .count();
+    if (replacements as f64) < (total as f64) * MOJIBAKE_REPLACEMENT_SHARE {
+        return None;
+    }
+    Some(format!(
+        "body did not decode as text ({replacements} of {total} characters were unreadable) \
+         - the response was probably compressed or binary despite its content type"
+    ))
 }
 
 /// The diagnostic a script tool sees for a binary body. Phrased for the model:
@@ -1395,6 +1432,18 @@ mod tests {
                         vec![0x93u8, 0xfa, 0x96, 0x7b, 0x8c, 0xea],
                     )
                 }),
+            )
+            // Declared text, answered with bytes that are not text in any
+            // charset: the shape a compressed body arrives in. `text()` decodes
+            // it lossily and succeeds, so only the decoded result gives it away.
+            .route(
+                "/gibberish",
+                get(|| async {
+                    (
+                        [(axum::http::header::CONTENT_TYPE, "text/html")],
+                        vec![0x1fu8, 0x8b, 0x08, 0x00, 0xff, 0xfe, 0xfd, 0xfc, 0xfb, 0xfa],
+                    )
+                }),
             );
         tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
             listener, app,
@@ -1483,6 +1532,36 @@ mod tests {
         let msg = oversized_body_message(Some(999_999_999), 1_000).expect("should refuse");
         assert!(msg.contains("999999999"), "{msg}");
         assert!(msg.contains("1000-byte limit"), "{msg}");
+    }
+
+    /// The mojibake guard in the real `send` path: a `text/html` response whose
+    /// body is not text in any charset is refused rather than handed on.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn send_refuses_a_body_that_did_not_decode_as_text() {
+        let base = mock_http().await;
+        let out = tokio::task::spawn_blocking(move || {
+            let client = RealScriptIo::client();
+            RealScriptIo::send(client.get(format!("{base}/gibberish")))
+        })
+        .await
+        .expect("join");
+        let err = out.expect_err("gibberish is not text");
+        assert!(err.contains("did not decode as text"), "{err}");
+    }
+
+    /// A body that decoded into replacement characters is refused, and real
+    /// text in any charset is not.
+    #[test]
+    fn mojibake_is_refused_and_ordinary_text_is_not() {
+        let msg = mojibake_message("\u{fffd}\u{fffd}\u{fffd}\u{fffd}a").expect("should refuse");
+        assert!(msg.contains("4 of 5 characters"), "{msg}");
+        assert!(msg.contains("compressed or binary"), "{msg}");
+        // Decoded Japanese, a lone stray replacement char in a long page, and
+        // an empty body all stay on the text path.
+        assert!(mojibake_message("\u{30a6}\u{30a7}\u{30cf}").is_none());
+        let mostly_text = format!("{}{}", char::REPLACEMENT_CHARACTER, "a".repeat(20));
+        assert!(mojibake_message(&mostly_text).is_none());
+        assert!(mojibake_message("").is_none());
     }
 
     /// A body at or under the cap proceeds, and so does one with no declared

--- a/crates/leviath-providers/src/rhai_provider/engine.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine.rs
@@ -69,6 +69,18 @@ pub fn build_exec_engine(cfg: ExecConfig) -> Engine {
 fn register_pure_fns(engine: &mut Engine, env_allowlist: Arc<Vec<String>>) {
     engine.register_fn("parse_json", parse_json_fn);
     engine.register_fn("to_json", to_json_fn);
+    // Rhai's own `map_basic` package registers `to_json(&mut Map)`. An object
+    // map is the argument every provider script actually passes, and that
+    // signature is more specific than the `Dynamic` one above, so it used to
+    // win overload resolution and the serde encoder here was never reached.
+    // Rhai's formatter (`format_map_as_json`) writes strings with Rust's
+    // `Debug`, which escapes any non-printable character as `\u{202f}`. That is
+    // not a JSON escape, so the request body stopped being JSON the moment a
+    // narrow no-break space, a zero-width space or a BOM reached the prompt,
+    // and the API answered 400 with a parse error pointing at that offset.
+    // Registering the same signature into the engine's own namespace puts this
+    // encoder back in front of it.
+    engine.register_fn("to_json", |map: Map| to_json_fn(Dynamic::from_map(map)));
     engine.register_fn("parse_sse", parse_sse_fn);
     engine.register_fn("encode_uri", |s: &str| {
         leviath_scripting::tool::percent_encode(s)

--- a/crates/leviath-providers/src/rhai_provider/engine/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine/tests.rs
@@ -213,6 +213,51 @@ fn print_and_debug_are_silenced() {
     engine.run(r#"print("hello"); debug("world");"#).unwrap();
 }
 
+/// A map carrying non-printable characters must come back as JSON, not as
+/// Rhai's `Debug`-escaped lookalike.
+///
+/// Rhai's `map_basic` package registers `to_json(&mut Map)`, and that
+/// signature used to beat ours, so every request body a provider script built
+/// went through `format_map_as_json`. That writes strings with `Debug`, which
+/// spells a narrow no-break space `\u{202f}`. JSON has no such escape, so the
+/// API refused the whole request and named the offset it choked on.
+///
+/// The characters are named as Rust escapes and interpolated into the script
+/// source, because pasting them in literally leaves an invisible test.
+#[test]
+fn to_json_on_a_map_is_valid_json_for_non_printable_characters() {
+    let engine = build_init_engine(no_env_allowlist());
+    // Narrow no-break space, zero-width space and a BOM are non-printable, so
+    // `Debug` escapes them. A non-breaking hyphen is printable and never was.
+    let text = "NASDAQ:\u{202f}CBRS\u{200b} wafer\u{2011}scale\u{feff}";
+    let out: String = engine
+        .eval(&format!("to_json(#{{ content: \"{text}\" }})"))
+        .expect("to_json");
+    assert!(
+        !out.contains("\\u{"),
+        "Rhai's Debug-escaped formatter answered: {out}"
+    );
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("body must be JSON");
+    assert_eq!(
+        parsed["content"],
+        serde_json::Value::String(text.to_string())
+    );
+}
+
+/// The same guarantee for the shapes that never reached Rhai's overload: a
+/// bare string, an array, and a map nested inside one.
+#[test]
+fn to_json_is_valid_json_for_nested_and_scalar_shapes() {
+    let engine = build_init_engine(no_env_allowlist());
+    let out: String = engine
+        .eval("to_json([#{ a: \"x\u{202f}y\" }, \"b\u{200b}c\", 1])")
+        .expect("to_json");
+    assert_eq!(
+        serde_json::from_str::<serde_json::Value>(&out).expect("JSON"),
+        serde_json::json!([{ "a": "x\u{202f}y" }, "b\u{200b}c", 1])
+    );
+}
+
 #[test]
 fn encode_uri_passes_unreserved_and_encodes_rest() {
     let engine = build_init_engine(no_env_allowlist());

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -652,6 +652,14 @@ fn register_host_functions(engine: &mut Engine, host: Arc<dyn ScriptHost>) {
     engine.register_fn("to_json", |v: Dynamic| -> HostRes<String> {
         guard_str("to_json", &mut || to_json_fn(&v))
     });
+    // An object map needs its own registration to shadow Rhai's `map_basic`
+    // `to_json(&mut Map)`, whose more specific signature would otherwise win.
+    // Rhai's formatter writes strings with Rust's `Debug`, so a non-printable
+    // character comes out as `\u{202f}` and the result is no longer JSON.
+    engine.register_fn("to_json", |map: Map| -> HostRes<String> {
+        let value = Dynamic::from_map(map);
+        guard_str("to_json", &mut || to_json_fn(&value))
+    });
     engine.register_fn("encode_uri", |s: &str| -> HostRes<String> {
         guard_str("encode_uri", &mut || Ok(percent_encode(s)))
     });
@@ -1679,6 +1687,24 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         let tool = tool_from("// @tool t\nencode_uri(\"a b&c-_.~\")");
         let out = execute(&tool, serde_json::json!({}), FakeHost::arc());
         assert_eq!(out, "a%20b%26c-_.~");
+    }
+
+    /// A tool script's `to_json(#{...})` must produce JSON, not Rhai's
+    /// `Debug`-escaped lookalike.
+    ///
+    /// Rhai's `map_basic` package registers `to_json(&mut Map)`, a more
+    /// specific signature than the `Dynamic` one this engine registers, so an
+    /// object map used to reach `format_map_as_json`. That writes strings with
+    /// `Debug`, which spells a narrow no-break space `\u{202f}`: not a JSON
+    /// escape, so whatever consumed the tool's output got something unparseable.
+    #[test]
+    fn to_json_on_a_map_is_valid_json_for_non_printable_characters() {
+        let text = "a\u{202f}b\u{200b}c\u{2011}d";
+        let script = format!("// @tool t\nto_json(#{{ s: \"{text}\" }})");
+        let out = execute(&tool_from(&script), serde_json::json!({}), FakeHost::arc());
+        assert!(!out.contains("\\u{"), "got: {out}");
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("output must be JSON");
+        assert_eq!(parsed["s"], serde_json::Value::String(text.to_string()));
     }
 
     #[test]

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -163,6 +163,11 @@ These are the only calls that reach outside the sandbox:
   `stream_request(url, body, headers, callback)` for SSE streaming. The callback is a Rhai closure
   invoked with each SSE `data:` payload.
 - Data: `parse_json(str)`, `to_json(value)`, `parse_sse(chunk)`.
+
+Build the request body as an object map and hand the whole map to `to_json`, the way the example
+below does. Never assemble the body by joining strings. A model reply routinely contains a quote,
+a newline or a backslash, and escaping those by hand is where a provider script breaks weeks later
+on one unusual page.
 - Env and encoding: `env_var(name)` (returns a string or `()`), `encode_uri(str)`,
   `encode_base64(str)`.
 - Tokens: `count_tokens_heuristic(text, hint)` where `hint` is `"openai"`, `"anthropic"`,
@@ -364,6 +369,30 @@ question without a run and without a key: it compiles the text and checks that `
 and `inference(state, request)` are both there. The rest of the [scripts
 API](/docs/api#tools-and-scripts) manages the directory itself, so a console can list, open, edit and
 save a provider the same way it does a script tool.
+
+## When the API refuses the body
+
+An API answering `HTTP 400` with a JSON parse error is complaining about the bytes your script
+sent, not about the conversation. The message names the offset:
+
+```
+API error: HTTP 400 Bad Request: {"message":": Invalid JSON: invalid escape at line 1 column 26527",
+"type":"invalid_request_error","param":"validation_error","code":"wrong_api_format"}
+```
+
+The tell is a run that worked for several turns and then stopped. Something reached the prompt that
+the body could not carry. Two causes account for almost all of it:
+
+| Symptom | Cause |
+|---|---|
+| Invalid escape, run had been fine for turns | A string joined by hand instead of passed through `to_json` |
+| Parse error that moves with the prompt size | Same, at a different offset |
+
+Leviath serializes with `to_json` for exactly this reason, including for an object map, where Rhai's
+own `to_json` would otherwise take over and write strings in Rust's debug spelling. That spelling
+renders an invisible character such as a narrow no-break space as `\u{202f}`, which JSON has no
+escape for, so one such character anywhere in the prompt invalidates the whole request. Passing your
+map to `to_json` is enough; nothing extra is needed.
 
 ## Not in scope
 

--- a/docs/examples/groq.rhai
+++ b/docs/examples/groq.rhai
@@ -6,7 +6,7 @@
 // @max_output_tokens 32768
 //
 // Drop this into ~/.leviath/providers/groq.rhai and set GROQ_API_KEY, then point
-// an agent stage at `provider = "groq"`. See docs/rhai-providers.md.
+// an agent stage at `provider = "groq"`. See docs/content/rhai-providers.md.
 
 fn initialize(config) {
     let api_key = config.api_key ?? env_var("GROQ_API_KEY");


### PR DESCRIPTION
Run `deep-researcher-1787218729-848bbd2d5fab` and all five of its `researcher-*`
children died with:

```
API error: HTTP 400 Bad Request: {"message":": Invalid JSON: invalid escape at line 1 column 26527",
"type":"invalid_request_error","param":"validation_error","code":"wrong_api_format"}
```

Each had been doing inference successfully for several turns first, which made it
read as a provider outage. It was ours.

## What was happening

Rhai's standard `map_basic` package registers `to_json(map: &mut Map) -> String`.
An object map is exactly what a provider script hands to `to_json`, and `Map` is
more specific than the `Dynamic` signature we register, so Rhai's overload won
resolution and our serde encoder was never reached. Rhai's `format_map_as_json`
writes every string with Rust's `Debug`, which spells a narrow no-break space
`\u{202f}`. JSON has no such escape, so a single invisible character anywhere in
the prompt made the entire request body unparseable.

Printable characters are untouched by `Debug`, which is why quotes, dashes, box
glyphs and CJK had been passing for months. The runs died the moment a model
reply or a fetched page carried a narrow no-break space, a zero-width space, a
BOM, a bidi mark or a stray control byte, and then the parent and every fan-out
worker went together.

The same shadowing applied to tool scripts, whose `to_json` is registered the
same way, so a tool building JSON output had the same latent defect.

## The fix

Both engines register the encoder for an object map explicitly, so `to_json`
means serde in a provider script and in a tool script alike. No script needs
editing; the bundled ones and the docs example were already correct.

Second commit, separate defect found in the same investigation: the workspace
HTTP stack was built with no `gzip`/`brotli`/`zstd`, so it advertised no encoding
and decoded a compressed response lossily into mojibake that `web_fetch` handed
to the model. One worker in this run took 5,183 replacement characters into its
context that way. The decoders are enabled and a body that still decodes mostly
to replacement characters is refused with a message that says so.

## Verification

Driving a real run through the real provider script against a local echo endpoint,
capturing every outbound body:

| | invalid JSON |
|---|---|
| before | 49 of 50 |
| after | 0 of 50 |

Also: full workspace suite green, `cargo xtask coverage` at 100% on all 13
packages, `cargo xtask docs` clean.

Along the way I checked the obvious suspect directly and it was wrong: the
Cerebras API accepts raw U+202F, U+200B, U+FEFF, bidi marks, DEL, C1 bytes, NUL,
`\b`, `\f`, ESC, U+2028 and astral characters without complaint, and it accepted a
hand-rebuilt copy of the failing prompt. The character class mattered only
because it is exactly what `escape_debug` escapes.
