### PR TITLE
feat(serve): POST /api/fs/dirs, so the picker can make a folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ same list.
 
 ## Unreleased
 
+- Added: `POST /api/fs/dirs` makes one directory, so the console's folder
+  picker can offer the "New Folder" a browser cannot get from a native dialog.
+  `GET /api/fs/dirs` let somebody choose an agent workdir without typing a path
+  blind, but there was no way to make one: noticing the folder you wanted did
+  not exist meant leaving the console, opening a terminal on the serving
+  machine, `mkdir`, and coming back. The body names the parent and one new
+  segment separately, so the `--workdir-root` check runs on ground the caller
+  has already proved it can list and a `name` carrying separators is malformed
+  input rather than something the fence has to catch. Every other guard mirrors
+  the listing route, an existing target is a `409` rather than a silent success,
+  and it is announced as `fs.mkdir` so one console can tell which daemons have
+  it.
 - Added: the dashboard's sub-agent tree folds. `←` folds the selected run's
   workers away and `→` puts them back; on a run without any, `←` moves up to its
   parent and `→` down into the first worker. A foldable row wears a `▸`/`▾`

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -401,6 +401,10 @@ mod tests {
             "blueprints.envelope",
             "blueprints.fan_outs",
             "context.history.page",
+            // The console decides whether to draw its "New Folder" button on
+            // this string, so a build that serves `POST /api/fs/dirs` without
+            // saying so is a button nobody gets.
+            "fs.mkdir",
         ] {
             assert!(
                 config.capabilities.iter().any(|c| c == expected),

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -131,6 +131,13 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // offered the kind anyway would put an editor in front of a 400.
     "scripts.providers",
     "config.gateways",
+    // `POST /api/fs/dirs`. The browser cannot open a native OS dialog onto the
+    // serving machine, so the console's folder picker has to offer its own
+    // "New Folder" - and one console serves every daemon version, so it needs
+    // to know whether to offer the button at all rather than offering one that
+    // 404s. The `GET` half is deliberately not announced: it shipped
+    // unannounced, so its absence from this list proves nothing.
+    "fs.mkdir",
 ];
 
 /// The server's numeric limits.

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -1,12 +1,21 @@
-//! `GET /api/fs/dirs` - directory browsing for the console's folder picker.
+//! `/api/fs/dirs` - the directory surface behind the console's folder picker.
 //!
-//! Read-only metadata about the host filesystem: one directory level per
-//! request, subdirectory names only, so the browser can let the user *choose*
-//! an agent workdir without typing a path blind. The spawn endpoint already
-//! accepts arbitrary workdirs subject to `--workdir-root`; this route shows
-//! exactly the directories that endpoint would accept, under the same fence.
+//! `GET` is read-only metadata about the host filesystem: one directory level
+//! per request, subdirectory names only, so the browser can let the user
+//! *choose* an agent workdir without typing a path blind. The spawn endpoint
+//! already accepts arbitrary workdirs subject to `--workdir-root`; this route
+//! shows exactly the directories that endpoint would accept, under the same
+//! fence.
+//!
+//! `POST` makes one. A browser cannot open a native OS dialog onto the serving
+//! machine, so the "New Folder" button every file dialog has had for thirty
+//! years has nowhere to come from - without it, "start this agent in a fresh
+//! directory" means leaving the console for a terminal, `mkdir`, and coming
+//! back. It adds no reach the API does not already grant: it creates one empty
+//! directory in a place the caller has already proved it can list and could
+//! already have pointed a run at.
 
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
@@ -131,6 +140,115 @@ pub(super) async fn list_dirs(
     }))
 }
 
