### PR TITLE
feat(agents): a credibility floor, the index for "which one", and questions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ same list.
 
 ## Unreleased
 
+- Added: `deep-researcher` and `wide-researcher` can ask a clarifying question
+  before they commit the run to a reading of the task. Granted only on the first
+  stage, where a wrong reading costs everything downstream; an unattended run is
+  never offered the tools at all (the resolver drops a blocking tool when nobody
+  is watching), so it costs `--yolo` nothing and cannot hang it.
+- Changed: credibility is about what a source IS, not how authoritative it
+  sounds. Only the primary artifact - the paper, spec, model card, official docs,
+  registry or leaderboard - can be high for a factual claim about that artifact,
+  and a number appearing in exactly one roundup with nothing corroborating it is
+  low. A run recommending local models graded an SEO listicle `high` and rested
+  every VRAM figure on it.
+- Changed: a "which one should I use" question has an authoritative index too,
+  even when it names none. Searching the question as asked returns roundups; the
+  research agents are now told to go to the model cards, the leaderboard or the
+  vendor's docs for anything they will state as a number. The same run fetched
+  ten sources and not one was a model card.
+- Changed: a qualifier travels with the claim it qualifies. The same run carried
+  "yes, with offload" and "~22 tok/s" in its comparison table and dropped both
+  from the recommendation - the one place the tradeoff mattered.
+
 - Fixed: a `required` region an earlier stage gave up on and a later stage filled
   is no longer reported as missing. The flag recorded a moment and consumers read
   it as a present-tense fact, so a `deep-researcher` run that abandoned

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.3.2"
+version = "0.3.3"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
@@ -20,7 +20,11 @@ mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather primary sources and key references on the topic"
 # web_search / web_fetch are provided by this agent's tools/ (issue #97).
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read", "ask_user_text", "ask_user_choice"]
+# The ask tools block on a person, which is the point: a wrong reading of the
+# question costs the whole run. An unattended run is never offered them (the
+# resolver drops a blocking tool when nobody is watching), so this is free there.
+allow_blocking_tools = true
 max_iterations = 25
 max_revisits = 3
 system_prompt = """
@@ -34,6 +38,13 @@ authoritative references, not a broad skim.
   the release feed, the standards list). Only then narrow. Skipping this step is
   how an investigation ends up thoroughly researching the answer from two years
   ago: every name you can recall is, by construction, older than your cutoff.
+  A "which one should I use" question has an authoritative index too, even when
+  it does not name one: the model cards, the leaderboard, the vendor's own docs,
+  the package registry. Searching the question as asked returns roundups and
+  listicles, which is what a run recommending local models came back with - ten
+  sources, not one of them a model card, and every hard number resting on a
+  single page nobody else corroborates. Go to the artifact itself for anything
+  you are going to state as a number.
 - Run a focused first round of web_search calls across the distinct facets of the
   question, then web_fetch the most authoritative results for detail. Prefer
   primary sources (papers, standards, official docs) over summaries. read_file for
@@ -66,6 +77,16 @@ authoritative references, not a broad skim.
   twenty sources fetched and an empty `sources_index` - which happened, and cost
   the run its bibliography until a later stage rebuilt it.
 - Note citations worth chasing - the analyze stage can send you to follow them.
+
+If the task is ambiguous in a way that would change what you research - a term
+with two common meanings, a constraint you cannot infer, a scope that could be
+read narrow or wide - ask before you spend the run on a guess. `ask_user_text`
+takes a free-text answer and `ask_user_choice` offers options; one good question
+at the start is worth more than a thorough answer to the wrong question.
+
+Ask once, early, and only when the answer changes what you would do. If nobody
+is attached to this run the tools are not offered at all - carry on, state the
+reading you chose, and say what you would have asked.
 
 Once you have solid primary coverage of the core facets, hand off to analyze.
 """
@@ -293,6 +314,13 @@ following the citation/confidence rules in `format`. Structure:
 
 Write for a technical audience. Be precise. Distinguish evidence from inference.
 
+A qualifier travels with the claim it qualifies. If the evidence says "yes, with
+offload" or "tight", or the figure came from one uncorroborated page, the
+recommendation says so too - a reader acting on your summary never sees the table
+it came from. A run recommending a local model carried "yes, with offload" and
+"~22 tok/s" in its comparison table and dropped both from the recommendation,
+which is the one place the tradeoff mattered.
+
 Citations are load-bearing, so two rules bind absolutely:
 
 1. Every `[n]` must resolve to a line already in `sources_index`. A reference is
