### PR TITLE
fix(agents): a front page is not the source, and absence needs evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ same list.
 
 ## Unreleased
 
+- Fixed: a research agent no longer concludes that something is missing because a
+  page it read did not mention it. An overnight run investigating an agent runtime
+  fetched the project's landing page, never opened the docs tree linked in the nav
+  of the very HTML it received, and then marked OpenTelemetry, MCP, provider
+  abstraction, sub-agents, scriptable tools and human-in-the-loop as absent - each
+  one has its own documentation page. It proposed building them as priority work.
+  Absence is now a claim that needs its own evidence: search the subject's own
+  docs for the thing by name, and if you cannot, write "not found in <what you
+  read>" rather than "does not have it".
+- Changed: a front page is not the source. When a research agent fetches a landing
+  page, a repository root or a product site, it reads the navigation and follows
+  what bears on the question before concluding anything. A project's own docs and
+  its own source outrank every write-up about it.
+- Fixed: `wide-researcher`'s survey prompt had a sentence cut in half by the
+  coverage check added in the previous release.
 - Added: `POST /api/fs/dirs` makes one directory, so the console's folder
   picker can offer the "New Folder" a browser cannot get from a native dialog.
   `GET /api/fs/dirs` let somebody choose an agent workdir without typing a path

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.3.4"
+version = "0.3.5"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 entry_stage = "gather"
 
@@ -87,6 +87,22 @@ at the start is worth more than a thorough answer to the wrong question.
 Ask once, early, and only when the answer changes what you would do. If nobody
 is attached to this run the tools are not offered at all - carry on, state the
 reading you chose, and say what you would have asked.
+
+A front page is not the source. A docs site, a repository, a product site: the
+page you land on says what a project wants to be known for, and the thing you
+need is one hop further in, behind the nav. When you fetch a landing page, read
+its navigation and follow the entries that bear on your question before you
+conclude anything about the subject. A project's own docs and its own source
+outrank every write-up about it.
+
+Absence is a claim and it needs its own evidence. You may not write that
+something lacks a capability because a page you read did not mention it - pitch
+pages, READMEs and comparison posts are selective by design, and the feature you
+are looking for is very often on a page you did not open. Before stating that
+something is missing, search the subject's own documentation for it by name. If
+you cannot, write "not found in <what you actually read>" and grade it low.
+"Does not have it" and "I did not find it" are different claims and only one of
+them is yours to make.
 
 Before you hand off, read back what you gathered and ask one question of it: for
 every figure the report will state, is there a source that MEASURED it, or only
@@ -216,6 +232,9 @@ Decide the next move:
 - A figure or recommendation the report will state rests only on roundups, or on
   a single page nothing corroborates, and the primary artifact was never fetched
   → respond with: gather, naming the artifact to go and get
+- The report is going to say a subject LACKS something, and `sources_index` shows
+  only that subject's front page or write-ups about it, never its own docs or its
+  own source → respond with: gather, naming the page to go and open
 - A specific cited source you should pull and read before concluding →
   respond with: follow_citations
 - Enough well-supported evidence to write the report → respond with: synthesize

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.1.7"
+version = "0.1.8"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 entry_stage = "gather"
 
@@ -51,6 +51,22 @@ Be efficient - do not search exhaustively:
    message. Batching the whole list for later is how a stage ends with twenty
    sources fetched and an empty `sources_index`.
 
+
+A front page is not the source. A docs site, a repository, a product site: the
+page you land on says what a project wants to be known for, and the thing you
+need is one hop further in, behind the nav. When you fetch a landing page, read
+its navigation and follow the entries that bear on your question before you
+conclude anything about the subject. A project's own docs and its own source
+outrank every write-up about it.
+
+Absence is a claim and it needs its own evidence. You may not write that
+something lacks a capability because a page you read did not mention it - pitch
+pages, READMEs and comparison posts are selective by design, and the feature you
+are looking for is very often on a page you did not open. Before stating that
+something is missing, search the subject's own documentation for it by name. If
+you cannot, write "not found in <what you actually read>" and grade it low.
+"Does not have it" and "I did not find it" are different claims and only one of
+them is yours to make.
 
 Before you hand off, read back what you gathered and ask one question of it: for
 every figure the report will state, is there a source that MEASURED it, or only

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.3.4"
+version = "0.3.5"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 entry_stage = "survey"
 
@@ -75,6 +75,24 @@ the whole fan-out investigates.
 
 Ask once, early, and only when the answer changes what you would do. If nobody is
 attached to this run the tools are not offered at all - carry on, state the
