### PR TITLE
fix(serve): make api_version the build's version instead of a literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,15 @@ same list.
   its cap when they came back. `lev validate` has always held that a fan_out
   stage needs no `max_iterations`; the runtime was enforcing one anyway, and now
   does not.
-
+- Changed: `api_version` on `GET /api/config` is this build's own version rather
+  than a hand-maintained literal. It was held equal to the OpenAPI spec by a test
+  and to the crates by nobody, so the two agreed only because somebody had last
+  typed the same string into both - and `cargo xtask version` wrote neither. The
+  first release after any bump would have served a version naming a build it was
+  not, silently, with the suite green. `cargo xtask version` now rewrites the
+  spec's `info.version` too, so the existing test guards the release instead of
+  just the document. It moves on every release now, including ones no client can
+  observe; `capabilities` is still what a client should feature-detect on.
 - Added: a run's rename now reaches a websocket subscriber. A run is created
   untitled and named a moment later, once a model has shortened its prompt into
   a title, and nothing on the wire said so - a console showed the prompt's first

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -39,10 +39,25 @@ pub(super) struct RedactedConfig {
     pub(super) limits: ApiLimits,
 }
 
-/// The API contract version. Held equal to the OpenAPI spec's `info.version` by
-/// a test, because a version that can silently disagree with the document it
-/// names is worse than no version at all.
-pub(super) const API_VERSION: &str = "0.4.0";
+/// The API contract version: this build's own version, and nothing to keep in
+/// step by hand.
+///
+/// It was a literal, held equal to the OpenAPI spec's `info.version` by a test
+/// and to the crates by nobody. The two agreed only because somebody had last
+/// set both to the same string, and `cargo xtask version` writes neither - so
+/// the first release after any bump would have served a version that named a
+/// build it was not, silently, with the suite green.
+///
+/// Derived, the test that guarded the spec now guards the release: bump the
+/// crates without regenerating `docs/schema/openapi.json` and it fails, which
+/// is the reminder rather than the trap. `leviath-cli` takes
+/// `version.workspace = true`, so this is the workspace version.
+///
+/// The cost is that it moves on every release, including ones no client can
+/// observe. That is the right trade while `capabilities` is what a client
+/// actually feature-detects on: a version that is always honest about the
+/// build beats one that is occasionally wrong about the contract.
+pub(super) const API_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Every capability a client may check for.
 pub(super) const API_CAPABILITIES: &[&str] = &[

--- a/xtask/src/version.rs
+++ b/xtask/src/version.rs
@@ -45,6 +45,15 @@ const CLI_MANIFEST: &str = "crates/leviath-cli/Cargo.toml";
 /// Path of the changelog whose `## Unreleased` heading a bump rolls over.
 const CHANGELOG: &str = "CHANGELOG.md";
 
+/// Path of the published OpenAPI spec, whose `info.version` names the API this
+/// build serves.
+///
+/// Bumped here because `API_VERSION` is now the crate version, and a test holds
+/// that equal to this document. Leave the spec behind and the next bump lands
+/// red - which is the point, but it should be this command's job to keep them
+/// together rather than the releaser's.
+const SPEC: &str = "docs/schema/openapi.json";
+
 // ── CLI argument parsing ─────────────────────────────────────────────────────
 
 /// What `cargo xtask version` was asked to do.
@@ -296,6 +305,45 @@ fn replace_pin(line: &str, new: &str) -> String {
     format!("{before}version = \"{new}\"{tail}")
 }
 
+/// Rewrite the OpenAPI spec's `info.version` to `new`.
+///
+/// Textual rather than a parse-and-reserialize, because the spec is a
+/// hand-maintained document: round-tripping it through `serde_json` would
+/// reformat every line of it and bury a one-line version bump in a diff nobody
+/// can review.
+///
+/// Anchored to the `info` block's own indentation so it cannot hit the
+/// `"version"` that appears inside a `required` array further down. Exactly one
+/// line may match; zero means the spec moved and this needs updating, and more
+/// than one means the anchor stopped being specific enough to trust.
+pub fn set_spec_version(spec: &str, new: &str) -> Result<String> {
+    let is_info_version =
+        |line: &str| line.starts_with("    \"version\": \"") && line.trim_end().ends_with("\",");
+    let matches = spec.lines().filter(|l| is_info_version(l)).count();
+    anyhow::ensure!(
+        matches == 1,
+        "expected exactly one `info.version` line in {SPEC}, found {matches}"
+    );
+    let out = spec
+        .lines()
+        .map(|line| {
+            if is_info_version(line) {
+                format!("    \"version\": \"{new}\",")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    // `lines()` drops the trailing newline the file ends with; put it back
+    // rather than leaving a no-newline-at-end-of-file diff on every bump.
+    Ok(if spec.ends_with('\n') {
+        format!("{out}\n")
+    } else {
+        out
+    })
+}
+
 /// Rename `## Unreleased` to a dated heading for this version.
 ///
 /// The entries themselves are left untouched: what was accumulating under
@@ -521,11 +569,18 @@ pub fn run_with(runner: &dyn Runner, mode: VersionMode) -> Result<()> {
             std::fs::write(CHANGELOG, roll_changelog(&changelog, &new, &today())?)
                 .with_context(|| format!("writing {CHANGELOG}"))?;
 
+            // `API_VERSION` is `env!("CARGO_PKG_VERSION")`, and a test in
+            // `serve/mod.rs` holds it equal to this document. Without this the
+            // bump itself would fail that test.
+            let spec = std::fs::read_to_string(SPEC).with_context(|| format!("reading {SPEC}"))?;
+            std::fs::write(SPEC, set_spec_version(&spec, &new)?)
+                .with_context(|| format!("writing {SPEC}"))?;
+
             // The lockfile records the workspace crates' own versions, and CI
             // rejects a lockfile that disagrees with the manifests.
             anyhow::ensure!(
                 runner.cargo(&["update", "--workspace"])?,
-                "cargo update --workspace failed; {MANIFEST} and {CHANGELOG} were still written"
+                "cargo update --workspace failed; {MANIFEST}, {CHANGELOG} and {SPEC} were still written"
             );
 
             println!("Version {previous} -> {new}.");
@@ -600,6 +655,76 @@ mod tests {
             VersionMode::parse(&args(&["--check"])).unwrap(),
             VersionMode::Check
         );
+    }
+
+    /// The spec's own `info.version` line, rewritten; everything else,
+    /// including the `"version"` that appears inside a `required` array, left
+    /// exactly as it was.
+    #[test]
+    fn set_spec_version_rewrites_only_the_info_block() {
+        let spec = concat!(
+            "{\n",
+            "  \"openapi\": \"3.1.0\",\n",
+            "  \"info\": {\n",
+            "    \"title\": \"Leviath HTTP API\",\n",
+            "    \"version\": \"0.4.0\",\n",
+            "    \"description\": \"d\"\n",
+            "  },\n",
+            "  \"components\": {\n",
+            "    \"required\": [\n",
+            "      \"version\"\n",
+            "    ]\n",
+            "  }\n",
+            "}\n",
+        );
+        let out = set_spec_version(spec, "0.5.1").expect("one info.version line");
+        assert!(out.contains("    \"version\": \"0.5.1\",\n"));
+        assert!(!out.contains("0.4.0"));
+        // The bare array entry is not a version declaration and is untouched.
+        assert!(out.contains("      \"version\"\n"));
+        assert!(
+            out.ends_with("}\n"),
+            "the trailing newline survives: {out:?}"
+        );
+    }
+
+    /// A spec with no `info.version` line has moved out from under the anchor,
+    /// and silently writing it back unchanged would hand the releaser a spec
+    /// naming the previous build.
+    #[test]
+    fn set_spec_version_refuses_a_spec_with_no_version_line() {
+        let err = set_spec_version("{\n  \"openapi\": \"3.1.0\"\n}\n", "0.5.1")
+            .expect_err("nothing to rewrite");
+        assert!(err.to_string().contains("found 0"), "{err}");
+    }
+
+    /// Two matching lines mean the anchor stopped being specific enough to
+    /// trust, so it refuses rather than rewriting whichever it saw first.
+    #[test]
+    fn set_spec_version_refuses_an_ambiguous_spec() {
+        let spec = "    \"version\": \"0.4.0\",\n    \"version\": \"0.4.0\",\n";
+        let err = set_spec_version(spec, "0.5.1").expect_err("ambiguous");
+        assert!(err.to_string().contains("found 2"), "{err}");
+    }
+
+    /// A spec that does not end in a newline gets none added, so the function
+    /// is a faithful rewrite rather than a reformatter.
+    #[test]
+    fn set_spec_version_leaves_a_missing_trailing_newline_missing() {
+        let out = set_spec_version("    \"version\": \"0.4.0\",", "0.5.1").expect("one line");
+        assert_eq!(out, "    \"version\": \"0.5.1\",");
+    }
+
+    /// The real spec on disk is the one this has to work on, and it is the one
+    /// that would otherwise only be exercised on release day.
+    #[test]
+    fn set_spec_version_rewrites_the_published_spec() {
+        let spec = include_str!("../../docs/schema/openapi.json");
+        let out = set_spec_version(spec, "9.9.9").expect("the published spec has one");
+        assert!(out.contains("    \"version\": \"9.9.9\","));
+        let parsed: serde_json::Value =
+            serde_json::from_str(&out).expect("the rewrite is still valid JSON");
+        assert_eq!(parsed["info"]["version"], "9.9.9");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #543. `api_version` and the crate version now match 1:1, by construction rather than by hand.

## The gap

```
API_VERSION ("0.4.0")  ←── test in serve/mod.rs ──→  openapi.json info.version ("0.4.0")

workspace version ("0.4.0")   ←──── nothing ────→  either of the above
```

`API_VERSION` was a literal. A test held it equal to the OpenAPI spec; **nothing** held it to the crates, and `cargo xtask version` writes neither — it only touches the root manifest, the cli manifest and the changelog. They agreed only because somebody had last typed the same string into both.

So the first release after any bump would have served `api_version: "0.4.0"` from a `0.4.1` build. Silently, with the whole suite green — exactly the failure the existing test's own doc comment argues against, one level up.

## The fix

`API_VERSION` is now `env!("CARGO_PKG_VERSION")` (leviath-cli takes `version.workspace = true`, so that is the workspace version). That flips the lockstep test from guarding the *document* to guarding the *release*: bump the crates without regenerating the spec and it fails by name.

So `cargo xtask version` now rewrites the spec's `info.version` too, keeping the pair together rather than leaving it to whoever cuts the release.

The rewrite is **textual, not parse-and-reserialize** — the spec is hand-maintained, and round-tripping it through `serde_json` would bury a one-line bump in a whole-file reformat. It is anchored to the `info` block's indentation so it cannot hit the `"version"` inside a `required` array further down, and refuses rather than guessing if it matches zero lines or more than one.

## Verified by running the bump for real

```
$ cargo xtask version 9.9.9
Version 0.4.0 -> 9.9.9.
```
→ crates **and** spec both at `9.9.9`, suite green.

Then the discriminating half — spec pinned back to `0.4.0` by hand while the crates said `9.9.9`:

```
assertion `left == right` failed
  left: "0.4.0"
 right: "9.9.9"
test the_api_version_matches_the_spec_it_names ... FAILED
```

The guard bites, with the exact drift named. Experiment reverted; only the two source files and the changelog are in this diff.

## The tradeoff, named

`api_version` now moves on **every** release, including ones no client can observe, so it is no longer a signal that the contract changed. `capabilities` is what clients should feature-detect on regardless (and is what `events.title` was added to in #543) — so a version that is always honest about the build beats one that is occasionally wrong about the contract.

Coverage gate at 100% across all 13 packages; five new tests cover the rewrite including both refusal paths and the real published spec.
