### PR TITLE
fix(mcp): let the caller set the handshake deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ same list.
 
 ## Unreleased
 
+- Fixed: the MCP handshake deadline is settable, so a stalled CI runner stops
+  failing the suite. `MCPClient::connect` gave the `initialize` handshake a
+  hardcoded 30 seconds - the right answer to "how long should a person's agent
+  startup hang on a broken server", and the wrong one for a test, whose clock
+  belongs to a build machine. On 2026-08-21 a `windows-latest` job stopped
+  executing for 159 seconds (zero tests completed; the binary took 241s against
+  a normal 40s) with all four subprocess-spawning MCP tests in flight, and the
+  one carrying this deadline was the only casualty - its panic reported the
+  instant the process was scheduled again, about a Python stub that had never
+  been given a chance to answer. Production keeps the 30s; the tests pass five
+  minutes, bounded so a genuinely wedged server still fails rather than hanging
+  CI.
 - Added: the run list's folds outlive the dashboard. Folding four finished
   fan-outs to see the two live ones is a decision, and having to make it again
   every time you open `lev dash` is the feature failing to be one. They are kept

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -58,6 +58,9 @@ impl Dashboard {
                 .join("mcp-auth.json"),
             opener: std::sync::Arc::new(|_| false),
             clock: || 1_000,
+            // No test built this way reaches a real handshake; the production
+            // value keeps the fixture honest about what it stands in for.
+            connect_timeout: leviath_mcp::DEFAULT_CONNECT_TIMEOUT,
         };
         // A test new-run context: an empty temp tree, so the agent picker and
         // the `@` completion never read the real agents dir or working

--- a/crates/leviath-cli/src/commands/dashboard/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mcp.rs
@@ -312,7 +312,7 @@ async fn run_test(ctx: &McpContext, name: &str) -> McpOutcome {
         Ok(header) => header,
         Err(e) => return fail(format!("Auth failed for '{name}': {e}")),
     };
