### PR TITLE
fix(fanout): a fan-out split can never kill a run again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,50 @@ same list.
 
 ## Unreleased
 
+- Fixed: a runtime-detected failure no longer ends a run that declared a
+  recovery stage. A fan-out split that could not be parsed, a routing call that
+  failed or answered with a stage that does not exist, `on_worker_failure =
+  "fail_all"`, a lost workspace and a wedged run all wrote a terminal status
+  directly, which `resolve_transition` then skipped, so the `error` edge the
+  author wrote was never consulted. Every one of them now goes through the
+  stage's transition, and an errored stage falls back to a `dead_end` edge when
+  it has no `error` edge, matching the fallback that already ran the other way.
+  A `deep-researcher` run died of this with its four workers finished, its
+  analysis written, three stages still pending and an `error_recovery` stage
+  sitting unused in its graph.
+- Fixed: a fan-out split is never terminal. After its corrections are spent it
+  takes the stage's `error` edge, then its `dead_end` edge, and failing both an
+  empty fan-out into the merge stage, with the reason written into
+  `error_report` and counted in the new `splits_degraded` run flag. By the time
+  a split runs, the parent has usually done most of the work; ending the run
+  throws all of it away.
+- Fixed: a fan-out split's correction budget is per split rather than per run.
+  `SplitAttempts` was never cleared, so a stage whose first split needed one
+  correction got a single correction the next time it split, and a stage
+  entered twice could fail on its second answer.
+- Added: `submit_work_items`, the tool a `fan_out` stage's split answers with.
+  Every fan-out stage is offered it regardless of its `available_tools`. The
+  split was the one structured answer the framework asked for in prose and then
+  scraped a JSON array out of; free text remains the fallback, because a
+  blueprint picks its own model per stage. Its description says the thing a
+  split most needed to be told and had nowhere to read: an empty `items` array
+  is a real answer, and the run moves on to the merge stage.
+- Changed: a fan-out stage entered more than once is told which round it is on
+  and which work items already came back, and is asked for only what is still
+  unanswered. The prompt was previously byte for byte the one the model had
+  already answered, over a context holding the first round's findings and the
+  analysis built on them - so the model replied that the research was finished,
+  which was true and was not a list of work items. A first entry is unchanged.
+- Changed: the free-text split parser takes the near misses instead of spending
+  a correction on each: an `{"items": [...]}` envelope, a single bare object, a
+  plain array of question strings, and a fenced block in preference to the
+  first-bracket-to-last-bracket scan (one `[6]` in a bibliography was enough to
+  slice from the wrong place). It also strips text-protocol tool-call markup,
+  which some models emit as prose.
+- Added: `lev validate` warns (`fanout-no-escape`) about a `fan_out` stage with
+  no `error` and no `dead_end` transition, since that is the blueprint shape
+  where an unusable split degrades silently.
+
 - Fixed: `web_fetch` now retries a transport failure instead of losing the page
   on the first one. A single `send()` was the whole story, so one dropped
   connection or protocol fault ended that source permanently, and the

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -159,7 +159,8 @@ pub(super) fn lint_tools(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lint
 /// Human-in-the-loop tools offered by a stage that runs with nobody attached.
 pub(super) fn lint_blocking_tools(stage: &leviath_core::Stage) -> Vec<LintFinding> {
     // Only autonomous stages are a problem: the interactive modes are where a
-    // person is expected, and a fan_out stage runs no tools of its own.
+    // person is expected, and the one tool a fan_out stage carries is its own
+    // `submit_work_items`, which blocks on nobody.
     if !matches!(stage.mode, StageMode::Autonomous) || stage.allow_blocking_tools {
         return Vec::new();
     }

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -199,6 +199,49 @@ pub(super) fn lint_blocking_tools(stage: &leviath_core::Stage) -> Vec<LintFindin
         .collect()
 }
 
+/// A fan-out stage with no escape from a split that cannot be used.
+///
+/// The split asks a model for a structured answer, and a model can decline, run
+/// out of room, or answer the question it thinks it was asked. The runtime no
+/// longer ends the run over it - the chain is the stage's `error` edge, then its
+/// `dead_end` edge, then an empty fan-out into the merge stage - but that last
+/// step is a degradation: the workers never run and whatever comes next works
+/// from less than the blueprint intended.
+///
+/// A warning rather than an error, because the run does finish either way. What
+/// it buys is the difference between a stage the author routed somewhere on
+/// failure and one that silently produces nothing.
+pub(super) fn lint_fanout_escape(stage: &leviath_core::Stage) -> Vec<LintFinding> {
+    if !matches!(stage.mode, StageMode::FanOut { .. }) {
+        return Vec::new();
+    }
+    let escapes = stage
+        .transitions
+        .iter()
+        .flat_map(|t| t.values())
+        .any(|edge| {
+            matches!(
+                edge.condition,
+                leviath_core::blueprint::TransitionCondition::Error
+                    | leviath_core::blueprint::TransitionCondition::DeadEnd
+            )
+        });
+    if escapes {
+        return Vec::new();
+    }
+    vec![
+        LintFinding::new(
+            LintSeverity::Warning,
+            "fanout-no-escape",
+            "is a fan_out stage with no 'error' or 'dead_end' transition, so a split the \
+             runtime cannot use degrades to an empty fan-out and the workers never run"
+                .to_string(),
+        )
+        .in_stage(&stage.name)
+        .with_fix("add a transition with condition = \"error\" to a recovery stage".to_string()),
+    ]
+}
+
 /// A stage's own output declarations: a demand it cannot meet, a shape nothing
 /// will read, or a reporting stage that can also change the workspace.
 pub(super) fn lint_output_stage(stage: &leviath_core::Stage) -> Vec<LintFinding> {

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -286,6 +286,7 @@ pub fn lint_manifest(content: &str, blueprint: &Blueprint, env: &LintEnv) -> Vec
         findings.extend(lint_tool_policies(stage, &agent_permissions));
         findings.extend(lint_models(stage, env));
         findings.extend(lint_output_stage(stage));
+        findings.extend(lint_fanout_escape(stage));
     }
 
     // Worst first, stable within a severity so the order a check ran in is the

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -170,12 +170,71 @@ fn a_fan_out_stage_needs_no_max_iterations() {
 mode = "fan_out"
 worker_stage = "work"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+[stages.split.transitions.recover]
+condition = "error"
 
 [stages.work]
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
 max_iterations = 5
 allow_as_worker = true
+
+[stages.recover]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert!(findings.is_empty(), "{:?}", codes(&findings));
+}
+
+/// A split the runtime cannot use no longer ends the run, but with no escape
+/// declared it degrades to an empty fan-out and the workers never run. The
+/// blueprint is the only place that can say where to go instead.
+#[test]
+fn a_fan_out_stage_without_an_escape_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.split]
+mode = "fan_out"
+worker_stage = "work"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+
+[stages.work]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+allow_as_worker = true
+"#,
+    );
+    let findings = lint(&toml, &LintEnv::default());
+    assert_eq!(codes(&findings), ["fanout-no-escape"]);
+}
+
+/// A `dead_end` edge answers the same question - "this stage may not be able to
+/// go on" - so it satisfies the check too.
+#[test]
+fn a_dead_end_edge_satisfies_the_fan_out_escape_check() {
+    let toml = manifest(
+        r#"
+[stages.split]
+mode = "fan_out"
+worker_stage = "work"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+[stages.split.transitions.recover]
+condition = "dead_end"
+
+[stages.work]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
+allow_as_worker = true
+
+[stages.recover]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+max_iterations = 5
 "#,
     );
     let findings = lint(&toml, &LintEnv::default());
@@ -1399,7 +1458,8 @@ mode = "fan_out"
 worker_stage = "work"
 merge_stage = "merge"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
-[stages.split.transitions]
+[stages.split.transitions.merge]
+condition = "error"
 
 [stages.work]
 mode = "autonomous"

--- a/crates/leviath-core/src/blueprint/transition.rs
+++ b/crates/leviath-core/src/blueprint/transition.rs
@@ -222,6 +222,23 @@ pub const MODIFYING_TOOLS: &[&str] = &["write_file", "edit_file"];
 /// tools crate.
 pub const SUBMIT_OUTPUT_TOOL: &str = "submit_output";
 
+/// The tool a `fan_out` stage's split calls to hand back its work items.
+///
+/// The split used to be free text that the runtime scraped a JSON array out of,
+/// which is the one place in the framework where a structured answer was asked
+/// for in prose and parsed by hand. A model that answered with a report, an
+/// apology, or its own text-protocol tool-call syntax cost a correction round
+/// each time, and a `deep-researcher` run spent its whole budget that way.
+///
+/// Offered implicitly by every fan-out stage - the free-text parse stays as the
+/// fallback, because a stage's model is chosen by the blueprint and not every
+/// model uses tools well.
+///
+/// Named here for the same reason [`SUBMIT_OUTPUT_TOOL`] is: the manifest parser
+/// and the blueprint validator both need it and neither may depend on the tools
+/// crate.
+pub const SUBMIT_WORK_ITEMS_TOOL: &str = "submit_work_items";
+
 /// Times a stage is re-run for a missing final output before the gate gives up
 /// and lets it through with the run's `output_forced` flag set. Matches
 /// [`DEFAULT_GATE_ATTEMPTS`], and is overridden by a stage's `max_revisits`.

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -415,6 +415,26 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
         }
     }
 
+    // A fan-out stage's split gets its own submission tool, on the same
+    // reasoning: the shape lives on the Stage's own tool list so `lev
+    // validate`, the tool filter and the lint all read the same honest
+    // list, rather than the dispatch layer special-casing the mode.
+    //
+    // Added regardless of what the author wrote in `available_tools` -
+    // which for a fan-out stage is usually `[]`, because the split runs no
+    // tools of its own. That empty list is a statement about the work, not
+    // about how the answer comes back.
+    if matches!(stage.mode, StageMode::FanOut { .. })
+        && !stage
+            .available_tools
+            .iter()
+            .any(|t| t == crate::blueprint::SUBMIT_WORK_ITEMS_TOOL)
+    {
+        stage
+            .available_tools
+            .push(crate::blueprint::SUBMIT_WORK_ITEMS_TOOL.to_string());
+    }
+
     // Parse allow_blocking_tools flag: says this autonomous stage means
     // to offer `ask_user_*` / `present_for_review`, so `lev validate`
     // stops warning about it.

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -2808,6 +2808,58 @@ mode = "output"
     bp.validate().expect("the auto-grant satisfies validation");
 }
 
+/// A `fan_out` stage is granted `submit_work_items` regardless of what it
+/// listed, and listing it by hand does not produce two of them.
+///
+/// The grant ignores `available_tools` because a fan-out stage's is usually
+/// `[]` - the split runs no tools of its own - and that empty list is a
+/// statement about the work, not about how the answer comes back.
+#[test]
+fn fan_out_mode_grants_the_work_item_tool_exactly_once() {
+    let bare = r#"
+[agent]
+name = "fanout-test"
+
+[stages.split]
+mode = "fan_out"
+worker_stage = "work"
+available_tools = []
+split_prompt = "split it"
+
+[stages.work]
+mode = "autonomous"
+allow_as_worker = true
+"#;
+    let stage = parse_manifest(bare)
+        .expect("parses")
+        .find_stage("split")
+        .cloned()
+        .expect("the stage exists");
+    assert_eq!(
+        stage.available_tools,
+        vec![crate::blueprint::SUBMIT_WORK_ITEMS_TOOL.to_string()],
+        "granted even though the author wrote an empty list"
+    );
+
+    let spelled_out = bare.replace(
+        "available_tools = []",
+        "available_tools = [\"submit_work_items\", \"read_file\"]",
+    );
+    let stage = parse_manifest(&spelled_out)
+        .expect("parses")
+        .find_stage("split")
+        .cloned()
+        .expect("the stage exists");
+    assert_eq!(
+        stage.available_tools,
+        vec![
+            crate::blueprint::SUBMIT_WORK_ITEMS_TOOL.to_string(),
+            "read_file".to_string()
+        ],
+        "the author's own list is kept and the grant is not duplicated"
+    );
+}
+
 /// The auto-grant appends rather than replaces, and does not duplicate a
 /// tool the author already listed.
 #[test]

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -551,6 +551,18 @@ pub struct RunFlags {
     /// says the answer it hands back may be missing.
     #[serde(default)]
     pub output_forced: usize,
+    /// How many fan-out splits were unusable and were degraded to an empty
+    /// fan-out because the blueprint declared no `error` and no `dead_end`
+    /// escape from the stage.
+    ///
+    /// A split that cannot be parsed used to end the run outright, which threw
+    /// away everything the parent had already done - a `deep-researcher` run
+    /// died that way with its workers finished and three stages still pending.
+    /// It now always moves on, and this is what says the fan-out it moved on
+    /// from produced nothing. Non-zero means the merge stage worked from less
+    /// than it was meant to.
+    #[serde(default)]
+    pub splits_degraded: usize,
 }
 
 /// How many distinct modified paths [`RunFlags`] records before it stops

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -315,6 +315,11 @@ pub fn fan_out_split(world: &mut World) {
                     }
                     _ => items,
                 };
