### PR TITLE
feat(dash): remember the run list's folds between sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ same list.
 
 ## Unreleased
 
+- Added: the run list's folds outlive the dashboard. Folding four finished
+  fan-outs to see the two live ones is a decision, and having to make it again
+  every time you open `lev dash` is the feature failing to be one. They are kept
+  in `dash/ui-state.json` under the data directory, beside the agent editor's
+  canvas arrangements, and written on the keystroke that makes them rather than
+  on the way out - a dashboard is usually closed by whatever closes the
+  terminal, so "save on quit" is a save that often never happens. A list still
+  starts fully expanded until you fold something. A fold whose run is deleted is
+  forgotten, but only once the dashboard can actually see a run list: an empty
+  one is also what the first tick and an unreadable runs directory look like,
+  and pruning against that would wipe every remembered fold on startup.
 - Fixed: a research agent no longer concludes that something is missing because a
   page it read did not mention it. An overnight run investigating an agent runtime
   fetched the project's landing page, never opened the docs tree linked in the nav

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -159,6 +159,7 @@ impl Dashboard {
             display_indices: Vec::new(),
             tree_rows: Vec::new(),
             collapsed_runs: std::collections::HashSet::new(),
+            ui_state_path: None,
             mcp_screen: false,
             mcp_add_mode: false,
             mcp_add_input: String::new(),

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -819,6 +819,10 @@ impl Dashboard {
             }
             self.collapsed_runs.insert(id.clone());
         }
+        // Written on the keystroke rather than on the way out: a dashboard is
+        // left running for days and closed by whatever closes the terminal, so
+        // "save on quit" is a save that often never happens.
+        self.save_ui_state();
         self.update_display_indices();
         // The run just folded is still on screen - it is the row the fold
         // happened on - so this lands back on it.
@@ -2099,6 +2103,29 @@ mod tests {
         dash.handle_key(key(KeyCode::Left));
         assert_eq!(dash.selected, 0, "a root leaf has no parent to climb to");
         assert!(dash.collapsed_runs.is_empty(), "and nothing folded");
+    }
+
+    /// The fold reaches disk on the keystroke that makes it, and the unfold
+    /// reaches disk too - a store that only ever grew would re-fold a run the
+    /// user had deliberately opened.
+    #[test]
+    fn folding_and_unfolding_both_reach_the_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ui-state.json");
+        let mut dash = dash_with_a_subtree();
+        dash.ui_state_path = Some(path.clone());
+
+        dash.handle_key(key(KeyCode::Left));
+        assert!(
+            std::fs::read_to_string(&path).unwrap().contains("parent"),
+            "the fold was written without waiting for a quit"
+        );
+
+        dash.handle_key(key(KeyCode::Right));
+        assert!(
+            !std::fs::read_to_string(&path).unwrap().contains("parent"),
+            "and so was the unfold"
+        );
     }
 
     /// Folding is keyed by run, so a row index that no longer names one (or a

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -20,6 +20,7 @@ mod state;
 #[cfg(test)]
 mod test_support;
 mod types;
+mod ui_state;
 
 /// The palette lives in the crate-level [`crate::tui`] module, shared with the
 /// `lev setup` wizard and the markdown renderer. Aliased here so the existing
@@ -259,6 +260,11 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
     );
     // The agent editor keeps its canvas arrangements under the data dir.
     dashboard.layout_store_path = crate::blueprint_edit::LayoutStore::default_path();
