### PR TITLE
feat(runs): say what a run is spending while it is still spending it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ same list.
 
 ## Unreleased
 
+- Added: `[limits] notify_spend_usd = [5, 25, 100]` emits an event the first
+  time a run's spend passes each figure, naming the running total and the stage
+  that was running when it crossed. A run that quietly spent $274 looked, from
+  outside, exactly like one making ordinary progress; this is what says so while
+  it is still going. Reporting only: it does not stop a run, since stopping one
+  mid-stage throws away work and is a different decision. A run holding calls
+  that could not be priced says its figure is not exact rather than reporting a
+  confident number that is wrong (#573).
+
 - Fixed: a cancelled run can be resumed. Cancelling stops a run rather than
   ending it, and everything needed to carry on is already written down: the
   journal in `run.lvr`, every region in `context.json`, the stage and iteration

--- a/crates/leviath-cli/src/commands/serve/events.rs
+++ b/crates/leviath-cli/src/commands/serve/events.rs
@@ -13,6 +13,29 @@ use super::types::FinalOutputResp;
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerEvent {
+    /// A run's spend passed a figure the operator asked to be told about.
+    ///
+    /// Sent once per threshold per run. The point is to arrive while the run is
+    /// still going: a run that quietly spent far more than intended looked, from
+    /// outside, exactly like one making ordinary progress.
+    AgentSpend {
+        /// The agent's live id in the world.
+        agent_id: String,
+        /// The durable run id, and what a per-run subscription filters on.
+        run_id: String,
+        /// The figure that was crossed, in dollars.
+        threshold_usd: f64,
+        /// What the run has spent so far, in dollars.
+        total_usd: f64,
+        /// Whether every call behind that total could be priced. When false the
+        /// run has spent at least this, and more by an unknown amount, so it
+        /// must not be shown as a final figure.
+        exact: bool,
+        /// The stage that was running when it crossed. The full per-stage
+        /// breakdown is in the run's `stages.json`.
+        stage: String,
+    },
+
     /// Where a run stands, re-sent whenever any of it changes.
     AgentStatus {
         /// The agent's live id in the world.
@@ -230,7 +253,8 @@ impl ServerEvent {
             | ServerEvent::Tokens { run_id, .. }
             | ServerEvent::StageTransition { run_id, .. }
             | ServerEvent::ToolCallStarted { run_id, .. }
-            | ServerEvent::ToolCallFinished { run_id, .. } => run_id,
+            | ServerEvent::ToolCallFinished { run_id, .. }
+            | ServerEvent::AgentSpend { run_id, .. } => run_id,
             ServerEvent::DaemonLink { .. } => "",
         }
     }
@@ -496,6 +520,17 @@ mod tests {
                     summary: "ok".to_string(),
                 },
                 "r10",
+            ),
+            (
+                ServerEvent::AgentSpend {
+                    agent_id: "a".to_string(),
+                    run_id: "r11".to_string(),
+                    threshold_usd: 25.0,
+                    total_usd: 27.5,
+                    exact: true,
+                    stage: "analyze".to_string(),
+                },
+                "r11",
             ),
         ];
         for (ev, want) in cases {

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -178,6 +178,21 @@ fn wire_status(label: &str) -> String {
 /// no client knows to unwrap.
 fn to_server_event(event: WorldEvent) -> ServerEvent {
     match event {
+        WorldEvent::Spend {
+            run_id,
+            agent_id,
+            threshold_usd,
+            total_usd,
+            exact,
+            stage,
+        } => ServerEvent::AgentSpend {
+            agent_id,
+            run_id,
+            threshold_usd,
+            total_usd,
+            exact,
+            stage,
+        },
         WorldEvent::Spawned {
             run_id,
             agent_id,
@@ -563,6 +578,17 @@ mod tests {
 
     #[test]
     fn to_server_event_maps_every_variant() {
+        assert_eq!(
+            mapped_tag(WorldEvent::Spend {
+                run_id: "r".into(),
+                agent_id: "a".into(),
+                threshold_usd: 25.0,
+                total_usd: 27.5,
+                exact: true,
+                stage: "analyze".into(),
+            }),
+            "agent_spend"
+        );
         assert_eq!(
             mapped_tag(WorldEvent::Spawned {
                 run_id: "r".into(),

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -329,6 +329,26 @@ pub struct LimitsConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_run_write_bytes: Option<u64>,
 
+    /// Dollar figures at which a running agent emits a spend event.
+    ///
+    /// ```toml
+    /// [limits]
+    /// notify_spend_usd = [5, 25, 100]
+    /// ```
+    ///
+    /// Each is reported once per run, the first time that run's total passes it,
+    /// with the stage that was running at the time. Empty by default: nothing is
+    /// emitted for an operator who has not asked.
+    ///
+    /// This is the reporting half only. It does not stop a run - killing one
+    /// mid-stage throws away work, which is a different decision from being told
+    /// what is happening (#573).
+    ///
+    /// A run whose models have no published price reports what it could price
+    /// and says the figure is not exact, rather than reporting a confident zero.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notify_spend_usd: Vec<f64>,
+
     /// Per-model overrides of `max_concurrent_inferences`, keyed by model id.
     ///
     /// ```toml
@@ -447,6 +467,8 @@ impl Default for LimitsConfig {
         Self {
             max_concurrent_inferences: default_max_concurrent_inferences(),
             max_concurrent_tools: default_max_concurrent_tools(),
+            // Empty: nothing is emitted for an operator who has not asked.
+            notify_spend_usd: Vec::new(),
             default_max_iterations: default_default_max_iterations(),
             exact_token_counting: false,
             script_shell_timeout_secs: default_script_shell_timeout_secs(),

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -3556,6 +3556,7 @@ enabled = false
                 max_run_write_bytes: None,
                 max_concurrent_inferences: Some(4),
                 max_concurrent_tools: 3,
+                notify_spend_usd: Vec::new(),
                 default_max_iterations: Some(99),
                 exact_token_counting: false,
                 script_shell_timeout_secs: 45,

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -320,6 +320,9 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // How long the daemon may sit with a full tool lane and no run moving before
     // it widens the lane to break the jam (issue #191).
     host.set_dead_cycles_before_relief(parts.config.limits.dead_cycles_before_relief);
+    // Told once at start, like the other limits: a run that crosses one of these
+    // says so while it is still running, which is the whole point (#573).
+    host.set_spend_notify_usd(parts.config.limits.notify_spend_usd.clone());
     // How long a finished run keeps its place in the listing, so a scheduler
     // polling on an interval can see how a run ended (issue #205).
     host.set_finished_retention_secs(parts.config.limits.finished_retention_secs);

--- a/crates/leviath-runtime/src/host/emit.rs
+++ b/crates/leviath-runtime/src/host/emit.rs
@@ -75,6 +75,12 @@ impl WorldHost {
                     cached_tokens: totals.cached_tokens,
                     cache_write_tokens: totals.cache_write_tokens,
                     context_tokens,
+                    // `priced_usd` rather than `total_usd()`: a run with an
+                    // unpriced call has still spent what it could price, and
+                    // reporting nothing until every call is priced would stay
+                    // silent through exactly the run worth interrupting.
+                    cost_micros: super::events::usd_to_micros(totals.cost.priced_usd),
+                    cost_exact: totals.cost.total_usd().is_some(),
                     terminal,
                     wait_reason: self.wait_reason(agent),
                     title: self
@@ -163,6 +169,25 @@ impl WorldHost {
                     cached_tokens: cur.cached_tokens,
                     cache_write_tokens: cur.cache_write_tokens,
                 });
+            }
+
+            // Every threshold the total passed since the last pass, in order.
+            // Compared against what was emitted before rather than a per-run
+            // "highest seen", so a threshold is announced once and a run that
+            // jumps several in one pass announces each of them.
+            let spent_before = prev.as_ref().map(|e| e.cost_micros).unwrap_or(0);
+            for threshold in &self.spend_notify_usd {
+                let crossing = super::events::usd_to_micros(*threshold);
+                if spent_before < crossing && cur.cost_micros >= crossing {
+                    let _ = self.events.send(WorldEvent::Spend {
+                        run_id: run_id.clone(),
+                        agent_id: agent_id.clone(),
+                        threshold_usd: *threshold,
+                        total_usd: cur.cost_micros as f64 / 1_000_000.0,
+                        exact: cur.cost_exact,
+                        stage: cur.stage.clone(),
+                    });
+                }
             }
 
             if prev.as_ref().map(|e| e.context_tokens) != Some(cur.context_tokens) {

--- a/crates/leviath-runtime/src/host/events.rs
+++ b/crates/leviath-runtime/src/host/events.rs
@@ -32,6 +32,29 @@ use leviath_core::interaction::InteractionRequest;
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "event", rename_all = "snake_case")]
 pub enum WorldEvent {
+    /// A run's spend crossed a threshold the operator asked to hear about.
+    ///
+    /// One event per threshold, the first time the total passes it. A run that
+    /// crosses several between two passes gets one for each, in order, so a
+    /// consumer that acts on the highest sees them all.
+    Spend {
+        /// The run id.
+        run_id: String,
+        /// The agent id.
+        agent_id: String,
+        /// The threshold that was crossed, in dollars.
+        threshold_usd: f64,
+        /// What the run has spent in total, in dollars.
+        total_usd: f64,
+        /// Whether every call in that total could be priced. When false the
+        /// real figure is higher by however much went unpriced, so a consumer
+        /// must not present it as the invoice.
+        exact: bool,
+        /// The stage the run was in when it crossed - the one doing the
+        /// spending. The full per-stage breakdown is in `stages.json`.
+        stage: String,
+    },
+
     /// A run first appeared in the world.
     Spawned {
         /// The run id.
@@ -206,6 +229,18 @@ pub enum WorldEvent {
     },
 }
 
+/// Dollars as millionths of a dollar, saturating.
+///
+/// The unit [`Emitted::cost_micros`] and the spend thresholds are both kept in,
+/// so the comparison between them is integer and exact. A negative or
+/// non-finite input is zero: neither is a sum of money.
+pub(super) fn usd_to_micros(usd: f64) -> u64 {
+    if !usd.is_finite() || usd <= 0.0 {
+        return 0;
+    }
+    (usd * 1_000_000.0).round() as u64
+}
+
 impl WorldEvent {
     /// The run id this event belongs to. Every variant carries one; this saves
     /// consumers an exhaustive match (which, with the enum non-exhaustive,
@@ -222,6 +257,7 @@ impl WorldEvent {
             | WorldEvent::StageTransition { run_id, .. }
             | WorldEvent::ToolCallStarted { run_id, .. }
             | WorldEvent::ToolCallFinished { run_id, .. }
+            | WorldEvent::Spend { run_id, .. }
             | WorldEvent::Log { run_id, .. } => run_id,
         }
     }
@@ -256,6 +292,17 @@ pub(super) struct Emitted {
     pub(super) cached_tokens: usize,
     pub(super) cache_write_tokens: usize,
     pub(super) context_tokens: usize,
+    /// What the run had spent as of the last pass, in millionths of a dollar,
+    /// so a crossing is recognised by comparing against this rather than by
+    /// re-deriving it.
+    ///
+    /// An integer because this struct is hashed for the progress fingerprint,
+    /// and because it makes the comparison exact - a sub-cent call still counts
+    /// instead of rounding away.
+    pub(super) cost_micros: u64,
+    /// Whether that figure covers every call. A run with unpriced calls has
+    /// spent at least this much, and the event says which it is.
+    pub(super) cost_exact: bool,
     pub(super) terminal: bool,
     /// Why the run is parked, so a change of reason counts as a change worth
     /// telling subscribers about.
@@ -268,4 +315,40 @@ pub(super) struct Emitted {
     /// iteration it already sent would say nothing new. The title rides the
     /// next status frame that fires on its own.
     pub(super) title: Option<String>,
+}
+
+#[cfg(test)]
+mod spend_tests {
+    use super::*;
+
+    /// Money is compared in whole micros, so the threshold check is exact and
+    /// a sub-cent call still moves the total instead of rounding away.
+    #[test]
+    fn usd_to_micros_is_exact_and_refuses_what_is_not_money() {
+        assert_eq!(usd_to_micros(1.0), 1_000_000);
+        assert_eq!(usd_to_micros(0.000_001), 1, "a millionth still counts");
+        assert_eq!(usd_to_micros(27.5), 27_500_000);
+        // Neither of these is a sum of money, and either would otherwise
+        // become a nonsense integer.
+        assert_eq!(usd_to_micros(-5.0), 0);
+        assert_eq!(usd_to_micros(f64::NAN), 0);
+        assert_eq!(usd_to_micros(f64::INFINITY), 0);
+        assert_eq!(usd_to_micros(0.0), 0);
+    }
+
+    /// Every event names the run it is about, which is what a per-run
+    /// subscription filters on. A variant that answered wrongly here would be
+    /// delivered to the wrong subscriber, or to none.
+    #[test]
+    fn a_spend_event_names_its_run() {
+        let event = WorldEvent::Spend {
+            run_id: "run-spendy".into(),
+            agent_id: "agent-spendy".into(),
+            threshold_usd: 25.0,
+            total_usd: 27.5,
+            exact: true,
+            stage: "analyze".into(),
+        };
+        assert_eq!(event.run_id(), "run-spendy");
+    }
 }

--- a/crates/leviath-runtime/src/host/mod.rs
+++ b/crates/leviath-runtime/src/host/mod.rs
@@ -49,6 +49,10 @@ pub struct WorldHost {
     reaper: Option<Reaper>,
     events: broadcast::Sender<WorldEvent>,
     emitted: HashMap<String, Emitted>,
+    /// Dollar figures the operator wants to hear about, ascending. Empty by
+    /// default, which is the current behaviour: no events, no cost to anyone
+    /// who has not asked.
+    spend_notify_usd: Vec<f64>,
     emitted_interactions: HashSet<String>,
     /// Sub-agent world-access requests from tool lanes. The host holds a `tx`
     /// clone so the receiver never closes (its `recv` never yields `None`).
@@ -175,6 +179,7 @@ impl WorldHost {
             reaper: None,
             events,
             emitted: HashMap::new(),
+            spend_notify_usd: Vec::new(),
             emitted_interactions: HashSet::new(),
             parked: HashMap::new(),
             subagent_tx,
@@ -292,6 +297,21 @@ impl WorldHost {
                 ),
             },
         }
+    }
+
+    /// Dollar figures to emit [`WorldEvent::Spend`] at, in any order.
+    ///
+    /// Sorted and de-duplicated here so the caller can pass a config list as
+    /// written. Empty disables the events, which is the default: a run that
+    /// nobody asked to be told about costs nothing to watch.
+    ///
+    /// A threshold is reported once per run, the first time the total passes
+    /// it, so a long run does not repeat itself every pass.
+    pub fn set_spend_notify_usd(&mut self, mut thresholds: Vec<f64>) {
+        thresholds.retain(|t| t.is_finite() && *t > 0.0);
+        thresholds.sort_by(|a, b| a.partial_cmp(b).expect("finite, filtered above"));
+        thresholds.dedup();
+        self.spend_notify_usd = thresholds;
     }
 
     /// Install the spawner used to service `Spawn` control ops. Without one, a

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -2539,6 +2539,131 @@ async fn a_completed_event_without_an_answer_carries_none() {
     assert!(answer.is_none());
 }
 
+/// A run announces each spend threshold once, as it passes it.
+///
+/// The run that motivated this spent $274 while looking, from outside, exactly
+/// like one making ordinary progress (#573).
+#[tokio::test]
+async fn a_run_announces_each_spend_threshold_once_as_it_passes_it() {
+    let mut host = host_with(vec![text("done")]);
+    host.set_spend_notify_usd(vec![5.0, 1.0, 5.0, -3.0]);
+    let mut rx = host.subscribe();
+    let agent = spawn(&mut host, "run-spendy", "agent-spendy");
+    let entity = agent.entity();
+
+    // Baseline: the first pass emits the spawn frames and no spend, because
+    // nothing has been spent.
+    host.emit_events();
+    let opening: Vec<WorldEvent> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+    assert!(
+        !opening
+            .iter()
+            .any(|e| matches!(e, WorldEvent::Spend { .. })),
+        "a run that has spent nothing has nothing to announce"
+    );
+
+    // The spawn bundle here carries no totals, so the run gets one to move.
+    let set_cost = |host: &mut WorldHost, priced_usd: f64, unpriced: usize| {
+        let mut totals = host
+            .world_mut()
+            .world()
+            .get::<crate::persistence::TokenTotals>(entity)
+            .copied()
+            .unwrap_or_default();
+        totals.cost.priced_usd = priced_usd;
+        totals.cost.unpriced_calls = unpriced;
+        host.world_mut()
+            .world_mut()
+            .entity_mut(entity)
+            .insert(totals);
+    };
+
+    // Past the first threshold and not the second.
+    set_cost(&mut host, 2.0, 0);
+    host.emit_events();
+    let crossed: Vec<WorldEvent> = std::iter::from_fn(|| rx.try_recv().ok())
+        .filter(|e| matches!(e, WorldEvent::Spend { .. }))
+        .collect();
+    assert_eq!(crossed.len(), 1, "one threshold passed: {crossed:?}");
+    let WorldEvent::Spend {
+        threshold_usd,
+        total_usd,
+        exact,
+        stage,
+        ..
+    } = &crossed[0]
+    else {
+        unreachable!("filtered to Spend above")
+    };
+    assert_eq!(*threshold_usd, 1.0);
+    assert!((*total_usd - 2.0).abs() < 1e-9, "the running total");
+    assert!(*exact, "every call in this total was priced");
+    assert!(
+        !stage.is_empty(),
+        "and it names the stage doing the spending"
+    );
+
+    // Past the second. The first is not repeated: it was already announced.
+    set_cost(&mut host, 6.0, 1);
+    host.emit_events();
+    let again: Vec<WorldEvent> = std::iter::from_fn(|| rx.try_recv().ok())
+        .filter(|e| matches!(e, WorldEvent::Spend { .. }))
+        .collect();
+    assert_eq!(again.len(), 1, "only the newly passed one: {again:?}");
+    let WorldEvent::Spend {
+        threshold_usd,
+        exact,
+        ..
+    } = &again[0]
+    else {
+        unreachable!("filtered to Spend above")
+    };
+    assert_eq!(*threshold_usd, 5.0);
+    assert!(
+        !exact,
+        "a run holding an unpriced call has spent at least this, not exactly it"
+    );
+
+    // Nothing further to say while the total sits still.
+    host.emit_events();
+    let quiet: Vec<WorldEvent> = std::iter::from_fn(|| rx.try_recv().ok())
+        .filter(|e| matches!(e, WorldEvent::Spend { .. }))
+        .collect();
+    assert!(quiet.is_empty(), "a total that has not moved says nothing");
+}
+
+/// A run that jumps several thresholds between two passes announces each of
+/// them, so a consumer watching for the highest one still sees it.
+#[tokio::test]
+async fn a_single_jump_past_several_thresholds_announces_all_of_them() {
+    let mut host = host_with(vec![text("done")]);
+    host.set_spend_notify_usd(vec![1.0, 5.0, 25.0]);
+    let mut rx = host.subscribe();
+    let agent = spawn(&mut host, "run-jump", "agent-jump");
+    host.emit_events();
+    let _ = std::iter::from_fn(|| rx.try_recv().ok()).count();
+
+    let mut totals = crate::persistence::TokenTotals::default();
+    totals.cost.priced_usd = 30.0;
+    host.world_mut()
+        .world_mut()
+        .entity_mut(agent.entity())
+        .insert(totals);
+    host.emit_events();
+
+    let crossed: Vec<f64> = std::iter::from_fn(|| rx.try_recv().ok())
+        .filter_map(|e| match e {
+            WorldEvent::Spend { threshold_usd, .. } => Some(threshold_usd),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        crossed,
+        vec![1.0, 5.0, 25.0],
+        "each threshold passed, in order"
+    );
+}
+
 #[tokio::test]
 async fn emit_events_broadcasts_agent_changes() {
     let mut host = host_with(vec![text("done")]);

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -181,12 +181,32 @@ cerebras = 1                     # every model this provider serves, together
 | `max_run_write_bytes` | unset | Most a whole run may write. See below |
 | `max_concurrent_inferences_by_model` | empty | Per-model overrides of the cap above. See below |
 | `max_concurrent_inferences_by_provider` | empty | Per-provider caps across every model a provider serves. See below |
+| `notify_spend_usd` | empty | Dollar figures to be told about while a run is still going. See below |
 
-Nine of those need more than a table cell.
+Ten of those need more than a table cell.
 
 **`exact_token_counting`** measures each assembled request before sending it and refuses one that
 would overflow the window. On providers with a remote counting endpoint that costs a network round
 trip per inference, so it is off by default.
+
+**`notify_spend_usd`** says which figures are worth interrupting you for:
+
+```toml
+[limits]
+notify_spend_usd = [5, 25, 100]
+```
+
+Each is reported once per run, the first time that run's total passes it, over the event stream and
+in the dashboard. The event carries the running total and the stage that was running when it
+crossed, which is the stage doing the spending; the full per-stage breakdown is in the run's
+`stages.json`.
+
+This is reporting, not a ceiling. It does not stop a run, because stopping one mid-stage throws away
+work and that is a different decision from wanting to know what is happening.
+
+A run whose models have no published price reports what it could price and says the figure is not
+exact, rather than a confident number that is wrong. See [providers](/docs/providers) for where
+prices come from and when they are a reconstruction rather than the invoice.
 
 **`max_concurrent_inferences_by_model`** and **`max_concurrent_inferences_by_provider`** are the
 two ways to say "not this one". The first replaces the global cap for one model id. The second adds

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -316,6 +316,24 @@ takes a slot before calling the provider and holds it for the whole request. The
 `[limits] max_concurrent_inferences` in the [config](/docs/configuration); a model named in
 `[limits.max_concurrent_inferences_by_model]` uses its own number instead.
 
+One pool per *model*, which is what decides how wide a fan-out actually runs. Workers that resolve
+to the same model share a single pool no matter how many of them were spawned, so a fan-out of
+fifty agents that all lead with the same model runs `max_concurrent_inferences` at a time and the
+rest wait their turn. Measured on a 67-agent run where 65 agents resolved to one model: 9.9
+inference turns a minute against a default pool of 8.
+
+If a fan-out is slower than its worker count suggests, that is the first thing to check, and there
+are two ways to widen it. Raise the pool for the model the workers pile onto:
+
+```toml
+[limits.max_concurrent_inferences_by_model]
+"claude-sonnet-5" = 32
+```
+
+Or give the stages different models, which spreads them across separate pools. Neither is a rate
+limit: a provider rate limit is configured per provider under `[model_providers.<name>.rate_limit]`
+and is a different mechanism, so a slow fan-out is worth measuring before it is blamed on one.
+
 A provider named in `[limits.max_concurrent_inferences_by_provider]` gets a second, coarser pool in
 front of that one, bounding every model it serves together. A request takes a slot in both and
 holds both for its duration. It is for the metered API where the point of a small pool is bounding


### PR DESCRIPTION
Closes #573.

## The problem

A `deep-researcher` run cost **$274** and nothing in Leviath said so at the time.
From outside it looked exactly like ordinary progress: running, making tool
calls, nothing wrong. The overspend was visible only afterwards, by reading
`stages.json` and multiplying by prices held outside the system.

## What changed

The issue names the blocker as prices, and that is no longer missing: after the
pricing work, `TokenTotals` carries `CostTotals`, so every run already knows what
it has spent and how well it knows it. Verified on the two runs that finished
tonight, 67 agents between them: `cost_is_exact: true`, `unpriced_calls: 0`.

What was left was to watch the number.

```toml
[limits]
notify_spend_usd = [5, 25, 100]
```

Each figure is announced once per run, the first time the total passes it,
carrying the running total and the stage that was running when it crossed. It
goes out as `WorldEvent::Spend` and over the wire as `agent_spend`.

## Two design calls worth stating

**The thresholds are the operator's, not the blueprint's.** A blueprint author
cannot know whose account is paying or what counts as a lot of money on it. That
is the same reasoning that moved provider choice out of blueprints, so this reads
from config and applies to every run rather than being something each agent has
to remember to declare. The issue offered a `[run.spend]` blueprint block as one
option; this takes the other.

**Money is compared in whole millionths of a dollar**, not as a float. The
crossing test becomes exact, a sub-cent call still moves the total instead of
rounding away, and the snapshot stays hashable for the existing progress
fingerprint.

## Scoped out on purpose

- **The per-stage breakdown.** The event names the stage that crossed, which is
  the one spending. The full history is already in `stages.json`, and carrying a
  per-stage ledger into the event loop to duplicate it is not worth the plumbing.
- **`--max-spend`.** The issue calls it separable and it is: killing a run
  mid-stage throws away work, which is a different decision from wanting to know.

A run holding calls that could not be priced reports what it could price and says
`exact: false`, rather than a confident number that is wrong.

## Tests

- a run announces each threshold once as it passes it, driven through the real
  emit path, and stays quiet when the total does not move
- a single jump past several thresholds announces each of them in order, so a
  consumer watching for the highest still sees it
- the unpriced case reports `exact: false`
- the dollars-to-micros conversion refuses what is not money (negative, NaN, inf)
- `to_server_event` maps the new variant, and both `run_id()` matches answer for it

## Gates

`cargo test --workspace --all-features`, `cargo xtask coverage` (100%, 13
packages), `cargo xtask docs`, `cargo xtask structure`, clippy clean.
