### PR TITLE
feat(serve): filter GET /api/runs to top-level runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ same list.
   before. `total` then counts what was asked for rather than every run on the
   machine, which is what makes it worth printing beside a list. Announced as
   `runs.parent`; cursors minted before this existed stay valid.
+- Fixed: the API guide explains every capability the server announces. `GET
+  /api/config` hands a client a list of strings and expects it to change what it
+  does based on them, and twenty-three of the thirty-six had never been written
+  down anywhere but the source, so the only way to learn what one meant was to
+  read the daemon. There is now a table of all of them, and a test that fails
+  when a capability is announced without being explained, because announcing and
+  documenting are one act or they drift.
 
 - Fixed: the dashboard's Context tree keeps its columns lined up whatever the
   regions are called. The name sat in a fixed sixteen-character column that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ same list.
 
 ## Unreleased
 
+- Added: `GET /api/runs` takes a `parent` filter. A run's sub-agents are runs,
+  so a console that draws workers nested under the run that started them was
+  paging by a unit it does not display: a page of fifty could be seven visible
+  rows and forty-three workers hanging off them, and on a fleet that fans out
+  ten ways one visible row per page is possible. `parent=none` lists only the
+  runs nobody started, which is what a top-level list wants; `parent=<run_id>`
+  lists that run's direct children, which is the paged, sorted, searchable form
+  of `GET /api/agents/{id}/children`. Omitting it lists every run exactly as
+  before. `total` then counts what was asked for rather than every run on the
+  machine, which is what makes it worth printing beside a list. Announced as
+  `runs.parent`; cursors minted before this existed stay valid.
+
 - Fixed: the dashboard's Context tree keeps its columns lined up whatever the
   regions are called. The name sat in a fixed sixteen-character column that
   padded a short name but never cut a long one, so `stage_instructions` - which

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -70,6 +70,13 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     "runs.fields",
     "runs.ids",
     "runs.since",
+    // `parent=none` / `parent=<run_id>` on the run listing. Worth announcing
+    // rather than leaving to be discovered, because the fallback is real work:
+    // a console that draws sub-agents nested under their parent has to page
+    // until enough top-level rows exist to fill a viewport, holding several
+    // hundred runs to show a few dozen. With this it pages by the rows it
+    // draws, and `total` counts them.
+    "runs.parent",
     "runs.files.listing",
     "runs.files.workdir",
     "runs.stages",

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -501,6 +501,9 @@ mod tests {
     /// The published OpenAPI spec for this API.
     const OPENAPI: &str = include_str!("../../../../../docs/schema/openapi.json");
 
+    /// The published API guide, which is where a capability is explained.
+    const API_GUIDE: &str = include_str!("../../../../../docs/content/api.md");
+
     /// `GET /api/config` reports an `api_version`, and it has to mean
     /// something. A version a client can read that disagrees with the document
     /// describing that version is worse than publishing no version at all - the
@@ -515,6 +518,27 @@ mod tests {
             .as_str()
             .expect("the spec declares a version");
         assert_eq!(documented, types::API_VERSION);
+    }
+
+    /// A capability is a promise, and a promise nobody can read is not one.
+    ///
+    /// `GET /api/config` hands a client a list of strings and expects it to
+    /// change its behaviour based on them. Twenty-three of them had never been
+    /// named in the guide, so the only way to learn what one meant was to read
+    /// this crate - which a browser console's author has no reason to have.
+    /// The same spirit as the route-drift test below: announcing it and
+    /// documenting it are one act, or they drift.
+    #[test]
+    fn every_announced_capability_is_explained_in_the_guide() {
+        let undocumented: Vec<&str> = types::API_CAPABILITIES
+            .iter()
+            .copied()
+            .filter(|capability| !API_GUIDE.contains(*capability))
+            .collect();
+        assert!(
+            undocumented.is_empty(),
+            "announced but never explained in docs/content/api.md: {undocumented:?}"
+        );
     }
 
     /// Every `(path, METHOD)` the spec documents.

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -134,6 +134,70 @@ impl Source {
     }
 }
 