+/// `POST /api/fs/dirs`: create one empty directory inside a directory the
+/// caller can already list.
+///
+/// The body names the parent and a single new segment rather than one joined
+/// path, so the containment check runs on ground the caller has already proved
+/// it can reach and a `name` carrying separators is malformed input rather
+/// than something the fence has to catch. Every guard mirrors
+/// [`list_dirs`]: absolute parent, inside `--workdir-root` when one is set,
+/// the parent must exist and be a directory. One level, `create_dir` rather
+/// than `create_dir_all`, matching the listing route's one-directory-level
+/// shape - and an existing target is a 409 rather than a silent success, so a
+/// picker can tell "I made it" from "it was already there".
+pub(super) async fn create_dir(
+    State(state): State<AppState>,
+    Json(req): Json<MkdirReq>,
+) -> Result<(StatusCode, Json<MkdirResp>), (StatusCode, Json<ErrorResponse>)> {
+    let parent = PathBuf::from(&req.path);
+    if !parent.is_absolute() {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "path must be absolute".to_string(),
+        ));
+    }
+    if let Some(root) = state.limits.workdir_root.as_deref()
+        && !leviath_core::resolves_within(&parent, root)
+    {
+        return Err(err(
+            StatusCode::FORBIDDEN,
+            format!(
+                "path '{}' is outside the configured --workdir-root",
+                req.path
+            ),
+        ));
+    }
+    match std::fs::metadata(&parent) {
+        Ok(m) if !m.is_dir() => {
+            return Err(err(
+                StatusCode::BAD_REQUEST,
+                format!("'{}' is a file, not a directory", parent.display()),
+            ));
+        }
+        Ok(_) => {}
+        Err(_) => {
+            return Err(err(
+                StatusCode::NOT_FOUND,
+                format!("directory '{}' not found", parent.display()),
+            ));
+        }
+    }
+    if !is_one_segment(&req.name) {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            format!("name '{}' must be a single directory name", req.name),
+        ));
+    }
+
+    let target = parent.join(&req.name);
+    // `create_dir` already fails on an existing path, but its error does not
+    // say *which* failure it was, and "already there" is the one a picker has
+    // to render differently from "the machine said no".
+    //
+    // `symlink_metadata`, not `exists`: a dangling symlink is something at that
+    // name too. `exists` follows the link, finds nothing, and would send this
+    // to `create_dir` for an `EEXIST` reported as a 500.
+    if target.symlink_metadata().is_ok() {
+        return Err(err(
+            StatusCode::CONFLICT,
+            format!("'{}' already exists", target.display()),
+        ));
+    }
+    std::fs::create_dir(&target).map_err(|e| {
+        err(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("could not create '{}': {e}", target.display()),
+        )
+    })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(MkdirResp {
+            path: target.to_string_lossy().into_owned(),
+            parent: parent.to_string_lossy().into_owned(),
+        }),
+    ))
+}
+
+/// Whether `name` is one ordinary directory name rather than a path.
+///
+/// Deliberately not [`leviath_core::is_safe_path_component`], whose
+/// `[A-Za-z0-9._-]` allowlist is right for a name that becomes a *Leviath*
+/// identifier (a blueprint name, a run id) and wrong for one the user is
+/// simply typing into a folder picker: `My Project` and `notas-españolas` are
+/// ordinary directory names, and refusing them would be a surprise rather than
+/// a safety property.
+///
+/// What matters here is only that `parent.join(name)` cannot leave `parent`,
+/// which a single `Normal` component cannot: separators, `.`, `..`, a leading
+/// `/`, and a Windows drive prefix all parse as something other than one
+/// `Normal`. A backslash is rejected explicitly because Unix parses it as an
+/// ordinary character, and a directory named `a\b` is a path on the next
+/// machine that reads it.
+fn is_one_segment(name: &str) -> bool {
+    !name.contains('\\')
+        && matches!(
+            Path::new(name).components().collect::<Vec<_>>().as_slice(),
+            [Component::Normal(only)] if *only == std::ffi::OsStr::new(name)
+        )
+}
+
 /// The filesystem root when a well-known directory (cwd, home) cannot be
 /// determined - the picker always has *somewhere* real to stand.
 fn known_dir_or_fs_root(dir: Option<PathBuf>) -> PathBuf {
@@ -174,8 +292,29 @@ mod tests {
             }),
         };
         Router::new()
-            .route("/api/fs/dirs", get(list_dirs))
+            .route("/api/fs/dirs", get(list_dirs).post(create_dir))
             .with_state(state)
+    }
+
+    /// POST `/api/fs/dirs` with `{path, name}`, returning status and body.
+    async fn post_dir(app: Router, path: &str, name: &str) -> (StatusCode, Vec<u8>) {
+        let body = serde_json::json!({ "path": path, "name": name }).to_string();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/fs/dirs")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, body.to_vec())
+    }
+
+    fn made_of(body: &[u8]) -> MkdirResp {
+        serde_json::from_slice(body).unwrap()
     }
 
     /// GET `/api/fs/dirs[?path=<path>]`, returning status and body. (`path`
