### PR TITLE
feat(serve): one status vocabulary on the wire, not two

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,30 @@ same list.
   code in that overlay like it is in every other long-form box: one chord
   meaning two things depending on which box you are in is worse than moving the
   rarer of the two.
+- Changed: the API speaks one status vocabulary. `agent_status` on the WebSocket
+  carried the engine's own words - `idle` and `active` for a run that is going,
+  `waiting` for one parked - while every REST route carried the run's:
+  `running`, `waiting_input`. Same field, same fact, four words apart, with the
+  mapping between them living in the daemon and nowhere in the API, so each
+  client re-derived it or guessed. One console's copy normalized the engine's
+  three words to nothing, which meant a status frame could not move a run there
+  for months; a periodic re-read kept supplying the right answer, until the
+  console started trusting the socket for a beat and a parent parked on its
+  workers sat on "working" indefinitely. The translation now happens once, on
+  the way out of the server. Two older spellings go with it:
+  `GET /api/agents/{id}/result` and the two tree routes rendered a status for a
+  human reader, so they said `WaitingInput` where the run said `waiting_input`.
+  Breaking for a client matching on the old words, and announced as
+  `events.run_status` so a console can tell which vocabulary it is being sent
+  rather than sniffing the strings.
+- Changed: a region's `kind` in a context snapshot is spelled the way the
+  blueprint spells it. A `sliding_window` region was written as `sliding` and a
+  `compact_history` as `history`, which is the same hazard one level down: a
+  console reading a snapshot and a console reading a blueprint disagreed about
+  what one region was. Announced as `context.region_kinds`. Snapshots already on
+  disk keep the old two words, so anything rendering a kind should accept both;
+  the dashboard does.
+
 - Fixed: an Anthropic model reached through OpenRouter can cache its prompt
   again. System blocks - the stage prompt and the pinned context regions, which
   are the stable and by far the largest part of a request - were sent as plain

--- a/crates/leviath-cli/src/commands/dashboard/context_tree.rs
+++ b/crates/leviath-cli/src/commands/dashboard/context_tree.rs
@@ -103,10 +103,13 @@ pub(super) fn flatten(
         } else {
             C_DIM
         };
+        // Two spellings each for the sliding window and the compacted
+        // history: the blueprint's, which is what a snapshot writes now, and
+        // the short one older snapshots on this disk still carry.
         let kind_color = match region.kind.as_str() {
             "pinned" => C_ACCENT,
-            "sliding" => C_SUCCESS,
-            "compacting" | "history" => C_WARN,
+            "sliding_window" | "sliding" => C_SUCCESS,
+            "compacting" | "compact_history" | "history" => C_WARN,
             "temporary" | "clearable" => C_MUTED,
             "custom" => C_SCRIPT,
             _ => C_DIM,
@@ -125,7 +128,10 @@ pub(super) fn flatten(
             ),
             Span::styled(format!("{:<16}", region.name), name_style),
             Span::styled(
-                format!("{:<12}", region.kind),
+                // 16, because `compact_history` is fifteen characters and a
+                // kind wider than its column pushes that row's bar out of line
+                // with every other row.
+                format!("{:<16}", region.kind),
                 Style::default().fg(kind_color),
             ),
             Span::styled(bar, Style::default().fg(bar_color)),
@@ -282,6 +288,35 @@ mod tests {
                     description: None,
                 },
             ],
