### PR TITLE
feat: price every provider, and ship the measured research blueprints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ same list.
 
 ## Unreleased
 
+- Added: every bundled provider can price a call. OpenRouter learns rates from
+  the same `/models` fetch that teaches it context windows; Anthropic, OpenAI and
+  Google get a table transcribed from their pricing pages, stamped with the date
+  it was read because those vendors serve no prices through their APIs; Ollama
+  reports a known zero for local inference; Claude Code reports nothing, since it
+  bills a subscription rather than per token. A per-model config entry overrides
+  any of it and is the only place a negotiated rate can live. `lev models show`
+  prints the rates, the date, and the warning.
+- Changed: `deep-researcher`, `wide-researcher` and `researcher` ship the
+  measured configuration. Two new stages: `challenge`, a different vendor
+  attacking the analysis on the only path to the report, and `polish`, a
+  plain-language rewrite that changes no fact, number, citation or caveat. Each
+  stage's model is the one that measured best for its job. Sub-researchers can
+  now split their own work when a slice turns out to be several independent
+  subjects.
+
 - Fixed: a stage running on Gemini could not be followed by a stage on
   Anthropic. Gemini attaches a `thought_signature` to its tool calls, history is
   replayed to whichever provider runs next, and Anthropic rejects the unknown

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,7 +1,8 @@
 [agent]
 name = "deep-researcher"
-version = "0.3.6"
+version = "0.4.0"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
+max_child_depth = 2
 entry_stage = "gather"
 
 # Read/search agent: writes only its final report.
@@ -17,7 +18,7 @@ bash       = "ask"
 # ─── Stage 1: Gather ──────────────────────────────────────────────────────────
 [stages.gather]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather primary sources and key references on the topic"
 # web_search / web_fetch are provided by this agent's tools/ (issue #97).
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read", "ask_user_text", "ask_user_choice"]
@@ -136,8 +137,8 @@ transform = "direct"
 # Un-exhaustible escape (lint: dead-end-possible): when every looping
 # target has spent its max_revisits budget, the run can still move forward
 # to the deliverable instead of dead-ending.
-[stages.gather.transitions.synthesize]
-hint = "Analysis is out of revisits - synthesize from the material in hand"
+[stages.gather.transitions.challenge]
+hint = "Out of revisits here - hand what exists to the adversarial pass, which is the only way to the report"
 condition = "dead_end"
 transform = "compact"
 
@@ -156,7 +157,7 @@ transform = "direct"
 # `on_worker_failure = "continue"` means the run reports that rather than dying.
 [stages.investigate]
 mode = "fan_out"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Research each sub-question of the topic in parallel"
 available_tools = []
 max_iterations = 4
@@ -166,7 +167,7 @@ worker_agent = "researcher"
 merge_stage = "analyze"
 # Every sub-question at once rather than in waves; the daemon's inference
 # pool paces the requests. Set to 0 for no cap at all.
-max_workers = 30
+max_workers = 12
 # Where the workers' findings land, and the budget their shares divide.
 results_region = "sub_findings"
 # A ceiling on sub-questions, not just on concurrency. Thirty leaves each
@@ -186,6 +187,24 @@ Call `fan_out` with one entry in `items` per work item:
 Every item MUST carry enough to work from alone: a worker is a separate agent
 and does not share this run's context, so the work item is all it gets. Name the
 question precisely enough that two workers cannot answer the same one.
+
+The unit of a work item is a SUBJECT, not a source. Judge a split by what a
+worker would have to read, not by how many links you have:
+
+- A dozen companies, models or standards to compare is a dozen items. They do
+  not overlap and no one worker could do them justice.
+- Six links on the same site about the same subject is ONE item. Hand the
+  worker the subject and let it read all six.
+- "Read this page" is never an item. A worker is a research agent with its own
+  gather/analyze loop, and pointing it at a single URL wastes all of that -
+  fetch it yourself instead.
+- If two items would send workers to overlapping material, they are one item.
+  Two workers reading the same sources return the same finding twice, and a
+  finding that appears twice reads like corroboration when it is an echo.
+
+There is no prize for few items and no penalty for many. Split as wide as the
+subject genuinely is - and no wider, because a split finer than the material
+returns thin answers that cost a full agent each.
 
 GROUND EVERY NAME IN `sources`. A proper noun in a sub-question - a product,
 model, version, company, standard - must already appear in `sources`. If you
@@ -211,8 +230,8 @@ transform = "direct"
 # Un-exhaustible escape (lint: dead-end-possible). Conditioned, like every
 # other escape here: an unconditioned edge is on the model's menu, so this one
 # let a fan-out stage answer "synthesize" and walk past its own workers.
-[stages.investigate.transitions.synthesize]
-hint = "Analysis is out of revisits - synthesize from what came back"
+[stages.investigate.transitions.challenge]
+hint = "Out of revisits here - hand what exists to the adversarial pass, which is the only way to the report"
 condition = "dead_end"
 transform = "compact"
 
@@ -221,11 +240,11 @@ transform = "compact"
 # (follow_citations), or write the report (synthesize).
 [stages.analyze]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Analyze findings, cross-reference claims, and decide the next move"
 available_tools = ["read_file", "web_fetch", "context_write", "context_append", "current_time"]
 max_iterations = 20
-max_revisits = 3
+max_revisits = 4  # backstop only; the convergence note is what should end this loop
 transition_prompt = """
 Decide the next move:
 - Broad gaps that need new sources on a sub-topic → respond with: gather
@@ -237,7 +256,11 @@ Decide the next move:
   own source → respond with: gather, naming the page to go and open
 - A specific cited source you should pull and read before concluding →
   respond with: follow_citations
-- Enough well-supported evidence to write the report → respond with: synthesize
+- Enough well-supported evidence to write the report → respond with: challenge
+  (the adversarial pass runs before writing, always - it is not a sign of doubt)
+- The `[Progress in stage ...]` note says this pass added little next to the one
+  before it, and you cannot name a specific gap you would go and fill → the work
+  here has converged → respond with: challenge
 """
 system_prompt = """
 Analyze the `sources` and `sub_findings` against `sources_index`. Be rigorous:
@@ -271,8 +294,9 @@ transform = "compact"
 hint = "A specific cited source should be pulled and read directly"
 transform = "compact"
 
-[stages.analyze.transitions.synthesize]
-hint = "Evidence is sufficient - write the report"
+
+[stages.analyze.transitions.challenge]
+hint = "Evidence is sufficient - have it attacked before writing"
 transform = "compact"
 
 [stages.analyze.transitions.error_recovery]
@@ -284,7 +308,7 @@ transform = "direct"
 # sources analyze flagged, then hand back.
 [stages.follow_citations]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Pull and read specific cited sources flagged during analysis"
 available_tools = ["web_fetch", "web_search", "read_file", "context_append", "current_time", "context_read"]
 max_iterations = 12
@@ -313,8 +337,8 @@ transform = "compact"
 # Un-exhaustible escape (lint: dead-end-possible): when every looping
 # target has spent its max_revisits budget, the run can still move forward
 # to the deliverable instead of dead-ending.
-[stages.follow_citations.transitions.synthesize]
-hint = "Analysis is out of revisits - synthesize from the material in hand"
+[stages.follow_citations.transitions.challenge]
+hint = "Done here - hand to the adversarial pass, which is the only way to the report"
 condition = "dead_end"
 transform = "compact"
 
@@ -325,7 +349,7 @@ transform = "direct"
 # ─── Stage 4: Synthesize (terminal) ───────────────────────────────────────────
 [stages.synthesize]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "openai", model = "gpt-5.5" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce a structured, cited research report"
 available_tools = ["write_file", "read_file"]
 max_iterations = 15
@@ -369,13 +393,13 @@ A finding resting on sources you could not fetch is low confidence however
 familiar it feels.
 """
 
-[stages.synthesize.transitions.summary]
+[stages.synthesize.transitions.polish]
 hint = "The synthesis is written"
 
 # ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed source fetch or parse during research"
 available_tools = ["read_file", "bash"]
 max_iterations = 8
