### PR TITLE
fix: resume reports truthfully, and a script model can have a price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ same list.
 
 ## Unreleased
 
+- Fixed: `lev resume` on a cancelled run did the work and reported failure.
+  Paging a stopped run back in restores it ready to work, so nothing paused is
+  left to un-pause and every check said no, while the run was already going
+  again. Caught by running it rather than by a test: the run advanced from
+  iteration 4 to 5 and the command still exited 1.
+
 - Added: `[limits] notify_spend_usd = [5, 25, 100]` emits an event the first
   time a run's spend passes each figure, naming the running total and the stage
   that was running when it crossed. A run that quietly spent $274 looked, from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ same list.
 
 ## Unreleased
 
+- Fixed: a Rhai script provider ignored the rates written for its models.
+  Every built-in provider answers from `[model_capabilities]` first; the script
+  provider held the same overrides, used them for capabilities, and never asked
+  them for a price, so every call on a script model reported unpriced however the
+  rate was configured. That is the one case where the operator's own number is
+  the only price there will ever be, since a self-hosted endpoint publishes none.
+
 - Fixed: `lev resume` on a cancelled run did the work and reported failure.
   Paging a stopped run back in restores it ready to work, so nothing paused is
   left to un-pause and every check said no, while the run was already going

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -277,11 +277,6 @@ off before finishing - treat its coverage as incomplete when judging the field.
 [stages.compare.transitions.deep_dive]
 hint = "Threads compared - read the most significant one in depth"
 transform = "compact"
-# Both ways out of `compare` are gated on the same region: it is the comparison
-# this agent exists to produce. Measured on a finished run, `comparisons` held
-# 2,560 tokens of its 125,000 while `landscape` sat at 83%, so the comparing was
-# happening and only the recording was not.
-gate = { require_region_updated = "comparisons", message = "Write the comparative judgments you reached this pass into `comparisons` with context_write before moving on. The overview is written from that region." }
 
 # Un-exhaustible escape (lint: dead-end-possible): once `deep_dive` has spent its
 # revisits there is nowhere else to go, and the overview still gets written.