@@ -425,6 +564,163 @@ mod tests {
         assert!(msg.starts_with(&expected), "{msg}");
 
         let _ = std::fs::set_permissions(&locked, std::fs::Permissions::from_mode(0o755));
+    }
+
+    // ─── POST /api/fs/dirs ────────────────────────────────────────────────
+
+    /// The whole point of the route: a directory that was not there is, and
+    /// the listing the picker re-runs afterwards shows it.
+    #[tokio::test]
+    async fn create_dir_makes_the_directory_and_says_where() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().to_string_lossy().into_owned();
+        let (status, body) = post_dir(app_with_root(None), &parent, "new-thing").await;
+        assert_eq!(status, StatusCode::CREATED);
+        let made = made_of(&body);
+        assert_eq!(made.parent, parent);
+        assert_eq!(made.path, dir.path().join("new-thing").to_string_lossy());
+        assert!(dir.path().join("new-thing").is_dir(), "it is really there");
+
+        let (status, body) = get_dirs(app_with_root(None), Some(&parent)).await;
+        assert_eq!(status, StatusCode::OK);
+        let names: Vec<String> = listing_of(&body).dirs.into_iter().map(|d| d.name).collect();
+        assert_eq!(names, ["new-thing"]);
+    }
+
+    /// A folder picker's New Folder has to accept the names people give
+    /// folders. A dotted one is allowed too: `hidden=true` already lists them,
+    /// so refusing to make one would be an inconsistency, not a guard.
+    #[tokio::test]
+    async fn create_dir_accepts_ordinary_folder_names() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().to_string_lossy().into_owned();
+        for name in ["My Project", "notas-españolas", ".hidden", "v1.2.3"] {
+            let (status, _) = post_dir(app_with_root(None), &parent, name).await;
+            assert_eq!(status, StatusCode::CREATED, "{name}");
+            assert!(dir.path().join(name).is_dir(), "{name}");
+        }
+    }
+
+    /// A `name` that is a path, not a name, is malformed input - caught here
+    /// rather than left for the containment fence, which is why the body takes
+    /// the parent and the segment separately.
+    #[tokio::test]
+    async fn create_dir_refuses_a_name_that_is_a_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().to_string_lossy().into_owned();
+        for name in ["a/b", "..", ".", "", "/abs", "../escape", "a\\b"] {
+            let (status, body) = post_dir(app_with_root(None), &parent, name).await;
+            assert_eq!(status, StatusCode::BAD_REQUEST, "{name:?}");
+            assert_eq!(
+                error_of(&body),
+                format!("name '{name}' must be a single directory name")
+            );
+        }
+        // Nothing was created on the way past the guard.
+        assert_eq!(std::fs::read_dir(dir.path()).unwrap().count(), 0);
+    }
+
+    #[tokio::test]
+    async fn create_dir_relative_parent_returns_400() {
+        let (status, body) = post_dir(app_with_root(None), "some/relative", "x").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(error_of(&body), "path must be absolute");
+    }
+
+    #[tokio::test]
+    async fn create_dir_missing_parent_returns_404() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope");
+        let (status, body) = post_dir(app_with_root(None), &missing.to_string_lossy(), "x").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(
+            error_of(&body),
+            format!("directory '{}' not found", missing.display())
+        );
+    }
+
+    #[tokio::test]
+    async fn create_dir_parent_that_is_a_file_returns_400() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("plain.txt");
+        std::fs::write(&file, "not a directory").unwrap();
+        let (status, body) = post_dir(app_with_root(None), &file.to_string_lossy(), "x").await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(
+            error_of(&body),
+            format!("'{}' is a file, not a directory", file.display())
+        );
+    }
+
+    /// The same fence as the listing: a parent the `GET` refuses to show is a
+    /// parent the `POST` refuses to write into.
+    #[tokio::test]
+    async fn create_dir_refuses_a_parent_outside_the_workdir_root() {
+        let root = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let app = app_with_root(Some(root.path().to_path_buf()));
+        let (status, body) = post_dir(app, &outside.path().to_string_lossy(), "x").await;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(
+            error_of(&body),
+            format!(
+                "path '{}' is outside the configured --workdir-root",
+                outside.path().display()
+            )
+        );
+        assert!(!outside.path().join("x").exists());
+
+        // The control: inside the fence the same request succeeds, so the 403
+        // is the fence and not something else about the request.
+        let app = app_with_root(Some(root.path().to_path_buf()));
+        let (status, _) = post_dir(app, &root.path().to_string_lossy(), "x").await;
+        assert_eq!(status, StatusCode::CREATED);
+    }
+
+    /// "It was already there" is a different answer from "I made it", and a
+    /// picker renders them differently.
+    #[tokio::test]
+    async fn create_dir_on_an_existing_name_returns_409() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().to_string_lossy().into_owned();
+        std::fs::create_dir(dir.path().join("taken")).unwrap();
+        let (status, body) = post_dir(app_with_root(None), &parent, "taken").await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(
+            error_of(&body),
+            format!("'{}' already exists", dir.path().join("taken").display())
+        );
+
+        // A file of that name is taken too - `create_dir` would fail anyway,
+        // and 409 says why better than the OS error would.
+        std::fs::write(dir.path().join("afile"), "x").unwrap();
+        let (status, _) = post_dir(app_with_root(None), &parent, "afile").await;
+        assert_eq!(status, StatusCode::CONFLICT);
+    }
+
+    /// The machine refusing is neither a bad request nor a missing one: a name
+    /// past the filesystem's per-component limit comes back as a 500 carrying
+    /// what the OS said.
+    #[tokio::test]
+    async fn create_dir_reports_what_the_filesystem_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let parent = dir.path().to_string_lossy().into_owned();
+        let too_long = "n".repeat(300);
+        let (status, body) = post_dir(app_with_root(None), &parent, &too_long).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        let msg = error_of(&body);
+        let expected = format!("could not create '{}", dir.path().display());
+        assert!(msg.starts_with(&expected), "{msg}");
+    }
+
+    /// One level, like the listing route: the parent has to exist already.
+    #[tokio::test]
+    async fn create_dir_does_not_make_intermediate_levels() {
+        let dir = tempfile::tempdir().unwrap();
+        let two_deep = dir.path().join("a");
+        let (status, _) = post_dir(app_with_root(None), &two_deep.to_string_lossy(), "b").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(!dir.path().join("a").exists(), "nothing was created");
     }
 
     /// The cwd/home fallback: a known directory passes through untouched, an

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -130,8 +130,9 @@ fn api_router() -> Router<AppState> {
         .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
         // Doctor - the same checks `lev doctor` runs, returned as data.
         .route("/api/doctor", get(doctor::run_doctor))
-        // Filesystem - directory browsing for the console's folder picker.
-        .route("/api/fs/dirs", get(fs::list_dirs))
+        // Filesystem - directory browsing for the console's folder picker,
+        // and the "New Folder" a browser cannot get from a native dialog.
+        .route("/api/fs/dirs", get(fs::list_dirs).post(fs::create_dir))
         // Tools - what an agent on this machine can actually call. Read-only:
         // there is nothing to write, since a tool is either built in or a file
         // the scripts routes below own.

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -959,6 +959,30 @@ pub(super) struct DirEntry {
     pub(super) path: String,
 }
 
+/// Body of `POST /api/fs/dirs`: make one directory inside another.
+///
+/// The parent and the new segment are separate fields rather than one joined
+/// path, so the `--workdir-root` check runs on ground the caller has already
+/// proved it can list, and a `name` carrying separators is malformed input
+/// instead of something the fence has to catch.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct MkdirReq {
+    /// The absolute directory to create it in. Must already exist.
+    pub(super) path: String,
+    /// The new directory's name: one segment, no separators, not `.` or `..`.
+    pub(super) name: String,
+}
+
+/// Response of `POST /api/fs/dirs`: where the new directory landed.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct MkdirResp {
+    /// The absolute path of the directory just created.
+    pub(super) path: String,
+    /// The directory it was created in, so a picker can re-list without
+    /// re-deriving it from the path it was handed.
+    pub(super) parent: String,
+}
+
 // ─── Tree types ─────────────────────────────────────────────────────────────
 
 #[derive(Serialize)]

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -179,6 +179,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
 | `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
+| `POST /api/fs/dirs` | Make one directory: `{"path": "<absolute parent>", "name": "<one segment>"}` → `201 {"path", "parent"}`. The same fence as the `GET`; `409` if it already exists. Announced as `fs.mkdir` |
 | `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
 
 On `/logs`, `stage` takes a stage index or `all`, and defaults to the current stage. `stream` is

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1059,6 +1059,41 @@
             "$ref": "#/components/responses/Ok"
           }
         }