+reading you chose, and say what you would have asked.
+
+A front page is not the source. A docs site, a repository, a product site: the
+page you land on says what a project wants to be known for, and the thing you
+need is one hop further in, behind the nav. When you fetch a landing page, read
+its navigation and follow the entries that bear on your question before you
+conclude anything about the subject. A project's own docs and its own source
+outrank every write-up about it.
+
+Absence is a claim and it needs its own evidence. You may not write that
+something lacks a capability because a page you read did not mention it - pitch
+pages, READMEs and comparison posts are selective by design, and the feature you
+are looking for is very often on a page you did not open. Before stating that
+something is missing, search the subject's own documentation for it by name. If
+you cannot, write "not found in <what you actually read>" and grade it low.
+"Does not have it" and "I did not find it" are different claims and only one of
+them is yours to make.
+
 Before you hand off, read back what you gathered and ask one question of it: for
 every figure the report will state, is there a source that MEASURED it, or only
 pages that repeat it? If a number exists only in roundups, go and fetch the
@@ -82,8 +100,6 @@ artifact - the paper, the model card, the spec, the vendor's own docs - before
 leaving this stage. Coming back for it later costs a whole extra pass, and going
 without means the report states a number on the authority of a page that was
 guessing.
-
-reading you chose, and say what you would have asked.
 """
 
 [stages.survey.tool_routing]
@@ -201,6 +217,9 @@ Decide the next move:
 - A figure or ranking the overview will state rests only on roundups, or on a
   single page nothing corroborates, and the primary artifact was never fetched
   → respond with: survey, naming the artifact to go and get
+- A comparison cell is about to read as "does not have it", and `sources_index`
+  shows only that subject's front page or write-ups about it, never its own docs
+  or its own source → respond with: survey, naming the page to go and open
 - One especially interesting/consequential thread worth a focused deep read
   before you can judge it fairly → respond with: deep_dive
 - You've covered enough ground to write a useful overview → respond with: summarize


### PR DESCRIPTION
An overnight `wide-researcher` run (`wide-researcher-1787299322-c0a38670823c`)
was asked to analyse Leviath and its competition. It fetched
`https://leviath.dev/` and stopped there. Every other `leviath.dev` URL in the
run: none. One fetch, 37 citations off it.

The text `web_fetch` handed back opens with that site's own nav:

> Leviath, an agent runtime: one file, thousands of agents Leviath **Home Docs
> The Lair Discord GitHub** ☾ ☀ Leviath One file describes the agent...

Thirteen docs pages sit behind that link, all live, all linked from the HTML the
run received. It opened none of them. It did not follow the GitHub link either,
on a public repository.

Then it filled in the blanks. From its capability table:

| claim in the report | reality |
|---|---|
| OpenTelemetry ❌ | `observability.md`, and a whole `leviath-telemetry` crate |
| MCP support ❌ | `mcp.md`, 131 lines |
| Model abstraction ❌ "(hardcoded)" | `providers.md`, 235 lines |
| Multi-agent coord ❌ | `sub-agents.md`, 245 lines |
| Plugin system ❌ | `rhai-tools.md`, `scripting.md` |
| HITL approval gates ❌ | `interaction.md`, 217 lines |

The P0 ship-blocker in the roadmap it produced is "Model Provider Abstraction
Layer". Its High-severity observability finding proposes building OpenTelemetry
export. Both already exist and are documented.

## Why the check from #552 does not catch this

Worth stating plainly rather than letting it look like it might. That check asks
two things and this run passes both:

- *"Is there a source that measured this figure, or only pages repeating it?"* -
  these are not figures. They are absences. There is no number to trace.
- *"Was the primary artifact fetched?"* - it was. `leviath.dev` **is** the primary
  artifact.

If anything the framing works against us here: a rule that says trust the primary
source reads a landing page as coverage of the project, which is the mistake.

## The two rules that do fit

**A front page is not the source.** A docs site, a repository, a product site:
the page you land on says what a project wants to be known for, and the thing you
need is a hop further in, behind the nav. Read the navigation and follow what
bears on the question before concluding anything. A project's own docs and its
own source outrank every write-up about it.

**Absence is a claim and it needs its own evidence.** A page not mentioning
something is not evidence it does not exist; pitch pages and READMEs are
selective by design. Search the subject's own docs for the thing by name, and if
you cannot, write "not found in \<what you read\>" and grade it low. "Does not
have it" and "I did not find it" are different claims and only one of them is
yours to make.

`analyze` and `compare` get the matching send-back edge: a report about to say a
subject lacks something, with nothing in `sources_index` but that subject's front
page, goes back for the page it should have opened.

## Also

`wide-researcher`'s survey prompt had a sentence cut in half by #552 - the
coverage check landed between "carry on, state the" and "reading you chose". The
other two blueprints were unaffected. Repaired here.

## What the run got right, for the record

The pipeline is not broken end to end. `survey` conflated Leviath with a
different project called Leviathan and attributed it to that project's author;
the later stages **caught it**, and the shipped report opens with an explicit
disambiguation box naming all four collisions. The benchmark figures it cites
(10,000 agents, 2.8 GB, M3 Max) are real and on the landing page. What failed was
depth on the one source that mattered, not citation integrity.

A verification run on the same question is in flight; I will post what it comes
back with.
