### PR TITLE
feat(tui): remember what the user already chose, everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,25 @@ same list.
 
 ## Unreleased
 
+- Added: the terminal UIs remember the choices you have already made, in one
+  `ui-state.json` under the data directory rather than each surface inventing
+  its own answer. `lev setup` no longer re-proposes an MCP server or a bundled
+  blueprint you turned down: it is still listed, so you can change your mind,
+  but it is not pre-selected and finishing the wizard again will not quietly
+  bring it in. Only refusals are kept, and only from a run you finished -
+  accepting needs no memory, since the server lands in your config and the
+  blueprint on disk. A blueprint's refusal is recorded against the version that
+  was offered, so a newer one is a fresh offer rather than something an old "no
+  thanks" hides. The dashboard joins it with two more: the sort order `s`
+  cycles, and the agent the new-run screen opens on, which is whichever you last
+  launched.
+- Changed: nothing transient or consequential is remembered, deliberately. A
+  filter, a search and the run marks are gone when you come back, because
+  reopening with yesterday's filter silently applied is a bug rather than a
+  convenience; and unattended (`Ctrl-Y`) stays off every time the new-run screen
+  opens, because a setting that runs tools without asking is the last one
+  anybody should inherit from last week out of sight.
+
 - Fixed: the MCP handshake deadline is settable, so a stalled CI runner stops
   failing the suite. `MCPClient::connect` gave the `initialize` handshake a
   hardcoded 30 seconds - the right answer to "how long should a person's agent
@@ -50,7 +69,7 @@ same list.
 - Added: the run list's folds outlive the dashboard. Folding four finished
   fan-outs to see the two live ones is a decision, and having to make it again
   every time you open `lev dash` is the feature failing to be one. They are kept
-  in `dash/ui-state.json` under the data directory, beside the agent editor's
+  in `ui-state.json` under the data directory, beside the agent editor's
   canvas arrangements, and written on the keystroke that makes them rather than
   on the way out - a dashboard is usually closed by whatever closes the
   terminal, so "save on quit" is a save that often never happens. A list still

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -163,6 +163,7 @@ impl Dashboard {
             tree_rows: Vec::new(),
             collapsed_runs: std::collections::HashSet::new(),
             ui_state_path: None,
+            last_launched_agent: None,
             mcp_screen: false,
             mcp_add_mode: false,
             mcp_add_input: String::new(),

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -266,7 +266,7 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
     // …and the run list keeps its folds beside them, restored before the first
     // sync so the list is drawn the way it was left rather than unfolding for a
     // frame first.
-    dashboard.ui_state_path = ui_state::default_path();
+    dashboard.ui_state_path = crate::ui_state::default_path();
     dashboard.load_ui_state();
 
     // Forward the dashboard's control commands to the daemon, and report each

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -51,6 +51,8 @@ impl Dashboard {
         self.new_run_focus = NewRunPane::Agents;
         self.new_run_filter.clear();
         self.new_run_selected = 0;
+        // Filled in below, once the catalog is built: the list has to exist
+        // before a name can be found in it.
         self.new_run_task = ratatui_textarea::TextArea::default();
         // Unattended is off every time the screen opens. It is a consequential
         // setting, and one that survived out of sight is one somebody can
@@ -58,7 +60,23 @@ impl Dashboard {
         self.new_run_yolo = false;
         self.close_file_ref();
         self.refresh_new_run_agents();
+        self.select_last_launched_agent();
         self.new_run_files = collect_workdir_files(&self.new_run_ctx.workdir, FILE_CANDIDATE_CAP);
+    }
+
+    /// Open on the agent last launched from here, when it is still offered.
+    ///
+    /// The cursor, not a filter: the whole catalog stays visible and one press
+    /// of `↑` reaches everything above it. An agent that has since been removed
+    /// or renamed simply is not found, and the list opens at the top as it
+    /// always did.
+    fn select_last_launched_agent(&mut self) {
+        let Some(name) = self.last_launched_agent.as_deref() else {
+            return;
+        };
+        if let Some(index) = self.new_run_agents.iter().position(|a| a.name == name) {
+            self.new_run_selected = index;
+        }
     }
 
     /// Close the screen, discarding whatever was typed.
@@ -160,6 +178,11 @@ impl Dashboard {
         };
         self.toast(format!("Starting '{}'{how}…", agent.name), ToastLevel::Info);
         self.add_log(format!("run requested: {}", agent.name));
+        // Recorded on the launch rather than on the selection: moving the
+        // cursor down the list to read a blueprint's preview is not a choice
+        // of agent, and starting a run is.
+        self.last_launched_agent = Some(agent.name.clone());
+        self.save_ui_state();
         self.close_new_run_screen();
     }
 
@@ -611,6 +634,65 @@ mod tests {
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    // ─── the agent the screen opens on ────────────────────────────────────
+
+    /// Someone who launches the same agent all day should find the cursor on
+    /// it, not scroll past everything alphabetically ahead of it.
+    #[test]
+    fn the_screen_opens_on_the_agent_last_launched() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents").join("alpha"), "alpha", "first");
+        write_agent(&dir.path().join("agents").join("zulu"), "zulu", "last");
+        let mut dash = dash_at(dir.path());
+
+        dash.open_new_run_screen();
+        assert_eq!(
+            dash.new_run_selected_agent().map(|a| a.name.as_str()),
+            Some("alpha"),
+            "with no memory the list opens at the top"
+        );
+
+        dash.last_launched_agent = Some("zulu".to_string());
+        dash.open_new_run_screen();
+        assert_eq!(
+            dash.new_run_selected_agent().map(|a| a.name.as_str()),
+            Some("zulu")
+        );
+
+        // An agent that has since been removed is simply not found, and the
+        // list opens where it always did rather than on nothing.
+        dash.last_launched_agent = Some("deleted-since".to_string());
+        dash.open_new_run_screen();
+        assert_eq!(
+            dash.new_run_selected_agent().map(|a| a.name.as_str()),
+            Some("alpha")
+        );
+    }
+
+    /// Recorded on the launch, not on the browse: moving the cursor to read a
+    /// blueprint's preview is not choosing it.
+    #[test]
+    fn the_last_agent_is_recorded_when_a_run_actually_starts() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents").join("alpha"), "alpha", "first");
+        write_agent(&dir.path().join("agents").join("zulu"), "zulu", "last");
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+
+        // By position, found rather than assumed: the catalog carries the
+        // bundled blueprints too, so the index of a written one is not 1.
+        dash.new_run_selected = dash
+            .new_run_agents
+            .iter()
+            .position(|a| a.name == "zulu")
+            .expect("the written agent is in the catalog");
+        assert_eq!(dash.last_launched_agent, None, "browsing decides nothing");
+
+        dash.new_run_task.insert_str("do the thing");
+        dash.submit_new_run();
+        assert_eq!(dash.last_launched_agent.as_deref(), Some("zulu"));
     }
 
     // ─── catalog ──────────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -134,10 +134,14 @@ pub(crate) struct Dashboard {
     /// re-sorting, filtering, and rows arriving above it - and, through
     /// `ui_state_path`, closing the dashboard.
     pub(super) collapsed_runs: std::collections::HashSet<String>,
