### PR TITLE
fix(fanout): a fan-out stage's own call is a stage fan-out again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ same list.
 
 ## Unreleased
 
+- Fixed: a `mode = "fan_out"` stage's own call is delivered as a stage fan-out
+  again, so `results_region` and `merge_stage` mean something. Making the stage
+  grant the `fan_out` tool left every call looking like a tool call, and the
+  stage door was wired to the tool exit: a live `deep-researcher` fan-out put
+  three workers' findings into `conversation` as a tool result and resumed the
+  split stage, instead of writing `sub_findings` and moving on to `analyze`. The
+  run then ended with nothing. `FanOutOrigin::Stage` had become unreachable
+  outside the tests that built it by hand, which is why nothing caught it.
+- Fixed: a fan-out stage no longer has two budgets fighting over the same loop.
+  `max_attempts` bounds how many times the stage is asked to call `fan_out`;
+  `max_iterations` was also counting those asks, and firing first. A live
+  `deep-researcher` run spent three of `investigate`'s four iterations answering
+  in prose, called `fan_out` on the fourth, and three workers then researched for
+  thirteen minutes - all of which was discarded, because the stage was already at
+  its cap when they came back. `lev validate` has always held that a fan_out
+  stage needs no `max_iterations`; the runtime was enforcing one anyway, and now
+  does not.
+
 - Added: a run's rename now reaches a websocket subscriber. A run is created
   untitled and named a moment later, once a model has shortened its prompt into
   a title, and nothing on the wire said so - a console showed the prompt's first

--- a/crates/leviath-runtime/src/fanout.rs
+++ b/crates/leviath-runtime/src/fanout.rs
@@ -471,14 +471,32 @@ pub fn start_pending_fan_outs(world: &mut World) {
                 })
             })
             .flatten();
+        // Which door this came through, and so how its report is delivered. A
+        // `mode = "fan_out"` stage answers with the same tool call as anybody
+        // else, so the call cannot tell us - only the stage can.
+        //
+        // Getting this wrong made `results_region` and `merge_stage` dead
+        // config: a live `deep-researcher` fan-out delivered three workers'
+        // findings into `conversation` as a tool result and resumed the split
+        // stage, instead of writing `sub_findings` and moving to `analyze`. The
+        // unit tests passed throughout, because they build the origin directly
+        // and never went through this decision.
+        // Which door this came through, and so how its report is delivered. A
+        // `mode = "fan_out"` stage answers with the same tool call as anybody
+        // else, so the call cannot tell us - only the stage can.
+        //
+        // Getting this wrong made `results_region` and `merge_stage` dead
+        // config: a live `deep-researcher` fan-out delivered three workers'
+        // findings into `conversation` as a tool result and resumed the split
+        // stage, instead of writing `sub_findings` and moving to `analyze`. The
+        // unit tests passed throughout, because they build the origin directly
+        // and never went through this decision.
+        let origin = match stage_config.is_some() {
+            true => FanOutOrigin::Stage,
+            false => FanOutOrigin::Tool { call_id },
+        };
         let config = config_for(&request, stage_config.as_ref());
-        begin_fan_out(
-            world,
-            entity,
-            config,
-            request.items,
-            FanOutOrigin::Tool { call_id },
-        );
+        begin_fan_out(world, entity, config, request.items, origin);
     }
 }
 
