### PR TITLE
fix(runtime): stop reporting a required region a later stage filled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ same list.
 
 ## Unreleased
 
+- Fixed: a `required` region an earlier stage gave up on and a later stage filled
+  is no longer reported as missing. The flag recorded a moment and consumers read
+  it as a present-tense fact, so a `deep-researcher` run that abandoned
+  `sources_index` in `gather`, had `analyze` write it, and finished with a
+  fifty-citation bibliography still warned that later stages had worked from an
+  artifact that was never written. The moment stays in the log; the flag now
+  answers "what is actually missing", checked at every stage boundary.
+- Changed: the research agents are told to append each bibliography line in the
+  same turn they read the source, and that writing the bibliography into their
+  reply does not count - it has to be a `context_append` call. One run in three
+  fetched twenty sources, wrote the whole bibliography out as prose at the end of
+  `gather`, and left `sources_index` empty; the region is what the next stage
+  reads, not the message.
+
 - Fixed: a `mode = "fan_out"` stage's own call is delivered as a stage fan-out
   again, so `results_region` and `merge_stage` mean something. Making the stage
   grant the `fan_out` tool left every call looking like a tool call, and the

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.3.1"
+version = "0.3.2"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
@@ -59,6 +59,12 @@ authoritative references, not a broad skim.
 - For every source you actually use, append one bibliography line to
   `sources_index` (context_append): `[n] <title> - <url/path> - <date> -
   credibility: <high/med/low + why>`.
+  Append it in the SAME turn you read the source, not at the end of the stage.
+  It has to be a `context_append` call: a bibliography written out in your reply
+  is not stored anywhere, and the stage after this one reads the region, not
+  your message. Batching the whole list for later is how a stage ends with
+  twenty sources fetched and an empty `sources_index` - which happened, and cost
+  the run its bibliography until a later stage rebuilt it.
 - Note citations worth chasing - the analyze stage can send you to follow them.
 
 Once you have solid primary coverage of the core facets, hand off to analyze.

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.1.4"
+version = "0.1.5"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
@@ -40,6 +40,12 @@ Be efficient - do not search exhaustively:
 3. As you go, append one bibliography line per source you actually use to the
    `sources_index` region with context_append:
    `[n] <title> - <url or path> - credibility: <high/med/low + why>`.
+
+   Append it in the SAME turn you read the source, not at the end of the stage. It
+   has to be a `context_append` call: a bibliography written out in your reply is
+   not stored anywhere, and the stage after this one reads the region, not your
+   message. Batching the whole list for later is how a stage ends with twenty
+   sources fetched and an empty `sources_index`.
 
 
 Today's date is in the `environment` region. Treat it as authoritative over

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.3.1"
+version = "0.3.2"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 
@@ -32,6 +32,11 @@ per facet, read_file for local material. Landscape material lands in `landscape`
 Issue a round's searches, and then that round's fetches, as ONE response each: a batch runs in parallel, so eight fetches cost about what one costs, while the inference call between two responses costs tens of seconds.
 For each source you use, append a bibliography line to `sources_index`
 (context_append): `[n] <title> - <url/path> - credibility: <high/med/low>`.