-    /// Where `collapsed_runs` is kept between sessions (see `ui_state.rs`).
-    /// `None` in tests and on a home with no data dir: nothing is read or
-    /// written then, so no test can reach the user's real file.
+    /// Where the remembered view state is kept between sessions (see
+    /// `ui_state.rs`). `None` in tests and on a home with no data dir: nothing
+    /// is read or written then, so no test can reach the user's real file.
     pub(super) ui_state_path: Option<std::path::PathBuf>,
+    /// The agent the new-run screen opens on: the last one actually launched
+    /// from here. `None` until somebody starts a run, and dropped back to the
+    /// top of the list when that agent is no longer offered.
+    pub(super) last_launched_agent: Option<String>,
     /// Filesystem path this dashboard appends its activity log to. Production
     /// construction resolves the real [`runstate::dashboard_log_path`]; tests
     /// (`make_test_dashboard`) inject a temp path so no test ever writes to the
@@ -966,9 +970,13 @@ impl Dashboard {
     }
 
     /// Cycle the run-list sort mode and say so in the log.
+    ///
+    /// Kept between sessions: somebody who works by status has said so, and
+    /// saying it again at every launch is the setting failing to be one.
     pub(super) fn cycle_sort_mode(&mut self) {
         self.sort_mode = self.sort_mode.next();
         self.add_log(format!("Sort: {}", self.sort_mode.label()));
+        self.save_ui_state();
         self.update_display_indices();
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -55,6 +55,18 @@ impl SortMode {
             Self::StatusGrouped => "status",
         }
     }
+
+    /// The mode a saved [`label`](Self::label) names, if this build has one.
+    ///
+    /// The remembered sort is stored as its label rather than an index, so
+    /// adding or reordering modes cannot silently turn a saved file into a
+    /// different choice. `None` for a label this build does not know, which
+    /// the caller treats as "no memory" rather than an error.
+    pub(super) fn from_label(label: &str) -> Option<Self> {
+        [Self::StartedAt, Self::RecentActivity, Self::StatusGrouped]
+            .into_iter()
+            .find(|mode| mode.label() == label)
+    }
 }
 
 /// Which pane of the main screen holds keyboard focus.

--- a/crates/leviath-cli/src/commands/dashboard/ui_state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/ui_state.rs
@@ -1,83 +1,47 @@
-//! What the dashboard remembers about how you left it looking.
+//! The dashboard's half of the shared UI memory (see [`crate::ui_state`]).
 //!
-//! Which runs' sub-agents you folded away is a decision, not a view: a person
-//! who folds four finished fan-outs to see the two live ones has said something
-//! about what they want on screen, and having to say it again every time they
-//! open the dashboard is the feature failing to be one. It is kept the same way
-//! the agent editor keeps its canvas arrangements - one small JSON file under
-//! the data dir, per home.
-//!
-//! Deliberately *not* in `config.toml`. That file is the user's to edit and is
-//! reloaded on change; this is UI residue the dashboard writes behind them, and
-//! mixing the two would mean a fold rewriting a hand-edited config.
-
-use std::collections::BTreeSet;
-use std::path::{Path, PathBuf};
-
-use serde::{Deserialize, Serialize};
+//! Three things are remembered, and they are the three a person would be
+//! annoyed to redo: which runs' sub-agents are folded away, how the run list is
+//! sorted, and which agent the new-run screen should open on. Everything else
+//! the dashboard holds is either transient (a filter, a search, the marks) or
+//! deliberately reset (`--yolo`), and reads there rather than here.
 
 use super::state::Dashboard;
-
-/// The dashboard's remembered view state.
-///
-/// A struct rather than a bare list of ids so the next thing worth remembering
-/// can join it without a second file or a format migration. Missing fields
-/// default, so an older file stays readable.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub(super) struct UiState {
-    /// Run ids whose sub-agents are folded away in the run list. A set, so the
-    /// file is stable rather than reordering itself on every save.
-    #[serde(default)]
-    pub(super) collapsed_runs: BTreeSet<String>,
-}
-
-/// The file under the data directory: `dash/ui-state.json`.
-///
-/// `None` when there is no resolvable data dir, which is also what tests get:
-/// nothing then reads or writes, so no test can touch the real one.
-pub(super) fn default_path() -> Option<PathBuf> {
-    leviath_core::paths::data_dir().map(|d| d.join("dash").join("ui-state.json"))
-}
-
-/// Read the state at `path`. A missing, unreadable or unparseable file is an
-/// empty state: this is a convenience, and losing it must never be louder than
-/// the thing it was helping with.
-fn read(path: &Path) -> UiState {
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|text| serde_json::from_str(&text).ok())
-        .unwrap_or_default()
-}
+use super::types::SortMode;
+use crate::ui_state;
 
 impl Dashboard {
     /// Restore the remembered view state, if this dashboard has a file.
     ///
     /// Called once at startup, before the first sync. Folds name runs by id, so
-    /// they can be restored before the runs themselves are known - a fold for a
+    /// they can be restored before the runs themselves are known; a fold for a
     /// run that no longer exists is dropped by the first sync that can see the
     /// run list.
     pub(super) fn load_ui_state(&mut self) {
         let Some(path) = &self.ui_state_path else {
             return;
         };
-        self.collapsed_runs = read(path).collapsed_runs.into_iter().collect();
+        let saved = ui_state::load(path).dashboard;
+        self.collapsed_runs = saved.collapsed_runs.into_iter().collect();
+        // An unknown label (a file from a build with different modes, or one
+        // somebody edited) leaves the default rather than failing to start.
+        if let Some(mode) = saved.sort_mode.as_deref().and_then(SortMode::from_label) {
+            self.sort_mode = mode;
+        }
+        self.last_launched_agent = saved.last_agent;
     }
 
-    /// Write the remembered view state. Best effort: a dashboard that cannot
-    /// write its folds still works, and a toast about it would be noise in the
-    /// middle of whatever the person was actually doing.
+    /// Write the remembered view state, keeping whatever `lev setup` put in the
+    /// same file.
     pub(super) fn save_ui_state(&self) {
         let Some(path) = &self.ui_state_path else {
             return;
         };
-        let state = UiState {
-            collapsed_runs: self.collapsed_runs.iter().cloned().collect(),
-        };
-        // A relative file name has an empty parent, which `create_dir_all`
-        // treats as already there.
-        let _ = std::fs::create_dir_all(path.parent().unwrap_or(Path::new("")));
-        let text = serde_json::to_string_pretty(&state).expect("a set of strings serializes");
-        let _ = std::fs::write(path, text);
+        ui_state::update(path, |state| {
+            state.dashboard.collapsed_runs = self.collapsed_runs.iter().cloned().collect();
+            state.dashboard.sort_mode = Some(self.sort_mode.label().to_string());
+            state.dashboard.last_agent = self.last_launched_agent.clone();
+        });
     }
 }
 
