### PR TITLE
fix: fill the regions the later stages read, and let a cancelled run resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ same list.
 
 ## Unreleased
 
+- Fixed: a cancelled run can be resumed. Cancelling stops a run rather than
+  ending it, and everything needed to carry on is already written down: the
+  journal in `run.lvr`, every region in `context.json`, the stage and iteration
+  in `meta.json`, and any parked fan-out in `fanout.json`. A status check was
+  treating `Cancelled` like `Complete`, so `lev resume` could not reach it.
+  Startup recovery still leaves cancelled runs alone: somebody stopped that run
+  on purpose, and restarting the daemon is not them changing their mind (#576).
+
 - Fixed: the researcher agents stopped writing the regions their own later
   stages read from. Measured over two finished runs, `claims`, `contradictions`
   and `analysis` held nothing across all 225 snapshots of one, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ same list.
 
 ## Unreleased
 
+- Fixed: the researcher agents stopped writing the regions their own later
+  stages read from. Measured over two finished runs, `claims`, `contradictions`
+  and `analysis` held nothing across all 225 snapshots of one, and
+  `comparisons` held 2% of its budget across 251 snapshots of the other, while
+  the accumulator regions sat at 83-99%. `challenge` was attacking empty
+  regions and `synthesize` was building the report without the claims it is
+  told to build from. The instruction lived only in `system_prompt`; it is now
+  named in `transition_prompt`, where the decision is actually made, and the
+  edge out of the stage is gated on the region having changed.
+
 - Fixed: `read_file` on a directory told the model to call `list_dir`, which 21
   of the bundled agents' stages do not grant. It now answers with the directory's
   contents, so the model can pick its next path in one call whatever the stage

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -258,6 +258,10 @@ Decide the next move:
   respond with: follow_citations
 - Enough well-supported evidence to write the report → respond with: challenge
   (the adversarial pass runs before writing, always - it is not a sign of doubt)
+  Before you choose this: the claims you extracted this pass must be in `claims`
+  and any source disagreements in `contradictions`. `challenge` reads those
+  regions and `synthesize` builds the report out of them, so a claim you leave
+  in your reply and not in the region is one neither of them can see.
 - The `[Progress in stage ...]` note says this pass added little next to the one
   before it, and you cannot name a specific gap you would go and fill → the work
   here has converged → respond with: challenge
@@ -298,6 +302,11 @@ transform = "compact"
 [stages.analyze.transitions.challenge]
 hint = "Evidence is sufficient - have it attacked before writing"
 transform = "compact"
+# `challenge` and `synthesize` both read `claims`, so leaving analyze without
+# having written it hands them an empty region. Measured on a finished run:
+# `claims` held nothing for all 225 snapshots while `sources` sat at 99% of its
+# budget, because everything went into the accumulator instead.
+gate = { require_region_updated = "claims", message = "Add the claims from this pass to `claims` with context_append, one per line as `<claim> [n]` with its source ref, and any source disagreements to `contradictions`. The adversarial pass reads those regions, and the report is written from them." }
 
 [stages.analyze.transitions.error_recovery]
 condition = "error"

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -242,6 +242,10 @@ Decide the next move:
 - One especially interesting/consequential thread worth a focused deep read
   before you can judge it fairly → respond with: deep_dive
 - You've covered enough ground to write a useful overview → respond with: challenge
+  Before you choose this or deep_dive: the comparative judgments you made this
+  pass must be in `comparisons`. That region is what the overview is written
+  from, so a judgment left in your reply and not in the region is one the
+  writing stage cannot use.
 - The `[Progress in stage ...]` note says this pass added little next to the one
   before it, and you cannot name a specific gap you would go and fill → the work
   here has converged → respond with: challenge
@@ -273,6 +277,11 @@ off before finishing - treat its coverage as incomplete when judging the field.
 [stages.compare.transitions.deep_dive]
 hint = "Threads compared - read the most significant one in depth"
 transform = "compact"
+# Both ways out of `compare` are gated on the same region: it is the comparison
+# this agent exists to produce. Measured on a finished run, `comparisons` held
+# 2,560 tokens of its 125,000 while `landscape` sat at 83%, so the comparing was
+# happening and only the recording was not.
+gate = { require_region_updated = "comparisons", message = "Write the comparative judgments you reached this pass into `comparisons` with context_write before moving on. The overview is written from that region." }
 
 # Un-exhaustible escape (lint: dead-end-possible): once `deep_dive` has spent its
 # revisits there is nowhere else to go, and the overview still gets written.
@@ -280,6 +289,7 @@ transform = "compact"
 [stages.compare.transitions.challenge]
 hint = "Evidence is sufficient - have it attacked before writing"
 transform = "compact"
+gate = { require_region_updated = "comparisons", message = "Write the comparative judgments you reached this pass into `comparisons` with context_write before moving on. The adversarial pass reads that region, and the overview is written from it." }
 
 [stages.compare.transitions.error_recovery]
 condition = "error"

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -899,6 +899,52 @@ mod tests {
         assert!(!rejects("[agent]\nname = \"a\"\n"), "a minimal manifest");
     }
 
+    /// A declared `gate` must actually check something.
+    ///
+    /// Its fields are parsed one by one, so a misspelt condition leaves them all
+    /// at their defaults and the gate passes every time. The edge still parses
+    /// and still validates, which is exactly how a gate silently stops gating.
+    #[test]
+    fn a_declared_gate_never_parses_to_one_that_checks_nothing() {
+        for agent in BUNDLED_AGENTS {
+            let manifest = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .map(|(_, c)| *c)
+                .expect("every bundled agent has a manifest");
+            // The raw text says which edges *declare* a gate; the parsed
+            // blueprint says what those gates actually check. Comparing the two
+            // is the point: a gate that parses to nothing is invisible in the
+            // blueprint alone.
+            let declared = manifest.matches("gate = {").count();
+            let blueprint =
+                leviath_core::manifest::parse_manifest(manifest).expect("manifest parses");
+            let mut checking = 0;
+            for stage in &blueprint.stages {
+                for (target, edge) in stage.transitions.iter().flatten() {
+                    let Some(gate) = &edge.gate else { continue };
+                    let checks = gate.require_modifications
+                        || gate.region.is_some()
+                        || gate.require_region_updated.is_some();
+                    assert!(
+                        checks,
+                        "{}: {} -> {} declares a gate that checks nothing, so it \
+                         passes every time; check the spelling of its keys",
+                        agent.name, stage.name, target
+                    );
+                    checking += 1;
+                }
+            }
+            assert_eq!(
+                declared, checking,
+                "{}: {declared} edges write `gate = {{`, but {checking} parsed \
+                 into a gate - the difference is gates that were dropped",
+                agent.name
+            );
+        }
+    }
+
     /// A `transform = "custom"` edge must actually name regions.
     ///
     /// `transform_config` is parsed key by key, so a misspelt key leaves every

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -116,7 +116,7 @@ pub fn reload_run(
 ) -> Option<leviath_runtime::world::AgentId> {
     let run_dir = runs_dir.join(run_id);
     let meta = read_meta(&run_dir)?;
-    if is_terminal(&meta.status) {
+    if is_finished(&meta.status) {
         return None; // a finished run isn't paged back in
     }
     let entity = reload_one(world, deps, &meta, &run_dir).ok()?;
@@ -266,11 +266,20 @@ fn mark_crashed(run_dir: &Path, meta: RunMeta, reason: &str, now_secs: i64) {
 }
 
 /// Whether a run's status means it should not be resumed.
-fn is_terminal(status: &RunStatus) -> bool {
-    matches!(
-        status,
-        RunStatus::Complete | RunStatus::Cancelled | RunStatus::Error
-    )
+/// Whether this run is over, as opposed to merely stopped.
+///
+/// `Cancelled` is deliberately not here. A cancelled run keeps its journal, its
+/// context regions, its stage and iteration, and its parked fan-out state, so
+/// there is something to carry on from and `lev resume` should be able to reach
+/// it (#576). A `Complete` run has nothing left to do, and an `Error` one should
+/// be read before it is continued.
+///
+/// This governs paging a run back in on demand. Startup recovery has its own
+/// filter in `triage_restores`, which still drops cancelled runs: somebody
+/// stopped that run on purpose, and restarting the daemon is not them changing
+/// their mind.
+fn is_finished(status: &RunStatus) -> bool {
+    matches!(status, RunStatus::Complete | RunStatus::Error)
 }
 
 /// Reload one run: spawn it fresh from its blueprint, then overlay the persisted
@@ -1633,6 +1642,44 @@ mod tests {
         assert_eq!(order, vec!["zzz-active", "aaa-blocked"]);
     }
 
+    /// #576: cancelling stops a run, it does not end it. Everything needed to
+    /// carry on is on disk, so `lev resume` has to be able to reach it, which
+    /// means it has to page back in.
+    #[tokio::test]
+    async fn reload_run_pages_in_a_cancelled_run_but_not_a_finished_one() {
+        let agent = agent_dir();
+        let manifest = agent.path().join("agent.leviath");
+        let mpath = manifest.to_str().unwrap();
+        let runs = tempfile::tempdir().unwrap();
+        write_run(runs.path(), "stopped", mpath, RunStatus::Cancelled, None);
+        write_run(runs.path(), "died", mpath, RunStatus::Error, None);
+
+        let (mut world, cli) = test_world();
+        let hub = InteractionHub::new();
+        let mcp = Arc::new(Mutex::new(ToolExecutor::new()));
+        let config = Config::default();
+        let owners = Default::default();
+        let deps = |mcp: Arc<Mutex<ToolExecutor>>| crate::daemon::spawn::SpawnDeps {
+            tool_service: cli.as_ref(),
+            config: &config,
+            shared_mcp: mcp,
+            mcp_tool_defs: &[],
+            mcp_tool_owners: &owners,
+            hub: &hub,
+            now_secs: 1,
+            subagent_tx: sub_tx().clone(),
+        };
+
+        assert!(
+            reload_run(&mut world, deps(mcp.clone()), "stopped", runs.path()).is_some(),
+            "a cancelled run keeps its journal, context and stage, so it pages in"
+        );
+        assert!(
+            reload_run(&mut world, deps(mcp.clone()), "died", runs.path()).is_none(),
+            "a run that errored is read before it is continued, not resumed blind"
+        );
+    }
+
     #[tokio::test]
     async fn reload_run_pages_in_nonterminal_only() {
         let agent = agent_dir();
@@ -2288,11 +2335,13 @@ mod tests {
     }
 
     #[test]
-    fn is_terminal_covers_all_statuses() {
-        assert!(is_terminal(&RunStatus::Complete));
-        assert!(is_terminal(&RunStatus::Cancelled));
-        assert!(is_terminal(&RunStatus::Error));
-        assert!(!is_terminal(&RunStatus::Running));
-        assert!(!is_terminal(&RunStatus::WaitingInput));
+    fn is_finished_covers_all_statuses() {
+        assert!(is_finished(&RunStatus::Complete));
+        assert!(is_finished(&RunStatus::Error));
+        // The point of #576: a cancelled run stopped, it did not end, and
+        // everything it needs to carry on is still on disk.
+        assert!(!is_finished(&RunStatus::Cancelled));
+        assert!(!is_finished(&RunStatus::Running));
+        assert!(!is_finished(&RunStatus::WaitingInput));
     }
 }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -2090,6 +2090,19 @@ mod tests {
         assert!(world.open_circuits().is_empty());
     }
 
+    /// #576: a cancelled agent is stopped, not finished, so an explicit resume
+    /// puts it back to work. Nothing else does: it stays stopped until asked.
+    #[tokio::test]
+    async fn resume_restarts_a_cancelled_agent() {
+        let mut world = build_world(registry_with(vec![text("t1")]));
+        let e = spawn(&mut world);
+        assert!(world.cancel(e));
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Cancelled));
+
+        assert!(world.resume(e), "a cancelled run can be picked up again");
+        assert_eq!(world.agent_status(e), Some(AgentStatus::Active));
+    }
+
     /// An id belonging to another world names a different agent here, so
     /// resuming with one refuses rather than resuming whatever happens to sit
     /// at that entity index. This is the check `AgentId` exists for.

--- a/crates/leviath-runtime/src/world/control.rs
+++ b/crates/leviath-runtime/src/world/control.rs
@@ -59,7 +59,9 @@ impl PipelineWorld {
     }
 
     /// Resume a paused agent. `Idle` is also accepted (resume-as-nudge for an
-    /// agent that has not ticked yet); anything else returns `false`.
+    /// agent that has not ticked yet), and so is `Cancelled`: cancelling stops a
+    /// run rather than ending it, and everything it needs to carry on is still
+    /// on disk (#576). Anything else returns `false`.
     pub fn resume(&mut self, agent: AgentId) -> bool {
         // Resolved once, up front. Doing it again inside the arm below would
         // be a second check that cannot fail - the status lookup already
@@ -69,7 +71,7 @@ impl PipelineWorld {
             return false;
         };
         match self.agent_status(agent) {
-            Some(AgentStatus::Paused | AgentStatus::Idle) => {
+            Some(AgentStatus::Paused | AgentStatus::Idle | AgentStatus::Cancelled) => {
                 // An explicit resume says conditions have changed - most often
                 // a top-up after a run paused on exhausted credits (issue
                 // #413). A tripped breaker would otherwise hold the retry


### PR DESCRIPTION
## Two fixes, both measured on the finished v10 runs

### The researcher agents stopped filling the regions their own later stages read

Measured over two completed runs, across every context snapshot each took (225
and 251):

| | region | peak | budget | fill |
|---|---|---|---|---|
| deep | `claims` | **0** | 40,000 | 0% |
| deep | `contradictions` | **0** | 15,000 | 0% |
| deep | `analysis` | **0** | 150,000 | 0% |
| deep | `sources` | 149,066 | 150,000 | **99%** |
| wide | `comparisons` | 2,560 | 125,000 | **2%** |
| wide | `challenges` | **0** | 20,000 | 0% |
| wide | `landscape` | 125,247 | 150,000 | **83%** |

High-water marks across all snapshots, not the end state, so nothing reads as
unused merely because a transform cleared it on the way out.

This is not cosmetic. `challenge` is told to *"go through `claims`,
`contradictions` and `analysis`"* and was handed three empty regions, so the
adversarial pass had nothing to attack. `synthesize` is told to build the report
*"from `claims`"* and pull disagreements *"straight from `contradictions`"*, and
had neither. `sources` sits at 99% because it absorbed all four jobs.

The instruction to write them lived only in `system_prompt`. The decision is made
against `transition_prompt`, which never mentioned those regions, and nothing
checked afterwards, so the model did what it was told about at the moment of
choosing and skipped what it was told about at the start.

Both halves of the pair that has worked before: name it where the decision is
made, and gate the edge on the region having changed during the pass. The gate
allows three attempts and then lets the run through with a warning, so a model
with genuinely nothing to record cannot strand a run.

### A cancelled run is stopped, not finished

Closes #576.

Everything needed to carry on is already on disk, and the machinery that rebuilds
a run from it runs on every daemon restart. A status check grouped `Cancelled`
with `Complete` and `Error`, so `reload_run` refused to page it back in and
`lev resume` had nothing to reach.

`Complete` and `Error` stay finished. Startup recovery is untouched and still
leaves cancelled runs alone: somebody stopped that run on purpose, and restarting
the daemon is not them changing their mind.

## Guards, both checked by mutation

- a declared `gate` must parse into one that checks something. Its fields are
  read key by key, so a misspelt condition leaves them at their defaults and the
  edge ships with a gate that passes every time. Verified by misspelling
  `require_region_updated` and watching the guard catch it.
- the #576 tests were run against the unfixed code first and fail there.

## Gates

`cargo test --workspace --all-features`, `cargo xtask coverage` (100%, 13
packages), `cargo xtask docs`, `cargo xtask structure`, clippy clean.
