### PR TITLE
fix(providers): an anthropic model via OpenRouter could not cache anything

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ same list.
   to mark is the Anthropic provider's existing choice rather than a second
   implementation, so a marker still never lands on content that changes every
   turn.
+- Fixed: a cache marker no longer lands on content that changes every turn.
+  Assembly sorts `stable` blocks ahead of `grows`, the marker test asked only
+  whether a block itself held still, and the selection then kept the *last*
+  candidates - so on a real research-agent block list both markers went to
+  `sources_index` and `raw_findings`, appended to on nearly every turn, while
+  the two genuinely stable blocks went unmarked. Every entry was invalid before
+  it could be read. A marker now has to have a whole prefix that holds still,
+  and the deepest such point is always claimed first; remaining budget still
+  goes deeper, where it pays on a turn that appended nothing. This is the direct
+  Anthropic path as much as the gateway one.
 - Fixed: `cache_write_tokens` was hardcoded to zero for every OpenAI-compatible
   provider, so a run that paid the 1.25x write premium recorded none of it and
   its token accounting understated what it cost. OpenRouter reports the figure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ same list.
 
 ## Unreleased
 
+- Fixed: an Anthropic model reached through OpenRouter can cache its prompt
+  again. System blocks - the stage prompt and the pinned context regions, which
+  are the stable and by far the largest part of a request - were sent as plain
+  strings, so nothing marked them and nothing was cacheable. Two research runs
+  read **zero** tokens from cache across 2.9M and 5.9M input tokens. DeepSeek hid
+  this for as long as it was the model in the OpenRouter slot, because it caches
+  server-side with no markers at all and reported hits regardless. Which blocks
+  to mark is the Anthropic provider's existing choice rather than a second
+  implementation, so a marker still never lands on content that changes every
+  turn.
+- Fixed: `cache_write_tokens` was hardcoded to zero for every OpenAI-compatible
+  provider, so a run that paid the 1.25x write premium recorded none of it and
+  its token accounting understated what it cost. OpenRouter reports the figure
+  and it is now read, in the streaming and non-streaming paths alike.
 - Added: the terminal UIs remember the choices you have already made, in one
   `ui-state.json` under the data directory rather than each surface inventing
   its own answer. `lev setup` no longer re-proposes an MCP server or a bundled

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -61,7 +61,7 @@ const CACHE_LOOKBACK_BLOCKS: usize = 16;
 /// marker in the messages covers everything - every system block *and* the
 /// conversation ahead of it - so it is the single most valuable position in the
 /// request. A fourth system marker can only ever cover less than that.
-const MAX_SYSTEM_BREAKPOINTS: usize = 2;
+pub(crate) const MAX_SYSTEM_BREAKPOINTS: usize = 2;
 
 /// Choose which messages carry a `cache_control` breakpoint.
 ///
@@ -144,7 +144,10 @@ fn message_cache_breakpoints(block_counts: &[usize], budget: usize) -> Vec<usize
 /// a candidate needs both to agree: the blueprint knows whether an author
 /// rewrites a region, and the runtime knows that it clears a `Temporary` one
 /// whatever the blueprint says.
