### PR TITLE
fix(agents): what four real research runs showed was wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,35 @@ same list.
   between reads the name off the next status instead of fetching the run.
   Announced as the `events.title` capability, so a console can drop that poll
   where the daemon has it and keep it where it does not.
+- Changed: the research agents cite with linked markers - `[[n]](<url>)`, which
+  renders as `[n]` and clicks through to the source - so checking a claim no
+  longer means scrolling to the bibliography and pasting a URL by hand. A source
+  with a local path instead of a URL stays a bare `[n]`.
+- Fixed: `wide-researcher` never asked for a bibliography section, so one run
+  produced a source table of titles and credibility grades with no URLs at all -
+  for a task whose whole point was a reading list. It now asks for the numbered
+  bibliography from `sources_index` with the URL on every line, as
+  `deep-researcher` already did.
+- Fixed: `deep-researcher` and `wide-researcher` never told their merge stage
+  where the fan-out results land. The workers' findings sat in a pinned region
+  the stage had not been pointed at, so it went looking for files named after the
+  work items - the same shape as the region-as-a-path misfire, one layer up. Both
+  now name the region and say plainly that the findings are not files.
+- Fixed: `researcher` was told to write its report and not where, so workers
+  invented plausible absolute paths (`/research/...`, `/home/user/output/...`)
+  that the workspace guard refused, losing the artifact. It now asks for a plain
+  relative filename and says the findings reach the caller either way.
+- Changed: a claim about something a task names only as a comparison is graded on
+  what that run actually read about it. Two mirrored runs - one researching
+  GLP-1s "like creatine", one researching creatine "like Ozempic" - agreed on the
+  substance, but the creatine run sourced a GLP-1 trial figure to a supplement
+  blog and graded it HIGH, while the run that read the trials reported a
+  different number and flagged the disagreement.
+- Changed: `read_file` on a directory now names `list_dir` instead of returning
+  the raw OS error. `read_file(".")` was the single most common failed tool call
+  across four research runs, and "Is a directory (os error 21)" names the problem
+  without naming the fix.
+
 - Added: `fan_out`, a tool any stage can grant to run many sub-agents at once and
   get their results back together. There were two ways to start sub-agents and
   they shared nothing: `spawn_agent` was a tool an agent called mid-work, while

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.3.0"
+version = "0.3.1"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
@@ -183,7 +183,7 @@ Decide the next move:
 - Enough well-supported evidence to write the report → respond with: synthesize
 """
 system_prompt = """
-Analyze the `sources` against `sources_index`. Be rigorous:
+Analyze the `sources` and `sub_findings` against `sources_index`. Be rigorous:
 1. Extract factual claims into `claims` (context_append), each with its source
    ref: `<claim> [n]`. Separate well-supported (multiple credible sources) from
    single-source or speculative.
@@ -191,6 +191,12 @@ Analyze the `sources` against `sources_index`. Be rigorous:
    what, with refs. Never silently pick a side.
 3. Evaluate source quality and bias; note gaps and the specific citations worth
    chasing next.
+
+The workers' findings are already here: the fan-out wrote them into
+`sub_findings`, which is rendered into this prompt under its own `## sub_findings`
+heading. They are not files. A work item's name is not a filename, and
+`read_file` on one finds nothing - the whole point of the fan-out is that the
+answers came back to you.
 
 Prefer following a key citation (follow_citations) over re-searching when a claim
 hinges on a source you haven't read directly.
@@ -271,7 +277,8 @@ Write the report (write_file), built from `claims` and citing `sources_index`,
 following the citation/confidence rules in `format`. Structure:
 - Executive summary (key findings in 3-5 sentences, each with a confidence level)
 - Background and context
-- Findings organized by theme, every non-obvious claim carrying a [n] citation
+- Findings organized by theme, every non-obvious claim carrying a linked
+  `[[n]](<url>)` citation
 - Disagreements - pull these straight from `contradictions`; never drop a
   recorded conflict
 - Analysis and implications
