### PR TITLE
chore(release): 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
+## 0.5.0 - 2026-08-24
 
 - Fixed: naming a script provider as `default_provider` did not send any stage
   to it. A blueprint entry that names a model and no provider is resolved by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dirs",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -2626,7 +2626,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "leviath-core",
  "rhai",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "fs4",
  "keyring",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.4.0" }
-leviath-core = { path = "crates/leviath-core", version = "0.4.0" }
-leviath-net = { path = "crates/leviath-net", version = "0.4.0" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.4.0" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.4.0" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.4.0" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.4.0" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.4.0" }
-leviath-package = { path = "crates/leviath-package", version = "0.4.0" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.4.0" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.4.0" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.4.0" }
+leviath = { path = "crates/leviath", version = "0.5.0" }
+leviath-core = { path = "crates/leviath-core", version = "0.5.0" }
+leviath-net = { path = "crates/leviath-net", version = "0.5.0" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.0" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.0" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.5.0" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.0" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.0" }
+leviath-package = { path = "crates/leviath-package", version = "0.5.0" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.5.0" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.5.0" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.0" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.4.0", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.5.0", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": {
       "name": "MIT"


### PR DESCRIPTION
> **Merging this cuts the alpha release.** It is prepared and green, and left for
> you to merge rather than merged overnight.

`0.4.0` → `0.5.0`. Rolls `## Unreleased` into a dated heading: **136 entries**,
30 added, 29 changed, 64 fixed, 1 removed.

## What earns the minor bump

**A blueprint names models, not routes — and gets the models it named.** A stage
asking for `gemini-3.1-pro-preview` was running `claude-sonnet-5`, because
entries were matched as whole `provider/model` pairs and `default_provider` chose
among routes rather than among models. Measured against the installed build:

| stage | asked for | before | after |
|---|---|---|---|
| `synthesize` | `gpt-5.5` | `claude-opus-5` | `gpt-5.5` |
| `polish` | `gemini-3.1-pro-preview` | `claude-sonnet-5` | `gemini-3.1-pro-preview` |

All seven bundled agents are rewritten to name models and leave routing to the
machine, which is the user's business and never was the blueprint's (#578).

**A run knows what it costs, and says so while it is still spending.** Every
provider can price a call, and `[limits] notify_spend_usd` emits an event as a
run passes each figure. Verified on live runs: 67 agents, every call priced,
`unpriced_calls: 0` (#573).

**A cancelled run is stopped, not finished.** Everything needed to carry on was
already on disk; a status check was in the way (#576).

**A conversation carried across a stage boundary no longer breaks Gemini.** A
blueprint that runs one stage on grok and the next on Gemini was handing Gemini
function calls it never signed, which killed a run at iteration 35.

**The researcher agents write the regions their own later stages read from.**
Measured over two finished runs, `claims`, `contradictions` and `analysis` held
nothing across 225 snapshots while `sources` sat at 99% doing all four jobs.

## Verification

Beyond the gates, the fixes in this release were run against a real daemon, which
caught four things the tests could not: `lev resume` reporting failure on a
successful resume, script providers ignoring configured prices, one word meaning
two things about the same money, and a new wire frame shipping undocumented and
unannounced.

## Gates

`cargo test --workspace --all-features`, `cargo xtask coverage` (100%, 13
packages), `cargo xtask docs`, `cargo xtask structure`, clippy clean — all run
after the bump, not only before it.
