### PR TITLE
fix(providers): an unreachable ollama is not a provider, and say which model a stage gets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,28 @@ same list.
   been given a chance to answer. Production keeps the 30s; the tests pass five
   minutes, bounded so a genuinely wedged server still fails rather than hanging
   CI.
+- Fixed: Ollama no longer registers as a usable provider when nothing is
+  listening for it. Every other provider registers only when it has an API key;
+  Ollama needs none, so it registered unconditionally and an install with no
+  local server still advertised a working provider. That is the reason
+  `default_provider` promotes its own entries to the front of a stage's model
+  list, which in turn is why an install with keys for four providers could send
+  every stage to the fallback its blueprint listed fourth.
+- Fixed: `lev doctor` no longer reports that a configured `default_provider`
+  with no `default_model` "is never chosen". That is true only of doctor's own
+  check, which resolves no blueprint. A real run promotes every entry on that
+  provider to the front, so the setting decides where every stage goes. The note
+  now says both, because reading the old one during an investigation of a
+  downgraded run sent it in the wrong direction.
+- Added: `lev validate` prints the model each stage would actually use on this
+  machine, and the blueprint's own order underneath when the two differ. A
+  config line could silently move every stage onto a fallback model, and the
+  only evidence was in a finished run's metadata.
+- Changed: the provider docs described `default_provider` on its own as buying
+  nothing. It buys the whole ordering. They now also say what `default_model`
+  costs: a blueprint chooses per stage on purpose, and pinning one model
+  flattens that, so cheap stages start paying top-tier prices while the stage
+  that decides things loses the model its author picked for it.
 - Added: the run list's folds outlive the dashboard. Folding four finished
   fan-outs to see the two live ones is a decision, and having to make it again
   every time you open `lev dash` is the feature failing to be one. They are kept

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -463,13 +463,18 @@ fn resolve_check(
 /// The note appended when the resolved provider is not the one the user named
 /// as their default.
 ///
-/// `default_provider` without a `default_model` is a half-configuration that
-/// silently does nothing: the resolver needs a model to send and has none, so
-/// it falls through to the hard-coded last resort. Someone who set
-/// `default_provider = "openrouter"`, pasted their key, and watched every run
-/// go to Anthropic (or, with no Anthropic key either, to a localhost Ollama
-/// that was not running) had no way to see that from here - the check said
-/// `resolve OK` and printed a provider they never asked for.
+/// This check resolves an empty `ModelConfig`, so `default_provider` really
+/// does lose here without a `default_model`: there is no blueprint entry to
+/// promote and no model to send. A real run is the opposite case, and the note
+/// used to describe only the first one - it said the default provider "is never
+/// chosen", which someone reasonably read as a statement about their runs.
+///
+/// It is not. `resolve_stage_candidates` moves every registered candidate on
+/// the default provider to the front of the blueprint's list, so
+/// `default_provider = "openrouter"` sends every stage of every bundled
+/// blueprint to that blueprint's OpenRouter entry. A run that had been quietly
+/// executing on a fallback model for weeks looked, from here, like a config
+/// line that did nothing at all.
 ///
 /// Not a failure: the resolution is legitimate and the run will work. It is
 /// only worth saying because it is not what the config appears to ask for.
@@ -493,8 +498,12 @@ fn default_provider_note(
     }
     let named = &config.default_provider;
     format!(
-        "  (note: default_provider is '{named}' but no default_model is set, \
-         so it is never chosen - add `default_model` to config.toml)"
+        "  (note: this check resolves no blueprint, so with no `default_model` \
+         set there is nothing to send to '{named}' and it loses here. A real run \
+         is different: a blueprint that lists '{named}' has that entry moved to \
+         the front, so your runs use '{named}' with whatever model the blueprint \
+         names for each stage. Set `default_model` only to pin one model across \
+         every stage, which overrides the per-stage choices a blueprint makes.)"
     )
 }
 

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -496,10 +496,13 @@ fn resolve_check_reports_an_unconfigured_provider_and_what_was_tried() {
 
 #[test]
 fn resolve_check_says_so_when_the_configured_default_never_wins() {
-    // `default_provider = "openrouter"` with no `default_model`: the resolver
-    // has no model to send, falls through to its hard-coded last resort, and
-    // used to report `resolve OK anthropic / claude-sonnet-4-6` with nothing
-    // anywhere saying the configured provider had been passed over.
+    // `default_provider = "openrouter"` with no `default_model`: this check
+    // resolves no blueprint, so there is no model to send and the configured
+    // provider loses here. The note has to say that WITHOUT implying it holds
+    // for real runs, where a blueprint listing openrouter has that entry
+    // promoted and every stage goes there. The old wording said the provider
+    // "is never chosen", which read as a statement about the user's runs and
+    // sent an investigation of a downgraded run in the wrong direction.
     let config = Config {
         default_provider: "openrouter".to_string(),
         default_model: None,
@@ -510,8 +513,18 @@ fn resolve_check_says_so_when_the_configured_default_never_wins() {
     let (check, _) = resolve_check(&config, None, &registry);
     assert_eq!(check.status, CheckStatus::Ok);
     assert!(
-        check.detail.contains("no default_model"),
-        "{}",
+        check.detail.contains("no blueprint"),
+        "the note must scope itself to this check: {}",
+        check.detail
+    );
+    assert!(
+        check.detail.contains("A real run is different"),
+        "the note must say what real runs do: {}",
+        check.detail
+    );
+    assert!(
+        !check.detail.contains("never chosen"),
+        "the claim that started this: {}",
         check.detail
     );
     assert!(check.detail.contains("openrouter"), "{}", check.detail);

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -17,7 +17,7 @@ use clap::Args;
 // Re-export the provider-registry builders used by the daemon setup.
 pub use session::{
     ProviderCreds, build_provider_registry, build_provider_registry_from_config,
-    provider_creds_from_config,
+    build_provider_registry_from_config_probing, provider_creds_from_config,
 };
 
 /// Arguments for `lev run`.

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -349,8 +349,12 @@ mod tests {
     #[test]
     fn build_provider_registry_with_empty_config() {
         let config = Config::default();
-        let registry =
-            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         // Ollama needs no key and is always on.
         assert!(registry.has("ollama"));
         // Claude Code needs no key either, but is opt-in - a default config
@@ -481,8 +485,12 @@ mod tests {
             openrouter_api_key: Some("sk-or-test-12345".to_string()),
             ..Config::default()
         };
-        let registry =
-            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         assert!(registry.has("openrouter"));
     }
 
@@ -801,8 +809,12 @@ mod tests {
     #[test]
     fn build_provider_registry_defaults_have_ollama_only() {
         let config = Config::default();
-        let registry =
-            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         // Ollama is present regardless of key configuration; claude-code is not,
         // until the user opts in.
         assert!(registry.has("ollama"));
@@ -898,8 +910,12 @@ mod tests {
             },
             ..crate::config::Config::default()
         };
-        let registry =
-            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         // Verify anthropic provider was registered
         assert!(registry.has("anthropic"));
         // Verify ollama always registered

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -161,9 +161,29 @@ pub fn build_provider_registry_from_config_with(
     config: &Config,
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
 ) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
-    let registry = leviath_runtime::provider_creds::build_provider_registry_with(
+    build_provider_registry_from_config_probing(
+        config,
+        build_client,
+        &leviath_runtime::provider_creds::tcp_reachable,
+    )
+}
+
+/// [`build_provider_registry_from_config_with`], with the Ollama reachability
+/// probe injected too.
+///
+/// Ollama registers on something answering at its address rather than on a
+/// key, so a test that wants it registered has to say so: the address in a
+/// test config resolves nowhere, and whether the machine running the suite
+/// happens to have Ollama up is not something a test should depend on.
+pub fn build_provider_registry_from_config_probing(
+    config: &Config,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+    reachable: &dyn Fn(&str) -> bool,
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    let registry = leviath_runtime::provider_creds::build_provider_registry_probing(
         &provider_creds_from_config(config),
         build_client,
+        reachable,
     )?;
     Ok(attach_script_layer(
         registry,
@@ -410,8 +430,12 @@ mod tests {
             },
             ..Config::default()
         };
-        let registry =
-            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         assert!(registry.has("anthropic"));
     }
 
@@ -468,8 +492,12 @@ mod tests {
             ollama_base_url: Some("http://my-server:11434".to_string()),
             ..Config::default()
         };
-        let registry =
-            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         assert!(registry.has("ollama"));
     }
 
@@ -620,8 +648,12 @@ mod tests {
             ollama_base_url: Some("http://custom:11434".to_string()),
             ..Config::default()
         };
-        let registry =
-            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         assert!(registry.has("anthropic"));
         assert!(registry.has("openai"));
         assert!(registry.has("google"));
@@ -897,8 +929,12 @@ mod tests {
             model_capabilities: caps,
             ..crate::config::Config::default()
         };
-        let registry =
-            build_provider_registry_from_config(&config).expect("an HTTPS client builds in tests");
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         assert!(registry.has("ollama"));
     }
 

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -1162,7 +1162,26 @@ mod tests {
 
     #[tokio::test]
     async fn the_models_endpoint_is_empty_when_no_https_client_can_be_built() {
-        let state = test_state();
+        // A keyed provider, so something actually asks for a client and the
+        // failing factory has a request to fail. Ollama used to be that
+        // something - it needed no key and so always reached the client cache -
+        // but it now registers only when its address answers, and on a machine
+        // without it nothing requested a client, no error was produced, and
+        // this test passed while exercising none of what it is named for.
+        let (tx, _) = broadcast::channel::<ServerEvent>(64);
+        let state = AppState {
+            config: crate::commands::serve::testutil::fixed_config(Config {
+                providers: crate::config::ProviderConfig {
+                    anthropic_api_key: Some("test-key".to_string()),
+                    ..Config::default().providers
+                },
+                ..Config::default()
+            }),
+            event_tx: tx,
+            control: crate::commands::serve::testutil::no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Default::default(),
+        };
         let Json(models) = super::models_with(&state, &|_t| {
             Err(leviath_providers::provider::malformed_url_error())
         })

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -296,11 +296,24 @@ mod tests {
     /// leviath-cli` fail locally while passing in CI, where nothing is
     /// listening. Port 1 is reserved and never bound, so the result stops
     /// depending on what happens to be running on the developer's machine.
+    /// A registered provider whose `list_models` cannot succeed, which is the
+    /// `Err` arm of the handler's `if let Ok(list)`.
+    ///
+    /// It used to be Ollama pointed at a dead port, but Ollama now registers
+    /// only when something answers there - so a dead address means no provider
+    /// at all, and the arm went unrun. A keyed provider is the reliable way to
+    /// put something in the registry that will then fail to list: the key
+    /// registers it, and nothing is listening at the address it calls.
     fn state_without_a_reachable_ollama() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
             config: crate::commands::serve::testutil::fixed_config(Config {
                 ollama_base_url: Some("http://127.0.0.1:1".to_string()),
+                providers: crate::config::ProviderConfig {
+                    anthropic_api_key: Some("test-key".to_string()),
+                    anthropic_base_url: Some("http://127.0.0.1:1".to_string()),
+                    ..Config::default().providers
+                },
                 ..Config::default()
             }),
             event_tx: tx,

--- a/crates/leviath-cli/src/commands/setup/verify.rs
+++ b/crates/leviath-cli/src/commands/setup/verify.rs
@@ -109,9 +109,17 @@ pub async fn verify_via_registry_with(
 ) -> Outcome {
     // A registry that cannot be built is exactly the failure this command
     // exists to report, so it is an outcome rather than a panic.
-    let registry = match leviath_runtime::provider_creds::build_provider_registry_with(
+    //
+    // The Ollama reachability probe is deliberately answered `true` here: this
+    // function's entire job is to find out whether the address answers and to
+    // say why when it does not. Gating registration on a probe would turn
+    // "nothing is listening" into "no such provider", which is the one message
+    // that does not help. It also keeps verification to a single connection,
+    // which is what the caller is measuring.
+    let registry = match leviath_runtime::provider_creds::build_provider_registry_probing(
         std::slice::from_ref(creds),
         build_client,
+        &|_| true,
     ) {
         Ok(registry) => registry,
         Err(e) => {

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -421,6 +421,9 @@ fn execute_reporting_outcome(
         // would default to, so it is what relative `[read_paths]` entries
         // resolve against.
         let workdir = crate::commands::resolve_cwd().unwrap_or_default();
+        if !args.json {
+            print_model_resolution(&checked.blueprint, config);
+        }
         env = env
             .with_providers(&checked.blueprint, config)
             .with_read_paths(&checked.blueprint, config, &workdir);
@@ -439,6 +442,71 @@ fn execute_reporting_outcome(
         return Ok(ValidateOutcome::LintFailed { errors, warnings });
     }
     Ok(ValidateOutcome::Success)
+}
+
+/// What each stage would actually dispatch to on this machine, and why.
+///
+/// A blueprint lists an ordered set of models per stage, and the resolver
+/// reorders it: registered candidates on `default_provider` move to the front,
+/// `default_model` first among them. Nothing surfaced the result, so a config
+/// line could silently move every stage onto a fallback model and the only
+/// evidence was in a finished run's metadata. The line under each stage is the
+/// blueprint's own order, so the promotion is visible as a difference rather
+/// than something to take on trust.
+fn print_model_resolution(blueprint: &leviath_core::Blueprint, config: &crate::config::Config) {
+    // A registry that will not build says nothing here rather than failing the
+    // validation: this block is extra information about an install, and the
+    // lint below has its own thing to say about unreachable providers.
+    let lines = crate::commands::run::build_provider_registry_from_config(config)
+        .map(|registry| model_resolution_lines(blueprint, config, &registry))
+        .unwrap_or_default();
+    for line in lines {
+        println!("{line}");
+    }
+}
+
+/// The lines [`print_model_resolution`] prints, so they can be asserted
+/// without capturing stdout.
+fn model_resolution_lines(
+    blueprint: &leviath_core::Blueprint,
+    config: &crate::config::Config,
+    registry: &leviath_runtime::ProviderRegistry,
+) -> Vec<String> {
+    let defaults = crate::daemon::spawn::model_defaults(config);
+    let mut lines = vec![String::new(), "Models this install would use:".to_string()];
+    for stage in &blueprint.stages {
+        // `resolve_stage_model` rather than the candidate list: it carries the
+        // "always at least one entry" invariant, so there is no empty case to
+        // write a branch for and then never reach.
+        let (provider, model) =
+            leviath_runtime::pipeline::resolve_stage_model(&stage.model, None, &defaults, registry);
+        let head = format!("{provider}/{model}");
+        lines.push(format!("  {:<16} {head}", stage.name));
+        let listed: Vec<String> = stage
+            .model
+            .models
+            .iter()
+            .map(|e| format!("{}/{}", e.provider, e.model))
+            .collect();
+        // Only when the install disagrees with the blueprint: printing the
+        // list under every stage that already got its first choice is noise,
+        // and the point of the line is to make a substitution visible.
+        if listed.first().is_some_and(|first| *first != head) {
+            lines.push(format!(
+                "  {:<16}   blueprint order: {}",
+                "",
+                listed.join(", ")
+            ));
+        }
+    }
+    if !config.default_provider.is_empty() {
+        let model = config.default_model.as_deref().unwrap_or("(unset)");
+        lines.push(format!(
+            "  default_provider = {}, default_model = {model}",
+            config.default_provider
+        ));
+    }
+    lines
 }
 
 /// The stage graph as text, the way the dashboard's stage explorer draws it
@@ -537,6 +605,118 @@ mod tests {
     use super::*;
     use crate::test_support::write_test_agent;
 
+    /// The line that would have answered "why is this run on deepseek".
+    ///
+    /// `default_provider` moves its registered candidates to the front of a
+    /// stage's list, so an install can dispatch somewhere the blueprint did
+    /// not ask for first. Nothing surfaced that, so the substitution is shown
+    /// against the blueprint's own order - and only when they differ, because
+    /// repeating the list under a stage that got its first choice is noise.
+    #[test]
+    fn model_resolution_shows_where_the_install_overrides_the_blueprint() {
+        let manifest = r#"
+[agent]
+name = "m"
+version = "0.1.0"
+entry_stage = "one"
+
+[stages.one]
+model = { models = [
+  { provider = "anthropic", model = "claude-sonnet-5" },
+  { provider = "openrouter", model = "deepseek/deepseek-v4-flash" },
+] }
+system_prompt = "hi"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_test_agent(dir.path(), manifest);
+        let checked = check_manifest(&path).expect("the manifest parses");
+        let blueprint = &checked.blueprint;
+
+        // A key is all it takes to register, and registration is all the
+        // resolver asks about - so the real providers stand in for themselves
+        // rather than a fake that would need a whole trait impl to answer one
+        // question. Ollama is probed away: whether this machine is running it
+        // is not part of what the test is about.
+        let with_keys = |default_provider: &str| crate::config::Config {
+            default_provider: default_provider.to_string(),
+            default_model: None,
+            openrouter_api_key: Some("test-key".to_string()),
+            providers: crate::config::ProviderConfig {
+                anthropic_api_key: Some("test-key".to_string()),
+                ..Default::default()
+            },
+            ..crate::config::Config::default()
+        };
+        let registry_for = |config: &crate::config::Config| {
+            crate::commands::run::build_provider_registry_from_config_probing(
+                config,
+                &leviath_providers::provider::build_http_client,
+                &|_| false,
+            )
+            .expect("an HTTPS client builds in tests")
+        };
+
+        // Preferring anthropic: the blueprint already leads with it, so there
+        // is nothing to report and no second line.
+        let anthropic_first = with_keys("anthropic");
+        let registry = registry_for(&anthropic_first);
+        let lines = model_resolution_lines(blueprint, &anthropic_first, &registry);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("anthropic/claude-sonnet-5")),
+            "{lines:#?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l.contains("blueprint order")),
+            "no substitution, so nothing to explain: {lines:#?}"
+        );
+
+        // Preferring openrouter: the second-listed entry is promoted over the
+        // blueprint's first choice, and the run silently goes there.
+        let openrouter_first = with_keys("openrouter");
+        let registry = registry_for(&openrouter_first);
+        let lines = model_resolution_lines(blueprint, &openrouter_first, &registry);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("openrouter/deepseek/deepseek-v4-flash")),
+            "{lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("blueprint order") && l.contains("anthropic/claude-sonnet-5")),
+            "the override has to be visible against what the blueprint asked for: {lines:#?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("default_provider = openrouter")
+                    && l.contains("default_model = (unset)")),
+            "and the setting responsible has to be named: {lines:#?}"
+        );
+
+        // No preference expressed: blueprint order stands on its own and
+        // there is no setting to name, so the trailing line is omitted.
+        let no_preference = crate::config::Config {
+            default_provider: String::new(),
+            ..with_keys("anthropic")
+        };
+        let registry = registry_for(&no_preference);
+        let lines = model_resolution_lines(blueprint, &no_preference, &registry);
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("anthropic/claude-sonnet-5")),
+            "{lines:#?}"
+        );
+        assert!(
+            !lines.iter().any(|l| l.contains("default_provider =")),
+            "nothing to name: {lines:#?}"
+        );
+    }
+
     /// A minimal manifest that lints clean, so a test can add exactly the one
     /// defect it is about.
     ///
@@ -612,6 +792,36 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             ..args_for(dir.path())
         };
         assert!(execute_reporting_outcome(&args, None).unwrap().is_success());
+    }
+
+    /// With a config in hand, the report also says which model each stage
+    /// would actually go to. Driven through the command so the `--json` guard
+    /// is exercised: the resolution block is prose, and a caller parsing JSON
+    /// must not find it spliced into the document.
+    #[test]
+    fn a_config_adds_the_model_resolution_to_the_prose_report() {
+        let dir = tempfile::tempdir().unwrap();
+        write_manifest(dir.path(), CLEAN_MANIFEST);
+        let config = crate::config::Config {
+            default_provider: "anthropic".to_string(),
+            providers: crate::config::ProviderConfig {
+                anthropic_api_key: Some("test-key".to_string()),
+                ..Default::default()
+            },
+            ..crate::config::Config::default()
+        };
+        assert!(
+            execute_reporting_outcome(&args_for(dir.path()), Some(&config))
+                .unwrap()
+                .is_success()
+        );
+        // The same run as JSON: the block is suppressed, and the outcome is
+        // the same either way.
+        assert!(
+            execute_reporting_outcome(&json_args_for(dir.path()), Some(&config))
+                .unwrap()
+                .is_success()
+        );
     }
 
     // ─── print_success ───────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -1141,24 +1141,38 @@ system = { kind = "pinned", max_tokens = 1000 }
     /// is the difference between the two.
     #[tokio::test]
     async fn warnings_only_fail_when_denied() {
-        crate::config::with_isolated_config_path_async("validate-deny-warnings", |_| async {
-            let dir = tempfile::tempdir().unwrap();
-            // No max_iterations on the one stage: exactly one warning, no errors.
-            write_manifest(
-                dir.path(),
-                &CLEAN_MANIFEST.replace("max_iterations = 5", ""),
-            );
+        crate::config::with_isolated_config_path_async(
+            "validate-deny-warnings",
+            |cfg_dir| async move {
+                // A key, so the blueprint's Anthropic entry is a reachable
+                // provider. This used to ride on Ollama registering without a
+                // credential; it now registers only when something answers at its
+                // address, so on a machine with no local Ollama the manifest also
+                // warned that nothing in its list was reachable - and the count
+                // this test is about went from one to two.
+                std::fs::write(
+                    cfg_dir.join("config.toml"),
+                    "[providers]\nanthropic_api_key = \"test-key\"\n",
+                )
+                .unwrap();
+                let dir = tempfile::tempdir().unwrap();
+                // No max_iterations on the one stage: exactly one warning, no errors.
+                write_manifest(
+                    dir.path(),
+                    &CLEAN_MANIFEST.replace("max_iterations = 5", ""),
+                );
 
-            let mut args = args_for(dir.path());
-            assert!(execute_reporting_outcome(&args, None).unwrap().is_success());
+                let mut args = args_for(dir.path());
+                assert!(execute_reporting_outcome(&args, None).unwrap().is_success());
 
-            args.deny_warnings = true;
-            let err = execute(args).await.unwrap_err();
-            assert_eq!(
-                err.to_string(),
-                "✗ Blueprint has 1 warning (--deny-warnings)"
-            );
-        })
+                args.deny_warnings = true;
+                let err = execute(args).await.unwrap_err();
+                assert_eq!(
+                    err.to_string(),
+                    "✗ Blueprint has 1 warning (--deny-warnings)"
+                );
+            },
+        )
         .await;
     }
 

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -613,7 +613,11 @@ mod tests {
         for name in ["anthropic", "openai", "google", "openrouter", "ollama"] {
             let mut cred = ProviderCreds::simple(name);
             cred.api_key = Some("k".to_string());
-            let err = build_provider_registry_with(&[cred], &failing_client)
+            // Ollama's arm is only reached when something answers at its
+            // address, so the probe is injected rather than left to depend on
+            // whether the machine running the suite has Ollama up. It does not
+            // on CI, and the arm returned before ever asking for a client.
+            let err = build_provider_registry_probing(&[cred], &failing_client, &|_| true)
                 .err()
                 .expect("a failing client factory should fail the registry");
             // Discriminant rather than `matches!`: the macro expands to a

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -115,6 +115,74 @@ pub fn build_provider_registry(
     build_provider_registry_with(creds, &leviath_providers::provider::build_http_client)
 }
 
+/// Ollama's own default port, used when a base URL names no port.
+const OLLAMA_DEFAULT_PORT: u16 = 11434;
+
+/// Whether something is listening at `base_url`, as a short TCP connect.
+///
+/// Ollama is the one provider with nothing to check: every other entry
+/// registers only when it has an API key, and a key is a cheap stand-in for
+/// "the user configured this". Ollama needs no key, so it used to register
+/// unconditionally, and an install with no local server still advertised a
+/// working provider. Blueprint order then sent stages to a localhost port
+/// nothing answered on.
+///
+/// A connect is the equivalent cheap stand-in: it does not prove Ollama is
+/// there, only that the address is not dead, which is exactly the case that
+/// was misreporting. The timeout is deliberately short - this runs while the
+/// daemon is starting, and a loopback address either answers immediately or
+/// is not there at all.
+pub fn tcp_reachable(base_url: &str) -> bool {
+    use std::net::{TcpStream, ToSocketAddrs};
+    let Some((host, port)) = host_and_port(base_url) else {
+        return false;
+    };
+    let timeout = std::time::Duration::from_millis(300);
+    // A name that does not resolve and an address that does not answer are
+    // the same answer here, so they share one expression rather than an arm
+    // each.
+    (host.as_str(), port).to_socket_addrs().is_ok_and(|addrs| {
+        addrs
+            .into_iter()
+            .any(|addr| TcpStream::connect_timeout(&addr, timeout).is_ok())
+    })
+}
+
+/// The host and port of an `http://host:port/path` base URL.
+///
+/// Hand-rolled because this crate does not depend on an HTTP client and one
+/// address is not worth taking one on. Anything without a recognisable host is
+/// `None`, which the caller reads as "not reachable" - the conservative answer
+/// for a provider that registers on reachability alone.
+fn host_and_port(base_url: &str) -> Option<(String, u16)> {
+    let rest = base_url
+        .split_once("://")
+        .map_or(base_url, |(scheme, rest)| {
+            let _ = scheme;
+            rest
+        });
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or("");
+    let authority = authority.rsplit_once('@').map_or(authority, |(_, a)| a);
+    if authority.is_empty() {
+        return None;
+    }
+    // `[::1]:11434` - the brackets delimit the address, so the port is
+    // whatever follows the closing one and the colons inside are not
+    // separators.
+    if let Some(rest) = authority.strip_prefix('[') {
+        let (host, after) = rest.split_once(']')?;
+        let port = match after.strip_prefix(':') {
+            Some(p) => p.parse().ok()?,
+            None => OLLAMA_DEFAULT_PORT,
+        };
+        return Some((host.to_string(), port));
+    }
+    match authority.rsplit_once(':') {
+        Some((h, p)) if !h.is_empty() => Some((h.to_string(), p.parse().ok()?)),
+        _ => Some((authority.to_string(), OLLAMA_DEFAULT_PORT)),
+    }
+}
+
 /// [`build_provider_registry`], with client construction injected.
 ///
 /// One client per distinct request timeout, shared by every provider that wants
@@ -126,6 +194,16 @@ pub fn build_provider_registry(
 pub fn build_provider_registry_with(
     creds: &[ProviderCreds],
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
+    build_provider_registry_probing(creds, build_client, &tcp_reachable)
+}
+
+/// [`build_provider_registry_with`], with the Ollama reachability probe
+/// injected so a test can decide the answer instead of opening a socket.
+pub fn build_provider_registry_probing(
+    creds: &[ProviderCreds],
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+    reachable: &dyn Fn(&str) -> bool,
 ) -> Result<ProviderRegistry, leviath_providers::ProviderError> {
     let mut registry = ProviderRegistry::new();
     // One client per distinct timeout, built on first use. Lazy because
@@ -218,14 +296,27 @@ pub fn build_provider_registry_with(
                     .base_url
                     .clone()
                     .unwrap_or_else(|| "http://localhost:11434".to_string());
-                registry.register(
-                    "ollama".to_string(),
-                    Arc::new(leviath_providers::OllamaProvider::with_overrides(
-                        clients.get_or_build(timeout, build_client)?,
-                        url,
-                        caps,
-                    )),
-                );
+                // The only provider that registers on something other than a
+                // key, because it has no key to register on. See
+                // [`tcp_reachable`]: an address nothing answers on is not a
+                // usable provider, and pretending otherwise put it ahead of
+                // providers that were actually configured.
+                if reachable(&url) {
+                    registry.register(
+                        "ollama".to_string(),
+                        Arc::new(leviath_providers::OllamaProvider::with_overrides(
+                            clients.get_or_build(timeout, build_client)?,
+                            url,
+                            caps,
+                        )),
+                    );
+                } else {
+                    tracing::info!(
+                        base_url = %url,
+                        "nothing is listening for ollama; not registering it. Start \
+                         ollama and reload the config to use it."
+                    );
+                }
             }
             "claude-code" => {
                 // Opt-in: the CLI puts the user's account email address into
@@ -367,7 +458,14 @@ mod tests {
                 options: Default::default(),
             },
         ];
-        let registry = build_provider_registry(&creds).expect("an HTTPS client builds in tests");
+        // The probe is injected: whether this machine happens to be running
+        // Ollama is not something the test should depend on.
+        let registry = build_provider_registry_probing(
+            &creds,
+            &leviath_providers::provider::build_http_client,
+            &|_| true,
+        )
+        .expect("an HTTPS client builds in tests");
         assert!(registry.has("anthropic"));
         assert!(registry.has("openai"));
         assert!(registry.has("google"));
@@ -375,6 +473,57 @@ mod tests {
         assert!(registry.has("ollama"));
         assert!(registry.has("claude-code"));
         assert!(!registry.has("totally-unknown"));
+    }
+
+    /// Ollama is the one provider with no key to gate on, so it gates on
+    /// something answering at its address instead. Registering it regardless
+    /// is what put a dead localhost port ahead of providers that were
+    /// actually configured.
+    #[test]
+    fn ollama_registers_only_when_something_answers() {
+        let creds = vec![ProviderCreds::simple("ollama")];
+        for reachable in [true, false] {
+            let registry = build_provider_registry_probing(
+                &creds,
+                &leviath_providers::provider::build_http_client,
+                &|_| reachable,
+            )
+            .expect("an HTTPS client builds in tests");
+            assert_eq!(registry.has("ollama"), reachable);
+        }
+    }
+
+    /// The probe reads an address out of a base URL without an HTTP client.
+    /// The bracketed form is the one worth pinning: the colons inside an IPv6
+    /// address are not port separators.
+    #[test]
+    fn a_base_url_yields_its_host_and_port() {
+        for (url, want) in [
+            ("http://localhost:11434", Some(("localhost", 11434))),
+            ("http://127.0.0.1:1", Some(("127.0.0.1", 1))),
+            ("http://example.com", Some(("example.com", 11434))),
+            ("http://example.com/v1/path", Some(("example.com", 11434))),
+            ("http://user:pw@host:9999/x", Some(("host", 9999))),
+            ("[::1]:11434", Some(("::1", 11434))),
+            ("http://[::1]", Some(("::1", 11434))),
+            ("bare-host", Some(("bare-host", 11434))),
+            ("http://host:notaport", None),
+            ("http://[::1]:notaport", None),
+            ("http://[::1", None),
+            ("http://", None),
+        ] {
+            let got = host_and_port(url);
+            let got = got.as_ref().map(|(h, p)| (h.as_str(), *p));
+            assert_eq!(got, want, "for {url}");
+        }
+    }
+
+    /// Nothing listens on port 1, and a name that does not resolve cannot be
+    /// connected to either. Both are the "not reachable" answer.
+    #[test]
+    fn tcp_reachable_says_no_to_a_dead_address() {
+        assert!(!tcp_reachable("http://127.0.0.1:1"));
+        assert!(!tcp_reachable("http://"));
     }
 
     #[test]

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -160,23 +160,42 @@ In order:
    [fan-out](/docs/sub-agents#fan-out) worker, and every sub-agent spawned with `spawn_agent`. A
    worker's own blueprint may list different models; they are its failover candidates when the run
    names no model, and are not consulted when it does.
-2. Your `default_provider` / `default_model` from `config.toml`, when `default_model` is set, the
-   provider is configured, and the stage did not set `allow_user_default = false`. It leads even
-   when the blueprint lists that same provider with a different model: `default_provider = "ollama"`
-   with `default_model = "qwen3.8:latest"` runs on `qwen3.8:latest`, and the blueprint's own
+2. Your `default_provider` from `config.toml`, when that provider is configured and the stage did
+   not set `allow_user_default = false`. Every entry in the stage's `models` on that provider moves
+   to the front, keeping the blueprint's order among them. This is what a preference means: your
+   provider first, then whatever the blueprint asked for.
+3. Your `default_model`, when it is set, first among the entries from step 2. It leads even when the
+   blueprint lists that same provider with a different model: `default_provider = "ollama"` with
+   `default_model = "qwen3.8:latest"` runs on `qwen3.8:latest`, and the blueprint's own
    `qwen3.5:9b` becomes the failover.
-3. The first entry in `models` whose provider is configured.
-4. The host-wide `fallback_order`, for the stages that got past everything above with nothing left.
-5. The first entry in the list, whether or not its provider exists. If it does not, the run fails at
+4. The first entry in `models` whose provider is configured.
+5. The host-wide `fallback_order`, for the stages that got past everything above with nothing left.
+6. The first entry in the list, whether or not its provider exists. If it does not, the run fails at
    spawn with `stage '<name>' has no usable provider`.
 
 Everything below the first line is the failover chain, in that same order, so a stage that starts on
 your default still has the blueprint's own entries to fall back to.
 
 > [!IMPORTANT]
-> `default_provider` on its own buys nothing. The resolver needs a model to send and has none, so it
-> falls through to whatever the blueprint listed. Set `default_model` alongside it. `lev doctor`
-> says so when you have not.
+> `default_model` pins **one** model across every stage, which is usually not what you want. A
+> blueprint picks per stage on purpose: `deep-researcher` gathers on a mid-tier model and analyses
+> on a top one. Setting `default_provider` alone keeps that shape and just moves it onto your
+> provider - gathering on that provider's mid-tier entry, analysing on its top one. Setting
+> `default_model` too flattens it, and the cheap stages start paying top-tier prices while the
+> deciding stage loses the model the author chose for it.
+
+Run `lev validate <agent>` to see the result before you spend anything on it. It prints the model
+each stage would actually use on this machine, and, where that differs from the blueprint's own
+order, prints that order underneath so the substitution is visible:
+
+```
+Models this install would use:
+  gather           openrouter/deepseek/deepseek-v4-flash
+                     blueprint order: anthropic/claude-sonnet-5, openai/gpt-5.4-mini, ...
+  analyze          openrouter/deepseek/deepseek-v4-pro
+                     blueprint order: anthropic/claude-opus-5, openai/gpt-5.5, ...
+  default_provider = openrouter, default_model = (unset)
+```
 
 `default_model` is a bare model id: `qwen3.8:latest`, not `ollama/qwen3.8:latest`. The provider is
 `default_provider`. That differs from `--model` and `[providers] fallback_order`, which take
@@ -193,12 +212,13 @@ provider is never on the list. Naming yours as the default is what puts it in fr
 
 ```toml
 default_provider = "openrouter"
-default_model = "deepseek/deepseek-v4-flash"
 openrouter_api_key = "sk-or-..."
 ```
 
-Every stage now starts on OpenRouter and keeps the blueprint's own list behind it. A stage that must
-stay on the provider its author picked opts out with `allow_user_default = false`.
+Every stage now starts on OpenRouter and keeps the blueprint's own list behind it, each stage still
+on the OpenRouter model its author picked for that stage. Add `default_model` only when you want one
+model everywhere regardless of stage. A stage that must stay on the provider its author picked opts
+out with `allow_user_default = false`.
 
 Two other ways in. A full override, for one run:
 


### PR DESCRIPTION
An install with keys for Anthropic, OpenAI, Google **and** OpenRouter ran every
stage of every bundled blueprint on the OpenRouter entry those blueprints list
**fourth**. Not a fallback after failures - the first choice, from spawn, on a
daemon with no failure history. One `wide-researcher` run made 53 inference
calls and not one went to the provider its blueprint names first, whose key
worked and answered a direct request in 1.7 seconds.

## What was actually happening

`resolve_stage_candidates` moves every registered candidate on
`default_provider` to the front of a stage's list. That is deliberate and it is
the behaviour we want: your provider first, your model first, then the
blueprint's own list. The problem was that **nothing surfaced it**, and the one
diagnostic that mentioned it said the opposite.

`lev doctor`:

> `resolve OK anthropic / claude-sonnet-4-6 (note: default_provider is
> 'openrouter' but no default_model is set, so it is never chosen)`

True of doctor's own check, which resolves an empty `ModelConfig` and so has no
blueprint entry to promote. False of every real run. I read it while
investigating a downgraded run and it sent me an hour in the wrong direction.

Measured, same blueprint, same keys, only the config line changed:

| `default_provider` | model chosen |
|---|---|
| `openrouter` | `openrouter/deepseek/deepseek-v4-flash` |
| `anthropic` | `anthropic/claude-sonnet-5` |

## Ollama is why the promotion exists

Every other provider registers only when it has an API key. Ollama needs none,
so it registered unconditionally - an install with no local server still
advertised a working provider, and blueprint order sent stages at a localhost
port nothing answered on. The promotion was added to route around that.

Ollama now registers on a 300ms connect to its own address: the same cheap
stand-in for "the user configured this" that a key is everywhere else. Verified
both ways against a real daemon:

- ollama running → `registered: anthropic, google, ollama, openai, openrouter`
- pointed at a dead port → `registered: anthropic, google, openai, openrouter`,
  plus `nothing is listening for ollama; not registering it. Start ollama and
  reload the config to use it.`

That knocked out one test's coverage in a way worth recording, because it is the
same mistake in miniature. `get_models_returns_ok` reached the "provider cannot
list its models" arm by pointing ollama at a dead port. With the gate in place a
dead address means *no provider at all*, so nothing reached that arm. It now
uses a keyed provider at a dead address, which registers and then fails to list.

## Seeing it before you spend anything

`lev validate <agent>` now prints what this machine would actually do:

```
Models this install would use:
  gather           openrouter/deepseek/deepseek-v4-flash
                     blueprint order: anthropic/claude-sonnet-5, openai/gpt-5.4-mini, ...
  analyze          openrouter/deepseek/deepseek-v4-pro
                     blueprint order: anthropic/claude-opus-5, openai/gpt-5.5, ...
  default_provider = openrouter, default_model = (unset)
```

The blueprint's order prints only where it differs from what was chosen, so a
substitution reads as a difference and a stage that got its first choice stays
quiet.

## The docs had one thing backwards

They said "`default_provider` on its own buys nothing." It buys the whole
ordering.

They also presented `default_model` as the missing half of it. It is a different
setting with a real cost: a blueprint picks per stage on purpose -
`deep-researcher` gathers on a mid-tier model and analyses on a top one - and
`default_provider` alone **preserves that shape** on your provider. Measured
with `default_provider = "anthropic"` and no `default_model`: a `researcher` run
used `claude-sonnet-5` for seven calls and `claude-opus-5` for the three in
`analyze`. Pinning `default_model` flattens that, so the cheap stages start
paying top-tier prices while the stage that decides things loses the model its
author chose for it.

## Checks

39 test suites green, all 13 packages at 100% coverage. The ollama gate and the
doctor note both have tests that fail against the old code - the gate's
`reachable = false` arm registered regardless before, and the note asserted the
exact phrase "never chosen" that started this.