+    // …and the run list keeps its folds beside them, restored before the first
+    // sync so the list is drawn the way it was left rather than unfolding for a
+    // frame first.
+    dashboard.ui_state_path = ui_state::default_path();
+    dashboard.load_ui_state();
 
     // Forward the dashboard's control commands to the daemon, and report each
     // result back so a refused command is surfaced rather than swallowed. A

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -131,8 +131,13 @@ pub(crate) struct Dashboard {
     pub(super) tree_rows: Vec<RunTreeRow>,
     /// Runs whose sub-agents are folded away (`←` on the row, or a click on
     /// its arrow). Keyed by run id rather than row position so a fold survives
-    /// re-sorting, filtering, and rows arriving above it.
+    /// re-sorting, filtering, and rows arriving above it - and, through
+    /// `ui_state_path`, closing the dashboard.
     pub(super) collapsed_runs: std::collections::HashSet<String>,
+    /// Where `collapsed_runs` is kept between sessions (see `ui_state.rs`).
+    /// `None` in tests and on a home with no data dir: nothing is read or
+    /// written then, so no test can reach the user's real file.
+    pub(super) ui_state_path: Option<std::path::PathBuf>,
     /// Filesystem path this dashboard appends its activity log to. Production
     /// construction resolves the real [`runstate::dashboard_log_path`]; tests
     /// (`make_test_dashboard`) inject a temp path so no test ever writes to the
@@ -381,11 +386,7 @@ impl Dashboard {
             .map(|a| a.id.clone());
         self.display_indices = indices;
         self.tree_rows = tree_rows;
-        // A fold whose parent has gone stops meaning anything; keeping it
-        // would silently re-fold a run that later reuses the id.
-        let agents = &self.agents;
-        self.collapsed_runs
-            .retain(|id| agents.iter().any(|a| a.id == *id));
+        self.forget_folds_for_vanished_runs();
         if let Some(id) = prev_id {
             // A fold can take the highlighted row off screen. Landing on the
             // ancestor that swallowed it keeps the eye where it was; row 0 is
@@ -1092,6 +1093,29 @@ impl Dashboard {
         }
     }
 
+    /// Drop folds naming runs that no longer exist, and write the store when
+    /// that changed anything.
+    ///
+    /// ⚠️ Skipped while the run list is empty. Folds outlive the process now,
+    /// and "no runs" is also what the very first tick sees, and what a runs
+    /// directory that could not be read for a moment sees - pruning against
+    /// that would delete every remembered fold on startup. An empty list has
+    /// nothing to draw, so keeping the folds through it costs nothing; the
+    /// first sync that can actually see runs does the pruning.
+    fn forget_folds_for_vanished_runs(&mut self) {
+        if self.agents.is_empty() {
+            return;
+        }
+        let before = self.collapsed_runs.len();
+        let agents = &self.agents;
+        self.collapsed_runs
+            .retain(|id| agents.iter().any(|a| a.id == *id));
+        // Only on the tick a run actually disappears, not ten times a second.
+        if self.collapsed_runs.len() != before {
+            self.save_ui_state();
+        }
+    }
+
     /// The `display_indices` position of the row holding `run_id`, if it is
     /// on screen (a folded-away child is not).
     pub(super) fn row_of_run(&self, run_id: &str) -> Option<usize> {
@@ -1675,13 +1699,43 @@ mod tests {
     }
 
     /// A fold on a run that later disappears is dropped, so a run that reuses
-    /// the id does not come back folded.
+    /// the id does not come back folded - but only once there is a run list to
+    /// compare against. Folds outlive the process, and an empty list is also
+    /// what the first tick and an unreadable runs dir look like.
     #[test]
-    fn a_fold_on_a_vanished_run_is_forgotten() {
+    fn a_fold_is_forgotten_when_its_run_goes_but_not_while_the_list_is_empty() {
         let mut dash = make_test_dashboard();
         dash.collapsed_runs.insert("ghost".to_string());
+
+        dash.update_display_indices();
+        assert!(
+            dash.collapsed_runs.contains("ghost"),
+            "nothing to prune against yet"
+        );
+
+        // A list that exists and does not contain it: now it is really gone.
+        dash.agents
+            .push(make_test_agent("someone-else", AgentDisplayStatus::Active));
         dash.update_display_indices();
         assert!(dash.collapsed_runs.is_empty());
+    }
+
+    /// The prune writes the store, so a run deleted in one session does not
+    /// come back folded in the next.
+    #[test]
+    fn forgetting_a_fold_rewrites_the_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ui-state.json");
+        let mut dash = make_test_dashboard();
+        dash.ui_state_path = Some(path.clone());
+        dash.collapsed_runs.insert("ghost".to_string());
+        dash.save_ui_state();
+        assert!(std::fs::read_to_string(&path).unwrap().contains("ghost"));
+
+        dash.agents
+            .push(make_test_agent("someone-else", AgentDisplayStatus::Active));
+        dash.update_display_indices();
+        assert!(!std::fs::read_to_string(&path).unwrap().contains("ghost"));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/ui_state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/ui_state.rs
@@ -1,0 +1,167 @@
+//! What the dashboard remembers about how you left it looking.
+//!
+//! Which runs' sub-agents you folded away is a decision, not a view: a person
+//! who folds four finished fan-outs to see the two live ones has said something
+//! about what they want on screen, and having to say it again every time they
+//! open the dashboard is the feature failing to be one. It is kept the same way
+//! the agent editor keeps its canvas arrangements - one small JSON file under
+//! the data dir, per home.
+//!
+//! Deliberately *not* in `config.toml`. That file is the user's to edit and is
+//! reloaded on change; this is UI residue the dashboard writes behind them, and
+//! mixing the two would mean a fold rewriting a hand-edited config.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::state::Dashboard;
+
+/// The dashboard's remembered view state.
+///
+/// A struct rather than a bare list of ids so the next thing worth remembering
+/// can join it without a second file or a format migration. Missing fields
+/// default, so an older file stays readable.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct UiState {
+    /// Run ids whose sub-agents are folded away in the run list. A set, so the
+    /// file is stable rather than reordering itself on every save.
+    #[serde(default)]
+    pub(super) collapsed_runs: BTreeSet<String>,
+}
+
+/// The file under the data directory: `dash/ui-state.json`.
+///
+/// `None` when there is no resolvable data dir, which is also what tests get:
+/// nothing then reads or writes, so no test can touch the real one.
+pub(super) fn default_path() -> Option<PathBuf> {
+    leviath_core::paths::data_dir().map(|d| d.join("dash").join("ui-state.json"))
+}
+
+/// Read the state at `path`. A missing, unreadable or unparseable file is an
+/// empty state: this is a convenience, and losing it must never be louder than
+/// the thing it was helping with.
+fn read(path: &Path) -> UiState {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default()
+}
+
+impl Dashboard {
+    /// Restore the remembered view state, if this dashboard has a file.
+    ///
+    /// Called once at startup, before the first sync. Folds name runs by id, so
+    /// they can be restored before the runs themselves are known - a fold for a
+    /// run that no longer exists is dropped by the first sync that can see the
+    /// run list.
+    pub(super) fn load_ui_state(&mut self) {
+        let Some(path) = &self.ui_state_path else {
+            return;
+        };
+        self.collapsed_runs = read(path).collapsed_runs.into_iter().collect();
+    }
+
+    /// Write the remembered view state. Best effort: a dashboard that cannot
+    /// write its folds still works, and a toast about it would be noise in the
+    /// middle of whatever the person was actually doing.
+    pub(super) fn save_ui_state(&self) {
+        let Some(path) = &self.ui_state_path else {
+            return;
+        };
+        let state = UiState {
+            collapsed_runs: self.collapsed_runs.iter().cloned().collect(),
+        };
+        // A relative file name has an empty parent, which `create_dir_all`
+        // treats as already there.
+        let _ = std::fs::create_dir_all(path.parent().unwrap_or(Path::new("")));
+        let text = serde_json::to_string_pretty(&state).expect("a set of strings serializes");
+        let _ = std::fs::write(path, text);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::commands::dashboard::test_support::make_test_dashboard;
+
+    /// The round trip that makes the feature a feature: fold, quit, come back,
+    /// and it is still folded.
+    #[test]
+    fn a_fold_survives_a_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("dash").join("ui-state.json");
+
+        let mut first = make_test_dashboard();
+        first.ui_state_path = Some(path.clone());
+        first.collapsed_runs.insert("run-parent".to_string());
+        first.save_ui_state();
+        assert!(path.exists(), "the store made its own directory");
+
+        let mut second = make_test_dashboard();
+        second.ui_state_path = Some(path);
+        second.load_ui_state();
+        assert!(second.collapsed_runs.contains("run-parent"));
+    }
+
+    /// Nothing saved yet, a file somebody truncated, a file holding something
+    /// else entirely: all of them are "no folds", never an error.
+    #[test]
+    fn an_unreadable_store_is_an_empty_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("never-written.json");
+        assert_eq!(read(&missing), UiState::default());
+
+        let junk = dir.path().join("junk.json");
+        std::fs::write(&junk, "not json at all").unwrap();
+        assert_eq!(read(&junk), UiState::default());
+
+        // A file from a build that knew fewer fields still reads.
+        let older = dir.path().join("older.json");
+        std::fs::write(&older, "{}").unwrap();
+        assert_eq!(read(&older), UiState::default());
+    }
+
+    /// Loading replaces whatever was in memory, so a stale fold from a previous
+    /// load cannot survive a store that no longer names it.
+    #[test]
+    fn loading_replaces_rather_than_merges() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ui-state.json");
+        std::fs::write(&path, r#"{"collapsed_runs":["kept"]}"#).unwrap();
+
+        let mut dash = make_test_dashboard();
+        dash.ui_state_path = Some(path);
+        dash.collapsed_runs.insert("stale".to_string());
+        dash.load_ui_state();
+        assert!(dash.collapsed_runs.contains("kept"));
+        assert!(!dash.collapsed_runs.contains("stale"));
+    }
+
+    /// A dashboard with no store (every test one, and any home without a data
+    /// dir) neither reads nor writes.
+    #[test]
+    fn without_a_path_nothing_touches_disk() {
+        let mut dash = make_test_dashboard();
+        assert!(
+            dash.ui_state_path.is_none(),
+            "tests get no store by default"
+        );
+        dash.collapsed_runs.insert("run-1".to_string());
+        dash.save_ui_state();
+        dash.load_ui_state();
+        assert!(
+            dash.collapsed_runs.contains("run-1"),
+            "load with no store left memory alone"
+        );
+    }
+
+    /// The production path lands under the data dir, beside the editor's
+    /// arrangements rather than in the user's config.
+    #[test]
+    fn the_default_path_is_under_the_data_dir() {
+        let path = default_path().expect("this machine has a data dir");
+        assert!(path.ends_with("dash/ui-state.json"), "{path:?}");
+    }
+}

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -96,6 +96,11 @@ many the fold is hiding. `←` and `→` work the tree, and clicking the arrow d
 remembered by run, so it survives sorting, filtering and new rows arriving above it, and folding
 the run you were inside moves the highlight onto the fold rather than back to the top.
 
+Folds also outlive the dashboard. They are written to `dash/ui-state.json` under the data
+directory as you make them, not on the way out, so a session that ends with the terminal window
+keeps them all the same. A run list starts fully expanded until you fold something; a fold whose
+run is later deleted is forgotten the next time the dashboard can see the run list.
+
 Marking selects several runs at once: press `Space` on each run, then `x` or `d` acts on all of
 them behind one confirmation. Marked rows show a check mark, the pane title counts them, and marks
 follow the run rather than the row, so sorting or filtering never changes what is marked. A kill


### PR DESCRIPTION
Follow-up to #550. Folding four finished fan-outs away to see the two live ones
is a decision about what belongs on screen, and the dashboard was making you
take it again every time you opened it.

Folds now live in `dash/ui-state.json` under the data directory, beside the
agent editor's canvas arrangements, restored before the first sync so the list
is drawn the way it was left rather than unfolding for a frame first. A list
still starts fully expanded until you fold something.

```jsonc
{ "collapsed_runs": ["run-parent"] }
```

**Written on the keystroke**, not on the way out. A dashboard is left running
for days and closed by whatever closes the terminal, so "save on quit" is a save
that often never happens. Unfolding writes too, or the store would only ever
grow and would eventually re-fold a run you had deliberately opened.

Deliberately not `config.toml`: that file is yours to edit and is reloaded on
change, and this is UI residue written behind you. It is a struct rather than a
bare list of ids so the next thing worth remembering can join it without a
second file; missing fields default, so a file from another build still reads. A
missing, truncated or garbage file is simply "no folds" - losing a convenience
must never be louder than the thing it was helping with.

## ⚠️ The part that needed a guard

The prune that forgets a fold whose run was deleted now **skips an empty run
list**. Folds outlive the process, and "no runs" is also what the very first
tick sees, and what a runs directory that could not be read for a moment sees.
Pruning against that deleted every remembered fold on startup.

This is not theoretical - I removed the guard and re-ran the probe:

```
FAIL  a session with no runs did not delete the fold
FAIL  the fold is still in effect
```

An empty list has nothing to draw, so keeping the folds through it costs
nothing; the first sync that can actually see runs does the pruning, and writes
the store when it drops something.

## Verification

Three separate `lev dash` processes in a pty, one real home:

```
PASS  session 1 starts unfolded
PASS  session 1 folded it
PASS  the fold reached the store
      { "collapsed_runs": [ "run-parent" ] }
PASS  session 2 came back folded
PASS  session 2 still says what it hid          (+4)
PASS  session 2 shows the folded arrow          (▸)
PASS  session 2 can unfold
PASS  session 3 came back unfolded
```

and the guard's own probe:

```
PASS  the fold was stored
PASS  the empty session drew an empty list
PASS  a session with no runs did not delete the fold
PASS  the fold is still in effect
```

`cargo xtask coverage` is at 100% for all 13 packages.

## Not included

The Context view's region/entry expansion is **not** persisted. It is reset
deliberately whenever the selected run changes (`reset_exploration`), so
persisting it across restarts while it still resets across run switches inside
one session would be incoherent - making it stick would mean changing that
reset too, which is a wider behaviour change than this asks for. Say the word if
you want that as well.
