### PR TITLE
feat(dash): remember how each run's Context tree was left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,11 @@ same list.
   accepting needs no memory, since the server lands in your config and the
   blueprint on disk. A blueprint's refusal is recorded against the version that
   was offered, so a newer one is a fresh offer rather than something an old "no
-  thanks" hides. The dashboard joins it with two more: the sort order `s`
-  cycles, and the agent the new-run screen opens on, which is whichever you last
-  launched.
+  thanks" hides. The dashboard joins it with three more: the sort order `s`
+  cycles, the agent the new-run screen opens on (whichever you last launched),
+  and how each run's Context view was left folded - per run, since folding
+  `conversation` on one says nothing about another, and dropped when that run is
+  deleted or put back to its defaults.
 - Changed: nothing transient or consequential is remembered, deliberately. A
   filter, a search and the run marks are gone when you come back, because
   reopening with yesterday's filter silently applied is a bug rather than a

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -379,6 +379,8 @@ impl Dashboard {
             None => {}
         }
         self.context_tree.follow_cursor = true;
+        // Kept per run, so reopening this one finds it the way it was left.
+        self.save_ui_state();
     }
 
     /// Show stage tab `idx`, from a number key or a click on the tab. Out of

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -426,6 +426,10 @@ impl Dashboard {
         // Default to the stage the run is actually on.
         self.selected_stage = self.selected_agent().map(|a| a.stage_index).unwrap_or(0);
         self.reset_exploration();
+        // …then put this run's Context tree back the way it was left. The reset
+        // above still clears the explorer and the band, which are canvases for
+        // a particular graph and have to be rebuilt for a different run.
+        self.restore_context_tree();
     }
 
     pub(super) fn selected_agent(&self) -> Option<&DashboardAgent> {

--- a/crates/leviath-cli/src/commands/dashboard/ui_state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/ui_state.rs
@@ -1,10 +1,11 @@
 //! The dashboard's half of the shared UI memory (see [`crate::ui_state`]).
 //!
-//! Three things are remembered, and they are the three a person would be
-//! annoyed to redo: which runs' sub-agents are folded away, how the run list is
-//! sorted, and which agent the new-run screen should open on. Everything else
-//! the dashboard holds is either transient (a filter, a search, the marks) or
-//! deliberately reset (`--yolo`), and reads there rather than here.
+//! Four things are remembered, and they are the four a person would be annoyed
+//! to redo: which runs' sub-agents are folded away, how the run list is sorted,
+//! which agent the new-run screen should open on, and how each run's Context
+//! tree was left. Everything else the dashboard holds is either transient (a
+//! filter, a search, the marks) or deliberately reset (`--yolo`), and reads
+//! there rather than here.
 
 use super::state::Dashboard;
 use super::types::SortMode;
@@ -33,6 +34,12 @@ impl Dashboard {
 
     /// Write the remembered view state, keeping whatever `lev setup` put in the
     /// same file.
+    ///
+    /// Also drops per-run Context state for runs that no longer exist. That
+    /// tidying happens here, on a write, rather than on the sync tick: only one
+    /// run's tree is in memory at a time, so noticing a stale row means reading
+    /// the file, and doing that ten times a second to find nothing would be a
+    /// poor trade. Every write is a user action, which is often enough.
     pub(super) fn save_ui_state(&self) {
         let Some(path) = &self.ui_state_path else {
             return;
@@ -41,7 +48,54 @@ impl Dashboard {
             state.dashboard.collapsed_runs = self.collapsed_runs.iter().cloned().collect();
             state.dashboard.sort_mode = Some(self.sort_mode.label().to_string());
             state.dashboard.last_agent = self.last_launched_agent.clone();
+            // Guarded on a non-empty list for the same reason the fold prune
+            // is: "no runs" is also what a runs directory that could not be
+            // read for a moment looks like, and pruning against that would
+            // throw away every run's Context state at once.
+            if !self.agents.is_empty() {
+                let agents = &self.agents;
+                state
+                    .dashboard
+                    .context
+                    .retain(|id, _| agents.iter().any(|a| a.id == *id));
+            }
+            if let Some(run) = self.open_run_id() {
+                let tree = &self.context_tree;
+                let entry = ui_state::ContextUi {
+                    collapsed_regions: tree.collapsed_regions.iter().cloned().collect(),
+                    expanded_entries: tree.expanded_entries.iter().cloned().collect(),
+                };
+                // A run back at its defaults keeps no row of its own, so the
+                // file does not accumulate one per run merely visited.
+                if entry == ui_state::ContextUi::default() {
+                    state.dashboard.context.remove(&run);
+                } else {
+                    state.dashboard.context.insert(run, entry);
+                }
+            }
         });
+    }
+
+    /// Put the Context tree back the way this run was left.
+    ///
+    /// Called when a run's page opens. Nothing saved (or no store) leaves the
+    /// default - regions open, entries closed - which is what a run being seen
+    /// for the first time should look like.
+    pub(super) fn restore_context_tree(&mut self) {
+        let (Some(path), Some(run)) = (&self.ui_state_path, self.open_run_id()) else {
+            return;
+        };
+        let Some(saved) = ui_state::load(path).dashboard.context.remove(&run) else {
+            return;
+        };
+        self.context_tree.collapsed_regions = saved.collapsed_regions.into_iter().collect();
+        self.context_tree.expanded_entries = saved.expanded_entries.into_iter().collect();
+    }
+
+    /// The run whose page is open, which is the one the Context tree belongs
+    /// to.
+    fn open_run_id(&self) -> Option<String> {
+        self.selected_agent().map(|a| a.id.clone())
     }
 }
 
@@ -49,6 +103,42 @@ impl Dashboard {
 mod tests {
     use super::*;
     use crate::commands::dashboard::test_support::make_test_dashboard;
+    use crate::commands::dashboard::types::{AgentDisplayStatus, DashboardAgent};
+
+    /// The least an agent can be and still occupy a row.
+    fn agent(id: &str) -> DashboardAgent {
+        DashboardAgent {
+            id: id.to_string(),
+            blueprint_name: "test-agent".to_string(),
+            stage: "main".to_string(),
+            stage_index: 0,
+            num_stages: 1,
+            status: AgentDisplayStatus::Active,
+            tokens_in: 0,
+            tokens_out: 0,
+            cached_tokens: 0,
+            iteration: 0,
+            waiting_prompt: None,
+            wait_reason: None,
+            pending_request: None,
+            last_answered_request_id: None,
+            context_snapshot: None,
+            stages: vec![],
+            workdir: "/tmp".to_string(),
+            task: "task".to_string(),
+            title: None,
+            model: None,
+            parent_id: None,
+            depth: 0,
+            started_at: 1000,
+            last_progress_at: None,
+            active_until: None,
+            waiting_secs: 0,
+            graph: None,
+            accepts_messages: true,
+            taint_summary: vec![],
+        }
+    }
 
     /// The round trip that makes the feature a feature: choose, quit, come
     /// back, and the choices are still there.
@@ -106,6 +196,104 @@ mod tests {
             dash.collapsed_runs.contains("run-1"),
             "load with no store left memory alone"
         );
+    }
+
+    /// One run's Context folds come back on that run, and do not leak onto
+    /// another. Folding `conversation` while reading run A says nothing about
+    /// run B.
+    #[test]
+    fn the_context_tree_is_remembered_per_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ui-state.json");
+        let mut dash = make_test_dashboard();
+        dash.ui_state_path = Some(path);
+        dash.agents.push(agent("run-a"));
+        dash.agents.push(agent("run-b"));
+        dash.update_display_indices();
+
+        // On run A: fold a region and open an entry.
+        dash.selected = dash.row_of_run("run-a").unwrap();
+        dash.context_tree
+            .collapsed_regions
+            .insert("conversation".to_string());
+        dash.context_tree
+            .expanded_entries
+            .insert(("system".to_string(), 2));
+        dash.save_ui_state();
+
+        // Opening run B starts clean.
+        dash.selected = dash.row_of_run("run-b").unwrap();
+        dash.open_detail_view();
+        assert!(dash.context_tree.collapsed_regions.is_empty());
+        assert!(dash.context_tree.expanded_entries.is_empty());
+
+        // Back to run A, and it is as it was left.
+        dash.selected = dash.row_of_run("run-a").unwrap();
+        dash.open_detail_view();
+        assert!(dash.context_tree.collapsed_regions.contains("conversation"));
+        assert!(
+            dash.context_tree
+                .expanded_entries
+                .contains(&("system".to_string(), 2))
+        );
+    }
+
+    /// A run that is deleted takes its Context state with it, so the file does
+    /// not keep a row per run ever opened.
+    #[test]
+    fn context_state_for_a_vanished_run_is_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ui-state.json");
+        let mut dash = make_test_dashboard();
+        dash.ui_state_path = Some(path.clone());
+        dash.agents.push(agent("run-a"));
+        dash.update_display_indices();
+        dash.context_tree
+            .collapsed_regions
+            .insert("conversation".to_string());
+        dash.save_ui_state();
+        assert!(
+            ui_state::load(&path)
+                .dashboard
+                .context
+                .contains_key("run-a")
+        );
+
+        // Run A is gone and another run exists, so there is a list to prune
+        // against.
+        dash.agents.clear();
+        dash.agents.push(agent("run-b"));
+        dash.update_display_indices();
+        dash.context_tree = Default::default();
+        dash.save_ui_state();
+        assert!(ui_state::load(&path).dashboard.context.is_empty());
+    }
+
+    /// A run put back to its defaults keeps no row, so merely visiting runs
+    /// does not grow the file.
+    #[test]
+    fn a_run_back_at_its_defaults_keeps_no_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("ui-state.json");
+        let mut dash = make_test_dashboard();
+        dash.ui_state_path = Some(path.clone());
+        dash.agents.push(agent("run-a"));
+        dash.update_display_indices();
+
+        dash.context_tree
+            .collapsed_regions
+            .insert("conversation".to_string());
+        dash.save_ui_state();
+        assert!(
+            ui_state::load(&path)
+                .dashboard
+                .context
+                .contains_key("run-a")
+        );
+
+        dash.context_tree.collapsed_regions.clear();
+        dash.save_ui_state();
+        assert!(ui_state::load(&path).dashboard.context.is_empty());
     }
 
     /// Saving the dashboard's memory must not erase setup's, since they share

