### PR TITLE
feat(serve): say when a run is renamed, so nobody has to poll for its name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ same list.
 
 ## Unreleased
 
+- Added: a run's rename now reaches a websocket subscriber. A run is created
+  untitled and named a moment later, once a model has shortened its prompt into
+  a title, and nothing on the wire said so - a console showed the prompt's first
+  line until an unrelated re-read or the next thirty-second poll replaced it,
+  which is the window where somebody is actually looking at the run they just
+  started. There is a `run_renamed` frame for the moment, and `title` on every
+  `agent_status` frame after it so a client that connected or reconnected in
+  between reads the name off the next status instead of fetching the run.
+  Announced as the `events.title` capability, so a console can drop that poll
+  where the daemon has it and keep it where it does not.
 - Added: `fan_out`, a tool any stage can grant to run many sub-agents at once and
   get their results back together. There were two ways to start sub-agents and
   they shared nothing: `spawn_agent` was a tool an agent called mid-work, while

--- a/crates/leviath-cli/src/commands/agent_client/tests.rs
+++ b/crates/leviath-cli/src/commands/agent_client/tests.rs
@@ -237,6 +237,7 @@ fn status_event() -> WorldEvent {
         tool_calls: 0,
         accepts_messages: false,
         wait_reason: None,
+        title: None,
     }
 }
 

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -83,6 +83,12 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // a console can place a fan-out worker in the tree the moment it starts
     // instead of fetching every new run to find out where it hangs.
     "events.spawn_parent",
+    // The `run_renamed` frame, plus `title` on `agent_status`. A run is named a
+    // moment after it starts and never again, so a client without this either
+    // polls every new run for its title or shows the prompt's first line until
+    // something unrelated makes it re-read. Announced so a console can drop
+    // that poll where the daemon has it and keep it where it does not.
+    "events.title",
     "blueprints.envelope",
     "blueprints.query",
     "blueprints.manifest",