@@ -376,7 +404,7 @@ environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_ti
 # the stages that can write context (gather, analyze, follow_citations) and
 # no-ops for the ones that cannot, so it can never deadlock the deliverable.
 sources_index  = { kind = "pinned", budget = "4%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url/path> - <date> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
-format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Mark each key finding's confidence as high / medium / low based on source count and credibility. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
+format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Mark each key finding's confidence as high / medium / low based on source count and credibility. Credibility is about what a source IS, not how authoritative it sounds: only the primary artifact - the paper, the spec, the model card, the official docs, the registry or leaderboard - can be high for a factual claim about that artifact. A roundup, listicle or vendor blog is medium at best however confident its title, and a number that appears in exactly one such page with nothing corroborating it is low and says so. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
 sources        = { kind = "temporary",      budget = "30%" }
 claims         = { kind = "sliding_window", max_items = 40, budget = "8%" }

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.1.5"
+version = "0.1.6"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
@@ -33,6 +33,10 @@ Be efficient - do not search exhaustively:
    the date in `environment` and fetch the authoritative index for the domain
    (registry, leaderboard, release feed). Every name you can recall is older
    than your cutoff, so a list from memory is a list from the past.
+   A "which one should I use" question has an index too, even when it names
+   none: the model cards, the leaderboard, the vendor's docs, the registry.
+   Searching the question as asked returns roundups; go to the artifact itself
+   for anything you will state as a number.
 1. Run a FOCUSED first round of 3-5 web_search calls covering the distinct
    sub-topics of the question (not many rephrasings of the same query).
 2. web_fetch only the 2-3 most promising sources for detail; the search snippets
@@ -161,6 +165,13 @@ Structure:
 Keep it tight and skimmable. Every non-obvious claim must carry a linked
 `[[n]](<url>)` citation.
 
+A qualifier travels with the claim it qualifies. If the evidence says "yes, with
+offload" or "tight", or the figure came from one uncorroborated page, the
+recommendation says so too - a reader acting on your summary never sees the table
+it came from. A run recommending a local model carried "yes, with offload" and
+"~22 tok/s" in its comparison table and dropped both from the recommendation,
+which is the one place the tradeoff mattered.
+
 Citations are load-bearing, so two rules bind absolutely:
 
 1. Every `[n]` must resolve to a line already in `sources_index`. A reference
@@ -254,7 +265,7 @@ environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_ti
 # deadlock the deliverable.
 sources_index  = { kind = "pinned", budget = "3%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url or path> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
 # Citation/confidence rules (seeded with a sensible default the agent follows).
-format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Mark each finding's confidence as high / medium / low based on source count and credibility. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
+format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Mark each finding's confidence as high / medium / low based on source count and credibility. Credibility is about what a source IS, not how authoritative it sounds: only the primary artifact - the paper, the spec, the model card, the official docs, the registry or leaderboard - can be high for a factual claim about that artifact. A roundup, listicle or vendor blog is medium at best however confident its title, and a number that appears in exactly one such page with nothing corroborating it is low and says so. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
 # Raw source material (bulk, evictable).
 raw_findings   = { kind = "temporary", budget = "30%" }

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.3.2"
+version = "0.3.3"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 
@@ -18,7 +18,10 @@ bash       = "ask"
 mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "deepseek/deepseek-v4-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Survey the landscape across multiple sub-topics"
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read", "ask_user_text", "ask_user_choice"]
+# The ask tools block on a person, which is the point: this stage decides what
+# the whole fan-out investigates. An unattended run is never offered them.
+allow_blocking_tools = true
 max_iterations = 25
 max_revisits = 2
 system_prompt = """
@@ -46,6 +49,11 @@ leaderboard, release feed) before you settle the list of threads. A landscape
 recalled rather than gathered is by construction the landscape from before your
 cutoff, and this stage decides what the whole fan-out investigates.
 
+A "which one should I use" question has an index too, even when it names none:
+the model cards, the leaderboard, the vendor's own docs, the package registry.
+Searching the question as asked returns roundups and listicles; go to the
+artifact itself for anything you are going to state as a number.
+
 Today's date is in the `environment` region. Treat it as authoritative over
 anything you remember: your training has a cutoff and this run does not. Judge
 "recent", "current", "active" and "state of the art" against it, and note how
@@ -57,6 +65,17 @@ an engine error, or an encyclopedia fallback - then this run cannot see the web.
 Record that in `sources_index` and do NOT close the gap from memory. A landscape
 reported as unmapped is a usable result; one assembled from recall is not, and a
 reader cannot tell the two apart after the fact.
+
+If the task is ambiguous in a way that would change what you survey - a term with
+two common meanings, a constraint you cannot infer, a scope that could be read
+narrow or wide - ask before you spend the run on a guess. `ask_user_text` takes a
+free-text answer and `ask_user_choice` offers options; one good question here is
+worth more than a thorough survey of the wrong field, and this stage decides what
+the whole fan-out investigates.
+
+Ask once, early, and only when the answer changes what you would do. If nobody is
+attached to this run the tools are not offered at all - carry on, state the
+reading you chose, and say what you would have asked.
 """
 
 [stages.survey.tool_routing]
@@ -281,6 +300,13 @@ reader can click through from the claim.
 Write concisely - the reader wants the lay of the land quickly. Cite sources for
 non-obvious claims.
 
+A qualifier travels with the claim it qualifies. If the evidence says "yes, with
+offload" or "tight", or the figure came from one uncorroborated page, the
+recommendation says so too - a reader acting on your summary never sees the table
+it came from. A run recommending a local model carried "yes, with offload" and
+"~22 tok/s" in its comparison table and dropped both from the recommendation,
+which is the one place the tradeoff mattered.
+
 The bibliography is the deliverable as much as the prose is: a survey is a
 reading list, and `[n]` markers over a source list with no URLs send the reader
 back to a search engine to find what this run already found. Carry the URL on
@@ -363,7 +389,7 @@ environment        = { kind = "pinned", budget = "1%", seed = { tools = ["curren
 # that can write context and no-ops for the ones that cannot, so it can never
 # deadlock the deliverable.
 sources_index      = { kind = "pinned", budget = "3%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url or path> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
-format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Prefer comparison tables where they clarify tradeoffs. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
+format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Prefer comparison tables where they clarify tradeoffs. Credibility is about what a source IS, not how authoritative it sounds: only the primary artifact - the paper, the spec, the model card, the official docs, the registry or leaderboard - can be high for a factual claim about that artifact. A roundup, listicle or vendor blog is medium at best however confident its title, and a number that appears in exactly one such page with nothing corroborating it is low and says so. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
 landscape          = { kind = "temporary",      budget = "30%" }
 deep_dives         = { kind = "sliding_window", max_items = 15, budget = "8%" }


### PR DESCRIPTION
Four changes from reviewing five real runs.

## What the runs showed

Three of the five were strong. One was the outlier that earned three of these changes — a `deep-researcher` recommending a local LLM for a 16 GB card:

- **4 searches** (vs 8–11 on the others), **10 sources, every one an SEO roundup**: `bestllmfor.com`, `whatllm.org`, `insiderllm.com`, `promptquorum.com`. No model card, no leaderboard, no vendor docs.
- **`promptquorum.com` graded `high`.** Four of ten graded high, none primary.
- Every hard number (15.2 GB, 22 tok/s) rests on a single content farm, uncorroborated.
- The Qwen3-Coder 32B recommendation carries "**yes, with offload**" and ~22 tok/s in the evidence table, and neither survives into the recommendation — the one place the tradeoff mattered.

The contrast is the useful part: a sibling run comparing plugin systems pulled **both products' own docs plus the competitor's GitHub architecture file**. The agents fetch the authoritative index when it is obvious, and not when the question is a recommendation.

## The changes

1. **Credibility is about what a source IS**, not how authoritative it sounds. Only the primary artifact can be `high` for a factual claim about that artifact; a number in exactly one roundup is `low`.
2. **"Which one should I use" has an index too**, even when it names none — model cards, leaderboard, vendor docs.
3. **A qualifier travels with its claim** into the recommendation.
4. **`deep-researcher` and `wide-researcher` can ask a clarifying question**, first stage only.

## The ask tools, checked live

This is the part with a real failure mode — a blocking prompt in an unattended run would hang forever — so it was measured, not reasoned about:

| | tools offered |
|---|---|
| `--yolo` | `read_file, list_dir, context_append, context_read, current_time, web_fetch, web_search` |
| attended | the same **plus `ask_user_text`, `ask_user_choice`** |

The resolver drops a blocking tool when nobody is watching, so an unattended run never sees them and cannot hang.

## Also confirmed in this review

The comparator-confidence rule from #542 works. The creatine run now writes: *"the Ozempic claims … rest on the STEP 1 trial extension, **which we did not retrieve directly** … should be verified against the primary trial data"* — where the previous pair stated the same figure flatly and graded it HIGH.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>