+        }
+    }
+
+    /// Both spellings of a kind get the same colour and the same cell width.
+    ///
+    /// A `context.json` written by an older daemon says `sliding` where one
+    /// written today says `sliding_window`, and nothing rewrites those files,
+    /// so both are on disk and both get drawn. The width is the half that is
+    /// easy to miss: the kind sits in a fixed column with the token bar after
+    /// it, and a word too long for the column pushes that row's bar out of
+    /// line with every other row.
+    #[test]
+    fn a_region_kind_keeps_its_colour_and_its_column() {
+        let cell = |kind: &str| {
+            let mut s = snap();
+            s.regions[1].kind = kind.to_string();
+            let span = flatten(&s, &ContextTreeState::default(), 0, false, 80)
+                .lines
+                .into_iter()
+                .flat_map(|line| line.spans)
+                .find(|span| span.content.trim() == kind)
+                .expect("the kind cell");
+            (span.style, span.content.chars().count())
+        };
+        for (old, new) in [
+            ("sliding", "sliding_window"),
+            ("history", "compact_history"),
+        ] {
+            assert_eq!(cell(old), cell(new));
         }
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -103,10 +103,13 @@ impl Dashboard {
                 .regions
                 .iter()
                 .take(6)
+                // Both spellings of each: the blueprint's word, which is
+                // what a snapshot writes now, and the short one older
+                // snapshots on this disk still carry.
                 .map(|r| match r.kind.as_str() {
                     "pinned" => "P",
-                    "sliding" => "S",
-                    "compacting" | "history" => "H",
+                    "sliding_window" | "sliding" => "S",
+                    "compacting" | "compact_history" | "history" => "H",
                     _ => "·",
                 })
                 .collect::<Vec<_>>()
@@ -980,7 +983,11 @@ mod tests {
                 },
                 runstate::RegionSnapshot {
                     name: "history".to_string(),
-                    kind: "sliding".to_string(),
+                    // The word a snapshot writes now. The older `sliding` has
+                    // to draw the same letter, which is what
+                    // `render_context_bar_regions_string_with_many_region_types`
+                    // covers with a snapshot spelled the old way.
+                    kind: "sliding_window".to_string(),
                     current_tokens: 3000,
                     max_tokens: 4000,
                     entries: vec![],

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -699,7 +699,11 @@ pub(super) async fn agent_result(
 
     Ok(Json(AgentResultResp {
         run_id: meta.run_id,
-        status: format!("{}", meta.status),
+        // The word every other route uses. This one rendered the status
+        // through `Display` - `WaitingInput`, `CompleteInteractive` - which is
+        // the spelling for a person reading a terminal, not for a client
+        // matching on it.
+        status: meta.status.wire().to_string(),
         output,
         // The answer, when the agent gave one. `output` above is the last
         // stage's log tail, which is what this endpoint served before an agent
@@ -2895,7 +2899,8 @@ system_prompt = "Plan the work"
                     .unwrap();
                 let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
                 assert_eq!(result["run_id"].as_str().unwrap(), run_id);
-                assert_eq!(result["status"].as_str().unwrap(), "Complete");
+                // The word every other route uses, not `Display`'s `Complete`.
+                assert_eq!(result["status"].as_str().unwrap(), "complete");
 
                 let _ = std::fs::remove_dir_all(runstate::run_dir(&run_id));
             },

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -995,9 +995,9 @@ system_prompt = "Plan the work"
                 },
                 {
                     "name": "chat",
-                    // The same spelling a context snapshot uses. Two spellings
-                    // of one kind is a trap for a console reading both.
-                    "kind": "sliding",
+                    // The blueprint's own word, and the one a context snapshot
+                    // writes: a console reading both sees one kind, not two.
+                    "kind": "sliding_window",
                     "describe_in_prompt": false,
                     "max_tokens": 900,
                 },

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -104,6 +104,24 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // something unrelated makes it re-read. Announced so a console can drop
     // that poll where the daemon has it and keep it where it does not.
     "events.title",
+    // One status vocabulary across the whole API. `agent_status` and
+    // `agent_completed` carry the same word a run carries - `running`,
+    // `waiting_input` - instead of the engine's own `idle`/`active`/`waiting`,
+    // and the three routes that rendered a status through `Display`
+    // (`GET /api/agents/{id}/result` and the two tree routes) now spell it the
+    // way every other route does.
+    //
+    // Breaking for a client matching on the old words, which is why it is
+    // announced rather than left to be discovered: a console can read this and
+    // know which spelling it is being sent instead of sniffing the strings.
+    "events.run_status",
+    // Region kinds in a context snapshot are spelled the way the blueprint
+    // spells them - `sliding_window`, `compact_history` - rather than the
+    // shorter `sliding`/`history` that only ever existed in a snapshot.
+    // Separate from the status capability because the old words are still on
+    // disk in older snapshots: this says what a *new* one says, not what every
+    // file a client reads back will say.
+    "context.region_kinds",
     "blueprints.envelope",
     "blueprints.query",
     "blueprints.manifest",

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -140,11 +140,35 @@ fn handle_event(state: &AppState, client: &reqwest::Client, event: WorldEvent) {
             client,
             &state.current_config().webhook,
             run_id,
-            status,
+            &wire_status(status),
             final_output.as_ref(),
         );
     }
     let _ = state.event_tx.send(to_server_event(event));
+}
+
+/// One status, in the vocabulary every route on this server speaks.
+///
+/// The engine has its own words for where a run stands - `idle` and `active`
+/// for a run that is going, `waiting` for one parked - and they arrive here on
+/// every [`WorldEvent`]. They used to go straight out on the socket, so
+/// `agent_status.status` and `GET /api/runs/{id}` described the same run in
+/// different words, and every client had to carry its own copy of the mapping
+/// between them to reconcile the two. One console's copy quietly normalized the
+/// engine's three words to nothing, which meant a status frame could never move
+/// a run: it heard a completion and a pause and nothing else, for months,
+/// because a 1.5s re-read of the run kept papering over it.
+///
+/// So the translation happens once, here, on the way out. The engine keeps its
+/// vocabulary inside the engine; the API has one.
+///
+/// A word this build does not know goes out untranslated. That means the daemon
+/// is newer than this gateway, and passing its word through is strictly better
+/// than dropping the frame or inventing a state for it.
+fn wire_status(label: &str) -> String {
+    leviath_runtime::persistence::run_status_for_label(label)
+        .map(|status| status.wire().to_string())
+        .unwrap_or_else(|| label.to_string())
 }
 
 /// Map a [`WorldEvent`] to the [`ServerEvent`] WebSocket clients consume.
@@ -178,7 +202,7 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
         } => ServerEvent::AgentStatus {
             agent_id,
             run_id,
-            status,
+            status: wire_status(&status),
             stage,
             iteration,
             tool_calls,
@@ -237,8 +261,8 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
             final_output,
         } => ServerEvent::AgentCompleted {
             agent_id,
+            status: wire_status(&status),
             run_id: run_id.clone(),
-            status,
             // Named `result` since before there was one; it carries the run's
             // *error*. The answer is `final_output`, beside it.
             result: runstate::read_meta(&run_id).ok().and_then(|m| m.error),
@@ -688,6 +712,69 @@ mod tests {
         // An untitled run says nothing rather than sending a null a client
         // would have to tell apart from a title it cleared.
         assert!(status(None).get("title").is_none());
+    }
+
+    /// The socket and the run have to say the same word for the same state.
+    ///
+    /// The engine's `idle`, `active` and `waiting` used to go out verbatim, so
+    /// a client watching the socket saw three words no REST route ever sends
+    /// and had to carry its own copy of this mapping to reconcile them. One
+    /// console's copy normalized them to nothing, which meant a status frame
+    /// could never move a run - it heard completions and pauses and nothing
+    /// else - and that went unnoticed because a periodic re-read of the run
+    /// kept supplying the right answer.
+    #[test]
+    fn a_status_frame_speaks_the_run_status_vocabulary() {
+        let word = |status: &str| {
+            serde_json::to_value(to_server_event(WorldEvent::Status {
+                run_id: "run-1".into(),
+                agent_id: "a".into(),
+                status: status.into(),
+                stage: "implement".into(),
+                iteration: 1,
+                tool_calls: 0,
+                accepts_messages: true,
+                wait_reason: None,
+                title: None,
+            }))
+            .unwrap()["status"]
+                .as_str()
+                .unwrap()
+                .to_string()
+        };
+
+        // The three that differed, and the two spellings the engine uses for
+        // one run that is simply going.
+        assert_eq!(word("idle"), "running");
+        assert_eq!(word("active"), "running");
+        assert_eq!(word("waiting"), "waiting_input");
+        // The ones that already agreed still agree.
+        assert_eq!(word("paused"), "paused");
+        assert_eq!(word("complete"), "complete");
+        assert_eq!(word("error"), "error");
+        assert_eq!(word("cancelled"), "cancelled");
+
+        // A word this build does not know belongs to a newer daemon on the
+        // other end of the socket. It goes out as it arrived: a client can
+        // still show it, where a dropped frame or an invented status leaves it
+        // with nothing or with a lie.
+        assert_eq!(word("hibernating"), "hibernating");
+    }
+
+    /// The terminal frame goes through the same translation. The three words
+    /// happen to be identical in both vocabularies, so nothing on the wire
+    /// changes here - the point is that the rule is applied once for every
+    /// status the server emits rather than remembered per call site.
+    #[test]
+    fn the_completion_frame_speaks_it_too() {
+        let json = serde_json::to_value(to_server_event(WorldEvent::Completed {
+            run_id: "run-1".into(),
+            agent_id: "a".into(),
+            status: "complete".into(),
+            final_output: None,
+        }))
+        .unwrap();
+        assert_eq!(json["status"], "complete");
     }
 
     /// The fine-grained events used to arrive wrapped as `{"type":"world",

--- a/crates/leviath-cli/src/commands/serve/tree.rs
+++ b/crates/leviath-cli/src/commands/serve/tree.rs
@@ -15,7 +15,7 @@ pub(super) fn build_tree(runs: &[RunMeta], parent_id: Option<&str>) -> Vec<Agent
             AgentTreeNode {
                 run_id: r.run_id.clone(),
                 agent_name: r.agent_name.clone(),
-                status: format!("{}", r.status),
+                status: r.status.wire().to_string(),
                 stage: r.current_stage.clone(),
                 iteration: r.iteration,
                 prompt_tokens: r.prompt_tokens,
@@ -44,7 +44,7 @@ pub(super) fn build_tree_status(runs: &[RunMeta], parent_id: Option<&str>) -> Ve
             TreeStatusNode {
                 run_id: r.run_id.clone(),
                 agent_name: r.agent_name.clone(),
-                status: format!("{}", r.status),
+                status: r.status.wire().to_string(),
                 stage: r.current_stage.clone(),
                 prompt_tokens: r.prompt_tokens,
                 completion_tokens: r.completion_tokens,
@@ -88,7 +88,7 @@ pub(super) async fn agent_tree_status(
     Ok(Json(TreeStatusNode {
         run_id: root.run_id.clone(),
         agent_name: root.agent_name.clone(),
-        status: format!("{}", root.status),
+        status: root.status.wire().to_string(),
         stage: root.current_stage.clone(),
         prompt_tokens: root.prompt_tokens,
         completion_tokens: root.completion_tokens,
@@ -170,6 +170,28 @@ mod tests {
         assert_eq!(c1.run_id, "c1");
         assert_eq!(c1.children.len(), 1);
         assert_eq!(c1.children[0].run_id, "gc");
+    }
+
+    /// The tree routes rendered a status through `Display`, which is
+    /// PascalCase and squashes the two multi-word states into `WaitingInput`
+    /// and `CompleteInteractive` - words no other route on this server sends.
+    /// A client walking a tree and then fetching one of its runs got two
+    /// different spellings of the one state.
+    #[test]
+    fn a_tree_node_spells_its_status_the_way_a_run_does() {
+        let mut waiting = make_meta("p", "a", None);
+        waiting.status = crate::runstate::RunStatus::WaitingInput;
+        let mut interactive = make_meta("c", "b", Some("p"));
+        interactive.status = crate::runstate::RunStatus::CompleteInteractive;
+        let runs = vec![waiting, interactive];
+
+        let tree = build_tree(&runs, None);
+        assert_eq!(tree[0].status, "waiting_input");
+        assert_eq!(tree[0].children[0].status, "complete_interactive");
+
+        let tree = build_tree_status(&runs, None);
+        assert_eq!(tree[0].status, "waiting_input");
+        assert_eq!(tree[0].children[0].status, "complete_interactive");
     }
 
     #[test]

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -37,6 +37,31 @@ pub enum RunStatus {
     Cancelled,
 }
 
+impl RunStatus {
+    /// The word this status goes on the wire as: `snake_case`, the same
+    /// spelling serde writes into `meta.json` and into every JSON body that
+    /// carries a whole run.
+    ///
+    /// Here rather than left to each caller because a status reaches a client
+    /// three ways - serialized inside a run, rendered into a `status` string by
+    /// a route that builds its own response shape, and forwarded off the
+    /// engine's event stream - and those used to be three different spellings
+    /// of the same state. [`Display`](std::fmt::Display) is PascalCase and is
+    /// for a person reading a terminal; this is for a client matching on it.
+    pub fn wire(&self) -> &'static str {
+        match self {
+            RunStatus::Starting => "starting",
+            RunStatus::Running => "running",
+            RunStatus::WaitingInput => "waiting_input",
+            RunStatus::Complete => "complete",
+            RunStatus::CompleteInteractive => "complete_interactive",
+            RunStatus::Paused => "paused",
+            RunStatus::Error => "error",
+            RunStatus::Cancelled => "cancelled",
+        }
+    }
+}
+
 impl std::fmt::Display for RunStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -715,7 +740,13 @@ pub struct RegionEntrySnapshot {
 pub struct RegionSnapshot {
     /// The region's name, matching its key under `[context.regions]`.
     pub name: String,
-    /// Stringified kind: "pinned", "temporary", "clearable", "sliding", "compacting", "history"
+    /// Stringified kind, spelled the way the blueprint spells it: `pinned`,
+    /// `temporary`, `clearable`, `sliding_window`, `compacting`,
+    /// `compact_history`, `hashmap`, `checklist`, `custom`.
+    ///
+    /// A snapshot written by an older build says `sliding` and `history` for
+    /// those two, and those files stay on disk, so a reader that renders this
+    /// accepts both spellings.
     pub kind: String,
     /// Tokens the region held when the snapshot was taken.
     pub current_tokens: usize,
@@ -896,6 +927,29 @@ mod tests {
             "/work".to_string(),
             3,
         )
+    }
+
+    /// `wire()` has to say exactly what serde says, because the two spellings
+    /// reach the same client from different routes - one from a whole run
+    /// serialized as JSON, the other from a route that builds its own `status`
+    /// string. Derived from serde here rather than compared to a second hand
+    /// written list, so a renamed variant fails this instead of shipping two
+    /// words for one state.
+    #[test]
+    fn the_wire_word_is_the_word_serde_writes() {
+        for status in [
+            RunStatus::Starting,
+            RunStatus::Running,
+            RunStatus::WaitingInput,
+            RunStatus::Complete,
+            RunStatus::CompleteInteractive,
+            RunStatus::Paused,
+            RunStatus::Error,
+            RunStatus::Cancelled,
+        ] {
+            let serde_word = serde_json::to_value(&status).unwrap();
+            assert_eq!(serde_word, serde_json::json!(status.wire()));
+        }
     }
 
     /// The webhook signing secret must not survive into anything served over

--- a/crates/leviath-runtime/src/components/mod.rs
+++ b/crates/leviath-runtime/src/components/mod.rs
@@ -163,6 +163,34 @@ impl AgentStatus {
             Self::Cancelled => "cancelled",
         }
     }
+
+    /// The status a [`label`](Self::label) came from, or `None` for a word this
+    /// build does not know.
+    ///
+    /// The inverse table, kept against the forward one so the two are read and
+    /// changed together. It exists because a status crosses the control socket
+    /// flattened to its label: the gateway receives words, not statuses, and
+    /// has to get back to the status to say what it means in the vocabulary its
+    /// own clients read (see
+    /// [`run_status_for_label`](crate::persistence::run_status_for_label)).
+    ///
+    /// An error's message does not survive the round trip - the label never
+    /// carried it - so this returns the variant with an empty one. Match on
+    /// what the status *is*; the message is on the event that carried it.
+    pub fn from_label(label: &str) -> Option<Self> {
+        Some(match label {
+            "idle" => Self::Idle,
+            "active" => Self::Active,
+            "waiting" => Self::Waiting,
+            "paused" => Self::Paused,
+            "complete" => Self::Complete,
+            "error" => Self::Error {
+                message: String::new(),
+            },
+            "cancelled" => Self::Cancelled,
+            _ => return None,
+        })
+    }
 }
 
 impl std::fmt::Display for AgentStatus {
@@ -319,6 +347,31 @@ mod tests {
     use super::*;
     use crate::test_support::with_tracing;
     use leviath_core::{EvictionStrategy, Region, RegionKind};
+
+    /// Every label this build writes has to be a label it can read back, or the
+    /// gateway silently stops translating the status it was handed.
+    #[test]
+    fn a_label_reads_back_as_the_status_that_wrote_it() {
+        for status in [
+            AgentStatus::Idle,
+            AgentStatus::Active,
+            AgentStatus::Waiting,
+            AgentStatus::Paused,
+            AgentStatus::Complete,
+            AgentStatus::Cancelled,
+        ] {
+            assert_eq!(AgentStatus::from_label(status.label()), Some(status));
+        }
+        // The message is not in the label, so an error comes back with an empty
+        // one rather than not coming back at all.
+        assert_eq!(
+            AgentStatus::from_label("error"),
+            Some(AgentStatus::Error {
+                message: String::new()
+            })
+        );
+        assert_eq!(AgentStatus::from_label("hibernating"), None);
+    }
 
     #[test]
     fn test_context_window_creation() {

--- a/crates/leviath-runtime/src/persistence.rs
+++ b/crates/leviath-runtime/src/persistence.rs
@@ -201,6 +201,25 @@ pub fn run_status_from(status: &AgentStatus) -> RunStatus {
     }
 }
 
+/// The [`RunStatus`] behind an engine status *label*, or `None` for a word this
+/// build does not know.
+///
+/// [`run_status_from`] is the authority and takes the status itself; this is
+/// the same mapping for a caller holding only the word. The gateway is that
+/// caller: a [`WorldEvent`](crate::host::WorldEvent) crosses the control socket
+/// with its status already flattened to a label, and the gateway has to name
+/// the same state in the vocabulary its own clients read - `running` where the
+/// engine says `idle` or `active`, `waiting_input` where it says `waiting`.
+/// Doing that here rather than in the gateway is what keeps the mapping in one
+/// place instead of copied into every console that watches the socket.
+///
+/// `None` means the daemon on the other end of the socket knows a status this
+/// build does not, which is a version skew rather than a bad value: the caller
+/// should pass the word through untranslated rather than invent a state.
+pub fn run_status_for_label(label: &str) -> Option<RunStatus> {
+    AgentStatus::from_label(label).map(|status| run_status_from(&status))
+}
+
 /// Map an agent's ECS status to the on-disk per-stage [`StageRunStatus`] for the
 /// stage it is currently in. `Cancelled` has no stage-level equivalent, so it
 /// surfaces as `Error` (the stage stopped without completing).
@@ -214,19 +233,22 @@ pub fn stage_status_from(status: &AgentStatus) -> StageRunStatus {
     }
 }
 
-/// The stringified region kind used in snapshots (matches the dashboard reader).
+/// The stringified region kind used in snapshots and by the blueprint API.
 ///
-/// Public because the blueprint API reports region kinds too, and two spellings
-/// of the same kind - `sliding` from a context snapshot, `sliding_window` from
-/// a blueprint - is a trap for any console reading both.
+/// One word per kind, and it is the word the blueprint's own TOML uses. It used
+/// to be a third spelling of its own - `sliding` for a `sliding_window`,
+/// `history` for a `compact_history` - which meant a console reading a context
+/// snapshot and a console reading a blueprint disagreed about what the same
+/// region was. Snapshots written by an older build still carry the old two
+/// words, so a reader that renders kinds should accept both.
 pub fn region_kind_str(kind: &RegionKind) -> &'static str {
     match kind {
         RegionKind::Pinned => "pinned",
         RegionKind::Temporary => "temporary",
         RegionKind::Clearable => "clearable",
-        RegionKind::SlidingWindow { .. } => "sliding",
+        RegionKind::SlidingWindow { .. } => "sliding_window",
         RegionKind::Compacting { .. } => "compacting",
-        RegionKind::CompactHistory { .. } => "history",
+        RegionKind::CompactHistory { .. } => "compact_history",
         RegionKind::HashMap { .. } => "hashmap",
         RegionKind::Checklist => "checklist",
         RegionKind::Custom { .. } => "custom",
@@ -575,6 +597,38 @@ mod tests {
             run_status_from(&AgentStatus::Cancelled),
             RunStatus::Cancelled
         );
+    }
+
+    /// Going through the label must land where going through the status lands.
+    /// The gateway only ever has the label, so if these two disagree the
+    /// websocket and the REST routes describe the same run differently - which
+    /// is the whole bug this mapping exists to close.
+    #[test]
+    fn the_label_route_and_the_status_route_agree() {
+        for status in [
+            AgentStatus::Idle,
+            AgentStatus::Active,
+            AgentStatus::Waiting,
+            AgentStatus::Paused,
+            AgentStatus::Complete,
+            AgentStatus::Error {
+                message: "x".to_string(),
+            },
+            AgentStatus::Cancelled,
+        ] {
+            assert_eq!(
+                run_status_for_label(status.label()),
+                Some(run_status_from(&status))
+            );
+        }
+    }
+
+    /// A word this build does not know is a daemon newer than the reader, not a
+    /// state to invent: the caller gets `None` and passes the word through.
+    #[test]
+    fn an_unknown_label_maps_to_nothing() {
+        assert_eq!(run_status_for_label("hibernating"), None);
+        assert_eq!(run_status_for_label(""), None);
     }
 
     #[test]
@@ -1073,9 +1127,11 @@ mod tests {
                 "pinned",
                 "temporary",
                 "clearable",
-                "sliding",
+                // The blueprint's own words for these two, not a spelling that
+                // only ever appeared in a snapshot.
+                "sliding_window",
                 "compacting",
-                "history",
+                "compact_history",
                 "hashmap",
                 "custom",
                 "checklist",

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -193,6 +193,48 @@ errors. `tail` is a byte budget for how much of the end you get back.
 > in one shared world, so there is no process per run. If you are tracking slots from outside, read
 > [reconciling an external work queue](/docs/work-queues) first.
 
+## Statuses
+
+A run's status is one word, and it is the same word everywhere: on the run itself, in a tree node,
+on `GET /api/agents/{id}/result`, and on the `agent_status` frames coming off the WebSocket.
+
+| Status | Means |
+|---|---|
+| `starting` | Accepted and being set up. No inference has been issued yet |
+| `running` | Working: inferring, calling tools, or moving between stages |
+| `waiting_input` | Parked. `wait_reason` says on what, and only some of those want a person |
+| `paused` | Paused by somebody. Resumes on request, and comes back paused after a daemon restart |
+| `complete` | Finished, with nothing further to accept |
+| `complete_interactive` | Every required stage is done and the run still takes follow-up input |
+| `error` | Stopped by a failure. The run's `error` carries what went wrong |
+| `cancelled` | Stopped from outside. Nothing went wrong, somebody decided |
+
+The engine keeps its own vocabulary inside the daemon, where a run that is going is `idle` or
+`active` and a parked one is `waiting`. Those words used to reach the socket untranslated, so a
+client watching `/ws` was matching on three words no route ever sent, and a status frame quietly did
+nothing for it. They are translated on the way out now.
+
+Two older spellings are gone with them: `GET /api/agents/{id}/result` and the two tree routes
+rendered the status for a human reader, which meant `WaitingInput` and `CompleteInteractive` where
+every other route said `waiting_input` and `complete_interactive`.
+
+`events.run_status` in the `capabilities` list is how you tell. A server without it sends the
+engine's words on `agent_status` and the older spellings on those three routes.
+
+The `status=` filter on `GET /api/runs` stays looser than this list on purpose: it also takes
+`waitinginput` and `Waiting-Input`, so a status read off any response can be handed straight back as
+a filter.
+
+## Region kinds
+
+A region's `kind`, wherever one appears (`GET /api/agents/{id}/context`, its history, the blueprint
+detail route), is the word the blueprint's own TOML uses: `pinned`, `temporary`, `clearable`,
+`sliding_window`, `compacting`, `compact_history`, `hashmap`, `checklist`, `custom`.
+
+Context snapshots written by an older daemon say `sliding` and `history` for the two multi-word
+kinds, and those files stay on disk, so accept both spellings wherever you render one.
+`context.region_kinds` says a server writes the blueprint's words.
+
 ## Listing and searching runs
 
 `GET /api/runs` returns a page, not the whole list:
@@ -560,6 +602,10 @@ title. `run_renamed` is that moment. The same `title` then rides every `agent_st
 client that connected or reconnected after the rename reads the name off the next status instead of
 fetching the run. Both are the `events.title` capability; without it a client has to poll each new
 run until it has a name. `title` is absent, not null, while a run has none.
+
+`status`, on `agent_status` and on `agent_completed`, is the word `GET /api/runs` uses for the same
+run. See [Statuses](#statuses) for the list and for what a server that predates
+`events.run_status` sends instead.
 
 `wait_reason` is present only on a parked run, and says what it is parked on rather than making
 you fetch the run to find out. `ok` on `tool_call_finished` is `false` for a result the engine

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1600,7 +1600,8 @@
             "type": "string"
           },
           "status": {
-            "type": "string"
+            "type": "string",
+            "description": "The run's status, in the same words a run object uses: starting, running, waiting_input, paused, complete, complete_interactive, error, cancelled. A server that does not announce `events.run_status` sends the Display spelling here instead (`WaitingInput`)."
           },
           "output": {
             "type": "string",


### PR DESCRIPTION
Closes #561.

## What was wrong

`agent_status` on the WebSocket carried `AgentStatus::label` (`idle`, `active`, `waiting`, …) while every REST route carried `RunStatus` (`running`, `waiting_input`, …). Same field name, same fact, four words apart, and the mapping between them lived in the daemon and nowhere in the API, so each client re-derived it or guessed.

Two spellings turned out to be three. `GET /api/agents/{id}/result`, `GET /api/agents/tree` and `GET /api/agents/{id}/tree-status` rendered the status through `Display`, which is PascalCase and for a person reading a terminal, so they answered `WaitingInput` where the run object answered `waiting_input`.

The same hazard one level down, which the issue flagged: a context snapshot wrote `sliding` for a `sliding_window` region and `history` for a `compact_history`, so a console reading a snapshot and a console reading a blueprint disagreed about what one region was.

## What changed

- The translation happens once, on the way out of the server (`to_server_event`), through the mapping that was already the authority. `run_status_for_label` reaches `run_status_from` by label, because a `WorldEvent` crosses the control socket with its status already flattened to a word. A word this build does not know goes out untranslated: that is a daemon newer than the gateway, not a value to invent a state for.
- `agent_completed` and the completion webhook go through the same call. The three terminal words are identical in both vocabularies, so nothing on the wire changes there; the point is that the rule is applied once rather than remembered per call site.
- The three `Display` routes now use `RunStatus::wire()`, the one place the snake_case word is defined. A test derives the expected word from serde, so a renamed variant fails there instead of shipping two spellings.
- `region_kind_str` writes the blueprint's own words (`sliding_window`, `compact_history`). Snapshots already on disk keep the old two, so the dashboard accepts both; its kind column widens to 16, because `compact_history` is fifteen characters and a word wider than its column pushes that row's token bar out of line with every other row.
- Announced as `events.run_status` and `context.region_kinds`, so a console can tell which vocabulary it is being sent rather than sniffing the strings. Documented in `docs/content/api.md` under **Statuses** and **Region kinds**.

Breaking for a client matching on the engine's words, or on `WaitingInput` / `CompleteInteractive` from those three routes.

## Verification

Every new test was run against the unfixed code first. The status one fails there with `left: "idle", right: "running"`; the dashboard one fails on the column width (12 against 14).

Live, with a mock provider and an isolated home, the released `lev 0.4.0` binary as the control and this build second, same blueprint, same run shape:

| | 0.4.0 | this build |
|---|---|---|
| `agent_status` (socket) | `active`, then `waiting` | `running`, then `waiting_input` |
| `GET /api/agents/{id}` | `waiting_input` | `waiting_input` |
| `GET /api/agents/tree` | `WaitingInput` | `waiting_input` |
| `…/result` | `WaitingInput` | `waiting_input` |
| `…/context` region kind | `sliding` | `sliding_window` |
| blueprint detail route | `sliding_window` | `sliding_window` |

The full run went `running` → `waiting_input` (`wait_reason: user_prompt`) → `running` → `complete`, with `agent_completed: complete`, every word a `RunStatus` word. The Context tree was captured out of a real pty through a screen model: the older build draws `conversation    sliding_window░░░░` with the bar shunted right, this one lines the column up.

Workspace tests green, clippy clean, `cargo xtask coverage` at 100% for all 13 packages.

## One thing left alone

The dashboard's region-name column is `{:<16}` and `stage_instructions` is eighteen characters, so it overflows the same way `sliding_window` did. That predates this change and is a separate call about how wide the tree should be, so I have not touched it.
