### PR TITLE
fix: retry and bound web_fetch transport, and stop citing sources the run never opened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,35 @@ same list.
 
 ## Unreleased
 
+- Fixed: `web_fetch` now retries a transport failure instead of losing the page
+  on the first one. A single `send()` was the whole story, so one dropped
+  connection or protocol fault ended that source permanently, and the
+  diagnostic the agent read said "the page may be too large (>1MB) or the
+  request was blocked" for every cause alike. An agent told the wrong reason
+  picks the wrong recovery, and one told "blocked" concludes the source is
+  unreachable and writes the citation from memory. That is how a research run
+  came to cite fifteen sources while having opened only eight of them, with a
+  credibility grade on each of the seven it never read. Transient failures now
+  get two more attempts, an HTTP/2 protocol fault pins the retry to an
+  HTTP/1.1-only client (a per-request version hint does not help, because ALPN
+  settles the protocol during the TLS handshake), and the message names what
+  actually happened and says outright that the fetch did not read the page.
+- Added: `[limits] script_http_max_per_host` (default `4`, `0` for unbounded)
+  and `[limits] script_http_timeout_secs` (default `30`). Nothing previously
+  bounded how many script-tool requests a run could aim at one origin: a
+  research stage batches six fetches, a fan-out multiplies that by the worker
+  count, and the result is most of two hundred simultaneous connections to a
+  single host. That reads as an attack, and the origin that answered such a
+  burst by failing every HTTP/2 stream is the same one whose pages the run then
+  cited without reading. Batching is unaffected; only requests sharing a host
+  stagger.
+- Changed: the batch-tool hint now names web searches and fetches, and says
+  that a batch runs in parallel. It previously listed only file and shell work,
+  so the agents doing the most fetching were the ones it spoke to least. The
+  three research blueprints say the same in their own words. Tool batches
+  already ran in parallel; what this buys is fewer, larger batches, and turns
+  are where a research run actually spends its wall clock.
+
 - Fixed: a Rhai script no longer builds a malformed request body when the
   prompt contains an invisible character. Rhai's own standard library registers
   `to_json(&mut Map)`, and an object map is exactly what a provider script

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "data-analyst"
-version = "0.0.5"
+version = "0.0.6"
 description = "Data analyst - searches the web for data on a subject, builds a clean CSV of it, and hands back a ready-to-use summary of what the numbers say"
 entry_stage = "scope"
 

--- a/crates/leviath-cli/agents/data-analyst/tools/web_fetch.rhai
+++ b/crates/leviath-cli/agents/data-analyst/tools/web_fetch.rhai
@@ -35,8 +35,23 @@ try {
         out = body;
     }
 } catch(e) {
-    // Most commonly the page exceeds the engine's 1MB string limit, or the host
-    // blocked the request. Report it so the agent can pick a smaller/other source.
-    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+    // Name what actually went wrong. The old text guessed "too large (>1MB) or
+    // blocked" for every failure, and both guesses were wrong for the two most
+    // common causes: a transport fault the host layer already retried, and a
+    // body this client could not decode. An agent told the wrong reason picks
+    // the wrong recovery - and one that reads "blocked" concludes the source is
+    // unreachable and cites it from memory instead.
+    let msg = `${e}`;
+    let lower = msg.to_lower();
+    let why = if lower.contains("unreadable body") {
+        "the response was not readable text (compressed, binary, or an encoding this client cannot decode). Try an API endpoint, an RSS/JSON feed, or a static mirror";
+    } else if lower.contains("http2") || lower.contains("connection") || lower.contains("timed out") {
+        "the connection failed even after retries, so the host is refusing this client or is down. Try a syndicated copy of the same content, or rely on the web_search snippets";
+    } else if lower.contains("http 4") || lower.contains("http 5") {
+        "the host answered with an error status. Check the URL, or try a syndicated copy";
+    } else {
+        "the page may exceed the engine's 1MB string limit, or the host blocked the request. Try a more specific page, or rely on the web_search snippets";
+    };
+    out = `[web_fetch could not retrieve ${params.url}: ${msg}. ${why}. Whatever this page says, this fetch did not read it - do not cite this URL or reconstruct its contents from memory.]`;
 }
 out

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.2.2"
+version = "0.2.3"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -38,6 +38,12 @@ authoritative references, not a broad skim.
   question, then web_fetch the most authoritative results for detail. Prefer
   primary sources (papers, standards, official docs) over summaries. read_file for
   local documents. Raw content lands in `sources`.
+- Batch your searches and fetches. A batch of tool calls runs in PARALLEL, so
+  eight fetches in one response cost about what one costs, while the inference
+  call between two responses costs tens of seconds. Fetch every promising URL
+  from a round of searches in a single response rather than one at a time; the
+  only reason to hold one back is that you need an earlier result to know
+  whether you want it.
 - Today's date is in the `environment` region. Treat it as authoritative over
   anything you remember: your training has a cutoff and this run does not. Judge
   "recent", "current" and "latest" against it, and say how old a source is when

--- a/crates/leviath-cli/agents/deep-researcher/tools/web_fetch.rhai
+++ b/crates/leviath-cli/agents/deep-researcher/tools/web_fetch.rhai
@@ -35,8 +35,23 @@ try {
         out = body;
     }
 } catch(e) {
-    // Most commonly the page exceeds the engine's 1MB string limit, or the host
-    // blocked the request. Report it so the agent can pick a smaller/other source.
-    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+    // Name what actually went wrong. The old text guessed "too large (>1MB) or
+    // blocked" for every failure, and both guesses were wrong for the two most
+    // common causes: a transport fault the host layer already retried, and a
+    // body this client could not decode. An agent told the wrong reason picks
+    // the wrong recovery - and one that reads "blocked" concludes the source is
+    // unreachable and cites it from memory instead.
+    let msg = `${e}`;
+    let lower = msg.to_lower();
+    let why = if lower.contains("unreadable body") {
+        "the response was not readable text (compressed, binary, or an encoding this client cannot decode). Try an API endpoint, an RSS/JSON feed, or a static mirror";
+    } else if lower.contains("http2") || lower.contains("connection") || lower.contains("timed out") {
+        "the connection failed even after retries, so the host is refusing this client or is down. Try a syndicated copy of the same content, or rely on the web_search snippets";
+    } else if lower.contains("http 4") || lower.contains("http 5") {
+        "the host answered with an error status. Check the URL, or try a syndicated copy";
+    } else {
+        "the page may exceed the engine's 1MB string limit, or the host blocked the request. Try a more specific page, or rely on the web_search snippets";
+    };
+    out = `[web_fetch could not retrieve ${params.url}: ${msg}. ${why}. Whatever this page says, this fetch did not read it - do not cite this URL or reconstruct its contents from memory.]`;
 }
 out

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -36,7 +36,7 @@ Be efficient - do not search exhaustively:
 1. Run a FOCUSED first round of 3-5 web_search calls covering the distinct
    sub-topics of the question (not many rephrasings of the same query).
 2. web_fetch only the 2-3 most promising sources for detail; the search snippets
-   in `raw_findings` are usually enough on their own.
+   in `raw_findings` are usually enough on their own. Issue a round's searches, and then that round's fetches, as ONE response each: a batch runs in parallel, so eight fetches cost about what one costs, while the inference call between two responses costs tens of seconds.
 3. As you go, append one bibliography line per source you actually use to the
    `sources_index` region with context_append:
    `[n] <title> - <url or path> - credibility: <high/med/low + why>`.

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.1.2"
+version = "0.1.3"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 