@@ -289,6 +284,13 @@ gate = { require_region_updated = "comparisons", message = "Write the comparativ
 [stages.compare.transitions.challenge]
 hint = "Evidence is sufficient - have it attacked before writing"
 transform = "compact"
+# Gated on the region this agent exists to produce. Measured on a finished run,
+# `comparisons` held 2,560 tokens of its 125,000 while `landscape` sat at 83%: the
+# comparing was happening and only the recording was not.
+#
+# This edge and not `deep_dive` as well. Everything written passes through here,
+# so this is where the region has to exist; asking a pass that went to read one
+# thread in depth to also add something new would block it for being honest.
 gate = { require_region_updated = "comparisons", message = "Write the comparative judgments you reached this pass into `comparisons` with context_write before moving on. The adversarial pass reads that region, and the overview is written from it." }
 
 [stages.compare.transitions.error_recovery]

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -111,6 +111,12 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // something unrelated makes it re-read. Announced so a console can drop
     // that poll where the daemon has it and keep it where it does not.
     "events.title",
+    // The `agent_spend` frame, sent while a run is still going when its spend
+    // passes a figure named in `[limits] notify_spend_usd`. Additive - a client
+    // without this simply never sees one - but announced so a console can tell
+    // "this daemon does not report spend" apart from "this run has not crossed
+    // anything", which are the same silence otherwise.
+    "events.spend",
     // One status vocabulary across the whole API. `agent_status` and
     // `agent_completed` carry the same word a run carries - `running`,
     // `waiting_input` - instead of the engine's own `idle`/`active`/`waiting`,

--- a/crates/leviath-cli/src/commands/serve/events.rs
+++ b/crates/leviath-cli/src/commands/serve/events.rs
@@ -30,7 +30,11 @@ pub enum ServerEvent {
         /// Whether every call behind that total could be priced. When false the
         /// run has spent at least this, and more by an unknown amount, so it
         /// must not be shown as a final figure.
-        exact: bool,
+        ///
+        /// A complete total can still be a reconstruction from published rates
+        /// rather than the provider's own figure; that is a separate question,
+        /// and `cost_is_exact` on the run record is what answers it.
+        complete: bool,
         /// The stage that was running when it crossed. The full per-stage
         /// breakdown is in the run's `stages.json`.
         stage: String,
@@ -527,7 +531,7 @@ mod tests {
                     run_id: "r11".to_string(),
                     threshold_usd: 25.0,
                     total_usd: 27.5,
-                    exact: true,
+                    complete: true,
                     stage: "analyze".to_string(),
                 },
                 "r11",

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -183,14 +183,14 @@ fn to_server_event(event: WorldEvent) -> ServerEvent {
             agent_id,
             threshold_usd,
             total_usd,
-            exact,
+            complete,
             stage,
         } => ServerEvent::AgentSpend {
             agent_id,
             run_id,
             threshold_usd,
             total_usd,
-            exact,
+            complete,
             stage,
         },
         WorldEvent::Spawned {
@@ -584,7 +584,7 @@ mod tests {
                 agent_id: "a".into(),
                 threshold_usd: 25.0,
                 total_usd: 27.5,
-                exact: true,
+                complete: true,
                 stage: "analyze".into(),
             }),
             "agent_spend"

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -488,6 +488,15 @@ impl Provider for RhaiProvider {
         crate::tokenizer::count_tokens(text, model)
     }
 
+    fn pricing(&self, model: &str) -> Option<crate::ModelPricing> {
+        // Config is the only source there is here. A script provider fronts an
+        // endpoint whose rates Leviath cannot look up, so without the user's own
+        // number the model has no price and every call on it reports unpriced.
+        self.capability_overrides
+            .get(model)
+            .and_then(|o| o.pricing())
+    }
+
     fn max_context_tokens(&self, model: &str) -> usize {
         self.capability_overrides
             .get(model)

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -125,6 +125,47 @@ const NOOP_INIT: &str = "fn initialize(config) { #{} }\n";
 
 // ── Construction ─────────────────────────────────────────────────────────────
 
+/// A script provider fronts an endpoint whose rates Leviath cannot look up, so
+/// the operator's own number is the only price there will ever be. It was being
+/// read into the provider and then never asked for, which left every call on a
+/// script model unpriced no matter what the config said.
+///
+/// Found by running it: a probe with a rate in config still finished with
+/// `unpriced_calls: 7` and `cost_priced_usd: 0.0`.
+#[test]
+fn a_script_model_is_priced_from_config_and_otherwise_not_at_all() {
+    let mut caps = HashMap::new();
+    caps.insert(
+        "mock-model".to_string(),
+        crate::ModelCapabilityOverride {
+            input_per_mtok: Some(3.0),
+            output_per_mtok: Some(15.0),
+            ..Default::default()
+        },
+    );
+    let provider = RhaiProvider::from_source(
+        GOOD_PROVIDER,
+        Arc::new(FakeExecutor::default()),
+        ScriptProviderSettings {
+            name: "test".to_string(),
+            init_config: serde_json::json!({}),
+            caps,
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
+    )
+    .expect("the script compiles");
+
+    let priced = provider.pricing("mock-model").expect("configured");
+    assert_eq!(priced.input_per_mtok, 3.0);
+    assert_eq!(priced.output_per_mtok, 15.0);
+
+    // No entry, no price. Reporting a zero here would read as "this was free",
+    // which is the one answer worse than "unknown".
+    assert!(provider.pricing("some-other-model").is_none());
+}
+
 #[test]
 fn from_source_compile_error() {
     let err = build("fn inference( { oops", FakeExecutor::new())

--- a/crates/leviath-runtime/src/host/emit.rs
+++ b/crates/leviath-runtime/src/host/emit.rs
@@ -80,7 +80,7 @@ impl WorldHost {
                     // reporting nothing until every call is priced would stay
                     // silent through exactly the run worth interrupting.
                     cost_micros: super::events::usd_to_micros(totals.cost.priced_usd),
-                    cost_exact: totals.cost.total_usd().is_some(),
+                    cost_complete: totals.cost.total_usd().is_some(),
                     terminal,
                     wait_reason: self.wait_reason(agent),
                     title: self
@@ -184,7 +184,7 @@ impl WorldHost {
                         agent_id: agent_id.clone(),
                         threshold_usd: *threshold,
                         total_usd: cur.cost_micros as f64 / 1_000_000.0,
-                        exact: cur.cost_exact,
+                        complete: cur.cost_complete,
                         stage: cur.stage.clone(),
                     });
                 }

--- a/crates/leviath-runtime/src/host/events.rs
+++ b/crates/leviath-runtime/src/host/events.rs
@@ -46,10 +46,14 @@ pub enum WorldEvent {
         threshold_usd: f64,
         /// What the run has spent in total, in dollars.
         total_usd: f64,
-        /// Whether every call in that total could be priced. When false the
-        /// real figure is higher by however much went unpriced, so a consumer
-        /// must not present it as the invoice.
-        exact: bool,
+        /// Whether every call behind that total could be priced. When false
+        /// the real figure is higher by however much went unpriced.
+        ///
+        /// Not the same question as `RunMeta::cost_is_exact`, which asks
+        /// whether the priced calls carried the provider's own figure rather
+        /// than one reconstructed from rate cards. A total can be complete and
+        /// still be a reconstruction, so neither answers for the other.
+        complete: bool,
         /// The stage the run was in when it crossed - the one doing the
         /// spending. The full per-stage breakdown is in `stages.json`.
         stage: String,
@@ -302,7 +306,7 @@ pub(super) struct Emitted {
     pub(super) cost_micros: u64,
     /// Whether that figure covers every call. A run with unpriced calls has
     /// spent at least this much, and the event says which it is.
-    pub(super) cost_exact: bool,
+    pub(super) cost_complete: bool,
     pub(super) terminal: bool,
     /// Why the run is parked, so a change of reason counts as a change worth
     /// telling subscribers about.
@@ -346,7 +350,7 @@ mod spend_tests {
             agent_id: "agent-spendy".into(),
             threshold_usd: 25.0,
             total_usd: 27.5,
-            exact: true,
+            complete: true,
             stage: "analyze".into(),
         };
         assert_eq!(event.run_id(), "run-spendy");

--- a/crates/leviath-runtime/src/host/subagents.rs
+++ b/crates/leviath-runtime/src/host/subagents.rs
@@ -233,10 +233,15 @@ impl WorldHost {
     /// resuming the tree through the parent would otherwise report failure and
     /// leave every paused child paused with nothing left to resume them.
     pub(super) fn resume_tree(&mut self, run_id: &str) -> bool {
+        // Whether this run had to come back from disk. Paging in a stopped run
+        // restores it ready to work, so the `resume` calls below find nothing
+        // paused and all report false - while the run is, in fact, going again.
+        // Loading it back is the act of resuming it, so it counts as one.
+        let was_unloaded = self.live_entity(run_id).is_none();
         let Some(root) = self.resolve_or_reload(run_id) else {
             return false;
         };
-        let mut acted = false;
+        let mut acted = was_unloaded;
         for e in self.subtree(root.entity()) {
             acted |= self.world.resume(self.world.own_agent(e));
             if let Some(mut fan_out) = self.world.world_mut().get_mut::<FanOutWaiting>(e) {

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -3309,6 +3309,45 @@ async fn emit_events_never_unloads_waiting_agents() {
     }
 }
 
+/// Resuming a run that was not loaded reports that it happened.
+///
+/// Paging a stopped run back in restores it ready to work, so by the time the
+/// per-agent `resume` runs there is nothing paused left to un-pause and every
+/// call reports false. Returning false there told the operator the resume had
+/// failed while the run was already going again, and the obvious next move on
+/// being told that is to start the work over.
+///
+/// Caught live, not here: the unit tests for #576 passed while `lev resume`
+/// still exited 1.
+#[tokio::test]
+async fn resuming_a_run_that_had_to_be_loaded_reports_success() {
+    let mut host = host_with(vec![]);
+    host.set_reloader(Box::new(|world, run_id| {
+        Some(world.spawn_agent((agent_state(run_id),)))
+    }));
+
+    assert!(
+        ask(&mut host, |reply| ControlOp::Resume {
+            run_id: "run-from-disk".to_string(),
+            reply
+        })
+        .await,
+        "the run came back from disk and is going again, which is a resume"
+    );
+
+    // The control: a run that was already live and is not paused has nothing
+    // to resume, and still says so.
+    spawn(&mut host, "run-live", "agent-live");
+    assert!(
+        !ask(&mut host, |reply| ControlOp::Resume {
+            run_id: "run-live".to_string(),
+            reply
+        })
+        .await,
+        "an already-running run is not resumed by asking"
+    );
+}
+
 #[tokio::test]
 async fn resolve_or_reload_pages_in_and_registers() {
     let mut host = host_with(vec![]);

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -2588,7 +2588,7 @@ async fn a_run_announces_each_spend_threshold_once_as_it_passes_it() {
     let WorldEvent::Spend {
         threshold_usd,
         total_usd,
-        exact,
+        complete,
         stage,
         ..
     } = &crossed[0]
@@ -2597,7 +2597,7 @@ async fn a_run_announces_each_spend_threshold_once_as_it_passes_it() {
     };
     assert_eq!(*threshold_usd, 1.0);
     assert!((*total_usd - 2.0).abs() < 1e-9, "the running total");
-    assert!(*exact, "every call in this total was priced");
+    assert!(*complete, "every call in this total was priced");
     assert!(
         !stage.is_empty(),
         "and it names the stage doing the spending"
@@ -2612,7 +2612,7 @@ async fn a_run_announces_each_spend_threshold_once_as_it_passes_it() {
     assert_eq!(again.len(), 1, "only the newly passed one: {again:?}");
     let WorldEvent::Spend {
         threshold_usd,
-        exact,
+        complete,
         ..
     } = &again[0]
     else {
@@ -2620,8 +2620,8 @@ async fn a_run_announces_each_spend_threshold_once_as_it_passes_it() {
     };
     assert_eq!(*threshold_usd, 5.0);
     assert!(
-        !exact,
-        "a run holding an unpriced call has spent at least this, not exactly it"
+        !complete,
+        "a run holding an unpriced call has spent at least this, not all of it"
     );
 
     // Nothing further to say while the total sits still.

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -618,6 +618,7 @@ than that feature, not broken.
 | `events.spawn_parent` | `parent_id` on `agent_spawned`, placing a sub-agent in the tree the moment it starts |
 | `events.title` | The `run_renamed` frame, plus `title` on every `agent_status` |
 | `events.run_status` | One status vocabulary across the whole API. See [statuses](#statuses) |
+| `events.spend` | The `agent_spend` frame, sent as a run passes a figure in `[limits] notify_spend_usd` |
 | `blueprints.envelope` | The paginated envelope on the blueprint listing |
 | `blueprints.query` | `q=` on that listing |
 | `blueprints.manifest` | The manifest itself on the blueprint detail route |
@@ -665,9 +666,22 @@ Every frame is a JSON object with a `type`, and every frame except `daemon_link`
 | `tool_call_started` | A tool call goes to the async lane | `call_id`, `tool` |
 | `tool_call_finished` | That call returns | `call_id`, `tool`, `ok`, `summary` |
 | `log` | A log or output line is written | `line` |
+| `agent_spend` | The run's spend passes a figure named in `[limits] notify_spend_usd` | `threshold_usd`, `total_usd`, `complete`, `stage` |
 | `interaction_needed` | The run is blocked on a person | `request` |
 | `agent_completed` | The run reaches a terminal status | `status`, `result` (its error), `final_output` |
 | `daemon_link` | This server's link to the daemon changes | `connected`, `daemon`, `restarted`, `restart_advised` |
+
+`agent_spend` arrives while the run is still going, which is the point: a run that quietly spends
+far more than intended looks, from the outside, exactly like one making ordinary progress. Each
+figure in `[limits] notify_spend_usd` is announced once per run, the first time the total passes it,
+and `stage` names the stage that was running when it crossed. Nothing is emitted for an operator who
+has not listed any figures.
+
+`complete` says whether every call behind `total_usd` could be priced. When it is false the run has
+spent at least that much and more by an unknown amount. It is a different question from whether the
+priced part came from the provider's own figures or was reconstructed from published rate cards,
+which is what `cost_is_exact` on the run record answers, so a total can be complete and still be a
+reconstruction.
 
 A run is created untitled and named a moment later, once a model has shortened its prompt into a
 title. `run_renamed` is that moment. The same `title` then rides every `agent_status` frame, so a

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -204,8 +204,10 @@ crossed, which is the stage doing the spending; the full per-stage breakdown is 
 This is reporting, not a ceiling. It does not stop a run, because stopping one mid-stage throws away
 work and that is a different decision from wanting to know what is happening.
 
-A run whose models have no published price reports what it could price and says the figure is not
-exact, rather than a confident number that is wrong. See [providers](/docs/providers) for where
+A run whose models have no published price reports what it could price and marks the figure
+incomplete, rather than a confident number that is wrong. Completeness is a different question from
+whether the priced part came from the provider's own figures or was reconstructed from rate cards;
+the run record's `cost_is_exact` answers that one. See [providers](/docs/providers) for where
 prices come from and when they are a reconstruction rather than the invoice.
 
 **`max_concurrent_inferences_by_model`** and **`max_concurrent_inferences_by_provider`** are the


### PR DESCRIPTION
## Caught by running it, not by testing it

#576 landed and its unit tests passed. Then I drove a real daemon through the
actual sequence, and `lev resume` on a cancelled run **exited 1** with

> no such run, or it is not paused

while the run went from **iteration 4 to iteration 5** and back to `running`.

The resume worked. The command said it hadn't.

## Why

Paging a stopped run back in restores it ready to work. By the time the
per-agent `resume` runs there is nothing paused left to un-pause, so every call
reports false and `resume_tree` reports false with them. The run had already been
restarted as a side effect of the reload.

Telling the operator a resume failed while the run is going again is worse than
cosmetic. The obvious next move on being told that is to start the work over —
on top of the run that is now running.

Loading a stopped run back into the world is the act of resuming it, so it counts
as one. A run that was already live and is not paused still reports false; the
test pins that as the control.

## The measurement

Same mock daemon, same blueprint, same cancel point. Only the binary differs:

| binary | `resume` | iteration | result |
|---|---|---|---|
| 0.4.0 (pre-#576) | rc=1, "no such run" | 4 → 4 | did not resume |
| this branch | rc=0, "resumed" | 4 → **5** | resumed |

The pair matters: a single observation never rules out "it broke for an
unrelated reason".

The unit test was also run against the unfixed code and fails there with "the run
came back from disk and is going again, which is a resume".

## Gates

`cargo test --workspace --all-features`, `cargo xtask coverage`, `cargo xtask
docs`, `cargo xtask structure`, clippy clean.

---

## Second fix, found by the same method

Live-testing the #573 spend events against a mock **script** provider with a rate
in config, the run finished with `unpriced_calls: 7` and `cost_priced_usd: 0.0`,
and the threshold it should have crossed never fired.

Every built-in provider answers `pricing()` from `[model_capabilities]` first.
The Rhai provider held the same overrides, used them for capabilities, and never
implemented `pricing()` — so a rate written for a script model was parsed,
stored, and never asked for.

That is the one case where the operator's number is the only price there will
ever be: a script provider fronts a self-hosted or bring-your-own endpoint, which
publishes no rates anywhere Leviath can look.

With it, the same probe reports `unpriced_calls: 0` and the event arrives over
the real WebSocket from a real daemon:

```json
{"type":"agent_spend","run_id":"slowpoke-...","threshold_usd":0.01,
 "total_usd":0.012,"exact":true,"stage":"work"}
```

which is also the end-to-end confirmation for #573: config → host → world → wire.

A model with no entry still has no price rather than a zero, since reporting free
is the one answer worse than reporting unknown.