+Append it in the SAME turn you read the source, not at the end of the stage. It
+has to be a `context_append` call: a bibliography written out in your reply is
+not stored anywhere, and the stage after this one reads the region, not your
+message. Batching the whole list for later is how a stage ends with twenty
+sources fetched and an empty `sources_index`.
 Note interesting threads worth pulling on later. If sent back, focus on the named
 coverage gap.
 

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -520,8 +520,8 @@ pub struct RunFlags {
     /// gate's re-run budget ran out.
     #[serde(default)]
     pub gates_forced: usize,
-    /// Regions declared `required` that were still empty when the stage that
-    /// owed them gave up and moved on, in the order they were abandoned.
+    /// Regions declared `required` that a stage gave up on and that are **still
+    /// empty**, in the order they were abandoned.
     ///
     /// The mechanism re-runs the stage a bounded number of times and then
     /// proceeds with a log line, which nothing downstream reads: a run whose
@@ -530,6 +530,15 @@ pub struct RunFlags {
     /// later stage's prompt says to work from (#371). Names rather than a count
     /// because knowing *which* region was abandoned is what makes it
     /// actionable, and a run cannot abandon many.
+    ///
+    /// A later stage can fill a region an earlier one gave up on, and when that
+    /// happens the name is dropped from here - the artifact exists, so a reader
+    /// told it is missing would be told something false. A `deep-researcher` run
+    /// abandoned `sources_index` in `gather`, `analyze` wrote it, and the run
+    /// finished with a fifty-citation bibliography while still reporting the
+    /// region as never written. The moment is kept in the log; this field
+    /// answers "what is actually missing", which is the question a consumer is
+    /// asking when it renders a warning.
     #[serde(default)]
     pub required_regions_abandoned: Vec<String>,
     /// The working directory disappeared mid-run.

--- a/crates/leviath-runtime/src/pipeline/requirements.rs
+++ b/crates/leviath-runtime/src/pipeline/requirements.rs
@@ -182,8 +182,27 @@ pub fn require_context_regions(
     mut commands: Commands,
 ) {
     crate::tick_scope::clear();
-    for (entity, bp, cursor, mut window, reentries, outcome, flags) in agents.iter_mut() {
+    for (entity, bp, cursor, mut window, reentries, outcome, mut flags) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
+        // A stage that gave up is not the last word: `sources_index` abandoned in
+        // `gather` can be written by `analyze`, and then the artifact exists.
+        // Reported as still missing, it tells a reader something false - one run
+        // finished with a fifty-citation bibliography while warning that the
+        // region had never been written. The moment stays in the log; this list
+        // is what is actually missing, checked at every stage boundary.
+        // A stage that gave up is not the last word: `sources_index` abandoned in
+        // `gather` can be written by `analyze`, and then the artifact exists.
+        // Reported as still missing, it tells a reader something false - one run
+        // finished with a fifty-citation bibliography while warning that the
+        // region had never been written. The moment stays in the log; this list
+        // is what is actually missing, checked at every stage boundary.
+        if let Some(flags) = flags.as_mut() {
+            flags.0.required_regions_abandoned.retain(|name| {
+                window
+                    .get_region(name)
+                    .is_none_or(|region| region.content.is_empty())
+            });
+        }
         if outcome.is_some() {
             continue; // error / max-iterations transition takes precedence
         }

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -15455,6 +15455,43 @@ fn abandoning_a_required_region_is_recorded_in_the_run() {
     assert!(world.get::<ResolveTransition>(capped).is_some());
 }
 
+/// A region an earlier stage gave up on and a later stage filled is no longer
+/// missing, so it stops being reported as missing.
+///
+/// The run that earned this abandoned `sources_index` in `gather`, had `analyze`
+/// write it, and finished with a fifty-citation bibliography - while still
+/// reporting that later stages had worked from an artifact that was never
+/// written. The moment stays in the log; this field answers "what is actually
+/// missing".
+#[test]
+fn a_required_region_a_later_stage_filled_stops_being_reported_missing() {
+    let mut world = World::new();
+    let mut flags = crate::persistence::RunOutcomeFlags::default();
+    flags.0.required_regions_abandoned = vec!["plan".to_string(), "gone".to_string()];
+    let e = world
+        .spawn((
+            required_bp(&["context_write"], None),
+            StageCursor { index: 0 },
+            // `plan` now has content; `gone` is not a region this window has.
+            window_with_plan(true),
+            flags,
+            ResolveTransition,
+        ))
+        .id();
+
+    run_require(&mut world);
+
+    assert_eq!(
+        world
+            .get::<crate::persistence::RunOutcomeFlags>(e)
+            .expect("flags")
+            .0
+            .required_regions_abandoned,
+        vec!["gone".to_string()],
+        "the filled region is dropped; one nobody filled is kept"
+    );
+}
+
 /// A stage that satisfies its required regions records nothing, or the field
 /// would be noise rather than a signal.
 #[test]


### PR DESCRIPTION
Investigating the warning on `deep-researcher-1787296158-1268deaf33ba`.

## The warning was false; the flag was correct

> Something it was told to write is missing. It gave up on `sources_index` and carried on, so later stages worked from an artifact that was never written.

They did not. From `stages.json`:

| stage | `sources_index` |
|---|---|
| gather | **0** — 23 sources fetched, no bibliography |
| investigate | 0 |
| analyze | **1338** — analyze wrote it |
| synthesize / summary | 1338 |

The run finished `complete` with **50 linked citations over 20 real URLs**. `required_regions_abandoned` records a *moment*; every consumer reads it as a present-tense fact, so the field was right by its own definition and the sentence built on it was wrong.

The list now means **what is actually missing**, rechecked at every stage boundary. The moment a stage gave up stays in the log, where it says something about that stage rather than about the run's output.

(The sentence itself is rendered outside this repo — it is not in the CLI or the binary. This makes the data it reads truthful, so no coordination is needed.)

## Why gather abandoned it

It fetched twenty sources and **wrote the entire bibliography out as prose in its reply** instead of calling `context_append`. The region the next stage reads stayed empty through three nudges.

Same shape as the fan-out bug: the model produced the right artifact in the wrong channel. All three research agents now say to append each line in the same turn the source is read, and that a bibliography written into the reply is not stored anywhere.

## Rate, measured

One `deep-researcher` in three across the runs that prompted this. The two healthy ones wrote `sources_index` during `gather` (599 and 1237 tokens); the third wrote 0.

## Also confirmed live

The `wide-researcher` bibliography fix from #542 works. Same agent, same topic as the run that produced a source table with **zero URLs**:

| | before | now |
|---|---|---|
| linked `[[n]](url)` citations | 0 | **82** |
| distinct URLs | 0 | **23** |
| Sources section | titles + grades only | 20 entries, each a link |

Coverage: all 13 packages at 100%. The regression test was checked against the unfixed code and fails there.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>