### PR TITLE
fix(providers): every request sent 0.699999988079071 instead of 0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,15 @@ same list.
   costing every other row the width its bar needs. Both columns keep a gap
   open, since a cell filled edge to edge reads as one word.
 
+- Fixed: a temperature reached the wire as `0.699999988079071` rather than
+  `0.7`. `InferenceRequest.temperature` is an `f32` and `serde_json` stores one
+  by widening it to `f64`, so every request carried the widened value. It read
+  as a Leviath bug in provider error text, and Z.AI refuses it outright - "The
+  temperature parameter is illegal", at most two decimal places - which made the
+  whole GLM family unusable: `z-ai/glm-5.3` failed at iteration 0 on every run.
+  An `f32` now serializes through its own `Display`, which gives the shortest
+  decimal that round-trips, so `0.7` stays `0.7` and an author who wrote `0.125`
+  keeps it. All four providers that send a temperature.
 - Fixed: a model that takes only its default temperature no longer kills the
   run. `gpt-5.5` rejects any other value outright, the capability table said it
   supports one because the rest of the `gpt-5` family does, and a research run

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -643,7 +643,7 @@ impl AnthropicProvider {
             serde_json::json!({
                 "model": request.model,
                 "max_tokens": request.max_tokens,
-                "temperature": request.temperature,
+                "temperature": crate::provider::json_number(request.temperature),
                 "messages": messages,
             })
         } else {

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -412,7 +412,7 @@ impl OllamaProvider {
         let caps = self.capabilities(&request.model);
         let options = if caps.supports_temperature {
             serde_json::json!({
-                "temperature": request.temperature,
+                "temperature": crate::provider::json_number(request.temperature),
                 "num_predict": request.max_tokens,
             })
         } else {

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -427,7 +427,7 @@ pub fn build_openai_request_body_with(
 
     let mut body = serde_json::json!({
         "model": request.model,
-        "temperature": request.temperature,
+        "temperature": crate::provider::json_number(request.temperature),
         "messages": messages,
     });
     body[token_limit.key()] = serde_json::json!(request.max_tokens);

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -228,7 +228,7 @@ impl OpenRouterProvider {
             serde_json::json!({
                 "model": request.model,
                 "max_tokens": request.max_tokens,
-                "temperature": request.temperature,
+                "temperature": crate::provider::json_number(request.temperature),
                 "messages": messages,
             })
         } else {

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -547,6 +547,25 @@ pub struct SystemBlock {
     pub volatility: leviath_core::Volatility,
 }
 
+/// An `f32` as JSON, at the precision it was written with.
+///
+/// `serde_json` widens an `f32` to `f64` to store it, and `0.7f32` widened is
+/// `0.699999988079071`. That is what every request carried: it read as a
+/// Leviath bug in provider error messages, and Z.AI rejects it outright with
+/// `The temperature parameter is illegal: 限制小数点[2]位` - at most two decimal
+/// places - which made an entire vendor family unusable.
+///
+/// `f32`'s own `Display` gives the shortest decimal that round-trips back to
+/// the same `f32`, so `0.7f32` prints "0.7". Parsing that as `f64` gets the
+/// number the blueprint author actually wrote, without imposing a fixed
+/// precision on someone who wanted `0.125`.
+pub fn json_number(value: f32) -> serde_json::Value {
+    // `f32::Display` always produces a decimal that parses back, including for
+    // the non-finite values, so the fallback is the same number rather than a
+    // branch nothing reaches.
+    serde_json::json!(value.to_string().parse::<f64>().unwrap_or(f64::from(value)))
+}
+
 /// Request for LLM inference.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InferenceRequest {
@@ -1138,6 +1157,37 @@ mod stream_once {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A temperature reaches the wire as the number that was written.
+    ///
+    /// `serde_json` stores an `f32` by widening it to `f64`, and `0.7f32`
+    /// widened is `0.699999988079071`. Every request carried that. It reads as
+    /// a Leviath bug in provider error text, and Z.AI rejects it outright -
+    /// "The temperature parameter is illegal", at most two decimal places -
+    /// which made the whole GLM family unusable.
+    #[test]
+    fn a_temperature_serializes_at_the_precision_it_was_written_with() {
+        assert_eq!(json_number(0.7f32).to_string(), "0.7");
+        assert_eq!(json_number(1.0f32).to_string(), "1.0");
+        assert_eq!(json_number(0.0f32).to_string(), "0.0");
+        // Someone who wanted three decimals keeps them: the shortest
+        // round-tripping form is the number itself, not a rounded one.
+        assert_eq!(json_number(0.125f32).to_string(), "0.125");
+
+        // What it used to do, and what Z.AI refused.
+        let widened = serde_json::json!(0.7f32);
+        assert_eq!(widened.to_string(), "0.699999988079071");
+        assert_ne!(json_number(0.7f32).to_string(), widened.to_string());
+    }
+
+    /// A non-finite value does not panic on the way through. Not a temperature
+    /// any caller sends, but the conversion should survive one.
+    #[test]
+    fn a_non_finite_number_does_not_panic() {
+        // serde_json has no NaN, so it lands as null - which is the same
+        // answer it gave before, and not a crash.
+        assert!(json_number(f32::NAN).is_null());
+    }
 
     // ─── A partial [model_capabilities] entry corrects, it does not replace ──
 


### PR DESCRIPTION
`z-ai/glm-5.3` failed at iteration 0 on every run:

```
HTTP 400: The temperature parameter is illegal.：限制小数点[2]位
```

"At most two decimal places." `InferenceRequest.temperature` is an `f32`, and
`serde_json` stores one by widening it to `f64` — and `0.7f32` widened is
**`0.699999988079071`**. That is what every request Leviath sends has carried.

## Why it mattered more than it looks

Most providers accept it. Z.AI validates the precision and refuses, which makes
the **entire GLM family unusable** — a vendor whose newest model shipped four
days ago.

It is also why both temperature errors earlier today quoted `0.699...071` rather
than the `0.7` the blueprint asks for. That read as the provider being confused
about a value we sent correctly. We weren't sending it correctly.

## The fix

An `f32` now serialises through its own `Display`, which yields the shortest
decimal that round-trips back to the same `f32` — `0.7f32` prints `"0.7"`.
Parsing that as `f64` gets the number the author actually wrote.

Deliberately *not* a fixed 2-decimal rounding: someone who writes `0.125` keeps
`0.125`. The test pins that.

Applied to all four providers that send a temperature: `anthropic`, `ollama`,
`openai_compat` (which `openai` builds on), `openrouter`.

## Verified against the model it broke

Not reasoned about — the same `--model openrouter/z-ai/glm-5.3` run now reaches
iteration 9 and keeps going, where before it died at 0.

## Checks

39 suites, 13 packages at 100%.

Related: #568, which proposes reading capabilities from the provider rather than
a built-in table. This is the fourth issue this week traceable to a value we
assumed rather than asked about.