--- a/crates/leviath-cli/agents/researcher/tools/web_fetch.rhai
+++ b/crates/leviath-cli/agents/researcher/tools/web_fetch.rhai
@@ -35,8 +35,23 @@ try {
         out = body;
     }
 } catch(e) {
-    // Most commonly the page exceeds the engine's 1MB string limit, or the host
-    // blocked the request. Report it so the agent can pick a smaller/other source.
-    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+    // Name what actually went wrong. The old text guessed "too large (>1MB) or
+    // blocked" for every failure, and both guesses were wrong for the two most
+    // common causes: a transport fault the host layer already retried, and a
+    // body this client could not decode. An agent told the wrong reason picks
+    // the wrong recovery - and one that reads "blocked" concludes the source is
+    // unreachable and cites it from memory instead.
+    let msg = `${e}`;
+    let lower = msg.to_lower();
+    let why = if lower.contains("unreadable body") {
+        "the response was not readable text (compressed, binary, or an encoding this client cannot decode). Try an API endpoint, an RSS/JSON feed, or a static mirror";
+    } else if lower.contains("http2") || lower.contains("connection") || lower.contains("timed out") {
+        "the connection failed even after retries, so the host is refusing this client or is down. Try a syndicated copy of the same content, or rely on the web_search snippets";
+    } else if lower.contains("http 4") || lower.contains("http 5") {
+        "the host answered with an error status. Check the URL, or try a syndicated copy";
+    } else {
+        "the page may exceed the engine's 1MB string limit, or the host blocked the request. Try a more specific page, or rely on the web_search snippets";
+    };
+    out = `[web_fetch could not retrieve ${params.url}: ${msg}. ${why}. Whatever this page says, this fetch did not read it - do not cite this URL or reconstruct its contents from memory.]`;
 }
 out

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -29,6 +29,7 @@ over depth:
 
 Run web_search across the distinct facets, web_fetch a few representative sources
 per facet, read_file for local material. Landscape material lands in `landscape`.
+Issue a round's searches, and then that round's fetches, as ONE response each: a batch runs in parallel, so eight fetches cost about what one costs, while the inference call between two responses costs tens of seconds.
 For each source you use, append a bibliography line to `sources_index`
 (context_append): `[n] <title> - <url/path> - credibility: <high/med/low>`.
 Note interesting threads worth pulling on later. If sent back, focus on the named

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.2.2"
+version = "0.2.3"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 

--- a/crates/leviath-cli/agents/wide-researcher/tools/web_fetch.rhai
+++ b/crates/leviath-cli/agents/wide-researcher/tools/web_fetch.rhai
@@ -35,8 +35,23 @@ try {
         out = body;
     }
 } catch(e) {
-    // Most commonly the page exceeds the engine's 1MB string limit, or the host
-    // blocked the request. Report it so the agent can pick a smaller/other source.
-    out = `[web_fetch could not retrieve ${params.url}: ${e}. The page may be too large (>1MB) or the request was blocked — try a more specific page or rely on the web_search snippets.]`;
+    // Name what actually went wrong. The old text guessed "too large (>1MB) or
+    // blocked" for every failure, and both guesses were wrong for the two most
+    // common causes: a transport fault the host layer already retried, and a
+    // body this client could not decode. An agent told the wrong reason picks
+    // the wrong recovery - and one that reads "blocked" concludes the source is
+    // unreachable and cites it from memory instead.
+    let msg = `${e}`;
+    let lower = msg.to_lower();
+    let why = if lower.contains("unreadable body") {
+        "the response was not readable text (compressed, binary, or an encoding this client cannot decode). Try an API endpoint, an RSS/JSON feed, or a static mirror";
+    } else if lower.contains("http2") || lower.contains("connection") || lower.contains("timed out") {
+        "the connection failed even after retries, so the host is refusing this client or is down. Try a syndicated copy of the same content, or rely on the web_search snippets";
+    } else if lower.contains("http 4") || lower.contains("http 5") {
+        "the host answered with an error status. Check the URL, or try a syndicated copy";
+    } else {
+        "the page may exceed the engine's 1MB string limit, or the host blocked the request. Try a more specific page, or rely on the web_search snippets";
+    };
+    out = `[web_fetch could not retrieve ${params.url}: ${msg}. ${why}. Whatever this page says, this fetch did not read it - do not cite this URL or reconstruct its contents from memory.]`;
 }
 out

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -22,6 +22,24 @@ fn default_max_concurrent_tools() -> usize {
     8
 }
 
+/// Seconds a script tool's HTTP request may take before it is abandoned.
+fn default_script_http_timeout_secs() -> u64 {
+    30
+}
+
+/// Concurrent script-tool HTTP requests allowed against any one host.
+///
+/// Four, not unbounded. A single research stage routinely batches six fetches,
+/// and a fan-out multiplies that by the worker count, so one agent could open
+/// nearly two hundred simultaneous connections to the same origin. That reads
+/// as an attack: `investors.cerebras.ai` answered such a burst by failing every
+/// HTTP/2 stream, and a run lost both of its primary sources to it. Batching
+/// still happens - this only staggers the requests that share a host, which is
+/// the only dimension where more concurrency stopped buying speed.
+fn default_script_http_max_per_host() -> usize {
+    4
+}
+
 fn default_script_shell_timeout_secs() -> u64 {
     60
 }