-    match connect_and_count(&server, auth_header, &allow_env).await {
+    match connect_and_count(&server, auth_header, &allow_env, ctx.connect_timeout).await {
         Ok(count) => ok(format!("'{name}' connected · {count} tool(s)")),
         Err(e) => fail(format!("'{name}' failed: {e}")),
     }
@@ -323,8 +323,11 @@ async fn connect_and_count(
     server: &MCPServerConfig,
     auth_header: Option<(String, String)>,
     allow_env: &[String],
+    connect_timeout: std::time::Duration,
 ) -> anyhow::Result<usize> {
-    let mut client = MCPClient::from_config_with_auth(server, auth_header, allow_env).await?;
+    let mut client = MCPClient::from_config_with_auth(server, auth_header, allow_env)
+        .await?
+        .with_connect_timeout(connect_timeout);
     client.connect().await?;
     let tools = client.list_tools().await?;
     let _ = client.shutdown().await;
@@ -648,8 +651,21 @@ mod tests {
             store_path: dir.join("mcp-auth.json"),
             opener: std::sync::Arc::new(opener),
             clock: || 1_000,
+            connect_timeout: TEST_CONNECT_TIMEOUT,
         }
     }
+
+    /// The handshake deadline these tests use, and why it is not the 30s a
+    /// person gets.
+    ///
+    /// The warm-up below removes the interpreter's cold start; this removes
+    /// the machine. On 2026-08-21 a `windows-latest` job stopped executing for
+    /// 159 seconds - zero tests completed, the binary took 241s against a
+    /// normal 40s - with all four of this suite's subprocess tests in flight.
+    /// A wall-clock deadline inside a process that is not running measures the
+    /// runner, not the server. Bounded rather than removed, so a genuinely
+    /// wedged server still fails instead of hanging CI.
+    const TEST_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
     fn no_browser(_: &str) -> bool {
         false

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -250,6 +250,9 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
         store_path: leviath_mcp::AuthStore::default_path().unwrap_or_default(),
         opener: std::sync::Arc::new(leviath_sys::open_url),
         clock: mcp_system_now,
+        // Somebody is watching the MCP screen, so the handshake keeps the
+        // deadline that is right for a person.
+        connect_timeout: leviath_mcp::DEFAULT_CONNECT_TIMEOUT,
     };
     let mut dashboard = Dashboard::new_with_log_path(
         cmd_tx,

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -488,6 +488,11 @@ pub(super) struct McpContext {
     pub(super) store_path: std::path::PathBuf,
     pub(super) opener: leviath_mcp::BrowserOpener,
     pub(super) clock: fn() -> u64,
+    /// How long the MCP screen's `test` waits for the `initialize` handshake.
+    /// Production uses [`leviath_mcp::DEFAULT_CONNECT_TIMEOUT`]; the tests use
+    /// a far longer one, for the reason
+    /// [`leviath_mcp::MCPClient::with_connect_timeout`] records.
+    pub(super) connect_timeout: std::time::Duration,
 }
 
 /// Which pane of the new-run screen holds keyboard focus (Tab toggles).

--- a/crates/leviath-cli/src/commands/mcp.rs
+++ b/crates/leviath-cli/src/commands/mcp.rs
@@ -119,6 +119,13 @@ pub struct McpEnv {
     /// `[security] allow_env_vars`: which credential-shaped variables an MCP
     /// server's `${VAR}` headers may interpolate.
     pub allow_env_vars: Vec<String>,
+    /// How long `lev mcp test` waits for the `initialize` handshake.
+    ///
+    /// Production passes [`leviath_mcp::DEFAULT_CONNECT_TIMEOUT`]; the tests
+    /// pass a far longer one, because their clock is a CI runner's rather than
+    /// a person's. See [`leviath_mcp::MCPClient::with_connect_timeout`] for
+    /// the freeze that made this worth a field.
+    pub connect_timeout: std::time::Duration,
 }
 
 /// Run a `lev mcp` subcommand against the injected environment.
@@ -273,8 +280,9 @@ async fn test(name: &str, env: &McpEnv) -> anyhow::Result<()> {
     let auth_header = OAuthClient::new()
         .authorization_header(name, &env.store_path, env.now)
         .await?;
-    let mut client =
-        MCPClient::from_config_with_auth(server, auth_header, &env.allow_env_vars).await?;
+    let mut client = MCPClient::from_config_with_auth(server, auth_header, &env.allow_env_vars)
+        .await?
+        .with_connect_timeout(env.connect_timeout);
     client.connect().await?;
     let tools = client.list_tools().await?;
     println!("✓ '{name}' connected · {} tool(s):", tools.len());
@@ -427,8 +435,26 @@ mod tests {
             tools_dir: None,
             credential_store: None,
             allow_env_vars: Vec::new(),
+            connect_timeout: TEST_CONNECT_TIMEOUT,
         }
     }
+
+    /// The handshake deadline for tests: long enough that only a real hang
+    /// trips it.
+    ///
+    /// Production's 30s asks "how long should a person's agent startup hang on
+    /// a broken server". A test asks something else, and answering it with a
+    /// person's number means the suite fails when the *machine* stalls rather
+    /// than when the server does. One did: a `windows-latest` job froze for
+    /// 159 seconds on 2026-08-21 - zero tests completed, the binary took 241s
+    /// against a normal 40s - and this deadline was the only casualty, its
+    /// panic reported the instant the process was scheduled again. The stub
+    /// had answered nothing because nothing was running.
+    ///
+    /// Five minutes is not a guess at how slow a runner gets; it is "longer
+    /// than any stall we have seen, and still bounded", so a genuinely wedged
+    /// server still fails the test rather than hanging CI forever.
+    const TEST_CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
 
     fn never_opens(_: &str) -> bool {
         false
@@ -1122,6 +1148,7 @@ for line in sys.stdin:
             tools_dir: None,
             credential_store: None,
             allow_env_vars: Vec::new(),
+            connect_timeout: TEST_CONNECT_TIMEOUT,
         }
     }
 
@@ -1201,6 +1228,7 @@ for line in sys.stdin:
             tools_dir: None,
             credential_store: None,
             allow_env_vars: Vec::new(),
+            connect_timeout: TEST_CONNECT_TIMEOUT,
         };
         assert!(
             execute_with(

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -214,6 +214,9 @@ impl RiskyExecutors for RealExecutors {
             credential_store: leviath_cli::credentials::store_for(config.security.credential_store)
                 .map_err(|e| anyhow::anyhow!("{e}"))?,
             allow_env_vars: config.security.allow_env_vars,
+            // A person is waiting at a terminal, so the handshake keeps the
+            // deadline that is right for one.
+            connect_timeout: leviath_mcp::DEFAULT_CONNECT_TIMEOUT,
         };
         commands::mcp::execute_with(args, &env).await
     }

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -165,6 +165,11 @@ pub struct MCPClient {
     next_id: AtomicU64,
     /// How long to wait for a response to an ordinary request.
     request_timeout: Duration,
+    /// How long to wait for the `initialize` handshake. Separate from
+    /// `request_timeout` because it means something different (see
+    /// [`DEFAULT_CONNECT_TIMEOUT`]), and settable because a *test* suite is
+    /// not a user: see [`MCPClient::with_connect_timeout`].
+    connect_timeout: Duration,
     /// Server capabilities after initialization
     capabilities: Option<ServerCapabilities>,
     /// The protocol revision agreed during `initialize`.
@@ -180,10 +185,33 @@ impl MCPClient {
             transport,
             next_id: AtomicU64::new(1),
             request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            connect_timeout: DEFAULT_CONNECT_TIMEOUT,
             capabilities: None,
             protocol_version: None,
             cached_tools: Vec::new(),
         }
+    }
+
+    /// Wait longer than [`DEFAULT_CONNECT_TIMEOUT`] for the handshake.
+    ///
+    /// For callers whose clock is not the user's. The 30s default answers
+    /// "how long should a person's agent startup hang on a broken server",
+    /// and a test suite is not a person: a CI runner that stalls for two
+    /// minutes fails a 30s deadline while proving nothing about the server.
+    ///
+    /// That is not hypothetical. On 2026-08-21 a `windows-latest` job froze
+    /// for 159 seconds - zero tests completed, the binary took 241s against a
+    /// normal 40s - and the one test carrying this deadline was the only
+    /// casualty, reported the instant the process was scheduled again. The
+    /// Python stub it was talking to had done nothing wrong; neither had the
+    /// transport.
+    ///
+    /// Production keeps the 30s: the trade this makes is only that a test may
+    /// wait a long time before failing, which costs a slow test rather than a
+    /// wrong one.
+    pub fn with_connect_timeout(mut self, timeout: Duration) -> Self {
+        self.connect_timeout = timeout;
+        self
     }
 
     /// Spawn an MCP server as a child process and talk to it over stdio.
@@ -272,7 +300,7 @@ impl MCPClient {
         // handshake in this long is broken, not busy, and it is holding up an
         // agent's startup.
         let result = self
-            .request_with_timeout("initialize", init_params, DEFAULT_CONNECT_TIMEOUT)
+            .request_with_timeout("initialize", init_params, self.connect_timeout)
             .await?;
 
         // Parse server capabilities
@@ -841,6 +869,41 @@ mod tests {
         MCPClient::spawn("python3", &["-c", script], &HashMap::new())
             .await
             .expect("Failed to spawn stub MCP server")
+    }
+
+    /// The handshake deadline really is the one the caller set, not the
+    /// constant.
+    ///
+    /// Asserted by *shortening* it rather than lengthening it: a test that set
+    /// five minutes and passed would pass just as well if the setter did
+    /// nothing. A stub that answers nothing, given 100ms, must fail in about
+    /// 100ms - and the wall clock proves the deadline moved, since the default
+    /// would have held this test for thirty seconds.
+    #[tokio::test]
+    async fn with_connect_timeout_replaces_the_default_handshake_deadline() {
+        let _guard = always_on_tracing_guard();
+        // Reads forever, answers nothing: the handshake can only end by
+        // deadline.
+        let mut client = spawn_stub_client("import sys\nfor line in sys.stdin: pass\n")
+            .await
+            .with_connect_timeout(Duration::from_millis(100));
+
+        let started = std::time::Instant::now();
+        let err = client
+            .connect()
+            .await
+            .expect_err("a silent server cannot complete a handshake");
+        let waited = started.elapsed();
+
+        assert!(
+            err.to_string().contains("did not respond to 'initialize'"),
+            "{err}"
+        );
+        assert!(
+            waited < DEFAULT_CONNECT_TIMEOUT,
+            "waited {waited:?}, which is the default rather than the 100ms asked for"
+        );
+        let _ = client.shutdown().await;
     }
 
     // Python script that answers initialize then tools/list then tools/call

--- a/crates/leviath-mcp/src/lib.rs
+++ b/crates/leviath-mcp/src/lib.rs
@@ -24,3 +24,7 @@ pub use auth::{
 pub use client::{EmbeddedResource, MCPClient, ToolResult};
 pub use discovery::{MCPServerConfig, MCPTransport, ResolvedTransport, ToolDiscovery};
 pub use execution::ToolExecutor;
+/// The handshake deadline a caller with a person waiting should use. Exported
+/// so a caller that overrides it (a test) still names the production value in
+/// the one place it does not.
+pub use transport::DEFAULT_CONNECT_TIMEOUT;


### PR DESCRIPTION
## The flake was not an MCP bug

`commands::mcp::tests::test_command_connects_and_lists_tools` failed once on
`windows-latest` with `MCP server did not respond to 'initialize' within 30s -
the server process is still running`. The transport, the test and the Python
stub are all correct. **The test binary stopped executing for 159 seconds.**

Measured from attempt 1's log (`filter=all` on the jobs API - a re-run flips the
run to success and hides the original attempt):

| minute | tests completed |
|---|---|
| 08:43 | 1222 |
| 08:44 | 3 |
| 08:45 | **0** |
| 08:46 | 1568 |
| 08:47 | 947 |

Gap analysis puts it exactly: `08:44:03.076 → 08:46:42.065`, nothing finished.
The binary took **240.92s**; the same binary on a healthy runner takes
**40.22s**, and this test costs ~70ms there.

Four subprocess-spawning MCP tests were in flight when it hit, and `cargo test`
on a 4-vCPU runner uses 4 threads, so they held every one and nothing else could
complete either:

```
08:44:42  background_test_lists_tools_of_a_live_stdio_server  over 60 seconds
08:44:43  background_test_reports_a_list_tools_failure        over 60 seconds
08:44:59  test_command_connects_and_lists_tools               over 60 seconds
08:45:03  test_surfaces_a_list_tools_failure                  over 60 seconds
```

Only one of the four carried a wall-clock deadline, so only it failed. Its test
started ~08:43:59, so the 30s expired at ~08:44:29 - but the panic was reported
at **08:46:42.07**, the instant the process was scheduled again, 133 seconds
later. Nothing about the server was being measured by then.

That rules out the theories worth naming, so nobody re-runs them: it is not
Python's cold start, not pipe buffering on Windows, and not the `PATH`-starving
tests racing the spawn (a real class, documented at `helpers.rs:449`, but it
produces a spawn failure, not this).

Frequency: 1 in ~60 CI runs.

## The change

`MCPClient::with_connect_timeout`, threaded through the two seams that already
exist for exactly this: `McpEnv` for `lev mcp test`, `McpContext` for the
dashboard's MCP screen.

- **Production is unchanged** - both pass `DEFAULT_CONNECT_TIMEOUT`, still 30s.
- **Tests pass five minutes** - not a guess at how slow a runner gets, but
  "longer than any stall we have seen, and still bounded", so a genuinely
  wedged server fails the test rather than hanging CI.

The dashboard's MCP tests already had a `warm_interpreter` helper for a
neighbouring symptom, noting it had "failed this suite in CI". Warming removes
the interpreter's cold start; it cannot help a process that is not running.

## The test

Asserted by **shortening** the deadline, not lengthening it - a test that set
five minutes and passed would pass just as well against a setter that did
nothing. Against a stub that answers nothing, 100ms must fail in about 100ms.
With the assignment removed:

```
waited 30.00200975s, which is the default rather than the 100ms asked for
test result: FAILED
```

`cargo xtask coverage` is at 100% for all 13 packages.