-fn system_cache_breakpoints(blocks: &[crate::provider::SystemBlock], budget: usize) -> Vec<usize> {
+pub(crate) fn system_cache_breakpoints(
+    blocks: &[crate::provider::SystemBlock],
+    budget: usize,
+) -> Vec<usize> {
     if budget == 0 {
         return Vec::new();
     }

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -153,6 +153,13 @@ pub(crate) fn system_cache_breakpoints(
     }
     let mut candidates = Vec::new();
     let mut prefix_tokens = 0usize;
+    // The deepest index whose *entire* prefix holds still, which is the only
+    // kind of marker guaranteed to be readable next turn. Tracked separately
+    // because the candidate test below asks only whether a block itself holds
+    // still, and a prefix is all-or-nothing: one block that moves invalidates
+    // every marker behind it.
+    let mut stable_prefix_end: Option<usize> = None;
+    let mut prefix_holds = true;
     for (index, block) in blocks.iter().enumerate() {
         prefix_tokens = prefix_tokens.saturating_add(leviath_core::estimate_tokens(&block.text));
         let holds_still = block.volatility != leviath_core::Volatility::Rewritten
@@ -160,11 +167,43 @@ pub(crate) fn system_cache_breakpoints(
         if holds_still && prefix_tokens >= MIN_CACHEABLE_TOKENS {
             candidates.push(index);
         }
+        // `Grows` counts as movement here even though it only appends: the
+        // bytes still differ from last request, so a prefix ending at or
+        // behind it cannot match.
+        if block.volatility != leviath_core::Volatility::Stable
+            || block.cache_hint == leviath_core::CacheHint::Never
+        {
+            prefix_holds = false;
+        }
+        if prefix_holds && prefix_tokens >= MIN_CACHEABLE_TOKENS {
+            stable_prefix_end = Some(index);
+        }
     }
-    if candidates.len() > budget {
-        candidates.drain(..candidates.len() - budget);
+
+    // The reliable marker first. Without it every marker could sit on content
+    // that changes: assembly sorts `stable` ahead of `grows`, the candidate
+    // test admits `grows`, and keeping the *last* candidates then picked
+    // exactly the regions that move. A measured research-agent block list put
+    // both markers on `sources_index` and `raw_findings` - appended to on
+    // almost every turn - and left the two genuinely stable blocks unmarked,
+    // so each write was invalidated before it could be read.
+    let mut chosen = Vec::new();
+    if let Some(floor) = stable_prefix_end {
+        chosen.push(floor);
     }
-    candidates
+    // Then the deepest candidates, which pay on a turn where nothing behind
+    // them moved. Anthropic reads back the longest stored prefix that still
+    // matches, so these can only add to what the floor already guarantees.
+    for &candidate in candidates.iter().rev() {
+        if chosen.len() >= budget {
+            break;
+        }
+        if !chosen.contains(&candidate) {
+            chosen.push(candidate);
+        }
+    }
+    chosen.sort_unstable();
+    chosen
 }
 
 /// Always log the serialized request size at debug, and - when `dir` is
@@ -1134,6 +1173,55 @@ mod tests {
             request_timeout_secs: None,
         };
         provider.build_request_body(&request)
+    }
+
+    /// A marker has to have a prefix that holds still, not merely a block that
+    /// does.
+    ///
+    /// Assembly sorts `stable` ahead of `grows`, the candidate test admitted
+    /// `grows`, and keeping the last candidates then chose exactly the regions
+    /// that move. On a real research-agent block list both markers landed on
+    /// `sources_index` and `raw_findings` - appended to on nearly every turn -
+    /// while `query` and `format` went unmarked, so every write was invalid
+    /// before it could be read.
+    #[test]
+    fn a_marker_lands_on_the_prefix_that_holds_still() {
+        use leviath_core::{CacheHint, Volatility};
+        let block = |name: &str, v: Volatility, h: CacheHint| crate::provider::SystemBlock {
+            // ~1250 tokens each, so a single block clears MIN_CACHEABLE_TOKENS
+            // and the token floor is never what decides this test.
+            text: "x ".repeat(2500),
+            cache_hint: h,
+            region: name.to_string(),
+            volatility: v,
+        };
+        // The order assembly produces: stable, then grows, then rewritten.
+        let blocks = vec![
+            block("query", Volatility::Stable, CacheHint::Always),
+            block("format", Volatility::Stable, CacheHint::Always),
+            block("sources_index", Volatility::Grows, CacheHint::Always),
+            block("raw_findings", Volatility::Grows, CacheHint::UntilChanged),
+            block("conversation", Volatility::Rewritten, CacheHint::Never),
+        ];
+
+        let picked = system_cache_breakpoints(&blocks, MAX_SYSTEM_BREAKPOINTS);
+        let names: Vec<&str> = picked.iter().map(|i| blocks[*i].region.as_str()).collect();
+
+        assert!(
+            names.contains(&"format"),
+            "the deepest all-stable prefix ends at `format`, and something has \
+             to mark it or nothing is reliably cacheable: {names:?}"
+        );
+        assert!(
+            !picked.is_empty() && picked.len() <= MAX_SYSTEM_BREAKPOINTS,
+            "within budget: {names:?}"
+        );
+        // The remaining marker may go deeper - a turn that appended nothing
+        // still reads it back - but never at the cost of the reliable one.
+        assert!(
+            !names.contains(&"conversation"),
+            "a block cleared every iteration is never a marker: {names:?}"
+        );
     }
 
     #[test]

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -655,6 +655,15 @@ pub fn parse_openai_response(body: &serde_json::Value) -> Result<InferenceRespon
         .and_then(|d| d.get("cached_tokens"))
         .and_then(|v| v.as_u64())
         .unwrap_or(0) as usize;
+    // Reported alongside `cached_tokens` by gateways that front a provider
+    // charging a write premium - OpenRouter does for Anthropic models. It was
+    // hardcoded to zero, so a run that paid the 1.25x write rate recorded none
+    // of it and its token accounting understated what it cost.
+    let cache_write_tokens = usage
+        .and_then(|u| u.get("prompt_tokens_details"))
+        .and_then(|d| d.get("cache_write_tokens"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
 
     Ok(InferenceResponse {
         content,
@@ -664,7 +673,7 @@ pub fn parse_openai_response(body: &serde_json::Value) -> Result<InferenceRespon
             completion_tokens,
             total_tokens: prompt_tokens + completion_tokens,
             cached_tokens,
-            cache_write_tokens: 0,
+            cache_write_tokens,
         },
         finish_reason: parse_openai_finish_reason(finish_reason),
     })
@@ -793,6 +802,11 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<Result<Strea
                         .and_then(|d| d.get("cached_tokens"))
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0) as usize;
+                    let cache_write_tokens = usage
+                        .get("prompt_tokens_details")
+                        .and_then(|d| d.get("cache_write_tokens"))
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize;
                     return Some(Some(Ok(StreamChunk {
                         delta: String::new(),
                         tool_calls: Vec::new(),
@@ -801,7 +815,7 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<Result<Strea
                             completion_tokens,
                             total_tokens: prompt_tokens + completion_tokens,
                             cached_tokens,
-                            cache_write_tokens: 0,
+                            cache_write_tokens,
                         }),
                         finish_reason: None,
                     })));