@@ -86,57 +50,44 @@ mod tests {
     use super::*;
     use crate::commands::dashboard::test_support::make_test_dashboard;
 
-    /// The round trip that makes the feature a feature: fold, quit, come back,
-    /// and it is still folded.
+    /// The round trip that makes the feature a feature: choose, quit, come
+    /// back, and the choices are still there.
     #[test]
-    fn a_fold_survives_a_restart() {
+    fn folds_sort_and_the_last_agent_all_survive_a_restart() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("dash").join("ui-state.json");
 
         let mut first = make_test_dashboard();
         first.ui_state_path = Some(path.clone());
         first.collapsed_runs.insert("run-parent".to_string());
+        first.sort_mode = SortMode::StatusGrouped;
+        first.last_launched_agent = Some("deep-researcher".to_string());
         first.save_ui_state();
-        assert!(path.exists(), "the store made its own directory");
 
         let mut second = make_test_dashboard();
         second.ui_state_path = Some(path);
         second.load_ui_state();
         assert!(second.collapsed_runs.contains("run-parent"));
+        assert_eq!(second.sort_mode, SortMode::StatusGrouped);
+        assert_eq!(
+            second.last_launched_agent.as_deref(),
+            Some("deep-researcher")
+        );
     }
 
-    /// Nothing saved yet, a file somebody truncated, a file holding something
-    /// else entirely: all of them are "no folds", never an error.
+    /// A label this build does not know leaves the default sort rather than
+    /// refusing to start.
     #[test]
-    fn an_unreadable_store_is_an_empty_one() {
-        let dir = tempfile::tempdir().unwrap();
-        let missing = dir.path().join("never-written.json");
-        assert_eq!(read(&missing), UiState::default());
-
-        let junk = dir.path().join("junk.json");
-        std::fs::write(&junk, "not json at all").unwrap();
-        assert_eq!(read(&junk), UiState::default());
-
-        // A file from a build that knew fewer fields still reads.
-        let older = dir.path().join("older.json");
-        std::fs::write(&older, "{}").unwrap();
-        assert_eq!(read(&older), UiState::default());
-    }
-
-    /// Loading replaces whatever was in memory, so a stale fold from a previous
-    /// load cannot survive a store that no longer names it.
-    #[test]
-    fn loading_replaces_rather_than_merges() {
+    fn an_unknown_sort_label_falls_back_to_the_default() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("ui-state.json");
-        std::fs::write(&path, r#"{"collapsed_runs":["kept"]}"#).unwrap();
+        std::fs::write(&path, r#"{"dashboard":{"sort_mode":"by-vibes"}}"#).unwrap();
 
         let mut dash = make_test_dashboard();
+        let default = dash.sort_mode;
         dash.ui_state_path = Some(path);
-        dash.collapsed_runs.insert("stale".to_string());
         dash.load_ui_state();
-        assert!(dash.collapsed_runs.contains("kept"));
-        assert!(!dash.collapsed_runs.contains("stale"));
+        assert_eq!(dash.sort_mode, default);
     }
 
     /// A dashboard with no store (every test one, and any home without a data
@@ -157,11 +108,23 @@ mod tests {
         );
     }
 
-    /// The production path lands under the data dir, beside the editor's
-    /// arrangements rather than in the user's config.
+    /// Saving the dashboard's memory must not erase setup's, since they share
+    /// one file.
     #[test]
-    fn the_default_path_is_under_the_data_dir() {
-        let path = default_path().expect("this machine has a data dir");
-        assert!(path.ends_with("dash/ui-state.json"), "{path:?}");
+    fn saving_keeps_what_setup_recorded() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ui-state.json");
+        ui_state::update(&path, |s| {
+            s.setup.declined_mcp.insert("cursor:linear".to_string());
+        });
+
+        let mut dash = make_test_dashboard();
+        dash.ui_state_path = Some(path.clone());
+        dash.collapsed_runs.insert("run-1".to_string());
+        dash.save_ui_state();
+
+        let got = ui_state::load(&path);
+        assert!(got.setup.declined_mcp.contains("cursor:linear"));
+        assert!(got.dashboard.collapsed_runs.contains("run-1"));
     }
 }

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -401,6 +401,7 @@ fn enter_on_agent_and_mcp_rows_toggles_like_space() {
         Vec::new(),
         dir.path(),
         std::sync::Arc::new(|_| true),
+        Default::default(),
     );
 
     w.enter(Step::Agents);
@@ -432,6 +433,7 @@ fn space_toggles_agents_and_mcp_rows_and_booleans() {
         Vec::new(),
         dir.path(),
         std::sync::Arc::new(|_| true),
+        Default::default(),
     );
 
     w.enter(Step::Agents);
@@ -852,6 +854,7 @@ fn o_opens_the_signup_page_from_both_provider_screens() {
             sink.lock().expect("not poisoned").push(url.to_string());
             true
         }),
+        Default::default(),
     );
 
     w.enter(Step::Providers);
@@ -883,6 +886,7 @@ fn a_browser_that_will_not_open_prints_the_url_instead() {
         Vec::new(),
         dir.path(),
         std::sync::Arc::new(|_| false),
+        Default::default(),
     );
     w.enter(Step::Providers);
 
@@ -1504,6 +1508,7 @@ fn a_configured_provider_outside_the_catalog_still_describes_itself() {
         Vec::new(),
         dir.path(),
         std::sync::Arc::new(|_| true),
+        Default::default(),
     );
     w.enter(Step::Defaults);
 

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -119,6 +119,10 @@ pub struct SetupEnv {
     pub env_lookup: EnvLookup,
     /// Opens a URL in a browser.
     pub opener: leviath_mcp::BrowserOpener,
+    /// Where the offers this user has already turned down are remembered (see
+    /// [`crate::ui_state`]). `None` reads and writes nothing, which is what
+    /// every test gets, so no test can reach the real file.
+    pub ui_state_path: Option<PathBuf>,
 }
 
 // The real `SetupEnv` - the user's actual home, a real `std::env` lookup, and