--- a/crates/leviath-cli/src/ui_state.rs
+++ b/crates/leviath-cli/src/ui_state.rs
@@ -63,6 +63,31 @@ pub struct DashboardUi {
     /// to it every time.
     #[serde(default)]
     pub last_agent: Option<String>,
+    /// How the Context view was left, per run.
+    ///
+    /// Per run rather than per region name: folding `conversation` on one run
+    /// says nothing about another, and an entry index certainly does not - the
+    /// third entry of one run's `system` is not the third of another's.
+    /// Pruned with [`DashboardUi::collapsed_runs`] when a run is deleted, which
+    /// is what stops this growing for every run ever opened.
+    #[serde(default)]
+    pub context: BTreeMap<String, ContextUi>,
+}
+
+/// How one run's Context tree was left.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextUi {
+    /// Regions whose entry list is folded away.
+    #[serde(default)]
+    pub collapsed_regions: BTreeSet<String>,
+    /// `(region, entry index)` pairs opened to their full content.
+    ///
+    /// An index, because that is what the view addresses an entry by. It can
+    /// drift on a *live* run whose region evicts from the front, which is
+    /// already true within a single session and is why this is a convenience
+    /// rather than a promise.
+    #[serde(default)]
+    pub expanded_entries: BTreeSet<(String, usize)>,
 }
 
 /// What `lev setup` remembers.

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -101,10 +101,11 @@ you make them, not on the way out, so a session that ends with the terminal wind
 the same. A run list starts fully expanded until you fold something; a fold whose run is later
 deleted is forgotten the next time the dashboard can see the run list.
 
