### PR TITLE
feat(dash): fold the sub-agent tree, and answer the mouse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ same list.
 
 ## Unreleased
 
+- Added: the dashboard's sub-agent tree folds. `←` folds the selected run's
+  workers away and `→` puts them back; on a run without any, `←` moves up to its
+  parent and `→` down into the first worker. A foldable row wears a `▸`/`▾`
+  arrow, a folded one says how many runs it is hiding, and the help bar offers
+  the keys only when there is a tree to work. Folds are keyed by run, so they
+  survive sorting, filtering and new rows, and folding the run you were inside
+  leaves the highlight on the fold rather than at the top of the list.
+- Added: the dashboard answers the mouse. Click a run to select it and again to
+  open it, click its `▸`/`▾` arrow to fold its workers, click a stage tab or one
+  of the content pane's `[l]` / `[o]` / `[c]` chips to switch to it, click a row
+  of the Context tree to fold or unfold it, click the log panel to move the keys
+  there. Every renderer registers what it drew and where, so a click acts on
+  what is under the pointer rather than on a position derived twice. Drag still
+  selects text and copies it on release.
+- Fixed: a finished run's last transition no longer animates on the stage graph.
+  The pulse means "the run is travelling this path", and it kept running into
+  the final stage of a run that had completed, errored or been cancelled. A run
+  that is merely parked keeps it: it has not finished, and the pulse is what
+  says where it stopped.
 - Added: `deep-researcher` and `wide-researcher` can ask a clarifying question
   before they commit the run to a reading of the task. Granted only on the first
   stage, where a wrong reading costs everything downstream; an unattended run is
@@ -46,7 +65,6 @@ same list.
   fetched twenty sources, wrote the whole bibliography out as prose at the end of
   `gather`, and left `sources_index` empty; the region is what the next stage
   reads, not the message.
-
 - Fixed: a `mode = "fan_out"` stage's own call is delivered as a stage fan-out
   again, so `results_region` and `merge_stage` mean something. Making the stage
   grant the `fan_out` tool left every call looking like a tool call, and the