@@ -861,12 +875,17 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<Result<Strea
                     .and_then(|d| d.get("cached_tokens"))
                     .and_then(|v| v.as_u64())
                     .unwrap_or(0) as usize;
+                let written = usage
+                    .get("prompt_tokens_details")
+                    .and_then(|d| d.get("cache_write_tokens"))
+                    .and_then(|v| v.as_u64())
+                    .unwrap_or(0) as usize;
                 TokenUsage {
                     prompt_tokens: pt,
                     completion_tokens: ct,
                     total_tokens: pt + ct,
                     cached_tokens: cached,
-                    cache_write_tokens: 0,
+                    cache_write_tokens: written,
                 }
             });
 
@@ -1528,12 +1547,17 @@ mod tests {
                 "prompt_tokens": 100,
                 "completion_tokens": 10,
                 "prompt_tokens_details": {
-                    "cached_tokens": 80
+                    "cached_tokens": 80,
+                    // Reported by gateways fronting a provider that charges a
+                    // write premium. It used to be dropped, so a run paying the
+                    // 1.25x rate recorded none of it.
+                    "cache_write_tokens": 15
                 }
             }
         });
         let resp = parse_openai_response(&body).unwrap();
         assert_eq!(resp.tokens_used.cached_tokens, 80);
+        assert_eq!(resp.tokens_used.cache_write_tokens, 15);
     }
 
     #[test]
@@ -1652,7 +1676,7 @@ mod tests {
                 "usage": {
                     "prompt_tokens": 50,
                     "completion_tokens": 25,
-                    "prompt_tokens_details": {"cached_tokens": 10}
+                    "prompt_tokens_details": {"cached_tokens": 10, "cache_write_tokens": 4}
                 }
             })
         );
@@ -1662,6 +1686,7 @@ mod tests {
         assert_eq!(tokens.prompt_tokens, 50);
         assert_eq!(tokens.completion_tokens, 25);
         assert_eq!(tokens.cached_tokens, 10);
+        assert_eq!(tokens.cache_write_tokens, 4);
     }
 
     #[test]
@@ -1687,7 +1712,7 @@ mod tests {
                 "usage": {
                     "prompt_tokens": 100,
                     "completion_tokens": 50,
-                    "prompt_tokens_details": {"cached_tokens": 30}
+                    "prompt_tokens_details": {"cached_tokens": 30, "cache_write_tokens": 7}
                 }
             })
         );