+/// Which runs a listing is about.
+///
+/// A run's sub-agents are runs, so a console that draws them nested under the
+/// run that started them was paging by a unit it does not display: a page of
+/// fifty could be seven visible rows and forty-three workers hanging off them,
+/// and there was no way to ask for anything better. This is that way.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ParentFilter {
+    /// No `parent` given: every run, sub-agents included. What this route has
+    /// always returned, so an existing caller sees nothing change.
+    Any,
+    /// `parent=none`: only runs nobody started. What a top-level list wants,
+    /// and what makes `total` a count of the rows a client will actually draw.
+    Roots,
+    /// `parent=<run_id>`: that run's direct children. `GET
+    /// /api/agents/{id}/children` answers the same question in one unpaged,
+    /// unsorted array, which a fan-out of two hundred workers has no windowed
+    /// form of.
+    Of(String),
+}
+
+impl ParentFilter {
+    /// `none` is the only keyword. Nothing else can collide with it: a run id
+    /// is `<agent>-<timestamp>-<hash>`, so no run is ever called `none`.
+    ///
+    /// An empty value reads as absent rather than as a filter matching nothing,
+    /// which is what a client that built its query string from an empty box
+    /// meant. Anything else is taken as a run id, and a run id that names
+    /// nothing gives an empty page - the same answer `status=` gives for a
+    /// status nothing is in, rather than a 404 for a run that may simply have
+    /// no children yet.
+    fn parse(raw: Option<&str>) -> Self {
+        match raw.map(str::trim).filter(|s| !s.is_empty()) {
+            None => Self::Any,
+            Some("none") => Self::Roots,
+            Some(id) => Self::Of(id.to_string()),
+        }
+    }
+
+    /// Whether this run belongs in the listing.
+    fn keeps(&self, meta: &RunMeta) -> bool {
+        match self {
+            Self::Any => true,
+            Self::Roots => meta.parent_run_id.is_none(),
+            Self::Of(parent) => meta.parent_run_id.as_deref() == Some(parent.as_str()),
+        }
+    }
+
+    /// This filter's contribution to the cursor digest, so a walk cannot change
+    /// what it is filtering halfway through.
+    ///
+    /// `None` for [`Any`](Self::Any), which contributes nothing at all rather
+    /// than an empty part - an empty part is still a part, and would have
+    /// changed the digest of every unfiltered listing and so invalidated every
+    /// cursor a client was holding when it upgraded.
+    fn digest_part(&self) -> Option<&str> {
+        match self {
+            Self::Any => None,
+            Self::Roots => Some("none"),
+            Self::Of(parent) => Some(parent.as_str()),
+        }
+    }
+}
+
 /// Query parameters of `GET /api/runs`.
 #[derive(serde::Deserialize, Default)]
 pub(super) struct RunsQuery {
@@ -147,6 +211,7 @@ pub(super) struct RunsQuery {
     pub(super) fields: Option<String>,
     pub(super) ids: Option<String>,
     pub(super) since: Option<i64>,
+    pub(super) parent: Option<String>,
 }
 
 /// A validated query. Every 400 this route can produce is decided here, so the
@@ -163,6 +228,7 @@ struct Resolved {
     fields: Option<HashSet<String>>,
     ids: Option<Vec<String>>,
     since: Option<i64>,
+    parent: ParentFilter,
     digest: String,
 }
 
@@ -194,6 +260,7 @@ fn resolve(query: &RunsQuery) -> Result<Resolved, ApiError> {
     // paging, ordering and filtering have nothing to act on. Rejecting the
     // combination is deliberate - a silently ignored parameter produces the
     // kind of bug report that takes a day to read.
+    let parent = ParentFilter::parse(query.parent.as_deref());
     let ids = query.ids.as_deref().map(comma_list);
     if let Some(ref ids) = ids {
         let conflicts = [
@@ -201,6 +268,9 @@ fn resolve(query: &RunsQuery) -> Result<Resolved, ApiError> {
             ("q", query.q.is_some()),
             ("status", query.status.is_some()),
             ("since", query.since.is_some()),
+            // The resolved filter rather than the raw parameter, so `parent=`
+            // is the no-op it looks like rather than a conflict.
+            ("parent", parent != ParentFilter::Any),
         ];
         if let Some((name, _)) = conflicts.iter().find(|(_, present)| *present) {
             return Err(bad_request(format!(
@@ -293,12 +363,22 @@ fn resolve(query: &RunsQuery) -> Result<Resolved, ApiError> {
 
     // The filters, in a fixed order, so the same filter set always digests the
     // same way.
-    let digest = cursor::filter_digest(&[
-        &statuses.join(","),
-        q.as_deref().unwrap_or(""),
-        sources_raw,
-        &query.since.map(|s| s.to_string()).unwrap_or_default(),
-    ]);
+    let since_part = query.since.map(|s| s.to_string()).unwrap_or_default();
+    let mut parts = vec![
+        statuses.join(","),
+        q.clone().unwrap_or_default(),
+        sources_raw.to_string(),
+        since_part,
+    ];
+    // Appended only when it filters something. A digest identifies the filter
+    // *set*, and `Any` is the absence of this one - so a listing that does not
+    // use it digests exactly as it did before the parameter existed, and every
+    // cursor a client is already holding stays valid across the upgrade.
+    if let Some(part) = parent.digest_part() {
+        parts.push(part.to_string());
+    }
+    let refs: Vec<&str> = parts.iter().map(String::as_str).collect();
+    let digest = cursor::filter_digest(&refs);
 
     let cursor = match query.cursor.as_deref() {
         None => None,
@@ -319,6 +399,7 @@ fn resolve(query: &RunsQuery) -> Result<Resolved, ApiError> {
         fields,
         ids,
         since: query.since,
+        parent,
         digest,
     })
 }
@@ -382,6 +463,9 @@ pub(super) async fn list_runs(
     }
 
     let mut runs = runstate::list_runs();
+    // Before the sort and before `total`, like every other filter here, so the
+    // count describes what was asked for rather than what is on the machine.
+    runs.retain(|meta| resolved.parent.keeps(meta));
     if !resolved.statuses.is_empty() {
         runs.retain(|meta| {
             resolved

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -25,6 +25,14 @@ fn meta_at(id: &str, started_at: i64) -> RunMeta {
     meta
 }
 
+/// A run started by `parent`, which is what makes it a sub-agent rather than a
+/// row a top-level listing draws.
+fn child_of(id: &str, started_at: i64, parent: &str) -> RunMeta {
+    let mut meta = meta_at(id, started_at);
+    meta.parent_run_id = Some(parent.to_string());
+    meta
+}
+
 /// Build a `RunsQuery` the way a real request would, through axum's own
 /// extractor, so these tests cannot pass on a struct shape the wire never
 /// produces.
@@ -164,7 +172,7 @@ fn fields_accepts_the_optional_ones_that_only_some_runs_carry() {
 /// reports, so each conflicting combination is refused by name.
 #[test]
 fn ids_cannot_be_combined_with_the_parameters_it_would_override() {
-    for conflicting in ["cursor", "q", "status", "since"] {
+    for conflicting in ["cursor", "q", "status", "since", "parent"] {
         let message = resolve_err(&[("ids", "a,b"), (conflicting, "1")]);
         assert!(
             message.contains(conflicting),
@@ -189,6 +197,55 @@ fn too_many_ids_are_refused() {
 #[test]
 fn an_empty_query_string_is_treated_as_no_search() {
     assert!(resolve_ok(&[("q", "")]).q.is_none());
+}
+
+/// The three things `parent` can mean, and the one spelling that is a keyword.
+#[test]
+fn parent_resolves_to_the_three_shapes_it_has() {
+    assert_eq!(resolve_ok(&[]).parent, ParentFilter::Any);
+    // Whitespace is the query-string equivalent of an empty box.
+    assert_eq!(resolve_ok(&[("parent", "  ")]).parent, ParentFilter::Any);
+    assert_eq!(
+        resolve_ok(&[("parent", "none")]).parent,
+        ParentFilter::Roots
+    );
+    assert_eq!(
+        resolve_ok(&[("parent", "run-7")]).parent,
+        ParentFilter::Of("run-7".to_string())
+    );
+
+    // And what each keeps, which is the half the handler leans on.
+    let root = meta_at("root", 1);
+    let child = child_of("child", 2, "root");
+    assert!(ParentFilter::Any.keeps(&root) && ParentFilter::Any.keeps(&child));
+    assert!(ParentFilter::Roots.keeps(&root) && !ParentFilter::Roots.keeps(&child));
+    let of_root = ParentFilter::Of("root".to_string());
+    assert!(of_root.keeps(&child) && !of_root.keeps(&root));
+}
+
+/// A cursor carries the filters it was minted under, so a walk cannot change
+/// what it is filtering halfway through - which for this one would mean a
+/// client paging past sub-agents it had asked not to see.
+#[test]
+fn a_cursor_is_bound_to_the_parent_filter_it_was_minted_for() {
+    let roots = resolve_ok(&[("parent", "none")]);
+    let raw = cursor::encode(
+        roots.sort.as_str(),
+        "desc",
+        &roots.digest,
+        CursorKey::Int(10),
+        "run-a",
+    );
+
+    assert!(resolve(&query(&[("parent", "none"), ("cursor", &raw)])).is_ok());
+    assert!(resolve_err(&[("cursor", &raw)]).contains("filters"));
+    assert!(resolve_err(&[("parent", "run-7"), ("cursor", &raw)]).contains("filters"));
+
+    // The unfiltered digest is unchanged by this parameter existing, so every
+    // cursor a client is holding from before it stays valid.
+    let anything = resolve_ok(&[]);
+    let before = cursor::filter_digest(&["", "", "meta,files", ""]);
+    assert_eq!(anything.digest, before);
 }
 
 // ─── cursor binding ─────────────────────────────────────────────────────────
@@ -560,6 +617,78 @@ async fn the_handler_filters_by_the_status_spelling_it_serves() {
         // The serde spelling, which is what a client reads back off the wire.
         let page = page_of(&[("status", "waiting_input")]).await;
         assert_eq!(item_ids(&page), vec!["run-waiting".to_string()]);
+    })
+    .await;
+}
+
+/// The listing pages by runs, and a run's sub-agents are runs, so a console
+/// that draws workers nested under the run that started them was paging by a
+/// unit it does not display. A real sidebar at `limit=50` got seven visible
+/// rows and forty-three workers hanging off them.
+#[tokio::test]
+async fn parent_none_lists_only_the_runs_nobody_started() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-parent-none", |_d| async move {
+        create_run(&meta_at("root-a", 100)).unwrap();
+        create_run(&meta_at("root-b", 200)).unwrap();
+        for i in 0..8 {
+            create_run(&child_of(&format!("worker-{i}"), 300 + i, "root-b")).unwrap();
+        }
+
+        let page = page_of(&[("parent", "none")]).await;
+        assert_eq!(
+            item_ids(&page),
+            vec!["root-b".to_string(), "root-a".to_string()]
+        );
+        // And the count is of what was asked for. `10` here would be counting
+        // runs the client will never draw, which is what made it not worth
+        // printing.
+        assert_eq!(page.total, Some(2));
+    })
+    .await;
+}
+
+/// The other direction: one run's workers, through the same paging, sorting and
+/// filtering as everything else. `GET /api/agents/{id}/children` answers this
+/// too, in one unpaged array, which a fan-out of two hundred has no windowed
+/// form of.
+#[tokio::test]
+async fn parent_by_id_lists_that_runs_direct_children() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-parent-id", |_d| async move {
+        create_run(&meta_at("root", 100)).unwrap();
+        create_run(&child_of("worker-1", 200, "root")).unwrap();
+        create_run(&child_of("worker-2", 300, "root")).unwrap();
+        create_run(&child_of("other-workers-child", 400, "worker-1")).unwrap();
+
+        // Direct children only - the grandchild belongs to `worker-1`.
+        let page = page_of(&[("parent", "root")]).await;
+        assert_eq!(
+            item_ids(&page),
+            vec!["worker-2".to_string(), "worker-1".to_string()]
+        );
+        assert_eq!(page.total, Some(2));
+
+        // A parent that started nothing, or that never existed, is an empty
+        // page rather than a 404: a run with no children yet is a normal
+        // answer, not a missing resource.
+        assert!(page_of(&[("parent", "worker-2")]).await.items.is_empty());
+        assert!(page_of(&[("parent", "no-such-run")]).await.items.is_empty());
+    })
+    .await;
+}
+
+/// Omitting it has to leave the route exactly as it was, or every existing
+/// caller silently loses its sub-agents.
+#[tokio::test]
+async fn omitting_parent_still_lists_every_run() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-parent-absent", |_d| async move {
+        create_run(&meta_at("root", 100)).unwrap();
+        create_run(&child_of("worker", 200, "root")).unwrap();
+
+        assert_eq!(page_of(&[]).await.total, Some(2));
+        // An empty value is the same as absent: a client that built its query
+        // from an empty box did not mean "runs whose parent is the empty
+        // string", which matches nothing.
+        assert_eq!(page_of(&[("parent", "")]).await.total, Some(2));
     })
     .await;
 }

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -693,6 +693,82 @@ async fn omitting_parent_still_lists_every_run() {
     .await;
 }
 
+/// The filters compose, which is the pair a sidebar actually asks for: the
+/// top-level runs that are still going. Each is a separate `retain`, so this
+/// pins the behaviour rather than the implementation.
+#[tokio::test]
+async fn parent_and_status_filter_together() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-parent-status", |_d| async move {
+        let mut busy_root = meta_at("root-busy", 100);
+        busy_root.status = RunStatus::Running;
+        create_run(&busy_root).unwrap();
+
+        let mut done_root = meta_at("root-done", 200);
+        done_root.status = RunStatus::Complete;
+        create_run(&done_root).unwrap();
+
+        // A worker that is running, so a filter on status alone would keep it.
+        let mut busy_worker = child_of("worker-busy", 300, "root-busy");
+        busy_worker.status = RunStatus::Running;
+        create_run(&busy_worker).unwrap();
+
+        let page = page_of(&[("parent", "none"), ("status", "running")]).await;
+        assert_eq!(item_ids(&page), vec!["root-busy".to_string()]);
+        assert_eq!(page.total, Some(1));
+
+        // Several statuses at once still work alongside it.
+        let page = page_of(&[("parent", "none"), ("status", "running,complete")]).await;
+        assert_eq!(
+            item_ids(&page),
+            vec!["root-done".to_string(), "root-busy".to_string()]
+        );
+    })
+    .await;
+}
+
+/// Every status a run can be in is selectable by the word the API hands back,
+/// whatever the spelling. A filter that silently matches nothing is worse than
+/// one that errors, and the two multi-word states are where it would happen.
+#[tokio::test]
+async fn every_status_is_selectable_by_the_word_the_api_returns() {
+    crate::runstate::with_isolated_runs_dir_async("runs-handler-every-status", |_d| async move {
+        let states = [
+            (RunStatus::Starting, "starting"),
+            (RunStatus::Running, "running"),
+            (RunStatus::WaitingInput, "waiting_input"),
+            (RunStatus::Paused, "paused"),
+            (RunStatus::Complete, "complete"),
+            (RunStatus::CompleteInteractive, "complete_interactive"),
+            (RunStatus::Error, "error"),
+            (RunStatus::Cancelled, "cancelled"),
+        ];
+        for (i, (status, word)) in states.iter().enumerate() {
+            let mut meta = meta_at(&format!("run-{word}"), i as i64);
+            meta.status = status.clone();
+            create_run(&meta).unwrap();
+        }
+
+        for (_, word) in states {
+            assert_eq!(
+                item_ids(&page_of(&[("status", word)]).await),
+                vec![format!("run-{word}")],
+                "filtering by {word}"
+            );
+        }
+
+        // And the loose spellings of the two that have more than one word, so a
+        // status taken from any response can be fed straight back as a filter.
+        for spelling in ["waitinginput", "Waiting-Input", "WaitingInput"] {
+            assert_eq!(
+                item_ids(&page_of(&[("status", spelling)]).await),
+                vec!["run-waiting_input".to_string()],
+                "filtering by {spelling}"
+            );
+        }
+    })
+    .await;
+}
+
 /// The batch fetch that replaces N separate `GET /api/agents/{id}` calls.
 #[tokio::test]
 async fn ids_fetches_exactly_those_runs_and_reports_the_ones_that_are_gone() {

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -586,6 +586,50 @@ one.
 after clicking it. Finding out whether the other routes exist costs a wasted request; finding out
 this way costs a deleted run.
 
+### What each capability means
+
+Every string this server can announce, and the thing it promises. A server that omits one is older
+than that feature, not broken.
+
+| Capability | The server has |
+|---|---|
+| `runs.envelope` | `GET /api/runs` answering `{items, next_cursor, total, server_time}` rather than a bare array |
+| `runs.cursor` | Keyset paging on that route: `cursor=` in, `next_cursor` out |
+| `runs.search` | `q=`, a case-insensitive substring over the run listing |
+| `runs.search.context` | `q_in=context`, searching each run's current context window |
+| `runs.search.logs` | `q_in=logs`, searching the tail of each stage's logs |
+| `runs.search.journal` | `q_in=journal`, searching the whole run journal |
+| `runs.fields` | `fields=`, trimming each item to the named top-level fields |
+| `runs.ids` | `ids=a,b,c`, fetching exactly those runs in one request |
+| `runs.since` | `since=`, filtering on whichever timestamp `sort` names |
+| `runs.parent` | `parent=none` / `parent=<run_id>`. See [listing by place in the tree](#listing-by-place-in-the-tree) |
+| `runs.files.listing` | `GET /api/agents/{id}/files`, the run's own record of what it changed |
+| `runs.files.workdir` | `source=workdir` on that route, reading the filesystem a directory at a time |
+| `runs.stages` | `GET /api/agents/{id}/stages`, the per-stage ledger |
+| `runs.waiting_on` | `wait_reason` on a run, saying what a parked run is parked on |
+| `runs.delete` | `DELETE /api/runs/{id}`, which removes the record rather than cancelling the run |
+| `runs.delete.bulk` | `DELETE /api/runs` with `before` or `ids`, bounded by `max_ids` |
+| `logs.stage` | `?stage=` on the logs route: an index, or `all` |
+| `logs.stream` | `?stream=` on it: `output` or `logs` |
+| `context.history.page` | Paging on `GET /api/agents/{id}/context/history` |
+| `context.region_kinds` | Region kinds spelled as the blueprint spells them. See [region kinds](#region-kinds) |
+| `events.waiting_on` | `wait_reason` on the socket too, not only on the run |
+| `events.stage_and_tool` | `stage_transition`, `tool_call_started` and `tool_call_finished` as flat frames instead of the old `world` envelope |
+| `events.spawn_parent` | `parent_id` on `agent_spawned`, placing a sub-agent in the tree the moment it starts |
+| `events.title` | The `run_renamed` frame, plus `title` on every `agent_status` |
+| `events.run_status` | One status vocabulary across the whole API. See [statuses](#statuses) |
+| `blueprints.envelope` | The paginated envelope on the blueprint listing |
+| `blueprints.query` | `q=` on that listing |
+| `blueprints.manifest` | The manifest itself on the blueprint detail route |
+| `blueprints.validate.name` | `POST /api/blueprints/validate` accepting an installed name, not only a body |
+| `blueprints.fan_outs` | `fan_outs` on the detail route. See [fan-out limits](#fan-out-limits) |
+| `tools.list` | `GET /api/tools?agent=`, what an agent here can actually call |
+| `scripts.read` | The `GET` half of the scripts routes |
+| `scripts.write` | That this build serves the write half. Whether *this* daemon mounts it is `--allow-admin`, which you find out by calling one and reading the status |
+| `scripts.providers` | `provider` as a fifth script `kind`, the machine's drop-in model providers |
+| `config.gateways` | `gateways` on `GET /api/config`, the script-backed providers this machine has |
+| `fs.mkdir` | `POST /api/fs/dirs`, so a folder picker can offer "New Folder" rather than one that 404s |
+
 ## Live updates over WebSocket
 
 Connect to `/ws` (all agents) or `/ws/agents/{id}` (one run) with `?token=<t>`; the server streams

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -262,6 +262,34 @@ Two parameters exist so a browser client does not have to make N requests: `ids=
 those runs, and `fields=run_id,status,title` trims each one. Ids that no longer exist come back in
 `missing` rather than failing the request.
 
+### Listing by place in the tree
+
+A run's sub-agents are runs, so a listing that pages by runs is not paging by the rows a console
+draws when it nests workers under the run that started them. At `limit=50`, seven visible rows and
+forty-three workers hanging off them is a real page.
+
+`parent=` fixes that from the server side:
+
+| Value | Keeps |
+|---|---|
+| omitted | Every run, sub-agents included. What this route has always returned |
+| `none` | Only runs nobody started. What a top-level list wants |
+| a run id | That run's direct children, one level down |
+
+`total` then counts what you asked for, which is what makes it worth printing beside a list: `382`
+under a sidebar drawing forty rows is comparing runs the reader can see against runs they cannot.
+
+`parent=<run_id>` is also the paged, sorted, searchable form of
+[`GET /api/agents/{id}/children`](#endpoints), which answers the same question in one unbounded
+array. A fan-out of two hundred workers has no windowed form there.
+
+A run id that names nothing gives an empty page rather than a `404`: a run with no children yet is
+a normal answer, not a missing resource. `none` is the only keyword, and no run can collide with it,
+since a run id is `<agent>-<timestamp>-<hash>`.
+
+Announced as `runs.parent`. Without it, page until enough top-level rows exist to fill the viewport
+and filter client-side, which is what The Lair does today.
+
 ### Search
 
 `q=` is a case-insensitive substring. It is not a regular expression, there are no boolean

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -292,6 +292,14 @@
             "description": "Comma-separated statuses to keep. Matched loosely: waiting_input, waitinginput and Waiting-Input are all accepted."
           },
           {
+            "name": "parent",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Which runs to list by their place in the tree. `none` keeps only runs nobody started, which is what a top-level list wants; a run id keeps that run's direct children. Omitted lists every run, sub-agents included. A run id that names nothing gives an empty page rather than a 404. Announced as `runs.parent`."
+          },
+          {
             "name": "sort",
             "in": "query",
             "schema": {


### PR DESCRIPTION
Closes #566.

Two commits: the filter, then a docs pass over the whole capability list that the filter's own capability made obvious was missing.

## The filter

One parameter on `GET /api/runs`:

| Value | Keeps |
|---|---|
| omitted | Every run, sub-agents included. Exactly what the route returns today |
| `none` | Only runs nobody started |
| a run id | That run's direct children |

`total` counts what was asked for, so it describes the rows a client will draw rather than every run on the machine.

It composes with `status`, which is the pair a sidebar actually asks for: `?parent=none&status=running` is "the top-level runs still going", one request.

### Details worth a look in review

**Cursors minted before this existed stay valid.** The filter joins the cursor digest, but only when it filters something. An empty part is still a part — `filter_digest` writes a separator after each one — so appending `""` for the unfiltered case would have changed the digest of every plain listing and 400'd every cursor a client was holding at the moment it upgraded. `digest_part()` returns `Option<&str>` for that reason, and there's a test pinning the unfiltered digest to the exact value it had before.

**`none` cannot collide with a run.** Run ids are `<agent>-<timestamp>-<hash>`, so no run is ever called `none`. An empty value (`parent=`) reads as absent.

**An unknown run id is an empty page, not a 404.** A run with no children yet is a normal answer.

**`ids` refuses it by name**, like the filters already there.

## The docs pass

`GET /api/config` hands a client a list of capability strings and expects it to change what it does based on them. **Twenty-three of the thirty-six had never been written down anywhere but this crate** — the only way to learn what `runs.files.workdir` or `blueprints.validate.name` promised was to read the daemon, which the author of a browser console has no reason to have.

The guide now has a table of all thirty-six, and a test fails when one is announced without being explained. Same reason the OpenAPI route list is held to the router by a test rather than by intent. I verified the guard in both directions: adding a fake `runs.undocumented_probe` fails it with the name.

Also pinned what was already true but untested about status filtering, since that is the filter a sidebar reaches for first: all eight statuses are selectable by the word the API returns, and the two multi-word ones by any spelling (`waiting_input`, `waitinginput`, `Waiting-Input`, `WaitingInput`).

## Verification

Live, against a real fan-out — a parent blueprint that spawns three workers, run twice, driven by a mock provider on an isolated home:

```
(omitted)              total=8   ['worker…5790', 'worker…b401', 'worker…26e6', 'parent…6666',
                                  'worker…948f', 'worker…b9f4', 'worker…51f2', 'parent…1744']
parent=none            total=2   ['parent…6666', 'parent…1744']
parent=<the parent>    total=3   ['worker…948f', 'worker…b9f4', 'worker…51f2']
parent=<a worker>      total=0   []
parent=no-such-run     total=0   []
parent= (empty)        total=8   [... all eight ...]
```

That top row is the issue: eight runs, two of which a nested sidebar draws.

And the cursor binding, live:

```
cursor minted under parent=none: 7b2276223a312c22…
  same filter, resumed   200 1 items
  filter dropped         400 Cursor was minted for a different set of filters; restart the walk
  filter changed         400 Cursor was minted for a different set of filters; restart the walk
  ids + parent           400 `ids` names exactly which runs to return, so it cannot be combined with `parent`
```

The first version of that probe was worthless and I nearly kept it: with only one root run there was no next page, so `next_cursor` was null and all three cases "passed" against the literal string `None`. Spawning a second root is what made it discriminating.

Both new handler tests were run against the unfixed code first. They fail there with the workers crowding out the roots — `["worker-7", …, "worker-0", "root-b", "root-a"]` where `["root-b", "root-a"]` was expected.

Workspace tests green, clippy clean, `cargo xtask coverage` at 100% for all 13 packages.