--- a/crates/leviath-cli/src/commands/dashboard/click.rs
+++ b/crates/leviath-cli/src/commands/dashboard/click.rs
@@ -1,0 +1,424 @@
+//! What a left click does, and the registry that says so.
+//!
+//! Mouse capture takes the terminal's own click handling away, so everything
+//! the pointer can do here has to be built. Rather than each handler
+//! re-deriving where its widget landed - which is how a click ends up acting
+//! on the row above the one under the pointer - every renderer registers the
+//! rect it actually drew together with the [`ClickTarget`] it stands for, and
+//! this module resolves a click against that frame's registry.
+//!
+//! Only a *plain* click arrives here: a press and release with no motion
+//! between them. A drag is a text selection (see `selection.rs`), and the
+//! graph canvases take their presses before either.
+
+use ratatui::layout::{Position, Rect};
+
+use super::state::Dashboard;
+use super::types::{ClickTarget, MainPane, StageContentMode};
+
+/// How long after a click a second one on the same cell still counts as a
+/// double click. 400ms is the interval most desktops ship as their default.
+pub(super) const DOUBLE_CLICK_MS: u64 = 400;
+
+impl Dashboard {
+    /// Register `target` as clickable over `rect`. Renderers call this with
+    /// the rect they actually drew into, every frame.
+    pub(in crate::commands::dashboard) fn register_click(
+        &mut self,
+        rect: Rect,
+        target: ClickTarget,
+    ) {
+        self.click_targets.push((rect, target));
+    }
+
+    /// The target under a cell: the last one registered that contains it, so
+    /// a fold arrow drawn inside its row beats the row.
+    fn click_target_at(&self, column: u16, row: u16) -> Option<ClickTarget> {
+        self.click_targets
+            .iter()
+            .rev()
+            .find(|(rect, _)| rect.contains(Position::new(column, row)))
+            .map(|(_, target)| *target)
+    }
+
+    /// Act on a plain click. Returns whether anything was under it, purely so
+    /// callers and tests can tell a hit from a click on empty background.
+    pub(super) fn handle_click(&mut self, column: u16, row: u16) -> bool {
+        let Some(target) = self.click_target_at(column, row) else {
+            return false;
+        };
+        // A second click on the same cell, soon enough, opens what the first
+        // one selected. Recorded for every click so a click elsewhere in
+        // between cannot be mistaken for the first half of a double.
+        let now = (self.mouse_clock)();
+        let double = self.last_click.is_some_and(|(cell, at)| {
+            cell == (column, row) && now.saturating_sub(at) <= DOUBLE_CLICK_MS
+        });
+        self.last_click = Some(((column, row), now));
+
+        match target {
+            ClickTarget::RunToggle(pos) => self.toggle_run_fold_at(pos),
+            ClickTarget::RunRow(pos) => {
+                self.main_focus = MainPane::RunList;
+                // Clamped rather than trusted: the registry is a frame old, and
+                // a tick between the draw and the release can have shortened
+                // the list.
+                let pos = pos.min(self.display_indices.len().saturating_sub(1));
+                self.selected = pos;
+                self.table_state.select(Some(pos));
+                if double {
+                    self.open_detail_view();
+                }
+            }
+            ClickTarget::LogPanel => self.main_focus = MainPane::LogPane,
+            ClickTarget::StageTab(idx) => self.select_stage_tab(idx),
+            ClickTarget::ContentMode(mode) => {
+                self.stage_content_mode = mode;
+                self.detail_scroll = 0;
+                if mode == StageContentMode::Context {
+                    self.reset_context_history();
+                }
+            }
+            ClickTarget::ContextRow(idx) => {
+                self.context_tree.cursor = idx;
+                self.toggle_context_row();
+            }
+        }
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::dashboard::state::Dashboard;
+    use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::types::{AgentDisplayStatus, DashboardAgent};
+    use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn make_test_agent(id: &str) -> DashboardAgent {
+        DashboardAgent {
+            id: id.to_string(),
+            blueprint_name: "test-agent".to_string(),
+            stage: "main".to_string(),
+            stage_index: 0,
+            num_stages: 3,
+            status: AgentDisplayStatus::Active,
+            tokens_in: 0,
+            tokens_out: 0,
+            cached_tokens: 0,
+            iteration: 0,
+            waiting_prompt: None,
+            wait_reason: None,
+            pending_request: None,
+            last_answered_request_id: None,
+            context_snapshot: None,
+            stages: vec![],
+            workdir: "/tmp".to_string(),
+            task: "test".to_string(),
+            title: Some(id.to_string()),
+            model: None,
+            parent_id: None,
+            depth: 0,
+            started_at: 1000,
+            last_progress_at: None,
+            active_until: None,
+            waiting_secs: 0,
+            graph: None,
+            accepts_messages: true,
+            taint_summary: vec![],
+        }
+    }
+
+    /// Draw a whole frame the way the loop does, so the click targets under
+    /// test are the ones the renderers actually registered.
+    fn draw(dash: &mut Dashboard, width: u16, height: u16) {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+    }
+
+    fn press_and_release(dash: &mut Dashboard, column: u16, row: u16) {
+        for kind in [
+            MouseEventKind::Down(MouseButton::Left),
+            MouseEventKind::Up(MouseButton::Left),
+        ] {
+            dash.handle_mouse(MouseEvent {
+                kind,
+                column,
+                row,
+                modifiers: crossterm::event::KeyModifiers::NONE,
+            });
+        }
+    }
+
+    /// A frozen clock, so a "double click" is two clicks and not a race with
+    /// the test runner.
+    fn frozen_clock() -> u64 {
+        10_000
+    }
+
+    /// A clock far enough on that the second click is its own click.
+    fn much_later() -> u64 {
+        10_000 + DOUBLE_CLICK_MS + 1
+    }
+
+    /// The whole gesture, through the real renderers: draw the list, click the
+    /// second run's row, and the selection follows the pointer.
+    #[test]
+    fn clicking_a_run_row_selects_that_run() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(make_test_agent("run-1"));
+        dash.agents.push(make_test_agent("run-2"));
+        dash.update_display_indices();
+        dash.main_focus = MainPane::LogPane;
+        draw(&mut dash, 120, 40);
+
+        // Row 0 of the table sits below the border and the header row.
+        press_and_release(&mut dash, 10, 3);
+        assert_eq!(dash.selected, 1, "the second run");
+        assert_eq!(
+            dash.main_focus,
+            MainPane::RunList,
+            "clicking the list also focuses it"
+        );
+        assert!(!dash.detail_view, "one click selects, it does not open");
+    }
+
+    /// A second click on the same row opens the run; the same two clicks
+    /// spread further apart do not.
+    #[test]
+    fn a_double_click_opens_the_run_and_two_slow_clicks_do_not() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(make_test_agent("run-1"));
+        dash.update_display_indices();
+        dash.mouse_clock = frozen_clock;
+        draw(&mut dash, 120, 40);
+
+        press_and_release(&mut dash, 10, 2);
+        assert!(!dash.detail_view);
+        press_and_release(&mut dash, 10, 2);
+        assert!(dash.detail_view, "the second click opened it");
+
+        dash.detail_view = false;
+        dash.mouse_clock = much_later;
+        draw(&mut dash, 120, 40);
+        press_and_release(&mut dash, 10, 2);
+        assert!(!dash.detail_view, "too slow to be a double click");
+    }
+
+    /// Clicking the fold arrow folds the subtree, and clicking it again puts
+    /// it back - without opening anything, even though the two clicks land on
+    /// the same cell in quick succession.
+    #[test]
+    fn clicking_the_fold_arrow_folds_the_subtree() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(make_test_agent("parent"));
+        let mut child = make_test_agent("worker");
+        child.parent_id = Some("parent".to_string());
+        dash.agents.push(child);
+        dash.update_display_indices();
+        dash.mouse_clock = frozen_clock;
+        draw(&mut dash, 120, 40);
+        assert_eq!(dash.display_indices.len(), 2);
+
+        // The arrow is the first two columns of the parent's title cell.
+        press_and_release(&mut dash, 2, 2);
+        assert_eq!(dash.display_indices.len(), 1, "the worker folded away");
+        assert!(!dash.detail_view);
+
+        draw(&mut dash, 120, 40);
+        press_and_release(&mut dash, 2, 2);
+        assert_eq!(dash.display_indices.len(), 2, "and came back");
+        assert!(!dash.detail_view, "an arrow click never opens the run");
+    }
+
+    /// A drag is a text selection, so it must not also act on what it started
+    /// over.
+    #[test]
+    fn dragging_across_a_row_selects_text_rather_than_the_row() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(make_test_agent("run-1"));
+        dash.agents.push(make_test_agent("run-2"));
+        dash.update_display_indices();
+        draw(&mut dash, 120, 40);
+
+        for (kind, column) in [
+            (MouseEventKind::Down(MouseButton::Left), 10),
+            (MouseEventKind::Drag(MouseButton::Left), 30),
+            (MouseEventKind::Up(MouseButton::Left), 30),
+        ] {
+            dash.handle_mouse(MouseEvent {
+                kind,
+                column,
+                row: 3,
+                modifiers: crossterm::event::KeyModifiers::NONE,
+            });
+        }
+        assert_eq!(dash.selected, 0, "the drag did not move the selection");
+    }
+
+    /// The detail view's stage tabs and mode chips are buttons.
+    #[test]
+    fn clicking_a_stage_tab_and_a_mode_chip_in_the_detail_view() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1");
+        agent.stages = (0..3)
+            .map(|i| crate::runstate::StageRecord {
+                name: format!("stage{i}"),
+                index: i,
+                status: crate::runstate::StageRunStatus::Pending,
+                entered: false,
+                prompt_tokens: 0,
+                completion_tokens: 0,
+                cached_tokens: 0,
+                cache_write_tokens: 0,
+                region_tokens: Default::default(),
+                first_call_prompt_tokens: None,
+                runaway_warned: false,
+                started_at: None,
+                ended_at: None,
+            })
+            .collect();
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        // Short enough that the stage row is the linear tab strip, not the
+        // graph band (which has its own click handling).
+        draw(&mut dash, 120, 24);
+
+        let tab = dash
+            .click_targets
+            .iter()
+            .find(|(_, t)| *t == ClickTarget::StageTab(2))
+            .map(|(r, _)| *r)
+            .expect("three stages, three tabs");
+        press_and_release(&mut dash, tab.x + 1, tab.y);
+        assert_eq!(dash.selected_stage, 2);
+
+        draw(&mut dash, 120, 24);
+        let chip = dash
+            .click_targets
+            .iter()
+            .find(|(_, t)| *t == ClickTarget::ContentMode(StageContentMode::Context))
+            .map(|(r, _)| *r)
+            .expect("the ctx chip is in the title");
+        press_and_release(&mut dash, chip.x + 1, chip.y);
+        assert_eq!(dash.stage_content_mode, StageContentMode::Context);
+    }
+
+    /// A click on a Context row folds it, exactly as enter would.
+    #[test]
+    fn clicking_a_context_region_folds_it() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1");
+        agent.num_stages = 1;
+        agent.context_snapshot = Some(std::sync::Arc::new(crate::runstate::ContextSnapshot {
+            stage_name: "main".to_string(),
+            total_tokens: 20,
+            max_tokens: 100,
+            regions: vec![crate::runstate::RegionSnapshot {
+                name: "system".to_string(),
+                kind: "pinned".to_string(),
+                current_tokens: 10,
+                max_tokens: 50,
+                entries: vec![leviath_core::run_meta::RegionEntrySnapshot {
+                    content: "hello".to_string(),
+                    tokens: 5,
+                    kind: Default::default(),
+                    metadata: None,
+                    key: None,
+                    taint: Default::default(),
+                }],
+                description: None,
+            }],
+        }));
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.stage_content_mode = StageContentMode::Context;
+        draw(&mut dash, 120, 40);
+
+        let header = dash
+            .click_targets
+            .iter()
+            .find(|(_, t)| *t == ClickTarget::ContextRow(0))
+            .map(|(r, _)| *r)
+            .expect("the region header is on screen");
+        press_and_release(&mut dash, header.x + 2, header.y);
+        assert!(
+            dash.context_tree.collapsed_regions.contains("system"),
+            "the click folded the region the pointer was over"
+        );
+    }
+
+    /// A click resolves to the innermost target: the toggle registered over
+    /// part of a row wins against the row it sits in.
+    #[test]
+    fn the_last_registered_target_over_a_cell_wins() {
+        let mut dash = make_test_dashboard();
+        dash.register_click(Rect::new(0, 5, 40, 1), ClickTarget::RunRow(0));
+        dash.register_click(Rect::new(2, 5, 2, 1), ClickTarget::RunToggle(0));
+        assert_eq!(
+            dash.click_target_at(3, 5),
+            Some(ClickTarget::RunToggle(0)),
+            "inside the toggle"
+        );
+        assert_eq!(
+            dash.click_target_at(20, 5),
+            Some(ClickTarget::RunRow(0)),
+            "elsewhere on the row"
+        );
+        assert_eq!(dash.click_target_at(20, 6), None, "off the row");
+    }
+
+    /// Clicking nothing is not an error, and does not disturb the selection.
+    #[test]
+    fn a_click_on_empty_background_does_nothing() {
+        let mut dash = make_test_dashboard();
+        assert!(!dash.handle_click(1, 1));
+        assert_eq!(dash.selected, 0);
+    }
+
+    #[test]
+    fn clicking_the_log_panel_moves_the_keyboard_there() {
+        let mut dash = make_test_dashboard();
+        dash.register_click(Rect::new(0, 0, 10, 10), ClickTarget::LogPanel);
+        assert!(dash.handle_click(5, 5));
+        assert_eq!(dash.main_focus, MainPane::LogPane);
+    }
+
+    /// Each chip switches to its own mode, and only the Context one leaves
+    /// history browsing (the other two do not show a context window at all).
+    #[test]
+    fn clicking_a_mode_chip_switches_the_content_pane() {
+        let mut dash = make_test_dashboard();
+        dash.detail_scroll = 12;
+        dash.context_history_idx = Some(3);
+        dash.register_click(
+            Rect::new(0, 0, 10, 1),
+            ClickTarget::ContentMode(StageContentMode::Logs),
+        );
+        assert!(dash.handle_click(3, 0));
+        assert_eq!(dash.stage_content_mode, StageContentMode::Logs);
+        assert_eq!(dash.detail_scroll, 0, "the new pane starts at the bottom");
+        assert_eq!(
+            dash.context_history_idx,
+            Some(3),
+            "the Logs pane does not touch which context point is browsed"
+        );
+
+        dash.click_targets.clear();
+        dash.register_click(
+            Rect::new(0, 0, 10, 1),
+            ClickTarget::ContentMode(StageContentMode::Context),
+        );
+        assert!(dash.handle_click(3, 0));
+        assert_eq!(dash.stage_content_mode, StageContentMode::Context);
+        assert_eq!(
+            dash.context_history_idx, None,
+            "the ctx chip shows the live window, like the `c` key"
+        );
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -24,6 +24,17 @@ fn system_now_secs() -> i64 {
         .unwrap_or(0)
 }
 
+/// Production clock for double-click detection: milliseconds since the epoch.
+/// Separate from [`system_now_secs`] because a second is far too coarse to
+/// tell one click from two, and injected for the same reason - a test that
+/// has to sleep to prove a double click is a test that fails on a busy CI box.
+fn system_now_millis() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
 impl Dashboard {
     /// Default/test constructor: points the activity log at a shared temp file
     /// and uses a no-op clipboard, so unit tests never touch the real
@@ -116,6 +127,9 @@ impl Dashboard {
             log_scroll: crate::tui::widgets::scroll::ScrollState::default(),
             pane_rects: Vec::new(),
             mouse_capture: None,
+            click_targets: Vec::new(),
+            last_click: None,
+            mouse_clock: system_now_millis,
             detail_band: None,
             explorer_cache: None,
             new_run_preview: None,
@@ -143,7 +157,8 @@ impl Dashboard {
             list_search_mode: false,
             list_search_query: String::new(),
             display_indices: Vec::new(),
-            tree_prefixes: Vec::new(),
+            tree_rows: Vec::new(),
+            collapsed_runs: std::collections::HashSet::new(),
             mcp_screen: false,
             mcp_add_mode: false,
             mcp_add_input: String::new(),
@@ -263,6 +278,16 @@ mod tests {
         // Well after 2020 and before 2100 - i.e. a real epoch second.
         let now = system_now_secs();
         assert!(now > 1_577_836_800 && now < 4_102_444_800, "got {now}");
+    }
+
+    /// The double-click clock reports the same instant in milliseconds (tests
+    /// inject a frozen one, so this is the only place it runs).
+    #[test]
+    fn the_millisecond_clock_agrees_with_the_second_one() {
+        let millis = system_now_millis();
+        let secs = system_now_secs() as u64;
+        assert!(millis / 1000 >= secs.saturating_sub(2), "got {millis}");
+        assert!(millis / 1000 <= secs + 2, "got {millis}");
     }
 
     // ─── load_log_seed: exercises the parsing code ───────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -748,6 +748,28 @@ condition = "llm_choice"
         );
         assert!(view.edge_animated("review", "implement"));
 
+        // The same run once it finishes: the path it took is still drawn, but
+        // nothing on it moves any more. A pulse into the last stage of a run
+        // that is over reads as a run still going.
+        dash.agents[0].status = AgentDisplayStatus::Complete;
+        draw(&mut dash);
+        let view = &dash.stage_explorer.as_ref().unwrap().view;
+        assert!(
+            !view.edge_animated("review", "implement"),
+            "a finished run is not travelling anything"
+        );
+        assert!(!view.edge_hidden("review", "implement"), "still drawn");
+        dash.agents[0].status = AgentDisplayStatus::Active;
+        draw(&mut dash);
+        assert!(
+            dash.stage_explorer
+                .as_ref()
+                .unwrap()
+                .view
+                .edge_animated("review", "implement"),
+            "and it moves again while the run does"
+        );
+
         // A run with no history, no ledger and no stage name: nothing current,
         // no workers, no transitions.
         let mut bare = agent("run-9", AgentDisplayStatus::Idle);

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -355,9 +355,9 @@ impl Dashboard {
         }
     }
 
-    /// Enter/Space in the Context view: fold or unfold the row under the
-    /// tree cursor.
-    fn toggle_context_row(&mut self) {
+    /// Enter/Space in the Context view (or a click on the row): fold or unfold
+    /// the row under the tree cursor.
+    pub(super) fn toggle_context_row(&mut self) {
         use super::context_tree::TreeRow;
         let rows = self.context_tree_rows();
         match rows.get(self.context_tree.cursor) {
@@ -379,6 +379,25 @@ impl Dashboard {
             None => {}
         }
         self.context_tree.follow_cursor = true;
+    }
+
+    /// Show stage tab `idx`, from a number key or a click on the tab. Out of
+    /// range does nothing: the run has no such stage to show.
+    pub(super) fn select_stage_tab(&mut self, idx: usize) {
+        let max_stage = self
+            .selected_agent()
+            .map(|a| a.num_stages.saturating_sub(1))
+            .unwrap_or(0);
+        if idx > max_stage {
+            return;
+        }
+        self.selected_stage = idx;
+        self.detail_scroll = 0;
+        self.review_scroll = 0;
+        self.search_mode = false;
+        self.search_query.clear();
+        self.search_match_idx = 0;
+        self.band_select_tab(idx);
     }
 
     /// Move the Context view's tree cursor, clamped, and scroll to it.
@@ -454,20 +473,7 @@ impl Dashboard {
             }
             // Number keys 1-9: jump to stage tab
             KeyCode::Char(c @ '1'..='9') => {
-                let idx = (c as usize) - ('1' as usize);
-                let max_stage = self
-                    .selected_agent()
-                    .map(|a| a.num_stages.saturating_sub(1))
-                    .unwrap_or(0);
-                if idx <= max_stage {
-                    self.selected_stage = idx;
-                    self.detail_scroll = 0;
-                    self.review_scroll = 0;
-                    self.search_mode = false;
-                    self.search_query.clear();
-                    self.search_match_idx = 0;
-                    self.band_select_tab(idx);
-                }
+                self.select_stage_tab((c as usize) - ('1' as usize));
             }
             // Content mode toggle
             KeyCode::Char('l') => {
@@ -748,6 +754,12 @@ impl Dashboard {
                     self.table_state.select(Some(self.selected));
                 }
             }
+            // ← and → work the sub-agent tree. On a run with workers they
+            // fold and unfold it; on a row that cannot fold, ← climbs to the
+            // parent and → steps into the first child, so the arrows always
+            // do something rather than dying on a leaf.
+            KeyCode::Left => self.collapse_or_climb(),
+            KeyCode::Right => self.expand_or_descend(),
             KeyCode::Tab | KeyCode::BackTab => {
                 self.main_focus = MainPane::LogPane;
             }
@@ -786,6 +798,76 @@ impl Dashboard {
             KeyCode::Char('a') => self.open_agents_screen(),
             _ => {}
         }
+    }
+
+    /// Fold or unfold the sub-agents of the run on row `pos`, and leave the
+    /// highlight on that row. A row with no sub-agents has nothing to fold.
+    pub(super) fn toggle_run_fold_at(&mut self, pos: usize) {
+        let Some(id) = self
+            .display_indices
+            .get(pos)
+            .and_then(|&i| self.agents.get(i))
+            .map(|a| a.id.clone())
+        else {
+            return;
+        };
+        if !self.collapsed_runs.remove(&id) {
+            // Only a run with sub-agents folds; folding a leaf would draw an
+            // arrow on it that does nothing.
+            if !self.tree_rows.get(pos).is_some_and(|r| r.expandable) {
+                return;
+            }
+            self.collapsed_runs.insert(id.clone());
+        }
+        self.update_display_indices();
+        // The run just folded is still on screen - it is the row the fold
+        // happened on - so this lands back on it.
+        let row = self.row_of_run(&id).unwrap_or(self.selected);
+        self.selected = row;
+        self.table_state.select(Some(row));
+    }
+
+    /// `←` on the run list: fold the selected run's sub-agents, or - when
+    /// there is nothing to fold - move up to its parent.
+    fn collapse_or_climb(&mut self) {
+        let Some(row) = self.tree_rows.get(self.selected).cloned() else {
+            return;
+        };
+        if row.expandable && !row.collapsed {
+            self.toggle_run_fold_at(self.selected);
+            return;
+        }
+        // The parent is the nearest row above with a shorter prefix: rows are
+        // in depth-first order, so that is the run this one hangs under.
+        let width = row.prefix.chars().count();
+        if let Some(parent) = self.tree_rows[..self.selected]
+            .iter()
+            .rposition(|r| r.prefix.chars().count() < width)
+        {
+            self.selected = parent;
+            self.table_state.select(Some(parent));
+        }
+    }
+
+    /// `→` on the run list: unfold the selected run's sub-agents, or - when
+    /// they are already showing - step down into the first of them.
+    fn expand_or_descend(&mut self) {
+        let Some(row) = self.tree_rows.get(self.selected).cloned() else {
+            return;
+        };
+        if !row.expandable {
+            return;
+        }
+        if row.collapsed {
+            self.toggle_run_fold_at(self.selected);
+            return;
+        }
+        // Depth-first order puts the first child immediately below, and an
+        // unfolded run with sub-agents always has one; the clamp is only so a
+        // stale row index cannot point past the list.
+        let child = (self.selected + 1).min(self.display_indices.len().saturating_sub(1));
+        self.selected = child;
+        self.table_state.select(Some(child));
     }
 
     /// Keys handled while the MCP management screen is open.
@@ -1946,6 +2028,93 @@ mod tests {
     }
 
     // ─── kill via x + confirmation ────────────────────────────────────────
+
+    // ─── ← / → on the run list: the sub-agent tree ───────────────────────
+
+    /// A parent with two sub-agents, selected on its own row.
+    fn dash_with_a_subtree() -> Dashboard {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("parent", AgentDisplayStatus::Active));
+        for id in ["worker-a", "worker-b"] {
+            let mut child = make_test_agent(id, AgentDisplayStatus::Active);
+            child.parent_id = Some("parent".to_string());
+            dash.agents.push(child);
+        }
+        dash.update_display_indices();
+        dash.selected = dash.row_of_run("parent").expect("the parent is a row");
+        dash
+    }
+
+    #[test]
+    fn left_and_right_fold_and_unfold_a_run_s_sub_agents() {
+        let mut dash = dash_with_a_subtree();
+        assert_eq!(dash.display_indices.len(), 3);
+
+        dash.handle_key(key(KeyCode::Left));
+        assert_eq!(dash.display_indices.len(), 1, "the workers folded away");
+        assert!(dash.tree_rows[0].collapsed);
+        assert_eq!(dash.selected, 0, "the highlight stayed on the parent");
+
+        dash.handle_key(key(KeyCode::Right));
+        assert_eq!(dash.display_indices.len(), 3, "and unfolded again");
+        assert!(!dash.tree_rows[0].collapsed);
+        assert_eq!(dash.selected, 0);
+    }
+
+    /// With nothing left to fold the arrows walk the tree instead of dying:
+    /// → steps into the first worker, ← climbs back to the parent.
+    #[test]
+    fn the_arrows_walk_the_tree_when_there_is_nothing_to_fold() {
+        let mut dash = dash_with_a_subtree();
+        dash.handle_key(key(KeyCode::Right));
+        assert_eq!(
+            dash.selected_agent().map(|a| a.id.as_str()),
+            Some("worker-a"),
+            "an unfolded parent steps down to its first worker"
+        );
+        // A worker has no sub-agents of its own, so → does nothing at all…
+        dash.handle_key(key(KeyCode::Right));
+        assert_eq!(
+            dash.selected_agent().map(|a| a.id.as_str()),
+            Some("worker-a")
+        );
+        // …and ← climbs out of the subtree.
+        dash.handle_key(key(KeyCode::Left));
+        assert_eq!(dash.selected_agent().map(|a| a.id.as_str()), Some("parent"));
+    }
+
+    /// ← on a run that is nobody's child, and the arrows on an empty list,
+    /// both leave the selection where it is rather than panicking.
+    #[test]
+    fn the_arrows_are_harmless_with_no_tree_to_walk() {
+        let mut dash = make_test_dashboard();
+        dash.handle_key(key(KeyCode::Left));
+        dash.handle_key(key(KeyCode::Right));
+        assert_eq!(dash.selected, 0);
+
+        dash.agents
+            .push(make_test_agent("lonely", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        dash.handle_key(key(KeyCode::Left));
+        assert_eq!(dash.selected, 0, "a root leaf has no parent to climb to");
+        assert!(dash.collapsed_runs.is_empty(), "and nothing folded");
+    }
+
+    /// Folding is keyed by run, so a row index that no longer names one (or a
+    /// run with no sub-agents) is a no-op rather than a phantom fold.
+    #[test]
+    fn folding_an_unfoldable_row_changes_nothing() {
+        let mut dash = dash_with_a_subtree();
+        dash.toggle_run_fold_at(99);
+        assert!(dash.collapsed_runs.is_empty(), "no such row");
+        let worker_row = dash.row_of_run("worker-a").unwrap();
+        dash.toggle_run_fold_at(worker_row);
+        assert!(
+            dash.collapsed_runs.is_empty(),
+            "a worker has nothing to fold"
+        );
+    }
 
     /// `c` no longer cancels from the list (it was an unconfirmed kill by
     /// another name); it is simply unbound there.

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -1,6 +1,7 @@
 //! `lev dash` - Interactive terminal UI for managing concurrent agents.
 
 mod agents;
+mod click;
 mod construct;
 mod context_tree;
 mod detail_band;

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -206,17 +206,16 @@ impl Dashboard {
         // Build content lines. `showing_final_output` records whether the
         // Output pane fell back to the run's final answer, so the file-path
         // hint below can point at the file actually being shown.
-        let (all_lines, context_cursor_line, showing_final_output): (
-            Vec<Line>,
-            Option<usize>,
-            bool,
-        ) = if is_context {
-            let (lines, cursor) = self.build_context_lines(agent, render_width);
-            (lines, cursor, false)
-        } else {
-            let (lines, showing_final) = self.build_output_lines(agent, is_output, render_width);
-            (lines, None, showing_final)
-        };
+        let (all_lines, context_row_lines, showing_final_output): (Vec<Line>, Vec<usize>, bool) =
+            if is_context {
+                let (lines, rows) = self.build_context_lines(agent, render_width);
+                (lines, rows, false)
+            } else {
+                let (lines, showing_final) =
+                    self.build_output_lines(agent, is_output, render_width);
+                (lines, Vec::new(), showing_final)
+            };
+        let context_cursor_line = context_row_lines.get(self.context_tree.cursor).copied();
 
         // ── Error / Cancelled banner ─────────────────────────────────────
         let mut all_lines = all_lines;
@@ -274,6 +273,26 @@ impl Dashboard {
         // the wrapped tail clipped past the pane bottom. `line_count` measures
         // exactly what `Paragraph` will render at this width.
         let total_rows = wrapped_rows(&all_lines, render_width);
+
+        // Which display row each interactive tree row starts on, so a click
+        // can be turned back into the row it landed on. One cumulative pass
+        // over the document; counting from the top per row would be quadratic
+        // in the size of a context window, ten times a second.
+        let context_row_offsets: Vec<usize> = if context_row_lines.is_empty() {
+            Vec::new()
+        } else {
+            let mut cumulative = Vec::with_capacity(all_lines.len() + 1);
+            let mut acc = 0usize;
+            cumulative.push(0);
+            for line in &all_lines {
+                acc += wrapped_rows(std::slice::from_ref(line), render_width);
+                cumulative.push(acc);
+            }
+            context_row_lines
+                .iter()
+                .map(|&line| cumulative[line.min(all_lines.len())])
+                .collect()
+        };
 
         // Clamp search_match_idx and jump to current match (centred by the
         // match's display row, since that is what the viewport scrolls by).
@@ -441,11 +460,18 @@ impl Dashboard {
             format!(" {} ", shortened)
         };
 
+        // The mode chips in the title are buttons: `[l] logs` and friends do
+        // by click exactly what their letter does by key.
+        self.register_mode_chip_clicks(content_area, &mode_label);
+
         let content_block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(C_BORDER_FOCUS))
-            .title(Span::styled(mode_label, Style::default().fg(C_ACCENT)))
+            .title(Span::styled(
+                mode_label.clone(),
+                Style::default().fg(C_ACCENT),
+            ))
             .title_bottom(
                 Line::from(Span::styled(file_path_hint, Style::default().fg(C_DIM))).left_aligned(),
             )
@@ -475,15 +501,71 @@ impl Dashboard {
                 &mut sb_state,
             );
         }
+
+        // Every tree row the viewport is actually showing becomes clickable,
+        // on the row it was drawn on. Rows scrolled off screen register
+        // nothing: a click cannot land on them.
+        for (idx, &offset) in context_row_offsets.iter().enumerate() {
+            let Some(y) = offset.checked_sub(scroll_y).filter(|y| *y < inner_h) else {
+                continue;
+            };
+            self.register_click(
+                Rect::new(
+                    content_area.x + 1,
+                    content_area.y + 1 + y as u16,
+                    render_width,
+                    1,
+                ),
+                ClickTarget::ContextRow(idx),
+            );
+        }
     }
 
-    /// The Context view's lines, plus the line index of the tree cursor's row
-    /// (for scroll-follow), when a snapshot exists.
+    /// Make the content pane's title chips (`[l] logs`, `[o] output`,
+    /// `[c] ctx`) clickable, over the exact columns they were drawn on.
+    ///
+    /// The title renders inside the top border, starting one cell in, so the
+    /// character offsets in the label are the screen columns. Only the chips
+    /// actually in this label are registered - the current mode has no chip of
+    /// its own, and registering a rect for text that is not there would put a
+    /// button over the run's search indicator.
+    fn register_mode_chip_clicks(&mut self, content_area: Rect, mode_label: &str) {
+        if content_area.width < 2 {
+            return;
+        }
+        for (chip, mode) in [
+            ("[l] logs", StageContentMode::Logs),
+            ("[o] output", StageContentMode::Output),
+            ("[c] ctx", StageContentMode::Context),
+        ] {
+            let Some(byte) = mode_label.find(chip) else {
+                continue;
+            };
+            // Characters, not bytes: the label carries a search indicator that
+            // can hold anything the user typed.
+            let before = mode_label
+                .char_indices()
+                .take_while(|(at, _)| *at < byte)
+                .count() as u16;
+            let column = content_area.x + 1 + before;
+            let width = chip.chars().count() as u16;
+            if column + width <= content_area.x + content_area.width {
+                self.register_click(
+                    Rect::new(column, content_area.y, width, 1),
+                    ClickTarget::ContentMode(mode),
+                );
+            }
+        }
+    }
+
+    /// The Context view's lines, plus the line each interactive tree row
+    /// (region header, entry stub) starts on - what the renderer needs to
+    /// scroll to the cursor and to hand a click the row it landed on.
     fn build_context_lines(
         &self,
         agent: &DashboardAgent,
         render_width: u16,
-    ) -> (Vec<Line<'static>>, Option<usize>) {
+    ) -> (Vec<Line<'static>>, Vec<usize>) {
         // When browsing the run's archived context history, show that point's
         // window; otherwise the live current window for the selected stage.
         let snap_opt = self
@@ -639,19 +721,17 @@ impl Dashboard {
                 searching,
                 render_width,
             );
-            let cursor_line = flat
-                .cursor_lines
-                .get(self.context_tree.cursor)
-                .map(|line| lines.len() + line);
+            let base = lines.len();
+            let row_lines = flat.cursor_lines.iter().map(|line| base + line).collect();
             lines.extend(flat.lines);
-            (lines, cursor_line)
+            (lines, row_lines)
         } else {
             (
                 vec![Line::from(Span::styled(
                     " no context snapshot available for this stage",
                     Style::default().fg(C_DIM),
                 ))],
-                None,
+                Vec::new(),
             )
         }
     }
@@ -1591,7 +1671,7 @@ mod tests {
         let dash = make_test_dashboard();
         let mut agent = make_test_agent("run-bcl", AgentDisplayStatus::Active);
         agent.context_snapshot = Some(std::sync::Arc::new(make_context_snapshot(4000, 8000)));
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
 
@@ -1599,7 +1679,7 @@ mod tests {
     fn build_context_lines_without_snapshot() {
         let dash = make_test_dashboard();
         let agent = make_test_agent("run-bcl2", AgentDisplayStatus::Active);
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty()); // should show "no context snapshot" message
     }
 
@@ -1642,7 +1722,7 @@ hint = "after plan"
             started_at: Some(chrono::Utc::now().timestamp() - 30),
             ended_at: None,
         }];
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1668,7 +1748,7 @@ name = "g"
         );
         agent.stages = vec![]; // no stage records at all -> .get(0) is None
 
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1701,7 +1781,7 @@ name = "g"
         };
         agent.stages = vec![rec.clone(), rec];
 
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1740,7 +1820,7 @@ condition = "error"
             ended_at: None,
         }];
 
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1783,7 +1863,7 @@ condition = "error"
                 description: None,
             }],
         }));
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1809,7 +1889,7 @@ condition = "error"
                 description: None,
             }],
         }));
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1851,7 +1931,7 @@ transform = "clear"
             ended_at: None,
         }];
         // selected_stage = 0, so we look up index 0 in stages which is "implement"
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1886,7 +1966,7 @@ transform = "clear"
             started_at: Some(chrono::Utc::now().timestamp() - 60),
             ended_at: Some(chrono::Utc::now().timestamp() - 10),
         }];
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1917,7 +1997,7 @@ transform = "clear"
             started_at: Some(chrono::Utc::now().timestamp() - 30),
             ended_at: None,
         }];
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines
             .iter()
             .flat_map(|l| l.spans.iter().map(|s| s.content.as_ref()))