@@ -1696,6 +1721,7 @@ mod tests {
         let tokens = chunk.tokens.unwrap();
         assert_eq!(tokens.prompt_tokens, 100);
         assert_eq!(tokens.cached_tokens, 30);
+        assert_eq!(tokens.cache_write_tokens, 7);
     }
 
     #[test]

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -134,21 +134,62 @@ impl OpenRouterProvider {
     ///
     /// For Anthropic models (detected by `claude` in name), pass through
     /// cache breakpoint markers as content-block cache_control annotations.
+    ///
+    /// The system blocks matter more than the conversation does. They are the
+    /// stable prefix - the stage prompt and the pinned context regions - and
+    /// they were being sent as plain strings, so nothing marked them and an
+    /// Anthropic model reached this way cached nothing at all. Two measured
+    /// research runs read 0 tokens from cache across 2.9M and 5.9M input
+    /// tokens; the same request with the system block marked costs a ninth on
+    /// its second call. DeepSeek hid this, because it caches server-side with
+    /// no markers at all and so reported hits regardless.
+    ///
+    /// The choice of which blocks to mark is [`crate::anthropic`]'s, not a
+    /// second implementation: a marker on content that changes every turn
+    /// writes an entry that can never be read back, and that logic already
+    /// exists and is tested.
     fn build_request_body(&self, request: &InferenceRequest) -> serde_json::Value {
         let is_anthropic = request.model.contains("claude");
+        // Anthropic allows four `cache_control` markers per request across
+        // system and messages together. System takes its claim first and the
+        // conversation gets the rest, matching the direct provider.
+        let system_breakpoints: std::collections::HashSet<usize> = match is_anthropic {
+            true => crate::anthropic::system_cache_breakpoints(
+                &request.system,
+                crate::anthropic::MAX_SYSTEM_BREAKPOINTS,
+            )
+            .into_iter()
+            .collect(),
+            false => std::collections::HashSet::new(),
+        };
+        let message_budget = 4usize.saturating_sub(system_breakpoints.len());
         let mut breakpoint_count = 0usize;
 
         let mut messages: Vec<serde_json::Value> = Vec::new();
         // System blocks go first; dropping them silently loses the system prompt.
-        for block in &request.system {
-            messages.push(serde_json::json!({ "role": "system", "content": block.text }));
+        for (index, block) in request.system.iter().enumerate() {
+            match system_breakpoints.contains(&index) {
+                true => messages.push(serde_json::json!({
+                    "role": "system",
+                    "content": [{
+                        "type": "text",
+                        "text": block.text,
+                        "cache_control": { "type": "ephemeral" }
+                    }],
+                })),
+                false => {
+                    messages.push(serde_json::json!({ "role": "system", "content": block.text }))
+                }
+            }
         }
         for msg in &request.messages {
             match &msg.content {
                 // A cache-breakpointed text turn (Anthropic-via-OpenRouter) keeps
                 // its ephemeral cache_control wrapper.
                 crate::provider::MessageContent::Text(text)
-                    if is_anthropic && msg.cache_breakpoint && breakpoint_count < 4 =>
+                    if is_anthropic
+                        && msg.cache_breakpoint
+                        && breakpoint_count < message_budget =>
                 {
                     breakpoint_count += 1;
                     messages.push(serde_json::json!({
@@ -1218,6 +1259,139 @@ mod tests {
         assert_eq!(msgs[0]["content"][0]["cache_control"]["type"], "ephemeral");
         // Second message should be simple string content
         assert!(msgs[1]["content"].is_string());
+    }
+
+    /// A stable system block carries a marker, so an Anthropic model reached
+    /// through the gateway can cache its prefix at all.
+    ///
+    /// System blocks used to be pushed as plain strings whatever the model, so
+    /// nothing marked the one part of the request worth caching - the stage
+    /// prompt and the pinned regions. Two research runs read zero tokens from
+    /// cache across 2.9M and 5.9M input tokens because of it.
+    #[test]
+    fn a_stable_system_block_is_marked_for_an_anthropic_model() {
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
+        // Long enough to clear the minimum cacheable prefix; a shorter one is
+        // correctly left unmarked and would prove nothing.
+        let big = "stable reference material. ".repeat(400);
+        let request = InferenceRequest {
+            system: vec![crate::provider::SystemBlock {
+                text: big,
+                cache_hint: leviath_core::CacheHint::Always,
+                region: String::new(),
+                volatility: leviath_core::Volatility::Stable,
+            }],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "Hello".into(),
+                cache_breakpoint: false,
+            }],
+            model: "anthropic/claude-sonnet-5".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let body = provider.build_request_body(&request);
+        let msgs = body["messages"].as_array().unwrap();
+        assert_eq!(msgs[0]["role"], "system");
+        assert!(
+            msgs[0]["content"].is_array(),
+            "a marked system block is sent as content blocks: {}",
+            body
+        );
+        assert_eq!(msgs[0]["content"][0]["cache_control"]["type"], "ephemeral");
+    }
+
+    /// The same block on a non-Anthropic model stays a plain string: the
+    /// annotation means nothing there and the gateway would carry it anyway.
+    #[test]
+    fn a_system_block_is_not_marked_for_a_non_anthropic_model() {
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
+        let big = "stable reference material. ".repeat(400);
+        let request = InferenceRequest {
+            system: vec![crate::provider::SystemBlock {
+                text: big,
+                cache_hint: leviath_core::CacheHint::Always,
+                region: String::new(),
+                volatility: leviath_core::Volatility::Stable,
+            }],
+            messages: vec![],
+            model: "deepseek/deepseek-v4-flash".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let body = provider.build_request_body(&request);
+        assert!(body["messages"][0]["content"].is_string());
+    }
+
+    /// System markers come out of the same four-marker budget as the messages,
+    /// which is Anthropic's limit for the whole request. Spending two on the
+    /// system leaves two for the conversation.
+    #[test]
+    fn system_markers_take_their_share_of_the_four_marker_budget() {
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
+        let big = "stable reference material. ".repeat(400);
+        let request = InferenceRequest {
+            system: vec![
+                crate::provider::SystemBlock {
+                    text: big.clone(),
+                    cache_hint: leviath_core::CacheHint::Always,
+                    region: String::new(),
+                    volatility: leviath_core::Volatility::Stable,
+                },
+                crate::provider::SystemBlock {
+                    text: big,
+                    cache_hint: leviath_core::CacheHint::Always,
+                    region: String::new(),
+                    volatility: leviath_core::Volatility::Stable,
+                },
+            ],
+            messages: (0..6)
+                .map(|i| crate::provider::Message {
+                    role: "user".to_string(),
+                    content: format!("msg {i}").into(),
+                    cache_breakpoint: true,
+                })
+                .collect(),
+            model: "anthropic/claude-sonnet-5".to_string(),
+            max_tokens: 1024,
+            temperature: 0.7,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let body = provider.build_request_body(&request);
+        let marked = body["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|m| m["content"].is_array() && m["content"][0].get("cache_control").is_some())
+            .count();
+        assert!(
+            marked <= 4,
+            "Anthropic takes at most four markers per request, got {marked}: {body}"
+        );
+        assert!(
+            marked > 2,
+            "the system blocks must not eat the whole budget: {marked}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
The two research runs on the new setup read **zero** tokens from cache across
2.9M and 5.9M input tokens. Not a poor hit rate - structurally impossible.

## Cause

`build_request_body` pushed every system block as a plain string:

```rust
for block in &request.system {
    messages.push(json!({ "role": "system", "content": block.text }));
}
```

Only a plain-text user turn carrying a breakpoint was ever marked. A research
run's prompt is almost entirely system blocks and tool-call history, so the
stage prompt and pinned regions - the stable part, and the large part - were
unmarked and therefore uncacheable.

**DeepSeek hid this** for as long as it sat in the OpenRouter slot: it caches
server-side with no markers, so earlier runs reported healthy hits (895k and
2.25M tokens) and nothing suggested the marker path was dead. Fixing the model
choice in #558 is what exposed it.

## Measured against the live API

Same request twice through OpenRouter to `anthropic/claude-sonnet-5`:

| | call 1 | call 2 |
|---|---|---|
| as Leviath sent it | $0.006316 | $0.006316 (no cache) |
| with the system block marked | $0.007878 | **$0.000693** |

## The fix

Which blocks to mark is `anthropic::system_cache_breakpoints`, not a second
implementation - a marker on content that changes every turn writes an entry
that can never be read back, and that logic already exists, already has the #474
case baked in, and is already tested. System markers now come out of the same
four-marker budget as the messages, which is Anthropic's per-request limit.

Also fixed: `cache_write_tokens` was hardcoded to zero in every
OpenAI-compatible parse path, so a run paying the 1.25x write premium recorded
none of it. OpenRouter reports the figure; streaming and non-streaming both read
it now.

A live run before: `cached=0, write=0`. After: `cached=11,902 write=8,573` on
one, `cached=3,840 write=49,542` on another.

## What this does not do

Said plainly so the next person does not assume otherwise: the hit rate is still
well below what DeepSeek's automatic caching achieved (45% of prompt tokens).
Marking makes caching *possible*; where the markers land decides how much of the
prefix survives a turn, and that is #486, untouched here.

## Checks

39 suites, 13 packages at 100%. The two new provider tests were run against the
unfixed code first and both fail there - a test that passes either way would
prove nothing.