### PR TITLE
fix(tui): the long-form boxes wrap, and format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,28 @@ same list.
   refusal is now read from the API's own error, the request retried without the
   field, and the answer remembered for the rest of the process. Both the direct
   OpenAI provider and the OpenRouter gateway, which reaches the same models.
+- Fixed: text in the dashboard's long-form boxes wraps instead of running off
+  the edge. The task editor on the new-run screen, the response box, and a
+  stage's system and transition prompts all sat on a textarea left in its
+  default no-wrap mode, which scrolls sideways; with the cursor at the end of
+  a long task, the beginning of what you had just written was off screen. They
+  now wrap at word boundaries and split a word too wide to fit, so a pasted URL
+  stays readable too.
+- Added: those same boxes are one component with markdown formatting. Bold,
+  italic, strikethrough, inline code, a code fence, links, headings, bullet and
+  numbered lists, and quotes, each with a keyboard chord and a clickable button
+  on a toolbar along the top of the box. A chord wraps the selection when there
+  is one (`shift` + arrows selects) and opens an empty pair at the cursor when
+  there is not; the list, heading and quote keys toggle, and apply to every line
+  a selection touches. Chords read `⌘B` on macOS and `ctrl-b` elsewhere, and
+  both modifiers are accepted everywhere, because most terminals never forward
+  Command to the program at all. `F1` / `?` lists the full set.
+- Changed: in a long-form box, `ctrl-b`, `ctrl-d`, `ctrl-e`, `ctrl-k`, `ctrl-l`
+  and `ctrl-o` now format rather than doing what the textarea's built-in emacs
+  bindings did (back a character, delete forward, end of line, delete to end of
+  line). The arrow, Delete and End keys do all of those. In the blueprint
+  editor's prompt overlay `ctrl-e` still hands the prompt to `$EDITOR`, so
+  inline code there is on its alias, `ctrl-t`.
 - Fixed: an Anthropic model reached through OpenRouter can cache its prompt
   again. System blocks - the stage prompt and the pinned context regions, which
   are the stable and by far the largest part of a request - were sent as plain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,13 @@ same list.
 - Changed: in a long-form box, `ctrl-b`, `ctrl-d`, `ctrl-e`, `ctrl-k`, `ctrl-l`
   and `ctrl-o` now format rather than doing what the textarea's built-in emacs
   bindings did (back a character, delete forward, end of line, delete to end of
-  line). The arrow, Delete and End keys do all of those. In the blueprint
-  editor's prompt overlay `ctrl-e` still hands the prompt to `$EDITOR`, so
-  inline code there is on its alias, `ctrl-t`.
+  line). The arrow, Delete and End keys do all of those.
+- Changed: in the agent editor's prompt overlay, "open this prompt in `$EDITOR`"
+  moved from `Ctrl-E` to `F2`, and `F1` now opens the help there (`?` types a
+  question mark inside a prompt, which is why it cannot). `Ctrl-E` is inline
+  code in that overlay like it is in every other long-form box: one chord
+  meaning two things depending on which box you are in is worse than moving the
+  rarer of the two.
 - Fixed: an Anthropic model reached through OpenRouter can cache its prompt
   again. System blocks - the stage prompt and the pinned context regions, which
   are the stable and by far the largest part of a request - were sent as plain

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -980,7 +980,7 @@ fn the_prompts_overlay_edits_applies_and_discards() {
     assert!(screen.contains("Prompts · work"), "{screen}");
     assert!(screen.contains("System prompt"), "{screen}");
     assert!(screen.contains("Transition prompt"), "{screen}");
-    assert!(screen.contains("^e $EDITOR"), "{screen}");
+    assert!(screen.contains("F2 $EDITOR"), "{screen}");
     // Typing lands in the focused box; Tab moves to the other; the keys on
     // the editor underneath (v, u, p) are letters here.
     type_str(&mut dash, " vup");
@@ -1128,12 +1128,13 @@ fn bold_buttons(dash: &mut Dashboard, w: u16, h: u16) -> Vec<(u16, u16)> {
     found
 }
 
-/// The chord path through the same overlay: `Ctrl-E` still means `$EDITOR`
-/// here, so inline code is on its alias, and the rest of the chords reach the
-/// focused box unchanged.
+/// The chord path through the same overlay. `Ctrl-E` is inline code here, the
+/// same as in every other long-form box: this is the overlay that used to
+/// spend that chord on `$EDITOR`, which is now on `F2`.
 #[test]
 fn formatting_chords_reach_the_focused_prompt_box() {
     let (mut dash, root) = dashboard("prompts_chords");
+    dash.external_edit_dir = root.join("scratch");
     open_stage(&mut dash, "own", "work", StageTab::Behaviour);
     goto(&mut dash, FieldId::EditPrompts);
     dash.handle_key(key(KeyCode::Enter));
@@ -1141,8 +1142,18 @@ fn formatting_chords_reach_the_focused_prompt_box() {
 
     dash.handle_key(ctrl('b'));
     type_str(&mut dash, "loud");
-    dash.handle_key(ctrl('t'));
+    dash.handle_key(ctrl('e'));
     type_str(&mut dash, "code");
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(p)) if p.transition.text() == "**loud`code`**"
+    ));
+    // And it formatted rather than reaching for an editor.
+    assert!(!dash.has_external_edit());
+
+    // F1 opens the help without typing into the prompt.
+    dash.handle_key(key(KeyCode::F(1)));
+    assert!(dash.show_help);
     assert!(matches!(
         &dash.agents().editor.as_ref().unwrap().overlay,
         Some(Overlay::Prompts(p)) if p.transition.text() == "**loud`code`**"
@@ -1151,7 +1162,7 @@ fn formatting_chords_reach_the_focused_prompt_box() {
 }
 
 #[test]
-fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
+fn f2_hands_a_prompt_to_the_editor_and_takes_it_back() {
     let (mut dash, root) = dashboard("prompts_external");
     dash.external_edit_dir = root.join("scratch");
     open_stage(&mut dash, "own", "work", StageTab::Behaviour);
@@ -1160,7 +1171,7 @@ fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
     dash.handle_key(key(KeyCode::Tab));
     type_str(&mut dash, "Before.");
     assert!(!dash.has_external_edit());
-    dash.handle_key(ctrl('e'));
+    dash.handle_key(key(KeyCode::F(2)));
     assert!(dash.has_external_edit());
     let edit = dash.take_external_edit().expect("a file to open");
     assert!(!dash.has_external_edit());
@@ -1186,7 +1197,7 @@ fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
             .is_some_and(|m| m.contains("updated"))
     );
     // An editor that failed leaves the box alone and says so.
-    dash.handle_key(ctrl('e'));
+    dash.handle_key(key(KeyCode::F(2)));
     let edit = dash.take_external_edit().unwrap();
     dash.finish_external_edit(edit, Err(std::io::Error::other("no editor")));
     assert!(matches!(
@@ -1203,7 +1214,7 @@ fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
             .is_some_and(|m| m.contains("no editor"))
     );
     // A file that vanished reads the same way.
-    dash.handle_key(ctrl('e'));
+    dash.handle_key(key(KeyCode::F(2)));
     let edit = dash.take_external_edit().unwrap();
     std::fs::remove_file(&edit.path).unwrap();
     dash.finish_external_edit(edit, Ok(()));
@@ -1218,7 +1229,7 @@ fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
     );
     // Coming back with the overlay closed, or the editor closed, or the
     // screen closed, drops the text quietly.
-    dash.handle_key(ctrl('e'));
+    dash.handle_key(key(KeyCode::F(2)));
     let edit = dash.take_external_edit().unwrap();
     dash.handle_key(ctrl('q'));
     dash.finish_external_edit(edit.clone(), Ok(()));
@@ -1235,7 +1246,7 @@ fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
     open_stage(&mut dash, "own", "work", StageTab::Behaviour);
     goto(&mut dash, FieldId::EditPrompts);
     dash.handle_key(key(KeyCode::Enter));
-    dash.handle_key(ctrl('e'));
+    dash.handle_key(key(KeyCode::F(2)));
     assert!(!dash.has_external_edit());
     assert!(
         dash.agents()
@@ -1246,7 +1257,7 @@ fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
             .as_deref()
             .is_some_and(|m| m.contains("Could not hand"))
     );
-    // Ctrl-E with no overlay is a no-op.
+    // F2 with no overlay is a no-op.
     dash.handle_key(ctrl('q'));
     dash.editor_request_external_edit();
     assert!(!dash.has_external_edit());
@@ -1661,7 +1672,7 @@ fn a_system_prompt_comes_back_from_the_editor_too() {
     open_stage(&mut dash, "own", "work", StageTab::Behaviour);
     goto(&mut dash, FieldId::EditPrompts);
     dash.handle_key(key(KeyCode::Enter));
-    dash.handle_key(ctrl('e'));
+    dash.handle_key(key(KeyCode::F(2)));
     let edit = dash.take_external_edit().unwrap();
     assert_eq!(edit.target, PromptFocus::System);
     std::fs::write(&edit.path, "Rewritten.").unwrap();

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -1061,6 +1061,95 @@ fn the_prompts_overlay_edits_applies_and_discards() {
     let _ = std::fs::remove_dir_all(&root);
 }
 
+/// The prompts overlay is two long-form boxes side by side, so it is where a
+/// toolbar press has to pick the right one. Clicking the transition box's `B`
+/// formats *that* box and moves the keys to it.
+#[test]
+fn a_prompt_boxs_toolbar_formats_the_box_that_was_clicked() {
+    let (mut dash, root) = dashboard("prompts_toolbar");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(p)) if p.focus == PromptFocus::System
+    ));
+
+    // Both boxes draw a toolbar; the second one down belongs to the
+    // transition prompt.
+    let buttons = bold_buttons(&mut dash, 160, 50);
+    assert_eq!(buttons.len(), 2, "one toolbar per prompt box");
+    let (x, y) = buttons[1];
+    dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+    let editor = dash.agents().editor.as_ref().unwrap();
+    assert!(matches!(
+        &editor.overlay,
+        Some(Overlay::Prompts(p))
+            if p.focus == PromptFocus::Transition && p.transition.text() == "****"
+    ));
+
+    // A press on the system box's toolbar goes back to it.
+    let (x, y) = buttons[0];
+    let _ = draw(&mut dash, 160, 50);
+    dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(p)) if p.focus == PromptFocus::System
+    ));
+
+    // Away from either toolbar, nothing formats.
+    assert!(!dash.prompts_toolbar_click(x, y + 3));
+
+    // Nor does it with the overlay closed, with the editor closed, or with no
+    // agents screen at all: the overlay's boxes are the only thing it owns.
+    dash.handle_key(ctrl('q'));
+    assert!(!dash.prompts_toolbar_click(x, y));
+    dash.agents().editor = None;
+    assert!(!dash.prompts_toolbar_click(x, y));
+    dash.agent_builder = None;
+    assert!(!dash.prompts_toolbar_click(x, y));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Every `B` button drawn in the frame, top to bottom. The row reads
+/// `" B │ I │ ..."`, so a `B` with an `I` four columns on is a toolbar.
+fn bold_buttons(dash: &mut Dashboard, w: u16, h: u16) -> Vec<(u16, u16)> {
+    let terminal = draw(dash, w, h);
+    let buf = terminal.backend().buffer().clone();
+    let at = |x: u16, y: u16| buf.cell((x, y)).map(|c| c.symbol().to_string());
+    let mut found = Vec::new();
+    for y in 0..h {
+        for x in 0..w.saturating_sub(4) {
+            if at(x, y).as_deref() == Some("B") && at(x + 4, y).as_deref() == Some("I") {
+                found.push((x, y));
+            }
+        }
+    }
+    found
+}
+
+/// The chord path through the same overlay: `Ctrl-E` still means `$EDITOR`
+/// here, so inline code is on its alias, and the rest of the chords reach the
+/// focused box unchanged.
+#[test]
+fn formatting_chords_reach_the_focused_prompt_box() {
+    let (mut dash, root) = dashboard("prompts_chords");
+    open_stage(&mut dash, "own", "work", StageTab::Behaviour);
+    goto(&mut dash, FieldId::EditPrompts);
+    dash.handle_key(key(KeyCode::Enter));
+    dash.handle_key(key(KeyCode::Tab));
+
+    dash.handle_key(ctrl('b'));
+    type_str(&mut dash, "loud");
+    dash.handle_key(ctrl('t'));
+    type_str(&mut dash, "code");
+    assert!(matches!(
+        &dash.agents().editor.as_ref().unwrap().overlay,
+        Some(Overlay::Prompts(p)) if p.transition.text() == "**loud`code`**"
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
 #[test]
 fn ctrl_e_hands_a_prompt_to_the_editor_and_takes_it_back() {
     let (mut dash, root) = dashboard("prompts_external");

--- a/crates/leviath-cli/src/commands/dashboard/agents/prompts.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/prompts.rs
@@ -1,9 +1,16 @@
 //! A stage's prompts, edited full screen: what the stage is told to do
 //! (`system_prompt`) and how it decides where to go next
 //! (`transition_prompt`). `Tab` moves between the two, `Ctrl-S` or `Esc`
-//! applies and closes, `Ctrl-Q` closes without applying, and `Ctrl-E` hands
+//! applies and closes, `Ctrl-Q` closes without applying, and `F2` hands
 //! the focused text to `$EDITOR`: the dashboard leaves the terminal, the
 //! editor runs, and the text comes back into the box.
+//!
+//! `$EDITOR` was on `Ctrl-E` until the boxes became
+//! [`MarkdownEdit`](crate::tui::widgets::markdown_edit::MarkdownEdit)s, where
+//! `Ctrl-E` is inline code in every other long-form box in the dashboard. One
+//! chord meaning two things depending on which box you are in is worse than
+//! moving the rarer of the two, and a function key is the one thing here no
+//! terminal mangles and no text field can swallow.
 
 use std::path::PathBuf;
 
@@ -101,7 +108,9 @@ impl Dashboard {
             }
             (KeyCode::Esc, _) | (KeyCode::Char('s'), true) => self.editor_apply_prompts(),
             (KeyCode::Char('q'), true) => self.editor().overlay = None,
-            (KeyCode::Char('e'), true) => self.editor_request_external_edit(),
+            (KeyCode::F(2), _) => self.editor_request_external_edit(),
+            // F1 rather than `?`, which is a question mark inside a prompt.
+            (KeyCode::F(1), _) => self.show_help = true,
             _ => {
                 prompts.focused_mut().handle_key(key);
             }
@@ -152,8 +161,8 @@ impl Dashboard {
         });
     }
 
-    /// Ctrl-E: write the focused text to a temp file and ask the loop to
-    /// run `$EDITOR` on it.
+    /// F2: write the focused text to a temp file and ask the loop to run
+    /// `$EDITOR` on it.
     pub(super) fn editor_request_external_edit(&mut self) {
         let Some(Overlay::Prompts(prompts)) = self.editor().overlay.as_mut() else {
             return;

--- a/crates/leviath-cli/src/commands/dashboard/agents/prompts.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/prompts.rs
@@ -7,8 +7,8 @@
 
 use std::path::PathBuf;
 
+use crate::tui::widgets::markdown_edit::MarkdownEdit;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use ratatui_textarea::TextArea;
 
 use super::super::state::Dashboard;
 use super::editor::Overlay;
@@ -28,8 +28,8 @@ pub(in crate::commands::dashboard) enum PromptFocus {
 pub(in crate::commands::dashboard) struct PromptsEditor {
     /// The stage whose prompts these are.
     pub(in crate::commands::dashboard) stage: String,
-    pub(in crate::commands::dashboard) system: TextArea<'static>,
-    pub(in crate::commands::dashboard) transition: TextArea<'static>,
+    pub(in crate::commands::dashboard) system: MarkdownEdit,
+    pub(in crate::commands::dashboard) transition: MarkdownEdit,
     pub(in crate::commands::dashboard) focus: PromptFocus,
 }
 
@@ -37,14 +37,14 @@ impl PromptsEditor {
     fn new(stage: &str, system: &str, transition: &str) -> Self {
         Self {
             stage: stage.to_string(),
-            system: textarea(system),
-            transition: textarea(transition),
+            system: MarkdownEdit::from_text(system),
+            transition: MarkdownEdit::from_text(transition),
             focus: PromptFocus::System,
         }
     }
 
     /// The focused box.
-    fn focused_mut(&mut self) -> &mut TextArea<'static> {
+    fn focused_mut(&mut self) -> &mut MarkdownEdit {
         match self.focus {
             PromptFocus::System => &mut self.system,
             PromptFocus::Transition => &mut self.transition,
@@ -52,8 +52,8 @@ impl PromptsEditor {
     }
 
     /// The text of a box, without the trailing newline a textarea adds.
-    fn text_of(area: &TextArea<'static>) -> String {
-        let mut text = area.lines().join("\n");
+    fn text_of(area: &MarkdownEdit) -> String {
+        let mut text = area.text();
         // One trailing newline is how a multi-line prompt ends in the file;
         // a single line has none.
         if text.contains('\n') && !text.ends_with('\n') {
@@ -61,13 +61,6 @@ impl PromptsEditor {
         }
         text
     }
-}
-
-fn textarea(text: &str) -> TextArea<'static> {
-    let mut area = TextArea::new(text.lines().map(str::to_string).collect());
-    area.move_cursor(ratatui_textarea::CursorMove::Bottom);
-    area.move_cursor(ratatui_textarea::CursorMove::End);
-    area
 }
 
 /// Text handed to `$EDITOR`, and where it goes when it comes back.
@@ -110,11 +103,39 @@ impl Dashboard {
             (KeyCode::Char('q'), true) => self.editor().overlay = None,
             (KeyCode::Char('e'), true) => self.editor_request_external_edit(),
             _ => {
-                prompts
-                    .focused_mut()
-                    .input(ratatui_textarea::Input::from(*key));
+                prompts.focused_mut().handle_key(key);
             }
         }
+    }
+
+    /// A press on one of the two prompt boxes' formatting toolbars.
+    ///
+    /// Lives here rather than in `click.rs` because [`Overlay`] and
+    /// [`PromptFocus`] are private to the agents screen, and reaching into an
+    /// overlay from outside it is how the two would drift.
+    pub(in crate::commands::dashboard) fn prompts_toolbar_click(
+        &mut self,
+        column: u16,
+        row: u16,
+    ) -> bool {
+        let Some(screen) = self.agent_builder.as_deref_mut() else {
+            return false;
+        };
+        let Some(editor) = screen.editor.as_mut() else {
+            return false;
+        };
+        let Some(Overlay::Prompts(prompts)) = editor.overlay.as_mut() else {
+            return false;
+        };
+        if prompts.system.click(column, row) {
+            prompts.focus = PromptFocus::System;
+            return true;
+        }
+        if prompts.transition.click(column, row) {
+            prompts.focus = PromptFocus::Transition;
+            return true;
+        }
+        false
     }
 
     /// Write both prompts back and close the overlay.
@@ -193,7 +214,7 @@ impl Dashboard {
                         PromptFocus::System => &mut prompts.system,
                         PromptFocus::Transition => &mut prompts.transition,
                     };
-                    *area = textarea(&text);
+                    *area = MarkdownEdit::from_text(&text);
                 }
                 editor.message = Some("Prompt updated from the editor".to_string());
             }

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
@@ -17,6 +17,7 @@ use super::editor::{Focus, InspectorHits, Overlay};
 use super::inspector::{Field, FieldValue, Panel, StageTab, panel_title};
 use crate::blueprint_edit::check::Severity;
 use crate::tui::widgets::footer::{draw_hint_bar, hint};
+use crate::tui::widgets::markdown_edit::{MdAction, chord_label};
 use crate::tui::widgets::popup::{centered, popup_frame};
 
 /// Under this many columns the panes take turns.
@@ -324,7 +325,9 @@ impl Dashboard {
                 hint("^q", "discard"),
                 hint("tab", "other prompt"),
                 hint("^e", "$EDITOR"),
-                hint("?", "help"),
+                hint(chord_label(MdAction::Bold), "bold"),
+                hint("toolbar", "click to format"),
+                hint("?", "every chord"),
             ]
         } else if editor.overlay.is_some() {
             vec![

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
@@ -324,10 +324,10 @@ impl Dashboard {
                 hint("esc / ^s", "apply"),
                 hint("^q", "discard"),
                 hint("tab", "other prompt"),
-                hint("^e", "$EDITOR"),
+                hint("F2", "$EDITOR"),
                 hint(chord_label(MdAction::Bold), "bold"),
                 hint("toolbar", "click to format"),
-                hint("?", "every chord"),
+                hint("F1", "every chord"),
             ]
         } else if editor.overlay.is_some() {
             vec![

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_prompts.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_prompts.rs
@@ -4,16 +4,16 @@
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
-use ratatui::style::{Color, Modifier, Style};
+use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph};
-use ratatui_textarea::TextArea;
+use ratatui::widgets::{Clear, Paragraph};
 
 use super::super::state::Dashboard;
 use super::super::theme::*;
 use super::editor::Overlay;
 use super::prompts::PromptFocus;
 use crate::tui::widgets::line_edit::LineEdit;
+use crate::tui::widgets::markdown_edit::{MarkdownEdit, MdEditView};
 use crate::tui::widgets::popup::{centered, popup_frame};
 
 impl Dashboard {
@@ -96,33 +96,16 @@ impl Dashboard {
 }
 
 /// One prompt box: framed, the focused one in the focus colour with a
-/// visible cursor.
+/// visible cursor and a lit toolbar.
 fn prompt_box(
     frame: &mut Frame,
     area: Rect,
-    text: &mut TextArea<'static>,
+    text: &mut MarkdownEdit,
     title: &'static str,
     focused: bool,
 ) {
     let colour = if focused { C_BORDER_FOCUS } else { C_BORDER };
-    text.set_block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .border_style(Style::default().fg(colour))
-            .title(Span::styled(
-                title,
-                Style::default().fg(colour).add_modifier(Modifier::BOLD),
-            )),
-    );
-    text.set_style(Style::default().fg(C_WHITE));
-    text.set_cursor_style(if focused {
-        Style::default().fg(Color::Black).bg(C_ACCENT)
-    } else {
-        Style::default()
-    });
-    text.set_cursor_line_style(Style::default());
-    frame.render_widget(&*text, area);
+    text.render(frame, area, &MdEditView::new(title, colour, focused));
 }
 
 /// A one-line name prompt with a help line under it.

--- a/crates/leviath-cli/src/commands/dashboard/click.rs
+++ b/crates/leviath-cli/src/commands/dashboard/click.rs
@@ -14,7 +14,7 @@
 use ratatui::layout::{Position, Rect};
 
 use super::state::Dashboard;
-use super::types::{ClickTarget, MainPane, StageContentMode};
+use super::types::{ClickTarget, MainPane, NewRunPane, StageContentMode};
 
 /// How long after a click a second one on the same cell still counts as a
 /// double click. 400ms is the interval most desktops ship as their default.
@@ -39,6 +39,29 @@ impl Dashboard {
             .rev()
             .find(|(rect, _)| rect.contains(Position::new(column, row)))
             .map(|(_, target)| *target)
+    }
+
+    /// Route a press to the formatting toolbar of whichever long-form editor
+    /// is on screen, reporting whether a button was under it.
+    ///
+    /// This runs ahead of the frame's click registry rather than through it.
+    /// The registry answers "what was drawn here", and an editor's toolbar is
+    /// drawn *over* whatever pane it floats above; a button press that fell
+    /// through to the registry would act on the thing underneath. Clicking a
+    /// button on an unfocused box also focuses it, because a press that
+    /// formats text somewhere the cursor is not is a press nobody meant.
+    pub(super) fn markdown_toolbar_click(&mut self, column: u16, row: u16) -> bool {
+        if self.agent_builder.is_some() {
+            return self.prompts_toolbar_click(column, row);
+        }
+        if self.new_run_screen {
+            if self.new_run_task.click(column, row) {
+                self.new_run_focus = NewRunPane::Task;
+                return true;
+            }
+            return false;
+        }
+        self.input_mode && self.input_textarea.click(column, row)
     }
 
     /// Act on a plain click. Returns whether anything was under it, purely so
@@ -137,6 +160,25 @@ mod tests {
     fn draw(dash: &mut Dashboard, width: u16, height: u16) {
         let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
         terminal.draw(|f| dash.draw(f)).unwrap();
+    }
+
+    /// Where the long-form editor's `B` button landed in the drawn frame.
+    ///
+    /// Found in the buffer rather than computed from the layout, so the test
+    /// clicks the cell a person would click and not the cell the test thinks
+    /// the renderer should have used. The row reads `" B │ I │ ..."`, so a `B`
+    /// with an `I` four columns later is the toolbar and nothing else is.
+    fn find_bold_button(dash: &mut Dashboard, width: u16, height: u16) -> (u16, u16) {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let at = |x: u16, y: u16| buf.cell((x, y)).map(|c| c.symbol().to_string());
+        (0..height)
+            .flat_map(|y| (0..width.saturating_sub(4)).map(move |x| (x, y)))
+            .find(|&(x, y)| {
+                at(x, y).as_deref() == Some("B") && at(x + 4, y).as_deref() == Some("I")
+            })
+            .expect("a formatting toolbar was drawn")
     }
 
     fn press_and_release(dash: &mut Dashboard, column: u16, row: u16) {
@@ -420,5 +462,63 @@ mod tests {
             dash.context_history_idx, None,
             "the ctx chip shows the live window, like the `c` key"
         );
+    }
+
+    // ─── the long-form editors' formatting toolbars ─────────────────────────
+
+    /// The new-run task box: clicking `B` wraps at the cursor and moves the
+    /// keys to the pane you just formatted, so the next thing typed lands
+    /// between the markers.
+    #[test]
+    fn clicking_the_task_boxs_bold_button_formats_it_and_takes_the_focus() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = make_test_dashboard();
+        dash.new_run_ctx.workdir = dir.path().to_path_buf();
+        dash.new_run_ctx.agents_dir = dir.path().join("agents");
+        dash.new_run_ctx.config_path = dir.path().join("config.toml");
+        dash.open_new_run_screen();
+        assert_eq!(dash.new_run_focus, NewRunPane::Agents);
+
+        let (x, y) = find_bold_button(&mut dash, 120, 40);
+        press_and_release(&mut dash, x, y);
+        assert_eq!(dash.new_run_task.text(), "****");
+        assert_eq!(dash.new_run_focus, NewRunPane::Task);
+
+        // A press inside the text itself is not a button press.
+        draw(&mut dash, 120, 40);
+        press_and_release(&mut dash, x, y + 2);
+        assert_eq!(dash.new_run_task.text(), "****");
+    }
+
+    /// The same component, in the response box: the wiring has to find it
+    /// there too, and nowhere else on the screen counts as a button.
+    #[test]
+    fn clicking_the_response_boxs_bold_button_formats_the_response() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(make_test_agent("run-1"));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+
+        let (x, y) = find_bold_button(&mut dash, 120, 40);
+        press_and_release(&mut dash, x, y);
+        assert_eq!(dash.input_textarea.text(), "****");
+
+        // With the box closed there is no toolbar to hit, so the same cell is
+        // an ordinary click again.
+        dash.input_mode = false;
+        draw(&mut dash, 120, 40);
+        assert!(!dash.markdown_toolbar_click(x, y));
+    }
+
+    /// A press on the run list, with no long-form box open anywhere, must not
+    /// be swallowed by the toolbar check that now runs ahead of everything.
+    #[test]
+    fn a_press_with_no_editor_open_falls_through_to_the_panes() {
+        let mut dash = make_test_dashboard();
+        dash.agents.push(make_test_agent("run-1"));
+        dash.update_display_indices();
+        draw(&mut dash, 120, 40);
+        assert!(!dash.markdown_toolbar_click(5, 5));
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -7,8 +7,8 @@
 //! one-time handover of the MCP, spawn, and daemon-command channel ends to the
 //! tasks that own them for the rest of the process.
 
+use crate::tui::widgets::markdown_edit::MarkdownEdit;
 use ratatui::widgets::TableState;
-use ratatui_textarea::TextArea;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
 
@@ -116,7 +116,7 @@ impl Dashboard {
             agents: Vec::new(),
             selected: 0,
             log,
-            input_textarea: TextArea::default(),
+            input_textarea: MarkdownEdit::default(),
             input_mode: false,
             detail_view: false,
             cmd_tx,
@@ -177,7 +177,7 @@ impl Dashboard {
             new_run_agents: Vec::new(),
             new_run_filter: String::new(),
             new_run_selected: 0,
-            new_run_task: TextArea::default(),
+            new_run_task: MarkdownEdit::default(),
             new_run_focus: NewRunPane::Agents,
             new_run_files: Vec::new(),
             new_run_file_ref: false,

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -6,6 +6,7 @@ use super::helpers::truncate;
 use super::state::Dashboard;
 use super::types::*;
 use crate::runstate;
+use crate::tui::widgets::markdown_edit::MarkdownEdit;
 use leviath_core::interaction;
 
 impl Dashboard {
@@ -201,10 +202,8 @@ impl Dashboard {
             .filter(|r| r.kind == InteractionKind::EditText)
             .and_then(|r| r.body.clone());
         self.input_textarea = match seed {
-            Some(body) => {
-                ratatui_textarea::TextArea::new(body.lines().map(|s| s.to_string()).collect())
-            }
-            None => ratatui_textarea::TextArea::default(),
+            Some(body) => MarkdownEdit::from_text(&body),
+            None => MarkdownEdit::default(),
         };
     }
 
@@ -314,21 +313,20 @@ impl Dashboard {
                     }
                     KeyCode::Esc => {
                         self.input_mode = false;
-                        self.input_textarea = ratatui_textarea::TextArea::default();
+                        self.input_textarea = MarkdownEdit::default();
                         self.choice_selected = 0;
                     }
                     KeyCode::PageUp if self.has_scrollable_document() => self.scroll_by(10),
                     KeyCode::PageDown if self.has_scrollable_document() => self.scroll_by(-10),
                     _ => {
-                        self.input_textarea
-                            .input(ratatui_textarea::Input::from(key));
+                        self.input_textarea.handle_key(&key);
                     }
                 }
             }
             _ => match key_code {
                 KeyCode::Esc => {
                     self.input_mode = false;
-                    self.input_textarea = ratatui_textarea::TextArea::default();
+                    self.input_textarea = MarkdownEdit::default();
                     self.choice_selected = 0;
                 }
                 KeyCode::Enter => {
@@ -1027,7 +1025,7 @@ impl Dashboard {
         };
 
         self.input_mode = false;
-        self.input_textarea = ratatui_textarea::TextArea::default();
+        self.input_textarea = MarkdownEdit::default();
         self.choice_selected = 0;
 
         let answered_id = resp.request_id.clone();
@@ -1772,7 +1770,7 @@ mod tests {
         dash.agents.push(agent);
         dash.update_display_indices();
 
-        dash.input_textarea.insert_str("stale");
+        dash.input_textarea.area_mut().insert_str("stale");
         dash.seed_input_textarea();
         // FreeText is not seeded from body → cleared to empty.
         assert_eq!(dash.input_textarea.lines(), vec!["".to_string()]);
@@ -1791,10 +1789,8 @@ mod tests {
         dash.detail_view = true;
         dash.input_mode = true;
 
-        dash.input_textarea = ratatui_textarea::TextArea::new(vec![
-            "  indented".to_string(),
-            "second line".to_string(),
-        ]);
+        dash.input_textarea =
+            MarkdownEdit::new(vec!["  indented".to_string(), "second line".to_string()]);
         dash.submit_input();
 
         assert!(!dash.input_mode);
@@ -1824,7 +1820,7 @@ mod tests {
         dash.input_mode = true;
 
         // Whitespace-only edit → trimmed empty → "(no changes)" display path.
-        dash.input_textarea = ratatui_textarea::TextArea::new(vec!["   ".to_string()]);
+        dash.input_textarea = MarkdownEdit::new(vec!["   ".to_string()]);
         dash.submit_input();
 
         assert!(!dash.input_mode);
@@ -2841,7 +2837,7 @@ mod tests {
         dash.input_mode = true;
 
         // Type something into the textarea
-        dash.input_textarea.insert_str("my answer");
+        dash.input_textarea.area_mut().insert_str("my answer");
 
         dash.submit_input();
 
@@ -2867,7 +2863,7 @@ mod tests {
         dash.detail_view = true;
         dash.input_mode = true;
 
-        dash.input_textarea.insert_str("/quit");
+        dash.input_textarea.area_mut().insert_str("/quit");
 
         dash.submit_input();
 
@@ -3010,7 +3006,9 @@ mod tests {
         dash.detail_view = true;
         dash.input_mode = true;
 
-        dash.input_textarea.insert_str("in-process answer");
+        dash.input_textarea
+            .area_mut()
+            .insert_str("in-process answer");
 
         dash.submit_input();
 
@@ -3018,6 +3016,33 @@ mod tests {
         // Should have sent EngineCommand::SendInput
         let cmd = cmd_rx.try_recv();
         assert!(cmd.is_ok());
+    }
+
+    /// The response box is the shared long-form editor too, so its formatting
+    /// chords have to survive the detail view's key routing.
+    #[test]
+    fn formatting_chords_reach_the_response_box() {
+        let (cmd_tx, _cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Active);
+        agent.pending_request = None;
+        agent.waiting_prompt = None;
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+
+        dash.handle_key(crossterm::event::KeyEvent::new(
+            KeyCode::Char('b'),
+            crossterm::event::KeyModifiers::CONTROL,
+        ));
+        for c in "urgent".chars() {
+            dash.handle_key(crossterm::event::KeyEvent::new(
+                KeyCode::Char(c),
+                crossterm::event::KeyModifiers::NONE,
+            ));
+        }
+        assert_eq!(dash.input_textarea.text(), "**urgent**");
     }
 
     // ─── submit_input with no pending request (mid-run message) ───────────
@@ -3034,7 +3059,7 @@ mod tests {
         dash.detail_view = true;
         dash.input_mode = true;
 
-        dash.input_textarea.insert_str("hello mid-run");
+        dash.input_textarea.area_mut().insert_str("hello mid-run");
 
         dash.submit_input();
 
@@ -3054,7 +3079,7 @@ mod tests {
         dash.detail_view = true;
         dash.input_mode = true;
 
-        dash.input_textarea.insert_str("/exit");
+        dash.input_textarea.area_mut().insert_str("/exit");
         dash.submit_input();
 
         assert!(!dash.input_mode);
@@ -3204,7 +3229,7 @@ mod tests {
         dash.detail_view = true;
         dash.input_mode = true;
 
-        dash.input_textarea.insert_str("answer");
+        dash.input_textarea.area_mut().insert_str("answer");
 
         // Enter with no modifiers should submit
         dash.handle_key(key(KeyCode::Enter));
@@ -3262,7 +3287,7 @@ mod tests {
         dash.detail_view = true;
         dash.input_mode = true;
 
-        dash.input_textarea.insert_str("answer");
+        dash.input_textarea.area_mut().insert_str("answer");
         dash.submit_input();
 
         assert_eq!(

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -25,6 +25,7 @@ use crate::commands::list::{ListFilter, build_list_report};
 use crate::config::Config;
 use crate::daemon::client::{LaunchRequest, never_interactive, resolve_spawn_args};
 use crate::tui::widgets::confirm::Confirm;
+use crate::tui::widgets::markdown_edit::MarkdownEdit;
 
 /// How many ticks the dashboard waits for a just-started run to appear before
 /// giving up on opening its page. At the 250ms tick the loop runs on, this is
@@ -53,7 +54,9 @@ impl Dashboard {
         self.new_run_selected = 0;
         // Filled in below, once the catalog is built: the list has to exist
         // before a name can be found in it.
-        self.new_run_task = ratatui_textarea::TextArea::default();
+        self.new_run_task = MarkdownEdit::default();
+        self.new_run_task
+            .set_placeholder("What should this agent do? Markdown is fine here.");
         // Unattended is off every time the screen opens. It is a consequential
         // setting, and one that survived out of sight is one somebody can
         // leave on and forget.
@@ -158,7 +161,7 @@ impl Dashboard {
             self.toast("Pick an agent blueprint first", ToastLevel::Error);
             return;
         };
-        let task = self.new_run_task.lines().join("\n").trim().to_string();
+        let task = self.new_run_task.text().trim().to_string();
         // An agent driven entirely by `--<region>` flags takes no task, and
         // there is no way to give it one here; that is a `lev run` command line,
         // and the daemon says so if this screen is pointed at such an agent.
@@ -264,9 +267,9 @@ impl Dashboard {
             .map(|p| p.to_string());
         if let Some(path) = chosen {
             for _ in 0..self.new_run_file_query.chars().count() {
-                self.new_run_task.delete_char();
+                self.new_run_task.area_mut().delete_char();
             }
-            self.new_run_task.insert_str(&path);
+            self.new_run_task.area_mut().insert_str(&path);
         }
         self.close_file_ref();
     }
@@ -385,11 +388,11 @@ impl Dashboard {
             KeyCode::Tab | KeyCode::BackTab => self.new_run_focus = NewRunPane::Agents,
             KeyCode::Enter if key.modifiers.is_empty() => self.submit_new_run(),
             KeyCode::Char('@') => {
-                self.new_run_task.insert_char('@');
+                self.new_run_task.area_mut().insert_char('@');
                 self.new_run_file_ref = true;
             }
             _ => {
-                self.new_run_task.input(ratatui_textarea::Input::from(key));
+                self.new_run_task.handle_key(&key);
             }
         }
     }
@@ -410,7 +413,7 @@ impl Dashboard {
                 }
             }
             KeyCode::Backspace => {
-                self.new_run_task.delete_char();
+                self.new_run_task.area_mut().delete_char();
                 // Backspacing over the `@` itself ends the reference; there is
                 // nothing left to complete.
                 match self.new_run_file_query.pop() {
@@ -420,7 +423,7 @@ impl Dashboard {
                 }
             }
             KeyCode::Char(c) => {
-                self.new_run_task.insert_char(c);
+                self.new_run_task.area_mut().insert_char(c);
                 self.new_run_file_query.push(c);
                 self.new_run_file_selected = 0;
             }
@@ -690,7 +693,7 @@ mod tests {
             .expect("the written agent is in the catalog");
         assert_eq!(dash.last_launched_agent, None, "browsing decides nothing");
 
-        dash.new_run_task.insert_str("do the thing");
+        dash.new_run_task.area_mut().insert_str("do the thing");
         dash.submit_new_run();
         assert_eq!(dash.last_launched_agent.as_deref(), Some("zulu"));
     }
@@ -1101,6 +1104,31 @@ mod tests {
         assert!(dash.file_ref_matches().is_empty());
     }
 
+    // ─── formatting ───────────────────────────────────────────────────────
+
+    /// The task box is the shared long-form editor, so its formatting chords
+    /// have to survive the screen's own key routing (which takes Enter, Esc,
+    /// Tab, `@` and Ctrl-Y before anything else sees them).
+    #[test]
+    fn formatting_chords_reach_the_task_box() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_focus = NewRunPane::Task;
+
+        dash.handle_new_run_key(ctrl(KeyCode::Char('b')));
+        for c in "ship it".chars() {
+            dash.handle_new_run_key(key(KeyCode::Char(c)));
+        }
+        assert_eq!(dash.new_run_task.text(), "**ship it**");
+
+        // Ctrl-Y still toggles unattended rather than pasting: the screen's
+        // own chords are matched first, and formatting does not claim `y`.
+        assert!(!dash.new_run_yolo);
+        dash.handle_new_run_key(ctrl(KeyCode::Char('y')));
+        assert_eq!(dash.new_run_task.text(), "**ship it**");
+    }
+
     // ─── submitting ───────────────────────────────────────────────────────
 
     #[test]
@@ -1111,7 +1139,7 @@ mod tests {
         dash.open_new_run_screen();
         dash.new_run_filter = "alpha".to_string();
         dash.new_run_focus = NewRunPane::Task;
-        dash.new_run_task.insert_str("  ship it  ");
+        dash.new_run_task.area_mut().insert_str("  ship it  ");
 
         dash.handle_new_run_key(key(KeyCode::Enter));
 
@@ -1132,7 +1160,7 @@ mod tests {
         let mut dash = dash_at(dir.path());
         dash.open_new_run_screen();
         dash.new_run_focus = NewRunPane::Task;
-        dash.new_run_task.insert_str("   ");
+        dash.new_run_task.area_mut().insert_str("   ");
 
         dash.handle_new_run_key(key(KeyCode::Enter));
         assert!(dash.new_run_screen, "the screen stays open to fix it");
@@ -1147,7 +1175,7 @@ mod tests {
         let mut dash = dash_at(dir.path());
         dash.open_new_run_screen();
         dash.new_run_filter = "no-such-agent-anywhere".to_string();
-        dash.new_run_task.insert_str("do a thing");
+        dash.new_run_task.area_mut().insert_str("do a thing");
 
         dash.submit_new_run();
         assert!(dash.spawn_cmd_rx_for_test().try_recv().is_err());
@@ -1408,7 +1436,7 @@ mod tests {
         let mut dash = dash_at(dir.path());
         dash.open_new_run_screen();
         dash.new_run_focus = NewRunPane::Task;
-        dash.new_run_task.insert_str("do the thing");
+        dash.new_run_task.area_mut().insert_str("do the thing");
         dash.new_run_yolo = true;
 
         dash.submit_new_run();

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -13,6 +13,7 @@ use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
 use crate::commands::dashboard::types::*;
 use crate::runstate;
+use crate::tui::widgets::markdown_edit::MdEditView;
 
 /// Replace a leading `home` prefix in `raw` with `~`. Split out so both the
 /// shortened and the raw (path-is-outside-home) branches are unit-testable on
@@ -177,24 +178,13 @@ impl Dashboard {
         // instead of the read-only stage output - so the user revises the plan
         // in place rather than in the bottom input bar.
         if self.editing_document() {
-            self.input_textarea.set_block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(C_SUCCESS))
-                    .title(Span::styled(
-                        " ✎ Editing this document - your changes replace it  ·  [Enter] save  \
-                         [Alt+↵] newline  [Esc] cancel ",
-                        Style::default().fg(C_SUCCESS).add_modifier(Modifier::BOLD),
-                    )),
+            let view = MdEditView::new(
+                " ✎ Editing this document - your changes replace it  ·  [Enter] save  \
+                 [Alt+↵] newline  [Esc] cancel ",
+                C_SUCCESS,
+                true,
             );
-            self.input_textarea.set_style(Style::default().fg(C_WHITE));
-            self.input_textarea.set_cursor_style(
-                Style::default()
-                    .fg(ratatui::style::Color::Black)
-                    .bg(C_ACCENT),
-            );
-            frame.render_widget(&self.input_textarea, content_area);
+            self.input_textarea.render(frame, content_area, &view);
             return;
         }
 

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -12,6 +12,7 @@ use crate::commands::dashboard::helpers::truncate;
 use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
 use crate::commands::dashboard::types::*;
+use crate::tui::widgets::markdown_edit::MdEditView;
 use leviath_core::interaction;
 
 impl Dashboard {
@@ -109,23 +110,10 @@ impl Dashboard {
             } else {
                 " Response  [Enter] send  [Alt+↵] newline  [Esc] cancel "
             };
-            self.input_textarea.set_block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_type(BorderType::Rounded)
-                    .border_style(Style::default().fg(C_SUCCESS))
-                    .title(Span::styled(
-                        hint,
-                        Style::default().fg(C_SUCCESS).add_modifier(Modifier::BOLD),
-                    )),
-            );
-            self.input_textarea.set_style(Style::default().fg(C_WHITE));
-            self.input_textarea.set_cursor_style(
-                Style::default()
-                    .fg(ratatui::style::Color::Black)
-                    .bg(C_ACCENT),
-            );
-            frame.render_widget(&self.input_textarea, prompt_area);
+            // The response box is a long-form field: it wraps, and it carries
+            // the same formatting toolbar as the task editor.
+            let view = MdEditView::new(hint, C_SUCCESS, true);
+            self.input_textarea.render(frame, prompt_area, &view);
         } else {
             let (title, prompt_lines): (&str, Vec<Line>) = if self.input_mode {
                 let mut lines: Vec<Line> = vec![];

--- a/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
@@ -12,6 +12,7 @@ use ratatui::widgets::{
 use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
 use crate::commands::dashboard::types::NewRunPane;
+use crate::tui::widgets::markdown_edit::{MdAction, MdEditView, chord_label};
 
 impl Dashboard {
     pub(in crate::commands::dashboard) fn draw_new_run_screen(
@@ -139,35 +140,30 @@ impl Dashboard {
             .new_run_selected_agent()
             .map(|a| a.name.clone())
             .unwrap_or_else(|| "no agent blueprint selected".to_string());
-        self.new_run_task.set_block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .border_style(focus_style(focused))
-                .title(Line::from(vec![
-                    Span::styled(
-                        format!(" Task for {agent} "),
-                        Style::default()
-                            .fg(focus_colour(focused))
-                            .add_modifier(Modifier::BOLD),
+        let view = MdEditView::titled(
+            Line::from(vec![
+                Span::styled(
+                    format!(" Task for {agent} "),
+                    Style::default()
+                        .fg(focus_colour(focused))
+                        .add_modifier(Modifier::BOLD),
+                ),
+                // On the title rather than the help bar: this is the pane
+                // you are looking at when you press Enter, and a setting
+                // this consequential should not be one line further away
+                // than the thing it changes.
+                match self.new_run_yolo {
+                    true => Span::styled(
+                        "[ unattended ] ",
+                        Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
                     ),
-                    // On the title rather than the help bar: this is the pane
-                    // you are looking at when you press Enter, and a setting
-                    // this consequential should not be one line further away
-                    // than the thing it changes.
-                    match self.new_run_yolo {
-                        true => Span::styled(
-                            "[ unattended ] ",
-                            Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
-                        ),
-                        false => Span::styled("", Style::default()),
-                    },
-                ])),
+                    false => Span::styled("", Style::default()),
+                },
+            ]),
+            focus_colour(focused),
+            focused,
         );
-        self.new_run_task.set_style(Style::default().fg(C_WHITE));
-        self.new_run_task
-            .set_cursor_style(Style::default().fg(Color::Black).bg(C_ACCENT));
-        frame.render_widget(&self.new_run_task, area);
+        self.new_run_task.render(frame, area, &view);
     }
 
     /// The `@` completion, drawn as a floating menu inside the task pane.
@@ -219,13 +215,18 @@ impl Dashboard {
 
     fn draw_new_run_help_bar(&self, frame: &mut Frame, area: Rect) {
         let hint = match (self.new_run_file_ref, self.new_run_focus) {
-            (true, _) => " ↑↓ choose · Enter/Tab insert · Esc dismiss ",
+            (true, _) => " ↑↓ choose · Enter/Tab insert · Esc dismiss ".to_string(),
             (false, NewRunPane::Agents) => {
                 " ↑↓ select · type to filter · Tab write task · ^Y unattended · F1 help · Esc back "
+                    .to_string()
             }
-            (false, NewRunPane::Task) => {
-                " Enter start · Alt+↵ newline · @ file · ^Y unattended · F1 help · Esc back "
-            }
+            // The formatting chord is named on the pane that has the toolbar,
+            // and only there: on the picker it would be a key that does
+            // nothing.
+            (false, NewRunPane::Task) => format!(
+                " Enter start · Alt+↵ newline · @ file · {} bold · ^Y unattended · F1 help · Esc back ",
+                chord_label(MdAction::Bold)
+            ),
         };
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(hint, Style::default().fg(C_DIM)))),

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -11,6 +11,7 @@ use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
 use crate::commands::dashboard::types::MainPane;
 use crate::tui::widgets::help::{HelpSection, draw_help};
+use crate::tui::widgets::markdown_edit::shortcut_help;
 
 impl Dashboard {
     pub(in crate::commands::dashboard) fn draw_toasts(&self, frame: &mut Frame) {
@@ -237,9 +238,36 @@ fn agent_editor_sections() -> Vec<HelpSection> {
                     "ctrl-e",
                     "open the focused prompt in $EDITOR (the dashboard waits for it)",
                 ),
+                (
+                    "",
+                    "so inline code is ctrl-t here; the toolbar button does it too",
+                ),
             ],
         },
+        formatting_section(),
     ]
+}
+
+/// The long-form editor's formatting chords.
+///
+/// Shown on every screen that has one of those boxes, because the box is the
+/// same component in all of them. Every chord has a button on the box's
+/// toolbar as well, which is the path that still works on a terminal that
+/// cannot report the chord at all.
+fn formatting_section() -> HelpSection {
+    let mut entries = shortcut_help();
+    entries.push((
+        "click",
+        "the same actions, from the button row along the top of the box",
+    ));
+    entries.push((
+        "shift + ← →",
+        "select first, to wrap text that is already written",
+    ));
+    HelpSection {
+        title: "Formatting a long-form box",
+        entries,
+    }
 }
 
 /// The run list: the screen `lev dash` opens on.
@@ -374,6 +402,7 @@ fn detail_sections() -> Vec<HelpSection> {
                 ("esc", "cancel"),
             ],
         },
+        formatting_section(),
     ]
 }
 
@@ -423,6 +452,7 @@ fn new_run_sections() -> Vec<HelpSection> {
                 ),
             ],
         },
+        formatting_section(),
     ]
 }
 

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -235,13 +235,10 @@ fn agent_editor_sections() -> Vec<HelpSection> {
                 ("ctrl-s / esc", "apply both and close"),
                 ("ctrl-q", "close without applying"),
                 (
-                    "ctrl-e",
+                    "F2",
                     "open the focused prompt in $EDITOR (the dashboard waits for it)",
                 ),
-                (
-                    "",
-                    "so inline code is ctrl-t here; the toolbar button does it too",
-                ),
+                ("F1", "this help (? types a question mark in a prompt)"),
             ],
         },
         formatting_section(),

--- a/crates/leviath-cli/src/commands/dashboard/run_actions.rs
+++ b/crates/leviath-cli/src/commands/dashboard/run_actions.rs
@@ -5,7 +5,7 @@ use super::helpers::truncate;
 use super::state::Dashboard;
 use super::types::*;
 use crate::runstate;
-use ratatui_textarea::TextArea;
+use crate::tui::widgets::markdown_edit::MarkdownEdit;
 
 impl Dashboard {
     /// Open the kill confirmation. Acts on every marked run that is killable
@@ -127,7 +127,7 @@ impl Dashboard {
         }
         // Any half-typed response to the killed run is moot.
         self.input_mode = false;
-        self.input_textarea = TextArea::default();
+        self.input_textarea = MarkdownEdit::default();
         self.add_log(format!("{run_id}: kill requested"));
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/selection.rs
+++ b/crates/leviath-cli/src/commands/dashboard/selection.rs
@@ -136,6 +136,14 @@ impl Dashboard {
     /// cursor, hit-tested against the rects each renderer registered this
     /// frame - not whichever pane the keyboard last touched.
     pub(super) fn handle_mouse(&mut self, event: MouseEvent) {
+        // A formatting button on a long-form editor takes a press before any
+        // pane does: the toolbar is drawn over the pane behind it, so a press
+        // routed by position alone would act on that pane instead.
+        if matches!(event.kind, MouseEventKind::Down(MouseButton::Left))
+            && self.markdown_toolbar_click(event.column, event.row)
+        {
+            return;
+        }
         // The Agents screen's chooser and canvas take the mouse first.
         if self.agent_builder.is_some() && self.handle_agents_mouse(event) {
             return;

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -2,9 +2,10 @@
 
 use leviath_runtime::control_socket::{ControlClient, ControlRequest, ControlResponse};
 use ratatui::widgets::TableState;
-use ratatui_textarea::TextArea;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
+
+use crate::tui::widgets::markdown_edit::MarkdownEdit;
 
 use super::graph::load_stage_graph;
 use super::helpers::truncate;
@@ -17,8 +18,10 @@ pub(crate) struct Dashboard {
     pub(super) agents: Vec<DashboardAgent>,
     pub(super) selected: usize,
     pub(super) log: Vec<LogEntry>,
-    /// Multi-line input textarea (active when input_mode = true and kind = FreeText).
-    pub(super) input_textarea: TextArea<'static>,
+    /// The long-form response editor (active when input_mode = true and the
+    /// interaction takes free text). Soft-wrapped and markdown-aware, the same
+    /// component the new-run task and the blueprint prompts use.
+    pub(super) input_textarea: MarkdownEdit,
     pub(super) input_mode: bool,
     /// True when the full-screen detail view is open for the selected agent
     pub(super) detail_view: bool,
@@ -186,9 +189,9 @@ pub(crate) struct Dashboard {
     pub(super) new_run_filter: String,
     /// Selected row of the *filtered* agent list.
     pub(super) new_run_selected: usize,
-    /// The task editor. The same `TextArea` the response pane uses, so word
+    /// The task editor. The same [`MarkdownEdit`] the response pane uses, so word
     /// motions, selection, and undo behave identically in both.
-    pub(super) new_run_task: TextArea<'static>,
+    pub(super) new_run_task: MarkdownEdit,
     /// Which of the two panes has the keys.
     pub(super) new_run_focus: NewRunPane,
     /// Workdir-relative file paths the `@` completion offers, walked once when

--- a/crates/leviath-cli/src/tui/widgets/markdown_edit.rs
+++ b/crates/leviath-cli/src/tui/widgets/markdown_edit.rs
@@ -1,0 +1,925 @@
+//! The crate's long-form text editor: soft-wrapped, markdown-aware, with a
+//! clickable formatting toolbar.
+//!
+//! Every multi-line box in the TUI (the new-run task, the response pane, a
+//! stage's system and transition prompts) used a bare `ratatui-textarea` with
+//! its default `WrapMode::None`, which scrolls sideways instead of wrapping.
+//! A task longer than the pane is wide therefore ran off the edge, and the
+//! text you had just typed was not on screen. This wraps at word boundaries,
+//! falling back to splitting a word wider than the pane, so what you type
+//! stays inside the box.
+//!
+//! On top of that it adds what a person expects from a text editor: chords for
+//! bold / italic / strikethrough / code / links, and a row of buttons that do
+//! the same thing with the mouse. Both go through [`MdAction`], so a binding
+//! and its button cannot drift apart.
+//!
+//! Short fields (an agent's name, a numeric limit) stay on
+//! [`LineEdit`](super::line_edit::LineEdit). This one is for prose.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::Frame;
+use ratatui::layout::{Position, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, BorderType, Borders, Paragraph};
+use ratatui_textarea::{CursorMove, TextArea, WrapMode};
+
+use crate::tui::theme::{C_ACCENT, C_BORDER, C_DIM, C_MUTED, C_WHITE};
+
+/// Each [`TOOLBAR`] action's chord, spelled the way this platform's users
+/// write it. Paired with `TOOLBAR` by index, and a test holds the two the same
+/// length.
+///
+/// macOS says Command, everybody else says Control. Only the *label* differs:
+/// both modifiers are accepted everywhere (see [`action_for`]), because most
+/// terminal emulators never forward Command to the program at all, and an
+/// editor that listened only for the platform-correct one would be an editor
+/// with no working chords on macOS Terminal.
+///
+/// `cfg` rather than a runtime branch, so there is no arm a platform's own
+/// coverage run can never reach.
+#[cfg(target_os = "macos")]
+const CHORD_LABELS: [&str; 10] = ["⌘B", "⌘I", "⌘D", "⌘E", "⌘⇧E", "⌘K", "⌘H", "⌘L", "⌘O", "⌘."];
+/// Each [`TOOLBAR`] action's chord, spelled for this platform.
+#[cfg(not(target_os = "macos"))]
+const CHORD_LABELS: [&str; 10] = [
+    "ctrl-b",
+    "ctrl-i",
+    "ctrl-d",
+    "ctrl-e",
+    "ctrl-shift-e",
+    "ctrl-k",
+    "ctrl-h",
+    "ctrl-l",
+    "ctrl-o",
+    "ctrl-.",
+];
+
+/// The chord that runs `action`, as a person reads it here.
+pub(crate) fn chord_label(action: MdAction) -> &'static str {
+    // `unwrap_or` rather than a guard: every action is in `TOOLBAR`, and a
+    // branch that cannot be taken is a branch no test can cover.
+    let i = TOOLBAR.iter().position(|a| *a == action).unwrap_or(0);
+    CHORD_LABELS[i]
+}
+
+/// Every chord and what it does, ready to drop into a help overlay.
+pub(crate) fn shortcut_help() -> Vec<(&'static str, &'static str)> {
+    TOOLBAR
+        .iter()
+        .zip(CHORD_LABELS)
+        .map(|(action, chord)| (chord, action.name()))
+        .collect()
+}
+
+/// One formatting command. A chord and a toolbar button both resolve to this.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MdAction {
+    /// `**bold**`.
+    Bold,
+    /// `*italic*`.
+    Italic,
+    /// `~~struck through~~`.
+    Strike,
+    /// `` `inline code` ``.
+    Code,
+    /// A fenced code block.
+    CodeBlock,
+    /// `[text](url)`.
+    Link,
+    /// Cycle the line between `#`, `##`, `###` and no heading.
+    Heading,
+    /// Toggle a `- ` bullet on the line.
+    Bullet,
+    /// Toggle a `1. ` number on the line.
+    Ordered,
+    /// Toggle a `> ` quote on the line.
+    Quote,
+}
+
+impl MdAction {
+    /// The button's face. Short on purpose: ten of these share one row.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Bold => "B",
+            Self::Italic => "I",
+            Self::Strike => "S",
+            Self::Code => "<>",
+            Self::CodeBlock => "```",
+            Self::Link => "[]",
+            Self::Heading => "H",
+            Self::Bullet => "•",
+            Self::Ordered => "1.",
+            Self::Quote => ">",
+        }
+    }
+
+    /// What the button does, in words.
+    pub(crate) fn name(self) -> &'static str {
+        match self {
+            Self::Bold => "bold",
+            Self::Italic => "italic",
+            Self::Strike => "strikethrough",
+            Self::Code => "inline code",
+            Self::CodeBlock => "code block",
+            Self::Link => "link",
+            Self::Heading => "heading",
+            Self::Bullet => "bullet list",
+            Self::Ordered => "numbered list",
+            Self::Quote => "quote",
+        }
+    }
+}
+
+/// The toolbar, left to right.
+pub(crate) const TOOLBAR: [MdAction; 10] = [
+    MdAction::Bold,
+    MdAction::Italic,
+    MdAction::Strike,
+    MdAction::Code,
+    MdAction::CodeBlock,
+    MdAction::Link,
+    MdAction::Heading,
+    MdAction::Bullet,
+    MdAction::Ordered,
+    MdAction::Quote,
+];
+
+/// Heading prefixes, in the order the heading key cycles them.
+const HEADINGS: [&str; 3] = ["# ", "## ", "### "];
+
+/// Resolve a key event to a formatting action.
+///
+/// Both `Ctrl` and `Super` count as the chord modifier (see [`CHORD_LABELS`]
+/// for why both). Terminals that cannot report a chord simply never produce
+/// one, and the toolbar is there for exactly that case.
+///
+/// Note what is deliberately load-bearing here: in a terminal without the
+/// kitty keyboard protocol, `Ctrl-I` arrives as `Tab` and `Ctrl-H` as
+/// `Backspace`, so those two chords only reach us where the terminal can tell
+/// them apart. Nothing regresses when it cannot; Tab and Backspace keep their
+/// meaning and the buttons still work.
+pub(crate) fn action_for(key: &KeyEvent) -> Option<MdAction> {
+    let mods = key.modifiers;
+    if !mods.contains(KeyModifiers::CONTROL) && !mods.contains(KeyModifiers::SUPER) {
+        return None;
+    }
+    let KeyCode::Char(c) = key.code else {
+        return None;
+    };
+    // A terminal may report Shift as the flag, as an uppercased char, or both.
+    let shift = mods.contains(KeyModifiers::SHIFT) || c.is_uppercase();
+    match (c.to_ascii_lowercase(), shift) {
+        ('b', _) => Some(MdAction::Bold),
+        ('i', _) => Some(MdAction::Italic),
+        ('d', _) => Some(MdAction::Strike),
+        ('e', false) => Some(MdAction::Code),
+        // `Ctrl-E` is already "hand this to $EDITOR" in the blueprint editor's
+        // prompt overlay, which takes its own keys before delegating here.
+        // `Ctrl-T` is the alias that works in every box.
+        ('t', _) => Some(MdAction::Code),
+        ('e', true) => Some(MdAction::CodeBlock),
+        ('k', _) => Some(MdAction::Link),
+        ('h', _) => Some(MdAction::Heading),
+        ('l', _) => Some(MdAction::Bullet),
+        ('o', _) => Some(MdAction::Ordered),
+        ('.', _) => Some(MdAction::Quote),
+        _ => None,
+    }
+}
+
+/// How a [`MarkdownEdit`] is framed this frame.
+pub(crate) struct MdEditView {
+    /// The block's title.
+    pub(crate) title: Line<'static>,
+    /// Border colour.
+    pub(crate) border: Color,
+    /// Whether this box has the keys: it gets a visible cursor and a lit
+    /// toolbar.
+    pub(crate) focused: bool,
+}
+
+impl MdEditView {
+    /// A framed box with a plain text title, styled to match its border.
+    pub(crate) fn new(title: impl Into<String>, border: Color, focused: bool) -> Self {
+        Self::titled(
+            Line::from(Span::styled(
+                title.into(),
+                Style::default().fg(border).add_modifier(Modifier::BOLD),
+            )),
+            border,
+            focused,
+        )
+    }
+
+    /// The same, with a title the caller has already styled.
+    pub(crate) fn titled(title: Line<'static>, border: Color, focused: bool) -> Self {
+        Self {
+            title,
+            border,
+            focused,
+        }
+    }
+}
+
+/// A soft-wrapping, markdown-aware multi-line editor.
+#[derive(Debug, Clone)]
+pub(crate) struct MarkdownEdit {
+    area: TextArea<'static>,
+    /// Where each toolbar button landed in the last frame, for hit testing.
+    /// Empty until the first draw, and rewritten by every draw.
+    buttons: Vec<(Rect, MdAction)>,
+}
+
+impl Default for MarkdownEdit {
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+impl MarkdownEdit {
+    /// An editor over `lines`, cursor at the end of the text.
+    pub(crate) fn new(lines: Vec<String>) -> Self {
+        let mut area = TextArea::new(lines);
+        // The whole point: a long line folds into the pane instead of running
+        // off it. `WordOrGlyph` keeps words whole where it can and splits the
+        // ones wider than the pane, which is the only way a pasted URL stays
+        // visible.
+        area.set_wrap_mode(WrapMode::WordOrGlyph);
+        area.move_cursor(CursorMove::Bottom);
+        area.move_cursor(CursorMove::End);
+        Self {
+            area,
+            buttons: Vec::new(),
+        }
+    }
+
+    /// An editor over `text`, split on newlines.
+    pub(crate) fn from_text(text: &str) -> Self {
+        Self::new(text.lines().map(str::to_string).collect())
+    }
+
+    /// The lines, as the textarea holds them.
+    pub(crate) fn lines(&self) -> &[String] {
+        self.area.lines()
+    }
+
+    /// The whole buffer as one string.
+    pub(crate) fn text(&self) -> String {
+        self.area.lines().join("\n")
+    }
+
+    /// The greyed-out prompt shown while the buffer is empty.
+    pub(crate) fn set_placeholder(&mut self, text: impl Into<String>) {
+        self.area.set_placeholder_text(text);
+        self.area.set_placeholder_style(Style::default().fg(C_DIM));
+    }
+
+    /// The wrapped textarea, for the few callers that need an operation this
+    /// wrapper does not name (inserting a completed file path, say).
+    pub(crate) fn area_mut(&mut self) -> &mut TextArea<'static> {
+        &mut self.area
+    }
+
+    /// Feed a key to the editor: a formatting chord if it is one, otherwise
+    /// the textarea's own editing keys. Reports whether the text changed.
+    ///
+    /// Callers take their own keys (Enter to submit, Esc to close) *before*
+    /// calling this, exactly as they did with the bare textarea.
+    pub(crate) fn handle_key(&mut self, key: &KeyEvent) -> bool {
+        match action_for(key) {
+            Some(action) => {
+                self.apply(action);
+                true
+            }
+            None => self.area.input(ratatui_textarea::Input::from(*key)),
+        }
+    }
+
+    /// Run a formatting action over the selection, or at the cursor when
+    /// nothing is selected.
+    pub(crate) fn apply(&mut self, action: MdAction) {
+        match action {
+            MdAction::Bold => self.wrap_inline("**"),
+            MdAction::Italic => self.wrap_inline("*"),
+            MdAction::Strike => self.wrap_inline("~~"),
+            MdAction::Code => self.wrap_inline("`"),
+            MdAction::CodeBlock => self.fence(),
+            MdAction::Link => self.link(),
+            MdAction::Heading => self.prefix_lines(next_heading),
+            MdAction::Bullet => self.prefix_lines(|line| toggle_prefix(line, "- ")),
+            MdAction::Ordered => self.prefix_lines(|line| toggle_prefix(line, "1. ")),
+            MdAction::Quote => self.prefix_lines(|line| toggle_prefix(line, "> ")),
+        }
+    }
+
+    /// Wrap the selection in `marker`, or unwrap it when it is already
+    /// wrapped. With no selection, insert an empty pair and park the cursor
+    /// between the halves.
+    fn wrap_inline(&mut self, marker: &str) {
+        let Some(text) = self.take_selection() else {
+            self.area.insert_str(format!("{marker}{marker}"));
+            self.move_back(marker.chars().count());
+            return;
+        };
+        let unwrapped = text
+            .strip_prefix(marker)
+            .and_then(|inner| inner.strip_suffix(marker))
+            .map(str::to_string);
+        match unwrapped {
+            Some(inner) => {
+                self.area.insert_str(inner);
+            }
+            None => {
+                self.area.insert_str(format!("{marker}{text}{marker}"));
+            }
+        }
+    }
+
+    /// Wrap the selection in a fenced block, or open an empty fence with the
+    /// cursor on the line between the fences.
+    fn fence(&mut self) {
+        match self.take_selection() {
+            Some(text) => {
+                self.area.insert_str(format!("```\n{text}\n```"));
+            }
+            None => {
+                self.area.insert_str("```\n\n```");
+                self.area.move_cursor(CursorMove::Up);
+                self.area.move_cursor(CursorMove::End);
+            }
+        }
+    }
+
+    /// `[selection]()` with the cursor between the parentheses, ready for a
+    /// URL, or `[]()` with the cursor in the brackets when nothing is
+    /// selected.
+    fn link(&mut self) {
+        match self.take_selection() {
+            Some(text) => {
+                self.area.insert_str(format!("[{text}]()"));
+                self.move_back(1);
+            }
+            None => {
+                self.area.insert_str("[]()");
+                self.move_back(3);
+            }
+        }
+    }
+
+    /// Apply `rule` to the head of every line the selection touches, or to the
+    /// cursor's line when nothing is selected.
+    ///
+    /// `rule` reports how many characters to strip and what to put in their
+    /// place, so "toggle it off" and "cycle to the next level" are one walk.
+    fn prefix_lines(&mut self, rule: fn(&str) -> (usize, &'static str)) {
+        let (first, last) = match self.area.selection_range() {
+            Some(((start, _), (end, _))) => (start, end),
+            None => {
+                let row = self.area.cursor().0;
+                (row, row)
+            }
+        };
+        self.area.cancel_selection();
+        for row in first..=last {
+            // `unwrap_or_default` rather than a guard: the rows come from the
+            // cursor or a selection range, so they are always in the buffer,
+            // and a guard here would be a branch no test could take.
+            let line = self.area.lines().get(row).cloned().unwrap_or_default();
+            let (strip, prefix) = rule(&line);
+            self.area
+                .move_cursor(CursorMove::Jump(row.min(u16::MAX as usize) as u16, 0));
+            for _ in 0..strip {
+                self.area.delete_next_char();
+            }
+            if !prefix.is_empty() {
+                self.area.insert_str(prefix);
+            }
+        }
+    }
+
+    /// Cut the selection out and hand it back, or `None` when nothing is
+    /// selected. The textarea's own yank buffer is how the text comes back.
+    fn take_selection(&mut self) -> Option<String> {
+        self.area.selection_range()?;
+        self.area.cut();
+        Some(self.area.yank_text())
+    }
+
+    fn move_back(&mut self, chars: usize) {
+        for _ in 0..chars {
+            self.area.move_cursor(CursorMove::Back);
+        }
+    }
+
+    /// Draw the framed editor: title, toolbar, wrapped text.
+    ///
+    /// The toolbar is dropped when the box is too short to spare a row for it,
+    /// and trailing buttons are dropped when it is too narrow. A cramped pane
+    /// loses buttons, never text.
+    pub(crate) fn render(&mut self, frame: &mut Frame, area: Rect, view: &MdEditView) {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(view.border))
+            .title(view.title.clone());
+        let inner = block.inner(area);
+        frame.render_widget(block, area);
+
+        self.buttons.clear();
+        let text_area = match inner.height >= 3 {
+            true => {
+                self.draw_toolbar(frame, Rect { height: 1, ..inner }, view.focused);
+                Rect {
+                    y: inner.y + 1,
+                    height: inner.height - 1,
+                    ..inner
+                }
+            }
+            false => inner,
+        };
+
+        self.area.set_style(Style::default().fg(C_WHITE));
+        self.area.set_cursor_line_style(Style::default());
+        self.area.set_cursor_style(match view.focused {
+            true => Style::default().fg(Color::Black).bg(C_ACCENT),
+            false => Style::default(),
+        });
+        frame.render_widget(&self.area, text_area);
+    }
+
+    /// The button row, and the registry that makes it clickable.
+    fn draw_toolbar(&mut self, frame: &mut Frame, row: Rect, focused: bool) {
+        let face = match focused {
+            true => C_ACCENT,
+            false => C_MUTED,
+        };
+        let mut spans: Vec<Span<'static>> = Vec::new();
+        let mut x = row.x;
+        for (i, action) in TOOLBAR.iter().enumerate() {
+            let cell = action.label().chars().count() as u16 + 2;
+            let sep = u16::from(i > 0);
+            if x + sep + cell > row.x + row.width {
+                break;
+            }
+            if sep > 0 {
+                spans.push(Span::styled("│", Style::default().fg(C_BORDER)));
+                x += 1;
+            }
+            spans.push(Span::styled(
+                format!(" {} ", action.label()),
+                Style::default().fg(face).add_modifier(emphasis(*action)),
+            ));
+            self.buttons.push((
+                Rect {
+                    x,
+                    y: row.y,
+                    width: cell,
+                    height: 1,
+                },
+                *action,
+            ));
+            x += cell;
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), row);
+    }
+
+    /// Act on a click at `(column, row)`, reporting whether a button was under
+    /// it. Coordinates are absolute, as crossterm reports them.
+    pub(crate) fn click(&mut self, column: u16, row: u16) -> bool {
+        let hit = self
+            .buttons
+            .iter()
+            .find(|(rect, _)| rect.contains(Position::new(column, row)))
+            .map(|(_, action)| *action);
+        match hit {
+            Some(action) => {
+                self.apply(action);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+/// The style a button's own face carries, so `B` reads as bold and `S` reads
+/// as struck through without a legend next to it.
+fn emphasis(action: MdAction) -> Modifier {
+    match action {
+        MdAction::Bold => Modifier::BOLD,
+        MdAction::Italic => Modifier::ITALIC,
+        MdAction::Strike => Modifier::CROSSED_OUT,
+        _ => Modifier::empty(),
+    }
+}
+
+/// `# ` → `## ` → `### ` → nothing → `# `.
+fn next_heading(line: &str) -> (usize, &'static str) {
+    match HEADINGS.iter().position(|level| line.starts_with(level)) {
+        Some(i) => (
+            HEADINGS[i].chars().count(),
+            HEADINGS.get(i + 1).copied().unwrap_or(""),
+        ),
+        None => (0, HEADINGS[0]),
+    }
+}
+
+/// Strip `prefix` when the line already has it, add it when it does not.
+///
+/// A numbered list also matches any other number, so toggling `2. ` off works
+/// as well as toggling `1. ` off: markdown renumbers a list itself, and a
+/// bullet key that only recognised the number it wrote is a bullet key that
+/// stops working on the second line.
+fn toggle_prefix(line: &str, prefix: &'static str) -> (usize, &'static str) {
+    if line.starts_with(prefix) {
+        return (prefix.chars().count(), "");
+    }
+    if prefix == "1. " {
+        let digits = line.chars().take_while(char::is_ascii_digit).count();
+        // Char-wise rather than `line[digits..]`: this crate denies byte-index
+        // slicing of user text, and the line under the cursor is user text.
+        let after: String = line.chars().skip(digits).take(2).collect();
+        if digits > 0 && after == ". " {
+            return (digits + 2, "");
+        }
+    }
+    (0, prefix)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    fn chord(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    fn plain(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::empty())
+    }
+
+    fn edit(text: &str) -> MarkdownEdit {
+        MarkdownEdit::from_text(text)
+    }
+
+    /// Select `chars` characters back from the cursor, the way Shift+← does.
+    fn select_back(md: &mut MarkdownEdit, chars: usize) {
+        md.area_mut().start_selection();
+        for _ in 0..chars {
+            md.area_mut().move_cursor(CursorMove::Back);
+        }
+    }
+
+    /// Draw into a `width` x `height` terminal and return every row as its own
+    /// string, so a test can say "this word is on screen" without caring which
+    /// row wrapping put it on.
+    fn draw(md: &mut MarkdownEdit, width: u16, height: u16) -> Vec<String> {
+        let mut terminal = Terminal::new(TestBackend::new(width, height)).unwrap();
+        terminal
+            .draw(|f| {
+                let view = MdEditView::new(" T ", C_ACCENT, true);
+                md.render(f, f.area(), &view);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        (0..height)
+            .map(|y| {
+                (0..width)
+                    .map(|x| buf.cell((x, y)).map_or(" ", |c| c.symbol()).to_string())
+                    .collect()
+            })
+            .collect()
+    }
+
+    // ── The bug this component exists for ──────────────────────────────────
+
+    /// The regression: a task longer than the pane is wide used to scroll
+    /// sideways, so with the cursor at the end the *start* of what you had
+    /// written was off screen. Both ends have to be visible at once.
+    #[test]
+    fn a_line_wider_than_the_pane_wraps_instead_of_scrolling_off_the_edge() {
+        let mut md = edit("the quick brown fox jumps over the lazy dog");
+        let rows = draw(&mut md, 24, 8).join("\n");
+        assert!(rows.contains("quick"), "the head is off screen:\n{rows}");
+        assert!(rows.contains("dog"), "the tail is off screen:\n{rows}");
+    }
+
+    /// A single word with no space in it (a pasted URL is the real case) still
+    /// has to fold, which is why the mode is `WordOrGlyph` and not `Word`.
+    #[test]
+    fn a_word_wider_than_the_pane_is_split_rather_than_hidden() {
+        let mut md = edit("https://example.com/a/very/long/path/that/never/breaks");
+        let rows = draw(&mut md, 24, 8).join("\n");
+        assert!(rows.contains("https"), "the head is off screen:\n{rows}");
+        assert!(rows.contains("breaks"), "the tail is off screen:\n{rows}");
+    }
+
+    // ── Chords ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn every_toolbar_action_has_a_chord_and_a_label() {
+        assert_eq!(TOOLBAR.len(), CHORD_LABELS.len());
+        let help = shortcut_help();
+        assert_eq!(help.len(), TOOLBAR.len());
+        for (i, action) in TOOLBAR.iter().enumerate() {
+            assert_eq!(chord_label(*action), CHORD_LABELS[i]);
+            assert_eq!(help[i], (CHORD_LABELS[i], action.name()));
+            assert!(!action.label().is_empty());
+        }
+    }
+
+    #[test]
+    fn the_control_chords_resolve_to_their_actions() {
+        for (c, action) in [
+            ('b', MdAction::Bold),
+            ('i', MdAction::Italic),
+            ('d', MdAction::Strike),
+            ('e', MdAction::Code),
+            ('t', MdAction::Code),
+            ('k', MdAction::Link),
+            ('h', MdAction::Heading),
+            ('l', MdAction::Bullet),
+            ('o', MdAction::Ordered),
+            ('.', MdAction::Quote),
+        ] {
+            assert_eq!(action_for(&chord(c)), Some(action), "ctrl-{c}");
+        }
+    }
+
+    /// macOS terminals that forward Command send `SUPER`, and the same
+    /// bindings have to answer to it.
+    #[test]
+    fn the_command_modifier_resolves_the_same_actions() {
+        let key = KeyEvent::new(KeyCode::Char('b'), KeyModifiers::SUPER);
+        assert_eq!(action_for(&key), Some(MdAction::Bold));
+    }
+
+    /// Shift reaches us as the flag, as an uppercased char, or both, and the
+    /// fence has to answer to all three spellings while plain `e` does not.
+    #[test]
+    fn shift_e_is_the_code_fence_however_the_terminal_spells_it() {
+        let flag = KeyEvent::new(
+            KeyCode::Char('e'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+        let upper = KeyEvent::new(KeyCode::Char('E'), KeyModifiers::CONTROL);
+        let both = KeyEvent::new(
+            KeyCode::Char('E'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+        for key in [flag, upper, both] {
+            assert_eq!(action_for(&key), Some(MdAction::CodeBlock), "{key:?}");
+        }
+        assert_eq!(action_for(&chord('e')), Some(MdAction::Code));
+    }
+
+    #[test]
+    fn a_plain_key_an_unbound_chord_and_a_non_character_are_not_formatting() {
+        assert_eq!(action_for(&plain('b')), None);
+        assert_eq!(action_for(&chord('z')), None);
+        assert_eq!(
+            action_for(&KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL)),
+            None
+        );
+    }
+
+    // ── Inline wrapping ────────────────────────────────────────────────────
+
+    #[test]
+    fn a_chord_with_nothing_selected_opens_an_empty_pair_around_the_cursor() {
+        let mut md = edit("");
+        md.handle_key(&chord('b'));
+        assert_eq!(md.text(), "****");
+        // The cursor sits between the halves, so typing lands inside them.
+        md.handle_key(&plain('h'));
+        md.handle_key(&plain('i'));
+        assert_eq!(md.text(), "**hi**");
+    }
+
+    #[test]
+    fn each_inline_chord_uses_its_own_marker() {
+        for (c, wrapped) in [
+            ('b', "**word**"),
+            ('i', "*word*"),
+            ('d', "~~word~~"),
+            ('e', "`word`"),
+        ] {
+            let mut md = edit("word");
+            select_back(&mut md, 4);
+            md.handle_key(&chord(c));
+            assert_eq!(md.text(), wrapped, "ctrl-{c}");
+        }
+    }
+
+    #[test]
+    fn wrapping_a_selection_that_is_already_wrapped_takes_the_markers_off() {
+        let mut md = edit("**word**");
+        select_back(&mut md, 8);
+        md.apply(MdAction::Bold);
+        assert_eq!(md.text(), "word");
+    }
+
+    #[test]
+    fn multibyte_text_survives_being_wrapped_and_unwrapped() {
+        let mut md = edit("héllo wörld");
+        select_back(&mut md, 11);
+        md.apply(MdAction::Italic);
+        assert_eq!(md.text(), "*héllo wörld*");
+        select_back(&mut md, 13);
+        md.apply(MdAction::Italic);
+        assert_eq!(md.text(), "héllo wörld");
+    }
+
+    // ── Links and fences ───────────────────────────────────────────────────
+
+    #[test]
+    fn a_link_keeps_the_selection_as_its_text_and_waits_for_the_url() {
+        let mut md = edit("docs");
+        select_back(&mut md, 4);
+        md.apply(MdAction::Link);
+        assert_eq!(md.text(), "[docs]()");
+        md.handle_key(&plain('x'));
+        assert_eq!(md.text(), "[docs](x)");
+    }
+
+    #[test]
+    fn a_link_with_nothing_selected_waits_for_the_text_first() {
+        let mut md = edit("");
+        md.apply(MdAction::Link);
+        assert_eq!(md.text(), "[]()");
+        md.handle_key(&plain('a'));
+        assert_eq!(md.text(), "[a]()");
+    }
+
+    #[test]
+    fn a_fence_wraps_the_selection_or_opens_an_empty_block() {
+        let mut md = edit("let x = 1;");
+        select_back(&mut md, 10);
+        md.apply(MdAction::CodeBlock);
+        assert_eq!(md.lines(), ["```", "let x = 1;", "```"]);
+
+        let mut empty = edit("");
+        empty.apply(MdAction::CodeBlock);
+        assert_eq!(empty.lines(), ["```", "", "```"]);
+        // The cursor is on the blank line between the fences.
+        empty.handle_key(&plain('y'));
+        assert_eq!(empty.lines(), ["```", "y", "```"]);
+    }
+
+    // ── Line prefixes ──────────────────────────────────────────────────────
+
+    #[test]
+    fn the_heading_key_cycles_the_levels_and_then_clears_them() {
+        let mut md = edit("title");
+        for expected in ["# title", "## title", "### title", "title", "# title"] {
+            md.apply(MdAction::Heading);
+            assert_eq!(md.text(), expected);
+        }
+    }
+
+    #[test]
+    fn the_list_and_quote_keys_toggle_their_own_prefix() {
+        for (action, prefixed) in [
+            (MdAction::Bullet, "- item"),
+            (MdAction::Ordered, "1. item"),
+            (MdAction::Quote, "> item"),
+        ] {
+            let mut md = edit("item");
+            md.apply(action);
+            assert_eq!(md.text(), prefixed);
+            md.apply(action);
+            assert_eq!(md.text(), "item", "{prefixed} did not toggle off");
+        }
+    }
+
+    /// Markdown renumbers a list itself, so the second line of one is `2. `.
+    /// A numbering key that only recognised `1. ` would refuse to clear it.
+    #[test]
+    fn the_numbering_key_clears_a_number_it_did_not_write() {
+        let mut md = edit("12. item");
+        md.apply(MdAction::Ordered);
+        assert_eq!(md.text(), "item");
+
+        // A bare number with no ". " after it is ordinary text.
+        let mut plain_number = edit("2001 was a year");
+        plain_number.apply(MdAction::Ordered);
+        assert_eq!(plain_number.text(), "1. 2001 was a year");
+    }
+
+    #[test]
+    fn a_prefix_applies_to_every_line_the_selection_touches() {
+        let mut md = edit("one\ntwo\nthree");
+        select_back(&mut md, 13);
+        md.apply(MdAction::Bullet);
+        assert_eq!(md.lines(), ["- one", "- two", "- three"]);
+    }
+
+    // ── Falling through to the textarea ────────────────────────────────────
+
+    #[test]
+    fn keys_that_are_not_chords_still_edit_the_text() {
+        let mut md = edit("ab");
+        md.handle_key(&plain('c'));
+        md.handle_key(&KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()));
+        md.handle_key(&KeyEvent::new(KeyCode::Enter, KeyModifiers::empty()));
+        md.handle_key(&plain('z'));
+        assert_eq!(md.lines(), ["ab", "z"]);
+    }
+
+    #[test]
+    fn the_buffer_round_trips_through_text_and_lines() {
+        let md = edit("first\nsecond");
+        assert_eq!(md.text(), "first\nsecond");
+        assert_eq!(md.lines(), ["first", "second"]);
+        assert_eq!(MarkdownEdit::default().text(), "");
+    }
+
+    // ── The toolbar ────────────────────────────────────────────────────────
+
+    #[test]
+    fn the_toolbar_draws_every_button_when_there_is_room() {
+        let mut md = edit("");
+        let bar = draw(&mut md, 60, 6).remove(1);
+        for action in TOOLBAR {
+            let label = action.label();
+            assert!(bar.contains(label), "{label} is missing from {bar}");
+        }
+    }
+
+    /// A cramped pane drops buttons off the end rather than drawing outside
+    /// its own rect, and a box with no room for a toolbar row keeps all of its
+    /// height for text.
+    #[test]
+    fn a_cramped_box_drops_buttons_and_then_the_whole_toolbar() {
+        let mut narrow = edit("");
+        let bar = draw(&mut narrow, 16, 6).remove(1);
+        assert!(bar.contains('B'), "{bar}");
+        assert!(!bar.contains("```"), "{bar}");
+
+        let mut short = edit("text");
+        let first = draw(&mut short, 40, 3).remove(1);
+        assert!(first.contains("text"), "{first}");
+        assert!(!short.click(2, 1), "no toolbar means nothing to click");
+    }
+
+    #[test]
+    fn clicking_a_button_runs_its_action_and_clicking_elsewhere_does_not() {
+        let mut md = edit("");
+        let bar = draw(&mut md, 60, 6).remove(1);
+        // The first button is ` B `, drawn just inside the left border, so
+        // column 2 of row 1 is the `B` itself.
+        assert_eq!(bar.chars().nth(2), Some('B'), "{bar}");
+        assert!(md.click(2, 1));
+        assert_eq!(md.text(), "****");
+
+        assert!(!md.click(2, 4), "the text area is not a button");
+        assert!(!md.click(59, 1), "past the last button");
+        assert_eq!(md.text(), "****");
+    }
+
+    /// An unfocused box still shows its toolbar (that is how you learn it is
+    /// there) but draws no cursor cell over the text.
+    #[test]
+    fn an_unfocused_box_draws_a_toolbar_and_no_cursor() {
+        let mut md = edit("hi");
+        let mut terminal = Terminal::new(TestBackend::new(40, 6)).unwrap();
+        terminal
+            .draw(|f| {
+                let view = MdEditView::titled(Line::from("t"), C_BORDER, false);
+                md.render(f, f.area(), &view);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let toolbar: String = (0..40)
+            .map(|x| buf.cell((x, 1)).map_or(" ", |c| c.symbol()).to_string())
+            .collect();
+        assert!(toolbar.contains('B'), "{toolbar}");
+        assert!(
+            !buf.content().iter().any(|c| c.style().bg == Some(C_ACCENT)),
+            "an unfocused box drew a cursor cell"
+        );
+    }
+
+    #[test]
+    fn the_placeholder_shows_only_while_the_box_is_empty() {
+        let mut md = MarkdownEdit::default();
+        md.set_placeholder("say something");
+        let rows = draw(&mut md, 40, 6).join("\n");
+        assert!(rows.contains("say something"), "{rows}");
+
+        md.handle_key(&plain('x'));
+        let rows = draw(&mut md, 40, 6).join("\n");
+        assert!(!rows.contains("say something"), "{rows}");
+    }
+
+    #[test]
+    fn a_buttons_face_carries_the_style_it_stands_for() {
+        assert_eq!(emphasis(MdAction::Bold), Modifier::BOLD);
+        assert_eq!(emphasis(MdAction::Italic), Modifier::ITALIC);
+        assert_eq!(emphasis(MdAction::Strike), Modifier::CROSSED_OUT);
+        assert_eq!(emphasis(MdAction::Link), Modifier::empty());
+    }
+}

--- a/crates/leviath-cli/src/tui/widgets/markdown_edit.rs
+++ b/crates/leviath-cli/src/tui/widgets/markdown_edit.rs
@@ -175,10 +175,6 @@ pub(crate) fn action_for(key: &KeyEvent) -> Option<MdAction> {
         ('i', _) => Some(MdAction::Italic),
         ('d', _) => Some(MdAction::Strike),
         ('e', false) => Some(MdAction::Code),
-        // `Ctrl-E` is already "hand this to $EDITOR" in the blueprint editor's
-        // prompt overlay, which takes its own keys before delegating here.
-        // `Ctrl-T` is the alias that works in every box.
-        ('t', _) => Some(MdAction::Code),
         ('e', true) => Some(MdAction::CodeBlock),
         ('k', _) => Some(MdAction::Link),
         ('h', _) => Some(MdAction::Heading),
@@ -638,7 +634,6 @@ mod tests {
             ('i', MdAction::Italic),
             ('d', MdAction::Strike),
             ('e', MdAction::Code),
-            ('t', MdAction::Code),
             ('k', MdAction::Link),
             ('h', MdAction::Heading),
             ('l', MdAction::Bullet),

--- a/crates/leviath-cli/src/tui/widgets/mod.rs
+++ b/crates/leviath-cli/src/tui/widgets/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod confirm;
 pub(crate) mod footer;
 pub(crate) mod help;
 pub(crate) mod line_edit;
+pub(crate) mod markdown_edit;
 pub(crate) mod picker;
 pub(crate) mod popup;
 pub(crate) mod scroll;

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -312,7 +312,7 @@ The models the chooser offers come from every provider in your config (asked whe
 opens, so the list fills in a moment later) on top of the built-in catalog, marked with the context
 window when it is known. The prompts open full screen: the system prompt (what the stage is told)
 and the transition prompt (how it picks the next path; only read when there is more than one), with
-`Tab` between them, `Ctrl-S` or `Esc` to apply, `Ctrl-Q` to discard, and `Ctrl-E` to hand the
+`Tab` between them, `Ctrl-S` or `Esc` to apply, `Ctrl-Q` to discard, and `F2` to hand the
 focused prompt to `$EDITOR` (`$VISUAL` first): the dashboard steps aside while the editor runs and
 the text comes back into the box when it closes.
 
@@ -367,7 +367,11 @@ In the prompts:
 | `Tab` | Move between the system prompt and the transition prompt |
 | `Ctrl-S` / `Esc` | Apply both and close |
 | `Ctrl-Q` | Close without applying |
-| `Ctrl-E` | Open the focused prompt in `$EDITOR`; the dashboard waits for it |
+| `F2` | Open the focused prompt in `$EDITOR`; the dashboard waits for it |
+| `F1` | Help. `?` types a question mark in a prompt |
+
+Both boxes wrap and carry the formatting toolbar; see
+[Formatting a long-form box](#formatting-a-long-form-box).
 
 On a terminal under 110 columns the graph and the inspector take turns; `Tab` swaps them.
 
@@ -426,9 +430,9 @@ equivalent) `Ctrl-I` arrives indistinguishable from `Tab` and `Ctrl-H` from
 `Backspace`, so italic and heading are on their buttons there. Nothing else
 changes: `Tab` and `Backspace` keep doing what they always did.
 
-In the agent editor's prompt overlay `Ctrl-E` already means "open this prompt
-in `$EDITOR`" and keeps that meaning, so inline code there is on its alias,
-`Ctrl-T`. `Ctrl-T` works in the other boxes too.
+Every box takes the same chords, including the agent editor's prompt overlay.
+`Ctrl-E` there used to mean "open this prompt in `$EDITOR`"; that moved to
+`F2` so the formatting chord means one thing everywhere.
 
 A box too narrow for the whole row drops buttons off the right, and one too
 short to spare a line drops the row entirely; the chords and the text are never

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -149,6 +149,12 @@ rather than back into the form.
 | `Esc` (in the agent list) | Clear the filter, then close the screen |
 | `Esc` or `Tab` (in the task) | Back to the agent list |
 
+The task box wraps: a task longer than the pane is wide folds onto the next
+row rather than scrolling sideways, so the beginning of what you wrote is
+still on screen when the cursor is at the end. See
+[Formatting a long-form box](#formatting-a-long-form-box) for what the toolbar
+along its top does.
+
 `Ctrl-Y` warns the first time you use it in a sitting, and the warning is worth reading: an
 unattended run approves its own file edits and shell commands, but it does **not** skip a checkpoint
 the blueprint asks a person for. Those still stop, and one nobody answers ends the run when the
@@ -378,6 +384,55 @@ On a terminal under 110 columns the graph and the inspector take turns; `Tab` sw
 | `?` / `F1` (`F1` while typing a URL) | Help |
 | `Esc` | Back to the run list |
 | `q` / `Ctrl-C` | Quit |
+
+### Formatting a long-form box
+
+Four boxes in the dashboard take prose rather than a word: the task on the
+new-run screen, the box you answer a waiting run in, the document you edit in
+place when a run asks you to revise one, and a stage's system and transition
+prompts in the agent editor. All four are the same editor. They wrap, and each
+one draws a row of buttons along its top:
+
+```
+ B │ I │ S │ <> │ ``` │ [] │ H │ • │ 1. │ >
+```
+
+Click a button, or use its chord. Select text first (hold `Shift` and use the
+arrow keys) and the chord wraps the selection; with nothing selected it opens
+an empty pair and leaves the cursor between the halves. The list, heading and
+quote keys toggle, and act on every line a selection touches.
+
+| Button | Chord | What it writes |
+|---|---|---|
+| `B` | `Ctrl-B` | `**bold**` |
+| `I` | `Ctrl-I` | `*italic*` |
+| `S` | `Ctrl-D` | `~~strikethrough~~` |
+| `<>` | `Ctrl-E` | `` `inline code` `` |
+| ` ``` ` | `Ctrl-Shift-E` | a fenced code block |
+| `[]` | `Ctrl-K` | `[text](url)`, cursor ready for the URL |
+| `H` | `Ctrl-H` | cycles `#`, `##`, `###`, none |
+| `•` | `Ctrl-L` | toggles `- ` on the line |
+| `1.` | `Ctrl-O` | toggles `1. ` on the line |
+| `>` | `Ctrl-.` | toggles `> ` on the line |
+
+On macOS these read as `⌘B`, `⌘I` and so on in the hint bar and the help
+overlay, and **both** `⌘` and `Ctrl` work. That is deliberate: Terminal.app and
+iTerm2 keep `⌘` for themselves and never hand it to the program, so a build
+that listened only for `⌘` would be a build with no working chords.
+
+Two chords depend on what the terminal can report. Without the kitty keyboard
+protocol (kitty, Ghostty, WezTerm and foot speak it; Windows Terminal has an
+equivalent) `Ctrl-I` arrives indistinguishable from `Tab` and `Ctrl-H` from
+`Backspace`, so italic and heading are on their buttons there. Nothing else
+changes: `Tab` and `Backspace` keep doing what they always did.
+
+In the agent editor's prompt overlay `Ctrl-E` already means "open this prompt
+in `$EDITOR`" and keeps that meaning, so inline code there is on its alias,
+`Ctrl-T`. `Ctrl-T` works in the other boxes too.
+
+A box too narrow for the whole row drops buttons off the right, and one too
+short to spare a line drops the row entirely; the chords and the text are never
+what gets cut.
 
 > [!TIP]
 > Prefer a browser, or want to drive Leviath from another machine?


### PR DESCRIPTION
## The bug

The task editor on the new-run screen sat on a `ratatui-textarea` left in its
default `WrapMode::None`, which **scrolls sideways** instead of folding. With
the cursor at the end of a long task, the beginning of what you had just typed
was off screen:

```
╭ Task for coder ──────────────────────────╮
│hat compares them without a constant-time │   <- before
╰──────────────────────────────────────────╯

╭ Task for coder ──────────────────────────╮
│ B │ I │ S │ <> │ ``` │ [] │ H │ • │ 1. │ >│   <- after
│Review the authentication module and write│
│a short report on every place a token is  │
│minted, stored, or compared, then propose │
│a fix for anything that compares them     │
│without a constant-time function.         │
╰──────────────────────────────────────────╯
```

The response box, the in-place document editor and a stage's system and
transition prompts had the same bug, because they were four separate copies of
the same setup. `ratatui-textarea` 0.9 does support wrapping; the older
`tui-textarea` it replaced did not, which is probably why nobody looked again.

## What this does

Folds all four into one component, `tui/widgets/markdown_edit.rs`.

- **Wraps** at word boundaries, splitting a word wider than the pane, so a
  pasted URL stays readable rather than becoming an invisible one-line scroll.
- **Formats.** Bold, italic, strikethrough, inline code, a code fence, links,
  headings, bullet and numbered lists, quotes. Each is a chord *and* a button
  on a toolbar drawn along the top of the box; both resolve to the same
  `MdAction`, so a binding and its button cannot drift apart. A chord wraps the
  selection when there is one and opens an empty pair at the cursor when there
  is not. The list, heading and quote keys toggle, and act on every line a
  selection touches.
- Short fields stay on `LineEdit`. An agent's name is not prose.

## Keys, and the terminal facts behind them

| Button | Chord | Writes |
|---|---|---|
| `B` | `Ctrl-B` | `**bold**` |
| `I` | `Ctrl-I` | `*italic*` |
| `S` | `Ctrl-D` | `~~strike~~` |
| `<>` | `Ctrl-E` | `` `code` `` |
| ` ``` ` | `Ctrl-Shift-E` | a fence |
| `[]` | `Ctrl-K` | `[text](url)` |
| `H` | `Ctrl-H` | cycles `#`, `##`, `###`, none |
| `•` | `Ctrl-L` | toggles `- ` |
| `1.` | `Ctrl-O` | toggles `1. ` |
| `>` | `Ctrl-.` | toggles `> ` |

Labels read `⌘B` on macOS and `ctrl-b` elsewhere, from cfg-gated tables. But
**both modifiers are accepted on every platform**, deliberately: Terminal.app
and iTerm2 keep `⌘` for themselves and never hand it to the program, so a build
that listened only for the platform-correct modifier would be a build with no
working chords on the platform it was correct for.

Two chords depend on what the terminal can report. Without the kitty keyboard
protocol, `Ctrl-I` arrives as `Tab` and `Ctrl-H` as `Backspace` - which is
exactly why they are safe to claim: they degrade to the key they already were,
nothing regresses, and the buttons cover them.

Deliberately avoided: `Ctrl-S`/`Ctrl-Q` (XON/XOFF, they can freeze the
terminal) and `Ctrl-Shift-C` (the terminal's own copy).

## Two binding changes

- In a long-form box, `Ctrl-B/D/E/K/L/O` now format rather than doing what the
  textarea's built-in emacs bindings did (back a character, delete forward, end
  of line, delete to end of line). The arrow, `Delete` and `End` keys do all of
  those.
- In the agent editor's prompt overlay, "open this prompt in `$EDITOR`" moved
  from `Ctrl-E` to **`F2`**, so the formatting chord means one thing everywhere.
  `F1` opens the help there now too, which the hint bar had been promising to
  `?` since before this branch - `?` types a question mark inside a prompt and
  always did.

## Also

A toolbar press is resolved **ahead of** the frame's click registry. The
registry answers "what was drawn here", and a toolbar is drawn *over* the pane
it floats above, so a button press routed by position alone would act on that
pane instead.

## Testing

- 26 component tests plus end-to-end tests at each of the four sites, driving
  the real renderers and real mouse events.
- **The two wrap tests were run against the unfixed code first**: flipping
  `WrapMode` back to `None` turns both red, so they are not certifying a no-op.
- 100% coverage (`cargo xtask coverage`), clippy, fmt, docs, full pre-commit.
- Live in a real pty (pyte): wrapping folded a 3-line task, `Ctrl-B` over a
  shift-arrow selection produced `f**unction.**`, `Ctrl-L` made a bullet, and an
  SGR click on the `<>` button inserted a backtick pair.

## Not done, deliberately

Agent/stage descriptions and edge hints stay single-line `LineEdit` fields.
They are single-line TOML strings, and allowing newlines would change what gets
written to the file.