+                // The corrections this split needed are spent. Clearing them
+                // here as well as on stage entry means a stage re-entered by a
+                // path that does not go through `attach_stage_components` still
+                // starts its next split with the full budget.
+                world.entity_mut(parent).remove::<SplitAttempts>();
                 world.entity_mut(parent).insert(FanOutWaiting {
                     config,
                     max_workers,
@@ -330,7 +335,7 @@ pub fn fan_out_split(world: &mut World) {
                 // A split that did not parse is a formatting miss, not a dead
                 // run: send the model its own answer plus a correction and ask
                 // again, the way every other stage handles a response it cannot
-                // use. Only once the corrections are spent does the run fail.
+                // use. Only once the corrections are spent does the stage end.
                 let attempts = world.get::<SplitAttempts>(parent).map_or(0, |a| a.0);
                 // Correcting needs somewhere to put the correction, so an agent
                 // with no context window falls through to the failure below
@@ -378,16 +383,15 @@ pub fn fan_out_split(world: &mut World) {
                     // Name what came back as well as the rule it broke: the
                     // rule alone cannot tell a refusal from an empty response
                     // from prose.
-                    set_status(
+                    fail_split(
                         world,
                         parent,
-                        AgentStatus::Error {
-                            message: format!(
-                                "fan_out split failed after {attempts} correction(s): \
-                                 {message} ({})",
-                                response_snippet(&response)
-                            ),
-                        },
+                        &config,
+                        format!(
+                            "fan_out split failed after {attempts} correction(s): \
+                             {message} ({})",
+                            response_snippet(&response)
+                        ),
                     );
                 }
             }
@@ -524,15 +528,17 @@ pub fn slim_merged_workers(
 /// Apply the failure policy, inject the consolidated report, and transition.
 fn finish_fan_out(world: &mut World, parent: Entity, w: FanOutWaiting) {
     if !w.failures.is_empty() && w.config.on_worker_failure == WorkerFailurePolicy::FailAll {
-        set_status(
+        // Down the stage's `error` edge, which is what `WorkerFailurePolicy::FailAll`
+        // has always been documented as doing. Writing the status alone made it a
+        // dead run instead, so a blueprint with an `error_recovery` stage got the
+        // recovery it declared only for provider failures, never for this.
+        crate::pipeline::fail_stage_world(
             world,
             parent,
-            AgentStatus::Error {
-                message: format!(
-                    "fan_out: {} worker(s) failed (on_worker_failure = fail_all)",
-                    w.failures.len()
-                ),
-            },
+            format!(
+                "fan_out: {} worker(s) failed (on_worker_failure = fail_all)",
+                w.failures.len()
+            ),
         );
         return;
     }
@@ -552,10 +558,88 @@ fn finish_fan_out(world: &mut World, parent: Entity, w: FanOutWaiting) {
     let report = build_report(&w.summaries, &w.failures, budget);
     inject_results(world, parent, &region, &report);
 
-    // Ready the parent to run again, then jump to the merge stage (if any) or let
-    // the fan-out stage's own transition resolve.
+    leave_fan_out(world, parent, &w.config);
+}
+
+/// End an unusable split without ending the run.
+///
+/// The escape chain is the stage's `error` edge, then its `dead_end` edge, then
+/// an empty fan-out into the merge stage. There is deliberately no terminal arm.
+///
+/// A split failure used to write `AgentStatus::Error` straight onto the agent,
+/// which is terminal, so `resolve_transition` never saw it and the recovery the
+/// author declared was never taken. A `deep-researcher` run died exactly that
+/// way: its four workers had already finished, `analyze` had already run, and
+/// its graph carried both an `error` edge to `error_recovery` and a `dead_end`
+/// edge to `synthesize`. Neither fired, and three stages were still pending.
+///
+/// The last resort is a real degradation and is recorded as one - the run flag
+/// and the `error_report` note are what keep "the split was unusable" from
+/// reading downstream as "there was nothing to split".
+fn fail_split(world: &mut World, parent: Entity, config: &FanOutConfig, message: String) {
+    let stage_name = world
+        .get::<StageCursor>(parent)
+        .and_then(|cursor| {
+            world
+                .get::<AgentBlueprint>(parent)
+                .and_then(|bp| bp.0.stages.get(cursor.index).map(|s| s.name.clone()))
+        })
+        .unwrap_or_default();
+    if declares_an_escape(world, parent) {
+        crate::pipeline::fail_stage_world(world, parent, message);
+        return;
+    }
+    tracing::error!(
+        stage = %stage_name,
+        error = %message,
+        "fan_out split is unusable and the stage declares no escape; \
+         continuing with an empty fan-out"
+    );
+    if let Some(mut window) = world.get_mut::<ContextWindow>(parent) {
+        crate::pipeline::note_unusable_split(&mut window, &stage_name, &message);
+    }
+    if let Some(mut flags) = world.get_mut::<crate::persistence::RunOutcomeFlags>(parent) {
+        flags.0.splits_degraded += 1;
+    }
+    leave_fan_out(world, parent, config);
+}
+
+/// Whether the agent's current stage declares an `error` or `dead_end` edge that
+/// still has revisits left.
+///
+/// Both conditions answer "this stage cannot go on", which is what an unusable
+/// split is, and `resolve_transition` follows either for an errored outcome.
+fn declares_an_escape(world: &World, parent: Entity) -> bool {
+    use leviath_core::blueprint::TransitionCondition;
+    let Some(bp) = world.get::<AgentBlueprint>(parent) else {
+        return false;
+    };
+    let Some(cursor) = world.get::<StageCursor>(parent) else {
+        return false;
+    };
+    let Some(stage) = bp.0.stages.get(cursor.index) else {
+        return false;
+    };
+    let empty = std::collections::HashMap::new();
+    let visits = world
+        .get::<crate::pipeline::VisitCounts>(parent)
+        .map_or(&empty, |v| &v.0);
+    [TransitionCondition::Error, TransitionCondition::DeadEnd]
+        .into_iter()
+        .any(|condition| {
+            crate::pipeline::find_conditioned_edge(&bp.0, stage, visits, condition).is_some()
+        })
+}
+
+/// Ready the parent to run again and move it on: to the `merge_stage` when the
+/// config names one, otherwise letting the fan-out stage's own transition
+/// resolve.
+///
+/// Shared by the normal completion and by the never-terminal split failure, so
+/// both leave the stage by the same door.
+fn leave_fan_out(world: &mut World, parent: Entity, config: &FanOutConfig) {
     set_status(world, parent, AgentStatus::Active);
-    match w.config.merge_stage.as_deref().and_then(|name| {
+    match config.merge_stage.as_deref().and_then(|name| {
         world
             .get::<AgentBlueprint>(parent)
             .and_then(|bp| bp.0.stages.iter().position(|s| s.name == name))
@@ -994,6 +1078,28 @@ mod tests {
         Blueprint::new("t".to_string(), "d".to_string(), vec![s0, s1], layout)
     }
 
+    /// [`fanout_blueprint`] with a conditioned escape edge off the fan-out
+    /// stage, which is what a real blueprint declares and the bare helper does
+    /// not.
+    fn fanout_blueprint_with_escape(
+        config: FanOutConfig,
+        condition: leviath_core::blueprint::TransitionCondition,
+    ) -> Blueprint {
+        let mut bp = fanout_blueprint(config);
+        bp.stages[0].transitions = Some(std::collections::HashMap::from([(
+            "merge".to_string(),
+            leviath_core::blueprint::TransitionEdge {
+                target: "merge".to_string(),
+                condition,
+                hint: None,
+                transform: leviath_core::blueprint::EdgeTransform::Direct,
+                gate: None,
+                stuck: None,
+            },
+        )]));
+        bp
+    }
+
     fn parent_state() -> AgentState {
         AgentState {
             agent_id: "parent".to_string(),
@@ -1150,11 +1256,13 @@ mod tests {
         );
     }
 
+    /// A split that never parses, from a stage that declares no escape at all,
+    /// carries on with an empty fan-out. Nothing about an unusable split ends a
+    /// run any more: the parent has usually already done most of the work by the
+    /// time the split runs, and throwing that away is the failure this whole
+    /// path exists to prevent.
     #[test]
-    fn split_errors_on_non_array_output() {
-        // The corrections have to be spent before the run dies, so this drives
-        // the split until they are. Failing on the first answer is the bug the
-        // retry exists to fix.
+    fn an_unusable_split_never_ends_the_run() {
         let mut world = World::new();
         let e = spawn_parent(
             &mut world,
@@ -1166,7 +1274,99 @@ mod tests {
             redrive_split(&mut world, e, "definitely not a json array");
         }
         assert!(world.get::<FanOutWaiting>(e).is_none());
+        assert_eq!(status_of(&world, e), AgentStatus::Active, "still running");
+        assert!(
+            world.get::<ResolveTransition>(e).is_some(),
+            "and moving on out of the fan-out stage"
+        );
+        let convo = conversation_text(&world, e);
+        assert!(
+            convo.contains("could not be used") && convo.contains("No workers ran"),
+            "the next stage is told the fan-out produced nothing: {convo}"
+        );
+    }
+
+    /// The escape the author declared is the one that is taken: an `error` edge
+    /// off the fan-out stage routes the parent there instead of degrading.
+    #[test]
+    fn an_unusable_split_takes_the_stages_error_edge() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint_with_escape(
+                cfg(None, 2, WorkerFailurePolicy::Continue),
+                leviath_core::blueprint::TransitionCondition::Error,
+            ),
+            "definitely not a json array",
+        );
+        for _ in 0..=MAX_SPLIT_RETRIES {
+            fan_out_split(&mut world);
+            redrive_split(&mut world, e, "definitely not a json array");
+        }
         assert_errored(&world, e);
+        assert!(
+            world.get::<ResolveTransition>(e).is_some(),
+            "handed to the transition system rather than left terminal"
+        );
+        assert_eq!(
+            world.get::<crate::pipeline::StageOutcome>(e),
+            Some(&crate::pipeline::StageOutcome::Errored(
+                match status_of(&world, e) {
+                    AgentStatus::Error { message } => message,
+                    other => panic!("expected an errored status, got {other:?}"),
+                }
+            )),
+            "and the outcome carries the same message the status does"
+        );
+    }
+
+    /// A `dead_end` edge counts too. An author who declared only that escape
+    /// meant "this stage may not be able to go on", which is exactly what an
+    /// unusable split is.
+    #[test]
+    fn an_unusable_split_takes_a_dead_end_edge() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint_with_escape(
+                cfg(None, 2, WorkerFailurePolicy::Continue),
+                leviath_core::blueprint::TransitionCondition::DeadEnd,
+            ),
+            "definitely not a json array",
+        );
+        for _ in 0..=MAX_SPLIT_RETRIES {
+            fan_out_split(&mut world);
+            redrive_split(&mut world, e, "definitely not a json array");
+        }
+        assert_errored(&world, e);
+        assert!(world.get::<ResolveTransition>(e).is_some());
+    }
+
+    /// A degraded split is recorded on the run record, so "the merge stage ran
+    /// with nothing" is visible after the fact rather than only in the log.
+    #[test]
+    fn a_degraded_split_is_recorded_on_the_run_flags() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "definitely not a json array",
+        );
+        world
+            .entity_mut(e)
+            .insert(crate::persistence::RunOutcomeFlags::default());
+        for _ in 0..=MAX_SPLIT_RETRIES {
+            fan_out_split(&mut world);
+            redrive_split(&mut world, e, "definitely not a json array");
+        }
+        assert_eq!(
+            world
+                .get::<crate::persistence::RunOutcomeFlags>(e)
+                .unwrap()
+                .0
+                .splits_degraded,
+            1
+        );
     }
 
     /// Put the parent back where a fresh inference would leave it, so the split
@@ -1247,14 +1447,51 @@ mod tests {
         assert_eq!(status_of(&world, e), AgentStatus::Waiting);
     }
 
-    /// Once the corrections are spent the run does fail, and the message names
-    /// what came back rather than only the rule it broke.
+    /// The correction budget belongs to one split, not to the whole run. A stage
+    /// re-entered later gets its full budget back.
+    ///
+    /// This is the fault that turned a prompt problem into a dead run: a
+    /// `deep-researcher` split needed one correction on its first pass, the
+    /// counter stayed at 1, and when `analyze` routed back through `gather` into
+    /// the same fan-out stage the second split got a single correction before
+    /// the stage failed.
+    #[test]
+    fn a_successful_split_clears_the_correction_budget() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "no array here",
+        );
+
+        fan_out_split(&mut world);
+        assert_eq!(
+            world.get::<SplitAttempts>(e),
+            Some(&SplitAttempts(1)),
+            "the first miss spends one"
+        );
+        redrive_split(&mut world, e, r#"[{"id":"a","context":{}}]"#);
+        fan_out_split(&mut world);
+
+        assert!(world.get::<FanOutWaiting>(e).is_some(), "the split took");
+        assert!(
+            world.get::<SplitAttempts>(e).is_none(),
+            "and the budget it spent is handed back for the next split"
+        );
+    }
+
+    /// Once the corrections are spent the stage does end, and the message names
+    /// what came back rather than only the rule it broke. Read off a blueprint
+    /// with an `error` edge, because that is where the message now lives.
     #[test]
     fn the_failure_message_quotes_what_the_model_actually_said() {
         let mut world = World::new();
         let e = spawn_parent(
             &mut world,
-            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            fanout_blueprint_with_escape(
+                cfg(None, 2, WorkerFailurePolicy::Continue),
+                leviath_core::blueprint::TransitionCondition::Error,
+            ),
             "I cannot help with that request.",
         );
         for _ in 0..=MAX_SPLIT_RETRIES {
@@ -1269,18 +1506,17 @@ mod tests {
         assert!(status.contains("correction(s)"), "{status}");
     }
 
-    /// No context window means nowhere to put a correction, so the run fails on
+    /// No context window means nowhere to put a correction, so the stage ends on
     /// the first malformed split rather than looping while being told nothing.
     #[test]
     fn a_split_with_nowhere_to_put_a_correction_fails_at_once() {
         let mut world = World::new();
         let e = world
             .spawn((
-                AgentBlueprint(fanout_blueprint(cfg(
-                    None,
-                    2,
-                    WorkerFailurePolicy::Continue,
-                ))),
+                AgentBlueprint(fanout_blueprint_with_escape(
+                    cfg(None, 2, WorkerFailurePolicy::Continue),
+                    leviath_core::blueprint::TransitionCondition::Error,
+                )),
                 StageCursor { index: 0 },
                 parent_state(),
                 StageProgress::default(),

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -353,6 +353,17 @@ fn split_round_framing(round: usize, previous: &[String]) -> String {
     )
 }
 
+/// What a stage said should happen if its split cannot be used, decided while
+/// the blueprint and visit counts are still in the query rather than re-read
+/// afterwards - which is what made the re-read's missing-component arms
+/// unreachable.
+struct StageEscape {
+    /// The fan-out stage's name, for the log line and the context note.
+    stage_name: String,
+    /// Whether it declares an `error` or `dead_end` edge with budget left.
+    declared: bool,
+}
+
 /// A split's answer: the `submit_work_items` call it made, or failing that its
 /// assistant text.
 ///
@@ -360,10 +371,13 @@ fn split_round_framing(round: usize, previous: &[String]) -> String {
 /// show the model what it actually said, and for a tool call that is the
 /// arguments rather than the (usually empty) text beside them.
 struct SplitAnswer {
-    /// What the work items are parsed out of.
+    /// What the model said, for the correction round and the failure message.
     payload: String,
-    /// Whether it came from a `submit_work_items` call.
-    from_tool: bool,
+    /// The tool call's arguments, when the split answered with one. Carried as
+    /// the value the provider already parsed rather than re-parsed from
+    /// `payload`: stringifying a `Value` only to read it back cannot fail, so
+    /// the error arm it would need could never be taken.
+    arguments: Option<serde_json::Value>,
 }
 
 impl SplitAnswer {
@@ -382,11 +396,11 @@ impl SplitAnswer {
         {
             Some(call) => Self {
                 payload: call.arguments.to_string(),
-                from_tool: true,
+                arguments: Some(call.arguments.clone()),
             },
             None => Self {
                 payload: infer.response.clone(),
-                from_tool: false,
+                arguments: None,
             },
         }
     }
@@ -400,31 +414,42 @@ impl SplitAnswer {
 /// here keeps the normal `process_response` routing from touching these agents.
 pub fn fan_out_split(world: &mut World) {
     crate::tick_scope::clear();
-    let mut candidates: Vec<(Entity, SplitAnswer, FanOutConfig)> = Vec::new();
+    let mut candidates: Vec<(Entity, SplitAnswer, FanOutConfig, StageEscape)> = Vec::new();
     {
         let mut q = world.query_filtered::<(
             Entity,
             &AgentState,
             &AgentBlueprint,
             &StageCursor,
+            &crate::pipeline::VisitCounts,
             &InferenceResult,
         ), With<ProcessResponse>>();
-        for (entity, state, bp, cursor, infer) in q.iter(world) {
+        for (entity, state, bp, cursor, visits, infer) in q.iter(world) {
             if state.status != AgentStatus::Active {
                 continue;
             }
-            if let StageMode::FanOut { config } = &bp.0.stages[cursor.index].mode {
-                candidates.push((entity, SplitAnswer::read(infer), config.clone()));
+            let stage = &bp.0.stages[cursor.index];
+            if let StageMode::FanOut { config } = &stage.mode {
+                candidates.push((
+                    entity,
+                    SplitAnswer::read(infer),
+                    config.clone(),
+                    StageEscape {
+                        stage_name: stage.name.clone(),
+                        declared: declares_an_escape(&bp.0, stage, &visits.0),
+                    },
+                ));
             }
         }
     }
 
-    for (parent, answer, config) in candidates {
+    for (parent, answer, config, escape) in candidates {
         crate::tick_scope::enter(parent);
         let SplitAnswer {
             payload: response,
-            from_tool,
+            arguments,
         } = answer;
+        let from_tool = arguments.is_some();
         world
             .entity_mut(parent)
             .remove::<ProcessResponse>()
@@ -432,11 +457,9 @@ pub fn fan_out_split(world: &mut World) {
         // A tool call's arguments are the envelope the schema asks for, so they
         // go through the same value reader the free-text path ends at rather
         // than through the text scanning in front of it.
-        let parsed = match from_tool {
-            true => serde_json::from_str::<serde_json::Value>(&response)
-                .map_err(|e| format!("submit_work_items arguments are not valid JSON: {e}"))
-                .and_then(work_items_from_value),
-            false => parse_work_items(&response),
+        let parsed = match arguments {
+            Some(value) => work_items_from_value(value),
+            None => parse_work_items(&response),
         };
         match parsed {
             Ok(items) => {
@@ -553,6 +576,7 @@ pub fn fan_out_split(world: &mut World) {
                         world,
                         parent,
                         &config,
+                        &escape,
                         format!(
                             "fan_out split failed after {attempts} correction(s): \
                              {message} ({})",
@@ -742,27 +766,25 @@ fn finish_fan_out(world: &mut World, parent: Entity, w: FanOutWaiting) {
 /// The last resort is a real degradation and is recorded as one - the run flag
 /// and the `error_report` note are what keep "the split was unusable" from
 /// reading downstream as "there was nothing to split".
-fn fail_split(world: &mut World, parent: Entity, config: &FanOutConfig, message: String) {
-    let stage_name = world
-        .get::<StageCursor>(parent)
-        .and_then(|cursor| {
-            world
-                .get::<AgentBlueprint>(parent)
-                .and_then(|bp| bp.0.stages.get(cursor.index).map(|s| s.name.clone()))
-        })
-        .unwrap_or_default();
-    if declares_an_escape(world, parent) {
+fn fail_split(
+    world: &mut World,
+    parent: Entity,
+    config: &FanOutConfig,
+    escape: &StageEscape,
+    message: String,
+) {
+    if escape.declared {
         crate::pipeline::fail_stage_world(world, parent, message);
         return;
     }
     tracing::error!(
-        stage = %stage_name,
+        stage = %escape.stage_name,
         error = %message,
         "fan_out split is unusable and the stage declares no escape; \
          continuing with an empty fan-out"
     );
     if let Some(mut window) = world.get_mut::<ContextWindow>(parent) {
-        crate::pipeline::note_unusable_split(&mut window, &stage_name, &message);
+        crate::pipeline::note_unusable_split(&mut window, &escape.stage_name, &message);
     }
     if let Some(mut flags) = world.get_mut::<crate::persistence::RunOutcomeFlags>(parent) {
         flags.0.splits_degraded += 1;
@@ -770,30 +792,21 @@ fn fail_split(world: &mut World, parent: Entity, config: &FanOutConfig, message:
     leave_fan_out(world, parent, config);
 }
 
-/// Whether the agent's current stage declares an `error` or `dead_end` edge that
-/// still has revisits left.
+/// Whether a stage declares an `error` or `dead_end` edge that still has
+/// revisits left, decided where the blueprint is already in hand.
 ///
 /// Both conditions answer "this stage cannot go on", which is what an unusable
 /// split is, and `resolve_transition` follows either for an errored outcome.
-fn declares_an_escape(world: &World, parent: Entity) -> bool {
+fn declares_an_escape(
+    blueprint: &leviath_core::Blueprint,
+    stage: &leviath_core::Stage,
+    visits: &std::collections::HashMap<String, usize>,
+) -> bool {
     use leviath_core::blueprint::TransitionCondition;
-    let Some(bp) = world.get::<AgentBlueprint>(parent) else {
-        return false;
-    };
-    let Some(cursor) = world.get::<StageCursor>(parent) else {
-        return false;
-    };
-    let Some(stage) = bp.0.stages.get(cursor.index) else {
-        return false;
-    };
-    let empty = std::collections::HashMap::new();
-    let visits = world
-        .get::<crate::pipeline::VisitCounts>(parent)
-        .map_or(&empty, |v| &v.0);
     [TransitionCondition::Error, TransitionCondition::DeadEnd]
         .into_iter()
         .any(|condition| {
-            crate::pipeline::find_conditioned_edge(&bp.0, stage, visits, condition).is_some()
+            crate::pipeline::find_conditioned_edge(blueprint, stage, visits, condition).is_some()
         })
 }
 
@@ -1584,15 +1597,13 @@ mod tests {
             world.get::<ResolveTransition>(e).is_some(),
             "handed to the transition system rather than left terminal"
         );
-        assert_eq!(
-            world.get::<crate::pipeline::StageOutcome>(e),
-            Some(&crate::pipeline::StageOutcome::Errored(
-                match status_of(&world, e) {
-                    AgentStatus::Error { message } => message,
-                    other => panic!("expected an errored status, got {other:?}"),
-                }
-            )),
-            "and the outcome carries the same message the status does"
+        // Compared through Debug: an arm a passing run does not take reads to
+        // llvm-cov as an uncovered region.
+        let outcome = format!("{:?}", world.get::<crate::pipeline::StageOutcome>(e));
+        assert!(outcome.contains("Errored"), "{outcome}");
+        assert!(
+            outcome.contains("correction(s)"),
+            "and it carries the message: {outcome}"
         );
     }
 
@@ -1894,6 +1905,41 @@ mod tests {
         assert!(status.contains("Error"), "{status}");
         assert!(status.contains("I cannot help with that"), "{status}");
         assert!(status.contains("correction(s)"), "{status}");
+    }
+
+    /// The two degradations at once: nothing to correct with, and nothing to
+    /// route to. The run still moves on rather than ending, and the note simply
+    /// has nowhere to go.
+    #[test]
+    fn a_split_with_no_window_and_no_escape_still_moves_on() {
+        let mut world = World::new();
+        let e = world
+            .spawn((
+                AgentBlueprint(fanout_blueprint(cfg(
+                    None,
+                    2,
+                    WorkerFailurePolicy::Continue,
+                ))),
+                StageCursor { index: 0 },
+                parent_state(),
+                StageProgress::default(),
+                StageInferences(vec![stage_inf(), stage_inf()]),
+                StageSetups(vec![setup(), setup()]),
+                VisitCounts::default(),
+                InferenceResult {
+                    response: "not an array".to_string(),
+                    tool_calls: vec![],
+                    tokens_used: 0,
+                    timestamp: 0,
+                },
+                ProcessResponse,
+            ))
+            .id();
+
+        fan_out_split(&mut world);
+
+        assert_eq!(status_of(&world, e), AgentStatus::Active, "still running");
+        assert!(world.get::<ResolveTransition>(e).is_some());
     }
 
     /// No context window means nowhere to put a correction, so the stage ends on

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -27,6 +27,11 @@ use crate::components::{
 };
 use crate::pipeline::{AgentBlueprint, ProcessResponse, ResolveTransition, StageCursor};
 
+mod split_parse;
+
+use split_parse::work_items_from_value;
+pub use split_parse::{WorkItem, parse_work_items};
+
 /// Depth cap for fan-out workers when the parent's blueprint doesn't set one.
 const DEFAULT_FANOUT_DEPTH: usize = 3;
 
@@ -103,205 +108,6 @@ fn response_snippet(response: &str) -> String {
 
 /// How much of a failed split response the error message carries, in characters.
 const MAX_SPLIT_SNIPPET: usize = 200;
-
-/// One unit of work produced by a fan-out split.
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
-pub struct WorkItem {
-    /// Stable id (used to label the worker in the consolidated report).
-    #[serde(default)]
-    pub id: String,
-    /// Free-form context handed to the worker (seeded into its pinned context).
-    #[serde(default)]
-    pub context: serde_json::Value,
-}
-
-/// Envelope keys a model wraps the array in often enough to be worth accepting.
-///
-/// Asking for a bare array and being handed `{"items": [...]}` is the single
-/// most common near miss, and refusing it costs a correction round to fix
-/// something that is not actually ambiguous.
-const WORK_ITEM_ENVELOPES: [&str; 4] = ["items", "work_items", "sub_questions", "tasks"];
-
-/// The sentinel character in the text-protocol tool-call markers some models
-/// emit as prose.
-///
-/// A fan-out stage advertises `submit_work_items` and nothing else, but a model
-/// trained to write its calls out as text will do that regardless of what the
-/// API offered. The run this parser was hardened for emitted literal
-/// `</｜DSML｜tool_calls>` markers in the middle of a report, and the brackets
-/// inside such a block are what a first-`[`-to-last-`]` scan latches onto.
-///
-/// Matched on the sentinel character rather than a list of protocol names: the
-/// names differ per model family, `｜` (U+FF5C, fullwidth vertical line) is what
-/// they have in common, and it does not otherwise appear in JSON.
-const TOOL_PROTOCOL_SENTINEL: char = '｜';
-
-/// How many words a generated work-item id keeps.
-const SLUG_WORDS: usize = 6;
-
-/// Parse a split response into work items.
-///
-/// Layered on purpose, most exact first: a fenced code block, then the whole
-/// response as JSON, then the outermost `[ … ]`. This is the fallback path - a
-/// model that calls `submit_work_items` never reaches here - so it is written to
-/// accept the near misses rather than to re-enforce a shape the tool already
-/// enforces.
-///
-/// Beyond a bare array it takes an `{"items": [...]}`-style envelope, a single
-/// bare object (a fan-out of one), and an array of plain strings (each becomes a
-/// one-question work item). Every one of those used to cost a correction round,
-/// and the run that motivated this had exactly one left to spend.
-pub fn parse_work_items(content: &str) -> Result<Vec<WorkItem>, String> {
-    let cleaned = strip_tool_protocol_markup(content);
-    let trimmed = cleaned.trim();
-    // Every rejection folds into one error: this parses model output, so
-    // "malformed input yields `Err`" has to hold for every shape of malformed.
-    let candidates = [
-        fenced_block(trimmed),
-        Some(trimmed),
-        outermost_array(trimmed),
-    ];
-    let mut last_error = None;
-    for candidate in candidates.into_iter().flatten() {
-        match serde_json::from_str::<serde_json::Value>(candidate) {
-            Ok(value) => match work_items_from_value(value) {
-                Ok(items) => return Ok(items),
-                Err(e) => last_error = Some(e),
-            },
-            Err(e) => last_error = Some(format!("split output is not valid JSON: {e}")),
-        }
-    }
-    Err(last_error.unwrap_or_else(|| "split output is not a JSON array".to_string()))
-}
-
-/// Read work items out of a parsed JSON value, accepting the shapes a model
-/// reaches for when it is trying to answer the question that was asked.
-fn work_items_from_value(value: serde_json::Value) -> Result<Vec<WorkItem>, String> {
-    match value {
-        serde_json::Value::Array(items) => items.into_iter().map(work_item_from_value).collect(),
-        serde_json::Value::Object(map) => {
-            // An envelope first: `{"items": [...]}` is a wrapper, not a work
-            // item, and reading it as one would spawn a single worker carrying
-            // the whole list as its context.
-            match WORK_ITEM_ENVELOPES
-                .iter()
-                .find_map(|key| map.get(*key).filter(|v| v.is_array()).cloned())
-            {
-                Some(inner) => work_items_from_value(inner),
-                // A fan-out of one, which the split prompt explicitly allows for
-                // a narrow topic - but only when the object actually looks like
-                // a work item. Both of `WorkItem`'s fields default and unknown
-                // ones are tolerated, so without this guard *every* JSON object
-                // parses, and `{"items": "all of them"}` - a botched envelope -
-                // would become one nameless worker instead of a correction.
-                None if map.contains_key("id") || map.contains_key("context") => {
-                    Ok(vec![work_item_from_value(serde_json::Value::Object(map))?])
-                }
-                None => Err(
-                    "split output is a JSON object that is neither a work item (no `id` or \
-                     `context`) nor a list of them (no `items` array)"
-                        .to_string(),
-                ),
-            }
-        }
-        // Rendered through `Display`, which for a `Value` is its JSON, rather
-        // than through a hand-written name per variant: the variants that could
-        // reach here are only the scalars, so naming all six would leave two
-        // arms that no input can take.
-        other => Err(format!("split output is not a JSON array (found {other})")),
-    }
-}
-
-/// One element of the array, as a work item.
-///
-/// A plain string is taken as the question itself: a model that answers
-/// `["how does X work", "what happens after Y"]` has done the actual thinking
-/// and only skipped the wrapper. The id it is given labels the worker in the
-/// consolidated report; it is not something the worker reads.
-fn work_item_from_value(value: serde_json::Value) -> Result<WorkItem, String> {
-    match value {
-        serde_json::Value::String(question) => Ok(WorkItem {
-            id: slug(&question),
-            context: serde_json::json!({ "question": question }),
-        }),
-        other => serde_json::from_value(other)
-            .map_err(|e| format!("split output is not a valid JSON array of work items: {e}")),
-    }
-}
-
-/// A short, stable id for a work item that arrived without one.
-///
-/// Lowercase ASCII words joined by dashes and bounded, so a whole question does
-/// not become a section heading in the consolidated report.
-fn slug(text: &str) -> String {
-    text.chars()
-        .map(|c| match c.is_ascii_alphanumeric() {
-            true => c.to_ascii_lowercase(),
-            false => '-',
-        })
-        .collect::<String>()
-        .split('-')
-        .filter(|word| !word.is_empty())
-        .take(SLUG_WORDS)
-        .collect::<Vec<_>>()
-        .join("-")
-}
-
-/// The contents of the first fenced code block, if the response has one.
-///
-/// Preferred over the bracket scan because a response that fences its answer has
-/// said exactly where the answer is, and the prose around it may carry brackets
-/// of its own - one bibliography citation like `[6]` is enough to make the scan
-/// slice from the wrong place.
-fn fenced_block(text: &str) -> Option<&str> {
-    let after_open = text.split_once("```")?.1;
-    // The opening fence may carry a language tag on the rest of its line.
-    let body = match after_open.split_once('\n') {
-        Some((tag, rest)) if !tag.contains("```") => rest,
-        _ => after_open,
-    };
-    Some(body.split_once("```")?.0.trim())
-}
-
-/// The outermost `[ … ]` in the text: the last-resort extraction.
-fn outermost_array(text: &str) -> Option<&str> {
-    match (text.find('['), text.rfind(']')) {
-        (Some(start), Some(end)) if end > start => text.get(start..=end),
-        _ => None,
-    }
-}
-
-/// Drop text-protocol tool-call markup, keeping everything around it.
-///
-/// Only pays for itself when a marker is actually present, which is rare, so the
-/// common path is one `contains` and a borrow.
-fn strip_tool_protocol_markup(text: &str) -> std::borrow::Cow<'_, str> {
-    if !text.contains(TOOL_PROTOCOL_SENTINEL) {
-        return std::borrow::Cow::Borrowed(text);
-    }
-    let mut out = String::with_capacity(text.len());
-    let mut rest = text;
-    // Split rather than index: the offsets a `find` returns are on character
-    // boundaries, but model output is arbitrary UTF-8 and the workspace lint
-    // does not distinguish a safe slice from an unsafe one. `split_once` cannot
-    // land inside a character at all.
-    while let Some((before, after_open)) = rest.split_once('<') {
-        let Some((tag, after_close)) = after_open.split_once('>') else {
-            // An unclosed `<` is ordinary prose ("3 < 4"), so the remainder -
-            // which `rest` still holds whole - is copied as it stands.
-            break;
-        };
-        out.push_str(before);
-        if !tag.contains(TOOL_PROTOCOL_SENTINEL) {
-            out.push('<');
-            out.push_str(tag);
-            out.push('>');
-        }
-        rest = after_close;
-    }
-    out.push_str(rest);
-    std::borrow::Cow::Owned(out)
-}
 
 /// Starts one worker for a fan-out work item. The implementor resolves the
 /// worker's blueprint (per `config`'s `worker_stage` / `worker_agent` /
@@ -451,6 +257,102 @@ pub fn restore_fan_out_waiting(
     });
 }
 
+/// The ids a fan-out stage's last split handed out, so a later split of the same
+/// stage can be told what has already been researched.
+///
+/// Set on every successful split and read only on a re-entry. Absent means this
+/// stage has not split before.
+#[derive(Component, Debug, Clone, Default, PartialEq, Eq)]
+pub struct PreviousWorkItems(pub Vec<String>);
+
+/// How many previous work-item ids the re-entry framing lists before it stops.
+///
+/// A fan-out can legitimately be thirty items wide, and thirty slugs at the top
+/// of a prompt is a wall the instruction after it has to compete with.
+const FRAMED_PREVIOUS_ITEMS: usize = 12;
+
+/// What [`frame_split_round`] selects.
+///
+/// `&'static` is bevy's `WorldQuery` convention, not a claim about lifetimes:
+/// the borrow is bound when the query is fetched.
+type FrameSplitRoundQuery = (
+    Entity,
+    &'static AgentBlueprint,
+    &'static StageCursor,
+    &'static crate::pipeline::VisitCounts,
+    &'static mut ContextWindow,
+    Option<&'static PreviousWorkItems>,
+);
+
+/// Tell a fan-out stage it has been here before.
+///
+/// The failure this exists for: a `deep-researcher` run finished its fan-out,
+/// ran `analyze`, routed back through `gather`, and re-entered the same fan-out
+/// stage. The split prompt was byte for byte the one it had already answered,
+/// while `conversation` still carried the first split, the workers'
+/// consolidated report and the analysis built on it. The model read all that and
+/// answered "I have completed the research", which is true and is not a list of
+/// work items. Two corrections later the run was dead.
+///
+/// So the second split is asked a different question from the first, and told
+/// that an empty list is a real answer to it. The stage's own `split_prompt` is
+/// unchanged, and a first entry is not touched at all - no framing, no extra
+/// tokens, no behaviour change for the run that splits once.
+pub fn frame_split_round(
+    mut agents: Query<FrameSplitRoundQuery, With<crate::pipeline::StageJustEntered>>,
+) {
+    crate::tick_scope::clear();
+    for (entity, bp, cursor, visits, mut window, previous) in agents.iter_mut() {
+        crate::tick_scope::enter(entity);
+        let stage = &bp.0.stages[cursor.index];
+        if !matches!(stage.mode, StageMode::FanOut { .. }) {
+            continue;
+        }
+        // `enter_stage` bumps the count before this runs, so a first entry reads
+        // as 1 and there is nothing to say.
+        let round = visits.0.get(&stage.name).copied().unwrap_or(1);
+        if round < 2 {
+            continue;
+        }
+        crate::pipeline::inject_system_nudge(
+            &mut window,
+            &split_round_framing(round, previous.map_or(&[], |p| p.0.as_slice())),
+        );
+    }
+}
+
+/// What a re-entered fan-out stage is told before it splits again.
+fn split_round_framing(round: usize, previous: &[String]) -> String {
+    let tool = leviath_core::blueprint::SUBMIT_WORK_ITEMS_TOOL;
+    let already = match previous.is_empty() {
+        // A previous round whose ids were lost - a daemon restart between the
+        // two entries drops the component - still gets the framing, because the
+        // part that matters is "you have been here before", not the list.
+        true => "Work has already been handed out from this stage once".to_string(),
+        false => format!(
+            "These work items have already been researched, and their findings are \
+             in this run's context:\n{}{}",
+            previous
+                .iter()
+                .take(FRAMED_PREVIOUS_ITEMS)
+                .map(|id| format!("  - {id}\n"))
+                .collect::<String>(),
+            match previous.len() > FRAMED_PREVIOUS_ITEMS {
+                true => format!("  ...and {} more\n", previous.len() - FRAMED_PREVIOUS_ITEMS),
+                false => String::new(),
+            }
+        ),
+    };
+    format!(
+        "This is split round {round} of this stage. {already}.\n\nName ONLY \
+         sub-questions that are still unanswered - do not hand out work that has \
+         already been done, and do not restate the previous round. If nothing is \
+         left to hand out, call `{tool}` with an empty `items` array: the run then \
+         moves on to the next stage, which is the right outcome when the work is \
+         finished. Answering that in prose is not."
+    )
+}
+
 /// A split's answer: the `submit_work_items` call it made, or failing that its
 /// assistant text.
 ///
@@ -564,6 +466,12 @@ pub fn fan_out_split(world: &mut World) {
                 // path that does not go through `attach_stage_components` still
                 // starts its next split with the full budget.
                 world.entity_mut(parent).remove::<SplitAttempts>();
+                // Kept for the next entry into this stage, which is told what
+                // was already researched rather than being asked the same
+                // question over a context that answers it.
+                world.entity_mut(parent).insert(PreviousWorkItems(
+                    items.iter().map(|i| i.id.clone()).collect(),
+                ));
                 world.entity_mut(parent).insert(FanOutWaiting {
                     config,
                     max_workers,
@@ -1423,158 +1331,139 @@ mod tests {
         });
     }
 
-    // ── parse_work_items ──────────────────────────────────────────────────────
+    // ── frame_split_round ─────────────────────────────────────────────────────
 
-    /// The envelope near miss. Asking for a bare array and being handed
-    /// `{"items": [...]}` is the shape a model reaches for most often, and
-    /// reading the wrapper as a work item would spawn one worker carrying the
-    /// whole list.
-    #[test]
-    fn parse_work_items_unwraps_an_envelope() {
-        for key in ["items", "work_items", "sub_questions", "tasks"] {
-            let json = format!(r#"{{"{key}": [{{"id":"a"}},{{"id":"b"}}]}}"#);
-            let items = parse_work_items(&json).unwrap_or_else(|e| panic!("{key}: {e}"));
-            assert_eq!(items.len(), 2, "{key}");
-            assert_eq!(items[0].id, "a", "{key}");
+    /// Run the framing system over a parent that has just entered its stage.
+    fn run_framing(world: &mut World, e: Entity, visits: &[(&str, usize)]) -> String {
+        let mut counts = VisitCounts::default();
+        for (name, n) in visits {
+            counts.0.insert((*name).to_string(), *n);
         }
+        world
+            .entity_mut(e)
+            .insert(counts)
+            .insert(crate::pipeline::StageJustEntered {
+                index: 0,
+                name: "fan".to_string(),
+            });
+        let mut schedule = Schedule::default();
+        schedule.add_systems(frame_split_round);
+        schedule.run(world);
+        conversation_text(world, e)
     }
 
-    /// A single bare object is a fan-out of one, which the split prompt
-    /// explicitly allows for a narrow topic.
+    /// A stage entered once has nothing to be told, and pays nothing for the
+    /// mechanism: the ordinary single-fan-out run is untouched.
     #[test]
-    fn parse_work_items_takes_a_single_bare_object() {
-        let items = parse_work_items(r#"{"id":"only","context":{"question":"q"}}"#).unwrap();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].id, "only");
-        assert_eq!(items[0].context["question"], "q");
+    fn a_first_split_round_is_not_framed() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "",
+        );
+
+        let convo = run_framing(&mut world, e, &[("fan", 1)]);
+
+        assert_eq!(convo, "", "nothing injected on a first entry");
     }
 
-    /// An array of plain strings: the model did the thinking and skipped the
-    /// wrapper. Each string becomes its own question, with a generated id.
+    /// The failure this exists for. On a re-entry the model is asked a different
+    /// question from the one it already answered, told what came back, and told
+    /// that an empty list is a real reply.
     #[test]
-    fn parse_work_items_takes_an_array_of_questions() {
-        let items =
-            parse_work_items(r#"["How does semaglutide work?", "What happens after"]"#).unwrap();
-        assert_eq!(items.len(), 2);
-        assert_eq!(items[0].id, "how-does-semaglutide-work");
-        assert_eq!(items[0].context["question"], "How does semaglutide work?");
-        assert_eq!(items[1].id, "what-happens-after");
+    fn a_repeat_split_round_is_framed_with_what_was_already_researched() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "",
+        );
+        world.entity_mut(e).insert(PreviousWorkItems(vec![
+            "glp1-mechanism".to_string(),
+            "post-cessation-regain".to_string(),
+        ]));
+
+        let convo = run_framing(&mut world, e, &[("fan", 2)]);
+
+        assert!(convo.contains("split round 2"), "{convo}");
+        assert!(convo.contains("glp1-mechanism"), "{convo}");
+        assert!(convo.contains("post-cessation-regain"), "{convo}");
+        assert!(convo.contains("still unanswered"), "{convo}");
+        assert!(
+            convo.contains("empty `items` array"),
+            "and that finishing is sayable: {convo}"
+        );
     }
 
-    /// A generated id keeps a bounded number of words, so a long question does
-    /// not become a section heading in the consolidated report.
+    /// The ids live on a component, and a daemon restart between the two entries
+    /// drops it. The framing still fires, because "you have been here before" is
+    /// the part that matters.
     #[test]
-    fn a_generated_id_is_bounded() {
-        let long = "one two three four five six seven eight nine";
-        let items = parse_work_items(&format!(r#"["{long}"]"#)).unwrap();
-        assert_eq!(items[0].id, "one-two-three-four-five-six");
+    fn a_repeat_round_is_framed_even_with_the_previous_ids_lost() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "",
+        );
+
+        let convo = run_framing(&mut world, e, &[("fan", 3)]);
+
+        assert!(convo.contains("split round 3"), "{convo}");
+        assert!(convo.contains("already been handed out"), "{convo}");
     }
 
-    /// The bibliography case. A report with `[6]` in its citations used to make
-    /// the bracket scan slice from the wrong place; a fenced block says exactly
-    /// where the answer is, so it wins.
+    /// A wide fan-out's ids are listed up to a bound, so the instruction after
+    /// them is not buried under thirty slugs.
     #[test]
-    fn parse_work_items_prefers_a_fenced_block_over_stray_brackets() {
-        let response = "See [6] and [14] above.\n```json\n[{\"id\":\"real\"}]\n```\nThanks!";
-        let items = parse_work_items(response).unwrap();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].id, "real");
+    fn a_wide_previous_round_lists_a_bounded_number_of_ids() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "",
+        );
+        let ids: Vec<String> = (0..20).map(|i| format!("item-{i}")).collect();
+        world.entity_mut(e).insert(PreviousWorkItems(ids));
+
+        let convo = run_framing(&mut world, e, &[("fan", 2)]);
+
+        assert!(convo.contains("item-0"), "{convo}");
+        assert!(!convo.contains("item-19"), "{convo}");
+        assert!(convo.contains("and 8 more"), "{convo}");
     }
 
-    /// A fence with no newline after it (so no language tag to strip) still
-    /// yields its body.
+    /// Only fan-out stages are framed; every other stage entry is untouched.
     #[test]
-    fn parse_work_items_reads_a_fence_with_no_language_tag() {
+    fn a_stage_that_is_not_a_fan_out_is_not_framed() {
+        let mut world = World::new();
+        let mut bp = fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue));
+        bp.stages[0].mode = StageMode::Autonomous;
+        let e = spawn_parent(&mut world, bp, "");
+
+        let convo = run_framing(&mut world, e, &[("fan", 2)]);
+
+        assert_eq!(convo, "");
+    }
+
+    /// A successful split records what it handed out, which is what the next
+    /// round is framed with.
+    #[test]
+    fn a_successful_split_records_its_work_item_ids() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            r#"[{"id":"a"},{"id":"b"}]"#,
+        );
+
+        fan_out_split(&mut world);
+
         assert_eq!(
-            parse_work_items("x ```[{\"id\":\"a\"}]``` y").unwrap()[0].id,
-            "a"
+            world.get::<PreviousWorkItems>(e),
+            Some(&PreviousWorkItems(vec!["a".to_string(), "b".to_string()]))
         );
-    }
-
-    /// An unterminated fence is not a fenced block, so the bracket scan is what
-    /// answers.
-    #[test]
-    fn parse_work_items_falls_through_an_unterminated_fence() {
-        assert_eq!(
-            parse_work_items("```json\n[{\"id\":\"a\"}]").unwrap()[0].id,
-            "a"
-        );
-    }
-
-    /// Text-protocol tool-call markup emitted as prose. The run this parser was
-    /// hardened for wrote a whole report with these markers in it, and the
-    /// brackets inside them are what the bracket scan latched onto.
-    #[test]
-    fn parse_work_items_strips_text_protocol_tool_call_markup() {
-        let response = concat!(
-            "Here is the plan.\n",
-            "</\u{ff5c}DSML\u{ff5c}parameter>\n",
-            "</\u{ff5c}DSML\u{ff5c}tool_calls>\n",
-            "[{\"id\":\"kept\"}]"
-        );
-        let items = parse_work_items(response).unwrap();
-        assert_eq!(items.len(), 1);
-        assert_eq!(items[0].id, "kept");
-    }
-
-    /// Markup stripping leaves ordinary tags alone, and survives a dangling `<`
-    /// with nothing closing it.
-    #[test]
-    fn stripping_markup_keeps_real_tags_and_survives_a_dangling_bracket() {
-        let response = concat!(
-            "</\u{ff5c}X\u{ff5c}call> <b>bold</b> 3 < 4\n",
-            "[{\"id\":\"a\"}]"
-        );
-        let items = parse_work_items(response).unwrap();
-        assert_eq!(items[0].id, "a");
-    }
-
-    /// A JSON scalar is not a work-item list, and the message says what came
-    /// back rather than only naming the rule.
-    #[test]
-    fn parse_work_items_rejects_a_scalar_and_says_what_it_got() {
-        let err = parse_work_items("42").unwrap_err();
-        assert!(err.contains("not a JSON array"), "{err}");
-        assert!(err.contains("42"), "{err}");
-    }
-
-    /// An array whose elements are neither objects nor strings is a real
-    /// malformation, not a near miss.
-    #[test]
-    fn parse_work_items_rejects_an_array_of_the_wrong_thing() {
-        let err = parse_work_items("[1, 2, 3]").unwrap_err();
-        assert!(err.contains("work items"), "{err}");
-    }
-
-    /// Nothing array-shaped anywhere: the last-resort scan finds no brackets and
-    /// the error names that.
-    #[test]
-    fn parse_work_items_rejects_prose_with_no_json_at_all() {
-        let err = parse_work_items("I have completed the research.").unwrap_err();
-        assert!(!err.is_empty(), "{err}");
-    }
-
-    #[test]
-    fn parse_work_items_handles_array_prose_and_errors() {
-        let ok = parse_work_items(r#"[{"id":"a"},{"id":"b","context":{"k":1}}]"#).unwrap();
-        assert_eq!(ok.len(), 2);
-        assert_eq!(ok[0].id, "a");
-        assert_eq!(ok[1].context["k"], 1);
-        // Missing fields default.
-        assert_eq!(parse_work_items("[{}]").unwrap()[0].id, "");
-        // Prose around the array is tolerated.
-        assert_eq!(
-            parse_work_items("Here you go:\n```json\n[{\"id\":\"x\"}]\n```")
-                .unwrap()
-                .len(),
-            1
-        );
-        // No brackets at all.
-        assert!(parse_work_items("no array here").is_err());
-        // Closing before opening (e <= s).
-        assert!(parse_work_items("]nope[").is_err());
-        // Brackets but not valid JSON.
-        assert!(parse_work_items("[not json]").is_err());
     }
 
     // ── fan_out_split ─────────────────────────────────────────────────────────

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -48,17 +48,35 @@ const MAX_SPLIT_RETRIES: usize = 2;
 #[derive(Component, Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SplitAttempts(pub usize);
 
-/// What the model is told after a split that could not be parsed.
+/// What the model is told after a split that could not be used.
 ///
 /// It names the failure and restates the shape rather than repeating the
 /// original instruction, because the original instruction is what just did not
 /// work.
-fn split_correction(reason: &str) -> String {
-    format!(
-        "Your previous response could not be used: {reason}. Reply with the JSON \
-         array of work items and nothing else - no prose before or after it, no \
-         markdown fences, no explanation. It must start with `[` and end with `]`."
-    )
+///
+/// The advice differs by how the answer arrived. A model that reached for the
+/// tool and got the arguments wrong needs the argument shape; one that answered
+/// in prose needs to be pointed at the tool, and told - because this is the
+/// thing a split gets wrong on a stage the run has entered before - that "the
+/// work is already done" is an answer it can give, as an empty list.
+fn split_correction(reason: &str, from_tool: bool) -> String {
+    let tool = leviath_core::blueprint::SUBMIT_WORK_ITEMS_TOOL;
+    match from_tool {
+        true => format!(
+            "Your `{tool}` call could not be used: {reason}. Call it again with an \
+             `items` array, each entry an object with a short `id` string and a \
+             `context` object holding everything its worker needs."
+        ),
+        false => format!(
+            "Your previous response could not be used: {reason}. Answer by calling \
+             `{tool}` with an `items` array - each entry an object with a short `id` \
+             string and a `context` object. If the work this stage would split is \
+             already done, call it with an empty `items` array; that is a real answer \
+             and the run moves on. If you cannot call tools, reply with the JSON array \
+             alone - no prose before or after it, no markdown fences. It must start \
+             with `[` and end with `]`."
+        ),
+    }
 }
 
 /// The first `MAX_SPLIT_SNIPPET` characters of what the model actually said,
@@ -97,19 +115,192 @@ pub struct WorkItem {
     pub context: serde_json::Value,
 }
 
-/// Parse a split response into work items. Tolerates markdown fences and prose by
-/// extracting the outermost `[ … ]`. (Ported from the deleted imperative engine.)
+/// Envelope keys a model wraps the array in often enough to be worth accepting.
+///
+/// Asking for a bare array and being handed `{"items": [...]}` is the single
+/// most common near miss, and refusing it costs a correction round to fix
+/// something that is not actually ambiguous.
+const WORK_ITEM_ENVELOPES: [&str; 4] = ["items", "work_items", "sub_questions", "tasks"];
+
+/// The sentinel character in the text-protocol tool-call markers some models
+/// emit as prose.
+///
+/// A fan-out stage advertises `submit_work_items` and nothing else, but a model
+/// trained to write its calls out as text will do that regardless of what the
+/// API offered. The run this parser was hardened for emitted literal
+/// `</｜DSML｜tool_calls>` markers in the middle of a report, and the brackets
+/// inside such a block are what a first-`[`-to-last-`]` scan latches onto.
+///
+/// Matched on the sentinel character rather than a list of protocol names: the
+/// names differ per model family, `｜` (U+FF5C, fullwidth vertical line) is what
+/// they have in common, and it does not otherwise appear in JSON.
+const TOOL_PROTOCOL_SENTINEL: char = '｜';
+
+/// How many words a generated work-item id keeps.
+const SLUG_WORDS: usize = 6;
+
+/// Parse a split response into work items.
+///
+/// Layered on purpose, most exact first: a fenced code block, then the whole
+/// response as JSON, then the outermost `[ … ]`. This is the fallback path - a
+/// model that calls `submit_work_items` never reaches here - so it is written to
+/// accept the near misses rather than to re-enforce a shape the tool already
+/// enforces.
+///
+/// Beyond a bare array it takes an `{"items": [...]}`-style envelope, a single
+/// bare object (a fan-out of one), and an array of plain strings (each becomes a
+/// one-question work item). Every one of those used to cost a correction round,
+/// and the run that motivated this had exactly one left to spend.
 pub fn parse_work_items(content: &str) -> Result<Vec<WorkItem>, String> {
-    let trimmed = content.trim();
+    let cleaned = strip_tool_protocol_markup(content);
+    let trimmed = cleaned.trim();
     // Every rejection folds into one error: this parses model output, so
     // "malformed input yields `Err`" has to hold for every shape of malformed.
-    let slice = match (trimmed.find('['), trimmed.rfind(']')) {
-        (Some(s), Some(e)) if e > s => trimmed.get(s..=e),
+    let candidates = [
+        fenced_block(trimmed),
+        Some(trimmed),
+        outermost_array(trimmed),
+    ];
+    let mut last_error = None;
+    for candidate in candidates.into_iter().flatten() {
+        match serde_json::from_str::<serde_json::Value>(candidate) {
+            Ok(value) => match work_items_from_value(value) {
+                Ok(items) => return Ok(items),
+                Err(e) => last_error = Some(e),
+            },
+            Err(e) => last_error = Some(format!("split output is not valid JSON: {e}")),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| "split output is not a JSON array".to_string()))
+}
+
+/// Read work items out of a parsed JSON value, accepting the shapes a model
+/// reaches for when it is trying to answer the question that was asked.
+fn work_items_from_value(value: serde_json::Value) -> Result<Vec<WorkItem>, String> {
+    match value {
+        serde_json::Value::Array(items) => items.into_iter().map(work_item_from_value).collect(),
+        serde_json::Value::Object(map) => {
+            // An envelope first: `{"items": [...]}` is a wrapper, not a work
+            // item, and reading it as one would spawn a single worker carrying
+            // the whole list as its context.
+            match WORK_ITEM_ENVELOPES
+                .iter()
+                .find_map(|key| map.get(*key).filter(|v| v.is_array()).cloned())
+            {
+                Some(inner) => work_items_from_value(inner),
+                // A fan-out of one, which the split prompt explicitly allows for
+                // a narrow topic - but only when the object actually looks like
+                // a work item. Both of `WorkItem`'s fields default and unknown
+                // ones are tolerated, so without this guard *every* JSON object
+                // parses, and `{"items": "all of them"}` - a botched envelope -
+                // would become one nameless worker instead of a correction.
+                None if map.contains_key("id") || map.contains_key("context") => {
+                    Ok(vec![work_item_from_value(serde_json::Value::Object(map))?])
+                }
+                None => Err(
+                    "split output is a JSON object that is neither a work item (no `id` or \
+                     `context`) nor a list of them (no `items` array)"
+                        .to_string(),
+                ),
+            }
+        }
+        // Rendered through `Display`, which for a `Value` is its JSON, rather
+        // than through a hand-written name per variant: the variants that could
+        // reach here are only the scalars, so naming all six would leave two
+        // arms that no input can take.
+        other => Err(format!("split output is not a JSON array (found {other})")),
+    }
+}
+
+/// One element of the array, as a work item.
+///
+/// A plain string is taken as the question itself: a model that answers
+/// `["how does X work", "what happens after Y"]` has done the actual thinking
+/// and only skipped the wrapper. The id it is given labels the worker in the
+/// consolidated report; it is not something the worker reads.
+fn work_item_from_value(value: serde_json::Value) -> Result<WorkItem, String> {
+    match value {
+        serde_json::Value::String(question) => Ok(WorkItem {
+            id: slug(&question),
+            context: serde_json::json!({ "question": question }),
+        }),
+        other => serde_json::from_value(other)
+            .map_err(|e| format!("split output is not a valid JSON array of work items: {e}")),
+    }
+}
+
+/// A short, stable id for a work item that arrived without one.
+///
+/// Lowercase ASCII words joined by dashes and bounded, so a whole question does
+/// not become a section heading in the consolidated report.
+fn slug(text: &str) -> String {
+    text.chars()
+        .map(|c| match c.is_ascii_alphanumeric() {
+            true => c.to_ascii_lowercase(),
+            false => '-',
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|word| !word.is_empty())
+        .take(SLUG_WORDS)
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+/// The contents of the first fenced code block, if the response has one.
+///
+/// Preferred over the bracket scan because a response that fences its answer has
+/// said exactly where the answer is, and the prose around it may carry brackets
+/// of its own - one bibliography citation like `[6]` is enough to make the scan
+/// slice from the wrong place.
+fn fenced_block(text: &str) -> Option<&str> {
+    let after_open = text.split_once("```")?.1;
+    // The opening fence may carry a language tag on the rest of its line.
+    let body = match after_open.split_once('\n') {
+        Some((tag, rest)) if !tag.contains("```") => rest,
+        _ => after_open,
+    };
+    Some(body.split_once("```")?.0.trim())
+}
+
+/// The outermost `[ … ]` in the text: the last-resort extraction.
+fn outermost_array(text: &str) -> Option<&str> {
+    match (text.find('['), text.rfind(']')) {
+        (Some(start), Some(end)) if end > start => text.get(start..=end),
         _ => None,
     }
-    .ok_or_else(|| "split output is not a JSON array".to_string())?;
-    serde_json::from_str(slice)
-        .map_err(|e| format!("split output is not a valid JSON array of work items: {e}"))
+}
+
+/// Drop text-protocol tool-call markup, keeping everything around it.
+///
+/// Only pays for itself when a marker is actually present, which is rare, so the
+/// common path is one `contains` and a borrow.
+fn strip_tool_protocol_markup(text: &str) -> std::borrow::Cow<'_, str> {
+    if !text.contains(TOOL_PROTOCOL_SENTINEL) {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    // Split rather than index: the offsets a `find` returns are on character
+    // boundaries, but model output is arbitrary UTF-8 and the workspace lint
+    // does not distinguish a safe slice from an unsafe one. `split_once` cannot
+    // land inside a character at all.
+    while let Some((before, after_open)) = rest.split_once('<') {
+        let Some((tag, after_close)) = after_open.split_once('>') else {
+            // An unclosed `<` is ordinary prose ("3 < 4"), so the remainder -
+            // which `rest` still holds whole - is copied as it stands.
+            break;
+        };
+        out.push_str(before);
+        if !tag.contains(TOOL_PROTOCOL_SENTINEL) {
+            out.push('<');
+            out.push_str(tag);
+            out.push('>');
+        }
+        rest = after_close;
+    }
+    out.push_str(rest);
+    std::borrow::Cow::Owned(out)
 }
 
 /// Starts one worker for a fan-out work item. The implementor resolves the
@@ -260,14 +451,54 @@ pub fn restore_fan_out_waiting(
     });
 }
 
+/// A split's answer: the `submit_work_items` call it made, or failing that its
+/// assistant text.
+///
+/// Both are carried because the failure message and the correction round need to
+/// show the model what it actually said, and for a tool call that is the
+/// arguments rather than the (usually empty) text beside them.
+struct SplitAnswer {
+    /// What the work items are parsed out of.
+    payload: String,
+    /// Whether it came from a `submit_work_items` call.
+    from_tool: bool,
+}
+
+impl SplitAnswer {
+    /// Read the split out of an inference result, preferring the tool call.
+    ///
+    /// The tool is the reliable path: its arguments are already JSON and the
+    /// provider validated them against the schema. Text is the fallback, for a
+    /// stage whose model ignores tools - which is a real case, because a
+    /// blueprint picks its own model per stage and some of them are small local
+    /// ones.
+    fn read(infer: &InferenceResult) -> Self {
+        match infer
+            .tool_calls
+            .iter()
+            .find(|call| call.name == leviath_core::blueprint::SUBMIT_WORK_ITEMS_TOOL)
+        {
+            Some(call) => Self {
+                payload: call.arguments.to_string(),
+                from_tool: true,
+            },
+            None => Self {
+                payload: infer.response.clone(),
+                from_tool: false,
+            },
+        }
+    }
+}
+
 /// Fan-out split system (exclusive): for each `ProcessResponse` agent whose
-/// current stage is a fan-out stage, consume its response as the split output -
-/// parse the work items and park the agent in [`FanOutWaiting`] (or mark it
-/// `Error` if the split output isn't a JSON array). Removing `ProcessResponse`
+/// current stage is a fan-out stage, consume its `submit_work_items` call (or
+/// failing that its response text) as the split output - parse the work items
+/// and park the agent in [`FanOutWaiting`], or end the stage down its declared
+/// escape when the corrections are spent. Removing `ProcessResponse`
 /// here keeps the normal `process_response` routing from touching these agents.
 pub fn fan_out_split(world: &mut World) {
     crate::tick_scope::clear();
-    let mut candidates: Vec<(Entity, String, FanOutConfig)> = Vec::new();
+    let mut candidates: Vec<(Entity, SplitAnswer, FanOutConfig)> = Vec::new();
     {
         let mut q = world.query_filtered::<(
             Entity,
@@ -281,18 +512,31 @@ pub fn fan_out_split(world: &mut World) {
                 continue;
             }
             if let StageMode::FanOut { config } = &bp.0.stages[cursor.index].mode {
-                candidates.push((entity, infer.response.clone(), config.clone()));
+                candidates.push((entity, SplitAnswer::read(infer), config.clone()));
             }
         }
     }
 
-    for (parent, response, config) in candidates {
+    for (parent, answer, config) in candidates {
         crate::tick_scope::enter(parent);
+        let SplitAnswer {
+            payload: response,
+            from_tool,
+        } = answer;
         world
             .entity_mut(parent)
             .remove::<ProcessResponse>()
             .remove::<InferenceResult>();
-        match parse_work_items(&response) {
+        // A tool call's arguments are the envelope the schema asks for, so they
+        // go through the same value reader the free-text path ends at rather
+        // than through the text scanning in front of it.
+        let parsed = match from_tool {
+            true => serde_json::from_str::<serde_json::Value>(&response)
+                .map_err(|e| format!("submit_work_items arguments are not valid JSON: {e}"))
+                .and_then(work_items_from_value),
+            false => parse_work_items(&response),
+        };
+        match parsed {
             Ok(items) => {
                 // Unlimited (`max_workers = 0`) is the largest cap there is,
                 // rather than a separate flag: the start loop below compares
@@ -348,20 +592,34 @@ pub fn fan_out_split(world: &mut World) {
                             None => false,
                             Some(mut window) => {
                                 // The model sees what it said before the
-                                // correction, so "reply with only the array"
-                                // has something to correct.
-                                let tokens = leviath_core::estimate_tokens(&response);
+                                // correction, so "that did not work" has
+                                // something to point at.
+                                //
+                                // As text, even when it was a tool call: an
+                                // `AssistantTurn` carrying a real call obliges a
+                                // matching `ToolResult` with the same id in the
+                                // next request, and the split never produced one.
+                                // A dangling call is a shape most providers
+                                // reject outright.
+                                let shown = match from_tool {
+                                    true => format!(
+                                        "[called {}] {response}",
+                                        leviath_core::blueprint::SUBMIT_WORK_ITEMS_TOOL
+                                    ),
+                                    false => response.clone(),
+                                };
+                                let tokens = leviath_core::estimate_tokens(&shown);
                                 let _ = window.add_typed_entry(
                                     "conversation",
                                     leviath_core::EntryKind::AssistantTurn {
                                         tool_calls: Vec::new(),
                                     },
-                                    response.clone(),
+                                    shown,
                                     tokens,
                                 );
                                 crate::pipeline::inject_system_nudge(
                                     &mut window,
-                                    &split_correction(&message),
+                                    &split_correction(&message, from_tool),
                                 );
                                 true
                             }
@@ -1167,6 +1425,135 @@ mod tests {
 
     // ── parse_work_items ──────────────────────────────────────────────────────
 
+    /// The envelope near miss. Asking for a bare array and being handed
+    /// `{"items": [...]}` is the shape a model reaches for most often, and
+    /// reading the wrapper as a work item would spawn one worker carrying the
+    /// whole list.
+    #[test]
+    fn parse_work_items_unwraps_an_envelope() {
+        for key in ["items", "work_items", "sub_questions", "tasks"] {
+            let json = format!(r#"{{"{key}": [{{"id":"a"}},{{"id":"b"}}]}}"#);
+            let items = parse_work_items(&json).unwrap_or_else(|e| panic!("{key}: {e}"));
+            assert_eq!(items.len(), 2, "{key}");
+            assert_eq!(items[0].id, "a", "{key}");
+        }
+    }
+
+    /// A single bare object is a fan-out of one, which the split prompt
+    /// explicitly allows for a narrow topic.
+    #[test]
+    fn parse_work_items_takes_a_single_bare_object() {
+        let items = parse_work_items(r#"{"id":"only","context":{"question":"q"}}"#).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "only");
+        assert_eq!(items[0].context["question"], "q");
+    }
+
+    /// An array of plain strings: the model did the thinking and skipped the
+    /// wrapper. Each string becomes its own question, with a generated id.
+    #[test]
+    fn parse_work_items_takes_an_array_of_questions() {
+        let items =
+            parse_work_items(r#"["How does semaglutide work?", "What happens after"]"#).unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "how-does-semaglutide-work");
+        assert_eq!(items[0].context["question"], "How does semaglutide work?");
+        assert_eq!(items[1].id, "what-happens-after");
+    }
+
+    /// A generated id keeps a bounded number of words, so a long question does
+    /// not become a section heading in the consolidated report.
+    #[test]
+    fn a_generated_id_is_bounded() {
+        let long = "one two three four five six seven eight nine";
+        let items = parse_work_items(&format!(r#"["{long}"]"#)).unwrap();
+        assert_eq!(items[0].id, "one-two-three-four-five-six");
+    }
+
+    /// The bibliography case. A report with `[6]` in its citations used to make
+    /// the bracket scan slice from the wrong place; a fenced block says exactly
+    /// where the answer is, so it wins.
+    #[test]
+    fn parse_work_items_prefers_a_fenced_block_over_stray_brackets() {
+        let response = "See [6] and [14] above.\n```json\n[{\"id\":\"real\"}]\n```\nThanks!";
+        let items = parse_work_items(response).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "real");
+    }
+
+    /// A fence with no newline after it (so no language tag to strip) still
+    /// yields its body.
+    #[test]
+    fn parse_work_items_reads_a_fence_with_no_language_tag() {
+        assert_eq!(
+            parse_work_items("x ```[{\"id\":\"a\"}]``` y").unwrap()[0].id,
+            "a"
+        );
+    }
+
+    /// An unterminated fence is not a fenced block, so the bracket scan is what
+    /// answers.
+    #[test]
+    fn parse_work_items_falls_through_an_unterminated_fence() {
+        assert_eq!(
+            parse_work_items("```json\n[{\"id\":\"a\"}]").unwrap()[0].id,
+            "a"
+        );
+    }
+
+    /// Text-protocol tool-call markup emitted as prose. The run this parser was
+    /// hardened for wrote a whole report with these markers in it, and the
+    /// brackets inside them are what the bracket scan latched onto.
+    #[test]
+    fn parse_work_items_strips_text_protocol_tool_call_markup() {
+        let response = concat!(
+            "Here is the plan.\n",
+            "</\u{ff5c}DSML\u{ff5c}parameter>\n",
+            "</\u{ff5c}DSML\u{ff5c}tool_calls>\n",
+            "[{\"id\":\"kept\"}]"
+        );
+        let items = parse_work_items(response).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "kept");
+    }
+
+    /// Markup stripping leaves ordinary tags alone, and survives a dangling `<`
+    /// with nothing closing it.
+    #[test]
+    fn stripping_markup_keeps_real_tags_and_survives_a_dangling_bracket() {
+        let response = concat!(
+            "</\u{ff5c}X\u{ff5c}call> <b>bold</b> 3 < 4\n",
+            "[{\"id\":\"a\"}]"
+        );
+        let items = parse_work_items(response).unwrap();
+        assert_eq!(items[0].id, "a");
+    }
+
+    /// A JSON scalar is not a work-item list, and the message says what came
+    /// back rather than only naming the rule.
+    #[test]
+    fn parse_work_items_rejects_a_scalar_and_says_what_it_got() {
+        let err = parse_work_items("42").unwrap_err();
+        assert!(err.contains("not a JSON array"), "{err}");
+        assert!(err.contains("42"), "{err}");
+    }
+
+    /// An array whose elements are neither objects nor strings is a real
+    /// malformation, not a near miss.
+    #[test]
+    fn parse_work_items_rejects_an_array_of_the_wrong_thing() {
+        let err = parse_work_items("[1, 2, 3]").unwrap_err();
+        assert!(err.contains("work items"), "{err}");
+    }
+
+    /// Nothing array-shaped anywhere: the last-resort scan finds no brackets and
+    /// the error names that.
+    #[test]
+    fn parse_work_items_rejects_prose_with_no_json_at_all() {
+        let err = parse_work_items("I have completed the research.").unwrap_err();
+        assert!(!err.is_empty(), "{err}");
+    }
+
     #[test]
     fn parse_work_items_handles_array_prose_and_errors() {
         let ok = parse_work_items(r#"[{"id":"a"},{"id":"b","context":{"k":1}}]"#).unwrap();
@@ -1445,6 +1832,120 @@ mod tests {
 
         assert!(world.get::<FanOutWaiting>(e).is_some(), "the split took");
         assert_eq!(status_of(&world, e), AgentStatus::Waiting);
+    }
+
+    /// Put the parent back with a `submit_work_items` call instead of text, the
+    /// way a model that uses the tool leaves it.
+    fn spawn_parent_calling_the_tool(
+        world: &mut World,
+        bp: Blueprint,
+        arguments: serde_json::Value,
+    ) -> Entity {
+        let e = spawn_parent(world, bp, "");
+        world.entity_mut(e).insert(InferenceResult {
+            response: String::new(),
+            tool_calls: vec![crate::components::ToolCall {
+                tool_id: "call-1".to_string(),
+                name: leviath_core::blueprint::SUBMIT_WORK_ITEMS_TOOL.to_string(),
+                arguments,
+                thought_signature: None,
+            }],
+            tokens_used: 0,
+            timestamp: 0,
+        });
+        e
+    }
+
+    /// The reliable path: the split answers with a tool call and the arguments
+    /// are already the shape the schema asked for, so no text is scanned.
+    #[test]
+    fn a_split_tool_call_is_the_split() {
+        let mut world = World::new();
+        let e = spawn_parent_calling_the_tool(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            serde_json::json!({"items": [
+                {"id": "a", "context": {"question": "q1"}},
+                {"id": "b", "context": {"question": "q2"}}
+            ]}),
+        );
+
+        fan_out_split(&mut world);
+
+        let w = world.get::<FanOutWaiting>(e).expect("parked");
+        assert_eq!(w.pending.len(), 2);
+        assert_eq!(w.pending[0].id, "a");
+        assert_eq!(w.pending[0].context["question"], "q1");
+    }
+
+    /// An empty list is a real answer: nothing left to hand out, so the stage
+    /// finishes and the run moves on rather than failing.
+    #[test]
+    fn an_empty_work_item_list_is_a_valid_split() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        let e = spawn_parent_calling_the_tool(
+            &mut world,
+            fanout_blueprint(cfg(Some("merge"), 2, WorkerFailurePolicy::Continue)),
+            serde_json::json!({"items": []}),
+        );
+
+        fan_out_split(&mut world);
+        assert!(world.get::<FanOutWaiting>(e).is_some(), "parked with none");
+        fan_out_collect(&mut world);
+
+        assert_eq!(status_of(&world, e), AgentStatus::Active);
+        assert_eq!(
+            world.get::<StageCursor>(e).map(|c| c.index),
+            Some(1),
+            "straight through to the merge stage"
+        );
+    }
+
+    /// A tool call whose arguments are the wrong shape is corrected like any
+    /// other miss, and the correction names the tool rather than telling a model
+    /// that just used it to reply in prose.
+    #[test]
+    fn a_malformed_tool_call_is_corrected_in_the_tools_own_terms() {
+        let mut world = World::new();
+        let e = spawn_parent_calling_the_tool(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            serde_json::json!({"items": "all of them"}),
+        );
+
+        fan_out_split(&mut world);
+
+        assert_eq!(status_of(&world, e), AgentStatus::Active);
+        assert_eq!(world.get::<SplitAttempts>(e), Some(&SplitAttempts(1)));
+        let convo = conversation_text(&world, e);
+        assert!(
+            convo.contains("[called submit_work_items]"),
+            "the model sees the call it made: {convo}"
+        );
+        assert!(
+            convo.contains("`submit_work_items` call could not be used"),
+            "and a correction in the tool's terms: {convo}"
+        );
+    }
+
+    /// The text fallback's correction points at the tool and says an empty list
+    /// is available, because "the work is already done" answered in prose is
+    /// what ends a re-entered fan-out stage.
+    #[test]
+    fn the_text_correction_points_at_the_tool_and_offers_an_empty_list() {
+        let mut world = World::new();
+        let e = spawn_parent(
+            &mut world,
+            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
+            "I have completed the research.",
+        );
+
+        fan_out_split(&mut world);
+
+        let convo = conversation_text(&world, e);
+        assert!(convo.contains("submit_work_items"), "{convo}");
+        assert!(convo.contains("empty `items` array"), "{convo}");
     }
 
     /// The correction budget belongs to one split, not to the whole run. A stage

--- a/crates/leviath-runtime/src/fanout/split_parse.rs
+++ b/crates/leviath-runtime/src/fanout/split_parse.rs
@@ -70,17 +70,20 @@ pub fn parse_work_items(content: &str) -> Result<Vec<WorkItem>, String> {
         Some(trimmed),
         outermost_array(trimmed),
     ];
-    let mut last_error = None;
+    // The whole response is always one of the candidates, so a failing parse
+    // always leaves a real message behind and there is no "nothing was tried"
+    // case to invent an error for.
+    let mut last_error = String::new();
     for candidate in candidates.into_iter().flatten() {
         match serde_json::from_str::<serde_json::Value>(candidate) {
             Ok(value) => match work_items_from_value(value) {
                 Ok(items) => return Ok(items),
-                Err(e) => last_error = Some(e),
+                Err(e) => last_error = e,
             },
-            Err(e) => last_error = Some(format!("split output is not valid JSON: {e}")),
+            Err(e) => last_error = format!("split output is not valid JSON: {e}"),
         }
     }
-    Err(last_error.unwrap_or_else(|| "split output is not a JSON array".to_string()))
+    Err(last_error)
 }
 
 /// Read work items out of a parsed JSON value, accepting the shapes a model
@@ -224,7 +227,7 @@ mod tests {
     fn parse_work_items_unwraps_an_envelope() {
         for key in ["items", "work_items", "sub_questions", "tasks"] {
             let json = format!(r#"{{"{key}": [{{"id":"a"}},{{"id":"b"}}]}}"#);
-            let items = parse_work_items(&json).unwrap_or_else(|e| panic!("{key}: {e}"));
+            let items = parse_work_items(&json).expect("the envelope is unwrapped");
             assert_eq!(items.len(), 2, "{key}");
             assert_eq!(items[0].id, "a", "{key}");
         }
@@ -238,6 +241,25 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "only");
         assert_eq!(items[0].context["question"], "q");
+    }
+
+    /// The bare-object guard takes either field. An item with only a `context`
+    /// is still a work item; the id is what labels it in the report, and a
+    /// missing one is a cosmetic loss, not a malformation.
+    #[test]
+    fn parse_work_items_takes_a_bare_object_with_only_a_context() {
+        let items = parse_work_items(r#"{"context":{"question":"q"}}"#).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "");
+        assert_eq!(items[0].context["question"], "q");
+    }
+
+    /// A bare object shaped like a work item but with the wrong types is a real
+    /// malformation, and the message says so rather than inventing an item.
+    #[test]
+    fn parse_work_items_rejects_a_bare_object_with_the_wrong_types() {
+        let err = parse_work_items(r#"{"id": 42, "context": {}}"#).unwrap_err();
+        assert!(err.contains("work items"), "{err}");
     }
 
     /// An array of plain strings: the model did the thinking and skipped the

--- a/crates/leviath-runtime/src/fanout/split_parse.rs
+++ b/crates/leviath-runtime/src/fanout/split_parse.rs
@@ -1,0 +1,370 @@
+//! Parsing a fan-out split's answer into work items.
+//!
+//! The split is the one structured answer the framework asks a model for that
+//! it may also give in prose. A stage advertises `submit_work_items` and a model
+//! that calls it lands in [`work_items_from_value`] with arguments the provider
+//! already validated; everything else in here exists for the models that answer
+//! in text anyway, which is a real case because a blueprint picks its own model
+//! per stage.
+//!
+//! The text path is deliberately generous. Each shape it refuses costs a
+//! correction round, and the `deep-researcher` run this was hardened for had one
+//! correction to spend.
+
+use bevy_ecs::prelude::*;
+
+/// One unit of work produced by a fan-out split.
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Default)]
+pub struct WorkItem {
+    /// Stable id (used to label the worker in the consolidated report).
+    #[serde(default)]
+    pub id: String,
+    /// Free-form context handed to the worker (seeded into its pinned context).
+    #[serde(default)]
+    pub context: serde_json::Value,
+}
+
+/// Envelope keys a model wraps the array in often enough to be worth accepting.
+///
+/// Asking for a bare array and being handed `{"items": [...]}` is the single
+/// most common near miss, and refusing it costs a correction round to fix
+/// something that is not actually ambiguous.
+const WORK_ITEM_ENVELOPES: [&str; 4] = ["items", "work_items", "sub_questions", "tasks"];
+
+/// The sentinel character in the text-protocol tool-call markers some models
+/// emit as prose.
+///
+/// A fan-out stage advertises `submit_work_items` and nothing else, but a model
+/// trained to write its calls out as text will do that regardless of what the
+/// API offered. The run this parser was hardened for emitted literal
+/// `</｜DSML｜tool_calls>` markers in the middle of a report, and the brackets
+/// inside such a block are what a first-`[`-to-last-`]` scan latches onto.
+///
+/// Matched on the sentinel character rather than a list of protocol names: the
+/// names differ per model family, `｜` (U+FF5C, fullwidth vertical line) is what
+/// they have in common, and it does not otherwise appear in JSON.
+const TOOL_PROTOCOL_SENTINEL: char = '｜';
+
+/// How many words a generated work-item id keeps.
+const SLUG_WORDS: usize = 6;
+
+/// Parse a split response into work items.
+///
+/// Layered on purpose, most exact first: a fenced code block, then the whole
+/// response as JSON, then the outermost `[ … ]`. This is the fallback path - a
+/// model that calls `submit_work_items` never reaches here - so it is written to
+/// accept the near misses rather than to re-enforce a shape the tool already
+/// enforces.
+///
+/// Beyond a bare array it takes an `{"items": [...]}`-style envelope, a single
+/// bare object (a fan-out of one), and an array of plain strings (each becomes a
+/// one-question work item). Every one of those used to cost a correction round,
+/// and the run that motivated this had exactly one left to spend.
+pub fn parse_work_items(content: &str) -> Result<Vec<WorkItem>, String> {
+    let cleaned = strip_tool_protocol_markup(content);
+    let trimmed = cleaned.trim();
+    // Every rejection folds into one error: this parses model output, so
+    // "malformed input yields `Err`" has to hold for every shape of malformed.
+    let candidates = [
+        fenced_block(trimmed),
+        Some(trimmed),
+        outermost_array(trimmed),
+    ];
+    let mut last_error = None;
+    for candidate in candidates.into_iter().flatten() {
+        match serde_json::from_str::<serde_json::Value>(candidate) {
+            Ok(value) => match work_items_from_value(value) {
+                Ok(items) => return Ok(items),
+                Err(e) => last_error = Some(e),
+            },
+            Err(e) => last_error = Some(format!("split output is not valid JSON: {e}")),
+        }
+    }
+    Err(last_error.unwrap_or_else(|| "split output is not a JSON array".to_string()))
+}
+
+/// Read work items out of a parsed JSON value, accepting the shapes a model
+/// reaches for when it is trying to answer the question that was asked.
+pub(super) fn work_items_from_value(value: serde_json::Value) -> Result<Vec<WorkItem>, String> {
+    match value {
+        serde_json::Value::Array(items) => items.into_iter().map(work_item_from_value).collect(),
+        serde_json::Value::Object(map) => {
+            // An envelope first: `{"items": [...]}` is a wrapper, not a work
+            // item, and reading it as one would spawn a single worker carrying
+            // the whole list as its context.
+            match WORK_ITEM_ENVELOPES
+                .iter()
+                .find_map(|key| map.get(*key).filter(|v| v.is_array()).cloned())
+            {
+                Some(inner) => work_items_from_value(inner),
+                // A fan-out of one, which the split prompt explicitly allows for
+                // a narrow topic - but only when the object actually looks like
+                // a work item. Both of `WorkItem`'s fields default and unknown
+                // ones are tolerated, so without this guard *every* JSON object
+                // parses, and `{"items": "all of them"}` - a botched envelope -
+                // would become one nameless worker instead of a correction.
+                None if map.contains_key("id") || map.contains_key("context") => {
+                    Ok(vec![work_item_from_value(serde_json::Value::Object(map))?])
+                }
+                None => Err(
+                    "split output is a JSON object that is neither a work item (no `id` or \
+                     `context`) nor a list of them (no `items` array)"
+                        .to_string(),
+                ),
+            }
+        }
+        // Rendered through `Display`, which for a `Value` is its JSON, rather
+        // than through a hand-written name per variant: the variants that could
+        // reach here are only the scalars, so naming all six would leave two
+        // arms that no input can take.
+        other => Err(format!("split output is not a JSON array (found {other})")),
+    }
+}
+
+/// One element of the array, as a work item.
+///
+/// A plain string is taken as the question itself: a model that answers
+/// `["how does X work", "what happens after Y"]` has done the actual thinking
+/// and only skipped the wrapper. The id it is given labels the worker in the
+/// consolidated report; it is not something the worker reads.
+fn work_item_from_value(value: serde_json::Value) -> Result<WorkItem, String> {
+    match value {
+        serde_json::Value::String(question) => Ok(WorkItem {
+            id: slug(&question),
+            context: serde_json::json!({ "question": question }),
+        }),
+        other => serde_json::from_value(other)
+            .map_err(|e| format!("split output is not a valid JSON array of work items: {e}")),
+    }
+}
+
+/// A short, stable id for a work item that arrived without one.
+///
+/// Lowercase ASCII words joined by dashes and bounded, so a whole question does
+/// not become a section heading in the consolidated report.
+fn slug(text: &str) -> String {
+    text.chars()
+        .map(|c| match c.is_ascii_alphanumeric() {
+            true => c.to_ascii_lowercase(),
+            false => '-',
+        })
+        .collect::<String>()
+        .split('-')
+        .filter(|word| !word.is_empty())
+        .take(SLUG_WORDS)
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
+/// The contents of the first fenced code block, if the response has one.
+///
+/// Preferred over the bracket scan because a response that fences its answer has
+/// said exactly where the answer is, and the prose around it may carry brackets
+/// of its own - one bibliography citation like `[6]` is enough to make the scan
+/// slice from the wrong place.
+fn fenced_block(text: &str) -> Option<&str> {
+    let after_open = text.split_once("```")?.1;
+    // The opening fence may carry a language tag on the rest of its line.
+    let body = match after_open.split_once('\n') {
+        Some((tag, rest)) if !tag.contains("```") => rest,
+        _ => after_open,
+    };
+    Some(body.split_once("```")?.0.trim())
+}
+
+/// The outermost `[ … ]` in the text: the last-resort extraction.
+fn outermost_array(text: &str) -> Option<&str> {
+    match (text.find('['), text.rfind(']')) {
+        (Some(start), Some(end)) if end > start => text.get(start..=end),
+        _ => None,
+    }
+}
+
+/// Drop text-protocol tool-call markup, keeping everything around it.
+///
+/// Only pays for itself when a marker is actually present, which is rare, so the
+/// common path is one `contains` and a borrow.
+fn strip_tool_protocol_markup(text: &str) -> std::borrow::Cow<'_, str> {
+    if !text.contains(TOOL_PROTOCOL_SENTINEL) {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    // Split rather than index: the offsets a `find` returns are on character
+    // boundaries, but model output is arbitrary UTF-8 and the workspace lint
+    // does not distinguish a safe slice from an unsafe one. `split_once` cannot
+    // land inside a character at all.
+    while let Some((before, after_open)) = rest.split_once('<') {
+        let Some((tag, after_close)) = after_open.split_once('>') else {
+            // An unclosed `<` is ordinary prose ("3 < 4"), so the remainder -
+            // which `rest` still holds whole - is copied as it stands.
+            break;
+        };
+        out.push_str(before);
+        if !tag.contains(TOOL_PROTOCOL_SENTINEL) {
+            out.push('<');
+            out.push_str(tag);
+            out.push('>');
+        }
+        rest = after_close;
+    }
+    out.push_str(rest);
+    std::borrow::Cow::Owned(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The envelope near miss. Asking for a bare array and being handed
+    /// `{"items": [...]}` is the shape a model reaches for most often, and
+    /// reading the wrapper as a work item would spawn one worker carrying the
+    /// whole list.
+    #[test]
+    fn parse_work_items_unwraps_an_envelope() {
+        for key in ["items", "work_items", "sub_questions", "tasks"] {
+            let json = format!(r#"{{"{key}": [{{"id":"a"}},{{"id":"b"}}]}}"#);
+            let items = parse_work_items(&json).unwrap_or_else(|e| panic!("{key}: {e}"));
+            assert_eq!(items.len(), 2, "{key}");
+            assert_eq!(items[0].id, "a", "{key}");
+        }
+    }
+
+    /// A single bare object is a fan-out of one, which the split prompt
+    /// explicitly allows for a narrow topic.
+    #[test]
+    fn parse_work_items_takes_a_single_bare_object() {
+        let items = parse_work_items(r#"{"id":"only","context":{"question":"q"}}"#).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "only");
+        assert_eq!(items[0].context["question"], "q");
+    }
+
+    /// An array of plain strings: the model did the thinking and skipped the
+    /// wrapper. Each string becomes its own question, with a generated id.
+    #[test]
+    fn parse_work_items_takes_an_array_of_questions() {
+        let items =
+            parse_work_items(r#"["How does semaglutide work?", "What happens after"]"#).unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0].id, "how-does-semaglutide-work");
+        assert_eq!(items[0].context["question"], "How does semaglutide work?");
+        assert_eq!(items[1].id, "what-happens-after");
+    }
+
+    /// A generated id keeps a bounded number of words, so a long question does
+    /// not become a section heading in the consolidated report.
+    #[test]
+    fn a_generated_id_is_bounded() {
+        let long = "one two three four five six seven eight nine";
+        let items = parse_work_items(&format!(r#"["{long}"]"#)).unwrap();
+        assert_eq!(items[0].id, "one-two-three-four-five-six");
+    }
+
+    /// The bibliography case. A report with `[6]` in its citations used to make
+    /// the bracket scan slice from the wrong place; a fenced block says exactly
+    /// where the answer is, so it wins.
+    #[test]
+    fn parse_work_items_prefers_a_fenced_block_over_stray_brackets() {
+        let response = "See [6] and [14] above.\n```json\n[{\"id\":\"real\"}]\n```\nThanks!";
+        let items = parse_work_items(response).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "real");
+    }
+
+    /// A fence with no newline after it (so no language tag to strip) still
+    /// yields its body.
+    #[test]
+    fn parse_work_items_reads_a_fence_with_no_language_tag() {
+        assert_eq!(
+            parse_work_items("x ```[{\"id\":\"a\"}]``` y").unwrap()[0].id,
+            "a"
+        );
+    }
+
+    /// An unterminated fence is not a fenced block, so the bracket scan is what
+    /// answers.
+    #[test]
+    fn parse_work_items_falls_through_an_unterminated_fence() {
+        assert_eq!(
+            parse_work_items("```json\n[{\"id\":\"a\"}]").unwrap()[0].id,
+            "a"
+        );
+    }
+
+    /// Text-protocol tool-call markup emitted as prose. The run this parser was
+    /// hardened for wrote a whole report with these markers in it, and the
+    /// brackets inside them are what the bracket scan latched onto.
+    #[test]
+    fn parse_work_items_strips_text_protocol_tool_call_markup() {
+        let response = concat!(
+            "Here is the plan.\n",
+            "</\u{ff5c}DSML\u{ff5c}parameter>\n",
+            "</\u{ff5c}DSML\u{ff5c}tool_calls>\n",
+            "[{\"id\":\"kept\"}]"
+        );
+        let items = parse_work_items(response).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].id, "kept");
+    }
+
+    /// Markup stripping leaves ordinary tags alone, and survives a dangling `<`
+    /// with nothing closing it.
+    #[test]
+    fn stripping_markup_keeps_real_tags_and_survives_a_dangling_bracket() {
+        let response = concat!(
+            "</\u{ff5c}X\u{ff5c}call> <b>bold</b> 3 < 4\n",
+            "[{\"id\":\"a\"}]"
+        );
+        let items = parse_work_items(response).unwrap();
+        assert_eq!(items[0].id, "a");
+    }
+
+    /// A JSON scalar is not a work-item list, and the message says what came
+    /// back rather than only naming the rule.
+    #[test]
+    fn parse_work_items_rejects_a_scalar_and_says_what_it_got() {
+        let err = parse_work_items("42").unwrap_err();
+        assert!(err.contains("not a JSON array"), "{err}");
+        assert!(err.contains("42"), "{err}");
+    }
+
+    /// An array whose elements are neither objects nor strings is a real
+    /// malformation, not a near miss.
+    #[test]
+    fn parse_work_items_rejects_an_array_of_the_wrong_thing() {
+        let err = parse_work_items("[1, 2, 3]").unwrap_err();
+        assert!(err.contains("work items"), "{err}");
+    }
+
+    /// Nothing array-shaped anywhere: the last-resort scan finds no brackets and
+    /// the error names that.
+    #[test]
+    fn parse_work_items_rejects_prose_with_no_json_at_all() {
+        let err = parse_work_items("I have completed the research.").unwrap_err();
+        assert!(!err.is_empty(), "{err}");
+    }
+
+    #[test]
+    fn parse_work_items_handles_array_prose_and_errors() {
+        let ok = parse_work_items(r#"[{"id":"a"},{"id":"b","context":{"k":1}}]"#).unwrap();
+        assert_eq!(ok.len(), 2);
+        assert_eq!(ok[0].id, "a");
+        assert_eq!(ok[1].context["k"], 1);
+        // Missing fields default.
+        assert_eq!(parse_work_items("[{}]").unwrap()[0].id, "");
+        // Prose around the array is tolerated.
+        assert_eq!(
+            parse_work_items("Here you go:\n```json\n[{\"id\":\"x\"}]\n```")
+                .unwrap()
+                .len(),
+            1
+        );
+        // No brackets at all.
+        assert!(parse_work_items("no array here").is_err());
+        // Closing before opening (e <= s).
+        assert!(parse_work_items("]nope[").is_err());
+        // Brackets but not valid JSON.
+        assert!(parse_work_items("[not json]").is_err());
+    }
+}

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -8651,6 +8651,32 @@ fn resolve_transition_routes_error_to_error_edge() {
     );
 }
 
+/// No `error` edge, but a `dead_end` one. Both say "this stage may not be able
+/// to go on", and the dead-end arm already falls back to the `error` edge; an
+/// author who declared only the one escape should get it either way.
+#[test]
+fn resolve_transition_routes_error_down_a_dead_end_edge_when_that_is_the_only_escape() {
+    let escape = conditioned_edge("recovery", TransitionCondition::DeadEnd);
+    let a = stage_named("a", Some(vec![("e".to_string(), escape)]), false, None);
+    let recovery = stage_named("recovery", None, false, None);
+    let bp = blueprint(vec![a, recovery]);
+    let mut world = World::new();
+    let e = spawn_outcome_agent(
+        &mut world,
+        bp,
+        StageOutcome::Errored("boom".to_string()),
+        AgentStatus::Error {
+            message: "boom".to_string(),
+        },
+    );
+    run_transition(&mut world);
+    assert_eq!(world.get::<StageCursor>(e).unwrap().index, 1);
+    assert_eq!(
+        world.get::<AgentState>(e).unwrap().status,
+        AgentStatus::Active
+    );
+}
+
 #[test]
 fn resolve_transition_errors_terminally_without_an_error_edge() {
     // Stage 'a' has only an Always edge to 'b' - no error edge.

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -8621,6 +8621,29 @@ fn spawn_outcome_agent(
     e
 }
 
+/// `fail_stage_world` is called from exclusive systems that may be looking at an
+/// entity another system already tore down. It records what it can and never
+/// panics: a run that went away mid-tick has nothing left to route.
+#[test]
+fn fail_stage_world_survives_a_gone_or_stateless_entity() {
+    let mut world = World::new();
+
+    let gone = world.spawn_empty().id();
+    world.despawn(gone);
+    fail_stage_world(&mut world, gone, "boom".to_string());
+    assert!(world.get_entity(gone).is_err(), "still gone");
+
+    // Present but carrying no `AgentState`: the outcome is still recorded, so
+    // whatever runs next sees the stage failed.
+    let bare = world.spawn_empty().id();
+    fail_stage_world(&mut world, bare, "boom".to_string());
+    assert_eq!(
+        world.get::<StageOutcome>(bare),
+        Some(&StageOutcome::Errored("boom".to_string()))
+    );
+    assert!(world.get::<ResolveTransition>(bare).is_some());
+}
+
 #[test]
 fn resolve_transition_routes_error_to_error_edge() {
     let err = conditioned_edge("recovery", TransitionCondition::Error);

--- a/crates/leviath-runtime/src/pipeline/transition.rs
+++ b/crates/leviath-runtime/src/pipeline/transition.rs
@@ -465,6 +465,60 @@ pub(crate) fn hold_for_gate(
         .insert(ReadyToInfer);
 }
 
+/// End a stage in failure the way its blueprint asked for.
+///
+/// Two things have to happen together and this is the only place that promises
+/// both: the status carries the message for the terminal case, and
+/// [`StageOutcome::Errored`] plus [`ResolveTransition`] hand the agent to
+/// [`resolve_transition`], which follows the stage's `error`-conditioned edge
+/// when one has revisits left.
+///
+/// Writing the status on its own is what several call sites used to do, and it
+/// silently discards the recovery the author declared. A `deep-researcher` run
+/// died that way with an `error_recovery` stage sitting unused in its graph and
+/// three stages still pending: a fan-out split that would not parse set
+/// `AgentStatus::Error` directly, and nothing ever consulted the edge. The
+/// distinction is invisible at the call site - both spellings "fail the run" -
+/// so the fix is one helper rather than a rule to remember.
+///
+/// Not for conditions that are terminal by nature (a cancel, a completed run).
+/// This is for "this stage could not go on", which is exactly what an
+/// `error` edge exists to answer.
+pub fn fail_stage(
+    commands: &mut Commands,
+    entity: Entity,
+    state: &mut AgentState,
+    message: String,
+) {
+    state.status = AgentStatus::Error {
+        message: message.clone(),
+    };
+    commands
+        .entity(entity)
+        .insert(StageOutcome::Errored(message))
+        .insert(ResolveTransition);
+}
+
+/// [`fail_stage`] for an exclusive system, which has a `&mut World` and no
+/// `Commands`.
+///
+/// A no-op for an entity that has already despawned, matching the rest of the
+/// exclusive-system helpers: a run that went away mid-tick has nothing left to
+/// route.
+pub fn fail_stage_world(world: &mut World, entity: Entity, message: String) {
+    let Ok(mut entity_mut) = world.get_entity_mut(entity) else {
+        return;
+    };
+    if let Some(mut state) = entity_mut.get_mut::<AgentState>() {
+        state.status = AgentStatus::Error {
+            message: message.clone(),
+        };
+    }
+    entity_mut
+        .insert(StageOutcome::Errored(message))
+        .insert(ResolveTransition);
+}
+
 /// What `resolve_transition` selects.
 ///
 /// `&'static` is bevy's `WorldQuery` convention, not a claim about
@@ -528,7 +582,22 @@ pub fn resolve_transition(
             // failed, and holding it back to demand file changes would strand a
             // run that can't make any.
             Some(StageOutcome::Errored(message)) => {
-                match find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::Error) {
+                // `error` first, then `dead_end`. Both are declarations that this
+                // stage may not be able to go on, and the dead-end arm below
+                // already falls back the other way; a run whose author wrote only
+                // the `dead_end` escape should not die because the thing that
+                // went wrong was spelled "error".
+                let escape =
+                    find_conditioned_edge(&bp.0, stage, &visits.0, TransitionCondition::Error)
+                        .or_else(|| {
+                            find_conditioned_edge(
+                                &bp.0,
+                                stage,
+                                &visits.0,
+                                TransitionCondition::DeadEnd,
+                            )
+                        });
+                match escape {
                     Some((i, t)) => {
                         // Put the error where the recovery stage will read it;
                         // without an error edge the run terminates and the
@@ -941,6 +1010,12 @@ pub(crate) fn attach_stage_components(
         .remove::<crate::interaction_points::InteractionPointRounds>()
         .remove::<RequiredReentries>()
         .remove::<OutputReentries>()
+        // The fan-out split's correction budget is one of those. Left standing,
+        // it is a per-run budget rather than a per-entry one: a split that
+        // needed one correction the first time through left the counter at 1,
+        // and the second entry into the same stage got a single correction
+        // before the stage failed. That is how a `deep-researcher` run ended.
+        .remove::<crate::fanout::SplitAttempts>()
         .insert(ReadyToInfer);
     match &setup.routing {
         Some(routing) => {

--- a/crates/leviath-runtime/src/pipeline/transition_choice.rs
+++ b/crates/leviath-runtime/src/pipeline/transition_choice.rs
@@ -318,12 +318,18 @@ pub fn collect_transition_choice(
         let response = match outcome.result {
             Ok(response) => response,
             Err(err) => {
-                state.status = AgentStatus::Error {
-                    message: err.to_string(),
-                };
                 commands
                     .entity(outcome.entity)
                     .remove::<AwaitingTransitionResponse>();
+                // The routing call failed, not the stage's work. Fail it through
+                // the stage's own `error` edge: `resolve_transition` reads an
+                // errored outcome and never comes back here for a second choice.
+                crate::pipeline::fail_stage(
+                    &mut commands,
+                    outcome.entity,
+                    &mut state,
+                    err.to_string(),
+                );
                 continue;
             }
         };
@@ -432,10 +438,15 @@ pub fn collect_transition_choice(
                         }
                     }
                     Err(message) => {
-                        state.status = AgentStatus::Error { message };
                         commands
                             .entity(outcome.entity)
                             .remove::<AwaitingTransitionResponse>();
+                        crate::pipeline::fail_stage(
+                            &mut commands,
+                            outcome.entity,
+                            &mut state,
+                            message,
+                        );
                     }
                 }
             }

--- a/crates/leviath-runtime/src/pipeline/watchdog.rs
+++ b/crates/leviath-runtime/src/pipeline/watchdog.rs
@@ -51,13 +51,19 @@ pub fn check_workspace_health(
             workdir = %md.workdir,
             "working directory is gone; failing the run"
         );
-        state.status = AgentStatus::Error {
-            message: format!("workspace '{}' is no longer accessible", md.workdir),
-        };
         if let Some(mut flags) = flags {
             flags.0.workspace_lost = true;
         }
         commands.entity(entity).remove::<ReadyToInfer>();
+        // Through the stage's transition rather than straight to a dead run: an
+        // `error_recovery` stage usually works in context alone, so it can still
+        // say what happened even with the directory gone.
+        crate::pipeline::fail_stage(
+            &mut commands,
+            entity,
+            &mut state,
+            format!("workspace '{}' is no longer accessible", md.workdir),
+        );
     }
 }
 
@@ -226,6 +232,23 @@ pub(crate) fn note_error(window: &mut ContextWindow, stage: &str, message: &str)
         format!(
             "[Inference error in stage '{stage}'] {message}. Diagnose this failure from \
              the error text above before retrying or working around it."
+        ),
+    );
+}
+
+/// Write a note saying a fan-out split could not be used, so the stage that
+/// runs next knows the workers never ran.
+///
+/// Distinct from [`note_error`] because it is not an inference error and the
+/// advice differs: nothing failed to reach the provider, the model answered
+/// with something that is not a work-item list, and whatever runs next has to
+/// work from the material already in context rather than from findings that
+/// were never gathered.
+pub(crate) fn note_unusable_split(window: &mut ContextWindow, stage: &str, message: &str) {
+    note_abnormal_ending(
+        window,
+        format!(
+            "[Fan-out split in stage '{stage}' could not be used] {message}. No workers ran,              so there are no sub-findings from this stage. Work from what is already in              context and say plainly which parts are unsupported because of it."
         ),
     );
 }

--- a/crates/leviath-runtime/src/pipeline/wedge.rs
+++ b/crates/leviath-runtime/src/pipeline/wedge.rs
@@ -217,8 +217,11 @@ pub fn fail_wedged_runs(
         if let Some(mut buffer) = buffer {
             buffer.logs.push((0, format!("[wedged] {message}")));
         }
-        state.status = AgentStatus::Error { message };
         commands.entity(entity).remove::<Wedged>();
+        // Routing it is also what un-wedges it: `ResolveTransition` is a marker a
+        // system acts on, so a run whose blueprint declares an `error` edge gets
+        // driven into that stage instead of ending here.
+        crate::pipeline::fail_stage(&mut commands, entity, &mut state, message);
     }
 }
 

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -513,7 +513,17 @@ impl PipelineWorld {
                 // the stage just entered, holding `ReadyToInfer` until the
                 // answers land - so the stage's first request carries the fresh
                 // values rather than the previous stage's.
-                (run_stage_enter_hooks, crate::stage_seeds::start_stage_seeds).chain(),
+                //
+                // `frame_split_round` rides along: it tells a re-entered fan-out
+                // stage it has been here before, and wants the same window - set
+                // last, so the framing is the final thing in front of the
+                // stage's first request.
+                (
+                    run_stage_enter_hooks,
+                    crate::stage_seeds::start_stage_seeds,
+                    crate::fanout::frame_split_round,
+                )
+                    .chain(),
                 sync_tool_stages,
                 // Store any finished run title, then start newly-marked ones.
                 // Collect precedes persistence so a landed title is written on

--- a/crates/leviath-tools/src/defs.rs
+++ b/crates/leviath-tools/src/defs.rs
@@ -55,6 +55,23 @@ pub fn submit_output_description(described: &str) -> String {
     }
 }
 
+/// What a fan-out split is told about handing back its work items.
+///
+/// Says the two things a split gets wrong. One: each item is all its worker
+/// gets, because a worker is a separate agent with its own clean context - a
+/// reference to "the topic above" reaches nobody. Two: an empty list is a real
+/// answer, which matters most on a stage the run has entered before, where the
+/// honest reply is that the work is already done. A split that could not say
+/// that answered in prose instead, and prose is what used to end the run.
+const SUBMIT_WORK_ITEMS_DESCRIPTION: &str = "Hand back the work items for this fan-out. Each item starts one worker, and they all \
+     run at the same time.\n\nA worker is a separate agent with a clean context: it never \
+     sees this conversation, so everything it needs has to be inside its own `context`. \
+     Name each item precisely enough that two workers cannot end up answering the same \
+     question.\n\nIf there is nothing left to hand out - the work is already done, or \
+     everything this stage would split has been covered - call this with an empty `items` \
+     array. That is a valid answer and the run moves on to the next stage. Do not explain \
+     that in prose instead; this tool is the only reply that is read.";
+
 /// [`shell_tool_description`] for the resolved shell, computed once.
 ///
 /// `detect_shell` reads `$SHELL` and probes the filesystem on Unix, and
@@ -433,6 +450,38 @@ impl BuiltinTools {
                 }),
             },
             Tool {
+                // The one structured answer the framework asks for that used to
+                // be scraped out of prose. Offered by every `fan_out` stage; the
+                // free-text parse stays as the fallback for models that ignore
+                // it.
+                name: crate::SUBMIT_WORK_ITEMS_TOOL.to_string(),
+                description: SUBMIT_WORK_ITEMS_DESCRIPTION.to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "items": {
+                            "type": "array",
+                            "description": "One entry per unit of work. An empty array means there is nothing left to hand out.",
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "id": {
+                                        "type": "string",
+                                        "description": "Short slug identifying this work item. Labels the worker in the consolidated report, so make it distinct and readable."
+                                    },
+                                    "context": {
+                                        "type": "object",
+                                        "description": "Everything the worker gets. It runs as a separate agent with a clean context and does not share yours, so this has to stand alone."
+                                    }
+                                },
+                                "required": ["id", "context"]
+                            }
+                        }
+                    },
+                    "required": ["items"]
+                }),
+            },
+            Tool {
                 name: "current_time".to_string(),
                 description: "Get the current date and time, in UTC and in this machine's local timezone. Your training data has a cutoff date; this does not. Call this before reasoning about anything current, recent, upcoming, or dated - what year it is, how old something is, whether a release has happened, or what counts as recent news. Do not assume today's date from memory.".to_string(),
                 parameters: json!({
@@ -652,6 +701,7 @@ impl BuiltinTools {
             "which_command",
             "runtime_info",
             crate::SUBMIT_OUTPUT_TOOL,
+            crate::SUBMIT_WORK_ITEMS_TOOL,
         ]
         .iter()
         // Drop any canonical built-in the current platform can't provide, so a

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -39,6 +39,14 @@ impl BuiltinTools {
             SUBMIT_OUTPUT_TOOL => {
                 "[error] submit_output must be handled by the runtime".to_string()
             }
+            // The fan-out split reads this off the inference result before the
+            // dispatch layer ever sees it, so reaching here means a stage that
+            // is not a fan-out called it. Refused rather than run, for the same
+            // reason as above: there is no work item list for it to go into.
+            SUBMIT_WORK_ITEMS_TOOL => {
+                "[error] submit_work_items is only answerable by a fan_out stage's split"
+                    .to_string()
+            }
             _ => format!("[error] Unknown built-in tool: {}", name),
         }
     }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -30,7 +30,7 @@ pub use validate::*;
 /// Re-exported from `leviath-core`, which owns the name because the blueprint
 /// validator and the manifest parser both need it and neither may depend on
 /// this crate.
-pub use leviath_core::blueprint::SUBMIT_OUTPUT_TOOL;
+pub use leviath_core::blueprint::{SUBMIT_OUTPUT_TOOL, SUBMIT_WORK_ITEMS_TOOL};
 
 /// Built-in tools: read_file, write_file, edit_file, list_dir, shell.
 ///
@@ -172,7 +172,7 @@ mod tests {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
         let defs = tools.tool_defs();
-        assert_eq!(defs.len(), 26);
+        assert_eq!(defs.len(), 27);
     }
 
     #[test]
@@ -261,6 +261,25 @@ mod tests {
             .await;
         assert!(
             result.contains("submit_output must be handled by the runtime"),
+            "{result}"
+        );
+    }
+
+    /// Same reasoning for the split's tool: the fan-out system reads it off the
+    /// inference result before dispatch, so a call reaching the executor came
+    /// from a stage that is not a fan-out and has nowhere to put work items.
+    #[tokio::test]
+    async fn submit_work_items_is_not_handled_by_builtin_execute() {
+        let dir = std::env::temp_dir();
+        let tools = make_tools(&dir);
+        let result = tools
+            .execute(
+                crate::SUBMIT_WORK_ITEMS_TOOL,
+                serde_json::json!({"items": []}),
+            )
+            .await;
+        assert!(
+            result.contains("only answerable by a fan_out stage"),
             "{result}"
         );
     }
@@ -424,7 +443,7 @@ mod tests {
     fn names_returns_every_tool_and_alias() {
         let dir = std::env::temp_dir();
         let tools = make_tools(&dir);
-        assert_eq!(tools.names().len(), 27);
+        assert_eq!(tools.names().len(), 28);
     }
 
     // ── Sub-agent tool definitions ────────────────────────────────────────
@@ -2098,8 +2117,8 @@ mod tests {
         let tools = make_mobile_tools(&dir);
         let names: Vec<String> = tools.tool_defs().iter().map(|t| t.name.clone()).collect();
         assert!(!names.contains(&"shell".to_string()));
-        // The other 16 built-ins remain.
-        assert_eq!(tools.tool_defs().len(), 25);
+        // The other 17 built-ins remain.
+        assert_eq!(tools.tool_defs().len(), 26);
         assert!(names.contains(&"read_file".to_string()));
         assert!(names.contains(&"context_write".to_string()));
         assert!(names.contains(&"present_for_review".to_string()));

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -173,6 +173,7 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 | warning | `compact-summarizes-deliverable` | A `compact` edge would hand a `required` region to the summarizer. See below |
 | warning | `unreachable-stage`, `cycle-without-max-revisits`, `broad-read-path` | Graph and `[read_paths]` shape. |
 | warning | `dead-end-possible` | Every route out of a stage can run out of budget. See below |
+| warning | `fanout-no-escape` | A `fan_out` stage with no `error` or `dead_end` edge, so an unusable split degrades to an empty fan-out. See [sub-agents](/docs/sub-agents) |
 | warning | `read-paths-not-granted` | The blueprint declares `[read_paths]` your `config.toml` does not grant. See below |
 | warning | `read-paths-grant-invalid` | A `read_paths` grant in your own config will not compile. It is a hard spawn error, named here first. |
 | note | `holds-under-yolo` | A checkpoint that still stops an unattended run for a person. See below |

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -60,10 +60,56 @@ Those keys sit directly on the stage next to `mode = "fan_out"`, not in a sub-ta
 | `max_items` | unset | Most work items the split may produce. `0` or unset means however many it produces |
 | `max_workers` | `30` | How many workers run at once. `0` means unlimited |
 | `on_worker_failure` | `"continue"` | `continue` merges what succeeded. `fail_all` fails the whole fan-out if any worker fails |
-| `split_prompt` | `""` | Added to the stage's system prompt. Its reply is parsed as the list of work items |
+| `split_prompt` | `""` | Added to the stage's system prompt. It asks for the work items; see below |
 
 Set exactly one of `worker_agent`, `worker_stage`, or `worker_query`. `lev validate` checks that,
 and checks that a named `worker_stage` exists and has opted in with `allow_as_worker`.
+
+### How the split answers
+
+The stage's single inference is the split. It carries `split_prompt` in its system prompt, and it
+is offered one tool, `submit_work_items`, which every fan-out stage gets whether or not it lists
+any `available_tools`:
+
+```json
+{"items": [
+  {"id": "half-life", "context": {"question": "How long does semaglutide stay active?"}},
+  {"id": "after-stopping", "context": {"question": "What happens when someone stops?"}}
+]}
+```
+
+Each item's `context` is everything its worker gets. A worker is a separate agent with a clean
+context window and never sees the parent's conversation, so a reference to "the topic above"
+reaches nobody.
+
+A model that ignores the tool and replies in text is still understood. The reply is read as JSON,
+and an `{"items": [...]}` envelope, a single bare object, or a plain array of question strings are
+all accepted. A reply that cannot be read at all is handed back with a correction and asked again,
+twice, before the stage gives up.
+
+**An empty list is a real answer.** `submit_work_items` with `items: []` means there is nothing to
+hand out, and the run moves on to `merge_stage`. That matters most on a stage a run enters more
+than once: the second time through, the honest answer is often that the work is already done, and
+without a way to say it the split answers in prose instead. A re-entered fan-out stage is told
+which round it is on and what the previous round already covered.
+
+### When a split cannot be used
+
+A split that is still unusable after its corrections never ends the run. It takes, in order:
+
+1. the stage's `error` transition, if it declares one;
+2. its `dead_end` transition, if it declares one;
+3. failing both, an empty fan-out into `merge_stage`, with the reason written into `error_report`
+   and counted in the run's `splits_degraded` flag.
+
+The third is a degradation - the workers never ran, and whatever comes next works from less than
+the blueprint intended - so `lev validate` warns (`fanout-no-escape`) about a fan-out stage that
+declares neither escape.
+
+```toml
+[stages.investigate.transitions.error_recovery]
+condition = "error"
+```
 
 ### A worker that is a whole other agent
 


### PR DESCRIPTION
A `deep-researcher` run died with:

> fan_out split failed after 2 correction(s): split output is not a JSON array (the response began: I have completed the research. All four work items were fully investigated…)

It was not stuck. Its four workers had already finished, `analyze` had already
run, three stages were still pending, and its graph carried both an `error` edge
to `error_recovery` and a `dead_end` edge to `synthesize`. Neither fired.

## What actually happened

Decoded from the run archive:

| iter | stage | |
|---|---|---|
| 1–7 | `gather` | sources collected |
| 8 | `investigate` | split #1 did not parse → one correction spent |
| 9 | `investigate` | corrected split parsed → 4 workers spawned |
| 10–14 | `analyze` | routing chose `gather` |
| 15–17 | `gather` | revisit; its only forward edge is `investigate` |
| 18 | `investigate` | re-entered. Wrote a finished report → no array |
| 19 | `investigate` | "I have completed the research." → run killed |

Five faults, stacked:

1. **`SplitAttempts` was never reset**, making `MAX_SPLIT_RETRIES` a per-run
   budget by accident. Split #1 spent one, so the re-entry got one correction
   instead of two.
2. **Nothing framed a repeat split round.** The prompt was byte for byte the one
   already answered, over a context holding the first round's findings and the
   analysis built on them. The model answered honestly; the prompt asked the
   wrong question.
3. **A failed split bypassed the declared escape edges** — it wrote
   `AgentStatus::Error` directly, which is terminal, so `resolve_transition`
   skipped it. The routing lane, `on_worker_failure = "fail_all"`, the
   lost-workspace watchdog and the wedge detector all did the same.
4. **The split was scraped out of free text.** `infer.tool_calls` was never read.
   This model also emitted literal `</｜DSML｜tool_calls>` markers as prose, and
   the brackets inside them are what the first-`[`-to-last-`]` scan latched onto.
5. `analyze → gather → investigate` is the only route, so every widening
   decision forces a second fan-out — which (2) guaranteed would be asked wrong.

## The fix

- **`fail_stage` / `fail_stage_world`** — one way to end a stage badly, used by
  all six sites. An errored stage also falls back to a `dead_end` edge when it
  has no `error` edge, the way the dead-end arm already fell back the other way.
  For the wedge detector this is also the cure: `ResolveTransition` is a marker
  something acts on.
- **A split is never terminal.** `error` edge → `dead_end` edge → an empty
  fan-out into the merge stage, with the reason in `error_report` and a new
  `splits_degraded` run flag. By the time a split runs the parent has usually
  done most of the work.
- **`submit_work_items`**, offered by every fan-out stage regardless of its
  `available_tools`. Its description says the thing a split most needed to be
  told and had nowhere to read: **an empty `items` array is a real answer**.
  Parking with no items already flowed to the merge stage; nothing said so.
- **Round framing** on re-entry: which round, which items already came back, and
  name only what is still open. A first entry is untouched.
- **A generous free-text fallback**: `{"items": […]}` envelopes, a bare object,
  an array of question strings, fenced blocks before the bracket scan, and
  text-protocol tool-call markup stripped first.
- **`SplitAttempts` cleared** on a successful split and on stage entry.
- **`lev validate` warns** (`fanout-no-escape`) about a fan-out stage with
  neither escape. Auditing the bundled set found nothing to change — all five
  fan-out stages already declared the escape they were never given.

## Verified live, not just green

Driven against a real daemon with a scripted Rhai provider (no API key), in an
isolated `LEVIATH_HOME`. The discriminating control is the same blueprint and the
same split answer against a build with the old behaviour restored:

| | escape declared | no escape |
|---|---|---|
| **pre-fix** | `error`, stuck at `split`, `recover` **skipped** | — |
| **post-fix** | `complete` at `recover` | `complete` at `merge`, `splits_degraded=1` |

Also confirmed live: a `submit_work_items` call spawns its workers; an empty
`items` array goes straight to the merge stage; and on a real re-entry the
split's own answer reports it saw both `split round 2` and the previously
researched item ids.

`cargo xtask coverage`: all 13 packages at 100%.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