--- a/crates/leviath-cli/src/commands/serve/events.rs
+++ b/crates/leviath-cli/src/commands/serve/events.rs
@@ -40,6 +40,30 @@ pub enum ServerEvent {
         /// exists to remove.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         wait_reason: Option<leviath_core::run_meta::WaitReason>,
+        /// The run's generated title, once it has one.
+        ///
+        /// [`RunRenamed`](Self::RunRenamed) is what announces the rename the
+        /// moment it happens; this is the same fact carried on every later
+        /// status frame, so a client that connected or reconnected after that
+        /// moment picks the name up without fetching the run.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+    },
+    /// The run acquired a title, or had the one it was showing replaced.
+    ///
+    /// A run is created untitled and named a moment later, once a model has
+    /// shortened its prompt into one. That is the one field guaranteed to
+    /// change shortly after a run starts and then never again, and the title is
+    /// the run's name in every list, notification and tab - so a client without
+    /// this frame either polls each new run or shows the wrong name until
+    /// something unrelated makes it re-read.
+    RunRenamed {
+        /// The agent's live id in the world.
+        agent_id: String,
+        /// The durable run id.
+        run_id: String,
+        /// The title the run now goes by.
+        title: String,
     },
     /// How full the run's context window is, after a turn changed it.
     ContextUpdate {
@@ -197,6 +221,7 @@ impl ServerEvent {
     pub fn run_id(&self) -> &str {
         match self {
             ServerEvent::AgentStatus { run_id, .. }
+            | ServerEvent::RunRenamed { run_id, .. }
             | ServerEvent::ContextUpdate { run_id, .. }
             | ServerEvent::Log { run_id, .. }
             | ServerEvent::InteractionNeeded { run_id, .. }
@@ -274,6 +299,7 @@ mod tests {
             tool_calls: 12,
             accepts_messages: true,
             wait_reason: None,
+            title: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"type\":\"agent_status\""));
@@ -374,8 +400,17 @@ mod tests {
                     tool_calls: 0,
                     accepts_messages: false,
                     wait_reason: None,
+                    title: None,
                 },
                 "r1",
+            ),
+            (
+                ServerEvent::RunRenamed {
+                    agent_id: "a".to_string(),
+                    run_id: "r1b".to_string(),
+                    title: "A short name".to_string(),
+                },
+                "r1b",
             ),
             (
                 ServerEvent::ContextUpdate {

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -1050,6 +1050,7 @@ model = "claude-sonnet-4-6"
             tool_calls: 0,
             accepts_messages: true,
             wait_reason: None,
+            title: None,
         };
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"type\":\"agent_status\""));

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -174,6 +174,7 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
             tool_calls,
             accepts_messages,
             wait_reason,
+            title,
         } => ServerEvent::AgentStatus {
             agent_id,
             run_id,
@@ -183,6 +184,16 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
             tool_calls,
             accepts_messages,
             wait_reason,
+            title,
+        },
+        WorldEvent::Renamed {
+            run_id,
+            agent_id,
+            title,
+        } => ServerEvent::RunRenamed {
+            agent_id,
+            run_id,
+            title,
         },
         WorldEvent::Tokens {
             run_id,
@@ -547,8 +558,17 @@ mod tests {
                 tool_calls: 0,
                 accepts_messages: true,
                 wait_reason: None,
+                title: None,
             }),
             "agent_status"
+        );
+        assert_eq!(
+            mapped_tag(WorldEvent::Renamed {
+                run_id: "r".into(),
+                agent_id: "a".into(),
+                title: "A short name".into(),
+            }),
+            "run_renamed"
         );
         assert_eq!(
             mapped_tag(WorldEvent::Tokens {
@@ -627,6 +647,47 @@ mod tests {
             }),
             "tool_call_finished"
         );
+    }
+
+    /// A run is named a moment after it starts, and nothing on the wire used
+    /// to say so. Both halves of the fix are asserted by name: the frame that
+    /// announces the rename, and the same title riding the status frames that
+    /// follow it, which is what a client that reconnected after the moment
+    /// reads instead of fetching the run.
+    #[test]
+    fn a_rename_is_announced_and_then_carried_on_status() {
+        let renamed = serde_json::to_value(to_server_event(WorldEvent::Renamed {
+            run_id: "run-1".into(),
+            agent_id: "a".into(),
+            title: "Fix the rename gap".into(),
+        }))
+        .unwrap();
+        assert_eq!(renamed["type"], "run_renamed");
+        assert_eq!(renamed["run_id"], "run-1");
+        assert_eq!(renamed["agent_id"], "a");
+        assert_eq!(renamed["title"], "Fix the rename gap");
+
+        let status = |title: Option<&str>| {
+            serde_json::to_value(to_server_event(WorldEvent::Status {
+                run_id: "run-1".into(),
+                agent_id: "a".into(),
+                status: "active".into(),
+                stage: "implement".into(),
+                iteration: 1,
+                tool_calls: 0,
+                accepts_messages: true,
+                wait_reason: None,
+                title: title.map(str::to_string),
+            }))
+            .unwrap()
+        };
+        assert_eq!(
+            status(Some("Fix the rename gap"))["title"],
+            "Fix the rename gap"
+        );
+        // An untitled run says nothing rather than sending a null a client
+        // would have to tell apart from a title it cleared.
+        assert!(status(None).get("title").is_none());
     }
 
     /// The fine-grained events used to arrive wrapped as `{"type":"world",
@@ -722,6 +783,7 @@ mod tests {
                 tool_calls: 0,
                 accepts_messages: true,
                 wait_reason: None,
+                title: None,
             },
         );
         assert_eq!(tag(&rx.try_recv().unwrap()), "agent_status");