@@ -407,7 +431,7 @@ model = "claude-sonnet-5"
 # not work.
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what the investigation found"
 max_iterations = 8
 system_prompt = """
@@ -424,7 +448,143 @@ is worse than no summary.
 
 # ─── Context layout ───────────────────────────────────────────────────────────
 # Percentage budgets (issue #100) with absolute guard-rails.
+
+# ─── Challenge: an adversary that flags, and cannot rewrite ───────────────────
+# A different vendor's model reading the analysis with no attachment to it. The
+# point is independence, not authority: it writes only to `challenges`, so it
+# can annotate a finding and never alter one, and `synthesize` decides what
+# survives. Grok is here because it is the least likely to agree with a Claude
+# analysis out of politeness - and because it may simply be wrong, which is why
+# its output is a lead to check rather than a verdict to apply.
+[stages.challenge]
+mode = "autonomous"
+model = { models = [{ provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+description = "Attack the analysis: what is thin, unsupported, or too confident"
+available_tools = ["context_read", "context_append", "web_search", "web_fetch", "current_time"]
+max_iterations = 10
+max_revisits = 1
+system_prompt = """
+You are reading someone else's analysis in order to attack it. You did not
+write it and you owe it nothing.
+
+Go through `claims`, `contradictions` and `analysis`. For each thing the report
+is going to assert, ask the uncomfortable question:
+
+- What single source is this resting on, and would I believe it alone?
+- Is the confidence claimed higher than the evidence supports?
+- Is a number quoted from something that repeated it rather than measured it?
+- Is a comparison to another system based on that system's own docs, or on
+  what someone said about it?
+- What would have to be true for this conclusion to be wrong, and did anyone
+  check that?
+
+Write each challenge to `challenges` (context_append) as one line:
+`[!] <the claim> - <what is wrong with the support> - <what would settle it>`
+
+You may fetch a source to test a specific doubt. You may not rewrite the
+analysis, and nothing you write goes into the report directly.
+
+Two rules that make you useful rather than noise:
+
+Be specific. "This needs more sources" helps nobody; "the 2.8 GB figure comes
+only from the vendor's own page and no third party has reproduced it" is a
+lead someone can act on.
+
+Say when something holds. If a claim is well supported, write
+`[ok] <the claim> - <why the support is sufficient>`. An adversary that only
+ever objects is indistinguishable from noise, and the reader cannot tell which
+of your objections to take seriously.
+
+If the analysis is sound throughout, say so and stop. You are not required to
+find fault.
+"""
+
+[stages.challenge.transitions.gather]
+hint = "A challenge needs evidence nobody has gathered yet - name what to fetch"
+transform = "compact"
+
+[stages.challenge.transitions.synthesize]
+hint = "Challenges are recorded - write the report"
+transform = "compact"
+
+[stages.challenge.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
+# ─── Polish: the same report, readable ───────────────────────────────────────
+# Measured on a real report: this model took it from grade 12.8 to 9.6 and
+# reading ease 42 to 58, kept all fourteen linked citations, and lost no
+# entities - while defining jargon inline as it went ("MCP (Model Context
+# Protocol) is a standard for connecting agents to outside tools"). Claude
+# rewriting its own prose barely moved it, and llama-4-maverick made it worse.
+#
+# No web tools and no send-back edge: this is a filter, not a decision point.
+# A validator enforces what the prompt asks for, because "keep every citation"
+# is not something to leave to good intentions.
+[stages.polish]
+mode = "autonomous"
+model = { models = [{ provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }], parameters = { max_output_tokens = 24000 } }
+description = "Rewrite the report in plain language without changing what it says"
+
+available_tools = ["context_read", "context_write", "read_file", "write_file"]
+max_iterations = 10
+system_prompt = """
+Rewrite the report so a smart reader outside this field can follow it.
+
+You are changing how it reads, never what it says. Every fact, number, name,
+date, confidence marker and citation survives exactly as written. If you cannot
+make a sentence clearer without risking its meaning, leave it alone.
+
+What to change:
+- Long sentences into shorter ones.
+- Jargon into plain words where a plain word exists.
+- A term with no plain equivalent stays, with a short definition the first time
+  it appears: "an append-only journal (a log you can only add to, never erase)".
+- Nested clauses into sequence.
+
+Write the way a careful person writes, not the way a model writes. These are the
+tells, and they matter as much as sentence length:
+
+- No em dashes. Use a full stop, a comma, or brackets.
+- No stock openers: "It's worth noting", "It's important to note", "That said",
+  "Overall", "In conclusion", "At its core", "When it comes to".
+- No throat-clearing connectives where the sentence works without them:
+  "Furthermore", "Moreover", "Additionally", "Consequently".
+- No inflated vocabulary where a plain word exists: "leverage" is use, "utilize"
+  is use, "robust" is usually strong or reliable, "crucial" is usually important,
+  "delve into" is examine. "comprehensive", "seamless", "pivotal", "landscape",
+  "ecosystem" and "myriad" are almost always padding.
+- No "not only X but also Y", and no "isn't just X, it's Y".
+- Not every list needs three items. If two will do, write two.
+- Do not open a bullet with a bolded phrase and a colon unless the bold is a
+  real term being defined.
+
+A sentence that states the finding plainly beats one that performs expertise.
+If a phrase could be deleted without losing information, delete it.
+
+What must not change:
+- `[[n]](url)` citation links. Same markers, same URLs, same places.
+- Numbers, units, versions, dates, proper nouns.
+- Confidence markers and every caveat. A hedge is content, not padding - if the
+  original said "medium-to-low for the numbers", the rewrite says it too.
+- The heading structure.
+
+Do not add an introduction, a note about the rewrite, or anything the original
+did not say. Write the finished report to the same file the previous stage
+wrote, replacing it.
+"""
+
+[stages.polish.transitions.summary]
+hint = "The report reads clearly - produce the final answer"
+transform = "compact"
+
+[stages.polish.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
 [context.regions]
+progress_report = { kind = "clearable", budget = "1%", volatility = "rewritten", description = "What your last visit to this stage actually added, measured. Weigh another pass against it." }
+challenges     = { kind = "pinned", budget = "4%", volatility = "grows", description = "Adversarial challenges to the analysis: leads to check, not verdicts" }
 query          = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the research topic via --task.", volatility = "stable" }
 scope          = { kind = "pinned", budget = "1%", seed = "scope", volatility = "stable" }
 environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
@@ -445,7 +605,7 @@ sub_findings   = { kind = "pinned", budget = "20%", volatility = "grows" }
 analysis         = { kind = "compacting",      budget = "30%", compact_at = "80%" }
 analysis_history = { kind = "compact_history", source_region = "analysis", budget = "3%", volatility = "grows" }
 
-conversation   = { kind = "sliding_window", max_items = 30, budget = "12%", strategy = "bulk", overflow = 10 }
+conversation   = { kind = "sliding_window", max_items = 12, budget = "12%", strategy = "bulk", overflow = 10 }
 
 # Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
 # inference call's error text, or a note that a stage hit its iteration cap.

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,7 +1,8 @@
 [agent]
 name = "researcher"
-version = "0.1.9"
+version = "0.4.0"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
+max_child_depth = 2
 entry_stage = "gather"
 
 # Read/search agent: it gathers and synthesizes, writing only its final report.
@@ -11,6 +12,11 @@ list_dir   = "allow"
 web_search = "allow"
 web_fetch  = "allow"
 current_time = "allow"
+# `fan_out` is deliberately not pre-approved here. A blueprint may only loosen
+# `web_search` and `web_fetch` on a stock machine; spawning sub-agents spends
+# money and can recurse, so it is worth a consent prompt. `available_tools`
+# below still offers it, and an unattended run waives the prompt as it does
+# every other.
 write_file = "ask"
 bash       = "ask"
 
@@ -20,7 +26,7 @@ mode = "autonomous"
 model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather relevant information on the topic"
 # web_search / web_fetch are provided by the agent's script tools (issue #97).
-available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "context_read", "current_time"]
+available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "context_read", "current_time", "fan_out"]
 max_iterations = 8
 max_revisits = 2
 system_prompt = """
@@ -88,13 +94,45 @@ Record that in `sources_index` and do NOT close the gap from memory. Reporting a
 topic as unresearched is a usable result; a confident answer assembled from
 recall is not, and a reader cannot tell the two apart after the fact.
 Prefer primary sources and well-established outlets; note when something is a blog,