-Two other choices live in that same file: the sort order `s` cycles, and the agent the new-run
-screen opens on, which is whichever one you last launched. Nothing transient joins them - a
-filter, a search and the marks are all gone when you come back, and unattended (`Ctrl-Y`) is
-deliberately off every time the new-run screen opens.
+Three other choices live in that same file: the sort order `s` cycles, the agent the new-run
+screen opens on (whichever one you last launched), and how each run's [Context view](#context-view)
+was left folded. Nothing transient joins them - a filter, a search and the marks are all gone when
+you come back, and unattended (`Ctrl-Y`) is deliberately off every time the new-run screen opens,
+because a setting that runs tools without asking is not one to inherit out of sight.
 
 Marking selects several runs at once: press `Space` on each run, then `x` or `d` acts on all of
 them behind one confirmation. Marked rows show a check mark, the pane title counts them, and marks
@@ -199,6 +200,14 @@ Space (or by clicking the row), and jump between regions with `[` and `]`. While
 temporarily unfolded so matches inside entries stay reachable. Browsing history with `,`/`.` keeps
 your scroll position and fold state, and the context card's title shows which archived point you
 are on, in which stage, recorded when.
+
+What you fold here is remembered **per run**, and outlives the dashboard: reopening a run finds its
+regions and entries as you left them, while a different run opens at the defaults. Folding
+`conversation` on one run says nothing about another, and an entry index certainly does not. A run
+you put back to its defaults keeps no record at all, and a run you delete takes its record with it.
+The one caveat is a *live* run whose region evicts from the front: entry numbers shift under an
+expansion, which is already true within a single session and is why this is a convenience rather
+than a promise.
 
 ### Stage explorer
 