+      },
+      "post": {
+        "tags": [
+          "diagnostics"
+        ],
+        "summary": "Create one directory, for a folder picker's New Folder",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "path",
+                  "name"
+                ],
+                "properties": {
+                  "path": {
+                    "type": "string",
+                    "description": "Absolute parent directory. Must exist, and lie inside --workdir-root when one is set."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The new directory's name: one segment, no separators, not . or .."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "$ref": "#/components/responses/Ok"
+          }
+        }
       }
     },
     "/api/config": {


### PR DESCRIPTION
Closes #548.

`GET /api/fs/dirs` lets the console's folder picker browse the serving machine,
so somebody can *choose* an agent workdir without typing a path blind. It had
no counterpart for **making** one, and the gap is felt precisely because of who
the picker is for: the browser cannot see that filesystem, so a native OS
dialog is unavailable, and a native dialog is exactly where a person reaches
for "New Folder". Today "start this agent in a fresh directory" means noticing
the folder is not there, leaving the console, opening a terminal on the serving
machine, `mkdir`, coming back, and re-browsing.

```jsonc
// POST /api/fs/dirs
{ "path": "/Users/x/projects", "name": "new-thing" }

// 201
{ "path": "/Users/x/projects/new-thing", "parent": "/Users/x/projects" }
```

The body names the parent and one new segment separately rather than a joined
path, so the containment check runs on ground the caller has already proved it
can reach, and a `name` carrying separators is malformed input instead of
something the fence has to catch.

| Case | Status |
|---|---|
| `path` not absolute | 400 |
| `path` outside `--workdir-root` | 403 |
| `path` missing | 404 |
| `path` is a file | 400 |
| `name` is not one segment | 400 |
| something is already at the target | 409 |
| created | 201 |

One level, `create_dir` rather than `create_dir_all`, matching the listing
route's one-directory-level shape. An existing target is a 409 rather than a
silent success, so a picker can tell "I made it" from "it was already there" -
and the existence test is `symlink_metadata`, not `exists`, because a dangling
symlink is something at that name too.

## The one judgement call

`name` is validated as a single `Normal` path component rather than through
`leviath_core::is_safe_path_component`. That allowlist is `[A-Za-z0-9._-]`,
which is right for a name that becomes a *Leviath* identifier (a blueprint
name, a run id) and wrong for one a person types into a folder picker: `My
Project` is an ordinary directory name, and refusing it would be a surprise
rather than a safety property.

What actually has to hold here is only that `parent.join(name)` cannot leave
`parent`, and a single `Normal` component cannot: separators, `.`, `..`, a
leading `/` and a Windows drive prefix all parse as something other than one
`Normal`. A backslash is rejected outright on every platform because Unix
parses it as an ordinary character, and a directory named `a\b` is a path on
the next machine that reads it.

## Capability

Announced as `fs.mkdir`. One console serves every daemon version, so it needs
to know whether to draw the button rather than drawing one that 404s. The `GET`
half is deliberately *not* added to the list: it shipped unannounced, so its
absence proves nothing about a daemon and announcing it now would imply
otherwise.

## Why this is safe

It adds no reach the API does not already grant. `POST /api/agents` accepts an
arbitrary `workdir` subject to the same `--workdir-root`, and `list_dirs`
already discloses the directory tree under that fence. This creates one empty
directory in a place the caller has already demonstrated it can list and could
already have pointed a run at.

## Verification

Unit tests cover every row of the table above, including a name past the
filesystem's per-component limit for the "the machine refused" branch.

Live, against a real `lev serve` fenced with `--workdir-root`:

```
PASS  fs.mkdir is announced
PASS  creating a folder answers 201
      {"path":"/tmp/lvfs/root/fresh start","parent":"/tmp/lvfs/root"}
PASS  the folder is really on disk
PASS  the picker's next listing shows it
PASS  a second create is a 409
PASS  a name that is a path is a 400
PASS  nothing was created outside
PASS  a parent outside --workdir-root is a 403
PASS  nothing was written outside the fence
PASS  a missing parent is a 404
PASS  a relative parent is a 400
```

`cargo xtask coverage` is at 100% for all 13 packages. The OpenAPI spec, the
API reference page and the changelog are updated.