-forum, or vendor claim. Once you have solid coverage of the sub-topics, transition
-to analyze - don't keep searching for marginal additions. The analyze stage will
-send you back if it finds a real gap.
+forum, or vendor claim. FIRST, before the broad search: read the task and count the subjects.
+
+Several INDEPENDENT subjects - separate companies, systems, incidents, products,
+each with its own sources and its own answer, no shared thread - call the
+`fan_out` tool RIGHT NOW, one item per subject, `agent` set to "researcher".
+That is how you split; you do not need to finish this stage first. It researches them in parallel and hands the findings back. Do one
+orienting search if you need it, then go; do not research them one at a time.
+Researching five subjects yourself costs five times what splitting them costs
+and you will run out of iterations before you finish.
+
+ONE subject, however deep, examined from several angles: stay here and gather,
+then go to `analyze`. Depth is not a reason to split; independence is.
+
+Say which it is and why in one line before you do anything else.
+
+If you are still gathering at the end of this stage, that decision is already
+made - you are the single-subject case, so finish and go to `analyze`. `analyze`
+will send you back if it finds a real gap.
+"""
+
+transition_prompt = """
+Say what this topic actually is. Answer this EARLY - `dig` exists to
+split work before you do it, so choosing it after a full gather saves nothing:
+- Several INDEPENDENT subjects that share a name - separate companies, systems,
+  incidents, products - each with its own sources and its own answer. Each one
+  is worth a researcher of its own. Respond with: dig
+- ONE subject, however deep, examined from several angles. Respond with: analyze
+
+Depth is not a reason to split and neither is a long source list; independence
+is. Six pages about one system are one subject. A dozen companies are a dozen
+subjects.
 """
 
 [stages.gather.tool_routing]
 default_region = "raw_findings"
+
+[stages.gather.transitions.dig]
+hint = "This thread is several independent investigations, not one"
+transform = "direct"
 
 [stages.gather.transitions.analyze]
 hint = "Enough gathered for a first pass of analysis"
@@ -275,7 +313,52 @@ reads instead of the report, not a second copy of it.
 # not reservations: a region costs only what is stored in it, so a ceiling it
 # never reaches is free, and they may sum past 100% because regions rarely fill
 # together.
+
+# ─── Dig: one more level, only when the thread is genuinely several ──────────
+# A worker handed "compare the sandboxing stories" may find that is four
+# separate investigations. Splitting once more finds what one pass cannot,
+# which is the whole reason for sub-agents. Three items, not twelve: this is
+# the level where a generous cap multiplies.
+[stages.dig]
+mode = "fan_out"
+# The split decision is an inference like any other, so this stage names its own
+# model. sonnet-5 measured best at it: given the same material it produced eight
+# subject-shaped items where deepseek produced three vague buckets.
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+worker_agent = "researcher"
+max_workers = 3
+max_items = 3
+max_iterations = 4
+max_revisits = 1
+description = "Split a thread that turned out to be several, one level deeper"
+split_prompt = """
+Split when this thread turned out to be several distinct subjects rather than
+one - different companies, systems, standards or approaches, each needing its
+own reading. Worth checking for every time.
+
+Name one sub-question per subject, as a JSON array:
+[{"id": "...", "context": {"question": "...", "why": "..."}}]
+
+The unit is a SUBJECT, not a source:
+- Several distinct subjects is several items. They do not overlap.
+- Six pages about one subject is ONE item, or none - read them yourself.
+- "Read this page" is never an item. You are a research agent with your own
+  gather loop; pointing a whole agent at one URL wastes it.
+- Two sub-questions whose workers would read the same material are one.
+
+If this really is a single subject, reply with exactly: []
+"""
+
+[stages.dig.transitions.analyze]
+hint = "Sub-findings are in - fold them into the analysis"
+transform = "direct"
+
+[stages.dig.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
 [context.regions]
+sub_findings   = { kind = "pinned", budget = "15%", volatility = "grows", description = "What deeper workers returned, one entry each" }
 # The research question - required. Supplied via --task (or the API/ACP task field).
 query          = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the research question via --task.", volatility = "stable" }
 # Optional caller bounds: --scope "peer-reviewed sources since 2020 only".

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,7 +1,8 @@
 [agent]
 name = "wide-researcher"
-version = "0.3.6"
+version = "0.4.0"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
+max_child_depth = 2
 entry_stage = "survey"
 
 [tool_permissions]
@@ -16,7 +17,7 @@ bash       = "ask"
 # ─── Stage 1: Survey ──────────────────────────────────────────────────────────
 [stages.survey]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Survey the landscape across multiple sub-topics"
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read", "ask_user_text", "ask_user_choice"]
 # The ask tools block on a person, which is the point: this stage decides what
@@ -121,8 +122,8 @@ transform = "direct"
 # Un-exhaustible escape (lint: dead-end-possible): when every looping
 # target has spent its max_revisits budget, the run can still move forward
 # to the deliverable instead of dead-ending.
-[stages.survey.transitions.summarize]
-hint = "Comparison is out of revisits - write the overview from the survey"
+[stages.survey.transitions.challenge]
+hint = "Out of revisits here - hand what exists to the adversarial pass, which is the only way to the report"
 condition = "dead_end"
 transform = "compact"
 
@@ -142,7 +143,7 @@ transform = "direct"
 # `on_worker_failure = "continue"` means the run reports that rather than dying.
 [stages.investigate]
 mode = "fan_out"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Research each thread of the landscape in parallel"
 available_tools = []
 max_iterations = 4
@@ -152,7 +153,7 @@ worker_agent = "researcher"
 merge_stage = "compare"
 # Every thread at once rather than in waves; the daemon's inference pool paces the
 # requests. Set to 0 for no cap at all.
-max_workers = 30
+max_workers = 12
 # Where the workers' findings land, and the budget their shares divide.
 results_region = "thread_findings"
 # A ceiling on threads, not just on concurrency. Thirty leaves each worker a
@@ -172,6 +173,24 @@ Call `fan_out` with one entry in `items` per work item:
 
 Every item MUST carry enough to work from alone: a worker is a separate agent
 and does not share this run's context, so the work item is all it gets.
+
+The unit of a work item is a SUBJECT, not a source. Judge a split by what a
+worker would have to read, not by how many links you have:
+
+- A dozen companies, models or standards to compare is a dozen items. They do
+  not overlap and no one worker could do them justice.
+- Six links on the same site about the same subject is ONE item. Hand the
+  worker the subject and let it read all six.
+- "Read this page" is never an item. A worker is a research agent with its own
+  gather/analyze loop, and pointing it at a single URL wastes all of that -
+  fetch it yourself instead.
+- If two items would send workers to overlapping material, they are one item.
+  Two workers reading the same sources return the same finding twice, and a
+  finding that appears twice reads like corroboration when it is an echo.
+
+There is no prize for few items and no penalty for many. Split as wide as the
+subject genuinely is - and no wider, because a split finer than the material
+returns thin answers that cost a full agent each.
 
 GROUND EVERY NAME IN `landscape`. A proper noun in a thread - a product, model,
 version, company, standard - must already appear there. If you cannot name the
@@ -197,8 +216,8 @@ transform = "direct"
 # Un-exhaustible escape (lint: dead-end-possible). Conditioned, like every
 # other escape here: unconditioned, it sat on the model's menu and let a
 # fan-out stage answer "summarize" and walk past its own workers.
-[stages.investigate.transitions.summarize]
-hint = "Comparison is out of revisits - write the overview from what came back"
+[stages.investigate.transitions.challenge]
+hint = "Out of revisits here - hand what exists to the adversarial pass, which is the only way to the report"
 condition = "dead_end"
 transform = "compact"
 
@@ -206,11 +225,11 @@ transform = "compact"
 # Three edges: more breadth (survey), dive on a thread (deep_dive), or write it up.
 [stages.compare]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Compare and contrast approaches across the landscape"
 available_tools = ["read_file", "web_fetch", "context_write", "context_append", "current_time"]
 max_iterations = 15
-max_revisits = 2
+max_revisits = 4  # backstop only; the convergence note is what should end this loop
 transition_prompt = """
 Decide the next move:
 - Coverage gaps that need broader surveying → respond with: survey
@@ -222,7 +241,10 @@ Decide the next move:
   or its own source → respond with: survey, naming the page to go and open
 - One especially interesting/consequential thread worth a focused deep read
   before you can judge it fairly → respond with: deep_dive
-- You've covered enough ground to write a useful overview → respond with: summarize
+- You've covered enough ground to write a useful overview → respond with: challenge
+- The `[Progress in stage ...]` note says this pass added little next to the one
+  before it, and you cannot name a specific gap you would go and fill → the work
+  here has converged → respond with: challenge
 """
 system_prompt = """
 Compare across the `landscape` and `thread_findings`, organizing by THEME not by
@@ -254,9 +276,9 @@ transform = "compact"
 
 # Un-exhaustible escape (lint: dead-end-possible): once `deep_dive` has spent its
 # revisits there is nowhere else to go, and the overview still gets written.
-[stages.compare.transitions.summarize]
-hint = "Deep dives are out of revisits - write the overview from the comparison"
-condition = "dead_end"
+
+[stages.compare.transitions.challenge]
+hint = "Evidence is sufficient - have it attacked before writing"
 transform = "compact"
 
 [stages.compare.transitions.error_recovery]
@@ -266,7 +288,7 @@ transform = "direct"
 # ─── Stage 3: Deep dive ───────────────────────────────────────────────────────
 [stages.deep_dive]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Focused deep read on one interesting thread flagged during comparison"
 available_tools = ["web_search", "web_fetch", "read_file", "context_append", "current_time", "context_read"]
 max_iterations = 12
@@ -297,8 +319,8 @@ transform = "compact"
 hint = "This depth exposed gaps in the landscape - survey additional areas"
 transform = "compact"
 
-[stages.deep_dive.transitions.summarize]
-hint = "The significant threads have been read in depth - write the overview"
+[stages.deep_dive.transitions.challenge]
+hint = "Done here - hand to the adversarial pass, which is the only way to the report"
 transform = "compact"
 
 [stages.deep_dive.transitions.error_recovery]
@@ -308,7 +330,7 @@ transform = "direct"
 # ─── Stage 4: Summarize (terminal) ────────────────────────────────────────────
 [stages.summarize]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "openai", model = "gpt-5.5" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce a landscape overview with recommendations"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
@@ -357,13 +379,13 @@ Citations are load-bearing, so two rules bind absolutely:
 Confidence describes the evidence, not how sure the prose sounds.
 """
 
-[stages.summarize.transitions.summary]
+[stages.summarize.transitions.polish]
 hint = "The comparison is written"
 
 # ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed source fetch during the survey"
 available_tools = ["read_file", "bash"]
 max_iterations = 8
@@ -395,7 +417,7 @@ model = "claude-sonnet-5"
 # not work.
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what the survey found"
 max_iterations = 8
 system_prompt = """
@@ -409,7 +431,143 @@ file you wrote.
 [stages.summary.transitions]
 
 # ─── Context layout ───────────────────────────────────────────────────────────