### PR DESCRIPTION
Follow-up to #557 — the last surface that forgot.

Folding `conversation` away to read the rest of a context window lasted exactly
as long as the page stayed open: `open_detail_view` reset the tree to defaults
every time, so coming back to the same run meant folding it again.

## Per run, because nothing else means anything here

Folding `conversation` on one run says nothing about another, and an entry index
says even less — the third entry of one run's `system` is not the third of
another's. So the store keeps a row per run: opening a run restores its row, and
a different run opens at the defaults.

That required dropping the reset, which is why it was not in #557: persisting
across restarts while still resetting between runs *inside* one session would
have been incoherent. `reset_exploration` still clears the explorer and the band
— those are canvases for a particular graph and have to be rebuilt for a
different run — and the Context tree is restored after it.

## Bounded, so the file cannot grow forever

- A run put back to its defaults keeps **no row**, so merely visiting runs costs
  nothing.
- A run that no longer exists has its row **dropped**.

⚠️ That prune runs on a *write*, not on the sync tick. Only one run's tree is in
memory at a time, so spotting a stale row means reading the file, and doing that
ten times a second to usually find nothing is a poor trade. Every write is a
user action, which is often enough. It carries the same empty-list guard as the
fold prune, since "no runs" is also what an unreadable runs directory looks
like.

## Verification

Three `lev dash` processes over one home:

```
PASS  the context tree is showing
PASS  clicking folded it
PASS  the store recorded it
PASS  the same run reopens folded
PASS  a different run is untouched     ← the control
```

The second run is what rules out "everything just comes back folded". With the
restore removed, `the same run reopens folded` fails and the control still
passes.

`cargo xtask coverage` is at 100% for all 13 packages.

## Unattended stays unremembered

Confirmed on your call, and worth writing down: `--yolo` is off every time the
new-run screen opens, and the yolo warning's "don't ask again" stays
once-per-sitting. A setting that runs tools without asking is not one to inherit
out of sight.
