### PR TITLE
feat(agents): ask the coverage question before the handoff, not after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ same list.
 - Changed: a qualifier travels with the claim it qualifies. The same run carried
   "yes, with offload" and "~22 tok/s" in its comparison table and dropped both
   from the recommendation - the one place the tradeoff mattered.
+- Changed: the research agents check their own coverage before they hand off and
+  the analysis stage can send them back for it. The question both ask is the same
+  one: for every figure the report will state, is there a source that measured
+  it, or only pages repeating it? A number that lives only in roundups sends the
+  run back to fetch the artifact. Re-running the weakest run we had on the old
+  prompts turned ten SEO listicles with four graded `high` into twenty sources
+  where every `high` is a model card, a vendor's own docs or a leaderboard, and
+  every roundup sits at `medium`. It costs roughly twice the tool calls.
 
 - Fixed: a `required` region an earlier stage gave up on and a later stage filled
   is no longer reported as missing. The flag recorded a moment and consumers read

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.3.3"
+version = "0.3.4"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
@@ -87,6 +87,14 @@ at the start is worth more than a thorough answer to the wrong question.
 Ask once, early, and only when the answer changes what you would do. If nobody
 is attached to this run the tools are not offered at all - carry on, state the
 reading you chose, and say what you would have asked.
+
+Before you hand off, read back what you gathered and ask one question of it: for
+every figure the report will state, is there a source that MEASURED it, or only
+pages that repeat it? If a number exists only in roundups, go and fetch the
+artifact - the paper, the model card, the spec, the vendor's own docs - before
+leaving this stage. Coming back for it later costs a whole extra pass, and going
+without means the report states a number on the authority of a page that was
+guessing.
 
 Once you have solid primary coverage of the core facets, hand off to analyze.
 """
@@ -205,6 +213,9 @@ max_revisits = 3
 transition_prompt = """
 Decide the next move:
 - Broad gaps that need new sources on a sub-topic → respond with: gather
+- A figure or recommendation the report will state rests only on roundups, or on
+  a single page nothing corroborates, and the primary artifact was never fetched
+  → respond with: gather, naming the artifact to go and get
 - A specific cited source you should pull and read before concluding →
   respond with: follow_citations
 - Enough well-supported evidence to write the report → respond with: synthesize

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.1.6"
+version = "0.1.7"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
@@ -51,6 +51,14 @@ Be efficient - do not search exhaustively:
    message. Batching the whole list for later is how a stage ends with twenty
    sources fetched and an empty `sources_index`.
 
+
+Before you hand off, read back what you gathered and ask one question of it: for
+every figure the report will state, is there a source that MEASURED it, or only
+pages that repeat it? If a number exists only in roundups, go and fetch the
+artifact - the paper, the model card, the spec, the vendor's own docs - before
+leaving this stage. Coming back for it later costs a whole extra pass, and going
+without means the report states a number on the authority of a page that was
+guessing.
 
 Today's date is in the `environment` region. Treat it as authoritative over
 anything you remember: your training has a cutoff and this run does not. Judge

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.3.3"
+version = "0.3.4"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 
@@ -75,6 +75,14 @@ the whole fan-out investigates.
 
 Ask once, early, and only when the answer changes what you would do. If nobody is
 attached to this run the tools are not offered at all - carry on, state the
+Before you hand off, read back what you gathered and ask one question of it: for
+every figure the report will state, is there a source that MEASURED it, or only
+pages that repeat it? If a number exists only in roundups, go and fetch the
+artifact - the paper, the model card, the spec, the vendor's own docs - before
+leaving this stage. Coming back for it later costs a whole extra pass, and going
+without means the report states a number on the authority of a page that was
+guessing.
+
 reading you chose, and say what you would have asked.
 """
 
@@ -190,6 +198,9 @@ max_revisits = 2
 transition_prompt = """
 Decide the next move:
 - Coverage gaps that need broader surveying → respond with: survey
+- A figure or ranking the overview will state rests only on roundups, or on a
+  single page nothing corroborates, and the primary artifact was never fetched
+  → respond with: survey, naming the artifact to go and get
 - One especially interesting/consequential thread worth a focused deep read
   before you can judge it fairly → respond with: deep_dive
 - You've covered enough ground to write a useful overview → respond with: summarize


### PR DESCRIPTION
The credibility floor in #549 grades a source once it is in hand. It does not go
and get a better one. This adds the step that does.

## What changed

**The coverage question gets asked before the handoff, not after.** Both research
agents read back what they gathered before leaving the gathering stage and ask
one thing of it: for every figure the report will state, is there a source that
*measured* it, or only pages repeating it? A number that lives only in roundups
means fetching the artifact - the paper, the model card, the spec, the vendor's
own docs - before moving on.

**`analyze` gets the same criterion as a send-back edge**, so the check has teeth
when the gatherer talks itself past it:

> A figure or recommendation the report will state rests only on roundups, or on
> a single page nothing corroborates, and the primary artifact was never fetched
> → respond with: gather, naming the artifact to go and get

Both stages already had that edge. This names the case. `wide-researcher` gets
the mirror of it on `compare` → `survey`, and the `researcher` worker gets the
pre-handoff check too, since in a fan-out it is the one doing the reading.

I had first proposed a minimum-search-count floor and talked myself out of it: a
model can run eight bad searches, and a transition gate can only test whether a
region exists or changed, not whether what is in it is any good. Asking about
source *type* is the check that has a right answer.

## Measured, not reasoned about

Re-ran the exact question that produced the worst run of the five I reviewed
("best local LLMs for a 16GB GPU, for orchestration and tool use"):

| | before | after |
|---|---|---|
| entries in `sources_index` | 1 | 20 |
| distinct sources | 10 | 20 |
| graded `high` | 4, **all SEO roundups** | 8, **all primary artifacts** |
| roundups | graded `high` | all `medium`, corroboration only |
| `follow_citations` | skipped | entered twice |

The eight `high` grades are NVIDIA's and OpenAI's own docs, four HuggingFace
model cards, Google's docs, and the Berkeley Function-Calling Leaderboard. Not
one roundup is graded `high` in the new run, and not one primary artifact was
fetched in the old one.

The report now leads with "only two of the four models most commonly recommended
actually fit" - the opposite of what the listicles said - and catches two factual
errors in the article the old run had graded `high`: a VRAM figure contradicted
by the primary GGUF artifact, and a model variant that does not exist.

Caveats travel into the decision matrix, which was the other thing #549 asked
for: "needs lower quant", "sequential dependency failure; needs CPU offload
(~34 tok/s)". And what it could not verify, it says so - the BFCL leaderboard
renders client-side and would not fetch, so those scores are an open question
rather than a number.

## The cost, stated plainly

61 tool calls against 36, 38 iterations against 31, roughly 2.9x the prompt
tokens. Most of that is the second and third pass through `analyze`, which is the
mechanism working - the send-back is what fetched the model cards.
`follow_citations` is bounded at 3 revisits and 12 iterations, so it cannot run
away.

## Versions

All three blueprints bump. Worth noting: #549 changed blueprint content without
bumping, so anyone who had 0.3.3 installed would not have been offered it
(`plan_agent_actions` compares version first and reads changed content under an
unchanged version as "the user edited this"). The 0.3.4 bump here covers both
changes.