@@ -146,9 +150,17 @@ pub fn run_non_interactive(args: &SetupArgs, env: &SetupEnv) -> anyhow::Result<(
     };
 
     let applied = plan::apply(
-        &plan::SetupPlan { config, agents },
+        // Nothing was offered here, so nothing was declined: the headless arm
+        // takes its answer from flags and must not rewrite what the wizard
+        // remembered about a person's choices.
+        &plan::SetupPlan {
+            config,
+            agents,
+            declined: Default::default(),
+        },
         &env.config_path,
         &env.agents_dir,
+        None,
     )?;
     report(&applied);
     Ok(())
@@ -249,6 +261,11 @@ fn retarget_default_provider(config: &mut Config) {
 pub fn build_wizard(env: &SetupEnv) -> Wizard {
     let base = Config::load_from_path_public(&env.config_path).unwrap_or_default();
     let (candidates, errors) = state::candidates_from_scans(import::scan(&env.roots));
+    let remembered = env
+        .ui_state_path
+        .as_deref()
+        .map(|p| crate::ui_state::load(p).setup)
+        .unwrap_or_default();
     Wizard::new(
         base,
         &env.env_lookup,
@@ -256,6 +273,7 @@ pub fn build_wizard(env: &SetupEnv) -> Wizard {
         errors,
         &env.agents_dir,
         env.opener.clone(),
+        remembered,
     )
 }
 
@@ -353,7 +371,12 @@ pub async fn execute_core<S: TerminalSetup, E: EventSource>(
 
     match result? {
         Some(plan) => {
-            let applied = plan::apply(&plan, &env.config_path, &env.agents_dir)?;
+            let applied = plan::apply(
+                &plan,
+                &env.config_path,
+                &env.agents_dir,
+                env.ui_state_path.as_deref(),
+            )?;
             report(&applied);
             print_next_steps(&applied);
         }
@@ -441,6 +464,9 @@ mod tests {
             },
             env_lookup: Box::new(|_| None),
             opener: std::sync::Arc::new(|_| true),
+            // Inside the tempdir like everything else, so a test that applies
+            // a plan writes its declines here and never to the real file.
+            ui_state_path: Some(dir.join("ui-state.json")),
         }
     }
 

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -22,6 +22,11 @@ pub struct SetupPlan {
     pub config: Config,
     /// Blueprints to install or update.
     pub agents: Vec<&'static BundledAgent>,
+    /// What was offered and turned down, so the next run does not propose it
+    /// again (see [`crate::ui_state`]). Part of the plan rather than something
+    /// the caller works out afterwards, because it is a thing the user decided
+    /// and this struct is where those live.
+    pub declined: crate::ui_state::SetupUi,
 }
 
 /// What actually happened, for the closing summary.
@@ -41,8 +46,22 @@ pub struct Applied {
 /// fails to install is reported as a warning rather than aborting, because a
 /// written config plus nine of ten agents is a far better place to leave
 /// someone than an abandoned run with nothing saved.
-pub fn apply(plan: &SetupPlan, config_path: &Path, agents_dir: &Path) -> anyhow::Result<Applied> {
+pub fn apply(
+    plan: &SetupPlan,
+    config_path: &Path,
+    agents_dir: &Path,
+    ui_state_path: Option<&Path>,
+) -> anyhow::Result<Applied> {
     plan.config.save_to_path_public(config_path)?;
+
+    // Recorded here rather than as the user toggles, so a wizard abandoned
+    // half-way remembers nothing: the decisions that count are the ones they
+    // finished with. Read-modify-write, since the dashboard keeps its own
+    // memory in the same file.
+    if let Some(path) = ui_state_path {
+        let declined = plan.declined.clone();
+        crate::ui_state::update(path, |state| state.setup = declined);
+    }
 
     let mut agents_installed = Vec::new();
     let mut warnings = Vec::new();
@@ -208,6 +227,7 @@ mod tests {
         SetupPlan {
             config,
             agents: Vec::new(),
+            declined: Default::default(),
         }
     }
 
@@ -223,9 +243,10 @@ mod tests {
         let plan = SetupPlan {
             config,
             agents: vec![&BUNDLED_AGENTS[0]],
+            declined: Default::default(),
         };
 
-        let applied = apply(&plan, &config_path, &agents_dir).unwrap();
+        let applied = apply(&plan, &config_path, &agents_dir, None).unwrap();
 
         assert_eq!(applied.config_path, config_path);
         assert_eq!(applied.agents_installed, vec![BUNDLED_AGENTS[0].name]);
@@ -243,6 +264,64 @@ mod tests {
         );
     }
 
+    /// Applying is what records the refusals, and it must not tread on the
+    /// dashboard's memory in the same file.
+    #[test]
+    fn apply_writes_the_declines_without_disturbing_the_dashboard() {
+        let dir = tempfile::tempdir().unwrap();
+        let ui_state = dir.path().join("ui-state.json");
+        crate::ui_state::update(&ui_state, |s| {
+            s.dashboard.collapsed_runs.insert("run-1".to_string());
+        });
+
+        let mut declined = crate::ui_state::SetupUi::default();
+        declined
+            .declined_mcp
+            .insert(crate::ui_state::mcp_decline_key("cursor", "linear"));
+        let plan = SetupPlan {
+            config: Config::default(),
+            agents: Vec::new(),
+            declined,
+        };
+
+        apply(
+            &plan,
+            &dir.path().join("config.toml"),
+            &dir.path().join("agents"),
+            Some(&ui_state),
+        )
+        .unwrap();
+
+        let saved = crate::ui_state::load(&ui_state);
+        assert!(saved.setup.declined_mcp.contains("cursor:linear"));
+        assert!(
+            saved.dashboard.collapsed_runs.contains("run-1"),
+            "setup must not forget what the dashboard remembered"
+        );
+    }
+
+    /// Without a store - the headless arm, and every test that does not ask
+    /// for one - nothing is written anywhere.
+    #[test]
+    fn apply_without_a_store_records_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut declined = crate::ui_state::SetupUi::default();
+        declined.declined_mcp.insert("cursor:linear".to_string());
+        let plan = SetupPlan {
+            config: Config::default(),
+            agents: Vec::new(),
+            declined,
+        };
+        apply(
+            &plan,
+            &dir.path().join("config.toml"),
+            &dir.path().join("agents"),
+            None,
+        )
+        .unwrap();
+        assert!(!dir.path().join("ui-state.json").exists());
+    }
+
     #[test]
     fn apply_with_nothing_to_install_still_writes_the_config() {
         let dir = tempfile::tempdir().unwrap();
@@ -252,6 +331,7 @@ mod tests {
             &plan_of(Config::default()),
             &config_path,
             &dir.path().join("agents"),
+            None,
         )
         .unwrap();
 
@@ -271,9 +351,10 @@ mod tests {
         let plan = SetupPlan {
             config: Config::default(),
             agents: vec![&BUNDLED_AGENTS[0]],
+            declined: Default::default(),
         };
 
-        let applied = apply(&plan, &config_path, &agents_dir).unwrap();
+        let applied = apply(&plan, &config_path, &agents_dir, None).unwrap();
 
         assert!(applied.agents_installed.is_empty());
         assert_eq!(applied.warnings.len(), 1);
@@ -292,6 +373,7 @@ mod tests {
             &plan_of(Config::default()),
             &blocked.join("config.toml"),
             &dir.path().join("agents"),
+            None,
         );
 
         assert!(result.is_err());
@@ -385,6 +467,7 @@ mod tests {
         let plan = SetupPlan {
             config: after,
             agents: vec![&BUNDLED_AGENTS[0], &BUNDLED_AGENTS[1]],
+            declined: Default::default(),
         };
 
         let lines = changes(&before, &plan);

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -1387,6 +1387,7 @@ mod tests {
             vec!["Zed: unreadable".to_string()],
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         w.providers[0].selected = true;
 
@@ -1430,6 +1431,7 @@ mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         w.providers[1].selected = true;
         w.providers[1].value = "sk-oai".to_string();
@@ -1715,6 +1717,7 @@ mod tests {
             vec!["Zed: couldn't parse this".to_string()],
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         w.enter(Step::Mcp);
 
@@ -1745,6 +1748,7 @@ mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         w.enter(Step::Mcp);
 
@@ -1768,6 +1772,7 @@ mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         w.providers[0].selected = true;
         w.providers[0].value = "sk-ant-x".to_string();

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -136,6 +136,7 @@ impl Wizard {
         scan_errors: Vec<String>,
         agents_dir: &std::path::Path,
         opener: leviath_mcp::BrowserOpener,
+        remembered: crate::ui_state::SetupUi,
     ) -> Self {
         let env_only = env_credentials(env_lookup);
 
@@ -161,30 +162,45 @@ impl Wizard {
         let agents = crate::bundled::plan_agent_actions(agents_dir)
             .into_iter()
             .map(|(agent, action)| AgentRow {
-                selected: action.preselect(),
+                // Still offered, just not pre-checked, when this exact version
+                // was turned down before. Keyed by version so a newer bundled
+                // blueprint is a fresh offer rather than something an old "no
+                // thanks" keeps hidden.
+                selected: action.preselect()
+                    && remembered
+                        .declined_agents
+                        .get(agent.name)
+                        .map(String::as_str)
+                        != Some(agent.version),
                 agent,
                 action,
             })
             .collect();
 
-        let mcp = candidates
-            .into_iter()
-            .map(|(source, candidate)| {
-                let collides =
-                    import::already_configured(&base.mcp_servers, &candidate.config.name);
-                let name = import::dedup_name(&base.mcp_servers, &candidate.config.name);
-                McpRow {
-                    // A server already configured under this name is offered
-                    // unchecked: the user has it, and silently adding a second
-                    // copy under a suffixed name is not what "import" means.
-                    selected: !collides,
-                    source,
-                    collides,
-                    name,
-                    candidate,
-                }
-            })
-            .collect();
+        let mcp =
+            candidates
+                .into_iter()
+                .map(|(source, candidate)| {
+                    let collides =
+                        import::already_configured(&base.mcp_servers, &candidate.config.name);
+                    let name = import::dedup_name(&base.mcp_servers, &candidate.config.name);
+                    McpRow {
+                        // A server already configured under this name is offered
+                        // unchecked: the user has it, and silently adding a second
+                        // copy under a suffixed name is not what "import" means.
+                        // So is one they have already said no to - still listed, so
+                        // they can change their mind, but not proposed again.
+                        selected: !collides
+                            && !remembered.declined_mcp.contains(
+                                &crate::ui_state::mcp_decline_key(&source, &candidate.config.name),
+                            ),
+                        source,
+                        collides,
+                        name,
+                        candidate,
+                    }
+                })
+                .collect();
 
         let (verify_tx, verify_rx) = mpsc::unbounded_channel();
         let (reply_tx, reply_rx) = mpsc::unbounded_channel();
@@ -1014,6 +1030,33 @@ impl Wizard {
                 .filter(|r| r.selected)
                 .map(|r| r.agent)
                 .collect(),
+            declined: self.declined(),
+        }
+    }
+
+    /// What was offered as a change and left unchecked.
+    ///
+    /// Only rows that were a real offer count. An MCP server that collides with
+    /// one already configured, and a blueprint that is up to date or locally
+    /// edited, are unchecked because *we* made them so - reading that back as
+    /// the user's refusal would mean an up-to-date blueprint stayed unchecked
+    /// forever once its next version arrived.
+    fn declined(&self) -> crate::ui_state::SetupUi {
+        crate::ui_state::SetupUi {
+            declined_mcp: self
+                .mcp
+                .iter()
+                .filter(|row| !row.selected && !row.collides)
+                .map(|row| {
+                    crate::ui_state::mcp_decline_key(&row.source, &row.candidate.config.name)
+                })
+                .collect(),
+            declined_agents: self
+                .agents
+                .iter()
+                .filter(|row| !row.selected && row.action.preselect())
+                .map(|row| (row.agent.name.to_string(), row.agent.version.to_string()))
+                .collect(),
         }
     }
 
@@ -1085,7 +1128,141 @@ pub(super) mod tests {
             Vec::new(),
             agents_dir,
             std::sync::Arc::new(|_| true),
+            Default::default(),
         )
+    }
+
+    // ─── remembering what was turned down ─────────────────────────────────
+
+    /// A wizard offered one importable server, with `remembered` as whatever
+    /// the last run recorded.
+    fn wizard_offering_mcp(
+        agents_dir: &std::path::Path,
+        remembered: crate::ui_state::SetupUi,
+    ) -> Wizard {
+        Wizard::new(
+            Config::default(),
+            &|_| None,
+            vec![("cursor".to_string(), candidate("linear"))],
+            Vec::new(),
+            agents_dir,
+            std::sync::Arc::new(|_| true),
+            remembered,
+        )
+    }
+
+    /// The whole point: a server turned down last time is still listed, and
+    /// still unchecked.
+    #[test]
+    fn a_declined_mcp_server_is_offered_again_but_not_preselected() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let fresh = wizard_offering_mcp(dir.path(), Default::default());
+        assert_eq!(fresh.mcp.len(), 1);
+        assert!(fresh.mcp[0].selected, "a first-time offer is pre-checked");
+
+        let mut remembered = crate::ui_state::SetupUi::default();
+        remembered
+            .declined_mcp
+            .insert(crate::ui_state::mcp_decline_key("cursor", "linear"));
+        let second = wizard_offering_mcp(dir.path(), remembered);
+        assert_eq!(
+            second.mcp.len(),
+            1,
+            "still shown, so it can be reconsidered"
+        );
+        assert!(!second.mcp[0].selected, "but not proposed again");
+    }
+
+    /// A decline recorded against a *different* source or name is not this
+    /// server's decline.
+    #[test]
+    fn a_decline_is_scoped_to_the_source_it_came_from() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut remembered = crate::ui_state::SetupUi::default();
+        remembered
+            .declined_mcp
+            .insert(crate::ui_state::mcp_decline_key("claude-code", "linear"));
+        let w = wizard_offering_mcp(dir.path(), remembered);
+        assert!(
+            w.mcp[0].selected,
+            "the same name from another harness is a different offer"
+        );
+    }
+
+    /// Leaving an offered row unchecked is what gets recorded; a row that was
+    /// never a real offer is not.
+    #[test]
+    fn the_plan_records_only_rows_that_were_genuinely_offered() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = wizard_offering_mcp(dir.path(), Default::default());
+        w.mcp[0].selected = false;
+        assert!(
+            w.build_plan()
+                .declined
+                .declined_mcp
+                .contains(&crate::ui_state::mcp_decline_key("cursor", "linear")),
+            "unchecked and importable: a refusal"
+        );
+
+        // Unchecked because it collides with one already configured is our
+        // doing, not the user's, and must not read as a refusal.
+        w.mcp[0].collides = true;
+        assert!(w.build_plan().declined.declined_mcp.is_empty());
+    }
+
+    /// A blueprint turned down stays unchecked - until a newer version makes
+    /// it a different offer.
+    #[test]
+    fn a_declined_blueprint_is_re_offered_when_its_version_moves() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents_dir = dir.path();
+        let offered = &BUNDLED_AGENTS[0];
+
+        let mut remembered = crate::ui_state::SetupUi::default();
+        remembered
+            .declined_agents
+            .insert(offered.name.to_string(), offered.version.to_string());
+        let w = Wizard::new(
+            Config::default(),
+            &|_| None,
+            Vec::new(),
+            Vec::new(),
+            agents_dir,
+            std::sync::Arc::new(|_| true),
+            remembered,
+        );
+        let row = w
+            .agents
+            .iter()
+            .find(|r| r.agent.name == offered.name)
+            .expect("the bundled agent is offered");
+        assert!(
+            row.action.preselect(),
+            "nothing installed, so it is an offer"
+        );
+        assert!(!row.selected, "and it was turned down at this version");
+
+        // A different version is a different offer.
+        let mut moved_on = crate::ui_state::SetupUi::default();
+        moved_on
+            .declined_agents
+            .insert(offered.name.to_string(), "0.0.0-ancient".to_string());
+        let w = Wizard::new(
+            Config::default(),
+            &|_| None,
+            Vec::new(),
+            Vec::new(),
+            agents_dir,
+            std::sync::Arc::new(|_| true),
+            moved_on,
+        );
+        let row = w
+            .agents
+            .iter()
+            .find(|r| r.agent.name == offered.name)
+            .expect("still offered");
+        assert!(row.selected, "a newer version is asked about again");
     }
 
     fn candidate(name: &str) -> Candidate {
@@ -1162,6 +1339,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         let row = wizard
@@ -1189,6 +1367,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         let row = wizard
@@ -1227,6 +1406,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         let row = &wizard.providers[0];
@@ -1245,6 +1425,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         assert!(wizard.env_only.is_empty());
@@ -1264,6 +1445,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         assert_eq!(wizard.mcp.len(), 1);
@@ -1290,6 +1472,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         assert!(!wizard.mcp[0].selected);
@@ -1318,6 +1501,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         wizard.mcp[1].selected = false;
         wizard.mcp[0].name = "renamed".to_string();
@@ -1344,6 +1528,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         assert_eq!(wizard.selected_inline_secrets(), vec!["leaky: API_TOKEN"]);
@@ -1455,6 +1640,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         wizard.enter(Step::Agents);
@@ -1475,6 +1661,7 @@ pub(super) mod tests {
             vec!["Zed: unreadable".to_string()],
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         wizard.enter(Step::Agents);
@@ -1573,6 +1760,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         let (mut requests, _replies) = wizard.take_verify_ends().expect("first take");
 
@@ -1794,6 +1982,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         wizard.providers[0].selected = true;
         wizard.providers[0].outcome = Outcome::Reachable {
@@ -1995,6 +2184,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         assert!(wizard.providers[0].from_env.is_some());
         wizard.edit = Some(Edit {
@@ -2081,6 +2271,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         wizard.providers[0].selected = true;
 
@@ -2128,6 +2319,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
         wizard.edit = Some(Edit {
             target: EditTarget::Credential(0),
@@ -2214,6 +2406,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         wizard.providers[0].selected = false;
@@ -2302,6 +2495,7 @@ pub(super) mod tests {
             Vec::new(),
             dir.path(),
             std::sync::Arc::new(|_| true),
+            Default::default(),
         );
 
         let index = wizard

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -31,4 +31,5 @@ mod test_support;
 pub mod tool_inventory;
 pub mod tools;
 pub mod tui;
+pub mod ui_state;
 pub mod workdir_guard;

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -791,6 +791,9 @@ async fn real_setup(args: commands::setup::SetupArgs) -> anyhow::Result<()> {
         ),
         env_lookup: Box::new(|name| std::env::var(name).ok()),
         opener: std::sync::Arc::new(leviath_sys::open_url),
+        // Shared with the dashboard, so an import somebody has already turned
+        // down is not proposed again the next time they run setup.
+        ui_state_path: leviath_cli::ui_state::default_path(),
     };
     if args.non_interactive {
         return commands::setup::run_non_interactive(&args, &env);

--- a/crates/leviath-cli/src/ui_state.rs
+++ b/crates/leviath-cli/src/ui_state.rs
@@ -1,0 +1,212 @@
+//! What the terminal UIs remember about the choices you have already made.
+//!
+//! A choice is not a view. Folding four finished fan-outs away, cycling the run
+//! list to sort by activity, telling setup you do not want a colleague's MCP
+//! server: each is a person saying what they want, and asking again next time
+//! is the feature failing to be one. One small JSON file under the data dir
+//! holds all of it, per home, so every surface behaves the same way rather than
+//! each inventing its own answer.
+//!
+//! Deliberately *not* `config.toml`. That file is the user's to hand-edit and
+//! is reloaded on change; this is residue the UI writes behind them, and mixing
+//! the two would mean a fold rewriting a hand-edited config.
+//!
+//! ## What belongs here, and what does not
+//!
+//! A remembered choice must be one the user would be annoyed to repeat, and one
+//! whose staleness cannot hurt them. So:
+//!
+//! * **Yes**: folds, sort order, the agent you launch most, the imports you
+//!   have already declined.
+//! * **No**: anything transient (a filter, a search, a selection of runs to
+//!   kill), because reopening the app with yesterday's filter silently applied
+//!   is a bug, not a convenience.
+//! * **No**: anything consequential that is safer off. `--yolo` on the new-run
+//!   screen is deliberately off every time; a setting that runs tools without
+//!   asking, restored out of sight, is exactly the one nobody should inherit
+//!   from last week.
+//!
+//! Every field defaults, so a file written by another build still reads, and a
+//! missing or corrupt one is simply "no memory" - losing a convenience must
+//! never be louder than the thing it was helping with.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+/// Everything the terminal UIs remember, in one file.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UiState {
+    /// `lev dash`.
+    #[serde(default)]
+    pub dashboard: DashboardUi,
+    /// `lev setup`.
+    #[serde(default)]
+    pub setup: SetupUi,
+}
+
+/// What the dashboard remembers.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DashboardUi {
+    /// Run ids whose sub-agents are folded away in the run list. A set, so the
+    /// file is stable rather than reordering itself on every save.
+    #[serde(default)]
+    pub collapsed_runs: BTreeSet<String>,
+    /// The run list's sort order, by its short label (`started`, `activity`,
+    /// `status`). Stored as the label rather than an index so reordering the
+    /// modes cannot silently change what a saved file means.
+    #[serde(default)]
+    pub sort_mode: Option<String>,
+    /// The agent the new-run screen should open on: the last one actually
+    /// launched. Someone who runs `deep-researcher` all day should not scroll
+    /// to it every time.
+    #[serde(default)]
+    pub last_agent: Option<String>,
+}
+
+/// What `lev setup` remembers.
+///
+/// Only *declines*. An acceptance needs no memory: importing a server puts it
+/// in the config, installing a blueprint puts it on disk, and the next run sees
+/// that and offers accordingly. A decline leaves no trace anywhere else, which
+/// is exactly why it has to leave one here.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SetupUi {
+    /// MCP servers offered by the import step and left unchecked, as
+    /// `<source>:<name>`. Still listed next time, just not pre-selected.
+    #[serde(default)]
+    pub declined_mcp: BTreeSet<String>,
+    /// Bundled blueprints offered and left unchecked, agent name to the
+    /// version that was declined.
+    ///
+    /// Keyed by version on purpose: "no thanks" is about the thing that was
+    /// offered, not about the blueprint forever. A newer bundled version is a
+    /// different offer and gets asked again, which is also what keeps a stale
+    /// decline from hiding an upgrade.
+    #[serde(default)]
+    pub declined_agents: BTreeMap<String, String>,
+}
+
+/// How a declined MCP import is named in [`SetupUi::declined_mcp`].
+///
+/// One function so the write and the read cannot spell it differently - a
+/// decline recorded under one key and looked up under another is a memory that
+/// silently does nothing, and nothing about the UI would show it.
+pub fn mcp_decline_key(source: &str, name: &str) -> String {
+    format!("{source}:{name}")
+}
+
+/// The file under the data directory: `ui-state.json`.
+///
+/// `None` when there is no resolvable data dir, which is also what tests get:
+/// nothing then reads or writes, so no test can touch the real one.
+pub fn default_path() -> Option<PathBuf> {
+    leviath_core::paths::data_dir().map(|d| d.join("ui-state.json"))
+}
+
+/// Read the state at `path`. A missing, unreadable or unparseable file is an
+/// empty state.
+pub fn load(path: &Path) -> UiState {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or_default()
+}
+
+/// Write `state` to `path`, creating its directory.
+///
+/// Best effort: a UI that cannot write its memory still works, and a toast
+/// about it would be noise in the middle of whatever the person was doing.
+pub fn save(path: &Path, state: &UiState) {
+    // A relative file name has an empty parent, which `create_dir_all` treats
+    // as already there.
+    let _ = std::fs::create_dir_all(path.parent().unwrap_or(Path::new("")));
+    let text = serde_json::to_string_pretty(state).expect("plain strings and sets serialize");
+    let _ = std::fs::write(path, text);
+}
+
+/// Read, modify, write - so one surface's save cannot drop another's memory.
+///
+/// The dashboard and setup share a file and never run at once, but they do run
+/// in either order, and a whole-struct write built from a stale read would let
+/// the second one silently forget what the first recorded.
+pub fn update(path: &Path, edit: impl FnOnce(&mut UiState)) {
+    let mut state = load(path);
+    edit(&mut state);
+    save(path, &state);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_round_trip_keeps_every_section() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("ui-state.json");
+        let mut state = UiState::default();
+        state.dashboard.collapsed_runs.insert("run-1".to_string());
+        state.dashboard.sort_mode = Some("activity".to_string());
+        state.dashboard.last_agent = Some("deep-researcher".to_string());
+        state
+            .setup
+            .declined_mcp
+            .insert("claude-code:github".to_string());
+        state
+            .setup
+            .declined_agents
+            .insert("researcher".to_string(), "1.2.0".to_string());
+
+        save(&path, &state);
+        assert!(path.exists(), "the store made its own directory");
+        assert_eq!(load(&path), state);
+    }
+
+    /// Nothing written yet, a truncated file, a file holding something else:
+    /// all of them are "no memory", never an error.
+    #[test]
+    fn an_unreadable_store_is_an_empty_one() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            load(&dir.path().join("never-written.json")),
+            UiState::default()
+        );
+
+        let junk = dir.path().join("junk.json");
+        std::fs::write(&junk, "not json at all").unwrap();
+        assert_eq!(load(&junk), UiState::default());
+
+        // A file from a build that knew fewer sections still reads.
+        let older = dir.path().join("older.json");
+        std::fs::write(&older, r#"{"dashboard":{"collapsed_runs":["a"]}}"#).unwrap();
+        let got = load(&older);
+        assert!(got.dashboard.collapsed_runs.contains("a"));
+        assert_eq!(got.setup, SetupUi::default());
+    }
+
+    /// The reason `update` exists: setup writing its declines must not erase
+    /// the folds the dashboard put in the same file.
+    #[test]
+    fn update_leaves_the_other_surface_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ui-state.json");
+
+        update(&path, |s| {
+            s.dashboard.collapsed_runs.insert("run-1".to_string());
+        });
+        update(&path, |s| {
+            s.setup.declined_mcp.insert("cursor:linear".to_string());
+        });
+
+        let got = load(&path);
+        assert!(got.dashboard.collapsed_runs.contains("run-1"), "kept");
+        assert!(got.setup.declined_mcp.contains("cursor:linear"), "added");
+    }
+
+    #[test]
+    fn the_default_path_is_under_the_data_dir() {
+        let path = default_path().expect("this machine has a data dir");
+        assert!(path.ends_with("ui-state.json"), "{path:?}");
+    }
+}

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -640,6 +640,15 @@ first and would take your edits with it.
 `lev run` says the same thing at the moment it matters: a run starting on an installed bundled
 blueprint that this build ships a different version of prints a one-line note before it spawns.
 
+Setup remembers what you turned down. An MCP server you left unchecked, or a blueprint you chose
+not to install, is still listed the next time you run `lev setup` - so you can change your mind -
+but it is no longer pre-selected, and finishing the wizard again will not quietly bring it in.
+Only refusals are remembered, and only from a run you finished: accepting needs no memory, because
+the server lands in your config and the blueprint lands on disk. A blueprint's refusal is recorded
+against the version that was offered, so a newer bundled version is a fresh offer and gets asked
+about again rather than being hidden by an old "no thanks". This lives in `ui-state.json` under the
+data directory, alongside what the dashboard remembers, and never in `config.toml`.
+
 Inside the wizard, the keys work the same way on every screen:
 
 | Key | Meaning |

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -96,10 +96,15 @@ many the fold is hiding. `←` and `→` work the tree, and clicking the arrow d
 remembered by run, so it survives sorting, filtering and new rows arriving above it, and folding
 the run you were inside moves the highlight onto the fold rather than back to the top.
 
-Folds also outlive the dashboard. They are written to `dash/ui-state.json` under the data
-directory as you make them, not on the way out, so a session that ends with the terminal window
-keeps them all the same. A run list starts fully expanded until you fold something; a fold whose
-run is later deleted is forgotten the next time the dashboard can see the run list.
+Folds also outlive the dashboard. They are written to `ui-state.json` under the data directory as
+you make them, not on the way out, so a session that ends with the terminal window keeps them all
+the same. A run list starts fully expanded until you fold something; a fold whose run is later
+deleted is forgotten the next time the dashboard can see the run list.
+
+Two other choices live in that same file: the sort order `s` cycles, and the agent the new-run
+screen opens on, which is whichever one you last launched. Nothing transient joins them - a
+filter, a search and the marks are all gone when you come back, and unattended (`Ctrl-Y`) is
+deliberately off every time the new-run screen opens.
 
 Marking selects several runs at once: press `Space` on each run, then `x` or `d` acts on all of
 them behind one confirmation. Marked rows show a check mark, the pane title counts them, and marks


### PR DESCRIPTION
`lev setup` re-proposed every MCP server it could find, every time. Telling it
no left no trace anywhere - the import simply did not happen - so the next run
had nothing to go on and asked again, with the box ticked.

## What setup remembers now

A declined row is **still listed**, so it can be reconsidered, but it is not
pre-selected and finishing the wizard again will not quietly bring it in.

Only *refusals* are kept. Accepting needs no memory: the server lands in the
config, the blueprint lands on disk, and the next run reads that and offers
accordingly. And only from a run that was **finished** - abandoning the wizard
half-way records nothing, because the decisions that count are the ones you
finished with.

A blueprint's refusal is recorded against **the version that was offered**, so a
newer bundled version is a fresh offer rather than something an old "no thanks"
keeps hidden. That is also the carve-out for "already installed or up to date":
those were never a pre-checked offer, so leaving them unchecked is our doing and
is not read back as the user's refusal.

## The other two surfaces

Same idea, same file (`ui-state.json` under the data dir) rather than each
surface inventing its own answer:

| Surface | Was | Now |
|---|---|---|
| Run list sort (`s`) | reset to `started` every launch | opens on the one you left it on |
| New-run agent picker | always row 0 | opens on the agent you last launched |

The agent is recorded on the **launch**, not on the browse - moving the cursor to
read a blueprint's preview is not choosing it.

## ⚠️ What is deliberately not remembered

The module doc states this, so the next person does not "fix" it:

- **Transient state** - a filter, a search, the run marks. Reopening the app with
  yesterday's filter silently applied is a bug, not a convenience.
- **`--yolo`** on the new-run screen, which is off every time on purpose. A
  setting that runs tools without asking, restored out of sight, is the last one
  anybody should inherit from last week.
- The yolo warning's **"don't ask again"** stays at once-per-sitting. Widening a
  safety prompt is a decision to take deliberately, not a consistency sweep - say
  the word if you want it.

## Housekeeping

The dashboard's store moves from `dash/ui-state.json` to `ui-state.json` beside
it. It shipped in this same unreleased window, so nothing in the wild has one.
Both halves write through a read-modify-write, or setup saving its declines would
drop the dashboard's folds - there is a test for exactly that.

## Verification

`lev setup` driven twice in a pty against an isolated home with a planted Claude
Code config:

```
      run 1 before space: │✓ linear
PASS  a first-time offer is pre-selected
      run 1 after space:  │○ linear
PASS  space turned it down
      declined_mcp: ['Claude Code:linear']
PASS  the refusal was recorded
PASS  and it was not imported
      run 2 declined row:  │○ linear
      run 2 fresh row:     │✓ filesystem
PASS  the refused server is still listed
PASS  but is no longer proposed
PASS  a fresh offer is still proposed
```

The fresh offer in the *same frame* is the control: without it, "everything is
unselected" would explain the result just as well as the feature does. With the
decline check removed, run 2 shows `✓ linear` and the probe fails.

`lev dash` three times: `s` cycles `started → activity`, and the next process
opens on `activity`.

`cargo xtask coverage` is at 100% for all 13 packages.

## Note on the main.rs guard

This needs one field on the production `SetupEnv` in `main.rs`
(`ui_state_path`), following that module's own rule that the real env "is built
in the binary, where those leaves belong". Keeping the path injected is what
stops a test writing to the real file. So the `allow-main-rs-change` label is
needed again, same as #556.