@@ -747,6 +809,7 @@ mod tests {
                 tool_calls: 0,
                 accepts_messages: false,
                 wait_reason: Some(WaitReason::FanOutWorkers { outstanding: 3 }),
+                title: None,
             },
         );
         // Asserted on the serialized form rather than by destructuring, because
@@ -1116,6 +1179,7 @@ mod tests {
                 tool_calls: 0,
                 accepts_messages: true,
                 wait_reason: None,
+                title: None,
             }],
         );
         let (state, mut rx) = state_with(control);
@@ -1159,6 +1223,7 @@ mod tests {
                     tool_calls: 0,
                     accepts_messages: true,
                     wait_reason: None,
+                    title: None,
                 })
                 .unwrap();
                 line.push('\n');
@@ -1264,6 +1329,7 @@ mod tests {
                 tool_calls: 0,
                 accepts_messages: true,
                 wait_reason: None,
+                title: None,
             });
             tokio::time::sleep(Duration::from_millis(50)).await;
             drop(events);

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -705,6 +705,12 @@ mod tests {
                 tool_calls: 0,
                 accepts_messages: true,
                 wait_reason: None,
+                title: None,
+            },
+            ServerEvent::RunRenamed {
+                agent_id: "a".to_string(),
+                run_id: "run-match".to_string(),
+                title: "A short name".to_string(),
             },
             ServerEvent::ContextUpdate {
                 agent_id: "a".to_string(),
@@ -1117,6 +1123,7 @@ mod tests {
             tool_calls: 0,
             accepts_messages: true,
             wait_reason: None,
+            title: None,
         };
         assert_eq!(ev.run_id(), "run-123");
     }
@@ -1200,6 +1207,7 @@ mod tests {
             tool_calls: 0,
             accepts_messages: true,
             wait_reason: None,
+            title: None,
         };
         let non_matching = ServerEvent::AgentStatus {
             agent_id: "a".to_string(),
@@ -1210,6 +1218,7 @@ mod tests {
             tool_calls: 0,
             accepts_messages: true,
             wait_reason: None,
+            title: None,
         };
 
         assert_eq!(matching.run_id(), filter);
@@ -1227,6 +1236,7 @@ mod tests {
             tool_calls: 0,
             accepts_messages: false,
             wait_reason: None,
+            title: None,
         };
         let json = serde_json::to_string(&ev).unwrap();
         assert!(json.contains("\"type\":\"agent_status\""));

--- a/crates/leviath-runtime/src/host/emit.rs
+++ b/crates/leviath-runtime/src/host/emit.rs
@@ -77,6 +77,11 @@ impl WorldHost {
                     context_tokens,
                     terminal,
                     wait_reason: self.wait_reason(agent),
+                    title: self
+                        .world
+                        .world()
+                        .get::<RunMetadata>(entity)
+                        .and_then(|m| m.title.clone()),
                 }
             };
             let max_tokens = self
@@ -96,6 +101,20 @@ impl WorldHost {
                     agent_id: agent_id.clone(),
                     blueprint,
                     parent_run_id,
+                });
+            }
+
+            // A run is created untitled and named a moment later, once the
+            // titling call lands. Nothing else on the wire said so, which left
+            // every client either polling each new run or showing the prompt's
+            // first line until unrelated traffic made it re-read.
+            if let Some(title) = cur.title.as_deref()
+                && prev.as_ref().and_then(|e| e.title.as_deref()) != Some(title)
+            {
+                let _ = self.events.send(WorldEvent::Renamed {
+                    run_id: run_id.clone(),
+                    agent_id: agent_id.clone(),
+                    title: title.to_string(),
                 });
             }
 
@@ -123,6 +142,7 @@ impl WorldHost {
                     tool_calls: cur.tool_calls,
                     accepts_messages: cur.accepts_messages,
                     wait_reason: cur.wait_reason.clone(),
+                    title: cur.title.clone(),
                 });
             }
 