@@ -112,6 +130,20 @@ pub struct LimitsConfig {
     /// hang an agent on a runaway command. Defaults to `60`.
     #[serde(default = "default_script_shell_timeout_secs")]
     pub script_shell_timeout_secs: u64,
+
+    /// Seconds a script tool's HTTP request may take. Defaults to `30`.
+    #[serde(default = "default_script_http_timeout_secs")]
+    pub script_http_timeout_secs: u64,
+
+    /// Concurrent script-tool HTTP requests allowed per host. Defaults to `4`;
+    /// `0` means unbounded.
+    ///
+    /// Four, not unbounded: a research stage routinely batches six fetches and a
+    /// fan-out multiplies that by the worker count, so one run could open nearly
+    /// two hundred simultaneous connections to a single origin. Batching is
+    /// untouched by this; only the requests that share a host stagger.
+    #[serde(default = "default_script_http_max_per_host")]
+    pub script_http_max_per_host: usize,
 
     /// How long (seconds) a run may sit ready to work but unable to dispatch
     /// before it is failed instead of left running.
@@ -418,6 +450,8 @@ impl Default for LimitsConfig {
             default_max_iterations: default_default_max_iterations(),
             exact_token_counting: false,
             script_shell_timeout_secs: default_script_shell_timeout_secs(),
+            script_http_timeout_secs: default_script_http_timeout_secs(),
+            script_http_max_per_host: default_script_http_max_per_host(),
             stall_timeout_secs: default_stall_timeout_secs(),
             dead_cycles_before_relief: default_dead_cycles_before_relief(),
             finished_retention_secs: default_finished_retention_secs(),

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -3553,6 +3553,8 @@ enabled = false
                 default_max_iterations: Some(99),
                 exact_token_counting: false,
                 script_shell_timeout_secs: 45,
+                script_http_timeout_secs: 15,
+                script_http_max_per_host: 2,
                 stall_timeout_secs: 90,
                 dead_cycles_before_relief: 6,
                 finished_retention_secs: 120,

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -496,15 +496,110 @@ static HTTP_CLIENT: std::sync::LazyLock<reqwest::blocking::Client> =
 /// "refused to follow redirect: private address" and "too many redirects" are
 /// different problems with different fixes, and both were reaching the script
 /// author as the same opaque sentence.
-fn error_chain(e: &dyn std::error::Error) -> String {
-    let mut parts = vec![e.to_string()];
-    let mut source = e.source();
-    while let Some(err) = source {
-        parts.push(err.to_string());
-        source = err.source();
-    }
-    parts.join(": ")
+fn error_chain(e: &(dyn std::error::Error + 'static)) -> String {
+    leviath_providers::rhai_provider::host::error_chain(e)
 }
+
+/// Concurrent script-tool HTTP requests allowed per host; `0` is unbounded.
+///
+/// A process-wide mirror of `[limits] script_http_max_per_host`, for the same
+/// reason [`ALLOW_LOCAL_REDIRECTS`] is one: [`HTTP_CLIENT`] is process-wide and
+/// the request path has no handle on the config.
+static HTTP_MAX_PER_HOST: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(4);
+
+/// Apply `[limits] script_http_max_per_host` for this process.
+pub fn set_script_http_max_per_host(max: usize) {
+    HTTP_MAX_PER_HOST.store(max, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// In-flight script-tool requests per host, and the condvar waiters park on.
+static IN_FLIGHT: std::sync::LazyLock<std::sync::Mutex<std::collections::HashMap<String, usize>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::collections::HashMap::new()));
+static IN_FLIGHT_FREED: std::sync::Condvar = std::sync::Condvar::new();
+
+/// A permit to have one request in flight against `host`, released on drop.
+///
+/// A condvar rather than a `tokio::sync::Semaphore` because script tools run on
+/// `spawn_blocking` threads with no runtime handle to await on.
+struct HostPermit(Option<String>);
+
+impl HostPermit {
+    /// Take a permit for `url`'s host, blocking while that host is at its cap.
+    ///
+    /// A URL with no host (and an unbounded cap) takes no permit at all, so the
+    /// unlimited setting costs nothing.
+    fn acquire(url: &str) -> Self {
+        let max = HTTP_MAX_PER_HOST.load(std::sync::atomic::Ordering::Relaxed);
+        let Some(host) = host_of(url).filter(|_| max > 0) else {
+            return Self(None);
+        };
+        let mut counts = IN_FLIGHT
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while counts.get(&host).copied().unwrap_or(0) >= max {
+            counts = IN_FLIGHT_FREED
+                .wait(counts)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+        }
+        *counts.entry(host.clone()).or_insert(0) += 1;
+        Self(Some(host))
+    }
+}
+
+impl Drop for HostPermit {
+    fn drop(&mut self) {
+        let Some(host) = self.0.take() else {
+            return;
+        };
+        let mut counts = IN_FLIGHT
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // `or_insert(1)` rather than `if let Some(..)`: acquire always inserted
+        // the key and this is its only remover, so the missing case cannot
+        // happen - and written as a branch it was a region no test could enter.
+        let remaining = counts.entry(host.clone()).or_insert(1);
+        *remaining = remaining.saturating_sub(1);
+        if *remaining == 0 {
+            counts.remove(&host);
+        }
+        drop(counts);
+        IN_FLIGHT_FREED.notify_all();
+    }
+}
+
+/// The host part of `url`, lowercased. `None` when it does not parse.
+fn host_of(url: &str) -> Option<String> {
+    reqwest::Url::parse(url)
+        .ok()?
+        .host_str()
+        .map(str::to_lowercase)
+}
+
+/// Seconds a script tool's HTTP request may take; `0` leaves the client's own
+/// deadline in charge.
+///
+/// Applied per request rather than on [`HTTP_CLIENT`] because that static is
+/// built lazily at first use, which may be before or after the config is read.
+/// A per-request timeout also wins over the client's, so this is the value that
+/// actually governs.
+static HTTP_TIMEOUT_SECS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(30);
+
+/// Apply `[limits] script_http_timeout_secs` for this process.
+pub fn set_script_http_timeout(secs: u64) {
+    HTTP_TIMEOUT_SECS.store(secs, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// The configured per-request deadline, if one is set.
+fn script_http_timeout() -> Option<Duration> {
+    match HTTP_TIMEOUT_SECS.load(std::sync::atomic::Ordering::Relaxed) {
+        0 => None,
+        secs => Some(Duration::from_secs(secs)),
+    }
+}
+
+/// How many extra attempts a script tool's request gets after a transport
+/// failure that looks transient.
+const SCRIPT_HTTP_RETRIES: u32 = 2;
 
 /// Whether *redirect hops* may land on loopback / private / link-local
 /// addresses.
@@ -556,16 +651,59 @@ impl RealScriptIo {
     /// `Response::text` decodes *anything* lossily, so a PNG or MP3 came back as
     /// a page of U+FFFD replacement characters reported as a **successful**
     /// fetch - no error, no signal, straight into the model's context.
-    fn send(req: reqwest::blocking::RequestBuilder) -> Result<String, String> {
-        Self::send_capped(req, MAX_RESPONSE_BYTES)
+    fn send(
+        url: &str,
+        build: &dyn Fn() -> reqwest::blocking::RequestBuilder,
+    ) -> Result<String, String> {
+        Self::send_capped(url, build, MAX_RESPONSE_BYTES)
+    }
+
+    /// Send `req`, retrying a transport failure that looks transient, and
+    /// holding a per-host permit for the duration so a batched fan-out cannot
+    /// open an unbounded number of connections to one origin.
+    ///
+    /// Takes a builder *factory* rather than a `RequestBuilder`, because `send`
+    /// consumes the builder and `try_clone` has a `None` arm (a streaming body)
+    /// that no script tool can reach - a branch nothing could ever test. Asking
+    /// the caller to rebuild removes it.
+    fn send_with_retry(
+        url: &str,
+        build: &dyn Fn() -> reqwest::blocking::RequestBuilder,
+    ) -> Result<reqwest::blocking::Response, String> {
+        let _permit = HostPermit::acquire(url);
+        let mut attempt = 0;
+        loop {
+            let req = match script_http_timeout() {
+                Some(t) => build().timeout(t),
+                None => build(),
+            };
+            match req.send() {
+                Ok(resp) => return Ok(resp),
+                Err(e) => {
+                    let chain = error_chain(&e);
+                    if attempt >= SCRIPT_HTTP_RETRIES
+                        || !leviath_providers::rhai_provider::host::is_retryable_transport(&chain)
+                    {
+                        return Err(format!("request failed: {chain}"));
+                    }
+                    attempt += 1;
+                    std::thread::sleep(Duration::from_millis(200 * u64::from(attempt)));
+                }
+            }
+        }
     }
 
     /// [`send`](Self::send) with the body cap injected, so the oversized-body
     /// refusal is testable against a small response instead of a 32 MiB one.
-    fn send_capped(req: reqwest::blocking::RequestBuilder, max: u64) -> Result<String, String> {
-        let resp = req
-            .send()
-            .map_err(|e| format!("request failed: {}", error_chain(&e)))?;
+    fn send_capped(
+        url: &str,
+        build: &dyn Fn() -> reqwest::blocking::RequestBuilder,
+        max: u64,
+    ) -> Result<String, String> {
+        // One `send()` used to be the whole story here, and a single HTTP/2
+        // stream error therefore lost the page for good: a research run cited
+        // two primary sources it had never opened because of exactly this.
+        let resp = Self::send_with_retry(url, build)?;
         let status = resp.status();
         let content_type = resp
             .headers()
@@ -732,7 +870,9 @@ pub(crate) fn cap_script_io(mut s: String) -> String {
 impl ScriptIo for RealScriptIo {
     fn http_get(&self, url: &str, headers: BTreeMap<String, String>) -> Result<String, String> {
         let client = Self::client();
-        Self::send(Self::with_headers(client.get(url), headers))
+        Self::send(url, &|| {
+            Self::with_headers(client.get(url), headers.clone())
+        })
     }
 
     fn http_post(
@@ -742,10 +882,9 @@ impl ScriptIo for RealScriptIo {
         headers: BTreeMap<String, String>,
     ) -> Result<String, String> {
         let client = Self::client();
-        Self::send(Self::with_headers(
-            client.post(url).body(body.to_string()),
-            headers,
-        ))
+        Self::send(url, &|| {
+            Self::with_headers(client.post(url).body(body.to_string()), headers.clone())
+        })
     }
 
     fn run_shell(&self, mut cmd: TokioCommand, timeout: Duration) -> Result<String, String> {
@@ -866,6 +1005,183 @@ pub(crate) fn combine_shell_output(stdout: &[u8], stderr: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+
+    /// A server that drops the first connection without answering, then serves
+    /// normally. Reproduces the "the socket did not work this time" shape that
+    /// used to lose a source outright.
+    ///
+    /// A blocking listener over exactly two connections, so the spawned body
+    /// *returns*. An `accept` loop that runs forever leaves its own closing
+    /// region uncovered, which is why [`mock_http`] hands `tokio::spawn` a
+    /// future with no block of ours in it.
+    fn flaky_http() -> String {
+        use std::io::{Read, Write};
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        std::thread::spawn(move || {
+            for (i, mut sock) in listener.incoming().take(2).flatten().enumerate() {
+                let mut buf = [0u8; 8192];
+                let _ = sock.read(&mut buf);
+                // The first caller gets a FIN mid-request and nothing else.
+                if i > 0 {
+                    let body = "RETRIED-OK";
+                    let _ = sock.write_all(
+                        format!(
+                            "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\n\
+                             Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                            body.len()
+                        )
+                        .as_bytes(),
+                    );
+                }
+            }
+        });
+        format!("http://{addr}")
+    }
+
+    /// Before the retry, one dropped connection was the whole story: the page
+    /// was lost and the bibliography still cited it.
+    #[test]
+    fn a_dropped_connection_is_retried_rather_than_lost() {
+        let base = flaky_http();
+        let client = RealScriptIo::client();
+        let url = format!("{base}/x");
+        let out = RealScriptIo::send(&url, &|| client.get(&url));
+        assert_eq!(out.expect("the retry recovers"), "RETRIED-OK");
+    }
+
+    /// A host that never answers still gives up rather than looping, and says
+    /// so in the message the agent reads.
+    #[test]
+    fn a_dead_host_gives_up_with_a_named_failure() {
+        let _guard = lock_http_limits();
+        let previous = HTTP_TIMEOUT_SECS.load(std::sync::atomic::Ordering::Relaxed);
+        // Also the no-deadline arm: `0` leaves the client's own timeout in
+        // charge rather than stamping one per request.
+        set_script_http_timeout(0);
+        let client = RealScriptIo::client();
+        // Nothing listening: connection refused is not retryable, so this
+        // returns on the first attempt instead of spending the budget.
+        let out = RealScriptIo::send("http://127.0.0.1:19997/x", &|| {
+            client.get("http://127.0.0.1:19997/x")
+        });
+        set_script_http_timeout(previous);
+        let err = out.expect_err("a dead host fails");
+        assert!(err.contains("request failed"), "got: {err}");
+    }
+
+    // ─── per-host request gate ──────────────────────────────────────────────
+
+    /// `HTTP_MAX_PER_HOST` and `HTTP_TIMEOUT_SECS` are process-wide, so every
+    /// test that writes one races every test that reads it - the same hazard
+    /// [`REDIRECT_MIRROR`] exists for, and it bit exactly the same way: a
+    /// concurrent test raising the cap made the "over the cap" test's second
+    /// request sail straight through.
+    static HTTP_LIMITS: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Take the script-HTTP limits lock.
+    fn lock_http_limits() -> std::sync::MutexGuard<'static, ()> {
+        HTTP_LIMITS
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+
+    #[test]
+    fn host_of_lowercases_and_ignores_unparseable_urls() {
+        assert_eq!(
+            host_of("https://Example.COM/a/b"),
+            Some("example.com".into())
+        );
+        assert_eq!(host_of("http://127.0.0.1:8080/x"), Some("127.0.0.1".into()));
+        assert_eq!(host_of("not a url"), None);
+        // A parseable URL with no host still yields nothing to key a permit on.
+        assert_eq!(host_of("data:text/plain,hi"), None);
+    }
+
+    #[test]
+    fn a_permit_is_held_then_released() {
+        let _guard = lock_http_limits();
+        let previous = HTTP_MAX_PER_HOST.load(std::sync::atomic::Ordering::Relaxed);
+        set_script_http_max_per_host(2);
+        {
+            let _a = HostPermit::acquire("https://gate.example/a");
+            let _b = HostPermit::acquire("https://gate.example/b");
+            let held = IN_FLIGHT
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .get("gate.example")
+                .copied();
+            assert_eq!(held, Some(2), "both permits counted against the host");
+            // A different host is counted separately, so one slow origin cannot
+            // stall fetches to every other one.
+            let _c = HostPermit::acquire("https://other.example/c");
+            assert_eq!(
+                IN_FLIGHT
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .get("other.example")
+                    .copied(),
+                Some(1)
+            );
+        }
+        // Dropping every permit removes the key rather than leaving a zero.
+        assert!(
+            !IN_FLIGHT
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .contains_key("gate.example")
+        );
+        set_script_http_max_per_host(previous);
+    }
+
+    #[test]
+    fn an_unbounded_cap_takes_no_permit_at_all() {
+        let _guard = lock_http_limits();
+        let previous = HTTP_MAX_PER_HOST.load(std::sync::atomic::Ordering::Relaxed);
+        set_script_http_max_per_host(0);
+        let _p = HostPermit::acquire("https://unbounded.example/x");
+        assert!(
+            !IN_FLIGHT
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .contains_key("unbounded.example"),
+            "0 means unlimited, so nothing is tracked"
+        );
+        set_script_http_max_per_host(previous);
+    }
+
+    #[test]
+    fn a_request_over_the_cap_waits_for_a_slot() {
+        let _guard = lock_http_limits();
+        let previous = HTTP_MAX_PER_HOST.load(std::sync::atomic::Ordering::Relaxed);
+        set_script_http_max_per_host(1);
+        let held = HostPermit::acquire("https://queue.example/first");
+        let waiter = std::thread::spawn(|| {
+            let _second = HostPermit::acquire("https://queue.example/second");
+            "got in"
+        });
+        // The second request cannot proceed while the first holds the only slot.
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            !waiter.is_finished(),
+            "the cap did not hold the second request"
+        );
+        drop(held);
+        assert_eq!(waiter.join().expect("waiter finishes"), "got in");
+        set_script_http_max_per_host(previous);
+    }
+
+    #[test]
+    fn the_http_timeout_switch_round_trips() {
+        let _guard = lock_http_limits();
+        let previous = HTTP_TIMEOUT_SECS.load(std::sync::atomic::Ordering::Relaxed);
+        set_script_http_timeout(7);
+        assert_eq!(script_http_timeout(), Some(Duration::from_secs(7)));
+        // Zero hands the deadline back to the client rather than meaning "now".
+        set_script_http_timeout(0);
+        assert_eq!(script_http_timeout(), None);
+        set_script_http_timeout(previous);
+    }
     use super::*;
     use std::sync::Mutex;
 
@@ -1541,7 +1857,8 @@ mod tests {
         let base = mock_http().await;
         let out = tokio::task::spawn_blocking(move || {
             let client = RealScriptIo::client();
-            RealScriptIo::send(client.get(format!("{base}/gibberish")))
+            let url = format!("{base}/gibberish");
+            RealScriptIo::send(&url, &|| client.get(&url))
         })
         .await
         .expect("join");
@@ -1583,7 +1900,8 @@ mod tests {
         let out = tokio::task::spawn_blocking(move || {
             let client = RealScriptIo::client();
             // `/ok` returns "GET-BODY" (8 bytes) with a Content-Length.
-            RealScriptIo::send_capped(client.get(format!("{base}/ok")), 4)
+            let url = format!("{base}/ok");
+            RealScriptIo::send_capped(&url, &|| client.get(&url), 4)
         })
         .await
         .unwrap();

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -140,6 +140,12 @@ pub async fn setup_daemon_host_with(
     // redirect policy has no per-agent context to consult; see
     // `script_host::set_local_network_allowed`.
     crate::daemon::script_host::set_local_network_allowed(config.security.allow_local_network);
+    // Same mirror, same reason: the shared blocking client has no handle on the
+    // config by the time a script tool calls through it.
+    crate::daemon::script_host::set_script_http_max_per_host(
+        config.limits.script_http_max_per_host,
+    );
+    crate::daemon::script_host::set_script_http_timeout(config.limits.script_http_timeout_secs);
     // Built before the registry, and shared with it: a script provider's
     // `[model_providers.<name>]` table is read through this, so editing it
     // takes effect on the next load exactly as editing the `.rhai` beside it

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -885,6 +885,30 @@ pub type HttpClientFactory<'a> =
 pub fn build_http_client(
     timeout_secs: Option<u64>,
 ) -> std::result::Result<reqwest::Client, reqwest::Error> {
+    outbound_builder(timeout_secs).build()
+}
+
+/// The same client, pinned to HTTP/1.1.
+///
+/// Some origins negotiate HTTP/2 over ALPN and then fail every stream on it.
+/// `investors.cerebras.ai` is one, measured: `curl` succeeds over either
+/// protocol, while this stack gets `http2 error: stream error received:
+/// unexpected internal error encountered` on **every** attempt, and both of
+/// that host's pages were primary sources a research run ended up citing
+/// without ever reading. A per-request `Version::HTTP_11` does not help,
+/// because ALPN picks the protocol during the TLS handshake and the request
+/// version is only a hint by then - it takes a separate client.
+///
+/// Built once and used only as a retry path, so the ordinary case still gets
+/// HTTP/2 multiplexing.
+pub fn build_http1_client(
+    timeout_secs: Option<u64>,
+) -> std::result::Result<reqwest::Client, reqwest::Error> {
+    outbound_builder(timeout_secs).http1_only().build()
+}
+
+/// The builder both outbound clients share.
+fn outbound_builder(timeout_secs: Option<u64>) -> reqwest::ClientBuilder {
     reqwest::Client::builder()
         .pool_max_idle_per_host(0)
         // Follow a redirect only while it stays on the host the key was meant
@@ -909,7 +933,6 @@ pub fn build_http_client(
         .timeout(std::time::Duration::from_secs(
             timeout_secs.unwrap_or(DEFAULT_INFERENCE_TIMEOUT_SECS),
         ))
-        .build()
 }
 
 /// Trait for LLM providers.

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -259,7 +259,7 @@ fn transport_backoff(attempt: u32) -> std::time::Duration {
 /// the interesting detail (an `h2` protocol fault) is several links down the
 /// chain, and `reqwest::Error` has no public constructor, so a chain string is
 /// also the only shape a test can drive.
-fn error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+pub fn error_chain(err: &(dyn std::error::Error + 'static)) -> String {
     let mut out = err.to_string();
     let mut source = err.source();
     while let Some(e) = source {
@@ -276,7 +276,7 @@ fn error_chain(err: &(dyn std::error::Error + 'static)) -> String {
 /// work this time". A DNS failure or a refused connection is not: retrying
 /// those just spends the deadline, so they fall through to the error the agent
 /// sees.
-pub(crate) fn is_retryable_transport(chain: &str) -> bool {
+pub fn is_retryable_transport(chain: &str) -> bool {
     let lower = chain.to_lowercase();
     is_h2_protocol_error(chain)
         || lower.contains("connection reset")
@@ -294,7 +294,7 @@ pub(crate) fn is_retryable_transport(chain: &str) -> bool {
 /// internal error encountered` and served the same URL fine over HTTP/1.1.
 /// Both of that host's pages were primary sources for a research run, and
 /// because nothing retried, the run cited two URLs it had never read.
-pub(crate) fn is_h2_protocol_error(chain: &str) -> bool {
+pub fn is_h2_protocol_error(chain: &str) -> bool {
     let lower = chain.to_lowercase();
     lower.contains("http2 error") || lower.contains("h2 error")
 }

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -100,6 +100,9 @@ pub trait HttpExecutor: Send + Sync {
 /// The production [`HttpExecutor`] backed by `reqwest`.
 pub struct ReqwestExecutor {
     client: reqwest::Client,
+    /// An HTTP/1.1-only client, used only to retry an HTTP/2 protocol fault.
+    /// `None` when one could not be built, which just means no fallback.
+    h1_client: Option<reqwest::Client>,
 }
 
 impl ReqwestExecutor {
@@ -107,14 +110,33 @@ impl ReqwestExecutor {
     /// `pool_max_idle_per_host(0)` fix); per-request deadlines come from
     /// [`HostRequest::timeout_secs`].
     pub fn new(client: reqwest::Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            h1_client: None,
+        }
+    }
+
+    /// An executor that can fall back to `h1_client` when an origin negotiates
+    /// HTTP/2 and then fails every stream on it. See
+    /// [`crate::provider::build_http1_client`].
+    pub fn with_h1_fallback(client: reqwest::Client, h1_client: reqwest::Client) -> Self {
+        Self {
+            client,
+            h1_client: Some(h1_client),
+        }
     }
 
     /// Build the `reqwest::RequestBuilder` for a [`HostRequest`].
     fn build(&self, req: &HostRequest) -> reqwest::RequestBuilder {
+        self.build_with(&self.client, req)
+    }
+
+    /// [`Self::build`] against a specific client, so the retry path can send
+    /// the identical request over the HTTP/1.1-only one.
+    fn build_with(&self, client: &reqwest::Client, req: &HostRequest) -> reqwest::RequestBuilder {
         let mut rb = match req.method {
-            HttpMethod::Get => self.client.get(&req.url),
-            HttpMethod::Post => self.client.post(&req.url),
+            HttpMethod::Get => client.get(&req.url),
+            HttpMethod::Post => client.post(&req.url),
         };
         for (k, v) in &req.headers {
             rb = rb.header(k, v);
@@ -123,6 +145,43 @@ impl ReqwestExecutor {
             rb = rb.body(body.clone());
         }
         crate::provider::apply_request_timeout(rb, req.timeout_secs)
+    }
+
+    /// Send `req`, retrying a transport failure that looks transient and
+    /// falling back to HTTP/1.1 once on an HTTP/2 protocol fault.
+    ///
+    /// Before this, one `send()` was the whole story: a single h2 stream error
+    /// permanently lost the source, and the tool script's diagnostic blamed
+    /// page size or blocking, neither of which was true.
+    async fn send_with_retry(&self, req: &HostRequest) -> Result<reqwest::Response, HostHttpError> {
+        let mut attempt = 0;
+        // Sticky for the rest of the loop, deliberately. An earlier cut kept
+        // this on the executor and recomputed it per attempt, so an h1 retry
+        // that failed for its own reason cleared the flag and the next attempt
+        // went straight back to the protocol already known to be broken here.
+        let mut use_h1 = false;
+        loop {
+            let client = retry_client(&self.client, self.h1_client.as_ref(), use_h1);
+            match self.build_with(client, req).send().await {
+                Ok(resp) => return Ok(resp),
+                Err(e) => {
+                    let chain = error_chain(&e);
+                    if attempt >= TRANSPORT_RETRIES || !is_retryable_transport(&chain) {
+                        return Err(HostHttpError::Transport(chain));
+                    }
+                    use_h1 = use_h1 || is_h2_protocol_error(&chain);
+                    attempt += 1;
+                    tracing::debug!(
+                        url = %req.url,
+                        attempt,
+                        over_http1 = use_h1,
+                        error = %chain,
+                        "retrying a transport failure"
+                    );
+                    tokio::time::sleep(transport_backoff(attempt)).await;
+                }
+            }
+        }
     }
 }
 
@@ -145,18 +204,173 @@ async fn classify(resp: reqwest::Response) -> Result<reqwest::Response, HostHttp
     Ok(resp)
 }
 
+/// Build the shared executor from the two outbound clients.
+///
+/// Takes both as `Result`s rather than building them, because the only caller
+/// is a daemon-start-up path with nothing to return an error to and `reqwest`
+/// cannot be made to fail from the outside. As parameters, "no HTTPS client at
+/// all" and "a client but no HTTP/1.1 fallback" are both reachable from a test.
+pub fn executor_from_clients(
+    main: std::result::Result<reqwest::Client, crate::provider::HttpError>,
+    h1: std::result::Result<reqwest::Client, crate::provider::HttpError>,
+) -> std::result::Result<std::sync::Arc<dyn HttpExecutor>, crate::provider::HttpError> {
+    main.map(|client| {
+        let exec = match h1 {
+            Ok(h1) => ReqwestExecutor::with_h1_fallback(client, h1),
+            // No fallback is a degraded executor, not a failure: every origin
+            // that works over HTTP/2 still works.
+            Err(_) => ReqwestExecutor::new(client),
+        };
+        std::sync::Arc::new(exec) as std::sync::Arc<dyn HttpExecutor>
+    })
+}
+
+/// Which client an attempt should use.
+///
+/// A free function because the HTTP/1.1 arm is otherwise only reachable from a
+/// live origin that negotiates HTTP/2 and then fails the stream, which no local
+/// test can stage. Here it is one comparison a test can make directly.
+fn retry_client<'a>(
+    main: &'a reqwest::Client,
+    h1: Option<&'a reqwest::Client>,
+    use_h1: bool,
+) -> &'a reqwest::Client {
+    match h1 {
+        Some(client) if use_h1 => client,
+        _ => main,
+    }
+}
+
+/// How many extra attempts a retryable transport failure gets.
+///
+/// Deliberately not `inference_retry_attempts`: that governs a whole inference
+/// call with a model's latency behind it, while this is a socket that failed
+/// before any work happened.
+const TRANSPORT_RETRIES: u32 = 2;
+
+/// Backoff before retry `n` (1-based).
+fn transport_backoff(attempt: u32) -> std::time::Duration {
+    std::time::Duration::from_millis(200 * u64::from(attempt))
+}
+
+/// Flatten an error and its `source()` chain into one string.
+///
+/// The classification below reads this rather than the `reqwest::Error` itself:
+/// the interesting detail (an `h2` protocol fault) is several links down the
+/// chain, and `reqwest::Error` has no public constructor, so a chain string is
+/// also the only shape a test can drive.
+fn error_chain(err: &(dyn std::error::Error + 'static)) -> String {
+    let mut out = err.to_string();
+    let mut source = err.source();
+    while let Some(e) = source {
+        out.push_str(": ");
+        out.push_str(&e.to_string());
+        source = e.source();
+    }
+    out
+}
+
+/// Whether a transport failure is worth another attempt.
+///
+/// Connection resets, timeouts and protocol faults are all "the socket did not
+/// work this time". A DNS failure or a refused connection is not: retrying
+/// those just spends the deadline, so they fall through to the error the agent
+/// sees.
+pub(crate) fn is_retryable_transport(chain: &str) -> bool {
+    let lower = chain.to_lowercase();
+    is_h2_protocol_error(chain)
+        || lower.contains("connection reset")
+        || lower.contains("connection closed")
+        || lower.contains("broken pipe")
+        || lower.contains("unexpected eof")
+        || lower.contains("timed out")
+}
+
+/// Whether the failure is an HTTP/2 protocol fault that a plain HTTP/1.1
+/// attempt is likely to clear.
+///
+/// Measured against `investors.cerebras.ai`, which answered a burst of
+/// concurrent fetches with `http2 error: stream error received: unexpected
+/// internal error encountered` and served the same URL fine over HTTP/1.1.
+/// Both of that host's pages were primary sources for a research run, and
+/// because nothing retried, the run cited two URLs it had never read.
+pub(crate) fn is_h2_protocol_error(chain: &str) -> bool {
+    let lower = chain.to_lowercase();
+    lower.contains("http2 error") || lower.contains("h2 error")
+}
+
+/// Content types that are not text a model can read.
+///
+/// Checked before the body is decoded, so a PDF or an image is named rather
+/// than shovelled into a context region as bytes.
+pub(crate) fn unsupported_content_type(content_type: Option<&str>) -> Option<String> {
+    let ct = content_type?;
+    let essence = ct.split(';').next().unwrap_or(ct).trim().to_lowercase();
+    let readable = essence.starts_with("text/")
+        || essence.contains("json")
+        || essence.contains("xml")
+        || essence.contains("javascript")
+        || essence.contains("x-yaml")
+        || essence.contains("urlencoded");
+    match readable {
+        true => None,
+        false => Some(format!(
+            "the response is {essence}, not text - this fetch read bytes, not a document"
+        )),
+    }
+}
+
+/// Whether a decoded body is mostly Unicode replacement characters.
+///
+/// This is the shape a compressed body takes after a lossy UTF-8 decode, and it
+/// is the last line of defence behind the `gzip`/`brotli`/`zstd` features: a
+/// server that compresses unsolicited (finance.yahoo.com does) used to land a
+/// whole gzip member in a research agent's sources region, and nothing noticed
+/// because the tool's own emptiness check only catches *short* output.
+///
+/// The ratio, not a count: a legitimate page may carry a stray replacement
+/// character from a genuinely malformed byte, but not one in ten.
+pub(crate) fn looks_like_mojibake(body: &str) -> bool {
+    let mut total = 0usize;
+    let mut bad = 0usize;
+    for ch in body.chars() {
+        total += 1;
+        if ch == char::REPLACEMENT_CHARACTER {
+            bad += 1;
+        }
+    }
+    total >= 64 && bad * 10 > total
+}
+
 #[async_trait]
 impl HttpExecutor for ReqwestExecutor {
     async fn execute(&self, req: HostRequest) -> Result<String, HostHttpError> {
-        let resp = self
-            .build(&req)
-            .send()
+        let resp = self.send_with_retry(&req).await?;
+        let resp = classify(resp).await?;
+        let content_type = resp
+            .headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned);
+        if let Some(reason) = unsupported_content_type(content_type.as_deref()) {
+            return Err(HostHttpError::Api(format!("unreadable body: {reason}")));
+        }
+        let body = resp
+            .text()
             .await
             .map_err(|e| HostHttpError::Transport(e.to_string()))?;
-        let resp = classify(resp).await?;
-        resp.text()
-            .await
-            .map_err(|e| HostHttpError::Transport(e.to_string()))
+        // Named rather than returned. A caller cannot tell mojibake from a page
+        // that genuinely says very little, and a model handed either will cite
+        // whatever it remembers being at that URL.
+        if looks_like_mojibake(&body) {
+            return Err(HostHttpError::Api(format!(
+                "unreadable body: {} decoded to mostly replacement characters, so it \
+                 was compressed or in an encoding this client could not decode. \
+                 This fetch did not read the page.",
+                content_type.as_deref().unwrap_or("the response")
+            )));
+        }
+        Ok(body)
     }
 
     async fn execute_stream(

--- a/crates/leviath-providers/src/rhai_provider/host/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/host/tests.rs
@@ -337,3 +337,350 @@ async fn reqwest_executor_stream_non_2xx_error() {
         Err(HostHttpError::Api(_))
     ));
 }
+
+// ─── transport retry classification ─────────────────────────────────────────
+//
+// Driven as chain strings rather than `reqwest::Error`s: that type has no
+// public constructor, and the detail these read sits several `source()` links
+// down anyway. `error_chain` is what turns one into the other.
+
+#[test]
+fn h2_protocol_fault_is_recognised_and_retryable() {
+    // Verbatim from the run archive of deep-researcher-1787212645, where this
+    // permanently lost both investors.cerebras.ai primary sources.
+    let chain = "error sending request for url (https://investors.cerebras.ai/x): \
+                 client error (SendRequest): http2 error: stream error received: \
+                 unexpected internal error encountered";
+    assert!(is_h2_protocol_error(chain));
+    assert!(is_retryable_transport(chain));
+}
+
+#[test]
+fn transient_socket_failures_are_retryable() {
+    for chain in [
+        "error sending request: connection reset by peer",
+        "connection closed before message completed",
+        "os error 32: Broken pipe",
+        "unexpected EOF during handshake",
+        "operation timed out",
+        "H2 error: GOAWAY",
+    ] {
+        assert!(is_retryable_transport(chain), "should retry: {chain}");
+    }
+}
+
+#[test]
+fn permanent_failures_are_not_retryable() {
+    // Retrying these only spends the deadline before showing the agent the
+    // same error, so they fall straight through.
+    for chain in [
+        "error sending request: dns error: failed to lookup address information",
+        "tcp connect error: Connection refused (os error 61)",
+        "invalid certificate: UnknownIssuer",
+    ] {
+        assert!(!is_retryable_transport(chain), "should not retry: {chain}");
+        assert!(!is_h2_protocol_error(chain));
+    }
+}
+
+#[test]
+fn error_chain_walks_every_source() {
+    #[derive(Debug)]
+    struct Inner;
+    impl std::fmt::Display for Inner {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("http2 error: stream error received")
+        }
+    }
+    impl std::error::Error for Inner {}
+
+    #[derive(Debug)]
+    struct Outer(Inner);
+    impl std::fmt::Display for Outer {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str("error sending request")
+        }
+    }
+    impl std::error::Error for Outer {
+        fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+            Some(&self.0)
+        }
+    }
+
+    let chain = error_chain(&Outer(Inner));
+    assert_eq!(
+        chain,
+        "error sending request: http2 error: stream error received"
+    );
+    // The whole point: the classification only works on the flattened chain,
+    // because the top-level message alone says nothing about h2.
+    assert!(!is_h2_protocol_error("error sending request"));
+    assert!(is_h2_protocol_error(&chain));
+}
+
+#[test]
+fn backoff_grows_with_the_attempt() {
+    assert_eq!(transport_backoff(1), std::time::Duration::from_millis(200));
+    assert_eq!(transport_backoff(2), std::time::Duration::from_millis(400));
+}
+
+// ─── body readability ───────────────────────────────────────────────────────
+
+#[test]
+fn text_content_types_pass() {
+    for ct in [
+        Some("text/html; charset=utf-8"),
+        Some("TEXT/PLAIN"),
+        Some("application/json"),
+        Some("application/xml"),
+        Some("application/xhtml+xml"),
+        Some("text/javascript"),
+        Some("application/x-yaml"),
+        Some("application/x-www-form-urlencoded"),
+        // No header at all is not evidence of binary, so it passes here and
+        // the mojibake check remains the backstop.
+        None,
+    ] {
+        assert!(
+            unsupported_content_type(ct).is_none(),
+            "should pass: {ct:?}"
+        );
+    }
+}
+
+#[test]
+fn binary_content_types_are_named() {
+    let reason = unsupported_content_type(Some("application/pdf")).expect("named");
+    assert!(reason.contains("application/pdf"), "{reason}");
+    assert!(reason.contains("read bytes, not a document"), "{reason}");
+    assert!(unsupported_content_type(Some("image/png")).is_some());
+    assert!(unsupported_content_type(Some("application/octet-stream")).is_some());
+}
+
+#[test]
+fn a_lossily_decoded_gzip_body_reads_as_mojibake() {
+    // What `Response::text` produces from a gzip member: the few ASCII bytes of
+    // the header survive and everything else becomes U+FFFD. finance.yahoo.com
+    // serves exactly this when the client cannot decode `Content-Encoding`.
+    let body: String = std::iter::repeat_n(char::REPLACEMENT_CHARACTER, 200).collect();
+    assert!(looks_like_mojibake(&body));
+    assert!(looks_like_mojibake(&format!("\u{1f}\u{8b}\u{8}{body}")));
+}
+
+#[test]
+fn ordinary_prose_is_not_mojibake() {
+    let prose = "Cerebras Systems introduced the CS-4, delivering 750 PFLOPS of AI \
+                 compute across three WSE-3 Turbo processors, with first shipments \
+                 beginning this quarter.";
+    assert!(!looks_like_mojibake(prose));
+    // A stray replacement character from one genuinely malformed byte is not
+    // enough: the check is a ratio precisely so this stays readable.
+    assert!(!looks_like_mojibake(&format!("{prose}\u{fffd}")));
+}
+
+#[test]
+fn short_bodies_are_never_called_mojibake() {
+    // Under the 64-char floor the ratio means nothing, and a short body has its
+    // own diagnostic in the tool script.
+    let tiny: String = std::iter::repeat_n(char::REPLACEMENT_CHARACTER, 8).collect();
+    assert!(!looks_like_mojibake(&tiny));
+    assert!(!looks_like_mojibake(""));
+}
+
+// ─── network-gated regression checks ────────────────────────────────────────
+//
+// `#[ignore]` so CI and the coverage gate never reach out. Run by hand with
+// `cargo test -p leviath-providers -- --ignored --nocapture` when touching the
+// transport. Both URLs are the ones that actually failed in
+// deep-researcher-1787212645; keeping them named is the point.
+
+#[tokio::test]
+#[ignore = "hits the live network"]
+async fn live_unsolicited_gzip_decodes_to_prose() {
+    // finance.yahoo.com answers `Content-Encoding: gzip` even when nothing
+    // asked for it. Without the reqwest gzip feature this returned a whole
+    // gzip member that `text()` decoded into U+FFFD noise, and that noise went
+    // straight into a research agent's `sources` region.
+    let client = crate::provider::build_http_client(Some(30)).expect("client builds");
+    let exec = ReqwestExecutor::new(client);
+    let body = exec
+        .execute(HostRequest {
+            method: HttpMethod::Get,
+            url: "https://finance.yahoo.com/quote/CBRS/".to_string(),
+            body: None,
+            headers: BTreeMap::new(),
+            timeout_secs: Some(30),
+        })
+        .await
+        .expect("fetch succeeds");
+    assert!(!looks_like_mojibake(&body), "body decoded to mojibake");
+    assert!(
+        body.to_lowercase().contains("cerebras"),
+        "expected readable prose, got {} chars starting {:?}",
+        body.len(),
+        body.chars().take(60).collect::<String>()
+    );
+}
+
+// ─── retry loop and body guards, end to end through the executor ────────────
+
+/// A server that kills the first `fail_first` connections without answering,
+/// then serves `body` once. Reproduces "the socket did not work this time",
+/// which is what the retry exists for.
+async fn flaky_server(fail_first: usize, body: &'static str) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let head = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\
+         Connection: close\r\n\r\n",
+        body.len()
+    );
+    tokio::spawn(async move {
+        for i in 0.. {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let mut buf = [0u8; 8192];
+            let _ = sock.read(&mut buf).await;
+            if i < fail_first {
+                // Drop mid-request: the FIN reaches reqwest as
+                // "connection closed before message completed", which is
+                // exactly the transient shape the retry is for.
+                drop(sock);
+                continue;
+            }
+            let _ = sock.write_all(head.as_bytes()).await;
+            let _ = sock.write_all(body.as_bytes()).await;
+            let _ = sock.flush().await;
+            let _ = sock.shutdown().await;
+        }
+    });
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn a_transient_transport_failure_is_retried() {
+    // Before the retry existed this was a permanently lost source: one failed
+    // send() and the URL was never read, while the bibliography still cited it.
+    let url = flaky_server(1, "recovered-body").await;
+    let out = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, url, None))
+    .await
+    .expect("the retry recovers");
+    assert_eq!(out, "recovered-body");
+}
+
+#[tokio::test]
+async fn retries_are_bounded() {
+    // One more failure than the budget allows, so the error still surfaces
+    // rather than the loop spinning.
+    let url = flaky_server(usize::MAX, "never-served").await;
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, url, None))
+    .await
+    .expect_err("gives up");
+    assert!(matches!(err, HostHttpError::Transport(_)), "{err:?}");
+}
+
+#[tokio::test]
+async fn the_h1_fallback_client_serves_the_retry() {
+    // The fallback path is only taken on an h2 fault, which a plaintext local
+    // server cannot produce, so this proves the wiring: an executor holding a
+    // fallback still succeeds normally, and `with_h1_fallback` is the
+    // constructor the runtime uses.
+    let url = flaky_server(1, "fallback-wired").await;
+    let exec = ReqwestExecutor::with_h1_fallback(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+        crate::provider::build_http1_client(None).expect("an h1 test client builds"),
+    );
+    let out = exec
+        .execute(req(HttpMethod::Get, url, None))
+        .await
+        .expect("the retry recovers");
+    assert_eq!(out, "fallback-wired");
+}
+
+#[tokio::test]
+async fn a_binary_content_type_is_refused_before_the_body_is_read() {
+    let url = mock_server("200 OK", &[("Content-Type", "application/pdf")], "%PDF-1.7").await;
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, url, None))
+    .await
+    .expect_err("refused");
+    let HostHttpError::Api(msg) = err else {
+        panic!("expected an Api error, got {err:?}");
+    };
+    assert!(msg.contains("unreadable body"), "{msg}");
+    assert!(msg.contains("application/pdf"), "{msg}");
+}
+
+#[tokio::test]
+async fn a_mojibake_body_is_refused_rather_than_returned() {
+    // A body that survived the content-type check but decoded to noise. The
+    // agent must be told the fetch failed, because it cannot tell this from a
+    // page that genuinely says very little, and will cite it either way.
+    const NOISE: &str = "\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\
+                         \u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\
+                         \u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\
+                         \u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\
+                         \u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\
+                         \u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\
+                         \u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\
+                         \u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\u{fffd}\
+                         \u{fffd}\u{fffd}";
+    let url = mock_server("200 OK", &[("Content-Type", "text/html")], NOISE).await;
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .execute(req(HttpMethod::Get, url, None))
+    .await
+    .expect_err("refused");
+    let HostHttpError::Api(msg) = err else {
+        panic!("expected an Api error, got {err:?}");
+    };
+    assert!(msg.contains("did not read the page"), "{msg}");
+}
+
+#[test]
+fn both_outbound_clients_build() {
+    assert!(crate::provider::build_http_client(Some(5)).is_ok());
+    assert!(crate::provider::build_http1_client(Some(5)).is_ok());
+}
+
+#[test]
+fn the_h1_client_is_chosen_only_after_an_h2_fault() {
+    let main = crate::provider::build_http_client(Some(5)).expect("main client builds");
+    let h1 = crate::provider::build_http1_client(Some(5)).expect("h1 client builds");
+
+    // The first attempt, and every attempt on an origin that never faulted,
+    // stays on HTTP/2 so the ordinary case keeps its multiplexing.
+    assert!(std::ptr::eq(retry_client(&main, Some(&h1), false), &main));
+    // Once an h2 fault is seen, the retry goes over HTTP/1.1.
+    assert!(std::ptr::eq(retry_client(&main, Some(&h1), true), &h1));
+    // With no fallback configured there is nothing to switch to, so the flag
+    // changes nothing rather than panicking.
+    assert!(std::ptr::eq(retry_client(&main, None, true), &main));
+    assert!(std::ptr::eq(retry_client(&main, None, false), &main));
+}
+
+#[test]
+fn the_executor_survives_losing_only_its_fallback() {
+    let ok = || crate::provider::build_http_client(Some(5)).expect("client builds");
+
+    // Both clients: the ordinary case.
+    assert!(executor_from_clients(Ok(ok()), Ok(ok())).is_ok());
+    // No HTTP/1.1 twin is a degraded executor, not a dead one - every origin
+    // that works over HTTP/2 still works, which is nearly all of them.
+    assert!(executor_from_clients(Ok(ok()), Err(crate::provider::malformed_url_error())).is_ok());
+    // No HTTPS client at all is the real failure, and it stays deferred to the
+    // moment a script provider is resolved.
+    assert!(executor_from_clients(Err(crate::provider::malformed_url_error()), Ok(ok()),).is_err());
+}

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -8,11 +8,22 @@ use super::*;
 /// the model it may emit several `tool_use` blocks per response and should batch
 /// *independent* operations - while explicitly forbidding batching of dependent
 /// ones.
-pub(crate) const BATCH_TOOL_HINT: &str = "You can call multiple tools in a single response. \
-When operations are independent (reading, editing, or writing different files, or \
-writing a file then running a command that doesn't need its output), batch them in \
-one response to cut round trips. Do NOT batch when a call depends on a previous \
-call's result, or when you must see a command's output before deciding the next step.";
+///
+/// The examples name searches and fetches first because that is where the round
+/// trips actually pile up: a batch is dispatched with `join_all`, so eight
+/// fetches finish in about the time one does (measured: six completed inside a
+/// one-second span), while the inference call between two batches costs tens of
+/// seconds. A research run that spends 27 inference calls on 36 tool calls is
+/// paying almost all of its wall clock for turns, not for the web. The old text
+/// listed only file and shell work, so the agents doing the most fetching were
+/// the ones it spoke to least.
+pub(crate) const BATCH_TOOL_HINT: &str = "You can call multiple tools in a single response, \
+and a batch runs in parallel rather than one after another. When operations are \
+independent (searching for or fetching several different URLs, reading, editing, or \
+writing different files, or writing a file then running a command that doesn't need its \
+output), batch them in one response to cut round trips. A batch of eight fetches costs \
+about what one costs. Do NOT batch when a call depends on a previous call's result, or \
+when you must see a command's output before deciding the next step.";
 
 /// What the `shell` tool actually runs on Windows, and the PowerShell commands
 /// that stand in for the POSIX ones a model reaches for by reflex. Prepended to

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -28,7 +28,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::SystemTime;
 
-use leviath_providers::rhai_provider::host::{HttpExecutor, ReqwestExecutor};
+use leviath_providers::rhai_provider::host::HttpExecutor;
 use leviath_providers::{ModelCapabilityOverride, Provider, RateLimitConfig, RhaiProvider};
 
 /// Per-provider configuration from `[model_providers.<name>]`. All fields are
@@ -178,8 +178,13 @@ impl ScriptProviderLayer {
     pub fn build_executor(
         request_timeout_secs: Option<u64>,
     ) -> std::result::Result<Arc<dyn HttpExecutor>, leviath_providers::provider::HttpError> {
-        leviath_providers::provider::build_http_client(request_timeout_secs)
-            .map(|client| Arc::new(ReqwestExecutor::new(client)) as Arc<dyn HttpExecutor>)
+        // An HTTP/1.1-only twin rides along as the retry path for origins that
+        // negotiate HTTP/2 and then fail every stream on it. Losing only the
+        // twin is a degraded executor, not a dead one.
+        leviath_providers::rhai_provider::host::executor_from_clients(
+            leviath_providers::provider::build_http_client(request_timeout_secs),
+            leviath_providers::provider::build_http1_client(request_timeout_secs),
+        )
     }
 
     /// Resolve `<name>` to its script path: an explicit `script` override


### PR DESCRIPTION
Came out of a post-mortem on `deep-researcher-1787212645-f91d3581e5eb`, which cited
fifteen sources and had never opened seven of them. Two of those seven were the primary
sources for the two things the run was actually asked about, and both were lost in the
transport rather than by the model.

## What was wrong

**`web_fetch` never retried.** One `send()`, and any transport error became the final
answer. A burst of concurrent fetches to `investors.cerebras.ai` came back
`http2 error: stream error received: unexpected internal error encountered`, and that
ended both pages. The tool script then reported "the page may be too large (>1MB) or the
request was blocked", which named neither cause, so the model concluded the source was
unreachable and wrote the citation from memory.

**Nothing bounded fan-out concurrency.** Six fetches per stage times seven workers is
most of two hundred simultaneous connections to one origin. That is what a WAF reads as
an attack, and while writing this the same host began refusing this IP over *both*
protocols, having served the URL fine an hour earlier. The unbounded concurrency is most
likely the cause of the transport failure, not a separate concern.

## What this changes

- Retry a transient transport failure twice with backoff, on both the provider-script
  path (`ReqwestExecutor`) and the tool-script path (`RealScriptIo`). Classification
  reads the flattened `source()` chain, because the h2 detail sits several links down and
  `reqwest::Error` has no public constructor, which also makes a chain string the only
  shape a test can drive.
- Pin the retry to an HTTP/1.1-only client once an h2 protocol fault is seen. A
  per-request `Version::HTTP_11` does not work: ALPN picks the protocol during the TLS
  handshake, so it takes a separate client.
- `[limits] script_http_max_per_host` (default 4, `0` unbounded) and
  `[limits] script_http_timeout_secs`. The per-host gate is a condvar permit, because
  script tools run on blocking threads with no runtime to await on. Batching is
  untouched; only requests sharing a host stagger.
- Refuse a non-text `Content-Type` or a body that decodes to mostly replacement
  characters on the provider path, matching what #0219ebac just did for tool scripts.
- `web_fetch.rhai` now names the actual cause and says outright that the fetch did not
  read the page.
- The batch hint named only file and shell work, so the agents doing the most fetching
  were the ones it spoke to least. It now names searches and fetches and says a batch
  runs in parallel. Same guidance in the three research blueprints.

## What this deliberately does not change

I measured tool parallelism before touching it, and it was already correct: every batch
in the reference run ran in parallel, in the parent and in all seven workers. Four
searches finished in the same second; six fetches inside a one-second span. `dispatch_tools`
already resolves interactive calls in order and `join_all`s the rest, and each script
tool gets a fresh Rhai engine on its own blocking thread. So nothing here tries to
"parallelize" anything that already was.

What the same measurement did show is that the run is inference-bound: 27 sequential
inference calls for 36 tool calls, with tool time inside the noise, and peak context use
at 54,952 of 1,048,576 tokens. That is why the batch-hint wording is in here: fewer,
bigger batches means fewer turns, and turns are what the wall clock is actually spent on.

## Verification

- Full workspace suite green; coverage gate at 100% for all 13 packages; clippy clean.
- The compression fix is verified against the live URL that reproduced it, as an
  `#[ignore]`d network test.
- The h2 fallback is **not** verified live. That origin now rate-limits this IP and hangs
  over both protocols, so there is nothing to assert against. Its selection and wiring
  are unit-tested instead, and I would rather say that than imply a check I did not run.

## Notes for review

- `send_with_retry` takes `&dyn Fn`, not `impl Fn`. As a generic it monomorphized per
  call site, and the copies that never ran in a given test binary counted as uncovered
  regions: a coverage failure with no uncovered *line* to point at, which took a while to
  chase down.
- The flaky-server test helper is a bounded blocking listener rather than an accept loop,
  because a spawned body that never returns leaves its own closing brace uncovered. That
  is the same reason `mock_http` hands `tokio::spawn` a future with no block of ours in it.
- Bundled agent versions are bumped because `matches_bundled` hashes `tools/` too and
  `plan_agent_actions` checks the version first, so a changed script under an unchanged
  version reads as user-modified and `lev setup` would skip it.
- **Follow-up, not done here:** `mojibake_message` in `script_host.rs` (from #0219ebac)
  and `looks_like_mojibake` in `rhai_provider/host.rs` (from this PR) are the same 10%
  rule, arrived at independently in two crates. Worth collapsing into the lower one, the
  way `error_chain` is in this PR. I left the freshly-landed one alone rather than
  refactor it inside an unrelated diff.
