### PR TITLE
fix(models): a blueprint names models, and gets the ones it named

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ same list.
 
 ## Unreleased
 
+- Fixed: `read_file` on a directory told the model to call `list_dir`, which 21
+  of the bundled agents' stages do not grant. It now answers with the directory's
+  contents, so the model can pick its next path in one call whatever the stage
+  allows. Long listings are capped and say how many entries they left out.
+
 - Fixed: a stage asking for a model got whichever model the matching route
   happened to name. Entries were matched as a whole `provider/model` pair, so
   `deep-researcher`'s `polish` stage, which lists `gemini-3.1-pro-preview`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ same list.
 
 ## Unreleased
 
+- Fixed: a stage asking for a model got whichever model the matching route
+  happened to name. Entries were matched as a whole `provider/model` pair, so
+  `deep-researcher`'s `polish` stage, which lists `gemini-3.1-pro-preview`
+  first, ran `claude-sonnet-5`, and `synthesize`, which lists `gpt-5.5` first,
+  ran `claude-opus-5`. Resolution now groups by model, so the blueprint's
+  preference order is the order that is tried (#578).
+- Changed: a blueprint names models, not routes. `models = ["gpt-5.5",
+  "claude-sonnet-5"]` asks each configured provider which of them serves the
+  model, the user's default provider first, so the same blueprint runs on
+  whichever provider a machine actually has. A table still pins a route where
+  only one exists: `{ provider = "ollama", model = "qwen3.5:9b" }`. The old
+  `{ provider = ..., model = ... }` form is still read. Every bundled agent has
+  been rewritten this way, which drops one entry per route: they listed the same
+  model up to five times to be reachable from any provider.
+- Fixed: a model no configured provider serves is skipped with a warning naming
+  it, and the stage falls through to the next model listed.
+- Fixed: the blueprint editor and The Lair showed a stage's models as one local
+  model. They read only entries carrying both a provider and a model, so a
+  blueprint that leaves routing open lost every entry but the pinned one.
+- Fixed: a run died with `Function call is missing a thought_signature in
+  functionCall parts` on reaching a Gemini stage. Nothing dropped the signature:
+  the calls were made by a different model. A blueprint that runs one stage on
+  grok and the next on Gemini carries the conversation across, and Gemini
+  rejects function calls it never signed. Calls it cannot have signed are now
+  folded into the assistant's text, which keeps what the run learned without
+  replaying a call the model will refuse.
+- Changed: `deep-researcher` and `wide-researcher` no longer carry the research
+  transcript into `polish`. That stage rewrites the report named in
+  `report_path` and never needed the turn-by-turn history, which was prompt
+  weight on the most expensive model in the run.
+
 - Added: every bundled provider can price a call. OpenRouter learns rates from
   the same `/models` fetch that teaches it context windows; Anthropic, OpenAI and
   Google get a table transcribed from their pricing pages, stamped with the date

--- a/crates/leviath-cli/agents/coder/agent.leviath
+++ b/crates/leviath-cli/agents/coder/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "coder"
-version = "0.1.2"
+version = "0.1.3"
 description = "Coding agent: discover the repo, plan with your sign-off, optionally spike, implement, and review, with stuck detection and graph-based recovery"
 entry_stage = "discover"
 
@@ -20,7 +20,7 @@ bash       = "ask"
 # hard iteration cap, and a single non-error edge (auto-followed, no routing call).
 [stages.discover]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Map the codebase and synthesize a verification workflow"
 available_tools = ["read_file", "list_dir", "bash", "context_write", "context_read"]
 max_iterations = 8
@@ -106,7 +106,7 @@ condition = "dead_end"
 
 [stages.plan]
 mode = "interactive_points"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Explore the codebase and produce a step-by-step implementation plan"
 available_tools = ["read_file", "list_dir", "ask_user_text", "ask_user_choice", "edit_document", "context_read"]
 # Attended, planning is where this agent most wants its user, and all three of
@@ -260,7 +260,7 @@ edit_options = ["Add detail - expand a section"]
 # user's approved GOAL is never renegotiated here, only the technical route.
 [stages.prototype]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Spike the riskiest assumption in the approved plan before executing it"
 available_tools = ["read_file", "list_dir", "write_file", "edit_file", "bash", "context_write", "context_append", "context_read"]
 max_iterations = 15
@@ -336,7 +336,7 @@ condition = "dead_end"
 
 [stages.implement]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-opus-5", "gpt-5.5", "gemini-3.1-pro-preview", { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Write code according to the approved plan"
 available_tools = ["write_file", "read_file", "edit_file", "list_dir", "bash", "ask_user_text", "ask_user_confirm", "context_append", "context_read"]
 max_iterations = 50
@@ -463,7 +463,7 @@ condition = "dead_end"
 
 [stages.review]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-opus-5", "gpt-5.5", "gemini-3.1-pro-preview", { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Review the implementation and evaluate code quality"
 available_tools = ["read_file", "list_dir", "bash", "context_read"]
 max_iterations = 20
@@ -549,7 +549,7 @@ transform = "direct"
 # before handing back to implement.
 [stages.reassess]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-opus-5", "gpt-5.5", "gemini-3.1-pro-preview", { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Step back after no progress: diagnose the dead end and re-plan"
 available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append", "context_read"]
 max_iterations = 8
@@ -619,7 +619,7 @@ condition = "dead_end"
 
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Diagnose and resolve errors encountered during implementation"
 available_tools = ["read_file", "bash", "context_append"]
 max_iterations = 10
@@ -669,7 +669,7 @@ model    = "claude-sonnet-5"
 # not work.
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what changed"
 max_iterations = 8
 system_prompt = """

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "data-analyst"
-version = "0.1.1"
+version = "0.1.2"
 description = "Data analyst - searches the web for data on a subject, builds a clean CSV of it, and hands back a ready-to-use summary of what the numbers say"
 entry_stage = "scope"
 
@@ -21,7 +21,7 @@ bash       = "ask"
 # were invented row by row is the usual way this work goes wrong.
 [stages.scope]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Decide the table's columns before gathering anything"
 available_tools = ["web_search", "context_write", "current_time"]
 max_iterations = 8
@@ -81,7 +81,7 @@ transform = "direct"
 # stage assembles them into a single table.
 [stages.split]
 mode = "fan_out"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Split the subject into slices, one worker each"
 available_tools = []
 max_iterations = 4
@@ -137,7 +137,7 @@ transform = "direct"
 # a hope.
 [stages.gather_worker]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather the rows for one slice of the subject"
 available_tools = ["web_search", "web_fetch", "submit_output", "current_time"]
 allow_as_worker = true
@@ -176,7 +176,7 @@ instructions = "A header line matching the schema's columns in order, then one r
 # wrote.
 [stages.build]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Assemble the workers' rows into one dataset"
 available_tools = ["write_file", "read_file", "context_read", "context_write"]
 max_iterations = 15
@@ -220,7 +220,7 @@ transform = "direct"
 # prose.
 [stages.present]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what the data shows"
 max_iterations = 8
 system_prompt = """
@@ -251,7 +251,7 @@ instructions = "Use a short `## Findings` list. Put figures inline, not in a tab
 # ─── Error recovery ───────────────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed fetch, parse, or write"
 available_tools = ["read_file", "context_read", "context_write"]
 max_iterations = 8

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.4.0"
+version = "0.4.1"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 max_child_depth = 2
 entry_stage = "gather"
@@ -18,7 +18,7 @@ bash       = "ask"
 # ─── Stage 1: Gather ──────────────────────────────────────────────────────────
 [stages.gather]
 mode = "autonomous"
-model = { models = [{ provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["grok-4.6", "claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather primary sources and key references on the topic"
 # web_search / web_fetch are provided by this agent's tools/ (issue #97).
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read", "ask_user_text", "ask_user_choice"]
@@ -157,7 +157,7 @@ transform = "direct"
 # `on_worker_failure = "continue"` means the run reports that rather than dying.
 [stages.investigate]
 mode = "fan_out"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "grok-4.6", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Research each sub-question of the topic in parallel"
 available_tools = []
 max_iterations = 4
@@ -240,7 +240,7 @@ transform = "compact"
 # (follow_citations), or write the report (synthesize).
 [stages.analyze]
 mode = "autonomous"
-model = { models = [{ provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["deepseek-v4-pro", "claude-opus-5", "gpt-5.5", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Analyze findings, cross-reference claims, and decide the next move"
 available_tools = ["read_file", "web_fetch", "context_write", "context_append", "current_time"]
 max_iterations = 20
@@ -308,7 +308,7 @@ transform = "direct"
 # sources analyze flagged, then hand back.
 [stages.follow_citations]
 mode = "autonomous"
-model = { models = [{ provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["deepseek-v4-pro", "claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Pull and read specific cited sources flagged during analysis"
 available_tools = ["web_fetch", "web_search", "read_file", "context_append", "current_time", "context_read"]
 max_iterations = 12
@@ -349,9 +349,9 @@ transform = "direct"
 # ─── Stage 4: Synthesize (terminal) ───────────────────────────────────────────
 [stages.synthesize]
 mode = "autonomous"
-model = { models = [{ provider = "openai", model = "gpt-5.5" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["gpt-5.5", "claude-opus-5", "claude-sonnet-5", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce a structured, cited research report"
-available_tools = ["write_file", "read_file"]
+available_tools = ["write_file", "read_file", "context_write"]
 max_iterations = 15
 system_prompt = """
 Write the report (write_file), built from `claims` and citing `sources_index`,
@@ -391,15 +391,29 @@ Citations are load-bearing, so two rules bind absolutely:
 Confidence is a claim about the evidence, not about how sure the prose sounds.
 A finding resting on sources you could not fetch is low confidence however
 familiar it feels.
+
+
+When you have written the report, record its filename with `context_write` to
+the `report_path` region, exactly as you passed it to `write_file` and nothing
+else. The stage after this one rewrites that file, and the working directory
+also holds a report from every worker, so a name it has to guess at is a name it
+gets wrong.
 """
 
 [stages.synthesize.transitions.polish]
 hint = "The synthesis is written"
+# The transcript of the research is not wanted here: this stage rewrites the
+# report named in `report_path`, and the turns that produced it are only
+# prompt weight on the run's most expensive model. Carrying them also handed
+# this stage function calls made by a different model family, which Gemini
+# refuses because it never signed them.
+transform = "custom"
+transform_config = { clear = ["conversation"] }
 
 # ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed source fetch or parse during research"
 available_tools = ["read_file", "bash"]
 max_iterations = 8
@@ -431,7 +445,7 @@ model = "claude-sonnet-5"
 # not work.
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what the investigation found"
 max_iterations = 8
 system_prompt = """
@@ -458,7 +472,7 @@ is worse than no summary.
 # its output is a lead to check rather than a verdict to apply.
 [stages.challenge]
 mode = "autonomous"
-model = { models = [{ provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["grok-4.6", "deepseek-v4-pro", "claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Attack the analysis: what is thin, unsupported, or too confident"
 available_tools = ["context_read", "context_append", "web_search", "web_fetch", "current_time"]
 max_iterations = 10
@@ -523,10 +537,10 @@ transform = "direct"
 # is not something to leave to good intentions.
 [stages.polish]
 mode = "autonomous"
-model = { models = [{ provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }], parameters = { max_output_tokens = 24000 } }
+model = { models = ["gemini-3.1-pro-preview", "claude-opus-5", "gpt-5.5", "claude-sonnet-5", { provider = "ollama", model = "qwen3.5:9b" }], parameters = { max_output_tokens = 24000 } }
 description = "Rewrite the report in plain language without changing what it says"
 
-available_tools = ["context_read", "context_write", "read_file", "write_file"]
+available_tools = ["context_read", "context_write", "read_file", "write_file", "list_dir"]
 max_iterations = 10
 system_prompt = """
 Rewrite the report so a smart reader outside this field can follow it.
@@ -570,11 +584,17 @@ What must not change:
 - The heading structure.
 
 Do not add an introduction, a note about the rewrite, or anything the original
-did not say. Write the finished report to the same file the previous stage
-wrote, replacing it.
+did not say.
+
+The file to rewrite is named in the `report_path` region. Read that file, and
+write your rewrite back to that same path, replacing it. Do not go looking for
+it: this directory also holds a separate report from every worker, and rewriting
+one of those instead would leave the real report untouched while the stage
+reports success.
 """
 
-[stages.polish.transitions.summary]
+[stages.polish.transitions.voice]
+gate = { require_modifications = true, message = "You have not written the report yet. Read the file named in `report_path`, rewrite it in plain language, and write it back to that same path with write_file. The stage is not done until that file has been replaced." }
 hint = "The report reads clearly - produce the final answer"
 transform = "compact"
 
@@ -582,7 +602,60 @@ transform = "compact"
 condition = "error"
 transform = "direct"
 
+
+# ─── Second pass: voice ───────────────────────────────────────────────────────
+# Measured: one pass leaves grade 11.2 and 30.3 LLM-tells per 1,000 words; a
+# second takes them to 8.0 and 5.1 without losing a citation. The first pass is
+# structural and its attention goes on sentences; the phrasing that makes a
+# report sound machine-written survives it and needs a pass of its own.
+[stages.voice]
+mode = "autonomous"
+model = { models = ["gemini-3.1-pro-preview", "claude-opus-5", "gpt-5.5", "claude-sonnet-5", { provider = "ollama", model = "qwen3.5:9b" }], parameters = { max_output_tokens = 24000 } }
+description = "Second pass: make it sound like a person wrote it"
+available_tools = ["context_read", "read_file", "write_file", "list_dir"]
+max_iterations = 8
+system_prompt = """
+The report is already readable. This pass is about how it SOUNDS, not how hard
+it is to parse. Read the file named in `report_path` and write your rewrite back
+to that same path.
+
+Change nothing that is a fact, a number, a citation marker, a URL, a heading or
+a caveat. If you cannot improve a sentence without risking its meaning, leave it
+exactly as it is. A pass that changes little is a good outcome; a pass that
+changes a number is a failure.
+
+What to go after, in order:
+
+- Stock openers and connectives: "It is worth noting", "That said", "Overall",
+  "In conclusion", "At its core", "Furthermore", "Moreover", "Additionally".
+  Most sentences work with them deleted and nothing put back.
+- Inflated words where a plain one exists: leverage is use, utilize is use,
+  robust is usually reliable, crucial is usually important, delve into is
+  examine. "comprehensive", "seamless", "pivotal", "myriad", "landscape" and
+  "ecosystem" are almost always padding.
+- Em dashes. A full stop, a comma or brackets.
+- "not only X but also Y", and "isn't just X, it's Y".
+- Lists padded to three when two would do.
+- Bullets that open with a bolded phrase and a colon, unless the bold is a real
+  term being defined.
+- Hedging stacked on hedging: "may potentially", "could possibly". One hedge is
+  a caveat and belongs; two is a tic.
+
+A sentence that states the finding plainly beats one that performs expertise.
+If a phrase could be deleted without losing information, delete it.
+"""
+
+[stages.voice.transitions.summary]
+gate = { require_modifications = true, message = "You have not written the report yet. Read the file named in `report_path`, rewrite it, and write it back to that same path with write_file. The stage is not done until that file has been replaced." }
+hint = "The report reads like a person wrote it - produce the final answer"
+transform = "compact"
+
+[stages.voice.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
 [context.regions]
+report_path    = { kind = "pinned", budget = "1%", volatility = "rewritten", description = "The exact filename of the report, written by the stage that created it so the polish stage rewrites that file rather than guessing among the workers' own reports in the same directory." }
 progress_report = { kind = "clearable", budget = "1%", volatility = "rewritten", description = "What your last visit to this stage actually added, measured. Weigh another pass against it." }
 challenges     = { kind = "pinned", budget = "4%", volatility = "grows", description = "Adversarial challenges to the analysis: leads to check, not verdicts" }
 query          = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the research topic via --task.", volatility = "stable" }

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "log-analyzer"
-version = "0.2.1"
+version = "0.2.2"
 description = "Analyzes log files - sweeps many files or time windows in parallel, then identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
 entry_stage = "ingest"
 
@@ -13,7 +13,7 @@ write_file = "ask"
 # ─── Stage 1: Ingest ──────────────────────────────────────────────────────────
 [stages.ingest]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Read log files, identify format and structure"
 available_tools = ["read_file", "list_dir", "bash", "context_write", "context_read"]
 max_iterations = 15
@@ -62,7 +62,7 @@ transform = "direct"
 # analyze stage takes them from there and digs into what they turned up.
 [stages.split_logs]
 mode = "fan_out"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Split the logs into files or time windows, one sweeper each"
 available_tools = []
 max_iterations = 4
@@ -119,7 +119,7 @@ transform = "direct"
 # this one's.
 [stages.scan_worker]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Sweep one log file or time window for errors, anomalies, and trends"
 available_tools = ["read_file", "bash", "submit_output"]
 allow_as_worker = true
@@ -154,7 +154,7 @@ instructions = "One finding per line, as `<severity> | <finding> | <evidence: co
 # ─── Stage 3: Analyze ─────────────────────────────────────────────────────────
 [stages.analyze]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-opus-5", "gpt-5.5", "gemini-3.1-pro-preview", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Identify anomalies, trends, and error patterns"
 available_tools = ["read_file", "bash", "context_write", "context_append", "context_read"]
 max_iterations = 25
@@ -209,7 +209,7 @@ transform = "direct"
 # ─── Stage 4: Script ──────────────────────────────────────────────────────────
 [stages.script]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Write and execute scripts to parse, filter, and aggregate log data"
 available_tools = ["read_file", "bash", "context_read"]
 max_iterations = 20
@@ -260,7 +260,7 @@ transform = "direct"
 # ─── Stage 5: Report ──────────────────────────────────────────────────────────
 [stages.report]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-opus-5", "gpt-5.5", "gemini-3.1-pro-preview", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce a structured analysis report with findings"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
@@ -287,7 +287,7 @@ hint = "The report is written"
 # ─── Stage 6: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed read or script execution"
 available_tools = ["read_file", "bash"]
 max_iterations = 10
@@ -320,7 +320,7 @@ model = "claude-sonnet-5"
 # not work.
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what the logs showed"
 max_iterations = 8
 system_prompt = """

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.4.0"
+version = "0.4.1"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 max_child_depth = 2
 entry_stage = "gather"
@@ -23,7 +23,7 @@ bash       = "ask"
 # ─── Stage 1: Gather ──────────────────────────────────────────────────────────
 [stages.gather]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Gather relevant information on the topic"
 # web_search / web_fetch are provided by the agent's script tools (issue #97).
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "context_read", "current_time", "fan_out"]
@@ -155,7 +155,7 @@ transform = "direct"
 # whether it needs more sources or is ready to summarize.
 [stages.analyze]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-opus-5", "gpt-5.5", "gemini-3.1-pro-preview", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Analyze and synthesize findings"
 available_tools = ["read_file", "web_fetch", "context_write", "context_append", "context_read", "current_time"]
 max_iterations = 20
@@ -201,7 +201,7 @@ transform = "direct"
 # ─── Stage 3: Summarize (terminal) ────────────────────────────────────────────
 [stages.summarize]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Create a concise, well-organized summary"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
@@ -255,7 +255,7 @@ hint = "The report is written"
 # ─── Stage 4: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Diagnose and recover from errors during gathering or analysis"
 available_tools = ["read_file", "bash"]
 max_iterations = 8
@@ -288,7 +288,7 @@ model = "claude-sonnet-5"
 # not work.
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what the research found"
 max_iterations = 8
 system_prompt = """
@@ -324,7 +324,7 @@ mode = "fan_out"
 # The split decision is an inference like any other, so this stage names its own
 # model. sonnet-5 measured best at it: given the same material it produced eight
 # subject-shaped items where deepseek produced three vague buckets.
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 worker_agent = "researcher"
 max_workers = 3
 max_items = 3

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "reviewer"
-version = "0.2.1"
+version = "0.2.2"
 description = "Code review agent - discover, scan, review the areas in parallel, then deep review and report, with error recovery and multi-provider fallback"
 entry_stage = "discover"
 
@@ -16,7 +16,7 @@ bash      = "ask"
 # iteration cap, one non-error edge (auto-followed, no routing call).
 [stages.discover]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Map the project and work out how to verify a hypothesis in it"
 available_tools = ["read_file", "list_dir", "bash", "context_write"]
 max_iterations = 6
@@ -57,7 +57,7 @@ transform = "direct"
 # ─── Stage 2: Scan ────────────────────────────────────────────────────────────
 [stages.scan]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Fast first pass for obvious issues"
 available_tools = ["read_file", "list_dir", "context_append", "context_read"]
 max_iterations = 12
@@ -106,7 +106,7 @@ transform = "direct"
 # them and does the work that needs the whole picture.
 [stages.split_review]
 mode = "fan_out"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Split the change into areas, one reviewer each"
 available_tools = []
 max_iterations = 4
@@ -163,7 +163,7 @@ transform = "direct"
 # at once, so verification stays in the merge, where `workflow`'s VERIFY line is.
 [stages.review_worker]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-opus-5", "gpt-5.5", "gemini-3.1-pro-preview", { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Review one area of the change in depth"
 available_tools = ["read_file", "list_dir", "submit_output"]
 allow_as_worker = true
@@ -200,7 +200,7 @@ instructions = "One finding per line, most severe first, as `severity | file:lin
 # ─── Stage 4: Deep review ─────────────────────────────────────────────────────
 [stages.deep_review]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-opus-5", "gpt-5.5", "gemini-3.1-pro-preview", { provider = "ollama", model = "devstral:24b" }, { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "In-depth analysis of correctness, security, and architecture"
 available_tools = ["read_file", "list_dir", "bash", "context_write", "context_append", "context_read"]
 max_iterations = 25
@@ -255,7 +255,7 @@ transform = "direct"
 # ─── Stage 5: Report ──────────────────────────────────────────────────────────
 [stages.report]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce an actionable, ranked review report"
 available_tools = ["read_file"]
 max_iterations = 10
@@ -282,7 +282,7 @@ hint = "The review is written"
 # ─── Stage 6: Error handler ───────────────────────────────────────────────────
 [stages.error_handler]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Handle errors encountered during scanning or review"
 available_tools = ["read_file", "bash"]
 max_iterations = 10
@@ -314,7 +314,7 @@ model = "claude-sonnet-5"
 # not work.
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4-mini" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what the review found"
 max_iterations = 8
 system_prompt = """

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.4.0"
+version = "0.4.1"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 max_child_depth = 2
 entry_stage = "survey"
@@ -17,7 +17,7 @@ bash       = "ask"
 # ─── Stage 1: Survey ──────────────────────────────────────────────────────────
 [stages.survey]
 mode = "autonomous"
-model = { models = [{ provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["grok-4.6", "claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Survey the landscape across multiple sub-topics"
 available_tools = ["web_search", "web_fetch", "read_file", "list_dir", "context_append", "current_time", "context_read", "ask_user_text", "ask_user_choice"]
 # The ask tools block on a person, which is the point: this stage decides what
@@ -143,7 +143,7 @@ transform = "direct"
 # `on_worker_failure = "continue"` means the run reports that rather than dying.
 [stages.investigate]
 mode = "fan_out"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "grok-4.6", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Research each thread of the landscape in parallel"
 available_tools = []
 max_iterations = 4
@@ -225,7 +225,7 @@ transform = "compact"
 # Three edges: more breadth (survey), dive on a thread (deep_dive), or write it up.
 [stages.compare]
 mode = "autonomous"
-model = { models = [{ provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["deepseek-v4-pro", "claude-opus-5", "gpt-5.5", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Compare and contrast approaches across the landscape"
 available_tools = ["read_file", "web_fetch", "context_write", "context_append", "current_time"]
 max_iterations = 15
@@ -288,7 +288,7 @@ transform = "direct"
 # ─── Stage 3: Deep dive ───────────────────────────────────────────────────────
 [stages.deep_dive]
 mode = "autonomous"
-model = { models = [{ provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["deepseek-v4-pro", "claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Focused deep read on one interesting thread flagged during comparison"
 available_tools = ["web_search", "web_fetch", "read_file", "context_append", "current_time", "context_read"]
 max_iterations = 12
@@ -330,9 +330,9 @@ transform = "direct"
 # ─── Stage 4: Summarize (terminal) ────────────────────────────────────────────
 [stages.summarize]
 mode = "autonomous"
-model = { models = [{ provider = "openai", model = "gpt-5.5" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openrouter", model = "anthropic/claude-opus-5" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["gpt-5.5", "claude-opus-5", "claude-sonnet-5", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Produce a landscape overview with recommendations"
-available_tools = ["write_file", "read_file"]
+available_tools = ["write_file", "read_file", "context_write"]
 max_iterations = 10
 system_prompt = """
 Write a landscape overview (write_file) built from `comparisons` and `deep_dives`,
@@ -377,15 +377,29 @@ Citations are load-bearing, so two rules bind absolutely:
    present what you have as background knowledge rather than findings.
 
 Confidence describes the evidence, not how sure the prose sounds.
+
+
+When you have written the report, record its filename with `context_write` to
+the `report_path` region, exactly as you passed it to `write_file` and nothing
+else. The stage after this one rewrites that file, and the working directory
+also holds a report from every worker, so a name it has to guess at is a name it
+gets wrong.
 """
 
 [stages.summarize.transitions.polish]
 hint = "The comparison is written"
+# The transcript of the research is not wanted here: this stage rewrites the
+# report named in `report_path`, and the turns that produced it are only
+# prompt weight on the run's most expensive model. Carrying them also handed
+# this stage function calls made by a different model family, which Gemini
+# refuses because it never signed them.
+transform = "custom"
+transform_config = { clear = ["conversation"] }
 
 # ─── Stage 5: Error recovery ──────────────────────────────────────────────────
 [stages.error_recovery]
 mode = "autonomous"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Recover from a failed source fetch during the survey"
 available_tools = ["read_file", "bash"]
 max_iterations = 8
@@ -417,7 +431,7 @@ model = "claude-sonnet-5"
 # not work.
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Say what the survey found"
 max_iterations = 8
 system_prompt = """
@@ -441,7 +455,7 @@ file you wrote.
 # its output is a lead to check rather than a verdict to apply.
 [stages.challenge]
 mode = "autonomous"
-model = { models = [{ provider = "openrouter", model = "x-ai/grok-4.6" }, { provider = "openrouter", model = "deepseek/deepseek-v4-pro" }, { provider = "anthropic", model = "claude-sonnet-5" }, { provider = "openai", model = "gpt-5.4" }, { provider = "google", model = "gemini-3.5-flash" }, { provider = "ollama", model = "qwen3.5:9b" }] }
+model = { models = ["grok-4.6", "deepseek-v4-pro", "claude-sonnet-5", "gpt-5.4", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
 description = "Attack the analysis: what is thin, unsupported, or too confident"
 available_tools = ["context_read", "context_append", "web_search", "web_fetch", "current_time"]
 max_iterations = 10
@@ -506,10 +520,10 @@ transform = "direct"
 # is not something to leave to good intentions.
 [stages.polish]
 mode = "autonomous"
-model = { models = [{ provider = "google", model = "gemini-3.1-pro-preview" }, { provider = "anthropic", model = "claude-opus-5" }, { provider = "openai", model = "gpt-5.5" }, { provider = "openrouter", model = "anthropic/claude-sonnet-5" }, { provider = "ollama", model = "qwen3.5:9b" }], parameters = { max_output_tokens = 24000 } }
+model = { models = ["gemini-3.1-pro-preview", "claude-opus-5", "gpt-5.5", "claude-sonnet-5", { provider = "ollama", model = "qwen3.5:9b" }], parameters = { max_output_tokens = 24000 } }
 description = "Rewrite the report in plain language without changing what it says"
 
-available_tools = ["context_read", "context_write", "read_file", "write_file"]
+available_tools = ["context_read", "context_write", "read_file", "write_file", "list_dir"]
 max_iterations = 10
 system_prompt = """
 Rewrite the report so a smart reader outside this field can follow it.
@@ -553,11 +567,17 @@ What must not change:
 - The heading structure.
 
 Do not add an introduction, a note about the rewrite, or anything the original
-did not say. Write the finished report to the same file the previous stage
-wrote, replacing it.
+did not say.
+
+The file to rewrite is named in the `report_path` region. Read that file, and
+write your rewrite back to that same path, replacing it. Do not go looking for
+it: this directory also holds a separate report from every worker, and rewriting
+one of those instead would leave the real report untouched while the stage
+reports success.
 """
 
-[stages.polish.transitions.summary]
+[stages.polish.transitions.voice]
+gate = { require_modifications = true, message = "You have not written the report yet. Read the file named in `report_path`, rewrite it in plain language, and write it back to that same path with write_file. The stage is not done until that file has been replaced." }
 hint = "The report reads clearly - produce the final answer"
 transform = "compact"
 
@@ -565,7 +585,60 @@ transform = "compact"
 condition = "error"
 transform = "direct"
 
+
+# ─── Second pass: voice ───────────────────────────────────────────────────────
+# Measured: one pass leaves grade 11.2 and 30.3 LLM-tells per 1,000 words; a
+# second takes them to 8.0 and 5.1 without losing a citation. The first pass is
+# structural and its attention goes on sentences; the phrasing that makes a
+# report sound machine-written survives it and needs a pass of its own.
+[stages.voice]
+mode = "autonomous"
+model = { models = ["gemini-3.1-pro-preview", "claude-opus-5", "gpt-5.5", "claude-sonnet-5", { provider = "ollama", model = "qwen3.5:9b" }], parameters = { max_output_tokens = 24000 } }
+description = "Second pass: make it sound like a person wrote it"
+available_tools = ["context_read", "read_file", "write_file", "list_dir"]
+max_iterations = 8
+system_prompt = """
+The report is already readable. This pass is about how it SOUNDS, not how hard
+it is to parse. Read the file named in `report_path` and write your rewrite back
+to that same path.
+
+Change nothing that is a fact, a number, a citation marker, a URL, a heading or
+a caveat. If you cannot improve a sentence without risking its meaning, leave it
+exactly as it is. A pass that changes little is a good outcome; a pass that
+changes a number is a failure.
+
+What to go after, in order:
+
+- Stock openers and connectives: "It is worth noting", "That said", "Overall",
+  "In conclusion", "At its core", "Furthermore", "Moreover", "Additionally".
+  Most sentences work with them deleted and nothing put back.
+- Inflated words where a plain one exists: leverage is use, utilize is use,
+  robust is usually reliable, crucial is usually important, delve into is
+  examine. "comprehensive", "seamless", "pivotal", "myriad", "landscape" and
+  "ecosystem" are almost always padding.
+- Em dashes. A full stop, a comma or brackets.
+- "not only X but also Y", and "isn't just X, it's Y".
+- Lists padded to three when two would do.
+- Bullets that open with a bolded phrase and a colon, unless the bold is a real
+  term being defined.
+- Hedging stacked on hedging: "may potentially", "could possibly". One hedge is
+  a caveat and belongs; two is a tic.
+
+A sentence that states the finding plainly beats one that performs expertise.
+If a phrase could be deleted without losing information, delete it.
+"""
+
+[stages.voice.transitions.summary]
+gate = { require_modifications = true, message = "You have not written the report yet. Read the file named in `report_path`, rewrite it, and write it back to that same path with write_file. The stage is not done until that file has been replaced." }
+hint = "The report reads like a person wrote it - produce the final answer"
+transform = "compact"
+
+[stages.voice.transitions.error_recovery]
+condition = "error"
+transform = "direct"
+
 [context.regions]
+report_path    = { kind = "pinned", budget = "1%", volatility = "rewritten", description = "The exact filename of the report, written by the stage that created it so the polish stage rewrites that file rather than guessing among the workers' own reports in the same directory." }
 progress_report = { kind = "clearable", budget = "1%", volatility = "rewritten", description = "What your last visit to this stage actually added, measured. Weigh another pass against it." }
 challenges     = { kind = "pinned", budget = "4%", volatility = "grows", description = "Adversarial challenges to the analysis: leads to check, not verdicts" }
 query              = { kind = "pinned", budget = "1%", required = true, seed = "task", required_message = "State the survey topic/area via --task.", volatility = "stable" }

--- a/crates/leviath-cli/src/blueprint_edit/doc.rs
+++ b/crates/leviath-cli/src/blueprint_edit/doc.rs
@@ -690,9 +690,13 @@ impl ManifestDoc {
     }
 }
 
-/// The `provider/model` chain a stage's `model` value stands for. A bare
-/// string is one entry (The Lair's reading; the runtime ignores that form,
-/// which is why the editor never writes it).
+/// The model chain a stage's `model` value stands for, each entry rendered as
+/// `provider/model` when the blueprint pins a route and as a bare model name
+/// when it leaves the route open.
+///
+/// Dropping the entries that name no provider is what made a migrated blueprint
+/// show a single local model where it lists five: the open-route form is now
+/// the ordinary one, so it has to read, not merely parse.
 fn model_chain(value: Option<&Item>) -> Vec<String> {
     let Some(value) = value else {
         return Vec::new();
@@ -709,13 +713,15 @@ fn model_chain(value: Option<&Item>) -> Vec<String> {
     models
         .iter()
         .filter_map(|entry| {
+            if let Some(name) = entry.as_str() {
+                return Some(name.to_string());
+            }
             let t = entry.as_inline_table()?;
-            match (
-                t.get("provider").and_then(Value::as_str),
-                t.get("model").and_then(Value::as_str),
-            ) {
-                (Some(provider), Some(model)) => Some(format!("{provider}/{model}")),
-                _ => None,
+            let model = t.get("model").and_then(Value::as_str)?;
+            // An empty provider is the same statement as omitting it.
+            match t.get("provider").and_then(Value::as_str) {
+                Some(provider) if !provider.is_empty() => Some(format!("{provider}/{model}")),
+                _ => Some(model.to_string()),
             }
         })
         .collect()

--- a/crates/leviath-cli/src/blueprint_edit/stages.rs
+++ b/crates/leviath-cli/src/blueprint_edit/stages.rs
@@ -318,7 +318,14 @@ impl ManifestDoc {
         }
         let mut models = Array::new();
         for entry in chain {
-            let (provider, model) = entry.split_once('/').unwrap_or(("", entry.as_str()));
+            // No route in the string means the author is naming a model and
+            // leaving the provider to the machine, which the bare-string form
+            // says directly. Writing `provider = ""` would say the same thing
+            // in a shape nobody would type by hand.
+            let Some((provider, model)) = entry.split_once('/') else {
+                models.push(Value::from(entry.as_str()));
+                continue;
+            };
             let mut t = InlineTable::new();
             t.insert("provider", Value::from(provider));
             t.insert("model", Value::from(model));

--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -173,8 +173,20 @@ fn the_views_read_the_coder_the_way_the_lair_does() {
     assert_eq!(discover.mode, StageModeView::Autonomous);
     assert_eq!(discover.max_iterations, Some(8));
     assert_eq!(discover.max_revisits, Some(2));
-    assert_eq!(discover.models[0], "anthropic/claude-sonnet-5");
-    assert_eq!(discover.models.len(), 5);
+    // A model the blueprint names without pinning a route reads back as the
+    // bare name. It has to survive the view: this stage lists several such
+    // models, and reading only the route-pinned ones showed just the local one.
+    assert_eq!(discover.models[0], "claude-sonnet-5");
+    assert!(
+        discover.models.len() > 1,
+        "open-route models must survive the view, got {:?}",
+        discover.models
+    );
+    assert!(
+        discover.models.iter().any(|m| m.starts_with("ollama/")),
+        "a local model still pins its route, got {:?}",
+        discover.models
+    );
     assert_eq!(
         discover.tools,
         [
@@ -272,7 +284,7 @@ fn the_views_read_the_coder_the_way_the_lair_does() {
     assert!(tools.contains(&"read_file".to_string()));
     assert!(tools.windows(2).all(|w| w[0] < w[1]), "sorted, deduped");
     let models = doc.known_models();
-    assert!(models.contains(&"anthropic/claude-opus-5".to_string()));
+    assert!(models.contains(&"claude-opus-5".to_string()));
     assert!(models.windows(2).all(|w| w[0] < w[1]));
 }
 
@@ -356,7 +368,10 @@ transitions = 4
 "#,
     )
     .unwrap();
-    assert_eq!(odder.stage("a").unwrap().models, ["p/m"]);
+    // `{ model = "y" }` is the open-route form, so it reads as the model it
+    // names - the same reading the runtime's parser gives it. Only the entries
+    // that name no model at all (`3`, `{ provider = "x" }`) are dropped.
+    assert_eq!(odder.stage("a").unwrap().models, ["y", "p/m"]);
     let edges = odder.edges();
     assert_eq!(edges.len(), 1);
     assert_eq!(edges[0].to, "c");
@@ -732,15 +747,22 @@ fn stage_fields_write_and_delete_the_way_the_lair_does() {
     doc.set_tools("work", &[]).unwrap();
     assert!(!doc.to_toml().contains("available_tools"));
 
-    // Models: the table form, keeping a sibling key; slashless keeps the
-    // model visible with an empty provider; empty deletes.
+    // Models: a slash pins the route and writes the table form; a slashless
+    // entry is a model with the route left open, and writes the bare form that
+    // says so. Both survive a round trip through the view; empty deletes.
     doc.set_models("work", &["anthropic/claude".into(), "gpt-4".into()])
         .unwrap();
     let text = doc.to_toml();
-    assert!(text.contains(r#"model = { models = [{ provider = "anthropic", model = "claude" }, { provider = "", model = "gpt-4" }] }"#), "{text}");
+    assert!(
+        text.contains(
+            r#"model = { models = [{ provider = "anthropic", model = "claude" }, "gpt-4"] }"#
+        ),
+        "{text}"
+    );
     assert_eq!(
         doc.stage("work").unwrap().models,
-        ["anthropic/claude", "/gpt-4"]
+        ["anthropic/claude", "gpt-4"],
+        "what was written reads back unchanged"
     );
     let mut kept = ManifestDoc::parse(
         "[agent]\nname = \"m\"\n[stages.a]\nmodel = { allow_user_default = false, models = [{ provider = \"x\", model = \"y\" }] }\n",

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -599,9 +599,50 @@ mod tests {
         }
     }
 
-    /// Every provider `lev setup` can configure. Claude Code is a transport
-    /// rather than a provider a stage names, so it is not in this list.
-    const SETUP_PROVIDERS: &[&str] = &["anthropic", "openai", "google", "openrouter", "ollama"];
+    /// Every provider `lev setup` can configure, built so a test can ask them
+    /// what they serve. Claude Code is a transport rather than a provider a
+    /// stage names, so it is not in this list.
+    ///
+    /// The keys are never used: `serves_model` reads a table compiled into the
+    /// build, which is exactly the offline answer wanted here.
+    fn setup_providers() -> Vec<(&'static str, Box<dyn leviath_providers::Provider>)> {
+        let client = reqwest::Client::new();
+        let key = || "not-used-offline".to_string();
+        vec![
+            (
+                "anthropic",
+                Box::new(leviath_providers::AnthropicProvider::new(
+                    client.clone(),
+                    key(),
+                )) as Box<dyn leviath_providers::Provider>,
+            ),
+            (
+                "openai",
+                Box::new(leviath_providers::OpenAIProvider::new(
+                    client.clone(),
+                    key(),
+                )),
+            ),
+            (
+                "google",
+                Box::new(leviath_providers::GeminiProvider::new(
+                    client.clone(),
+                    key(),
+                )),
+            ),
+            (
+                "openrouter",
+                Box::new(leviath_providers::OpenRouterProvider::new(
+                    client.clone(),
+                    key(),
+                )),
+            ),
+            (
+                "ollama",
+                Box::new(leviath_providers::OllamaProvider::new(client)),
+            ),
+        ]
+    }
 
     /// The published JSON Schema for `agent.leviath`.
     ///
@@ -858,11 +899,57 @@ mod tests {
         assert!(!rejects("[agent]\nname = \"a\"\n"), "a minimal manifest");
     }
 
+    /// A `transform = "custom"` edge must actually name regions.
+    ///
+    /// `transform_config` is parsed key by key, so a misspelt key leaves every
+    /// list empty and the edge becomes an expensive no-op that still parses and
+    /// still validates. Discovered from BUNDLED_AGENTS so it covers whatever
+    /// ships, not a list kept by hand.
+    #[test]
+    fn a_custom_transform_never_parses_to_nothing() {
+        for agent in BUNDLED_AGENTS {
+            let manifest = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .map(|(_, c)| *c)
+                .expect("every bundled agent has a manifest");
+            let blueprint =
+                leviath_core::manifest::parse_manifest(manifest).expect("manifest parses");
+            for stage in &blueprint.stages {
+                for (target, edge) in stage.transitions.iter().flatten() {
+                    let leviath_core::blueprint::EdgeTransform::Custom {
+                        carry,
+                        compact,
+                        clear,
+                        ..
+                    } = &edge.transform
+                    else {
+                        continue;
+                    };
+                    assert!(
+                        !(carry.is_empty() && compact.is_empty() && clear.is_empty()),
+                        "{}: {} -> {} declares a custom transform that names no \
+                         regions, so it does nothing; check the spelling of the \
+                         keys under transform_config",
+                        agent.name,
+                        stage.name,
+                        target
+                    );
+                }
+            }
+        }
+    }
+
     #[test]
     fn every_bundled_stage_offers_every_provider_setup_can_configure() {
-        // Getting Started promises that one provider is all you need. That is
-        // only true if each stage lists them all: a stage naming a subset fails
-        // at spawn on a machine holding a key for a provider it left out.
+        // Getting Started promises that one provider is all you need: on a
+        // machine configured with exactly one of them, every stage still runs.
+        //
+        // Asked of the providers themselves rather than of the spelling. A
+        // blueprint names models and leaves routing to the machine, so "does
+        // this stage name a provider" no longer answers the question - "does
+        // this provider serve anything this stage named" does.
         //
         // Discovered from BUNDLED_AGENTS rather than enumerated, so a new
         // blueprint is covered the day it lands.
@@ -884,13 +971,31 @@ mod tests {
                     .iter()
                     .map(|entry| entry.provider.as_str())
                     .collect();
-                for provider in SETUP_PROVIDERS {
+                let providers = setup_providers();
+                // A gateway fronts the other vendors, so it reaches whatever
+                // they reach. Its own answer comes from a catalogue fetched at
+                // startup, which a test with no network cannot consult.
+                let native = |key: &str| {
+                    providers
+                        .iter()
+                        .any(|(n, p)| *n != "openrouter" && p.serves_model(key).is_some())
+                };
+                for (name, provider) in &providers {
+                    let reachable = stage.model.models.iter().any(|entry| {
+                        if !entry.provider.is_empty() {
+                            return entry.provider == *name;
+                        }
+                        let key = entry.model.rsplit('/').next().unwrap_or(&entry.model);
+                        if *name == "openrouter" {
+                            return native(key);
+                        }
+                        provider.serves_model(key).is_some()
+                    });
                     assert!(
-                        listed.contains(provider),
-                        "{}/{} omits provider {}",
-                        agent.name,
-                        stage_name,
-                        provider
+                        reachable,
+                        "{}/{} names nothing {} can run, so a machine holding \
+                         only that provider cannot reach this stage: {:?}",
+                        agent.name, stage_name, name, stage.model.models
                     );
                 }
                 // Ollama needs no API key, so it registers on every machine. Any

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -672,22 +672,23 @@ system_prompt = "hi"
             "no substitution, so nothing to explain: {lines:#?}"
         );
 
-        // Preferring openrouter: the second-listed entry is promoted over the
-        // blueprint's first choice, and the run silently goes there.
+        // Preferring openrouter no longer substitutes a different MODEL. The
+        // blueprint asked for claude-sonnet-5 first and a route to it exists,
+        // so that is what runs: `default_provider` chooses between routes to a
+        // model, not between models (#578). Before this, the second-listed
+        // entry was promoted and the run silently went to deepseek.
         let openrouter_first = with_keys("openrouter");
         let registry = registry_for(&openrouter_first);
         let lines = model_resolution_lines(blueprint, &openrouter_first, &registry);
         assert!(
-            lines
-                .iter()
-                .any(|l| l.contains("openrouter/deepseek/deepseek-v4-flash")),
-            "{lines:#?}"
+            lines.iter().any(|l| l.contains("claude-sonnet-5")),
+            "the blueprint's first model still wins: {lines:#?}"
         );
         assert!(
-            lines
+            !lines
                 .iter()
-                .any(|l| l.contains("blueprint order") && l.contains("anthropic/claude-sonnet-5")),
-            "the override has to be visible against what the blueprint asked for: {lines:#?}"
+                .any(|l| l.contains("openrouter/deepseek/deepseek-v4-flash")),
+            "a preference for a provider must not pick a different model: {lines:#?}"
         );
         assert!(
             lines

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -465,6 +465,16 @@ fn print_model_resolution(blueprint: &leviath_core::Blueprint, config: &crate::c
     }
 }
 
+/// A model id without its vendor prefix, for comparing what was asked for
+/// against what resolved.
+///
+/// The same model is spelled differently by route (`gpt-5.5` on OpenAI,
+/// `openai/gpt-5.5` on a gateway), so comparing the full ids would report a
+/// substitution every time a gateway serves the model the blueprint named.
+fn model_key(model: &str) -> &str {
+    model.rsplit('/').next().unwrap_or(model)
+}
+
 /// The lines [`print_model_resolution`] prints, so they can be asserted
 /// without capturing stdout.
 fn model_resolution_lines(
@@ -482,16 +492,31 @@ fn model_resolution_lines(
             leviath_runtime::pipeline::resolve_stage_model(&stage.model, None, &defaults, registry);
         let head = format!("{provider}/{model}");
         lines.push(format!("  {:<16} {head}", stage.name));
+        // Written the way the blueprint writes them: a bare name for an entry
+        // that left the route open, `provider/model` for one that pinned it.
+        // Rendering an open entry as `/gpt-5.5` would show a route it does not
+        // claim to have.
         let listed: Vec<String> = stage
             .model
             .models
             .iter()
-            .map(|e| format!("{}/{}", e.provider, e.model))
+            .map(|e| {
+                if e.provider.is_empty() {
+                    e.model.clone()
+                } else {
+                    format!("{}/{}", e.provider, e.model)
+                }
+            })
             .collect();
         // Only when the install disagrees with the blueprint: printing the
         // list under every stage that already got its first choice is noise,
         // and the point of the line is to make a substitution visible.
-        if listed.first().is_some_and(|first| *first != head) {
+        //
+        // Compared by MODEL, not by the whole route. An open entry names no
+        // provider, so comparing the rendered strings would differ every time
+        // and print the list under every stage.
+        let first_model = stage.model.models.first().map(|e| e.model.as_str());
+        if first_model.is_some_and(|first| model_key(first) != model_key(&model)) {
             lines.push(format!(
                 "  {:<16}   blueprint order: {}",
                 "",
@@ -612,6 +637,66 @@ mod tests {
     /// not ask for first. Nothing surfaced that, so the substitution is shown
     /// against the blueprint's own order - and only when they differ, because
     /// repeating the list under a stage that got its first choice is noise.
+    /// A blueprint leading with a model nothing configured serves falls through
+    /// to the next one, and the listing says so. This is the surviving reason
+    /// for a substitution: #578 removed the other one, where preferring a
+    /// provider silently changed which model ran.
+    #[test]
+    fn model_resolution_explains_falling_through_to_the_next_model() {
+        let manifest = r#"
+[agent]
+name = "m"
+version = "0.1.0"
+entry_stage = "one"
+
+[stages.one]
+model = { models = ["a-model-nobody-serves", "claude-sonnet-5"] }
+system_prompt = "hi"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let path = write_test_agent(dir.path(), manifest);
+        let checked = check_manifest(&path).expect("the manifest parses");
+        let blueprint = &checked.blueprint;
+
+        let config = crate::config::Config {
+            default_provider: "anthropic".to_string(),
+            default_model: None,
+            providers: crate::config::ProviderConfig {
+                anthropic_api_key: Some("test-key".to_string()),
+                ..Default::default()
+            },
+            ..crate::config::Config::default()
+        };
+        let registry = crate::commands::run::build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| false,
+        )
+        .expect("an HTTPS client builds in tests");
+
+        let lines = model_resolution_lines(blueprint, &config, &registry);
+        assert!(
+            lines.iter().any(|l| l.contains("blueprint order")),
+            "the substitution is explained: {lines:#?}"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("a-model-nobody-serves")),
+            "and it names what was asked for: {lines:#?}"
+        );
+        // The open-route entries are printed as the blueprint wrote them, not
+        // as `/claude-sonnet-5` with an empty provider in front.
+        // Checked on the blueprint-order line alone: the resolved line above it
+        // legitimately shows the route the run will take.
+        let order = lines
+            .iter()
+            .find(|l| l.contains("blueprint order"))
+            .expect("the line asserted above");
+        assert!(
+            !order.contains("/claude-sonnet-5"),
+            "an entry that pinned no route is not shown with one: {order}"
+        );
+    }
+
     #[test]
     fn model_resolution_shows_where_the_install_overrides_the_blueprint() {
         let manifest = r#"

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -564,22 +564,23 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
     if let Some(mt) = model_table {
         let mut models = Vec::new();
 
-        // New format: [[stages.<name>.model.models]] list
+        // An entry may be a bare model name, or a table naming a provider only
+        // when the route matters (a local or self-hosted model). An absent
+        // provider is EMPTY, not "anthropic": an author cannot know what a
+        // machine has configured, and defaulting made omission a silent choice.
         if let Some(models_arr) = mt.get("models").and_then(|v| v.as_array()) {
             for entry in models_arr {
-                if let Some(entry_table) = entry.as_table() {
-                    models.push(ModelEntry::new(
-                        entry_table
-                            .get("provider")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("anthropic")
-                            .to_string(),
-                        entry_table
-                            .get("model")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("claude-sonnet-4-6")
-                            .to_string(),
-                    ));
+                if let Some(name) = entry.as_str() {
+                    models.push(ModelEntry::new(String::new(), name.to_string()));
+                    continue;
+                }
+                // A table naming no model names nothing, so it is dropped.
+                if let Some(t) = entry.as_table()
+                    && let Some(model) = t.get("model").and_then(|v| v.as_str())
+                {
+                    let route = t.get("provider").and_then(|v| v.as_str());
+                    let route = route.unwrap_or_default().to_string();
+                    models.push(ModelEntry::new(route, model.to_string()));
                 }
             }
         }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -1548,25 +1548,38 @@ allow_user_default = false
 }
 
 #[test]
-fn parse_manifest_models_array_skips_non_table_and_applies_defaults() {
-    // A non-table entry in the `models` array is skipped; table entries
-    // missing `provider`/`model` fall back to the per-field defaults.
+fn parse_manifest_models_array_takes_bare_names_and_leaves_the_route_open() {
+    // A bare string names a model and leaves the route open. A table may pin a
+    // provider when the route matters, and one naming no model names nothing.
     let toml = r#"
 [agent]
 name = "models-defaults"
 
 [stages.main.model]
-models = ["skip-me", { provider = "openai" }, { model = "custom-model" }]
+models = ["gpt-5.5", { provider = "openai" }, { model = "custom-model" }, 7, { provider = "ollama", model = "q:9b" }]
 "#;
     let bp = parse_manifest(toml).unwrap();
     let stage = bp.find_stage("main").unwrap();
-    assert_eq!(stage.model.models.len(), 2);
-    // provider given, model defaulted
-    assert_eq!(stage.model.models[0].provider, "openai");
-    assert_eq!(stage.model.models[0].model, "claude-sonnet-4-6");
-    // model given, provider defaulted
-    assert_eq!(stage.model.models[1].provider, "anthropic");
+    assert_eq!(
+        stage.model.models.len(),
+        3,
+        "an entry naming no model is dropped, whether it is a table without one \
+         or not a model entry at all"
+    );
+
+    // A bare name: the model is what the author asked for, the route is not
+    // theirs to know.
+    assert_eq!(stage.model.models[0].model, "gpt-5.5");
+    assert_eq!(stage.model.models[0].provider, "");
+
+    // An absent provider is empty, NOT "anthropic". Defaulting it made omitting
+    // the field a silent specific choice rather than an open one.
     assert_eq!(stage.model.models[1].model, "custom-model");
+    assert_eq!(stage.model.models[1].provider, "");
+
+    // A named provider still pins the route, which a local model needs.
+    assert_eq!(stage.model.models[2].provider, "ollama");
+    assert_eq!(stage.model.models[2].model, "q:9b");
 }
 
 #[test]

--- a/crates/leviath-providers/src/capabilities.rs
+++ b/crates/leviath-providers/src/capabilities.rs
@@ -1,0 +1,126 @@
+//! What a model can do, and the per-model corrections a user can apply.
+//!
+//! Separate from [`crate::provider`] for the same reason [`crate::pricing`] is:
+//! that module is how a provider is CALLED, this one describes the model it
+//! calls. They meet where a provider answers [`crate::Provider::capabilities`].
+
+use serde::{Deserialize, Serialize};
+
+/// Capabilities supported by a model.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelCapabilities {
+    /// Whether the model supports temperature sampling
+    pub supports_temperature: bool,
+
+    /// Whether the model supports streaming responses
+    pub supports_streaming: bool,
+
+    /// Whether the model supports tool/function calling
+    pub supports_tools: bool,
+
+    /// Whether the model supports a system prompt
+    pub supports_system_prompt: bool,
+
+    /// Maximum number of context (input) tokens
+    pub max_context_tokens: usize,
+
+    /// Maximum number of output tokens
+    pub max_output_tokens: usize,
+}
+
+impl Default for ModelCapabilities {
+    fn default() -> Self {
+        Self {
+            supports_temperature: true,
+            supports_streaming: true,
+            supports_tools: true,
+            supports_system_prompt: true,
+            max_context_tokens: 8192,
+            max_output_tokens: 4096,
+        }
+    }
+}
+
+/// A `[model_capabilities]` entry: the fields an operator chose to change.
+///
+/// Every field is optional and unset means "leave it alone", so an entry names
+/// only what it is correcting. The alternative - deserializing straight into
+/// [`ModelCapabilities`] - has two failure modes, and this repo has now seen
+/// both. Without field defaults a partial table fails to deserialize and the
+/// override is dropped in silence (#338). With `#[serde(default)]` it succeeds
+/// and quietly substitutes [`ModelCapabilities::default`] for everything the
+/// operator did not mention, so correcting one boolean would drop a 400 000
+/// token window to 8 192.
+///
+/// Merging onto the provider's own answer for that model is the only reading
+/// that matches what the table looks like it does.
+// No `Eq`: rates are `f64`, which has no total equality.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ModelCapabilityOverride {
+    /// See [`ModelCapabilities::supports_temperature`].
+    pub supports_temperature: Option<bool>,
+    /// See [`ModelCapabilities::supports_streaming`].
+    pub supports_streaming: Option<bool>,
+    /// See [`ModelCapabilities::supports_tools`].
+    pub supports_tools: Option<bool>,
+    /// See [`ModelCapabilities::supports_system_prompt`].
+    pub supports_system_prompt: Option<bool>,
+    /// See [`ModelCapabilities::max_context_tokens`].
+    pub max_context_tokens: Option<usize>,
+    /// See [`ModelCapabilities::max_output_tokens`].
+    pub max_output_tokens: Option<usize>,
+
+    /// USD per million fresh input tokens. Overrides the shipped rate table,
+    /// and is the only place a negotiated price can be recorded - no public
+    /// pricing page shows one. See `crate::pricing::published_rates`.
+    #[serde(default)]
+    pub input_per_mtok: Option<f64>,
+    /// USD per million cached input tokens. Defaults to the input rate.
+    #[serde(default)]
+    pub cached_input_per_mtok: Option<f64>,
+    /// USD per million tokens written to cache. Defaults to the input rate.
+    #[serde(default)]
+    pub cache_write_per_mtok: Option<f64>,
+    /// USD per million output tokens.
+    #[serde(default)]
+    pub output_per_mtok: Option<f64>,
+}
+
+impl ModelCapabilityOverride {
+    /// `base` with every field this entry names replaced.
+    pub fn apply_to(&self, base: ModelCapabilities) -> ModelCapabilities {
+        ModelCapabilities {
+            supports_temperature: self
+                .supports_temperature
+                .unwrap_or(base.supports_temperature),
+            supports_streaming: self.supports_streaming.unwrap_or(base.supports_streaming),
+            supports_tools: self.supports_tools.unwrap_or(base.supports_tools),
+            supports_system_prompt: self
+                .supports_system_prompt
+                .unwrap_or(base.supports_system_prompt),
+            max_context_tokens: self.max_context_tokens.unwrap_or(base.max_context_tokens),
+            max_output_tokens: self.max_output_tokens.unwrap_or(base.max_output_tokens),
+        }
+    }
+}
+
+impl From<ModelCapabilities> for ModelCapabilityOverride {
+    /// Every field named, for a caller that already has a complete set.
+    fn from(c: ModelCapabilities) -> Self {
+        Self {
+            supports_temperature: Some(c.supports_temperature),
+            supports_streaming: Some(c.supports_streaming),
+            supports_tools: Some(c.supports_tools),
+            supports_system_prompt: Some(c.supports_system_prompt),
+            max_context_tokens: Some(c.max_context_tokens),
+            max_output_tokens: Some(c.max_output_tokens),
+            // Capabilities describe what a model can do, not what it charges,
+            // so a set converted from them names no rates.
+            input_per_mtok: None,
+            cached_input_per_mtok: None,
+            cache_write_per_mtok: None,
+            output_per_mtok: None,
+        }
+    }
+}

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -11,6 +11,7 @@
 //! - Provider-specific features (caching, etc.)
 
 pub mod anthropic;
+pub mod capabilities;
 pub mod claude_code;
 #[cfg(feature = "debug-http")]
 pub mod debug_http;
@@ -30,6 +31,7 @@ pub mod tokenizer;
 mod test_support;
 
 pub use anthropic::AnthropicProvider;
+pub use capabilities::{ModelCapabilities, ModelCapabilityOverride};
 pub use claude_code::ClaudeCodeProvider;
 pub use gemini::GeminiProvider;
 pub use ollama::OllamaProvider;
@@ -38,9 +40,9 @@ pub use openrouter::OpenRouterProvider;
 pub use pricing::{CostTotals, ModelPricing};
 pub use provider::{
     ContentBlock, DEFAULT_INFERENCE_TIMEOUT_SECS, FinishReason, InferenceRequest,
-    InferenceResponse, Message, MessageContent, ModelCapabilities, ModelCapabilityOverride,
-    ModelInfo, Provider, ProviderConfig, ProviderError, RateLimitConfig, Result, RetryAdvice,
-    SystemBlock, TokenUsage, Tool, ToolCall, UnavailableReason, build_http_client,
+    InferenceResponse, Message, MessageContent, ModelInfo, Provider, ProviderConfig, ProviderError,
+    RateLimitConfig, Result, RetryAdvice, SystemBlock, TokenUsage, Tool, ToolCall,
+    UnavailableReason, build_http_client,
 };
 pub use rhai_provider::RhaiProvider;
 

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -227,7 +227,117 @@ pub fn openai_messages_with(
     for msg in &request.messages {
         messages.extend(message_to_openai_with(&msg.role, &msg.content, tool_args));
     }
-    ensure_user_turn(satisfy_call_turn_order(drop_unpaired_tool_turns(messages)))
+    // After the unpaired sweep, not before: a call with no answer is dropped
+    // outright, and folding it first would preserve it as text instead.
+    let messages = drop_unpaired_tool_turns(messages);
+    let messages = if wants_signed_tool_calls(&request.model) {
+        fold_unsigned_tool_calls(messages)
+    } else {
+        messages
+    };
+    ensure_user_turn(satisfy_call_turn_order(messages))
+}
+
+/// Whether this model rejects a function call replayed without the signature it
+/// would have issued.
+///
+/// Matched on the model rather than the provider: the same Gemini model is
+/// reached natively and through a gateway, and it refuses either way. The name
+/// carries a vendor prefix on some routes (`google/gemini-3.1-pro-preview`) and
+/// not on others, so this looks for the family anywhere in the id.
+fn wants_signed_tool_calls(model: &str) -> bool {
+    model.contains("gemini")
+}
+
+/// Fold every unsigned function call, and the result that answered it, into the
+/// assistant's own words.
+///
+/// A call this model did not sign cannot be replayed to it as a call. Removing
+/// it alone would strand its result, and removing both would lose what the run
+/// actually learned, so both are rewritten as text on the turn that made the
+/// call. A signed call is left exactly as it is.
+fn fold_unsigned_tool_calls(messages: Vec<serde_json::Value>) -> Vec<serde_json::Value> {
+    let signed = |call: &serde_json::Value| {
+        call.pointer("/extra_content/google/thought_signature")
+            .and_then(|v| v.as_str())
+            .is_some_and(|sig| !sig.is_empty())
+    };
+
+    // What each call returned, so the fold can say so where the call was made.
+    let mut answers: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    for m in &messages {
+        if m["role"] != "tool" {
+            continue;
+        }
+        let id = m["tool_call_id"].as_str().unwrap_or_default();
+        let body = m["content"].as_str().unwrap_or_default().to_string();
+        answers.insert(id.to_string(), body);
+    }
+
+    let mut folded_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out: Vec<serde_json::Value> = Vec::new();
+    for mut m in messages {
+        if m["role"] == "tool" {
+            // Emitted as part of the assistant turn that called it, or kept if
+            // its call survived as a call.
+            let id = m["tool_call_id"].as_str().unwrap_or_default();
+            if !folded_ids.contains(id) {
+                out.push(m);
+            }
+            continue;
+        }
+        let Some(calls) = m["tool_calls"].as_array() else {
+            out.push(m);
+            continue;
+        };
+        let (keep, fold): (Vec<_>, Vec<_>) = calls.iter().cloned().partition(signed);
+        if fold.is_empty() {
+            out.push(m);
+            continue;
+        }
+
+        let mut told = String::new();
+        for call in &fold {
+            let name = call
+                .pointer("/function/name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("a tool");
+            let args = call
+                .pointer("/function/arguments")
+                .map(render_call_arguments)
+                .unwrap_or_default();
+            let id = call["id"].as_str().unwrap_or_default();
+            let answer = answers.get(id).map(String::as_str).unwrap_or("");
+            folded_ids.insert(id.to_string());
+            // Every call reaching here was answered: the unpaired sweep ran
+            // first. An answer that is empty reads as one, which is true.
+            told.push_str(&format!(
+                "\n\n[Earlier in this run I called {name}({args}) and it \
+                 returned:\n{answer}]"
+            ));
+        }
+
+        let text = m["content"].as_str().unwrap_or_default();
+        m["content"] = serde_json::Value::String(format!("{text}{told}"));
+        if keep.is_empty() {
+            m.as_object_mut().map(|o| o.remove("tool_calls"));
+        } else {
+            m["tool_calls"] = serde_json::Value::Array(keep);
+        }
+        out.push(m);
+    }
+    out
+}
+
+/// A call's arguments as text, however this wire format rendered them.
+///
+/// [`ToolArgsFormat`] means they arrive here as either a JSON string or an
+/// object, and the fold quotes them back to the model either way.
+fn render_call_arguments(args: &serde_json::Value) -> String {
+    match args.as_str() {
+        Some(text) => text.to_string(),
+        None => args.to_string(),
+    }
 }
 
 /// The minimal user turn this layer inserts when a wire format demands one that
@@ -2203,6 +2313,217 @@ mod tests {
 
     /// The shape Gemini rejects with HTTP 400: a call turn whose response has
     /// aged out of the context window (or vice versa) must not be sent.
+    /// The shape that killed `wide-researcher-x-1787453815`: a `challenge`
+    /// stage ran grok on OpenRouter and called tools, then `polish` handed the
+    /// same conversation to Gemini, which refused function calls it never
+    /// signed ("Function call is missing a thought_signature in functionCall
+    /// parts ... `default_api:read_file`, position 9").
+    ///
+    /// Nothing had dropped a signature. Grok never issues one, and the
+    /// conversation region carries turns across a stage boundary, so any
+    /// blueprint that changes model family mid-run arrives here.
+    #[test]
+    fn a_call_made_by_another_model_is_folded_into_text_for_gemini() {
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![
+                Message {
+                    role: "assistant".to_string(),
+                    content: MessageContent::Blocks(vec![
+                        ContentBlock::Text {
+                            text: "Checking the source.".to_string(),
+                        },
+                        ContentBlock::ToolUse {
+                            id: "call_grok_1".to_string(),
+                            name: "read_file".to_string(),
+                            input: serde_json::json!({ "path": "README.md" }),
+                            // Grok issues no signature. This is the whole bug.
+                            thought_signature: None,
+                        },
+                    ]),
+                    cache_breakpoint: false,
+                },
+                Message {
+                    role: "user".to_string(),
+                    content: MessageContent::Blocks(vec![ContentBlock::ToolResult {
+                        tool_use_id: "call_grok_1".to_string(),
+                        content: "# Leviath\nAn agent framework.".to_string(),
+                        is_error: false,
+                    }]),
+                    cache_breakpoint: false,
+                },
+            ],
+            model: "google/gemini-3.1-pro-preview".to_string(),
+            max_tokens: 100,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let msgs = openai_messages(&request);
+        let wire = serde_json::to_string(&msgs).expect("serialises");
+
+        // The claim the API makes: no functionCall part may be unsigned. The
+        // simplest way to satisfy it for a call this model did not make is to
+        // stop calling it a call.
+        assert!(
+            !wire.contains("tool_calls"),
+            "an unsigned call must not be replayed as a call: {wire}"
+        );
+        assert!(
+            !wire.contains("\"role\":\"tool\""),
+            "and its result must not be left stranded as a tool turn: {wire}"
+        );
+
+        // What the run learned still has to reach the model, or the polish
+        // stage rewrites a report it can no longer see the evidence for.
+        assert!(wire.contains("read_file"), "the call is still described");
+        assert!(
+            wire.contains("An agent framework."),
+            "and so is what it returned: {wire}"
+        );
+        assert!(wire.contains("Checking the source."), "original text kept");
+    }
+
+    /// The signed call is the one Gemini itself made, so it must survive as a
+    /// call. Folding everything would throw away the turn structure the model
+    /// depends on when it is talking to itself.
+    #[test]
+    fn a_signed_call_is_left_alone_and_an_unsigned_neighbour_is_not() {
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![Message {
+                role: "assistant".to_string(),
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: "call_signed".to_string(),
+                        name: "web_search".to_string(),
+                        input: serde_json::json!({ "q": "leviath" }),
+                        thought_signature: Some("sig-abc".to_string()),
+                    },
+                    ContentBlock::ToolUse {
+                        id: "call_unsigned".to_string(),
+                        name: "read_file".to_string(),
+                        input: serde_json::json!({ "path": "x" }),
+                        thought_signature: None,
+                    },
+                    // Both answered: an unanswered call is dropped before the
+                    // fold ever sees it, so it would prove nothing here.
+                    ContentBlock::ToolResult {
+                        tool_use_id: "call_signed".to_string(),
+                        content: "results".to_string(),
+                        is_error: false,
+                    },
+                    ContentBlock::ToolResult {
+                        tool_use_id: "call_unsigned".to_string(),
+                        content: "file body".to_string(),
+                        is_error: false,
+                    },
+                ]),
+                cache_breakpoint: false,
+            }],
+            model: "gemini-3.1-pro-preview".to_string(),
+            max_tokens: 100,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let msgs = openai_messages(&request);
+        let wire = serde_json::to_string(&msgs).expect("serialises");
+        assert!(
+            wire.contains("sig-abc"),
+            "the signed call keeps its signature"
+        );
+        assert!(wire.contains("web_search"), "and stays a call");
+        assert!(
+            wire.contains("[Earlier in this run I called read_file"),
+            "while the unsigned one beside it is folded: {wire}"
+        );
+    }
+
+    /// Arguments reach the fold as an object on the routes that send them that
+    /// way, and as a JSON string on the rest. Both have to come back out as
+    /// something the model can read.
+    #[test]
+    fn the_fold_quotes_object_arguments_too() {
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![Message {
+                role: "assistant".to_string(),
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: "call_1".to_string(),
+                        name: "read_file".to_string(),
+                        input: serde_json::json!({ "path": "notes.md" }),
+                        thought_signature: None,
+                    },
+                    ContentBlock::ToolResult {
+                        tool_use_id: "call_1".to_string(),
+                        content: "the notes".to_string(),
+                        is_error: false,
+                    },
+                ]),
+                cache_breakpoint: false,
+            }],
+            model: "gemini-3.1-pro-preview".to_string(),
+            max_tokens: 100,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let msgs = openai_messages_with(&request, ToolArgsFormat::Object);
+        let wire = serde_json::to_string(&msgs).expect("serialises");
+        assert!(!wire.contains("tool_calls"), "still folded: {wire}");
+        assert!(
+            wire.contains("notes.md"),
+            "the arguments survive the fold as text: {wire}"
+        );
+        assert!(wire.contains("the notes"), "and so does the answer");
+    }
+
+    /// A model with no such rule is untouched, so this costs nothing anywhere
+    /// else: the same unsigned call replays as a call.
+    #[test]
+    fn a_model_that_does_not_sign_calls_replays_them_unchanged() {
+        let request = InferenceRequest {
+            system: vec![],
+            messages: vec![Message {
+                role: "assistant".to_string(),
+                content: MessageContent::Blocks(vec![
+                    ContentBlock::ToolUse {
+                        id: "call_1".to_string(),
+                        name: "read_file".to_string(),
+                        input: serde_json::json!({ "path": "x" }),
+                        thought_signature: None,
+                    },
+                    ContentBlock::ToolResult {
+                        tool_use_id: "call_1".to_string(),
+                        content: "file body".to_string(),
+                        is_error: false,
+                    },
+                ]),
+                cache_breakpoint: false,
+            }],
+            model: "gpt-5.5".to_string(),
+            max_tokens: 100,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+
+        let wire = serde_json::to_string(&openai_messages(&request)).expect("serialises");
+        assert!(
+            wire.contains("tool_calls"),
+            "untouched for a model with no rule"
+        );
+    }
+
     /// Gemini 3.x returns an opaque per-call `thought_signature` under
     /// `extra_content.google` and rejects a follow-up request that omits it.
     /// Capture on parse ...
@@ -2294,7 +2615,7 @@ mod tests {
                         id: "orphan".into(),
                         name: "search".into(),
                         input: serde_json::json!({}),
-                        thought_signature: None,
+                        thought_signature: Some("sig".into()),
                     }]),
                     cache_breakpoint: false,
                 },
@@ -2346,7 +2667,7 @@ mod tests {
                         id: "c1".into(),
                         name: "search".into(),
                         input: serde_json::json!({}),
-                        thought_signature: None,
+                        thought_signature: Some("sig".into()),
                     }]),
                     cache_breakpoint: false,
                 },
@@ -2391,7 +2712,7 @@ mod tests {
                         id: "c1".into(),
                         name: "list_dir".into(),
                         input: serde_json::json!({}),
-                        thought_signature: None,
+                        thought_signature: Some("sig".into()),
                     },
                     ContentBlock::ToolResult {
                         tool_use_id: "c1".into(),
@@ -2448,7 +2769,7 @@ mod tests {
                     id: format!("c{n}"),
                     name: "list_dir".into(),
                     input: serde_json::json!({}),
-                    thought_signature: None,
+                    thought_signature: Some("sig".into()),
                 },
                 ContentBlock::ToolResult {
                     tool_use_id: format!("c{n}"),
@@ -2513,7 +2834,7 @@ mod tests {
                             id: "c1".into(),
                             name: "list_dir".into(),
                             input: serde_json::json!({}),
-                            thought_signature: None,
+                            thought_signature: Some("sig".into()),
                         },
                         ContentBlock::ToolResult {
                             tool_use_id: "c1".into(),

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -733,6 +733,29 @@ impl Provider for OpenRouterProvider {
         }
     }
 
+    fn serves_model(&self, model_key: &str) -> Option<String> {
+        // Answered from the primed catalogue rather than the built-in table:
+        // OpenRouter fronts hundreds of models and the table lists a few dozen,
+        // so the table would deny models the gateway serves perfectly well.
+        // Matching on the last path segment because the gateway prefixes a
+        // vendor namespace (`openai/gpt-5.5`) that the blueprint does not name.
+        let primed = leviath_core::sync::lock(&self.api_windows)
+            .keys()
+            .find(|id| id.rsplit('/').next().unwrap_or(id) == model_key)
+            .cloned();
+        // An empty catalogue means priming failed or has not run, and answering
+        // "no" to everything there would deny models this gateway plainly
+        // carries. The compiled-in table is the fallback, read directly rather
+        // than through `serves_model_from_table`: that helper treats "differs
+        // from the default capabilities" as "known", and an unlisted model here
+        // falls through to FALLBACK_CAPABILITIES, which differs from the default
+        // too. Going through it would claim every model in existence.
+        primed.or_else(|| {
+            (builtin_capabilities(model_key) != FALLBACK_CAPABILITIES)
+                .then(|| model_key.to_string())
+        })
+    }
+
     fn pricing(&self, model: &str) -> Option<crate::ModelPricing> {
         leviath_core::sync::lock(&self.api_pricing)
             .get(model)
@@ -2020,6 +2043,53 @@ mod tests {
             leviath_core::sync::lock(&provider.warned_unknown).contains("nobody/knows"),
             "a model with no answer anywhere is still called out"
         );
+    }
+
+    /// The gateway answers a blueprint's bare model name from its live
+    /// catalogue, translating to the vendor-prefixed id it wants in a request.
+    /// The blueprint says `gpt-5.5`; only the gateway knows it is
+    /// `openai/gpt-5.5` here.
+    #[tokio::test]
+    async fn serves_model_translates_a_bare_name_to_the_gateway_id() {
+        let body = br#"{"data":[{"id":"openai/gpt-5.5","context_length":400000},{"id":"x-ai/grok-4.6","context_length":256000}]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = provider_with_url(url);
+        provider.prime_capabilities().await.expect("primes");
+
+        assert_eq!(
+            provider.serves_model("gpt-5.5"),
+            Some("openai/gpt-5.5".to_string())
+        );
+        assert_eq!(
+            provider.serves_model("grok-4.6"),
+            Some("x-ai/grok-4.6".to_string()),
+            "a model no built-in table names is still served once the catalogue \
+             says so, which is the whole reason to ask the gateway"
+        );
+        assert_eq!(
+            provider.serves_model("not-on-this-gateway"),
+            None,
+            "a primed catalogue that does not list it, and no table entry either"
+        );
+    }
+
+    /// Priming can fail or simply not have run. Answering "I serve nothing"
+    /// there would deny models the gateway plainly carries, so an empty
+    /// catalogue falls through to the table compiled into this build.
+    #[test]
+    fn an_unprimed_gateway_answers_from_the_built_in_table() {
+        let provider = provider_with_url("http://127.0.0.1:1".to_string());
+        assert!(
+            leviath_core::sync::lock(&provider.api_windows).is_empty(),
+            "nothing has primed this one"
+        );
+        assert_eq!(
+            provider.serves_model("deepseek-v4-pro"),
+            Some("deepseek-v4-pro".to_string()),
+            "the built-in table names this model, so an unprimed gateway still \
+             offers it rather than degrading to nothing"
+        );
+        assert_eq!(provider.serves_model("nobody-has-heard-of-this"), None);
     }
 
     /// An entry with no `id` cannot be looked up by one, so it is skipped.

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -1,5 +1,8 @@
 //! Provider trait and common types.
 
+// Re-exported so `use crate::provider::*` keeps working: the types moved for
+// structural reasons (the 1200-line rule), not as an interface change.
+pub use crate::capabilities::{ModelCapabilities, ModelCapabilityOverride};
 use async_trait::async_trait;
 use futures_core::Stream;
 use serde::{Deserialize, Serialize};
@@ -323,125 +326,6 @@ impl ProviderError {
             // with a usable OpenRouter fallback sitting untouched behind it.
             ProviderError::RequestFailed(_) => Some(UnavailableReason::Unreachable),
             _ => None,
-        }
-    }
-}
-
-/// Capabilities supported by a model.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelCapabilities {
-    /// Whether the model supports temperature sampling
-    pub supports_temperature: bool,
-
-    /// Whether the model supports streaming responses
-    pub supports_streaming: bool,
-
-    /// Whether the model supports tool/function calling
-    pub supports_tools: bool,
-
-    /// Whether the model supports a system prompt
-    pub supports_system_prompt: bool,
-
-    /// Maximum number of context (input) tokens
-    pub max_context_tokens: usize,
-
-    /// Maximum number of output tokens
-    pub max_output_tokens: usize,
-}
-
-impl Default for ModelCapabilities {
-    fn default() -> Self {
-        Self {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 8192,
-            max_output_tokens: 4096,
-        }
-    }
-}
-
-/// A `[model_capabilities]` entry: the fields an operator chose to change.
-///
-/// Every field is optional and unset means "leave it alone", so an entry names
-/// only what it is correcting. The alternative - deserializing straight into
-/// [`ModelCapabilities`] - has two failure modes, and this repo has now seen
-/// both. Without field defaults a partial table fails to deserialize and the
-/// override is dropped in silence (#338). With `#[serde(default)]` it succeeds
-/// and quietly substitutes [`ModelCapabilities::default`] for everything the
-/// operator did not mention, so correcting one boolean would drop a 400 000
-/// token window to 8 192.
-///
-/// Merging onto the provider's own answer for that model is the only reading
-/// that matches what the table looks like it does.
-// No `Eq`: rates are `f64`, which has no total equality.
-#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
-#[serde(default, deny_unknown_fields)]
-pub struct ModelCapabilityOverride {
-    /// See [`ModelCapabilities::supports_temperature`].
-    pub supports_temperature: Option<bool>,
-    /// See [`ModelCapabilities::supports_streaming`].
-    pub supports_streaming: Option<bool>,
-    /// See [`ModelCapabilities::supports_tools`].
-    pub supports_tools: Option<bool>,
-    /// See [`ModelCapabilities::supports_system_prompt`].
-    pub supports_system_prompt: Option<bool>,
-    /// See [`ModelCapabilities::max_context_tokens`].
-    pub max_context_tokens: Option<usize>,
-    /// See [`ModelCapabilities::max_output_tokens`].
-    pub max_output_tokens: Option<usize>,
-
-    /// USD per million fresh input tokens. Overrides the shipped rate table,
-    /// and is the only place a negotiated price can be recorded - no public
-    /// pricing page shows one. See `crate::pricing::published_rates`.
-    #[serde(default)]
-    pub input_per_mtok: Option<f64>,
-    /// USD per million cached input tokens. Defaults to the input rate.
-    #[serde(default)]
-    pub cached_input_per_mtok: Option<f64>,
-    /// USD per million tokens written to cache. Defaults to the input rate.
-    #[serde(default)]
-    pub cache_write_per_mtok: Option<f64>,
-    /// USD per million output tokens.
-    #[serde(default)]
-    pub output_per_mtok: Option<f64>,
-}
-
-impl ModelCapabilityOverride {
-    /// `base` with every field this entry names replaced.
-    pub fn apply_to(&self, base: ModelCapabilities) -> ModelCapabilities {
-        ModelCapabilities {
-            supports_temperature: self
-                .supports_temperature
-                .unwrap_or(base.supports_temperature),
-            supports_streaming: self.supports_streaming.unwrap_or(base.supports_streaming),
-            supports_tools: self.supports_tools.unwrap_or(base.supports_tools),
-            supports_system_prompt: self
-                .supports_system_prompt
-                .unwrap_or(base.supports_system_prompt),
-            max_context_tokens: self.max_context_tokens.unwrap_or(base.max_context_tokens),
-            max_output_tokens: self.max_output_tokens.unwrap_or(base.max_output_tokens),
-        }
-    }
-}
-
-impl From<ModelCapabilities> for ModelCapabilityOverride {
-    /// Every field named, for a caller that already has a complete set.
-    fn from(c: ModelCapabilities) -> Self {
-        Self {
-            supports_temperature: Some(c.supports_temperature),
-            supports_streaming: Some(c.supports_streaming),
-            supports_tools: Some(c.supports_tools),
-            supports_system_prompt: Some(c.supports_system_prompt),
-            max_context_tokens: Some(c.max_context_tokens),
-            max_output_tokens: Some(c.max_output_tokens),
-            // Capabilities describe what a model can do, not what it charges,
-            // so a set converted from them names no rates.
-            input_per_mtok: None,
-            cached_input_per_mtok: None,
-            cache_write_per_mtok: None,
-            output_per_mtok: None,
         }
     }
 }
@@ -1052,6 +936,31 @@ pub trait Provider: Send + Sync {
     /// their available models.
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
         Ok(Vec::new())
+    }
+
+    /// This provider's id for `model_key`, or `None` if it does not serve it.
+    ///
+    /// A blueprint names a model; the route to it belongs to the machine, so
+    /// asking each provider lets an author stop enumerating routes they cannot
+    /// know. `model_key` carries no vendor prefix (`gpt-5.5`), because the same
+    /// model is spelled `openai/gpt-5.5` through a gateway; the answer is
+    /// whatever THIS provider wants in a request.
+    ///
+    /// Defaults to whether [`Self::capabilities`] is a real entry rather than
+    /// the fallback. A gateway fronting hundreds of models overrides it.
+    fn serves_model(&self, model_key: &str) -> Option<String> {
+        self.serves_model_from_table(model_key)
+    }
+
+    /// [`Self::serves_model`] answered from the compiled-in capability table.
+    ///
+    /// Split out so an override can fall back to it: a gateway answers from its
+    /// live catalogue, and when that catalogue is empty (priming failed, or has
+    /// not run yet) the table is a better answer than "no".
+    fn serves_model_from_table(&self, model_key: &str) -> Option<String> {
+        let caps = self.capabilities(model_key);
+        let fallback = ModelCapabilities::default();
+        (caps.max_context_tokens != fallback.max_context_tokens).then(|| model_key.to_string())
     }
 
     /// What this provider charges for `model`, or `None` when it does not know.
@@ -1958,9 +1867,34 @@ mod tests {
             "minimal"
         }
 
-        fn capabilities(&self, _model: &str) -> ModelCapabilities {
-            ModelCapabilities::default()
+        fn capabilities(&self, model: &str) -> ModelCapabilities {
+            // Knows one model and nothing else, so `serves_model` has a real
+            // answer to give in both directions. Everything else falls through
+            // to the fallback capabilities, which is how a provider says it does
+            // not recognise a model.
+            let mut caps = ModelCapabilities::default();
+            if model == "only-this-one" {
+                caps.max_context_tokens += 1;
+            }
+            caps
         }
+    }
+
+    /// The question a blueprint's bare model name asks of every provider. A
+    /// provider answers from its own table, so the one model it names comes back
+    /// with the id to call it by and everything else comes back as "not mine".
+    #[test]
+    fn serves_model_answers_from_the_capability_table() {
+        assert_eq!(
+            MinimalProvider.serves_model("only-this-one"),
+            Some("only-this-one".to_string()),
+            "a model the table names is served, under the id it was asked about"
+        );
+        assert_eq!(
+            MinimalProvider.serves_model("some-other-model"),
+            None,
+            "a model the table does not name is not claimed"
+        );
     }
 
     /// A provider whose capability table is compiled in has nothing to fetch,

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -65,6 +65,21 @@ pub fn resolve_stage_model(
 /// host-wide `fallback_order`. Deduplicated, because the same pair reaching the
 /// list twice would spend a failover step going nowhere. Never empty: with
 /// nothing registered it yields the blueprint's own first entry, exactly as
+/// A model's identity, independent of the route it is reached by.
+///
+/// The same model is spelled differently depending on the provider serving it:
+/// `gpt-5.5` on OpenAI is `openai/gpt-5.5` on OpenRouter, and
+/// `claude-opus-5` is `anthropic/claude-opus-5`. Comparing the raw strings
+/// makes one model look like two, which is what let a route preference be read
+/// as a model preference (issue #578).
+///
+/// The last segment is the model; anything before it is the vendor namespace a
+/// gateway prefixes. A local model with no slash (`qwen3.5:9b`) is already its
+/// own key.
+fn model_key(model: &str) -> &str {
+    model.rsplit('/').next().unwrap_or(model)
+}
+
 /// before, and `resolve_stages` rejects that unusable case with a clear error.
 pub fn resolve_stage_candidates(
     model_cfg: &ModelConfig,
@@ -103,14 +118,44 @@ pub fn resolve_stage_candidates(
         }
     };
 
-    // Every listed model whose provider is registered, in blueprint order. A
-    // bare `--model` override renames the model but keeps the provider order.
+    // Every listed model, in blueprint order. A bare `--model` override renames
+    // the model but keeps the order.
+    //
+    // An entry with no provider names a model and leaves the route open: ask
+    // the registered providers which of them serves it. That is the point of
+    // letting a blueprint omit the provider - the author knows which model the
+    // stage needs, and only the machine knows how to reach it.
     for entry in &model_cfg.models {
-        if registry.has(&entry.provider) {
-            let model = override_model
-                .clone()
-                .unwrap_or_else(|| entry.model.clone());
-            push(entry.provider.clone(), model);
+        let model = override_model
+            .clone()
+            .unwrap_or_else(|| entry.model.clone());
+        if !entry.provider.is_empty() {
+            if registry.has(&entry.provider) {
+                push(entry.provider.clone(), model);
+            }
+            continue;
+        }
+        let key = model_key(&model);
+        // Default provider first, so an open route follows the same preference
+        // a named model's routes do.
+        let mut candidates_for_model = registry.native_providers();
+        candidates_for_model.sort_by_key(|(name, _)| *name != defaults.provider);
+        let mut routed = false;
+        for (name, provider) in candidates_for_model {
+            if let Some(id) = provider.serves_model(key) {
+                push(name.to_string(), id);
+                routed = true;
+            }
+        }
+        // Say so when nothing serves it. The chain carries on to the next model,
+        // which is what a fallback list is for, but an unroutable name is worth
+        // seeing: it is equally a typo, a model no configured provider carries,
+        // or a gateway whose catalogue never primed.
+        if !routed {
+            tracing::warn!(
+                model = %model,
+                "no configured provider serves this model, so it is skipped;                  the stage falls through to the next model listed"
+            );
         }
     }
 
@@ -143,13 +188,42 @@ pub fn resolve_stage_candidates(
     // must pin its own provider already has the way to say so -
     // `allow_user_default = false` - and that suppresses this too.
     if model_cfg.allow_user_default && registry.has(&defaults.provider) {
-        let (mut preferred, rest): (Vec<ModelEntry>, Vec<ModelEntry>) = candidates
-            .into_iter()
-            .partition(|c| c.provider == defaults.provider);
-        // Stable, so the blueprint's order survives behind the default.
+        // Grouped by MODEL, not by provider. `default_provider` says where a
+        // run should go, which is a statement about routes; letting it reorder
+        // across models turns it into a statement about which model to use, and
+        // a blueprint that deliberately chose one per stage silently gets
+        // another (issue #578).
+        //
+        // Models keep blueprint order, except that the user's own
+        // `default_model` leads - that IS a model preference, and someone who
+        // named a model meant it.
         let default_model = user_default.as_ref().map(|(_, m)| m.as_str());
-        preferred.sort_by_key(|c| Some(c.model.as_str()) != default_model);
-        candidates = preferred.into_iter().chain(rest).collect();
+        let mut order: Vec<String> = Vec::new();
+        for c in &candidates {
+            let key = model_key(&c.model).to_string();
+            if !order.contains(&key) {
+                order.push(key);
+            }
+        }
+        if let Some(dm) = default_model
+            && let Some(at) = order.iter().position(|k| k == model_key(dm))
+        {
+            let key = order.remove(at);
+            order.insert(0, key);
+        }
+        let mut grouped: Vec<ModelEntry> = Vec::with_capacity(candidates.len());
+        for key in order {
+            let mut group: Vec<ModelEntry> = candidates
+                .iter()
+                .filter(|c| model_key(&c.model) == key)
+                .cloned()
+                .collect();
+            // Stable: the default provider's route to this model first, the
+            // blueprint's order behind it.
+            group.sort_by_key(|c| c.provider != defaults.provider);
+            grouped.extend(group);
+        }
+        candidates = grouped;
     }
 
     if candidates.is_empty() {
@@ -575,15 +649,48 @@ mod tests {
         }
     }
 
+    /// A stage config whose entries name models and leave the route open.
+    fn model_cfg_open(models: Vec<&str>) -> ModelConfig {
+        ModelConfig {
+            models: models
+                .into_iter()
+                .map(|m| ModelEntry::new(String::new(), m.to_string()))
+                .collect(),
+            allow_user_default: true,
+            parameters: HashMap::new(),
+            request_timeout_secs: None,
+        }
+    }
+
     fn registry_with(providers: &[&str]) -> ProviderRegistry {
         let mut r = ProviderRegistry::new();
         for p in providers {
-            r.register(p.to_string(), Arc::new(FakeProvider));
+            r.register(p.to_string(), Arc::new(FakeProvider::default()));
         }
         r
     }
 
-    struct FakeProvider;
+    /// A registry whose providers each serve a named set of models, for the
+    /// entries that name a model and leave the route open.
+    fn registry_serving(providers: &[(&str, &[&str])]) -> ProviderRegistry {
+        let mut r = ProviderRegistry::new();
+        for (name, models) in providers {
+            r.register(
+                (*name).to_string(),
+                Arc::new(FakeProvider {
+                    serves: models.iter().map(|m| (*m).to_string()).collect(),
+                }),
+            );
+        }
+        r
+    }
+
+    #[derive(Default)]
+    struct FakeProvider {
+        /// Models this provider claims. Empty is the ordinary fixture: the
+        /// resolver only asks `has()` for a route-pinned entry.
+        serves: Vec<String>,
+    }
     #[async_trait::async_trait]
     impl leviath_providers::Provider for FakeProvider {
         async fn infer(
@@ -606,6 +713,12 @@ mod tests {
         fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
             leviath_providers::ModelCapabilities::default()
         }
+        fn serves_model(&self, model_key: &str) -> Option<String> {
+            self.serves
+                .iter()
+                .any(|m| m == model_key)
+                .then(|| model_key.to_string())
+        }
     }
 
     #[tokio::test]
@@ -613,7 +726,7 @@ mod tests {
         // The resolver only asks the registry `has()`, so the fixture provider
         // is inert; this pins its stub answers so the impl stays measured.
         use leviath_providers::Provider as _;
-        let p = FakeProvider;
+        let p = FakeProvider::default();
         let request: leviath_providers::InferenceRequest =
             serde_json::from_value(serde_json::json!({
                 "messages": [],
@@ -1019,6 +1132,40 @@ mod tests {
     }
 
     #[test]
+    fn an_entry_with_no_provider_resolves_to_whoever_serves_the_model() {
+        // What a blueprint that names models rather than routes produces. The
+        // author asks for `gpt-5.5`; which providers can reach it is a property
+        // of the machine, so every registered one is asked.
+        let cfg = model_cfg_open(vec!["gpt-5.5"]);
+        let registry = registry_serving(&[
+            ("anthropic", &[][..]),
+            ("openai", &["gpt-5.5"][..]),
+            ("openrouter", &["gpt-5.5"][..]),
+        ]);
+        let defaults = ModelDefaults {
+            provider: "openrouter".to_string(),
+            ..Default::default()
+        };
+        let got = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+        assert_eq!(
+            pairs(&got),
+            vec![("openrouter", "gpt-5.5"), ("openai", "gpt-5.5")],
+            "both routes are offered, the user's default provider first, and \
+             the provider that does not serve it is not offered at all"
+        );
+    }
+
+    #[test]
+    fn a_model_nobody_serves_is_skipped_and_the_next_one_is_used() {
+        // An unroutable name is not fatal: the chain carries on, which is what
+        // a fallback list is for. It warns rather than failing the stage.
+        let cfg = model_cfg_open(vec!["nobody-serves-this", "claude-sonnet-5"]);
+        let registry = registry_serving(&[("anthropic", &["claude-sonnet-5"][..])]);
+        let got = resolve_stage_candidates(&cfg, None, &ModelDefaults::default(), &registry);
+        assert_eq!(pairs(&got), vec![("anthropic", "claude-sonnet-5")]);
+    }
+
+    #[test]
     fn the_global_chain_rescues_a_single_model_stage() {
         // The reported configuration: every stage names one OpenRouter model,
         // so the blueprint alone offers nowhere to fail over to.
@@ -1066,11 +1213,15 @@ mod tests {
     }
 
     /// Every bundled blueprint lists Ollama as `qwen3.5:9b`. A user who set
-    /// `default_model = "qwen3.8:latest"` next to `default_provider = "ollama"`
-    /// was still sent to the blueprint's model, because the preference only
-    /// moved the *provider* forward and left the blueprint's entry ahead of
-    /// the user's. The named default leads; the blueprint's entry stays behind
-    /// it as the fallback.
+    /// `default_model = "qwen3.8:latest"` was still sent to the blueprint's
+    /// model, so the named default leads.
+    ///
+    /// What it does NOT do is drag the rest of that provider's entries with it.
+    /// `default_model` is a statement about a model and moves that model;
+    /// `default_provider` is a statement about a route and reorders routes
+    /// within a model. So the blueprint's own first model stays ahead of the
+    /// blueprint's later ones, and only falls through when nothing registered
+    /// can serve it (issue #578).
     #[test]
     fn the_users_default_model_leads_the_blueprints_entry_on_the_same_provider() {
         let cfg = model_cfg(vec![
@@ -1089,14 +1240,16 @@ mod tests {
             pairs(&got),
             vec![
                 ("ollama", "qwen3.8:latest"),
+                ("anthropic", "claude-sonnet-5"),
                 ("ollama", "qwen3.5:9b"),
                 ("ollama", "qwen3.6:27b"),
-                ("anthropic", "claude-sonnet-5"),
             ],
         );
 
-        // A default that repeats the blueprint's own entry changes nothing but
-        // the head, and is listed once.
+        // A default that repeats the blueprint's own entry moves that model to
+        // the head and is listed once. The models behind it keep the
+        // blueprint's order rather than the provider's: `default_provider`
+        // reorders the routes to a model, not the models themselves (#578).
         let repeated = ModelDefaults {
             provider: "ollama".to_string(),
             model: Some("qwen3.6:27b".to_string()),
@@ -1107,8 +1260,8 @@ mod tests {
             pairs(&got),
             vec![
                 ("ollama", "qwen3.6:27b"),
-                ("ollama", "qwen3.5:9b"),
                 ("anthropic", "claude-sonnet-5"),
+                ("ollama", "qwen3.5:9b"),
             ],
         );
     }

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -101,6 +101,20 @@ impl ProviderRegistry {
         self.providers.keys().map(|k| k.as_str()).collect()
     }
 
+    /// Every natively registered provider, with the name it is registered under.
+    ///
+    /// The pair form for callers that ask each provider a question rather than
+    /// looking one up by name: [`Self::provider_names`] plus [`Self::get`] leaves
+    /// the caller holding an `Option` that cannot be `None`, because both read
+    /// the same map. Script providers are excluded for the reason
+    /// [`Self::prime_capabilities`] gives: `get` compiles them on demand.
+    pub fn native_providers(&self) -> Vec<(&str, Arc<dyn Provider>)> {
+        self.providers
+            .iter()
+            .map(|(name, provider)| (name.as_str(), provider.clone()))
+            .collect()
+    }
+
     /// Every provider name this registry could answer for right now: the
     /// natively registered ones, then the script providers the layer can see.
     ///

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -2,6 +2,46 @@
 
 use super::*;
 
+/// What a directory holds, one entry per line, for the `read_file` correction.
+///
+/// Capped: a directory of thousands would bury the answer it is meant to give,
+/// and the model only needs enough to pick its next path. Directories are marked
+/// so a second wrong `read_file` is avoidable rather than merely explained.
+fn directory_listing(path: &std::path::Path) -> String {
+    const MAX_ENTRIES: usize = 50;
+    let mut names: Vec<String> = std::fs::read_dir(path)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            match e.file_type().map(|ft| ft.is_dir()) {
+                Ok(true) => format!("{name}/"),
+                _ => name,
+            }
+        })
+        .collect();
+    names.sort();
+    if names.is_empty() {
+        // Empty, or unreadable. The model does the same thing next either way.
+        return "  (no entries to show)".to_string();
+    }
+    let total = names.len();
+    names.truncate(MAX_ENTRIES);
+    let mut out = names
+        .iter()
+        .map(|n| format!("  {n}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    if total > MAX_ENTRIES {
+        out.push_str(&format!(
+            "\n  ... and {} more (call list_dir for the rest)",
+            total - MAX_ENTRIES
+        ));
+    }
+    out
+}
+
 impl BuiltinTools {
     /// Execute a built-in tool by name (resolving aliases), returning the result
     /// as a string.
@@ -265,10 +305,19 @@ impl BuiltinTools {
             // call, and the raw OS message ("Is a directory (os error 21)")
             // names the problem without naming the fix, so the next call was
             // usually another guess.
-            Err(_) if path.is_dir() => format!(
-                "[error] '{path_str}' is a directory, not a file. Use list_dir to see what \
-                 is in it, then read_file on one of the entries."
-            ),
+            //
+            // The listing comes back with the error rather than a pointer to
+            // `list_dir`, because 21 of the bundled agents' stages grant
+            // `read_file` and not `list_dir`: there, naming that tool asks for
+            // something the stage cannot do. Answering here settles it in one
+            // call and reads the same in every stage.
+            Err(_) if path.is_dir() => {
+                let listing = directory_listing(&path);
+                format!(
+                    "[error] '{path_str}' is a directory, not a file. It contains:\n{listing}\n\
+                     Call read_file again on one of these entries."
+                )
+            }
             Err(e) => format!("[error] Failed to read '{}': {}", path_str, e),
         }
     }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -1369,15 +1369,54 @@ mod tests {
     /// four research runs, and the raw OS message ("Is a directory (os error
     /// 21)") named the problem without naming the fix.
     #[tokio::test]
-    async fn read_file_on_a_directory_points_at_list_dir() {
+    async fn read_file_on_a_directory_answers_with_what_is_in_it() {
         let dir = tempfile::tempdir().unwrap();
         let tools = make_tools(dir.path());
         fs::create_dir(dir.path().join("adir")).unwrap();
+        fs::write(dir.path().join("adir/notes.md"), "hi").unwrap();
+        fs::create_dir(dir.path().join("adir/nested")).unwrap();
 
         let result = tools.execute("read_file", json!({"path": "adir"})).await;
         assert!(result.contains("[error]"), "{result}");
         assert!(result.contains("is a directory, not a file"), "{result}");
-        assert!(result.contains("list_dir"), "{result}");
+        // The listing comes back here rather than a pointer to `list_dir`: most
+        // stages that grant `read_file` do not grant `list_dir`, so naming it
+        // asks for something they cannot do.
+        assert!(result.contains("notes.md"), "names what is in it: {result}");
+        assert!(
+            result.contains("nested/"),
+            "and marks the entries that are themselves directories: {result}"
+        );
+    }
+
+    /// An empty directory still has to read as an answer, not as a blank.
+    #[tokio::test]
+    async fn read_file_on_an_empty_directory_says_it_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        fs::create_dir(dir.path().join("hollow")).unwrap();
+
+        let result = tools.execute("read_file", json!({"path": "hollow"})).await;
+        assert!(result.contains("no entries to show"), "{result}");
+    }
+
+    /// A directory of thousands would bury the answer, so the listing is capped
+    /// and says how much it left out.
+    #[tokio::test]
+    async fn a_long_directory_listing_is_capped_and_says_so() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools = make_tools(dir.path());
+        fs::create_dir(dir.path().join("many")).unwrap();
+        for n in 0..60 {
+            fs::write(dir.path().join(format!("many/f{n:03}.txt")), "x").unwrap();
+        }
+
+        let result = tools.execute("read_file", json!({"path": "many"})).await;
+        assert!(result.contains("f000.txt"), "the first entries are there");
+        assert!(
+            result.contains("and 10 more"),
+            "and the rest are accounted for: {result}"
+        );
     }
 
     #[tokio::test]

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -42,10 +42,7 @@ bash       = "ask"
 
 [stages.analyze]
 mode = "autonomous"
-model = { models = [
-  { provider = "anthropic", model = "claude-sonnet-4-6" },
-  { provider = "openai",    model = "gpt-5.4-mini" },
-] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini"] }
 available_tools = ["read_file", "list_dir"]
 required_tools = []                # human-in-the-loop tools kept in an unattended run
 max_iterations = 15
@@ -106,17 +103,18 @@ run is stuck.
 
 ## Stages and models
 
-Each stage gets its own **model** (an ordered provider/model fallback list: the first configured
-provider wins), tools, iteration cap, and context layout. Transitions form a
+Each stage gets its own **model** (an ordered list of models, best first: the first one a configured
+provider serves wins), tools, iteration cap, and context layout. Transitions form a
 [graph](/docs/stages): linear by default, or branch on conditions like `error` and `stuck`.
 
 ```toml
 [stages.analyze.model]
 allow_user_default = true          # fall back to the user's default model, else fail closed
-models = [
-  { provider = "anthropic", model = "claude-sonnet-4-6" },
-  { provider = "openai",    model = "gpt-5.4-mini" },
-]
+models = ["claude-sonnet-5", "gpt-5.4-mini"]
+                                   # name models, not routes: whichever provider
+                                   # the user configured is asked which it serves.
+                                   # Pin one only for a model a single route can
+                                   # reach: { provider = "ollama", model = "..." }
 request_timeout_secs = 120         # per-stage inference wall-clock cap
 
 [stages.analyze.model.parameters]  # free-form, passed through to the provider

--- a/docs/content/first-agent.md
+++ b/docs/content/first-agent.md
@@ -114,10 +114,7 @@ A **stage** is one phase of the work, with its own prompt, model, and tools:
 [stages.survey]
 mode = "autonomous"
 description = "Sort the commits into what a user would notice and what they would not"
-model = { models = [
-  { provider = "anthropic", model = "claude-sonnet-5" },
-  { provider = "openai", model = "gpt-5.4-mini" },
-] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini"] }
 available_tools = ["context_write"]
 max_iterations = 10
 system_prompt = """
@@ -163,10 +160,7 @@ Now the stage it points at:
 [stages.draft]
 mode = "autonomous"
 description = "Turn the sorted changes into release notes"
-model = { models = [
-  { provider = "anthropic", model = "claude-opus-5" },
-  { provider = "openai", model = "gpt-5.5" },
-] }
+model = { models = ["claude-opus-5", "gpt-5.5"] }
 available_tools = ["bash", "read_file"]
 max_iterations = 15
 system_prompt = """
@@ -197,10 +191,7 @@ A run's result should be something a script can use, not a transcript to read. T
 mode = "output"
 description = "Hand back the finished notes"
 max_iterations = 3
-model = { models = [
-  { provider = "anthropic", model = "claude-sonnet-5" },
-  { provider = "openai", model = "gpt-5.4-mini" },
-] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini"] }
 
 [stages.publish.output]
 format = "markdown"
@@ -234,10 +225,7 @@ condition = "error"
 [stages.recover]
 mode = "autonomous"
 description = "Say what went wrong when a stage fails"
-model = { models = [
-  { provider = "anthropic", model = "claude-sonnet-5" },
-  { provider = "openai", model = "gpt-5.4-mini" },
-] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini"] }
 available_tools = []
 max_iterations = 3
 system_prompt = """
@@ -325,10 +313,7 @@ conversation = { kind = "sliding_window", budget = "25%", max_items = 20 }
 [stages.survey]
 mode = "autonomous"
 description = "Sort the commits into what a user would notice and what they would not"
-model = { models = [
-  { provider = "anthropic", model = "claude-sonnet-5" },
-  { provider = "openai", model = "gpt-5.4-mini" },
-] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini"] }
 available_tools = ["context_write"]
 max_iterations = 10
 system_prompt = """
@@ -350,10 +335,7 @@ condition = "error"
 [stages.draft]
 mode = "autonomous"
 description = "Turn the sorted changes into release notes"
-model = { models = [
-  { provider = "anthropic", model = "claude-opus-5" },
-  { provider = "openai", model = "gpt-5.5" },
-] }
+model = { models = ["claude-opus-5", "gpt-5.5"] }
 available_tools = ["bash", "read_file"]
 max_iterations = 15
 system_prompt = """
@@ -377,10 +359,7 @@ condition = "error"
 mode = "output"
 description = "Hand back the finished notes"
 max_iterations = 3
-model = { models = [
-  { provider = "anthropic", model = "claude-sonnet-5" },
-  { provider = "openai", model = "gpt-5.4-mini" },
-] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini"] }
 
 [stages.publish.output]
 format = "markdown"
@@ -389,10 +368,7 @@ instructions = "The release notes only. Start at the first heading, with no prea
 [stages.recover]
 mode = "autonomous"
 description = "Say what went wrong when a stage fails"
-model = { models = [
-  { provider = "anthropic", model = "claude-sonnet-5" },
-  { provider = "openai", model = "gpt-5.4-mini" },
-] }
+model = { models = ["claude-sonnet-5", "gpt-5.4-mini"] }
 available_tools = []
 max_iterations = 3
 system_prompt = """

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -35,7 +35,7 @@ hint = "The work is done"
 
 [stages.summary]
 mode = "output"
-model = { models = [{ provider = "anthropic", model = "claude-sonnet-5" }] }
+model = { models = ["claude-sonnet-5"] }
 description = "Say what changed"
 max_iterations = 8
 system_prompt = """

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -206,35 +206,36 @@ Models this install would use:
 
 ### A gateway is a route, not a model
 
-`default_provider` picks among the entries a stage lists, so what that provider's entry *names*
-decides what you get. This matters most for OpenRouter, which serves models from every vendor: an
-entry naming a different model there is not a different route to the same answer, it is a different
-answer.
+`default_provider` picks the route, not the answer. This matters most for OpenRouter, which serves
+models from every vendor: preferring the gateway should change who bills you and nothing else.
 
-The bundled agents therefore name the same model in their OpenRouter slot as in their first entry -
-`anthropic/claude-sonnet-5` on OpenRouter where the blueprint's first choice is `claude-sonnet-5` on
-Anthropic. Preferring the gateway changes who bills you and nothing else. They used to name a much
-cheaper model there, so `default_provider = "openrouter"` quietly meant "run every stage on the
-cheapest model this blueprint mentions", which is not what preferring a provider should mean.
+It once took discipline to keep that true. A stage listed one entry per route, and the entries were
+matched whole, so `{ provider = "openrouter", model = "..." }` naming a cheaper model than the
+Anthropic entry beside it meant `default_provider = "openrouter"` quietly ran the cheaper model
+everywhere. A blueprint asking for `gemini-3.1-pro-preview` could and did run sonnet instead,
+because the route it happened to match named sonnet.
 
-Write your own blueprint's OpenRouter entry the same way unless you mean the substitution: name the
-model you actually want, prefixed by its vendor, because that is how OpenRouter ids are spelled.
+Stages now name models and leave the route open, so the substitution has nowhere to hide. There is
+one entry per model rather than one per route, and the provider is whichever configured one serves
+it. The same spelling works everywhere: write `gpt-5.5`, and OpenAI serves it as `gpt-5.5` while
+OpenRouter serves it as `openai/gpt-5.5`, without the blueprint knowing either id.
 
 ### Running the bundled agents on your provider
 
-The [bundled agents](/docs/agent-catalog) list all five providers, so any configured key works out
-of the box. But each blueprint's own order decides which is tried first, and a custom Rhai
-provider is never on the list. Naming yours as the default is what puts it in front:
+The [bundled agents](/docs/agent-catalog) name models rather than routes, so any configured key
+works out of the box: whichever provider you set up is asked which of the listed models it serves.
+Each blueprint's own order still decides which model is tried first, and a custom Rhai provider is
+never consulted for an open route. Naming yours as the default is what puts it in front:
 
 ```toml
 default_provider = "openrouter"
 openrouter_api_key = "sk-or-..."
 ```
 
-Every stage now starts on OpenRouter and keeps the blueprint's own list behind it, each stage still
-on the OpenRouter model its author picked for that stage. Add `default_model` only when you want one
-model everywhere regardless of stage. A stage that must stay on the provider its author picked opts
-out with `allow_user_default = false`.
+Every stage now starts on OpenRouter, on the model its author picked for that stage, and keeps the
+blueprint's own order behind it. Add `default_model` only when you want one model everywhere
+regardless of stage. A stage that must stay on the provider its author picked opts out with
+`allow_user_default = false`.
 
 Two other ways in. A full override, for one run:
 
@@ -242,21 +243,28 @@ Two other ways in. A full override, for one run:
 lev run coder -t "fix the failing test" --model openrouter/deepseek/deepseek-v4-flash
 ```
 
-Or, for something permanent and per stage, copying the blueprint and naming your provider on the
-stages you care about:
+Or, for something permanent and per stage, copying the blueprint and naming the models you want on
+the stages you care about, best first:
 
 ```toml
-model = { models = [
-  { provider = "openrouter", model = "deepseek/deepseek-v4-flash" },
-  { provider = "anthropic",  model = "claude-sonnet-5" },
-] }
+model = { models = ["deepseek-v4-flash", "claude-sonnet-5"] }
 ```
+
+Pin a provider only for a model that one route alone can reach, such as anything local:
+
+```toml
+model = { models = ["claude-sonnet-5", { provider = "ollama", model = "qwen3.5:9b" }] }
+```
+
+A model no configured provider serves is skipped, with a warning naming it, and the stage falls
+through to the next model listed.
 
 > [!WARNING]
 > Ollama needs no key, so it is registered whether or not a server is running. Leave
 > `default_model` unset on a machine with no Ollama and every stage that lists it starts against
 > `http://localhost:11434`. The run moves on to its next candidate rather than dying there, but
-> it still spends four attempts finding out.
+> it still spends the attempts finding out. This is why the bundled agents pin their Ollama entry
+> explicitly and put it last.
 
 ### Turning off an Ollama model's thinking
 

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -4,14 +4,20 @@
   "title": "Leviath agent blueprint (agent.leviath)",
   "description": "The TOML manifest defining a Leviath agent: its stages, the model each one runs on, the tools it may call, and the shape of its context. Written against the parser in crates/leviath-core/src/manifest.rs, and checked against every bundled blueprint by a test in crates/leviath-cli/src/bundled.rs. See https://leviath.dev/docs/agents.",
   "type": "object",
-  "required": ["agent"],
+  "required": [
+    "agent"
+  ],
   "additionalProperties": false,
   "properties": {
-    "agent": { "$ref": "#/$defs/agent" },
+    "agent": {
+      "$ref": "#/$defs/agent"
+    },
     "stages": {
       "type": "object",
       "description": "One entry per stage, keyed by stage name.",
-      "additionalProperties": { "$ref": "#/$defs/stage" }
+      "additionalProperties": {
+        "$ref": "#/$defs/stage"
+      }
     },
     "context": {
       "type": "object",
@@ -20,27 +26,49 @@
         "regions": {
           "type": "object",
           "description": "One entry per context region, keyed by region name.",
-          "additionalProperties": { "$ref": "#/$defs/region" }
+          "additionalProperties": {
+            "$ref": "#/$defs/region"
+          }
         },
         "file_tracking": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "region": { "type": "string", "default": "files" },
-            "track_reads": { "type": "boolean", "default": true },
-            "track_writes": { "type": "boolean", "default": true },
-            "max_file_tokens": { "type": "integer", "minimum": 0 }
+            "region": {
+              "type": "string",
+              "default": "files"
+            },
+            "track_reads": {
+              "type": "boolean",
+              "default": true
+            },
+            "track_writes": {
+              "type": "boolean",
+              "default": true
+            },
+            "max_file_tokens": {
+              "type": "integer",
+              "minimum": 0
+            }
           }
         }
       }
     },
-    "tool_permissions": { "$ref": "#/$defs/toolPermissions" },
+    "tool_permissions": {
+      "$ref": "#/$defs/toolPermissions"
+    },
     "security": {
       "type": "object",
       "description": "Taint tracking for this blueprint. A machine-wide ceiling still applies.",
-      "properties": { "taint_tracking": { "type": "boolean" } }
+      "properties": {
+        "taint_tracking": {
+          "type": "boolean"
+        }
+      }
     },
-    "sandbox": { "$ref": "#/$defs/sandbox" },
+    "sandbox": {
+      "$ref": "#/$defs/sandbox"
+    },
     "read_paths": {
       "type": "object",
       "description": "Paths outside the workdir this agent may read. Inert until the host grants them under [agent_read_paths] in config.toml.",
@@ -81,20 +109,39 @@
       "description": "The model that summarizes a compacting region. Skipped without error when its provider is not registered, so a run on another provider loses compaction rather than failing.",
       "additionalProperties": false,
       "properties": {
-        "provider": { "type": "string" },
-        "model": { "type": "string" },
-        "system_prompt": { "type": "string" },
-        "max_summary_tokens": { "type": "integer", "minimum": 1 },
-        "temperature": { "type": "number" }
+        "provider": {
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "system_prompt": {
+          "type": "string"
+        },
+        "max_summary_tokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "temperature": {
+          "type": "number"
+        }
       }
     },
     "repetition_detection": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": { "type": "boolean" },
-        "max_repeat_calls": { "type": "integer", "minimum": 1 },
-        "max_readonly_streak": { "type": "integer", "minimum": 1 }
+        "enabled": {
+          "type": "boolean"
+        },
+        "max_repeat_calls": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_readonly_streak": {
+          "type": "integer",
+          "minimum": 1
+        }
       }
     },
     "transforms": {
@@ -104,18 +151,37 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "from_blueprint": { "type": "string" },
-          "to_blueprint": { "type": "string" },
+          "from_blueprint": {
+            "type": "string"
+          },
+          "to_blueprint": {
+            "type": "string"
+          },
           "mappings": {
             "type": "array",
             "items": {
               "type": "object",
               "additionalProperties": false,
               "properties": {
-                "from_region": { "type": "string" },
-                "to_region": { "type": "string" },
-                "transform": { "enum": ["direct", "summarize", "extract"] },
-                "fields": { "type": "array", "items": { "type": "string" } }
+                "from_region": {
+                  "type": "string"
+                },
+                "to_region": {
+                  "type": "string"
+                },
+                "transform": {
+                  "enum": [
+                    "direct",
+                    "summarize",
+                    "extract"
+                  ]
+                },
+                "fields": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
               }
             }
           }
@@ -128,22 +194,44 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "name": { "type": "string", "default": "unnamed" },
-        "version": { "type": "string", "default": "0.1.0" },
-        "description": { "type": "string", "default": "" },
+        "name": {
+          "type": "string",
+          "default": "unnamed"
+        },
+        "version": {
+          "type": "string",
+          "default": "0.1.0"
+        },
+        "description": {
+          "type": "string",
+          "default": ""
+        },
         "entry_stage": {
           "type": "string",
           "description": "The stage a run starts in. Defaults to the first stage declared."
         },
-        "max_child_depth": { "type": "integer", "minimum": 0 },
-        "dynamic_tools": { "type": "boolean", "default": false },
-        "batch_tool_hint": { "type": "boolean" },
-        "shell_hint": { "type": "boolean" },
-        "nudge": { "$ref": "#/$defs/nudge" },
-        "output": { "$ref": "#/$defs/outputSpec" }
+        "max_child_depth": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "dynamic_tools": {
+          "type": "boolean",
+          "default": false
+        },
+        "batch_tool_hint": {
+          "type": "boolean"
+        },
+        "shell_hint": {
+          "type": "boolean"
+        },
+        "nudge": {
+          "$ref": "#/$defs/nudge"
+        },
+        "output": {
+          "$ref": "#/$defs/outputSpec"
+        }
       }
     },
-
     "outputSpec": {
       "type": "object",
       "additionalProperties": false,
@@ -171,7 +259,6 @@
         }
       }
     },
-
     "stage": {
       "type": "object",
       "additionalProperties": false,
@@ -187,18 +274,28 @@
             "output"
           ]
         },
-        "description": { "type": "string" },
-        "system_prompt": { "type": "string" },
-        "transition_prompt": { "type": "string" },
+        "description": {
+          "type": "string"
+        },
+        "system_prompt": {
+          "type": "string"
+        },
+        "transition_prompt": {
+          "type": "string"
+        },
         "available_tools": {
           "type": "array",
           "description": "The only tools the model is offered here. Anything absent is refused at dispatch.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "available_connectors": {
           "type": "array",
           "description": "MCP servers whose whole tool set this stage may use, by server name. Resolved at spawn against what each server actually advertises, and merged with available_tools - so a tool the server gains later is offered without editing the manifest.",
-          "items": { "type": "string" },
+          "items": {
+            "type": "string"
+          },
           "$comment": "Kept separate from available_tools because that field is exact-match, and because an MCP tool's advertised name does not reliably carry its server - there is no prefix a wildcard could match."
         },
         "require_output": {
@@ -207,48 +304,103 @@
           "description": "This stage must call submit_output before it transitions. Unlike required_tools, which is never checked afterwards, this is enforced: a stage that finishes without submitting is nudged and re-run, bounded, then let through with the run's output_forced flag set. `mode = \"output\"` sets it for you.",
           "$comment": "A stage that sets this must also grant submit_output; lev validate refuses it otherwise."
         },
-        "output": { "$ref": "#/$defs/outputSpec" },
+        "output": {
+          "$ref": "#/$defs/outputSpec"
+        },
         "required_tools": {
           "type": "array",
           "description": "Tools this stage cannot work without. Every entry must also appear in available_tools. Survives an unattended run, where the blocking interaction tools are otherwise withheld.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
-        "max_iterations": { "type": "integer", "minimum": 1 },
-        "max_revisits": { "type": "integer", "minimum": 0 },
-        "requires_children": { "type": "boolean", "default": false },
-        "allow_complete": { "type": "boolean", "default": false },
-        "allow_as_worker": { "type": "boolean", "default": false },
-        "accepts_messages": { "type": "boolean", "default": true },
-        "allow_blocking_tools": { "type": "boolean", "default": false },
-        "batch_tool_hint": { "type": "boolean" },
-        "shell_hint": { "type": "boolean" },
-        "model": { "$ref": "#/$defs/modelConfig" },
-        "nudge": { "$ref": "#/$defs/nudge" },
-        "hooks": { "$ref": "#/$defs/stageHooks" },
-        "sandbox": { "$ref": "#/$defs/sandbox" },
-        "security": { "type": "object" },
-        "tool_permissions": { "$ref": "#/$defs/toolPermissions" },
+        "max_iterations": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "max_revisits": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "requires_children": {
+          "type": "boolean",
+          "default": false
+        },
+        "allow_complete": {
+          "type": "boolean",
+          "default": false
+        },
+        "allow_as_worker": {
+          "type": "boolean",
+          "default": false
+        },
+        "accepts_messages": {
+          "type": "boolean",
+          "default": true
+        },
+        "allow_blocking_tools": {
+          "type": "boolean",
+          "default": false
+        },
+        "batch_tool_hint": {
+          "type": "boolean"
+        },
+        "shell_hint": {
+          "type": "boolean"
+        },
+        "model": {
+          "$ref": "#/$defs/modelConfig"
+        },
+        "nudge": {
+          "$ref": "#/$defs/nudge"
+        },
+        "hooks": {
+          "$ref": "#/$defs/stageHooks"
+        },
+        "sandbox": {
+          "$ref": "#/$defs/sandbox"
+        },
+        "security": {
+          "type": "object"
+        },
+        "tool_permissions": {
+          "$ref": "#/$defs/toolPermissions"
+        },
         "tool_routing": {
           "type": "object",
           "description": "Where a tool result lands in context.",
           "additionalProperties": false,
           "properties": {
-            "default_region": { "type": "string" },
-            "persist": { "type": "boolean" },
-            "max_result_tokens": { "type": "integer", "minimum": 1 },
+            "default_region": {
+              "type": "string"
+            },
+            "persist": {
+              "type": "boolean"
+            },
+            "max_result_tokens": {
+              "type": "integer",
+              "minimum": 1
+            },
             "overrides": {
               "type": "object",
               "description": "Tool name to a region name, or to a table carrying that tool's region, its result ceiling, or both.",
               "additionalProperties": {
                 "oneOf": [
-                  { "type": "string" },
+                  {
+                    "type": "string"
+                  },
                   {
                     "type": "object",
                     "additionalProperties": false,
                     "minProperties": 1,
                     "properties": {
-                      "region": { "type": "string" },
-                      "max_result_tokens": { "type": "integer", "minimum": 0 }
+                      "region": {
+                        "type": "string"
+                      },
+                      "max_result_tokens": {
+                        "type": "integer",
+                        "minimum": 0
+                      }
                     }
                   }
                 ]
@@ -257,7 +409,10 @@
             "max_result_tokens_per_tool": {
               "type": "object",
               "description": "Tool name to that tool's result ceiling, overriding max_result_tokens for it.",
-              "additionalProperties": { "type": "integer", "minimum": 0 }
+              "additionalProperties": {
+                "type": "integer",
+                "minimum": 0
+              }
             }
           }
         },
@@ -267,31 +422,52 @@
           "properties": {
             "regions": {
               "type": "object",
-              "additionalProperties": { "$ref": "#/$defs/region" }
+              "additionalProperties": {
+                "$ref": "#/$defs/region"
+              }
             }
           }
         },
         "transitions": {
           "type": "object",
           "description": "Outgoing edges, keyed by target stage name. An empty table marks a terminal stage.",
-          "additionalProperties": { "$ref": "#/$defs/transition" }
+          "additionalProperties": {
+            "$ref": "#/$defs/transition"
+          }
         },
         "interaction_points": {
           "type": "array",
-          "items": { "$ref": "#/$defs/interactionPoint" }
+          "items": {
+            "$ref": "#/$defs/interactionPoint"
+          }
         },
-        "on_worker_failure": { "enum": ["continue", "fail_all"] },
+        "on_worker_failure": {
+          "enum": [
+            "continue",
+            "fail_all"
+          ]
+        },
         "max_workers": {
           "type": "integer",
           "minimum": 0,
           "default": 30,
           "description": "How many workers run at once. 0 means unlimited: every work item starts as soon as the split has produced it, and the daemon's inference pool paces the requests."
         },
-        "worker_agent": { "type": "string" },
-        "worker_stage": { "type": "string" },
-        "worker_query": { "type": "string" },
-        "merge_stage": { "type": "string" },
-        "split_prompt": { "type": "string" },
+        "worker_agent": {
+          "type": "string"
+        },
+        "worker_stage": {
+          "type": "string"
+        },
+        "worker_query": {
+          "type": "string"
+        },
+        "merge_stage": {
+          "type": "string"
+        },
+        "split_prompt": {
+          "type": "string"
+        },
         "results_region": {
           "type": "string",
           "description": "Context region the consolidated worker report is written to. Defaults to conversation, which is also carrying the message history. Worth naming when the results are bulky: the region's budget is what each worker's share is divided from."
@@ -309,7 +485,6 @@
         }
       }
     },
-
     "modelConfig": {
       "type": "object",
       "description": "Which model this stage runs on. `models` is an ordered fallback list: the first entry whose provider is registered wins.",
@@ -317,7 +492,9 @@
       "properties": {
         "models": {
           "type": "array",
-          "items": { "$ref": "#/$defs/modelEntry" }
+          "items": {
+            "$ref": "#/$defs/modelEntry"
+          }
         },
         "provider": {
           "type": "string",
@@ -330,14 +507,19 @@
         "fallbacks": {
           "type": "array",
           "description": "Back-compat: folded onto the end of `models`.",
-          "items": { "$ref": "#/$defs/modelEntry" }
+          "items": {
+            "$ref": "#/$defs/modelEntry"
+          }
         },
         "allow_user_default": {
           "type": "boolean",
           "default": true,
           "description": "Whether the host's default model may be used when nothing listed is registered."
         },
-        "request_timeout_secs": { "type": "integer", "minimum": 1 },
+        "request_timeout_secs": {
+          "type": "integer",
+          "minimum": 1
+        },
         "parameters": {
           "type": "object",
           "description": "Passed to the provider verbatim, so the accepted keys are the provider's.",
@@ -345,23 +527,32 @@
         }
       }
     },
-
     "modelEntry": {
-      "type": "object",
-      "required": ["provider", "model"],
-      "additionalProperties": false,
-      "properties": {
-        "provider": {
+      "description": "A model this stage may run on. Either a bare model name, which leaves the route to whichever configured provider serves it, or a table that pins a provider for a model only one route can reach (a local or self-hosted model). Entries are tried in order.",
+      "oneOf": [
+        {
           "type": "string",
-          "description": "A registered provider name. The built-ins are anthropic, openai, google, openrouter, ollama, and claude-code; a Rhai provider resolves by its script name."
+          "description": "A model name with no route. Every configured provider is asked which of them serves it, the user's default provider first."
         },
-        "model": {
-          "type": "string",
-          "description": "Passed to the provider verbatim and never validated locally, so a typo surfaces on the first live call."
+        {
+          "type": "object",
+          "required": [
+            "model"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "provider": {
+              "type": "string",
+              "description": "A registered provider name. The built-ins are anthropic, openai, google, openrouter, ollama, and claude-code; a Rhai provider resolves by its script name. Omit it unless the model is reachable only one way; omitting it lets the user's own provider choice decide."
+            },
+            "model": {
+              "type": "string",
+              "description": "Passed to the provider verbatim and never validated locally, so a typo surfaces on the first live call."
+            }
+          }
         }
-      }
+      ]
     },
-
     "region": {
       "type": "object",
       "description": "One region of the context window. Budgets are ceilings, not allocations, and may sum past 100%.",
@@ -387,34 +578,97 @@
           "pattern": "^[0-9]+(\\.[0-9]+)?%$",
           "description": "A percentage of the window, as a string such as \"35%\"."
         },
-        "max_tokens": { "type": "integer", "minimum": 1, "default": 5000 },
-        "min_tokens": { "type": "integer", "minimum": 0 },
-        "required": { "type": "boolean", "default": false },
-          "volatility": { "type": "string", "enum": ["stable", "grows", "rewritten"], "default": "rewritten", "description": "How much this region's contents move between requests, which decides where it sits in the prompt and whether it is split for caching. A provider caches by prefix, so a region that changes invalidates the cache for every region behind it: \"stable\" is seeded and never written, \"grows\" is appended to, \"rewritten\" changes in place. The default is the pessimistic value, so leaving it out never makes a blueprint slower." },
-          "summarizable": { "type": "boolean", "default": true, "description": "Set false to keep an edge transform = \"compact\" from handing this region to the summarizer. Protects the region wherever it is used, and wins over an explicit compact list." },
-        "description": { "type": "string", "description": "One line on what this region is for, shown to the model above the region's contents on every turn. Optional - most regions are named well enough that a sentence would only cost tokens; use it where the contents do not explain themselves." },
-        "admission": { "enum": ["evict", "reject"], "default": "evict", "description": "What the region does when a write does not fit. \"evict\" makes room by dropping the oldest entry; \"reject\" refuses the write and tells the agent to release something first, so nothing is discarded without the agent knowing." },
+        "max_tokens": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 5000
+        },
+        "min_tokens": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "required": {
+          "type": "boolean",
+          "default": false
+        },
+        "volatility": {
+          "type": "string",
+          "enum": [
+            "stable",
+            "grows",
+            "rewritten"
+          ],
+          "default": "rewritten",
+          "description": "How much this region's contents move between requests, which decides where it sits in the prompt and whether it is split for caching. A provider caches by prefix, so a region that changes invalidates the cache for every region behind it: \"stable\" is seeded and never written, \"grows\" is appended to, \"rewritten\" changes in place. The default is the pessimistic value, so leaving it out never makes a blueprint slower."
+        },
+        "summarizable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Set false to keep an edge transform = \"compact\" from handing this region to the summarizer. Protects the region wherever it is used, and wins over an explicit compact list."
+        },
+        "description": {
+          "type": "string",
+          "description": "One line on what this region is for, shown to the model above the region's contents on every turn. Optional - most regions are named well enough that a sentence would only cost tokens; use it where the contents do not explain themselves."
+        },
+        "admission": {
+          "enum": [
+            "evict",
+            "reject"
+          ],
+          "default": "evict",
+          "description": "What the region does when a write does not fit. \"evict\" makes room by dropping the oldest entry; \"reject\" refuses the write and tells the agent to release something first, so nothing is discarded without the agent knowing."
+        },
         "required_message": {
           "type": "string",
           "description": "Shown when a required region is empty. `{region}` interpolates."
         },
-        "seed": { "$ref": "#/$defs/regionSeed" },
-        "max_items": { "type": "integer", "minimum": 1, "default": 10 },
-        "strategy": { "enum": ["per_item", "bulk", "compact"] },
-        "overflow": { "type": "integer", "minimum": 0 },
-        "compact_count": { "type": "integer", "minimum": 1 },
-        "compact_at": { "type": "string", "pattern": "^[0-9]+(\\.[0-9]+)?%$" },
-        "threshold_tokens": { "type": "integer", "minimum": 1 },
-        "source_region": { "type": "string" },
-        "max_entries": { "type": "integer", "minimum": 1 },
+        "seed": {
+          "$ref": "#/$defs/regionSeed"
+        },
+        "max_items": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 10
+        },
+        "strategy": {
+          "enum": [
+            "per_item",
+            "bulk",
+            "compact"
+          ]
+        },
+        "overflow": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "compact_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "compact_at": {
+          "type": "string",
+          "pattern": "^[0-9]+(\\.[0-9]+)?%$"
+        },
+        "threshold_tokens": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "source_region": {
+          "type": "string"
+        },
+        "max_entries": {
+          "type": "integer",
+          "minimum": 1
+        },
         "script": {
           "type": "string",
           "description": "For `kind = \"custom\"`: the Rhai script under context_hooks/."
         },
-        "persistent": { "type": "boolean" }
+        "persistent": {
+          "type": "boolean"
+        }
       }
     },
-
     "regionSeed": {
       "description": "What fills the region at spawn. The table form is checked key by key in the order below, so the first one present wins.",
       "oneOf": [
@@ -434,7 +688,9 @@
             "files": {
               "type": "array",
               "description": "Concatenated contents of these workdir-relative paths.",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             },
             "literal": {
               "type": "string",
@@ -465,17 +721,28 @@
                   {
                     "type": "object",
                     "additionalProperties": false,
-                    "required": ["name"],
+                    "required": [
+                      "name"
+                    ],
                     "properties": {
-                      "name": { "type": "string", "description": "The tool to call." },
-                      "args": { "type": "object", "description": "The arguments object." }
+                      "name": {
+                        "type": "string",
+                        "description": "The tool to call."
+                      },
+                      "args": {
+                        "type": "object",
+                        "description": "The arguments object."
+                      }
                     }
                   }
                 ]
               }
             },
             "refresh": {
-              "enum": ["once", "each_stage"],
+              "enum": [
+                "once",
+                "each_stage"
+              ],
               "default": "once",
               "description": "For `tool`/`tools`: when the calls run again. `once` (the default, and what every other seed kind does) resolves at spawn. `each_stage` resolves again on every stage entry, for a seed whose answer moves - a clock, say - at the cost of a tool call per stage."
             },
@@ -487,7 +754,6 @@
         }
       ]
     },
-
     "transition": {
       "type": "object",
       "description": "One outgoing edge. A `hint` with no `condition` implies `llm_choice`.",
@@ -499,20 +765,50 @@
         },
         "condition": {
           "description": "An unrecognised value is a hard parse error.",
-          "enum": ["always", "llm_choice", "error", "max_iterations", "stuck", "dead_end"]
+          "enum": [
+            "always",
+            "llm_choice",
+            "error",
+            "max_iterations",
+            "stuck",
+            "dead_end"
+          ]
         },
         "transform": {
           "description": "What happens to context on this edge. `custom` reads transform_config. Anything else is a hard parse error rather than a silent downgrade to `direct`.",
-          "enum": ["direct", "clear", "compact", "summarize", "custom"]
+          "enum": [
+            "direct",
+            "clear",
+            "compact",
+            "summarize",
+            "custom"
+          ]
         },
         "transform_config": {
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "carry": { "type": "array", "items": { "type": "string" } },
-            "compact": { "type": "array", "items": { "type": "string" } },
-            "clear": { "type": "array", "items": { "type": "string" } },
-            "compact_prompt": { "type": "string" }
+            "carry": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "compact": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "clear": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "compact_prompt": {
+              "type": "string"
+            }
           }
         },
         "gate": {
@@ -520,11 +816,15 @@
           "description": "A condition the stage must satisfy before this edge may be taken.",
           "additionalProperties": false,
           "properties": {
-            "require_modifications": { "type": "boolean" },
+            "require_modifications": {
+              "type": "boolean"
+            },
             "require_regions": {
               "type": "array",
               "description": "Regions that must all hold content before this edge may be taken. ANDed with every other condition on the gate, unlike `region`.",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             },
             "require_region_updated": {
               "type": "string",
@@ -534,60 +834,108 @@
               "type": "string",
               "description": "A checklist region that must have no open items before this edge is taken."
             },
-            "message": { "type": "string" },
+            "message": {
+              "type": "string"
+            },
             "region": {
               "type": "string",
               "description": "An alternative way to satisfy require_modifications: the gate also passes when this region is non-empty. A restart-durable stand-in for the per-stage counters, not a requirement - use require_regions for that."
             },
-            "tools": { "type": "array", "items": { "type": "string" } },
-            "max_attempts": { "type": "integer", "minimum": 1 }
+            "tools": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "max_attempts": {
+              "type": "integer",
+              "minimum": 1
+            }
           }
         },
-        "stuck_after_iterations": { "type": "integer" },
-        "stuck_after_minutes": { "type": "integer" },
-        "stuck_after_same_file_edits": { "type": "integer" },
-        "stuck_after_tool_calls": { "type": "integer" }
+        "stuck_after_iterations": {
+          "type": "integer"
+        },
+        "stuck_after_minutes": {
+          "type": "integer"
+        },
+        "stuck_after_same_file_edits": {
+          "type": "integer"
+        },
+        "stuck_after_tool_calls": {
+          "type": "integer"
+        }
       }
     },
-
     "interactionPoint": {
       "type": "object",
       "description": "A checkpoint the runtime raises at the stage boundary, every time, rather than one the model chooses to raise.",
       "additionalProperties": false,
       "properties": {
-        "name": { "type": "string" },
-        "prompt": { "type": "string" },
-        "required": { "type": "boolean", "default": true },
+        "name": {
+          "type": "string"
+        },
+        "prompt": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean",
+          "default": true
+        },
         "unattended": {
           "description": "What a --yolo run does here. `auto_approve` (the default) resolves it without asking. `ask` holds for a person even unattended, and the run then waits for [limits] interaction_timeout_secs.",
-          "enum": ["ask", "auto_approve"]
+          "enum": [
+            "ask",
+            "auto_approve"
+          ]
         },
-        "style": { "enum": ["free_text", "multiple_choice", "confirm"] },
-        "options": { "type": "array", "items": { "type": "string" } },
+        "style": {
+          "enum": [
+            "free_text",
+            "multiple_choice",
+            "confirm"
+          ]
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "choices": {
           "type": "array",
           "description": "Alias for `options`.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "directives": {
           "type": "object",
           "description": "Option text to the instruction added when it is picked.",
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "followups": {
           "type": "object",
           "description": "Alias for `directives`.",
-          "additionalProperties": { "type": "string" }
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "abort_options": {
           "type": "array",
           "description": "Options that end the run immediately, with no further inference.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "edit_options": {
           "type": "array",
           "description": "Options that open the document for the user to edit directly.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "document_region": {
           "type": "string",
@@ -595,55 +943,110 @@
         }
       }
     },
-
     "toolPermissions": {
       "type": "object",
       "description": "Tool name to policy. May only tighten the machine-wide ceiling in config.toml, never loosen it. `ask` blocks until answered.",
-      "additionalProperties": { "enum": ["allow", "ask", "deny"] }
+      "additionalProperties": {
+        "enum": [
+          "allow",
+          "ask",
+          "deny"
+        ]
+      }
     },
-
     "sandbox": {
       "type": "object",
       "description": "Where tools execute. An agent and a stage resolve to the stronger of the pair.",
       "additionalProperties": false,
       "properties": {
-        "kind": { "enum": ["none", "namespace", "container"] },
-        "image": { "type": "string" },
-        "engine": { "enum": ["docker", "podman", "nerdctl", "finch"] },
-        "network": { "type": "boolean" },
-        "mount": { "type": "array", "items": { "type": "string" } },
-        "mounts": { "type": "array", "items": { "type": "string" } },
-        "persist": { "type": "boolean" },
-        "on_unavailable": { "enum": ["error", "warn"] }
+        "kind": {
+          "enum": [
+            "none",
+            "namespace",
+            "container"
+          ]
+        },
+        "image": {
+          "type": "string"
+        },
+        "engine": {
+          "enum": [
+            "docker",
+            "podman",
+            "nerdctl",
+            "finch"
+          ]
+        },
+        "network": {
+          "type": "boolean"
+        },
+        "mount": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "mounts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "persist": {
+          "type": "boolean"
+        },
+        "on_unavailable": {
+          "enum": [
+            "error",
+            "warn"
+          ]
+        }
       }
     },
-
     "nudge": {
       "type": "object",
       "description": "What to say to a stage that has gone quiet. Cascades stage over agent over config.",
       "additionalProperties": false,
       "properties": {
-        "enabled": { "type": "boolean" },
-        "max": { "type": "integer", "minimum": 0 },
+        "enabled": {
+          "type": "boolean"
+        },
+        "max": {
+          "type": "integer",
+          "minimum": 0
+        },
         "text": {
           "type": "string",
           "description": "`{stage}` and `{regions}` interpolate."
         }
       }
     },
-
     "stageHooks": {
       "type": "object",
       "description": "Rhai scripts run at points in this stage's lifecycle. Each value is a script path relative to the agent directory.",
       "additionalProperties": false,
       "properties": {
-        "on_stage_enter": { "type": "string" },
-        "on_stage_exit": { "type": "string" },
-        "before_inference": { "type": "string" },
-        "after_inference": { "type": "string" },
-        "on_tool_call": { "type": "string" },
-        "on_completion": { "type": "string" },
-        "on_error": { "type": "string" }
+        "on_stage_enter": {
+          "type": "string"
+        },
+        "on_stage_exit": {
+          "type": "string"
+        },
+        "before_inference": {
+          "type": "string"
+        },
+        "after_inference": {
+          "type": "string"
+        },
+        "on_tool_call": {
+          "type": "string"
+        },
+        "on_completion": {
+          "type": "string"
+        },
+        "on_error": {
+          "type": "string"
+        }
       }
     }
   }


### PR DESCRIPTION
## What was wrong

A stage listing `gemini-3.1-pro-preview` first ran `claude-sonnet-5`.

Model entries were matched as whole `provider/model` pairs, so `default_provider`
picked among **routes** and whatever model that route happened to name came back.
On a machine with `default_provider = "openrouter"`, `deep-researcher` resolved
like this:

| stage | blueprint asked for | before | after |
|---|---|---|---|
| `synthesize` | `gpt-5.5` (first) | `claude-opus-5` ❌ | `gpt-5.5` ✓ |
| `polish` | `gemini-3.1-pro-preview` (first) | `claude-sonnet-5` ❌ | `gemini-3.1-pro-preview` ✓ |

Measured with the installed build as the "before" control, not reasoned about.

Closes #578.

## The change

Resolution groups by model, so the blueprint's order is the order tried. That
makes naming the route unnecessary, and the blueprint author was never the one
who knew it: which providers exist is the user's configuration, not the
blueprint's business. Entries may now be bare names:

```toml
models = ["gpt-5.5", "claude-sonnet-5", { provider = "ollama", model = "qwen3.5:9b" }]
```

A table still pins a route for a model only one route can reach. The old
`{ provider = ..., model = ... }` form is still read, so nothing breaks.

Every bundled agent is rewritten this way. They had been listing the same model
up to five times so any configured provider could reach the stage; that
redundancy is what the pair matching turned into a silent substitution.

## Two other bugs, both found while testing the above

**The editor and The Lair showed a migrated stage as one local model.**
`model_chain` kept only entries carrying both keys, so every open route vanished
and the pinned Ollama entry was all that was left.

**A run died on reaching a Gemini stage:**

> Function call is missing a thought_signature in functionCall parts ...
> function call `default_api:read_file`, position 9

Nothing had dropped the signature. The calls were made by **grok**, one stage
earlier. `challenge` runs `x-ai/grok-4.6` with tools, `polish` runs Gemini, and
the `conversation` region carries the turns across the boundary. Gemini refuses
function calls it never signed, so **any blueprint that changes model family
mid-run while carrying its conversation hits this**. That run died at iteration
35 having spent $15.83.

Calls this model cannot have signed are folded into the assistant's own text
(what was called, and what came back), so the run keeps what it learned without
replaying a call that will be refused. Separately, `deep-researcher` and
`wide-researcher` stop carrying the transcript into `polish` at all: that stage
rewrites the report named in `report_path` and never needed the turn history,
which was prompt weight on the run's most expensive model.

## Guards

Both verified by mutation, not just by passing:

- every bundled stage must be reachable from every provider `lev setup` can
  configure, asked of the providers themselves rather than of the spelling
- a `transform = "custom"` edge must name regions. `transform_config` is parsed
  key by key, so a misspelt key yields empty lists and the edge becomes a no-op
  that still parses, still validates, and still ships

The signature fix was run against the unfixed code first and reproduces the
exact wire shape Google rejected.

## Gates

`cargo test --workspace --all-features` (3859), `cargo xtask coverage` (100%,
13 packages), `cargo xtask docs`, `cargo xtask structure`, clippy clean.

Bundled blueprint versions bumped, as `lev setup` requires to offer the update.