--- a/crates/leviath-runtime/src/host/events.rs
+++ b/crates/leviath-runtime/src/host/events.rs
@@ -15,8 +15,9 @@ use leviath_core::interaction::InteractionRequest;
 
 /// A change in the world, broadcast to subscribers (the HTTP/WS gateway and
 /// in-process embedders) so they get pushed updates instead of polling. The
-/// coarse per-run variants (`Spawned`/`Status`/`Tokens`/`Context`/`Completed`)
-/// are emitted by the host's change-detection pass as it drives the world;
+/// coarse per-run variants
+/// (`Spawned`/`Status`/`Renamed`/`Tokens`/`Context`/`Completed`) are emitted by
+/// the host's change-detection pass as it drives the world;
 /// `StageTransition`/`ToolCallStarted`/`ToolCallFinished`/`Log` are pushed at
 /// the source by pipeline systems through [`WorldEventSink`]. Streamed over the
 /// control transport via `ControlRequest::Subscribe`.
@@ -70,6 +71,29 @@ pub enum WorldEvent {
         /// and answer something" or "its workers are still going" - which is
         /// the guess this vocabulary exists to remove.
         wait_reason: Option<leviath_core::run_meta::WaitReason>,
+        /// The run's generated title, once it has one.
+        ///
+        /// Carried on every status frame rather than only on the one that
+        /// announced it: [`Renamed`](Self::Renamed) is the moment, this is the
+        /// fact, and a subscriber that joined or reconnected after the moment
+        /// picks the name up from the next status without a fetch.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        title: Option<String>,
+    },
+    /// A run acquired a title, or had the one it was showing replaced.
+    ///
+    /// A run starts untitled and is named a moment later, once the one-shot
+    /// titling call comes back. That rename is the one field guaranteed to
+    /// change shortly after a run starts and then never again, so without an
+    /// event for it every client either polls each new run or shows the wrong
+    /// name until something unrelated makes it re-read.
+    Renamed {
+        /// The run id.
+        run_id: String,
+        /// The agent id.
+        agent_id: String,
+        /// The title the run now goes by.
+        title: String,
     },
     /// A run's token totals changed.
     Tokens {
@@ -190,6 +214,7 @@ impl WorldEvent {
         match self {
             WorldEvent::Spawned { run_id, .. }
             | WorldEvent::Status { run_id, .. }
+            | WorldEvent::Renamed { run_id, .. }
             | WorldEvent::Tokens { run_id, .. }
             | WorldEvent::Context { run_id, .. }
             | WorldEvent::Interaction { run_id, .. }
@@ -235,4 +260,12 @@ pub(super) struct Emitted {
     /// Why the run is parked, so a change of reason counts as a change worth
     /// telling subscribers about.
     pub(super) wait_reason: Option<leviath_core::run_meta::WaitReason>,
+    /// The run's title as of the last pass, so the pass that first sees one can
+    /// announce the rename.
+    ///
+    /// Deliberately *not* part of the status change key: a rename is not a move
+    /// in execution state, and a status frame that repeated the stage and
+    /// iteration it already sent would say nothing new. The title rides the
+    /// next status frame that fires on its own.
+    pub(super) title: Option<String>,
 }

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -2578,6 +2578,111 @@ async fn emit_events_broadcasts_agent_changes() {
     );
 }
 
+/// A run is created untitled and named a moment later, once the titling call
+/// lands. Nothing on the wire used to say so, so a subscriber showed the
+/// prompt's first line until an unrelated re-read replaced it. Both halves are
+/// asserted here: the `Renamed` frame that announces the moment, and the title
+/// riding the status frames that follow, which is what a subscriber that joined
+/// after the moment reads instead of fetching the run.
+#[tokio::test]
+async fn a_generated_title_is_announced_once_and_then_carried_on_status() {
+    let mut host = host_with(vec![text("done")]);
+    let mut rx = host.subscribe();
+    let entity = spawn(&mut host, "run-a", "agent-a");
+    host.world_mut()
+        .world_mut()
+        .entity_mut(entity.entity())
+        .insert(RunMetadata {
+            run_id: "run-a".to_string(),
+            agent_name: "coder".to_string(),
+            agent_path: "/a".to_string(),
+            task: "Do the thing, and then the other thing".to_string(),
+            model: None,
+            workdir: "/w".to_string(),
+            num_stages: 1,
+            started_at: 0,
+            parent_run_id: None,
+            metadata: std::collections::HashMap::new(),
+            callback_url: None,
+            callback_secret: None,
+            title: None,
+            unattended: false,
+            read_paths: None,
+            output_request: None,
+            model_override: None,
+        });
+
+    // Untitled: the first pass says nothing about a name, and the status frame
+    // it does send omits the field rather than sending an empty one.
+    host.emit_events();
+    let first: Vec<WorldEvent> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert!(
+        !first
+            .iter()
+            .any(|e| matches!(e, WorldEvent::Renamed { .. })),
+        "an untitled run has nothing to announce"
+    );
+    assert!(
+        first
+            .iter()
+            .any(|e| matches!(e, WorldEvent::Status { title: None, .. })),
+        "the status frame carries no title yet: {first:?}"
+    );
+
+    // The titling call lands, exactly as `collect_title` stores it.
+    host.world_mut()
+        .world_mut()
+        .entity_mut(entity.entity())
+        .get_mut::<RunMetadata>()
+        .unwrap()
+        .title = Some("Do the thing".to_string());
+
+    host.emit_events();
+    let renamed: Vec<WorldEvent> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert!(
+        renamed.iter().any(|e| matches!(
+            e,
+            WorldEvent::Renamed { run_id, agent_id, title }
+                if run_id == "run-a" && agent_id == "agent-a" && title == "Do the thing"
+        )),
+        "the rename should be announced: {renamed:?}"
+    );
+
+    // The rename alone is not a move in execution state, so it fires no status
+    // frame of its own. The next one that fires for its own reasons carries the
+    // name, which is what a subscriber that missed the announcement reads.
+    assert!(
+        !renamed
+            .iter()
+            .any(|e| matches!(e, WorldEvent::Status { .. })),
+        "a rename is not a status change: {renamed:?}"
+    );
+    {
+        let ecs = host.world_mut().world_mut();
+        ecs.entity_mut(entity.entity())
+            .get_mut::<AgentState>()
+            .unwrap()
+            .iteration = 7;
+    }
+    host.emit_events();
+    let after: Vec<WorldEvent> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert!(
+        after.iter().any(|e| matches!(
+            e,
+            WorldEvent::Status { title: Some(t), .. } if t == "Do the thing"
+        )),
+        "later status frames carry the name: {after:?}"
+    );
+
+    // Announced once. A title that has not moved is not news.
+    assert!(
+        !after
+            .iter()
+            .any(|e| matches!(e, WorldEvent::Renamed { .. })),
+        "an unchanged title should not re-announce: {after:?}"
+    );
+}
+
 /// A subscriber watching live gets the same vocabulary `lev ps` and the
 /// dashboard use, so it never has to fetch the run to find out whether a parked
 /// run needs a person. And because the reason is part of the change key, a
@@ -3677,6 +3782,12 @@ fn every_world_event_variant_carries_its_run_id() {
             tool_calls: 0,
             accepts_messages: false,
             wait_reason: None,
+            title: None,
+        },
+        WorldEvent::Renamed {
+            run_id: rid.clone(),
+            agent_id: aid.clone(),
+            title: "A short name".to_string(),
         },
         WorldEvent::Tokens {
             run_id: rid.clone(),

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -542,7 +542,8 @@ Every frame is a JSON object with a `type`, and every frame except `daemon_link`
 | `type` | Sent when | Beyond `agent_id` and `run_id` |
 | --- | --- | --- |
 | `agent_spawned` | A run first appears | `blueprint`, and `parent_id` for a sub-agent |
-| `agent_status` | Status, stage, iteration or tool count moves | `status`, `stage`, `iteration`, `tool_calls`, `accepts_messages`, `wait_reason` |
+| `agent_status` | Status, stage, iteration or tool count moves | `status`, `stage`, `iteration`, `tool_calls`, `accepts_messages`, `wait_reason`, `title` |
+| `run_renamed` | The run acquires a generated title | `title` |
 | `tokens` | The run's token totals move | `prompt_tokens`, `completion_tokens`, `cached_tokens`, `cache_write_tokens` |
 | `context_update` | The context window's usage moves | `total_tokens`, `max_tokens` |
 | `stage_transition` | A new stage is entered | `from`, `to`, `iteration` |
@@ -552,6 +553,12 @@ Every frame is a JSON object with a `type`, and every frame except `daemon_link`
 | `interaction_needed` | The run is blocked on a person | `request` |
 | `agent_completed` | The run reaches a terminal status | `status`, `result` (its error), `final_output` |
 | `daemon_link` | This server's link to the daemon changes | `connected`, `daemon`, `restarted`, `restart_advised` |
+
+A run is created untitled and named a moment later, once a model has shortened its prompt into a
+title. `run_renamed` is that moment. The same `title` then rides every `agent_status` frame, so a
+client that connected or reconnected after the rename reads the name off the next status instead of
+fetching the run. Both are the `events.title` capability; without it a client has to poll each new
+run until it has a name. `title` is absent, not null, while a run has none.
 
 `wait_reason` is present only on a parked run, and says what it is parked on rather than making
 you fetch the run to find out. `ok` on `tool_call_finished` is `false` for a result the engine


### PR DESCRIPTION
Closes #540.

A run is created untitled and named a moment later, once a model has shortened its prompt into a title. Nothing on the wire said so, so a console watching `/ws` showed the prompt's first line until something unrelated made it re-read the run, or until the next thirty-second poll — the window where somebody is actually looking at the run they just started.

The issue offered two shapes and this does both, because they answer different questions.

**`run_renamed` is the moment.** A new `WorldEvent::Renamed`, mapped to a flat `run_renamed` frame, fires once when the title first appears and never again for an unchanged one.

```json
{"type":"run_renamed","agent_id":"…","run_id":"…","title":"Websocket rename, live"}
```

**`title` on `agent_status` is the fact.** A client that connected or reconnected after the rename reads the name off the next status frame instead of fetching the run. Absent, not null, while a run has none.

The title is deliberately **not** part of the status change key. A rename is not a move in execution state, and a status frame repeating the stage and iteration it already sent would say nothing new — so a rename fires exactly one frame, not two.

Both are announced as the **`events.title`** capability on `GET /api/config`, so a console can drop its poll-until-named loop where the daemon has this and keep it where it does not.

## Verified live

Not just green tests: a real daemon and `lev serve`, driven by a mock provider on an isolated `LEVIATH_HOME`, with a raw websocket subscribed to `/ws` before the run started.

```
{"type":"agent_status",  … "iteration":0}                          ← no title key yet
{"type":"log", "line":"All done here."}
{"type":"run_renamed",   … "title":"Websocket rename, live"}       ← the moment
{"type":"agent_status",  … "iteration":1, "title":"Websocket rename, live"}
{"type":"agent_status",  … "status":"complete", "title":"Websocket rename, live"}
{"type":"agent_completed", …}
```

One `run_renamed`, not repeated. `events.title` present in `capabilities`. Zero probe runs leaked into the real home.

## Notes

- `WorldEvent` is deliberately not `#[non_exhaustive]`, so the new variant is a compile error at every consumer rather than something a catch-all arm swallows. Only `to_server_event` matches exhaustively; it is wired.
- Coverage gate: all 13 packages at 100%.
- Full suite, clippy, `cargo xtask docs` and the structure check all pass.