@@ -1995,7 +2075,7 @@ transform = "clear"
                 },
             ],
         }));
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
 
@@ -2018,7 +2098,7 @@ transform = "clear"
                 description: None,
             }],
         }));
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
 
@@ -2041,7 +2121,7 @@ transform = "clear"
                 description: None,
             }],
         }));
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
 
@@ -2064,7 +2144,7 @@ transform = "clear"
                 description: None,
             }],
         }));
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         assert!(!lines.is_empty());
     }
 
@@ -2534,9 +2614,114 @@ transform = "clear"
             }),
         );
         dash.context_history_idx = Some(0);
-        let (lines, _cursor) = dash.build_context_lines(&agent, 80);
+        let (lines, _rows) = dash.build_context_lines(&agent, 80);
         let text: String = lines.iter().map(|l| format!("{l:?}")).collect::<String>();
         assert!(text.contains("hist-region"), "browsed region rendered");
+    }
+
+    // ─── Clickable chips and tree rows ────────────────────────────────────
+
+    /// A context window with more rows than a short pane can show.
+    fn tall_context_agent(id: &str) -> DashboardAgent {
+        let entry = |text: &str| runstate::RegionEntrySnapshot {
+            content: text.to_string(),
+            tokens: 5,
+            kind: Default::default(),
+            metadata: None,
+            key: None,
+            taint: Default::default(),
+        };
+        let mut agent = make_test_agent(id, AgentDisplayStatus::Active);
+        agent.context_snapshot = Some(std::sync::Arc::new(runstate::ContextSnapshot {
+            stage_name: "main".to_string(),
+            total_tokens: 40,
+            max_tokens: 100,
+            regions: (0..4)
+                .map(|i| runstate::RegionSnapshot {
+                    name: format!("region{i}"),
+                    kind: "pinned".to_string(),
+                    current_tokens: 10,
+                    max_tokens: 25,
+                    entries: vec![entry("alpha"), entry("beta")],
+                    description: None,
+                })
+                .collect(),
+        }));
+        agent
+    }
+
+    /// Only the rows the viewport is showing become clickable; the ones
+    /// scrolled past the bottom register nothing, so a click cannot land on a
+    /// row that is not there.
+    #[test]
+    fn only_the_visible_context_rows_are_clickable() {
+        let backend = TestBackend::new(100, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.stage_content_mode = StageContentMode::Context;
+        let agent = tall_context_agent("run-ctx-click");
+        terminal
+            .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 10), &agent, 100))
+            .unwrap();
+        let rows: Vec<usize> = dash
+            .click_targets
+            .iter()
+            .filter_map(|(_, t)| match t {
+                ClickTarget::ContextRow(i) => Some(*i),
+                _ => None,
+            })
+            .collect();
+        assert!(!rows.is_empty(), "some rows are on screen");
+        assert!(
+            rows.len() < 12,
+            "four regions with two entries each do not fit in eight rows: {rows:?}"
+        );
+        // Every registered row sits inside the pane's inner area.
+        for (rect, target) in &dash.click_targets {
+            if matches!(target, ClickTarget::ContextRow(_)) {
+                assert!((1..9).contains(&rect.y), "{rect:?}");
+            }
+        }
+    }
+
+    /// The chips are registered only for the modes the label actually offers,
+    /// and only when there is room to draw them.
+    #[test]
+    fn the_mode_chips_registered_match_the_label() {
+        let backend = TestBackend::new(100, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        let agent = make_test_agent("run-chips", AgentDisplayStatus::Active);
+        dash.stage_content_mode = StageContentMode::Output;
+        terminal
+            .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &agent, 100))
+            .unwrap();
+        // The pane registers nothing else here (no snapshot, so no tree rows),
+        // so the whole registry is the chips.
+        let chips: Vec<ClickTarget> = dash.click_targets.iter().map(|(_, t)| *t).collect();
+        assert!(chips.contains(&ClickTarget::ContentMode(StageContentMode::Logs)));
+        assert!(chips.contains(&ClickTarget::ContentMode(StageContentMode::Context)));
+        assert!(
+            !chips.contains(&ClickTarget::ContentMode(StageContentMode::Output)),
+            "the mode already showing has no chip of its own"
+        );
+
+        // A pane too narrow for the title registers nothing rather than
+        // buttons over columns that were never drawn. (`draw` clears the
+        // registry each frame; this test drives one pane at a time.)
+        dash.click_targets.clear();
+        let backend = TestBackend::new(6, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 6, 6), &agent, 6))
+            .unwrap();
+        assert!(dash.click_targets.is_empty(), "no room for a chip");
+        // …and neither does a pane with no width at all.
+        dash.click_targets.clear();
+        terminal
+            .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 1, 6), &agent, 1))
+            .unwrap();
+        assert!(dash.click_targets.is_empty());
     }
 
     // ─── render_content_pane: Context mode with is_run_state (disk fallback)

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -29,6 +29,9 @@ impl Dashboard {
         // Wheel hit-testing rects are also per-frame: each pane's renderer
         // registers where it actually drew.
         self.pane_rects.clear();
+        // …and so is what a click acts on, for the same reason: a target left
+        // over from a previous layout is a click on the wrong thing.
+        self.click_targets.clear();
 
         if self.agent_builder.is_some() {
             self.draw_agents_screen(frame, frame.area());

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -250,6 +250,14 @@ fn run_list_sections() -> Vec<HelpSection> {
             ("↑ ↓ / k j", "select a run"),
             ("home / end (g / G)", "first / last run"),
             ("enter", "open the detail view"),
+            (
+                "← →",
+                "fold / unfold a run's sub-agents (the ▸ ▾ arrow is clickable too)",
+            ),
+            (
+                "",
+                "on a run with none: ← goes up to the parent, → down to the first child",
+            ),
             ("n", "start a new run"),
             ("tab / shift-tab", "focus the log panel"),
             ("/", "filter runs; enter keeps it, esc clears it"),
@@ -312,6 +320,7 @@ fn detail_sections() -> Vec<HelpSection> {
             entries: vec![
                 ("↑ ↓ / k j", "move the tree cursor, not the scroll"),
                 ("enter / space", "fold or unfold a row"),
+                ("click", "the same, on the row under the pointer"),
                 ("[ / ]", "previous / next region"),
             ],
         },
@@ -465,7 +474,18 @@ fn shared_sections() -> Vec<HelpSection> {
                 ("wheel", "scrolls whichever pane is under the pointer"),
                 ("wheel on the run list", "moves the selection"),
                 ("drag", "select text; releasing copies it"),
-                ("click", "clears a selection; it does not open a run"),
+                (
+                    "click a run",
+                    "select it; the ▸ ▾ arrow folds its sub-agents",
+                ),
+                ("double click a run", "open its detail view"),
+                ("click the log panel", "move the keyboard there, like tab"),
+                ("click a stage tab", "open that stage"),
+                (
+                    "click [l] [o] [c]",
+                    "switch the content pane, like the letter",
+                ),
+                ("click a context row", "fold or unfold it"),
             ],
         },
         HelpSection {

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -32,7 +32,7 @@ impl Dashboard {
         self.draw_linear_tabs(frame, tabs_area, agent);
     }
 
-    fn draw_linear_tabs(&self, frame: &mut Frame, tabs_area: Rect, agent: &DashboardAgent) {
+    fn draw_linear_tabs(&mut self, frame: &mut Frame, tabs_area: Rect, agent: &DashboardAgent) {
         // Build tab titles with status glyphs
         let tab_titles: Vec<Line> = if agent.stages.is_empty() {
             // Fallback: synthesize stage names from RunMeta info
@@ -113,6 +113,28 @@ impl Dashboard {
         };
         if agent.graph.is_some() {
             tab_nav.push_str("  ·  [g] graph");
+        }
+
+        // Where each tab lands, so clicking one opens it. `Tabs` lays them out
+        // as (one space, title, one space) joined by the divider, from the
+        // inside edge of the block - the same walk it does when it renders.
+        let mut column = tabs_area.x.saturating_add(1);
+        let right = tabs_area.x.saturating_add(tabs_area.width);
+        for (i, title) in tab_titles.iter().enumerate() {
+            let width = title.width() as u16 + 2;
+            if column >= right {
+                break;
+            }
+            self.register_click(
+                Rect::new(
+                    column,
+                    tabs_area.y.saturating_add(1),
+                    width.min(right - column),
+                    1,
+                ),
+                ClickTarget::StageTab(i),
+            );
+            column = column.saturating_add(width).saturating_add(3);
         }
 
         let tabs_widget = Tabs::new(tab_titles)
@@ -337,7 +359,7 @@ mod tests {
     fn draw_linear_tabs_various_statuses() {
         let backend = TestBackend::new(120, 10);
         let mut terminal = Terminal::new(backend).unwrap();
-        let dash = make_test_dashboard();
+        let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-vs", AgentDisplayStatus::Active);
         agent.stages = vec![
             make_stage_record("s1", StageRunStatus::Complete),
@@ -363,6 +385,59 @@ mod tests {
         assert!(buf.contains("s3"), "{buf}");
         assert!(buf.contains("s4"), "{buf}");
         assert!(buf.contains("s5"), "{buf}");
+    }
+
+    /// Each tab is registered over the columns it was drawn on, and a strip
+    /// too narrow to hold them all stops registering rather than putting
+    /// buttons past the edge.
+    #[test]
+    fn the_stage_tabs_register_where_they_were_drawn() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-tabs", AgentDisplayStatus::Active);
+        agent.stages = vec![
+            make_stage_record("plan", StageRunStatus::Complete),
+            make_stage_record("implement", StageRunStatus::Active),
+            make_stage_record("review", StageRunStatus::Pending),
+        ];
+        agent.num_stages = 3;
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 10)).unwrap();
+        terminal
+            .draw(|f| dash.draw_linear_tabs(f, Rect::new(0, 0, 120, 3), &agent))
+            .unwrap();
+        let tabs: Vec<_> = dash
+            .click_targets
+            .iter()
+            .filter(|(_, t)| matches!(t, ClickTarget::StageTab(_)))
+            .collect();
+        assert_eq!(tabs.len(), 3, "one target per tab");
+        // "plan" is drawn inside the first tab's rect.
+        let first = tabs[0].0;
+        let buf = rendered_buffer(&terminal);
+        let width = 120usize;
+        let row: String = buf
+            .chars()
+            .skip(width * (first.y as usize))
+            .take(width)
+            .collect();
+        let at = row.find("plan").expect("the first tab is drawn");
+        assert!(
+            (first.x as usize..(first.x + first.width) as usize).contains(&at),
+            "the rect covers the tab's text: {first:?} vs column {at}"
+        );
+
+        // Narrow enough that the later tabs never make it onto the strip.
+        dash.click_targets.clear();
+        let mut terminal = Terminal::new(TestBackend::new(14, 10)).unwrap();
+        terminal
+            .draw(|f| dash.draw_linear_tabs(f, Rect::new(0, 0, 14, 3), &agent))
+            .unwrap();
+        let narrow = dash
+            .click_targets
+            .iter()
+            .filter(|(_, t)| matches!(t, ClickTarget::StageTab(_)))
+            .count();
+        assert!(narrow < 3, "the strip ran out of room: {narrow} tabs");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -5,6 +5,7 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
+use unicode_width::UnicodeWidthStr;
 
 use crate::commands::dashboard::helpers::{format_tokens, relative_time, truncate};
 use crate::commands::dashboard::state::Dashboard;
@@ -59,8 +60,8 @@ impl Dashboard {
             .enumerate()
             .map(|(pos, &idx)| {
                 let agent = &self.agents[idx];
-                // Tree-connector prefix (parent → child nesting); empty when flat.
-                let tree_prefix = self.tree_prefixes.get(pos).cloned().unwrap_or_default();
+                // Tree shape (parent → child nesting); default when flat.
+                let tree = self.tree_rows.get(pos).cloned().unwrap_or_default();
                 // A parked run only wears the attention colour when a person is
                 // actually needed. A parent whose workers are still running is
                 // healthy, and colouring it like a question is what taught
@@ -122,12 +123,35 @@ impl Dashboard {
                         title_spans.push(Span::raw("  "));
                     }
                 }
-                title_spans.push(Span::styled(tree_prefix, Style::default().fg(C_DIM)));
+                title_spans.push(Span::styled(
+                    tree.prefix.clone(),
+                    Style::default().fg(C_DIM),
+                ));
+                // The fold arrow, on runs that have sub-agents. Leaves get the
+                // same two columns of blank so every title still lines up.
+                title_spans.push(Span::styled(
+                    if !tree.expandable {
+                        "  "
+                    } else if tree.collapsed {
+                        "▸ "
+                    } else {
+                        "▾ "
+                    },
+                    Style::default().fg(C_ACCENT),
+                ));
                 title_spans.push(Span::styled(title_str, Style::default().fg(C_WHITE)));
                 title_spans.push(Span::styled(
                     format!(" #{}", short_id),
                     Style::default().fg(C_DIM),
                 ));
+                // A fold has to say what it swallowed, or the run simply looks
+                // like it has no workers.
+                if tree.collapsed {
+                    title_spans.push(Span::styled(
+                        format!(" +{}", tree.hidden),
+                        Style::default().fg(C_ACCENT),
+                    ));
+                }
                 let title_cell = Cell::from(Line::from(title_spans));
                 Row::new(vec![
                     title_cell,
@@ -227,10 +251,49 @@ impl Dashboard {
         );
 
         frame.render_stateful_widget(table, area, &mut self.table_state);
+        self.register_run_row_clicks(area, any_marked);
+    }
+
+    /// Register a click target per visible run row, and a second one over its
+    /// fold arrow.
+    ///
+    /// Runs after the table renders because that is when `TableState` knows
+    /// how far it scrolled; deriving the offset ourselves would be a second
+    /// implementation of the widget's own scrolling, free to disagree with it.
+    fn register_run_row_clicks(&mut self, area: Rect, any_marked: bool) {
+        // Inside the border, below the one-row header.
+        let first_row_y = area.y.saturating_add(2);
+        let visible = area.height.saturating_sub(3);
+        let offset = self.table_state.offset();
+        let title_x = area.x.saturating_add(1);
+        // The tick column, present only while something is marked.
+        let mark_w = if any_marked { 2u16 } else { 0 };
+        for screen in 0..visible {
+            let pos = offset + screen as usize;
+            if pos >= self.display_indices.len() {
+                break;
+            }
+            let y = first_row_y + screen;
+            self.register_click(
+                Rect::new(area.x, y, area.width, 1),
+                ClickTarget::RunRow(pos),
+            );
+            let tree = self.tree_rows.get(pos).cloned().unwrap_or_default();
+            if !tree.expandable {
+                continue;
+            }
+            let prefix_w = UnicodeWidthStr::width(tree.prefix.as_str()) as u16;
+            let arrow_x = title_x.saturating_add(mark_w).saturating_add(prefix_w);
+            if arrow_x + 2 <= area.x + area.width {
+                self.register_click(Rect::new(arrow_x, y, 2, 1), ClickTarget::RunToggle(pos));
+            }
+        }
     }
 
     pub(in crate::commands::dashboard) fn draw_log_panel(&mut self, frame: &mut Frame, area: Rect) {
         self.pane_rects.push((PaneId::LogPanel, area));
+        // Clicking the panel is the mouse's Tab: it moves the keyboard here.
+        self.register_click(area, ClickTarget::LogPanel);
         let viewport = area.height.saturating_sub(2) as usize;
         self.log_viewport = viewport;
         let window = self.log_scroll.window(self.log.len(), viewport);
@@ -565,6 +628,17 @@ impl Dashboard {
                 Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
             ),
             Span::raw(" detail  "),
+        ];
+        // Only worth a slot on the bar when there is a tree to work: on a list
+        // of plain runs the arrows have nothing to fold.
+        if self.tree_rows.iter().any(|r| r.expandable) {
+            spans.push(Span::styled(
+                "[←/→]",
+                Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+            ));
+            spans.push(Span::raw(" fold sub-agents  "));
+        }
+        spans.extend([
             Span::styled(
                 "[n]",
                 Style::default().fg(C_SUCCESS).add_modifier(Modifier::BOLD),
@@ -593,7 +667,7 @@ impl Dashboard {
             Span::raw(" mark  "),
             Span::styled("[m]", Style::default().add_modifier(Modifier::BOLD)),
             Span::raw(" mcp  "),
-        ];
+        ]);
         if can_kill {
             spans.push(Span::styled(
                 "[x]",
@@ -1467,10 +1541,121 @@ mod tests {
             })
             .unwrap();
         let buf = rendered_buffer(&terminal);
-        assert!(buf.contains("✓ My Test #1"), "{buf}");
-        assert!(!buf.contains("✓ My Test #2"), "{buf}");
+        // The two columns between the tick and the title are the fold-arrow
+        // gutter, blank on a run with no sub-agents so titles stay aligned.
+        assert!(buf.contains("✓   My Test #1"), "{buf}");
+        assert!(!buf.contains("✓   My Test #2"), "{buf}");
         assert!(buf.contains("My Test #2"), "the unmarked row still renders");
         assert!(buf.contains("1 marked"), "{buf}");
+    }
+
+    // ── The sub-agent fold ────────────────────────────────────────────────
+
+    /// A parent with one worker, the shape the run list draws as a tree.
+    fn dash_with_a_worker() -> crate::commands::dashboard::state::Dashboard {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("parent", AgentDisplayStatus::Active));
+        let mut child = make_test_agent("worker", AgentDisplayStatus::Active);
+        child.parent_id = Some("parent".to_string());
+        dash.agents.push(child);
+        dash.update_display_indices();
+        dash
+    }
+
+    /// The arrow says which way the fold goes, and a folded row says how many
+    /// runs are behind it.
+    #[test]
+    fn the_fold_arrow_and_its_hidden_count_are_drawn() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = dash_with_a_worker();
+        terminal
+            .draw(|f| dash.draw_agent_table(f, f.area()))
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("▾ My Test"), "an unfolded parent: {buf}");
+        assert!(!buf.contains("▸ "), "nothing is folded yet: {buf}");
+
+        dash.collapsed_runs.insert("parent".to_string());
+        dash.update_display_indices();
+        terminal
+            .draw(|f| dash.draw_agent_table(f, f.area()))
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("▸ My Test"), "a folded parent: {buf}");
+        assert!(buf.contains("+1"), "and what it hides: {buf}");
+    }
+
+    /// The arrow's rect is registered where the arrow was actually drawn, and
+    /// only for rows that have one.
+    #[test]
+    fn only_a_foldable_row_registers_a_fold_arrow() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = dash_with_a_worker();
+        terminal
+            .draw(|f| dash.draw_agent_table(f, f.area()))
+            .unwrap();
+        let toggles: Vec<_> = dash
+            .click_targets
+            .iter()
+            .filter(|(_, t)| matches!(t, ClickTarget::RunToggle(_)))
+            .collect();
+        assert_eq!(toggles.len(), 1, "the parent only, not the worker");
+        assert_eq!(toggles[0].1, ClickTarget::RunToggle(0));
+        let rows = dash
+            .click_targets
+            .iter()
+            .filter(|(_, t)| matches!(t, ClickTarget::RunRow(_)))
+            .count();
+        assert_eq!(rows, 2, "both rows are clickable");
+    }
+
+    /// A table too narrow to hold the arrow registers the row but no arrow,
+    /// rather than a rect hanging off the right edge.
+    #[test]
+    fn a_table_narrower_than_the_arrow_registers_no_arrow() {
+        let backend = TestBackend::new(2, 8);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = dash_with_a_worker();
+        terminal
+            .draw(|f| dash.draw_agent_table(f, f.area()))
+            .unwrap();
+        assert!(
+            !dash
+                .click_targets
+                .iter()
+                .any(|(_, t)| matches!(t, ClickTarget::RunToggle(_))),
+            "no room for an arrow to click"
+        );
+    }
+
+    /// The fold hint earns its place on the bar only when there is a tree.
+    #[test]
+    fn the_fold_hint_appears_only_with_sub_agents() {
+        let backend = TestBackend::new(200, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("solo", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        terminal
+            .draw(|f| dash.draw_help_bar(f, Rect::new(0, 0, 200, 1)))
+            .unwrap();
+        assert!(
+            !rendered_buffer(&terminal).contains("fold sub-agents"),
+            "no tree, no hint"
+        );
+
+        let dash = dash_with_a_worker();
+        terminal
+            .draw(|f| dash.draw_help_bar(f, Rect::new(0, 0, 200, 1)))
+            .unwrap();
+        assert!(
+            rendered_buffer(&terminal).contains("fold sub-agents"),
+            "the hint shows once a run has workers"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/selection.rs
+++ b/crates/leviath-cli/src/commands/dashboard/selection.rs
@@ -155,7 +155,13 @@ impl Dashboard {
                 self.selection_drag(event.column, event.row);
             }
             MouseEventKind::Up(MouseButton::Left) => {
-                self.selection_release(event.column, event.row);
+                // A release with no motion behind it is a click, not a
+                // selection: it goes to whatever was drawn under it (see
+                // `click.rs`). A drag stays a copy highlight.
+                let plain_click = self.selection_release(event.column, event.row);
+                if plain_click {
+                    self.handle_click(event.column, event.row);
+                }
             }
             _ => {}
         }
@@ -222,16 +228,24 @@ impl Dashboard {
     /// Release ends the drag: with motion it schedules the copy for the next
     /// draw (extraction needs the drawn buffer), without motion it was a plain
     /// click and clears.
-    fn selection_release(&mut self, column: u16, row: u16) {
+    ///
+    /// Returns whether this was a plain click, so the caller can hand it to
+    /// the click targets. A release with no drag behind it at all (the press
+    /// landed outside every selectable region) counts as one too - the frame
+    /// is one selection region, so in practice this is a release the graph
+    /// canvases let through.
+    fn selection_release(&mut self, column: u16, row: u16) -> bool {
         let Some(sel) = self.selection.as_mut().filter(|s| s.dragging) else {
-            return;
+            return true;
         };
         sel.cursor = clamp_to_region(sel.region, column, row);
         sel.dragging = false;
         if sel.moved {
             sel.pending_copy = true;
+            false
         } else {
             self.selection = None;
+            true
         }
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -48,6 +48,17 @@ pub(crate) struct Dashboard {
     /// The graph pane holding the mouse between a left press and its
     /// release, so a pan that leaves the canvas keeps panning.
     pub(super) mouse_capture: Option<PaneId>,
+    /// What a left click acts on, re-registered by each renderer every frame
+    /// (see [`ClickTarget`]). Hit-tested last-match-first, so a target drawn
+    /// inside another wins.
+    pub(super) click_targets: Vec<(ratatui::layout::Rect, ClickTarget)>,
+    /// The cell and time of the last plain click, so a second click on the
+    /// same cell inside [`DOUBLE_CLICK_MS`](super::click::DOUBLE_CLICK_MS)
+    /// reads as a double click.
+    pub(super) last_click: Option<((u16, u16), u64)>,
+    /// Monotonic milliseconds, injected so double-click detection is testable
+    /// without sleeping (mirroring `clock`/`yank_fn`).
+    pub(super) mouse_clock: fn() -> u64,
     /// The detail view's graph band, kept between frames; rebuilt when the
     /// selected run changes.
     pub(super) detail_band: Option<super::detail_band::DetailBand>,
@@ -114,10 +125,14 @@ pub(crate) struct Dashboard {
     pub(super) list_search_query: String,
     /// Sorted + filtered indices into self.agents (drives both display and selection).
     pub(super) display_indices: Vec<usize>,
-    /// Tree-connector prefix for each `display_indices` row (parent → child
-    /// nesting), parallel to `display_indices`. Empty strings when filtering (the
-    /// list is flat then).
-    pub(super) tree_prefixes: Vec<String>,
+    /// Parent → child tree shape for each `display_indices` row (connector
+    /// prefix, whether it folds, whether it is folded), parallel to
+    /// `display_indices`. Default rows when filtering (the list is flat then).
+    pub(super) tree_rows: Vec<RunTreeRow>,
+    /// Runs whose sub-agents are folded away (`←` on the row, or a click on
+    /// its arrow). Keyed by run id rather than row position so a fold survives
+    /// re-sorting, filtering, and rows arriving above it.
+    pub(super) collapsed_runs: std::collections::HashSet<String>,
     /// Filesystem path this dashboard appends its activity log to. Production
     /// construction resolves the real [`runstate::dashboard_log_path`]; tests
     /// (`make_test_dashboard`) inject a temp path so no test ever writes to the
@@ -337,7 +352,7 @@ impl Dashboard {
         // With no filter, re-order into a parent → child tree so sub-agents and
         // fan-out workers nest under their parent (roots keep their recency order);
         // a filter keeps the flat sorted list (a partial match can't form a tree).
-        let prefixes: Vec<String> = if query.is_empty() {
+        let tree_rows: Vec<RunTreeRow> = if query.is_empty() {
             // Roots keep the status-sorted order; an agent whose parent is absent
             // is treated as a root so it can't disappear from the list.
             let present: std::collections::HashSet<&str> =
@@ -354,9 +369,9 @@ impl Dashboard {
                 .collect();
             let tree = self.build_tree_order(&roots);
             indices = tree.iter().map(|(i, _)| *i).collect();
-            tree.into_iter().map(|(_, prefix)| prefix).collect()
+            tree.into_iter().map(|(_, row)| row).collect()
         } else {
-            vec![String::new(); indices.len()]
+            vec![RunTreeRow::default(); indices.len()]
         };
         // Preserve selection: try to keep the same agent highlighted after recompute
         let prev_id = self
@@ -365,17 +380,20 @@ impl Dashboard {
             .and_then(|&i| self.agents.get(i))
             .map(|a| a.id.clone());
         self.display_indices = indices;
-        self.tree_prefixes = prefixes;
+        self.tree_rows = tree_rows;
+        // A fold whose parent has gone stops meaning anything; keeping it
+        // would silently re-fold a run that later reuses the id.
+        let agents = &self.agents;
+        self.collapsed_runs
+            .retain(|id| agents.iter().any(|a| a.id == *id));
         if let Some(id) = prev_id {
-            if let Some(pos) = self
-                .display_indices
-                .iter()
-                .position(|&i| self.agents.get(i).map(|a| a.id == id).unwrap_or(false))
-            {
-                self.selected = pos;
-            } else {
-                self.selected = 0;
-            }
+            // A fold can take the highlighted row off screen. Landing on the
+            // ancestor that swallowed it keeps the eye where it was; row 0 is
+            // a jump to the top of an unrelated run.
+            self.selected = self
+                .row_of_run(&id)
+                .or_else(|| self.visible_ancestor_row(&id))
+                .unwrap_or(0);
         }
         if self.display_indices.is_empty() {
             self.selected = 0;
@@ -994,12 +1012,14 @@ impl Dashboard {
         self.selected_stage == input_stage_idx
     }
 
-    /// Build a tree-ordered list of agent indices with tree connector prefixes.
+    /// Build a tree-ordered list of agent indices with their row shape.
     ///
     /// Depth-first tree order over the given root agent indices (in the order
-    /// supplied - the caller sorts them), nesting each root's children beneath it.
-    /// Returns `Vec<(original_index, tree_prefix)>`.
-    pub(super) fn build_tree_order(&self, root_order: &[usize]) -> Vec<(usize, String)> {
+    /// supplied - the caller sorts them), nesting each root's children beneath
+    /// it. A run in `collapsed_runs` still gets its own row, carrying the
+    /// number of descendants the fold hides; none of them are emitted.
+    /// Returns `Vec<(original_index, row)>`.
+    pub(super) fn build_tree_order(&self, root_order: &[usize]) -> Vec<(usize, RunTreeRow)> {
         let mut result = Vec::new();
         for &idx in root_order {
             self.collect_tree_children(idx, "", &mut result, true);
@@ -1007,28 +1027,56 @@ impl Dashboard {
         result
     }
 
-    fn collect_tree_children(
-        &self,
-        idx: usize,
-        prefix: &str,
-        result: &mut Vec<(usize, String)>,
-        is_root: bool,
-    ) {
-        let display_prefix = if is_root {
-            String::new()
-        } else {
-            prefix.to_string()
-        };
-        result.push((idx, display_prefix));
-
+    /// The agent indices whose `parent_id` is `idx`'s id.
+    fn children_of(&self, idx: usize) -> Vec<usize> {
         let agent_id = &self.agents[idx].id;
-        let children: Vec<usize> = self
-            .agents
+        self.agents
             .iter()
             .enumerate()
             .filter(|(_, a)| a.parent_id.as_deref() == Some(agent_id))
             .map(|(i, _)| i)
-            .collect();
+            .collect()
+    }
+
+    /// How many rows a fold on `idx` hides: its children, their children, and
+    /// so on, whatever their own fold state (the number is what the row shows,
+    /// and "4 hidden" that is really 9 would be a lie).
+    fn descendant_count(&self, idx: usize) -> usize {
+        self.children_of(idx)
+            .into_iter()
+            .map(|c| 1 + self.descendant_count(c))
+            .sum()
+    }
+
+    fn collect_tree_children(
+        &self,
+        idx: usize,
+        prefix: &str,
+        result: &mut Vec<(usize, RunTreeRow)>,
+        is_root: bool,
+    ) {
+        let children = self.children_of(idx);
+        let collapsed = self.collapsed_runs.contains(&self.agents[idx].id);
+        result.push((
+            idx,
+            RunTreeRow {
+                prefix: if is_root {
+                    String::new()
+                } else {
+                    prefix.to_string()
+                },
+                expandable: !children.is_empty(),
+                collapsed: collapsed && !children.is_empty(),
+                hidden: if collapsed {
+                    self.descendant_count(idx)
+                } else {
+                    0
+                },
+            },
+        ));
+        if collapsed {
+            return;
+        }
 
         for (ci, &child_idx) in children.iter().enumerate() {
             let is_last = ci == children.len() - 1;
@@ -1042,6 +1090,35 @@ impl Dashboard {
 
             self.collect_tree_children(child_idx, &child_prefix, result, false);
         }
+    }
+
+    /// The `display_indices` position of the row holding `run_id`, if it is
+    /// on screen (a folded-away child is not).
+    pub(super) fn row_of_run(&self, run_id: &str) -> Option<usize> {
+        self.display_indices
+            .iter()
+            .position(|&i| self.agents.get(i).is_some_and(|a| a.id == run_id))
+    }
+
+    /// Walking up from `run_id`, the row of the first ancestor that is on
+    /// screen - where a run that a fold just hid went.
+    fn visible_ancestor_row(&self, run_id: &str) -> Option<usize> {
+        let mut current = run_id.to_string();
+        // Bounded by the agent count: a `parent_id` chain longer than that has
+        // a cycle in it, and walking one forever would hang the draw loop.
+        for _ in 0..self.agents.len() {
+            let parent = self
+                .agents
+                .iter()
+                .find(|a| a.id == current)?
+                .parent_id
+                .clone()?;
+            if let Some(row) = self.row_of_run(&parent) {
+                return Some(row);
+            }
+            current = parent;
+        }
+        None
     }
 }
 
@@ -1523,8 +1600,88 @@ mod tests {
         assert_eq!(dash.display_indices.len(), 2);
         assert_eq!(dash.agents[dash.display_indices[0]].id, "parent");
         assert_eq!(dash.agents[dash.display_indices[1]].id, "child");
-        assert_eq!(dash.tree_prefixes[0], ""); // root: no prefix
-        assert!(dash.tree_prefixes[1].contains('─')); // child: tree connector
+        assert_eq!(dash.tree_rows[0].prefix, ""); // root: no prefix
+        assert!(dash.tree_rows[1].prefix.contains('─')); // child: tree connector
+    }
+
+    /// A grandparent's fold hides the whole subtree, and says how much of it.
+    #[test]
+    fn a_folded_run_hides_its_whole_subtree_and_counts_it() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("root", AgentDisplayStatus::Active));
+        let mut child = make_test_agent("child", AgentDisplayStatus::Active);
+        child.parent_id = Some("root".to_string());
+        dash.agents.push(child);
+        let mut grandchild = make_test_agent("grandchild", AgentDisplayStatus::Active);
+        grandchild.parent_id = Some("child".to_string());
+        dash.agents.push(grandchild);
+        dash.update_display_indices();
+        assert_eq!(dash.display_indices.len(), 3);
+        assert!(dash.tree_rows[0].expandable);
+        assert!(!dash.tree_rows[0].collapsed);
+        assert!(!dash.tree_rows[2].expandable, "the leaf cannot fold");
+
+        dash.collapsed_runs.insert("root".to_string());
+        dash.update_display_indices();
+        assert_eq!(dash.display_indices.len(), 1, "only the root is left");
+        assert!(dash.tree_rows[0].collapsed);
+        assert_eq!(
+            dash.tree_rows[0].hidden, 2,
+            "both descendants, not just the direct child"
+        );
+    }
+
+    /// Folding the run the highlight was inside moves it to the fold, not to
+    /// the top of the list.
+    #[test]
+    fn folding_a_parent_moves_the_highlight_onto_it() {
+        let mut dash = make_test_dashboard();
+        dash.agents
+            .push(make_test_agent("other", AgentDisplayStatus::Active));
+        dash.agents
+            .push(make_test_agent("root", AgentDisplayStatus::Active));
+        let mut child = make_test_agent("child", AgentDisplayStatus::Active);
+        child.parent_id = Some("root".to_string());
+        dash.agents.push(child);
+        dash.update_display_indices();
+        let child_row = dash.row_of_run("child").expect("the child is on screen");
+        dash.selected = child_row;
+
+        dash.collapsed_runs.insert("root".to_string());
+        dash.update_display_indices();
+        assert_eq!(dash.row_of_run("child"), None, "the child is folded away");
+        assert_eq!(
+            dash.selected,
+            dash.row_of_run("root").unwrap(),
+            "the highlight followed the fold that swallowed it"
+        );
+    }
+
+    /// A `parent_id` cycle is walked at most once per run rather than forever.
+    #[test]
+    fn a_parent_cycle_does_not_hang_the_ancestor_walk() {
+        let mut dash = make_test_dashboard();
+        let mut a = make_test_agent("a", AgentDisplayStatus::Active);
+        a.parent_id = Some("b".to_string());
+        let mut b = make_test_agent("b", AgentDisplayStatus::Active);
+        b.parent_id = Some("a".to_string());
+        dash.agents.push(a);
+        dash.agents.push(b);
+        dash.update_display_indices();
+        assert_eq!(dash.visible_ancestor_row("a"), None);
+        // A parent that is not a run at all ends the walk too.
+        assert_eq!(dash.visible_ancestor_row("nobody"), None);
+    }
+
+    /// A fold on a run that later disappears is dropped, so a run that reuses
+    /// the id does not come back folded.
+    #[test]
+    fn a_fold_on_a_vanished_run_is_forgotten() {
+        let mut dash = make_test_dashboard();
+        dash.collapsed_runs.insert("ghost".to_string());
+        dash.update_display_indices();
+        assert!(dash.collapsed_runs.is_empty());
     }
 
     #[test]
@@ -1538,7 +1695,7 @@ mod tests {
         // A child whose parent is absent is treated as a root, not dropped.
         assert_eq!(dash.display_indices.len(), 1);
         assert_eq!(dash.agents[dash.display_indices[0]].id, "orphan");
-        assert_eq!(dash.tree_prefixes[0], "");
+        assert_eq!(dash.tree_rows[0].prefix, "");
     }
 
     #[test]
@@ -1687,7 +1844,7 @@ mod tests {
         let tree = dash.build_tree_order(&roots_of(&dash));
         assert_eq!(tree.len(), 1);
         assert_eq!(tree[0].0, 0);
-        assert!(tree[0].1.is_empty()); // root has no prefix
+        assert!(tree[0].1.prefix.is_empty()); // root has no prefix
     }
 
     #[test]
@@ -1702,7 +1859,7 @@ mod tests {
         assert_eq!(tree.len(), 2);
         assert_eq!(tree[0].0, 0); // parent
         assert_eq!(tree[1].0, 1); // child
-        assert!(tree[1].1.contains("└─")); // last child connector
+        assert!(tree[1].1.prefix.contains("└─")); // last child connector
     }
 
     #[test]
@@ -1798,13 +1955,13 @@ mod tests {
         let tree = dash.build_tree_order(&roots_of(&dash));
         assert_eq!(tree.len(), 3);
         assert_eq!(tree[0].0, 0); // parent
-        assert!(tree[0].1.is_empty()); // root has no prefix
+        assert!(tree[0].1.prefix.is_empty()); // root has no prefix
         // First child
         assert_eq!(tree[1].0, 1);
-        assert!(tree[1].1.contains("├─")); // not last child
+        assert!(tree[1].1.prefix.contains("├─")); // not last child
         // Second child (last)
         assert_eq!(tree[2].0, 2);
-        assert!(tree[2].1.contains("└─")); // last child
+        assert!(tree[2].1.prefix.contains("└─")); // last child
     }
 
     #[test]
@@ -1917,14 +2074,14 @@ mod tests {
         let tree = dash.build_tree_order(&roots_of(&dash));
         assert_eq!(tree.len(), 4);
         assert_eq!(tree[0].0, 0); // root
-        assert!(tree[0].1.is_empty()); // root has no prefix
+        assert!(tree[0].1.prefix.is_empty()); // root has no prefix
         assert_eq!(tree[1].0, 1); // child1
-        assert!(tree[1].1.contains("├─")); // not last child
+        assert!(tree[1].1.prefix.contains("├─")); // not last child
         assert_eq!(tree[2].0, 3); // grandchild (under child1)
         // grandchild should have deeper connector
-        assert!(tree[2].1.len() > tree[1].1.len());
+        assert!(tree[2].1.prefix.len() > tree[1].1.prefix.len());
         assert_eq!(tree[3].0, 2); // child2
-        assert!(tree[3].1.contains("└─")); // last child
+        assert!(tree[3].1.prefix.contains("└─")); // last child
     }
 
     // ─── build_tree_order with multiple roots ─────────────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -16,7 +16,7 @@ use ratatui::style::Color;
 pub struct DashboardArgs {}
 
 /// Whether the detail content pane shows Output or Logs.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum StageContentMode {
     Output,
     Logs,
@@ -130,6 +130,49 @@ impl ExplorerState {
             view,
         }
     }
+}
+
+/// One row of the run list's parent → child tree: the connector prefix drawn
+/// before the title, plus whether the row can fold and whether it is folded.
+///
+/// Parallel to `display_indices`, rebuilt by `update_display_indices`. It is
+/// one vector rather than three because every consumer (the renderer, the
+/// arrow keys, the click hit-test) needs all three facts about the same row,
+/// and parallel vectors that can disagree about their length are how a row
+/// ends up drawn with another row's connector.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(super) struct RunTreeRow {
+    /// Tree connectors drawn before the title (empty for a root).
+    pub(super) prefix: String,
+    /// True when the run has sub-agents, so the row can fold.
+    pub(super) expandable: bool,
+    /// True when its sub-agents are folded away.
+    pub(super) collapsed: bool,
+    /// How many descendants the fold is hiding (0 unless collapsed).
+    pub(super) hidden: usize,
+}
+
+/// Something on screen a left click acts on, registered with its rect by the
+/// renderer that drew it.
+///
+/// Hit-testing runs over the rects registered this frame, last match wins, so
+/// a target drawn inside another (a fold arrow inside its row) takes the
+/// click. The alternative - each handler re-deriving where its widget landed -
+/// is how a click ends up acting on the row above the one under the pointer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum ClickTarget {
+    /// A run row in the main list, by its `display_indices` position.
+    RunRow(usize),
+    /// The fold arrow of a run row, by its `display_indices` position.
+    RunToggle(usize),
+    /// The log panel: clicking it moves the keyboard there.
+    LogPanel,
+    /// A stage tab in the detail view, by stage index.
+    StageTab(usize),
+    /// One of the content pane's mode chips (`[l] logs` and friends).
+    ContentMode(StageContentMode),
+    /// A row of the Context view's tree, by interactive-row index.
+    ContextRow(usize),
 }
 
 /// Cursor + expansion state of the structured Context view.

--- a/crates/leviath-cli/src/tui/flowgraph/content.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/content.rs
@@ -52,6 +52,22 @@ impl RunPhase {
         }
     }
 
+    /// Whether the run has stopped for good, so nothing about it can move
+    /// again.
+    ///
+    /// The animated edge means "the run is travelling this path". On a run
+    /// that has finished it was still pulsing into the last node it reached,
+    /// which reads as a run still going - the one thing the graph is there to
+    /// tell you at a glance. A parked run (waiting, paused, idle, stale) keeps
+    /// the animation: it has not finished, and the pulse is what says where it
+    /// stopped.
+    pub(crate) fn is_finished(self) -> bool {
+        matches!(
+            self,
+            RunPhase::Complete | RunPhase::Error | RunPhase::Cancelled
+        )
+    }
+
     /// The word the node shows for the phase; the spinner says "running"
     /// on its own, so `Active` has none.
     fn word(self) -> Option<&'static str> {

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -864,9 +864,14 @@ impl FlowView {
             .collect();
         self.taken = live.taken.iter().cloned().collect();
         self.current = live.current.clone();
+        // The pulse on the newest transition means the run is travelling that
+        // path. A run that has finished is not, so its last edge is drawn as
+        // taken and still - see `RunPhase::is_finished`.
+        let finished = live.run.is_some_and(|phase| phase.is_finished());
         let last = live
             .last_transition
             .as_ref()
+            .filter(|_| !finished)
             .map(|(f, t)| (f.as_str(), t.as_str()));
         for meta in &self.edges {
             let key = (meta.edge.from.as_str(), meta.edge.to.as_str());
@@ -1304,6 +1309,37 @@ mode = "output"
                 errored: false
             })
         );
+        // …and it does not still pulse along the path it arrived by: the
+        // animation means "travelling", and this run has stopped.
+        assert!(
+            !v.edge_animated("implement", "review"),
+            "a finished run is not moving"
+        );
+        assert!(
+            !v.edge_hidden("implement", "review"),
+            "the path it took is still drawn, just still"
+        );
+        // Every terminal phase, not only the happy one.
+        for phase in [RunPhase::Error, RunPhase::Cancelled] {
+            let mut stopped = next.clone();
+            stopped.run = Some(phase);
+            v.apply_live(&stopped);
+            assert!(!v.edge_animated("implement", "review"), "{phase:?}");
+        }
+        // A run that is merely parked has not finished, and the pulse is what
+        // says where it stopped.
+        for phase in [
+            RunPhase::Waiting,
+            RunPhase::Paused,
+            RunPhase::Idle,
+            RunPhase::Stale,
+        ] {
+            let mut parked = next.clone();
+            parked.run = Some(phase);
+            v.apply_live(&parked);
+            assert!(v.edge_animated("implement", "review"), "{phase:?}");
+        }
+
         // Same current again: no new reveal.
         v.apply_live(&next);
         assert!(v.reveal.is_none());

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -44,8 +44,11 @@ panel and answer. `lev respond` does the same from the shell.
 - **Agents**: the catalog of agents this machine can run (`a`), and an editor that builds one on
   the same graph canvas: stages as boxes, paths drawn between them, an inspector for whatever is
   selected. The same editor The Lair has, in the terminal.
-- **Mouse support**: wheel scroll, click-drag select with copy-on-release, OSC52 copy over SSH,
-  `y` to yank a pane, Shift+drag for native selection.
+- **Mouse support**: click a run to select it and again to open it, click the `▸`/`▾` arrow to fold
+  a run's sub-agents, click a stage tab or a content-pane chip (`[l]`, `[o]`, `[c]`) to switch to
+  it, click a Context row to fold or unfold it, click the log panel to move the keys there. Wheel
+  scroll, click-drag select with copy-on-release, OSC52 copy over SSH, `y` to yank a pane,
+  Shift+drag for native selection.
 - **`m`** opens the MCP management screen without leaving the dashboard.
 - **The daemon link**: the dashboard polls the [daemon](/docs/daemon) ten times a second, so a
   daemon restart costs it nothing but a moment. It says so in the log pane and a toast when the
@@ -70,6 +73,7 @@ the detail view).
 | `↑` / `↓` (or `k` / `j`) | Select a run |
 | `Home` / `End` (or `g` / `G`) | Jump to the first / last run |
 | `Enter` | Open detail view |
+| `←` / `→` | Fold / unfold the selected run's sub-agents. On a run that has none, `←` moves up to its parent and `→` down to its first worker |
 | `n` | Start a run: pick an agent, write the task, press Enter |
 | `Tab` / `Shift-Tab` | Focus the log panel (keys below) |
 | `/` | Filter runs by name or status |
@@ -85,6 +89,12 @@ the detail view).
 
 By default runs are listed newest first and keep their row for their whole life, so nothing jumps
 around when a run finishes. The sort indicator sits in the table's top-right corner.
+
+A run that spawned sub-agents (a fan-out, or the sub-agent tool) shows them nested under it, each
+row wearing a `▾` while its workers are showing and a `▸` once they are folded, with `+N` for how
+many the fold is hiding. `←` and `→` work the tree, and clicking the arrow does the same. A fold is
+remembered by run, so it survives sorting, filtering and new rows arriving above it, and folding
+the run you were inside moves the highlight onto the fold rather than back to the top.
 
 Marking selects several runs at once: press `Space` on each run, then `x` or `d` acts on all of
 them behind one confirmation. Marked rows show a check mark, the pane title counts them, and marks
@@ -175,7 +185,7 @@ activates it, and a stray keypress does nothing. The safe answer holds focus to 
 
 The Context view is a tree, not one long scroll. Each region is a header row with its token bar;
 its entries are one-line stubs with a preview. Move with `↑`/`↓`, fold or unfold with `Enter` or
-Space, and jump between regions with `[` and `]`. While a search (`/`) is active everything is
+Space (or by clicking the row), and jump between regions with `[` and `]`. While a search (`/`) is active everything is
 temporarily unfolded so matches inside entries stay reachable. Browsing history with `,`/`.` keeps
 your scroll position and fold state, and the context card's title shows which archived point you
 are on, in which stage, recorded when.
@@ -190,7 +200,8 @@ chain; a graph blueprint is a graph):
   does (`r` turns it by hand); boxes are never shrunk to make a graph fit, the canvas pans instead,
   with a minimap in the corner when there is more graph than screen. The stage the run is in
   spins in the run's colour, stages it has been through show a visit count (`×2`) and the time of
-  their last visit, the last transition it took is animated, and revisit loops run along a lane
+  their last visit, the last transition it took is animated while the run is still going, and
+  revisit loops run along a lane
   beside the boxes. While a run is on the canvas the picture is the path and the options: the
   stages the run has been through and the one it is in, the transitions between them, and the
   transitions it can take from where it is with the stages they lead to. Everything else waits


### PR DESCRIPTION
The run list has drawn sub-agents as a tree for a while, but always fully
expanded: five fan-out workers pushed four other runs off the screen and there
was no way to say "not now". And mouse capture takes the terminal's own click
handling away, so a dashboard that only answers the wheel and drag-to-copy has
taken something from the user without giving it back.

## The fold

`←` folds the selected run's workers away, `→` puts them back. On a run with
none, `←` climbs to the parent and `→` steps into the first worker, so the
arrows always do something rather than dying on a leaf.

A foldable row wears a `▸`/`▾` arrow, a folded one says how many runs it hides
(`+4`), and the help bar carries `[←/→] fold sub-agents` only when the list
actually has a tree. Folds are keyed by run id, so they survive sorting,
filtering and rows arriving above them, and folding the run the highlight was
inside leaves it on the fold rather than jumping to the top of an unrelated
run.

## The mouse

New `click.rs`. Every renderer registers the rect it actually drew together
with what a click there means, and one hit-test (innermost wins) resolves a
plain click against that frame's registry. That is deliberately the whole
design: each handler re-deriving where its widget landed is how a click ends
up acting on the row above the one under the pointer.

| Gesture | What it does |
|---|---|
| click a run | select it, and focus the list |
| double click a run | open its detail view |
| click the `▸`/`▾` | fold or unfold its sub-agents |
| click a stage tab | open that stage |
| click `[l]` / `[o]` / `[c]` | switch the content pane, like the letter |
| click a Context row | fold or unfold it, like Enter |
| click the log panel | move the keyboard there, like Tab |

A drag is untouched: still a text selection that copies on release.

## And the graph

A finished run's last transition no longer marches on the stage graph. The
animation means "the run is travelling this path", and it kept running into the
final stage of a run that had completed, errored or been cancelled - the one
thing the graph is there to say at a glance, said wrong. A run that is merely
parked (waiting, paused, idle, stale) keeps it: it has not finished, and the
pulse is what says where it stopped.

## Verification

Unit tests aside, a pty harness drove the real `lev dash` at 200x50 with real
SGR mouse reports and a screen emulator reading the frames back (ratatui writes
diffs, so nothing short of an emulator can read a frame honestly). 22 checks:
the folding keys, the climb/descend fallbacks, every click target, and
drag-still-copies.

The graph fix has its own discriminating pair - the same run, `status` flipped
under a running dashboard. Worth recording that my first two attempts at that
probe passed against the **unfixed** build and so proved nothing: the animation
is marching ants, and the run I first picked had a one-cell edge with nothing to
march. With a run whose last transition is a long back edge, the unfixed build
leaves seven cells moving on a completed run and this one leaves zero.

`cargo xtask coverage` is at 100% for all 13 packages.