@@ -1688,11 +1706,11 @@ mod tests {
     fn start_pending_fan_outs_starts_what_the_dispatcher_accepted() {
         let mut world = World::new();
         install(&mut world, TestSpawner::ok());
-        let e = spawn_parent(
-            &mut world,
-            fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue)),
-            "",
-        );
+        // An ordinary stage, so this is the tool door: a fan-out stage's own
+        // call is a stage fan-out and is covered separately.
+        let mut bp = fanout_blueprint(cfg(None, 2, WorkerFailurePolicy::Continue));
+        bp.stages[0].mode = StageMode::Autonomous;
+        let e = spawn_parent(&mut world, bp, "");
         world.entity_mut(e).insert(PendingFanOut {
             call_id: "call-1".to_string(),
             request: parse_fan_out_call(&serde_json::json!({
@@ -1717,6 +1735,73 @@ mod tests {
             w.config.worker_agent.as_deref(),
             Some("researcher"),
             "the call named its worker"
+        );
+    }
+
+    /// A `mode = "fan_out"` stage's call comes back through the STAGE door, not
+    /// the tool one: its report goes to `results_region` and it moves on to
+    /// `merge_stage`.
+    ///
+    /// The call itself is identical either way, so only the stage can say which
+    /// this is - and getting it wrong made `results_region` and `merge_stage`
+    /// dead config. A live `deep-researcher` fan-out delivered three workers'
+    /// findings into `conversation` as a tool result and resumed the split stage
+    /// instead of writing `sub_findings` and moving to `analyze`. Every unit test
+    /// passed, because they all built the origin by hand and never came through
+    /// `start_pending_fan_outs`.
+    #[test]
+    fn a_fan_out_stages_call_is_delivered_as_a_stage_not_a_tool_result() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        let mut config = cfg(Some("merge"), 2, WorkerFailurePolicy::Continue);
+        config.results_region = Some("sub_findings".to_string());
+        let e = spawn_parent(&mut world, fanout_blueprint(config), "");
+        world
+            .get_mut::<ContextWindow>(e)
+            .unwrap()
+            .add_region(Region::new(
+                "sub_findings".to_string(),
+                RegionKind::Pinned,
+                4_000,
+            ));
+        world.entity_mut(e).insert(PendingFanOut {
+            call_id: "call-1".to_string(),
+            request: parse_fan_out_call(&serde_json::json!({
+                "items": [{"id": "a", "context": {}}]
+            }))
+            .unwrap(),
+        });
+
+        start_pending_fan_outs(&mut world);
+        assert_eq!(
+            world.get::<FanOutWaiting>(e).expect("parked").origin,
+            FanOutOrigin::Stage,
+            "a fan-out stage's own call is a stage fan-out"
+        );
+
+        fan_out_collect(&mut world);
+        let worker = world.get::<SubAgentChildren>(e).expect("linked").children[0];
+        complete_worker(&mut world, worker, "what the worker found");
+        fan_out_collect(&mut world);
+
+        let findings = world
+            .get::<ContextWindow>(e)
+            .unwrap()
+            .get_region("sub_findings")
+            .expect("the results region")
+            .content
+            .iter()
+            .map(|entry| entry.content.clone())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            findings.contains("what the worker found"),
+            "the report goes to results_region: {findings}"
+        );
+        assert_eq!(
+            world.get::<StageCursor>(e).map(|c| c.index),
+            Some(1),
+            "and the stage moves on to its merge stage"
         );
     }
 
@@ -1780,6 +1865,89 @@ mod tests {
         assert_eq!(
             w.config.merge_stage, None,
             "an ordinary stage has no merge stage to fall into"
+        );
+    }
+
+    /// A stage that names a `results_region` gets its report there, not in the
+    /// conversation. This is the region the merge stage is told to read, so a
+    /// report that misses it is a fan-out whose findings nobody sees.
+    #[test]
+    fn a_stage_fan_out_writes_to_its_results_region() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        let mut config = cfg(Some("merge"), 2, WorkerFailurePolicy::Continue);
+        config.results_region = Some("sub_findings".to_string());
+        let e = spawn_parent(&mut world, fanout_blueprint(config.clone()), "");
+        world
+            .get_mut::<ContextWindow>(e)
+            .unwrap()
+            .add_region(Region::new(
+                "sub_findings".to_string(),
+                RegionKind::Pinned,
+                4_000,
+            ));
+        begin_fan_out(&mut world, e, config, vec![item("a")], FanOutOrigin::Stage);
+
+        fan_out_collect(&mut world);
+        let worker = world.get::<SubAgentChildren>(e).expect("linked").children[0];
+        complete_worker(&mut world, worker, "what the worker found");
+        fan_out_collect(&mut world);
+
+        let region = world
+            .get::<ContextWindow>(e)
+            .unwrap()
+            .get_region("sub_findings")
+            .expect("the results region")
+            .content
+            .iter()
+            .map(|entry| entry.content.clone())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(region.contains("what the worker found"), "{region}");
+    }
+
+    /// A fan-out whose stage has already spent its `max_iterations` must still
+    /// deliver. The nudges that get a reluctant model to call the tool are
+    /// inferences, so they spend the stage's budget: `deep-researcher` allows
+    /// `investigate` four, a live run spent three answering in prose and the
+    /// fourth calling `fan_out`, and three workers then researched for thirteen
+    /// minutes. Discarding that because the split took four tries is the same
+    /// failure - finished work thrown away - that this whole path exists to stop.
+    #[test]
+    fn a_fan_out_still_merges_when_its_stage_is_out_of_iterations() {
+        let mut world = World::new();
+        install(&mut world, TestSpawner::ok());
+        let mut bp = fanout_blueprint(cfg(Some("merge"), 2, WorkerFailurePolicy::Continue));
+        bp.stages[0].max_iterations = Some(4);
+        let e = spawn_parent(&mut world, bp, "");
+        // The stage is at its cap, exactly as it is when the fan-out starts on
+        // the last iteration the stage had.
+        world.entity_mut(e).insert(StageProgress {
+            iterations: 4,
+            ..Default::default()
+        });
+        begin_fan_out(
+            &mut world,
+            e,
+            cfg(Some("merge"), 2, WorkerFailurePolicy::Continue),
+            vec![item("a")],
+            FanOutOrigin::Stage,
+        );
+
+        fan_out_collect(&mut world); // starts the worker
+        let worker = world.get::<SubAgentChildren>(e).expect("linked").children[0];
+        complete_worker(&mut world, worker, "what the worker found");
+        fan_out_collect(&mut world); // reaps and merges
+
+        assert_eq!(
+            world.get::<StageCursor>(e).map(|c| c.index),
+            Some(1),
+            "the merge stage is entered, not skipped"
+        );
+        let convo = conversation_text(&world, e);
+        assert!(
+            convo.contains("what the worker found"),
+            "and the findings survive: {convo}"
         );
     }
 

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -8247,6 +8247,53 @@ fn enforce_max_iterations_caps_at_the_limit() {
     );
 }
 