@@ -363,7 +370,7 @@ environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_ti
 # the stages that can write context (gather, analyze, follow_citations) and
 # no-ops for the ones that cannot, so it can never deadlock the deliverable.
 sources_index  = { kind = "pinned", budget = "4%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url/path> - <date> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
-format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Mark each key finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
+format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Mark each key finding's confidence as high / medium / low based on source count and credibility. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
 sources        = { kind = "temporary",      budget = "30%" }
 claims         = { kind = "sliding_window", max_items = 40, budget = "8%" }

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.1.3"
+version = "0.1.4"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
@@ -137,6 +137,14 @@ system_prompt = """
 Write the research report (write_file), built from the `claims` region and citing
 `sources_index`. Follow the citation/confidence rules in the `format` region.
 
+Give it a plain relative filename - `<topic-slug>.md`, no leading `/` and no
+invented parent directory. It is written inside the run's working directory, and
+a path that climbs out of it is refused: `/research/...`, `/home/user/output/...`
+and similar look reasonable and are not real, and the write is simply lost. Your
+findings reach whoever asked for them either way - the file is the artifact, not
+the hand-off - so do not spend turns hunting for a directory that will accept a
+path you invented.
+
 Structure:
 - Key findings organized by theme, each with a confidence level.
 - Notable disagreements - pull these straight from the `contradictions` region;
@@ -144,7 +152,8 @@ Structure:
 - Open questions.
 - Sources - the numbered bibliography from `sources_index`.
 
-Keep it tight and skimmable. Every non-obvious claim must carry a [n] citation.
+Keep it tight and skimmable. Every non-obvious claim must carry a linked
+`[[n]](<url>)` citation.
 
 Citations are load-bearing, so two rules bind absolutely:
 
@@ -239,7 +248,7 @@ environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_ti
 # deadlock the deliverable.
 sources_index  = { kind = "pinned", budget = "3%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url or path> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
 # Citation/confidence rules (seeded with a sensible default the agent follows).
-format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Mark each finding's confidence as high / medium / low based on source count and credibility." }, volatility = "stable" }
+format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Mark each finding's confidence as high / medium / low based on source count and credibility. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
 # Raw source material (bulk, evictable).
 raw_findings   = { kind = "temporary", budget = "30%" }

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.3.0"
+version = "0.3.1"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 
@@ -171,13 +171,20 @@ Decide the next move:
 - You've covered enough ground to write a useful overview → respond with: summarize
 """
 system_prompt = """
-Compare across the `landscape`, organizing by THEME not by source:
+Compare across the `landscape` and `thread_findings`, organizing by THEME not by
+source:
 - Patterns; where approaches converge or diverge
 - The tradeoffs each approach makes
 - What's overhyped vs underappreciated
 Record the key comparative judgments in `comparisons` (context_write) and any
 source disagreements you notice. Flag threads that deserve a deep_dive before you
 can rank them fairly. Help the reader see the shape of the field.
+
+The workers' findings are already here: the fan-out wrote them into
+`thread_findings`, which is rendered into this prompt under its own `## thread_findings`
+heading. They are not files. A work item's name is not a filename, and
+`read_file` on one finds nothing - the whole point of the fan-out is that the
+answers came back to you.
 
 If `error_report` says a previous stage hit its iteration cap, that stage was cut
 off before finishing - treat its coverage as incomplete when judging the field.
@@ -260,9 +267,19 @@ citing `sources_index` per the rules in `format`. Include:
 - Notable projects/implementations worth watching (draw on deep_dives)
 - Trends and trajectory
 - Recommendations (what to look at first, by goal)
+- Sources - the numbered bibliography from `sources_index`, every line carrying
+  its URL
+
+Every `[n]` in the prose is a link to its source - `[[n]](<url>)` - so the
+reader can click through from the claim.
 
 Write concisely - the reader wants the lay of the land quickly. Cite sources for
 non-obvious claims.
+
+The bibliography is the deliverable as much as the prose is: a survey is a
+reading list, and `[n]` markers over a source list with no URLs send the reader
+back to a search engine to find what this run already found. Carry the URL on
+every line, even when the title looks searchable.
 
 Citations are load-bearing, so two rules bind absolutely:
 
@@ -341,7 +358,7 @@ environment        = { kind = "pinned", budget = "1%", seed = { tools = ["curren
 # that can write context and no-ops for the ones that cannot, so it can never
 # deadlock the deliverable.
 sources_index      = { kind = "pinned", budget = "3%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url or path> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
-format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Prefer comparison tables where they clarify tradeoffs." }, volatility = "stable" }
+format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Prefer comparison tables where they clarify tradeoffs. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
 landscape          = { kind = "temporary",      budget = "30%" }
 deep_dives         = { kind = "sliding_window", max_items = 15, budget = "8%" }

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -259,6 +259,16 @@ impl BuiltinTools {
 
         match std::fs::read_to_string(&path) {
             Ok(content) => cap_file_content(&content, MAX_READ_FILE_BYTES),
+            // A directory is not a malformed path, it is the wrong tool: the
+            // model wanted to see what is in there. Measured across four
+            // research runs, `read_file(".")` was the single most common failed
+            // call, and the raw OS message ("Is a directory (os error 21)")
+            // names the problem without naming the fix, so the next call was
+            // usually another guess.
+            Err(_) if path.is_dir() => format!(
+                "[error] '{path_str}' is a directory, not a file. Use list_dir to see what \
+                 is in it, then read_file on one of the entries."
+            ),
             Err(e) => format!("[error] Failed to read '{}': {}", path_str, e),
         }
     }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1364,15 +1364,20 @@ mod tests {
         assert!(result.contains("Failed to create directories"));
     }
 
+    /// A directory is the wrong tool, not a malformed path, so the refusal names
+    /// the right one. `read_file(".")` was the most common failed call across
+    /// four research runs, and the raw OS message ("Is a directory (os error
+    /// 21)") named the problem without naming the fix.
     #[tokio::test]
-    async fn read_file_fails_when_path_is_a_directory() {
+    async fn read_file_on_a_directory_points_at_list_dir() {
         let dir = tempfile::tempdir().unwrap();
         let tools = make_tools(dir.path());
         fs::create_dir(dir.path().join("adir")).unwrap();
 
         let result = tools.execute("read_file", json!({"path": "adir"})).await;
-        assert!(result.contains("[error]"));
-        assert!(result.contains("Failed to read"));
+        assert!(result.contains("[error]"), "{result}");
+        assert!(result.contains("is a directory, not a file"), "{result}");
+        assert!(result.contains("list_dir"), "{result}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Audited four completed research runs and fixed what they exposed. Citation integrity is healthy now (60-78 URLs fetched each, no thin searches, every cited URL at least seen in a search result) - these are the remaining defects.

## What the runs showed

**`wide-researcher` never asked for a bibliography.** One run produced a 16-row source table of titles and credibility grades with **zero URLs**, for a task that asked for reading. `deep-researcher` lists "References" in its structure and got it right; `wide-researcher`'s list ended at "Recommendations", so the model invented the section and its columns.

**Neither researcher told its merge stage where fan-out results land.** `sub_findings` / `thread_findings` appeared only in the fan-out config and the layout, never in a prompt - so the parent went hunting for files named after the work items (`emerging-non-metabolic-benefits.md`). Same shape as the region-as-a-path misfire, one layer up.

**`researcher` was told to write a report and not where.** Workers invented `/research/...`, `/home/user/output/...`, `/root/...`; all refused by the workspace guard, losing the artifact. Findings still reached the parent through the fan-out, which is why nobody noticed.

**`read_file(".")` was the most common failed call** across all four runs. "Is a directory (os error 21)" names the problem without naming the fix, so the next call was another guess. It now names `list_dir`.

## The mirrored pair

GLP-1s "like creatine" vs creatine "like Ozempic" **agree on the substance**: both call the comparison a category error, both cite the same source for muscle preservation, both give the same 25-40% lean-mass figure.

One inconsistency, and it is instructive: the creatine run attributed a STEP-1 cessation figure to a supplement blog and graded it **HIGH**, while the run that actually read the BMJ and Lancet meta-analyses gave a different number and flagged that the two disagree. A claim about the thing you are compared against is now graded on what that run read about it.

## Also

Citations are now linked markers - `[[n]](<url>)` renders as `[n]` and clicks through - so checking a claim does not mean scrolling to the bibliography and pasting a URL.

## Verified

A provider that reports what its system prompt contained confirms the link rule and the comparator rule both reach the model. `require_fan_out` degraded correctly (`splits_degraded = 1`) against a model that never calls the tool. All seven bundled agents validate with zero errors. Coverage: all 13 packages at 100%.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>