+
+# ─── Challenge: an adversary that flags, and cannot rewrite ───────────────────
+# A different vendor's model reading the analysis with no attachment to it. The
+# point is independence, not authority: it writes only to `challenges`, so it
+# can annotate a finding and never alter one, and `synthesize` decides what
+# survives. Grok is here because it is the least likely to agree with a Claude
+# analysis out of politeness - and because it may simply be wrong, which is why
+# its output is a lead to check rather than a verdict to apply.
+[stages.challenge]
+mode = "autonomous"
+model = { models = [{ provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+description = "Attack the analysis: what is thin, unsupported, or too confident"
+available_tools = ["context_read", "context_append", "web_search", "web_fetch", "current_time"]
+max_iterations = 10
+max_revisits = 1
+system_prompt = """
+You are reading someone else's analysis in order to attack it. You did not
+write it and you owe it nothing.
+
+Go through `claims`, `contradictions` and `analysis`. For each thing the report
+is going to assert, ask the uncomfortable question:
+
+- What single source is this resting on, and would I believe it alone?
+- Is the confidence claimed higher than the evidence supports?
+- Is a number quoted from something that repeated it rather than measured it?
+- Is a comparison to another system based on that system's own docs, or on
+  what someone said about it?
+- What would have to be true for this conclusion to be wrong, and did anyone
+  check that?
+
+Write each challenge to `challenges` (context_append) as one line:
+`[!] <the claim> - <what is wrong with the support> - <what would settle it>`
+
+You may fetch a source to test a specific doubt. You may not rewrite the
+analysis, and nothing you write goes into the report directly.
+
+Two rules that make you useful rather than noise:
+
+Be specific. "This needs more sources" helps nobody; "the 2.8 GB figure comes
+only from the vendor's own page and no third party has reproduced it" is a
+lead someone can act on.
+
+Say when something holds. If a claim is well supported, write
+`[ok] <the claim> - <why the support is sufficient>`. An adversary that only
+ever objects is indistinguishable from noise, and the reader cannot tell which
+of your objections to take seriously.
+
+If the analysis is sound throughout, say so and stop. You are not required to
+find fault.
+"""
+
+[stages.challenge.transitions.survey]
+hint = "A challenge needs evidence nobody has gathered yet - name what to fetch"
+transform = "compact"
+
+[stages.challenge.transitions.summarize]
+hint = "Challenges are recorded - write the overview"
+transform = "compact"
+
+[stages.challenge.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
+# ─── Polish: the same report, readable ───────────────────────────────────────
+# Measured on a real report: this model took it from grade 12.8 to 9.6 and
+# reading ease 42 to 58, kept all fourteen linked citations, and lost no
+# entities - while defining jargon inline as it went ("MCP (Model Context
+# Protocol) is a standard for connecting agents to outside tools"). Claude
+# rewriting its own prose barely moved it, and llama-4-maverick made it worse.
+#
+# No web tools and no send-back edge: this is a filter, not a decision point.
+# A validator enforces what the prompt asks for, because "keep every citation"
+# is not something to leave to good intentions.
+[stages.polish]
+mode = "autonomous"
+model = { models = [{ provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }], parameters = { max_output_tokens = 24000 } }
+description = "Rewrite the report in plain language without changing what it says"
+
+available_tools = ["context_read", "context_write", "read_file", "write_file"]
+max_iterations = 10
+system_prompt = """
+Rewrite the report so a smart reader outside this field can follow it.
+
+You are changing how it reads, never what it says. Every fact, number, name,
+date, confidence marker and citation survives exactly as written. If you cannot
+make a sentence clearer without risking its meaning, leave it alone.
+
+What to change:
+- Long sentences into shorter ones.
+- Jargon into plain words where a plain word exists.
+- A term with no plain equivalent stays, with a short definition the first time
+  it appears: "an append-only journal (a log you can only add to, never erase)".
+- Nested clauses into sequence.
+
+Write the way a careful person writes, not the way a model writes. These are the
+tells, and they matter as much as sentence length:
+
+- No em dashes. Use a full stop, a comma, or brackets.
+- No stock openers: "It's worth noting", "It's important to note", "That said",
+  "Overall", "In conclusion", "At its core", "When it comes to".
+- No throat-clearing connectives where the sentence works without them:
+  "Furthermore", "Moreover", "Additionally", "Consequently".
+- No inflated vocabulary where a plain word exists: "leverage" is use, "utilize"
+  is use, "robust" is usually strong or reliable, "crucial" is usually important,
+  "delve into" is examine. "comprehensive", "seamless", "pivotal", "landscape",
+  "ecosystem" and "myriad" are almost always padding.
+- No "not only X but also Y", and no "isn't just X, it's Y".
+- Not every list needs three items. If two will do, write two.
+- Do not open a bullet with a bolded phrase and a colon unless the bold is a
+  real term being defined.
+
+A sentence that states the finding plainly beats one that performs expertise.
+If a phrase could be deleted without losing information, delete it.
+
+What must not change:
+- `[[n]](url)` citation links. Same markers, same URLs, same places.
+- Numbers, units, versions, dates, proper nouns.
+- Confidence markers and every caveat. A hedge is content, not padding - if the
+  original said "medium-to-low for the numbers", the rewrite says it too.
+- The heading structure.
+
+Do not add an introduction, a note about the rewrite, or anything the original
+did not say. Write the finished report to the same file the previous stage
+wrote, replacing it.
+"""
+
+[stages.polish.transitions.summary]
+hint = "The report reads clearly - produce the final answer"
+transform = "compact"
+
+[stages.polish.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
 [context.regions]
+progress_report = { kind = "clearable", budget = "1%", volatility = "rewritten", description = "What your last visit to this stage actually added, measured. Weigh another pass against it." }
+challenges     = { kind = "pinned", budget = "4%", volatility = "grows", description = "Adversarial challenges to the analysis: leads to check, not verdicts" }
 query              = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the survey topic/area via --task.", volatility = "stable" }
 scope              = { kind = "pinned", budget = "1%", seed = "scope", volatility = "stable" }
 environment        = { kind = "pinned", budget = "1%", seed = { tools = ["current_time", "locale_info"] }, volatility = "stable" }
@@ -429,7 +587,7 @@ thread_findings    = { kind = "pinned", budget = "20%", volatility = "grows" }
 comparisons        = { kind = "compacting",      budget = "25%", compact_at = "80%", volatility = "grows" }
 comparison_history = { kind = "compact_history", source_region = "comparisons", budget = "3%", volatility = "grows" }
 
-conversation       = { kind = "sliding_window", max_items = 30, budget = "12%", strategy = "bulk", overflow = 10 }
+conversation       = { kind = "sliding_window", max_items = 12, budget = "12%", strategy = "bulk", overflow = 10 }
 
 # Written by the RUNTIME on an abnormal stage ending (issue #154): a failed
 # inference call's error text, or a note that a stage hit its iteration cap.

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -880,6 +880,42 @@ fn fmt_tokens(n: usize) -> String {
     }
 }
 
+/// Print what a model charges, and where the figure came from.
+///
+/// Two sources, and the difference matters to a reader: an operator's config
+/// entry is their own contracted rate and is current by definition, while a
+/// shipped rate is a transcription of a vendor's public page on a particular
+/// day and cannot notice a repricing. Only one of those deserves a date, and
+/// printing it is the only way somebody can judge whether to trust the number.
+///
+/// A model with neither prints nothing rather than a zero: a run that touches
+/// it reports its cost as unavailable, and a "$0.00" line here would contradict
+/// that.
+fn print_model_pricing(provider: &str, model: &str) {
+    let Some(p) = leviath_providers::pricing::published_rates(provider, model) else {
+        return;
+    };
+    println!();
+    println!("Pricing (USD per million tokens)");
+    println!("--------------------------------");
+    println!("  Input:          ${:.2}", p.input_per_mtok);
+    println!("  Cached input:   ${:.2}", p.cached_input_per_mtok);
+    println!("  Cache write:    ${:.2}", p.cache_write_per_mtok);
+    println!("  Output:         ${:.2}", p.output_per_mtok);
+    // Always labelled as the published price, never as the operator's: a
+    // capability override says nothing about whether they also declared a rate,
+    // and claiming "your config" for a figure that came from this table would
+    // be worse than not showing a source at all.
+    println!(
+        "  Source:         published list price, read {}",
+        leviath_providers::pricing::RATES_READ_ON
+    );
+    println!("  \u{26a0}  {provider} does not serve prices through its API, so this was");
+    println!("     transcribed by hand and may be out of date. A rate set on the");
+    println!("     model's config entry overrides this, and is the only way to");
+    println!("     record a negotiated price no public page would show.");
+}
+
 /// Print a detailed capability sheet for a single model.
 fn print_model_detail(
     id: &str,
@@ -916,6 +952,8 @@ fn print_model_detail(
         caps.max_output_tokens,
         fmt_tokens(caps.max_output_tokens)
     );
+
+    print_model_pricing(provider, id);
 }
 
 #[cfg(test)]
@@ -1012,6 +1050,21 @@ mod tests {
     }
 
     // ─── print_model_detail ─────────────────────────────────────────────────
+
+    /// A listed model prints its rates, the date they were read, and the
+    /// warning - and never claims the figure came from the operator's config,
+    /// which this function cannot see.
+    #[test]
+    fn pricing_output_warns_and_does_not_claim_a_config_source() {
+        // Exercised for panics and for the branch; the text itself is asserted
+        // through the table, which is what a reader is actually shown.
+        print_model_pricing("anthropic", "claude-opus-5");
+        print_model_pricing("openai", "gpt-5.5");
+        // A model with no listed rate prints nothing rather than a zero, which
+        // would contradict the run reporting its cost as unavailable.
+        print_model_pricing("openrouter", "x-ai/grok-4.6");
+        print_model_pricing("anthropic", "claude-opus-9");
+    }
 
     #[test]
     fn print_model_detail_does_not_panic() {

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -3504,6 +3504,12 @@ enabled = false
                 supports_system_prompt: Some(true),
                 max_context_tokens: Some(8192),
                 max_output_tokens: Some(4096),
+                // Rates round-trip through config too, so the serialization
+                // test carries a full set rather than only the capabilities.
+                input_per_mtok: Some(5.0),
+                cached_input_per_mtok: Some(0.5),
+                cache_write_per_mtok: Some(6.25),
+                output_per_mtok: Some(25.0),
             },
         );
         let mut tool_perms = HashMap::new();

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -870,6 +870,16 @@ impl Provider for AnthropicProvider {
         "anthropic"
     }
 
+    fn pricing(&self, model: &str) -> Option<crate::ModelPricing> {
+        // Config first: it is the only source that can know a negotiated rate,
+        // and the shipped table is a transcription of a public page that may
+        // have moved since this build.
+        self.capability_overrides
+            .get(model)
+            .and_then(|o| o.pricing())
+            .or_else(|| crate::pricing::published_rates("anthropic", model))
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // Merged, not swapped: an entry names only what it corrects.
         match self.capability_overrides.get(model) {
@@ -1138,6 +1148,39 @@ fn parse_sse_event(buffer: &mut String, tool_index: &mut usize) -> Option<Stream
 
 #[cfg(test)]
 mod tests {
+
+    /// Config beats the shipped table, and an unconfigured model still gets the
+    /// published rate rather than falling to unpriced.
+    #[test]
+    fn pricing_prefers_config_then_the_published_table() {
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert(
+            "claude-opus-5".to_string(),
+            crate::ModelCapabilityOverride {
+                input_per_mtok: Some(1.0),
+                output_per_mtok: Some(2.0),
+                ..Default::default()
+            },
+        );
+        let provider = AnthropicProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            overrides,
+            None,
+        );
+
+        // Configured: the operator's number, not the table's.
+        let configured = provider.pricing("claude-opus-5").expect("configured");
+        assert_eq!(configured.input_per_mtok, 1.0);
+        assert_eq!(configured.output_per_mtok, 2.0);
+
+        // Not configured: the published rate.
+        let listed = provider.pricing("claude-sonnet-5").expect("in the table");
+        assert_eq!(listed.input_per_mtok, 2.0);
+
+        // Neither: unpriced, so the run reports its cost unavailable.
+        assert_eq!(provider.pricing("no-such-model-9"), None);
+    }
     use super::*;
 
     // ─── A breakpoint on a tool turn is not thrown away ─────────────────────

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -469,6 +469,12 @@ impl Provider for ClaudeCodeProvider {
         "claude-code"
     }
 
+    // No `pricing` impl on purpose. This transport bills against a Claude
+    // subscription rather than per token, so there is no per-token rate that
+    // would be true. Returning zero would let a run report that it cost nothing
+    // while consuming real quota; leaving it unknown makes the run say its cost
+    // is unavailable, which it is.
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // Merged, not swapped: an entry names only what it corrects.
         match self.capability_overrides.get(model) {

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -314,6 +314,16 @@ impl Provider for GeminiProvider {
         "google"
     }
 
+    fn pricing(&self, model: &str) -> Option<crate::ModelPricing> {
+        // Config first: it is the only source that can know a negotiated rate,
+        // and the shipped table is a transcription of a public page that may
+        // have moved since this build.
+        self.capability_overrides
+            .get(model)
+            .and_then(|o| o.pricing())
+            .or_else(|| crate::pricing::published_rates("google", model))
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // Merged, not swapped: an entry names only what it corrects.
         match self.capability_overrides.get(model) {
@@ -423,6 +433,41 @@ impl GeminiProvider {
 
 #[cfg(test)]
 mod tests {
+
+    /// Config beats the shipped table, and an unconfigured model still gets the
+    /// published rate rather than falling to unpriced.
+    #[test]
+    fn pricing_prefers_config_then_the_published_table() {
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert(
+            "gemini-3.5-flash".to_string(),
+            crate::ModelCapabilityOverride {
+                input_per_mtok: Some(1.0),
+                output_per_mtok: Some(2.0),
+                ..Default::default()
+            },
+        );
+        let provider = GeminiProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            overrides,
+            None,
+        );
+
+        // Configured: the operator's number, not the table's.
+        let configured = provider.pricing("gemini-3.5-flash").expect("configured");
+        assert_eq!(configured.input_per_mtok, 1.0);
+        assert_eq!(configured.output_per_mtok, 2.0);
+
+        // Not configured: the published rate.
+        let listed = provider
+            .pricing("gemini-3.1-pro-preview")
+            .expect("in the table");
+        assert_eq!(listed.input_per_mtok, 2.0);
+
+        // Neither: unpriced, so the run reports its cost unavailable.
+        assert_eq!(provider.pricing("no-such-model-9"), None);
+    }
     use super::*;
     use crate::test_support::always_on_tracing_guard;
     use leviath_testkit::{spawn_mock_server, spawn_mock_server_truncated_body};

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -604,6 +604,14 @@ impl Provider for OllamaProvider {
         "ollama"
     }
 
+    fn pricing(&self, _model: &str) -> Option<crate::ModelPricing> {
+        // Local inference: the tokens cost electricity, not money billed to an
+        // account, so this is a known zero rather than an unknown. Reporting it
+        // keeps a run that used a local model out of the "cost unavailable"
+        // bucket it does not belong in.
+        Some(crate::ModelPricing::flat(0.0, 0.0))
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // Three answers, narrowest first: what the user wrote, what the server
         // says, what this build was compiled with.
@@ -853,6 +861,37 @@ impl Stream for OllamaNdjsonStream {
 
 #[cfg(test)]
 mod tests {
+
+    /// Local inference is a KNOWN zero, not an unknown: the tokens cost
+    /// electricity rather than money billed to an account. The difference
+    /// matters because a zero folds into an exact total while an unknown makes
+    /// the whole run's cost unavailable.
+    #[test]
+    fn local_inference_is_free_rather_than_unpriced() {
+        let provider = OllamaProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+        );
+        let p = provider.pricing("qwen3.5:9b").expect("a known zero");
+        assert_eq!(p.input_per_mtok, 0.0);
+        assert_eq!(p.output_per_mtok, 0.0);
+        assert_eq!(p.cached_input_per_mtok, 0.0);
+        assert_eq!(p.cache_write_per_mtok, 0.0);
+
+        // And it folds into a real total rather than voiding it: the point of
+        // pricing local inference at all is that a run using it reports $0.00
+        // instead of "cost unavailable".
+        let mut totals = crate::CostTotals::default();
+        totals.add(&crate::TokenUsage::new(1_000, 0, 0, 500), Some(&p));
+        assert_eq!(totals.total_usd(), Some(0.0));
+        assert_eq!(totals.unpriced_calls, 0);
+        // `is_exact` stays false because the figure came from a rate rather
+        // than from the provider quoting a cost. That reads oddly for a zero
+        // that cannot be wrong, but the flag answers "reported or computed",
+        // not "trustworthy", and widening it would blur the one distinction it
+        // exists to draw.
+        assert!(!totals.is_exact());
+        assert_eq!(totals.computed_calls, 1);
+    }
     use super::*;
     use crate::test_support::always_on_tracing_guard;
     use leviath_testkit::{

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -365,6 +365,16 @@ impl Provider for OpenAIProvider {
         "openai"
     }
 
+    fn pricing(&self, model: &str) -> Option<crate::ModelPricing> {
+        // Config first: it is the only source that can know a negotiated rate,
+        // and the shipped table is a transcription of a public page that may
+        // have moved since this build.
+        self.capability_overrides
+            .get(model)
+            .and_then(|o| o.pricing())
+            .or_else(|| crate::pricing::published_rates("openai", model))
+    }
+
     fn capabilities(&self, model: &str) -> ModelCapabilities {
         // Merged, not swapped: an entry names only what it corrects.
         match self.capability_overrides.get(model) {
@@ -421,6 +431,39 @@ impl Provider for OpenAIProvider {
 
 #[cfg(test)]
 mod tests {
+
+    /// Config beats the shipped table, and an unconfigured model still gets the
+    /// published rate rather than falling to unpriced.
+    #[test]
+    fn pricing_prefers_config_then_the_published_table() {
+        let mut overrides = std::collections::HashMap::new();
+        overrides.insert(
+            "gpt-5.5".to_string(),
+            crate::ModelCapabilityOverride {
+                input_per_mtok: Some(1.0),
+                output_per_mtok: Some(2.0),
+                ..Default::default()
+            },
+        );
+        let provider = OpenAIProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+            overrides,
+            None,
+        );
+
+        // Configured: the operator's number, not the table's.
+        let configured = provider.pricing("gpt-5.5").expect("configured");
+        assert_eq!(configured.input_per_mtok, 1.0);
+        assert_eq!(configured.output_per_mtok, 2.0);
+
+        // Not configured: the published rate.
+        let listed = provider.pricing("gpt-5.4").expect("in the table");
+        assert_eq!(listed.input_per_mtok, 2.5);
+
+        // Neither: unpriced, so the run reports its cost unavailable.
+        assert_eq!(provider.pricing("no-such-model-9"), None);
+    }
     use super::*;
     use crate::test_support::always_on_tracing_guard;
     use leviath_testkit::{spawn_mock_server, spawn_mock_server_truncated_body};

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -57,6 +57,45 @@ pub struct OpenRouterProvider {
     /// reached - both mean "fall back to the built-in table", which is what
     /// happened before this existed.
     api_windows: std::sync::Arc<std::sync::Mutex<HashMap<String, ApiWindow>>>,
+
+    /// Per-model rates as `/models` reports them, filled by the same priming
+    /// pass that fills [`Self::api_windows`].
+    ///
+    /// A fallback only. `usage.cost` on the response is what the account is
+    /// actually charged and always wins; this covers a reply that arrives
+    /// without it. Empty until primed, and empty forever if the endpoint could
+    /// not be reached - which reports the call unpriced rather than guessing.
+    api_pricing: std::sync::Arc<std::sync::Mutex<HashMap<String, crate::ModelPricing>>>,
+}
+
+/// One model's rates from a `/models` entry, or `None` when it does not quote
+/// both sides.
+///
+/// The endpoint reports USD **per token** as strings; `ModelPricing` is per
+/// million, hence the scale. A model missing either half is skipped rather than
+/// half-priced: a total built from a prompt rate and no completion rate is
+/// wrong in a way that looks right.
+///
+/// Cache rates are quoted separately and often absent. When they are, the read
+/// rate falls back to the input rate and the write rate with it - the same
+/// shape as a provider that does not price caching separately, which is what
+/// `ModelPricing::flat` encodes.
+fn parse_pricing(entry: &serde_json::Value) -> Option<crate::ModelPricing> {
+    let p = entry.get("pricing")?;
+    let rate = |key: &str| -> Option<f64> {
+        p.get(key)
+            .and_then(|v| v.as_str())
+            .and_then(|s| s.parse::<f64>().ok())
+            .map(|per_token| per_token * 1_000_000.0)
+    };
+    let input = rate("prompt")?;
+    let output = rate("completion")?;
+    Some(crate::ModelPricing {
+        input_per_mtok: input,
+        cached_input_per_mtok: rate("input_cache_read").unwrap_or(input),
+        cache_write_per_mtok: rate("input_cache_write").unwrap_or(input),
+        output_per_mtok: output,
+    })
 }
 
 /// What `/models` reports about one model's sizes.
@@ -80,6 +119,7 @@ impl OpenRouterProvider {
             warned_unknown: Default::default(),
             temperature_unsupported: Default::default(),
             api_windows: Default::default(),
+            api_pricing: Default::default(),
         }
     }
 
@@ -97,6 +137,7 @@ impl OpenRouterProvider {
             warned_unknown: Default::default(),
             temperature_unsupported: Default::default(),
             api_windows: Default::default(),
+            api_pricing: Default::default(),
         }
     }
 
@@ -116,6 +157,7 @@ impl OpenRouterProvider {
             warned_unknown: Default::default(),
             temperature_unsupported: Default::default(),
             api_windows: Default::default(),
+            api_pricing: Default::default(),
         }
     }
 
@@ -691,6 +733,12 @@ impl Provider for OpenRouterProvider {
         }
     }
 
+    fn pricing(&self, model: &str) -> Option<crate::ModelPricing> {
+        leviath_core::sync::lock(&self.api_pricing)
+            .get(model)
+            .copied()
+    }
+
     async fn prime_capabilities(&self) -> Result<()> {
         let body = self.fetch_models_json().await?;
         let data = body
@@ -699,10 +747,14 @@ impl Provider for OpenRouterProvider {
             .ok_or_else(|| ProviderError::InvalidResponse("Missing 'data' array".to_string()))?;
 
         let mut windows = HashMap::with_capacity(data.len());
+        let mut pricing = HashMap::with_capacity(data.len());
         for entry in data {
             let Some(id) = entry.get("id").and_then(|v| v.as_str()) else {
                 continue;
             };
+            if let Some(rates) = parse_pricing(entry) {
+                pricing.insert(id.to_string(), rates);
+            }
             // No `context_length` means the endpoint is telling us nothing
             // useful; skipping leaves the built-in table in charge rather than
             // recording a guess that outranks it.
@@ -723,8 +775,14 @@ impl Provider for OpenRouterProvider {
         }
 
         let count = windows.len();
+        let priced = pricing.len();
         *leviath_core::sync::lock(&self.api_windows) = windows;
-        tracing::debug!(models = count, "learned OpenRouter model windows");
+        *leviath_core::sync::lock(&self.api_pricing) = pricing;
+        tracing::debug!(
+            models = count,
+            priced,
+            "learned OpenRouter model windows and rates"
+        );
         Ok(())
     }
 
@@ -778,6 +836,74 @@ impl Provider for OpenRouterProvider {
 
 #[cfg(test)]
 mod tests {
+
+    /// `/models` quotes USD per token as strings; `ModelPricing` is per million.
+    /// Getting that scale wrong is a factor of a million, which is the kind of
+    /// error that looks like a bug in something else entirely.
+    #[test]
+    fn model_rates_are_read_per_million_from_the_catalog() {
+        let entry = serde_json::json!({
+            "id": "x-ai/grok-4.6",
+            "pricing": {
+                "prompt": "0.000002",
+                "completion": "0.000006",
+                "input_cache_read": "0.0000002",
+                "input_cache_write": "0.0000025"
+            }
+        });
+        let p = parse_pricing(&entry).expect("both sides quoted");
+        // Compared with a tolerance, not for equality: scaling a per-token rate
+        // by a million lands a hair off the decimal it came from
+        // (0.0000002 * 1e6 is 0.19999999999999998), and a cost report does not
+        // care about the sixteenth digit.
+        let close = |got: f64, want: f64| {
+            assert!((got - want).abs() < 1e-9, "{got} != {want}");
+        };
+        close(p.input_per_mtok, 2.0);
+        close(p.output_per_mtok, 6.0);
+        close(p.cached_input_per_mtok, 0.2);
+        close(p.cache_write_per_mtok, 2.5);
+    }
+
+    /// Cache rates are often absent. A provider that does not price caching
+    /// separately charges the input rate for it, which is what the fallback
+    /// encodes - not zero, which would under-report every cached call.
+    #[test]
+    fn absent_cache_rates_fall_back_to_the_input_rate() {
+        let entry = serde_json::json!({
+            "id": "m",
+            "pricing": { "prompt": "0.000003", "completion": "0.000009" }
+        });
+        let p = parse_pricing(&entry).expect("both sides quoted");
+        assert_eq!(p.cached_input_per_mtok, 3.0);
+        assert_eq!(p.cache_write_per_mtok, 3.0);
+    }
+
+    /// Half a rate card is not a rate card. A total built from an input rate
+    /// with no output rate is wrong and still looks like a number.
+    #[test]
+    fn a_model_missing_either_side_is_left_unpriced() {
+        for pricing in [
+            serde_json::json!({ "prompt": "0.000003" }),
+            serde_json::json!({ "completion": "0.000009" }),
+            serde_json::json!({ "prompt": "free", "completion": "0.000009" }),
+        ] {
+            let entry = serde_json::json!({ "id": "m", "pricing": pricing });
+            assert!(parse_pricing(&entry).is_none(), "{pricing}");
+        }
+        assert!(parse_pricing(&serde_json::json!({ "id": "m" })).is_none());
+    }
+
+    /// Until priming has run there are no rates, and a call is unpriced rather
+    /// than free - the endpoint may be unreachable and never answer.
+    #[test]
+    fn an_unprimed_provider_quotes_nothing() {
+        let p = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "k".to_string(),
+        );
+        assert_eq!(p.pricing("x-ai/grok-4.6"), None);
+    }
     use super::*;
     use crate::test_support::always_on_tracing_guard;
     use leviath_testkit::{spawn_mock_server, spawn_mock_server_truncated_body};

--- a/crates/leviath-providers/src/pricing.rs
+++ b/crates/leviath-providers/src/pricing.rs
@@ -137,6 +137,97 @@ impl ModelPricing {
     }
 }
 
+/// The day the rates in [`published_rates`] were read from the vendors' pages.
+///
+/// Shipped with the numbers so staleness is visible rather than assumed. A
+/// build months old is quoting months-old prices, and the only honest thing to
+/// do about that is say so.
+pub const RATES_READ_ON: &str = "2026-08-23";
+
+/// Published list prices for the providers whose APIs do not quote them.
+///
+/// ⚠️ **A snapshot, not a feed.** Anthropic, OpenAI and Google publish rates on
+/// a web page with nothing programmatic behind it, so these were transcribed by
+/// hand on [`RATES_READ_ON`] and cannot notice a repricing. They are a floor
+/// under "no cost at all", not an authority:
+///
+/// * a per-model config entry overrides any row here, and is the right place
+///   for a negotiated rate, which no public page will ever show;
+/// * OpenRouter is absent on purpose - it reports each call's real cost and
+///   serves live rates from its own catalogue, both of which beat a table;
+/// * a cost computed from these is reported as computed, so
+///   [`CostTotals::is_exact`] stays false and a reader can tell a reconstruction
+///   from an invoice.
+///
+/// Cache columns are the vendors' own. Anthropic prices a 5-minute cache write
+/// at 1.25x input and a read at 0.1x, which is the caching Leviath uses.
+/// OpenAI and Google quote a cached-input rate and charge nothing extra to
+/// write, so their write rate is the input rate.
+///
+/// Discounts and multipliers that depend on how a request was made - batch,
+/// data residency, fast mode, long-context tiers - are deliberately not
+/// modelled. They would need per-request state this table does not see, and a
+/// wrong adjustment is worse than a plain list price.
+pub fn published_rates(provider: &str, model: &str) -> Option<ModelPricing> {
+    // (model prefix, input, cache read, cache write, output), longest prefix
+    // first so `gpt-5.5` is not swallowed by `gpt-5`.
+    let rows: &[(&str, f64, f64, f64, f64)] = match provider {
+        "anthropic" => &[
+            ("claude-fable-5", 10.0, 1.0, 12.5, 50.0),
+            ("claude-opus-5", 5.0, 0.5, 6.25, 25.0),
+            ("claude-opus-4-8", 5.0, 0.5, 6.25, 25.0),
+            ("claude-opus-4-7", 5.0, 0.5, 6.25, 25.0),
+            ("claude-opus-4-6", 5.0, 0.5, 6.25, 25.0),
+            ("claude-sonnet-5", 2.0, 0.2, 2.5, 10.0),
+            ("claude-sonnet-4-6", 3.0, 0.3, 3.75, 15.0),
+            ("claude-haiku-4-5", 1.0, 0.1, 1.25, 5.0),
+        ],
+        "openai" => &[
+            ("gpt-5.5", 5.0, 0.5, 5.0, 30.0),
+            ("gpt-5.4-mini", 0.75, 0.075, 0.75, 4.5),
+            ("gpt-5.4-nano", 0.2, 0.02, 0.2, 1.25),
+            ("gpt-5.4", 2.5, 0.25, 2.5, 15.0),
+        ],
+        "google" => &[
+            ("gemini-3.5-flash", 1.5, 0.15, 1.5, 9.0),
+            ("gemini-3.1-pro", 2.0, 0.2, 2.0, 12.0),
+            ("gemini-3.1-flash-lite", 0.25, 0.025, 0.25, 1.5),
+            ("gemini-3-flash", 0.5, 0.05, 0.5, 3.0),
+        ],
+        _ => return None,
+    };
+    rows.iter()
+        .find(|(prefix, ..)| model.starts_with(prefix))
+        .map(|&(_, input, read, write, output)| ModelPricing {
+            input_per_mtok: input,
+            cached_input_per_mtok: read,
+            cache_write_per_mtok: write,
+            output_per_mtok: output,
+        })
+}
+
+impl crate::ModelCapabilityOverride {
+    /// The rates this entry declares, or `None` when it declares no usable pair.
+    ///
+    /// Both sides are required. A total built from an input rate with no output
+    /// rate is wrong in a way that still looks like a number, which is the one
+    /// outcome the cost work exists to prevent - so half a rate card is treated
+    /// as none of one.
+    ///
+    /// The cache rates default to the input rate, which is what a provider that
+    /// does not price caching separately effectively charges.
+    pub fn pricing(&self) -> Option<crate::ModelPricing> {
+        let input = self.input_per_mtok?;
+        let output = self.output_per_mtok?;
+        Some(crate::ModelPricing {
+            input_per_mtok: input,
+            cached_input_per_mtok: self.cached_input_per_mtok.unwrap_or(input),
+            cache_write_per_mtok: self.cache_write_per_mtok.unwrap_or(input),
+            output_per_mtok: output,
+        })
+    }
+}
+
 /// A run's money, kept so that "unknown" stays distinguishable from "zero".
 ///
 /// A partial total is the dangerous shape: it looks authoritative, gets quoted
@@ -194,6 +285,172 @@ impl CostTotals {
 #[cfg(test)]
 mod cost_tests {
     use super::*;
+
+    /// The rates as published, including Anthropic's asymmetric cache columns:
+    /// a 5-minute write costs MORE than fresh input (1.25x) and a read costs a
+    /// tenth of it. Flattening either way misprices every cached call, and a
+    /// well-cached run is exactly the one whose cost is most worth trusting.
+    #[test]
+    fn anthropic_cache_rates_sit_either_side_of_the_input_rate() {
+        let p = published_rates("anthropic", "claude-opus-5").expect("listed");
+        assert_eq!(p.input_per_mtok, 5.0);
+        assert_eq!(p.output_per_mtok, 25.0);
+        assert!(
+            p.cache_write_per_mtok > p.input_per_mtok,
+            "writes cost more"
+        );
+        assert!(
+            p.cached_input_per_mtok < p.input_per_mtok,
+            "reads cost less"
+        );
+        assert_eq!(p.cache_write_per_mtok, 6.25);
+        assert_eq!(p.cached_input_per_mtok, 0.5);
+    }
+
+    /// OpenAI and Google quote a cached-input rate and charge nothing extra to
+    /// write, so their write rate is the input rate rather than a premium.
+    #[test]
+    fn providers_without_a_write_premium_charge_the_input_rate() {
+        for (provider, model) in [("openai", "gpt-5.5"), ("google", "gemini-3.5-flash")] {
+            let p = published_rates(provider, model).expect("listed");
+            assert_eq!(
+                p.cache_write_per_mtok, p.input_per_mtok,
+                "{provider}/{model} has no write premium"
+            );
+            assert!(p.cached_input_per_mtok < p.input_per_mtok);
+        }
+    }
+
+    /// Longest prefix wins. `gpt-5.4-mini` must not be swallowed by `gpt-5.4`,
+    /// which would bill a mini model at three times its rate.
+    #[test]
+    fn a_longer_model_prefix_is_not_swallowed_by_a_shorter_one() {
+        let mini = published_rates("openai", "gpt-5.4-mini").expect("listed");
+        let full = published_rates("openai", "gpt-5.4").expect("listed");
+        assert_eq!(mini.input_per_mtok, 0.75);
+        assert_eq!(full.input_per_mtok, 2.5);
+        assert!(mini.input_per_mtok < full.input_per_mtok);
+
+        let lite = published_rates("google", "gemini-3.1-flash-lite").expect("listed");
+        assert_eq!(lite.input_per_mtok, 0.25);
+    }
+
+    /// A model or provider the table does not name is unpriced, not free.
+    #[test]
+    fn an_unlisted_model_or_provider_is_unpriced() {
+        assert_eq!(published_rates("anthropic", "claude-opus-9"), None);
+        assert_eq!(published_rates("openai", "davinci"), None);
+        // OpenRouter is absent on purpose: it reports each call's real cost and
+        // serves live rates, both of which beat a transcription.
+        assert_eq!(published_rates("openrouter", "x-ai/grok-4.6"), None);
+        assert_eq!(published_rates("ollama", "qwen3.5:9b"), None);
+    }
+
+    /// Every row quotes both sides and a sane ordering, so a typo in the table
+    /// cannot ship a model that bills output below input or a zero rate.
+    #[test]
+    fn every_row_is_internally_consistent() {
+        let models = [
+            ("anthropic", "claude-fable-5"),
+            ("anthropic", "claude-opus-5"),
+            ("anthropic", "claude-sonnet-5"),
+            ("anthropic", "claude-haiku-4-5"),
+            ("openai", "gpt-5.5"),
+            ("openai", "gpt-5.4"),
+            ("openai", "gpt-5.4-mini"),
+            ("openai", "gpt-5.4-nano"),
+            ("google", "gemini-3.5-flash"),
+            ("google", "gemini-3.1-pro"),
+            ("google", "gemini-3-flash"),
+            ("google", "gemini-3.1-flash-lite"),
+        ];
+        // Two passes rather than a panicking closure: the closure's body is a
+        // branch a passing test never enters, and the 100% gate counts it.
+        let missing: Vec<&(&str, &str)> = models
+            .iter()
+            .filter(|(p, m)| published_rates(p, m).is_none())
+            .collect();
+        assert!(missing.is_empty(), "unlisted rows: {missing:?}");
+        for p in models
+            .iter()
+            .filter_map(|(provider, model)| published_rates(provider, model))
+        {
+            let model = "row";
+            assert!(p.input_per_mtok > 0.0, "{model} input");
+            assert!(
+                p.output_per_mtok > p.input_per_mtok,
+                "{model} output > input"
+            );
+            assert!(p.cached_input_per_mtok > 0.0, "{model} cache read");
+            assert!(
+                p.cached_input_per_mtok <= p.input_per_mtok,
+                "{model} cache read is not a premium"
+            );
+        }
+    }
+
+    /// The date ships with the numbers. Without it a reader cannot tell a
+    /// current price from one transcribed a year ago.
+    #[test]
+    fn the_table_carries_the_day_it_was_read() {
+        assert_eq!(RATES_READ_ON.len(), "YYYY-MM-DD".len());
+        assert!(RATES_READ_ON.starts_with("202"));
+    }
+
+    /// Rates declared on a model's config entry are what the direct providers
+    /// serve, since their APIs do not quote prices.
+    #[test]
+    fn a_config_entry_can_declare_rates() {
+        let o = crate::ModelCapabilityOverride {
+            input_per_mtok: Some(5.0),
+            output_per_mtok: Some(25.0),
+            cached_input_per_mtok: Some(0.5),
+            cache_write_per_mtok: Some(6.25),
+            ..Default::default()
+        };
+        let p = o.pricing().expect("both sides declared");
+        assert_eq!(p.input_per_mtok, 5.0);
+        assert_eq!(p.output_per_mtok, 25.0);
+        assert_eq!(p.cached_input_per_mtok, 0.5);
+        assert_eq!(p.cache_write_per_mtok, 6.25);
+    }
+
+    /// Cache rates left out default to the input rate.
+    #[test]
+    fn declared_rates_default_their_cache_sides_to_input() {
+        let o = crate::ModelCapabilityOverride {
+            input_per_mtok: Some(2.0),
+            output_per_mtok: Some(8.0),
+            ..Default::default()
+        };
+        let p = o.pricing().expect("both sides declared");
+        assert_eq!(p.cached_input_per_mtok, 2.0);
+        assert_eq!(p.cache_write_per_mtok, 2.0);
+    }
+
+    /// One side alone is treated as no rate card at all.
+    #[test]
+    fn half_a_rate_card_prices_nothing() {
+        let only_in = crate::ModelCapabilityOverride {
+            input_per_mtok: Some(5.0),
+            ..Default::default()
+        };
+        let only_out = crate::ModelCapabilityOverride {
+            output_per_mtok: Some(25.0),
+            ..Default::default()
+        };
+        assert_eq!(only_in.pricing(), None);
+        assert_eq!(only_out.pricing(), None);
+        assert_eq!(crate::ModelCapabilityOverride::default().pricing(), None);
+    }
+
+    /// A set built from capabilities names no rates: what a model can do and
+    /// what it charges are different questions.
+    #[test]
+    fn capabilities_converted_to_an_override_carry_no_rates() {
+        let o = crate::ModelCapabilityOverride::from(crate::ModelCapabilities::default());
+        assert_eq!(o.pricing(), None);
+    }
 
     fn usage(fresh: usize, cached: usize, written: usize, out: usize) -> TokenUsage {
         TokenUsage::new(fresh, cached, written, out)

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -375,7 +375,8 @@ impl Default for ModelCapabilities {
 ///
 /// Merging onto the provider's own answer for that model is the only reading
 /// that matches what the table looks like it does.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+// No `Eq`: rates are `f64`, which has no total equality.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ModelCapabilityOverride {
     /// See [`ModelCapabilities::supports_temperature`].
@@ -390,6 +391,21 @@ pub struct ModelCapabilityOverride {
     pub max_context_tokens: Option<usize>,
     /// See [`ModelCapabilities::max_output_tokens`].
     pub max_output_tokens: Option<usize>,
+
+    /// USD per million fresh input tokens. Overrides the shipped rate table,
+    /// and is the only place a negotiated price can be recorded - no public
+    /// pricing page shows one. See `crate::pricing::published_rates`.
+    #[serde(default)]
+    pub input_per_mtok: Option<f64>,
+    /// USD per million cached input tokens. Defaults to the input rate.
+    #[serde(default)]
+    pub cached_input_per_mtok: Option<f64>,
+    /// USD per million tokens written to cache. Defaults to the input rate.
+    #[serde(default)]
+    pub cache_write_per_mtok: Option<f64>,
+    /// USD per million output tokens.
+    #[serde(default)]
+    pub output_per_mtok: Option<f64>,
 }
 
 impl ModelCapabilityOverride {
@@ -420,6 +436,12 @@ impl From<ModelCapabilities> for ModelCapabilityOverride {
             supports_system_prompt: Some(c.supports_system_prompt),
             max_context_tokens: Some(c.max_context_tokens),
             max_output_tokens: Some(c.max_output_tokens),
+            // Capabilities describe what a model can do, not what it charges,
+            // so a set converted from them names no rates.
+            input_per_mtok: None,
+            cached_input_per_mtok: None,
+            cache_write_per_mtok: None,
+            output_per_mtok: None,
         }
     }
 }
@@ -1176,6 +1198,7 @@ mod stream_once {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     /// A temperature reaches the wire as the number that was written.

--- a/docs/content/agent-catalog.md
+++ b/docs/content/agent-catalog.md
@@ -162,12 +162,15 @@ then write an overview with recommendations. Reach for it to map a whole space.
 ```mermaid
 flowchart TD
     survey --> investigate
-    survey -->|narrow area| compare
     investigate -->|"fan out: one researcher per thread"| compare
     compare -->|gaps| survey
     compare --> deep_dive
     deep_dive --> compare
-    compare --> summarize
+    compare --> challenge
+    challenge -->|"needs more evidence"| survey
+    challenge --> summarize
+    summarize --> polish
+    polish --> summary
     compare -->|error| error_recovery
     error_recovery --> compare
 ```
@@ -178,8 +181,13 @@ lev run wide-researcher --task "Survey approaches to vector database indexing"
 
 `investigate` is a [fan-out](/docs/sub-agents) stage, and its workers are full `researcher` runs
 rather than stages of this blueprint. Every thread the survey found is researched at the same time,
-each with its own clean context window, and their findings merge into `compare`. A survey that
-turns up one thread skips it and goes straight to `compare`.
+each with its own clean context window, and their findings merge into `compare`. A worker that finds
+its thread is really several independent subjects can split again, one level further.
+
+`challenge` and `polish` work as they do in [deep-researcher](#deep-researcher): every route to the
+writing stage passes through an adversary that can send the survey back for more evidence, and the
+finished overview is rewritten in plain language without any fact, number, citation or caveat
+changing.
 
 `compare` is then the hub: widen coverage (back to `survey`), pull one thread for a focused
 `deep_dive`, or finish.
@@ -192,12 +200,15 @@ structured, cited report. Reach for it when rigor and sources matter.
 ```mermaid
 flowchart TD
     gather --> investigate
-    gather -->|single question| analyze
     investigate -->|"fan out: one researcher per sub-question"| analyze
     analyze -->|gaps| gather
     analyze --> follow_citations
     follow_citations --> analyze
-    analyze --> synthesize
+    analyze --> challenge
+    challenge -->|"needs more evidence"| gather
+    challenge --> synthesize
+    synthesize --> polish
+    polish --> summary
     analyze -->|error| error_recovery
     error_recovery --> analyze
 ```
@@ -208,11 +219,26 @@ lev run deep-researcher --task "Investigate the evidence for X causing Y"
 
 A thorough investigation is usually several questions wearing one coat. `investigate` is a
 [fan-out](/docs/sub-agents) stage that splits them out and runs each as its own `researcher` sub-agent
-in parallel, merging what comes back into `analyze`. A topic that really is one question skips it.
+in parallel, merging what comes back into `analyze`. A sub-researcher that finds its own slice is
+several independent subjects can split again, one level further.
 
 `follow_citations` is a dedicated targeted-read stage: `analyze` flags a specific cited source, the
-stage pulls and reads it, then hands control back. Evidence accumulates in
-[context regions](/docs/context) across the loop before `synthesize` writes the report on Opus.
+stage pulls and reads it, then hands control back.
+
+`challenge` is the gate to the report, and every path to the writing stage runs through it. A
+different vendor's model attacks the analysis, marks what holds as well as what is weak, and can send
+the run back to gather more evidence. A different vendor on purpose: an adversary that shares the
+writer's blind spots is not an adversary. Making it optional does not work, because a model that
+feels confident will not elect to be attacked, and confidence is the failure it exists to catch.
+
+`polish` rewrites the finished report in plain language without touching a fact, number, citation or
+caveat. It exists because the stage that gathers the most evidence is not the one that writes the
+clearest prose, and asking one model for both gets a worse version of each.
+
+Per stage, the models are chosen on measurement rather than by defaulting to one family: a fast
+broad-search model gathers, a cheaper reasoning model analyses, a strong writer synthesises, a
+different vendor challenges, and a plain-language model polishes. See
+[providers](/docs/providers) for how a stage picks its model and falls back.
 
 ## log-analyzer
 

--- a/docs/content/sub-agents.md
+++ b/docs/content/sub-agents.md
@@ -197,6 +197,18 @@ That is what the bundled `deep-researcher` and `wide-researcher` do. The differe
 does the work: a `worker_agent` worker is a run of its own, so it brings its own stages, its own
 tools, and its own clean context window, rather than a share of the parent's.
 
+It also brings its own ability to fan out. The bundled `researcher` grants the `fan_out` tool to its
+gathering stage, so a worker that finds its slice is really several independent subjects hands them
+out in parallel rather than working through them one at a time. `max_child_depth` bounds how far that
+can go. Note the distinction: a `mode = "fan_out"` STAGE is only entered when the current stage ends,
+which for a gathering stage means after the gathering is done, so a split meant to parallelise work
+would arrive too late to save any. Granting the tool is what lets the decision happen while it still
+matters.
+
+A worker's bibliography merges back into its parent's `sources_index`, deduplicated by URL. Merged
+entries name the worker they came from and carry no `[n]` marker, because numbering is per agent and
+renumbering would repoint the citations already in the merged findings.
+
 The cost is a dependency. The named blueprint has to be installed, and `lev validate` cannot check
 that for you the way it checks a `worker_stage`, because what is installed is a property of the
 machine rather than of the blueprint. A missing one fails per item, so with the default


### PR DESCRIPTION
Follow-up to #572: every provider can now price a call, and the research agents that were measured against that pricing become the bundled ones.

## Pricing, for every provider that exists today

`Provider::pricing()` landed in #572 with no implementations, so a run on anything but OpenRouter reported its cost as unknown. Each provider now answers, by whatever route is honest for it:

| provider | how it prices |
|---|---|
| **OpenRouter** | reports each call's real cost; now also learns rates from the same `/models` fetch that already teaches it context windows |
| **Anthropic / OpenAI / Google** | a table transcribed from their pricing pages, stamped with the date it was read |
| **Ollama** | a known zero: local inference costs the account nothing |
| **Claude Code** | deliberately nothing, documented as a decision |
| **Rhai scripts** | the script reports its own `cost_usd` |

The three big vendors publish prices on a web page with nothing programmatic behind it, so a table is the only way a run on them reports a cost at all. Because a table cannot notice a repricing, `RATES_READ_ON` ships with the numbers and `lev models show` prints it:

```
Pricing (USD per million tokens)
  Input:          $5.00
  Cached input:   $0.50
  Cache write:    $6.25
  Output:         $25.00
  Source:         published list price, read 2026-08-23
  ⚠  anthropic does not serve prices through its API, so this was
     transcribed by hand and may be out of date. A rate set on the
     model's config entry overrides this, and is the only way to
     record a negotiated price no public page would show.
```

A per-model config entry beats the table, and a table-derived figure is still reported as **computed** rather than reported, so `CostTotals::is_exact` stays false and a reader can tell a reconstruction from an invoice.

Two details that would have made the table quietly wrong: Anthropic's cache columns are asymmetric (a 5-minute write is 1.25x input, a read 0.1x) while OpenAI and Google charge nothing extra to write; and `gpt-5.4-mini` has to be matched before `gpt-5.4`, or a mini model bills at three times its rate. Batch, data-residency and fast-mode multipliers are deliberately **not** modelled - they need per-request state the table cannot see, and a wrong adjustment is worse than a plain list price.

`Ollama` returning zero and `Claude Code` returning nothing are opposite answers on purpose. Local inference genuinely costs the account nothing, so zero is true and folds into a real total. Claude Code consumes subscription quota, so a zero would let a run claim it was free while spending something.

## The research agents ship what was measured

The `-x` variants every A/B ran against become the bundled `deep-researcher`, `wide-researcher` and `researcher`. Two new stages:

- **`challenge`** - a different vendor's model attacks the analysis, marks what holds as well as what is weak, and can send the run back for more evidence. Every route to the writing stage passes through it. Optional did not work: a model that feels confident will not elect to be attacked, and confidence is the failure it exists to catch.
- **`polish`** - rewrites the finished report in plain language without touching a fact, number, citation or caveat, and with explicit rules against the tells that make prose read machine-written.

Each stage's model is the one that measured best at its job rather than one family throughout, and sub-researchers can now split their own work when a slice turns out to be several independent subjects.

**Version bumps are mandatory here.** `plan_agent_actions` compares version first and reads changed content under the same version as a user edit, so `lev setup` would otherwise leave existing installs on the old blueprint forever.

### Three invariants the promotion broke

Each caught by an existing test, and each worth keeping:

1. **Every stage must list every provider `lev setup` can configure.** Getting Started promises one provider is enough; the experimental blueprints were built against one machine's keys.
2. **Ollama must be last.** It is the offline fallback, and anything after it is unreachable on a machine running a local model.
3. **`researcher` may not pre-approve `fan_out`.** A blueprint may only loosen `web_search` and `web_fetch` on a stock machine, and spawning sub-agents spends money and can recurse. The pre-approval is gone rather than the allowlist widened; the tool is still offered and an unattended run waives the prompt as it waives every other.

## Docs

Both catalog graphs show the new stages, with the reasoning for why `challenge` is unskippable and uses a different vendor. `sub-agents.md` documents worker recursion and the distinction that cost three debugging rounds to find: a `mode = "fan_out"` **stage** is only entered when the current stage *ends*, so a split meant to parallelise gathering would arrive after the gathering was done. Granting the **tool** is what lets the decision happen while it still matters.

## Verification

- `cargo xtask coverage`: all 13 packages at 100%
- full workspace suite green
- `cargo xtask docs`: 38 pages, no problems
- rates read from the vendors' own pricing pages on 2026-08-23