+/// A fan-out stage is bounded by `max_attempts`, not by iterations, so the cap
+/// must not fire on one.
+///
+/// The failure this guards: `deep-researcher` allows `investigate` four
+/// iterations. A live run spent three of them answering in prose - each one a
+/// `require_fan_out` nudge - and called `fan_out` on the fourth. Three workers
+/// then researched for thirteen minutes, and the stage was already at its cap
+/// when they came back, so all of it was discarded. Two budgets bounding one
+/// loop, and the iteration cap won because it fires first.
+#[test]
+fn enforce_max_iterations_leaves_a_fan_out_stage_alone() {
+    let mut world = World::new();
+    let e = spawn_ready_agent(&mut world, Some(4), 4, AgentStatus::Active);
+    // Same agent, same spent budget - only the mode differs.
+    let capped = spawn_ready_agent(&mut world, Some(4), 4, AgentStatus::Active);
+    let mut bp = world.get::<AgentBlueprint>(e).unwrap().0.clone();
+    bp.stages[0].mode = leviath_core::blueprint::StageMode::FanOut {
+        config: leviath_core::blueprint::FanOutConfig {
+            worker_agent: Some("w".to_string()),
+            worker_stage: None,
+            worker_query: None,
+            merge_stage: None,
+            max_workers: 4,
+            on_worker_failure: leviath_core::blueprint::WorkerFailurePolicy::Continue,
+            split_prompt: "split".to_string(),
+            results_region: None,
+            max_items: None,
+            max_attempts: None,
+        },
+    };
+    world.entity_mut(e).insert(AgentBlueprint(bp));
+
+    run_enforce(&mut world);
+
+    assert!(
+        world.get::<ReadyToInfer>(e).is_some(),
+        "the fan-out stage is still allowed to make its call"
+    );
+    assert!(world.get::<StageOutcome>(e).is_none(), "and is not cut off");
+    // The control: an ordinary stage in exactly the same position IS capped, so
+    // this is the mode doing the work rather than the cap silently not applying.
+    assert_eq!(
+        world.get::<StageOutcome>(capped).unwrap(),
+        &StageOutcome::MaxIterations
+    );
+}
+
 #[test]
 fn enforce_max_iterations_below_limit_or_unlimited_or_paused_is_noop() {
     let mut world = World::new();

--- a/crates/leviath-runtime/src/pipeline/watchdog.rs
+++ b/crates/leviath-runtime/src/pipeline/watchdog.rs
@@ -94,7 +94,27 @@ pub fn enforce_max_iterations(
         if state.status != AgentStatus::Active {
             continue;
         }
-        let max = bp.0.stages[cursor.index].max_iterations.unwrap_or(0);
+        let stage = &bp.0.stages[cursor.index];
+        // A fan-out stage is bounded by `max_attempts`, not by iterations. Its
+        // "iterations" are the framework asking again for the one call the stage
+        // exists to make, and letting the iteration cap count them means two
+        // budgets bound the same loop - with the cap winning, because it fires
+        // first and ends the stage.
+        //
+        // That is not hypothetical. `deep-researcher` allows `investigate` four
+        // iterations; a live run spent three answering in prose and called
+        // `fan_out` on the fourth, and the stage was already at its cap when the
+        // three workers came back, so thirteen minutes of finished research was
+        // discarded. `lev validate` has always held that a fan_out stage needs no
+        // `max_iterations` (see the lint's `counts_iterations`); the runtime was
+        // enforcing one anyway.
+        if matches!(
+            stage.mode,
+            leviath_core::blueprint::StageMode::FanOut { .. }
+        ) {
+            continue;
+        }
+        let max = stage.max_iterations.unwrap_or(0);
         if max > 0 && progress.iterations >= max {
             // Record it on the run: a stage that ran out of iterations is one of
             // the ways a run ends up with nothing to show (issue #107).

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -160,6 +160,12 @@ many times may the graph re-enter this stage" and "how many times do we ask a mo
 done what the stage is for" - and each retry re-sends the whole stage context, so borrowing the
 first for the second is how a routing setting quietly multiplies an inference bill.
 
+`max_attempts` is also the *only* thing bounding those asks: **`max_iterations` does not apply to a
+fan-out stage**. It once did, and the two budgets fought - a run that spent three of its four
+iterations being asked, then called `fan_out` on the fourth, was already at its cap when the workers
+came back, and thirteen minutes of finished research was discarded. Setting `max_iterations` on a
+fan-out stage is harmless and does nothing.
+
 That count is worth watching in a batch. A merge stage running on nothing and one running on a
 genuinely empty fan-out look identical from the far side, and this is the only thing that tells
 them apart.


### PR DESCRIPTION
Two bugs found by running `deep-researcher` against a real model. Neither was visible to 61 green checks at 100% coverage.

## The stage door was wired to the tool exit

Making `mode = "fan_out"` grant the `fan_out` tool left every call looking like a tool call, so `start_pending_fan_outs` tagged even a fan-out stage's own split `FanOutOrigin::Tool`.

`results_region` and `merge_stage` became dead config. A live run put three workers' findings into `conversation` as a tool result and resumed the split stage, instead of writing `sub_findings` and moving to `analyze`:

```
[conversation] [fan_out results: 3 succeeded, 0 failed] | ## worker wal-vs-rollback ...
```

The run then ended with nothing to show for five minutes of research. **`FanOutOrigin::Stage` was unreachable outside the tests that built it by hand** — which is exactly why every test passed.

## Two budgets, one loop

`require_fan_out`'s nudges spend the stage's `max_iterations`, and the cap fires first. `deep-researcher` allows `investigate` four; a run spent three answering in prose, called `fan_out` on the fourth, and was already at its cap when the workers came back — so thirteen minutes of finished research was discarded.

`lev validate` has always held that a fan-out stage needs no `max_iterations` (the lint's `counts_iterations`). The runtime enforced one anyway; now it does not, and `max_attempts` is the only bound.

## Verified end to end

The same task failed twice and now completes:

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| workers | 3 | 3 | **4** |
| reached `analyze` | no | no | **yes** |
| `sub_findings` | empty | empty | **4 succeeded, 0 failed** |
| outcome | error | error | **complete** |

The report carries **33 linked `[[n]](url)` citations**, confirming the citation change works against a real model rather than only reaching it.

Both regression tests were checked against the unfixed code and **fail** there — after a test earlier in this work passed either way and guarded nothing. One existing test changed: it asserted the tool origin for a fan-out stage, which was the bug.

Coverage: all 13 packages at 100%.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>