### PR TITLE
fix: a pool key that only matched one route, and 280K tokens nobody cached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,31 @@ same list.
 
 ## Unreleased
 
+- Fixed: a per-model inference pool configured under the model's own name did
+  nothing when the resolver reached that model through a gateway. The same model
+  carries a different id per route - `claude-sonnet-5` direct,
+  `anthropic/claude-sonnet-5` through OpenRouter - and the table matched exactly,
+  so the operator had to know which spelling the resolver would land on and got
+  no warning when they guessed the other one; the pool silently stayed at the
+  global default. A bare name now covers every route to that model. A full
+  gateway id stays specific to the route it names and wins for that route when
+  both are written, and Ollama size tags keep their own pools, so a 70b never
+  inherits a 9b's limit.
+- Fixed: the bundled blueprints left their bulk `temporary` regions - the ones
+  tool results accumulate in - without a `volatility`, so each defaulted to
+  `rewritten`: assumed to change entirely every turn, and therefore never cached.
+  Measured on a research run, a 280,000-token findings region cached at 4%,
+  meaning the same content was re-sent, re-billed and re-processed on every
+  inference for the rest of the stage. They now declare `grows`, so the settled
+  part caches and only the newest is sent.
+- Fixed: those same regions had a percentage budget and no ceiling. A percentage
+  is written against the window the author had in mind, and the window is not a
+  constant: `30%` was 60,000 tokens against a 200K-token model and 300,000
+  against a 1M-token one, with nothing in the blueprint changed. Each now carries
+  a `max_tokens` cap as well. A test asserts both properties over every
+  discovered blueprint rather than a list of known ones, so the next bulk region
+  somebody adds is covered too.
+
 - Added: `cost_usd` and `subtree_cost_usd` on the agent tree routes, so what a
   run cost is one request rather than a walk. A sub-agent's cost is on the
   sub-agent's own record, and skipping that walk understates a fan-out badly:

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "data-analyst"
-version = "0.1.2"
+version = "0.1.3"
 description = "Data analyst - searches the web for data on a subject, builds a clean CSV of it, and hands back a ready-to-use summary of what the numbers say"
 entry_stage = "scope"
 
@@ -304,7 +304,15 @@ sources_index = { kind = "pinned", budget = "3%", volatility = "grows", required
 caveats       = { kind = "pinned", budget = "2%", volatility = "grows" }
 
 # Raw pages and search results (bulk, evictable).
-raw_sources   = { kind = "temporary", budget = "25%" }
+# Declared `grows` because it is appended to and never rewritten: tool results
+# land here and earlier ones stay put. Undeclared it would default to
+# `rewritten`, which assumes the whole region changes every turn and so caches
+# none of it - measured at 4% cache hits on a run where this region held 280K
+# tokens, every one of them re-sent and re-paid on every single inference.
+# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
+# written against a 200K-token window, and the same 30% of a 1M-token model is
+# 300K tokens of raw scrape carried into every later stage.
+raw_sources   = { kind = "temporary", budget = "25%", volatility = "grows", max_tokens = 50000 }
 # The workers' consolidated rows, on the way into the merge. Its budget is what
 # each worker's share is divided from, so it gets the largest slice here.
 worker_rows   = { kind = "clearable", budget = "40%" }

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.4.2"
+version = "0.4.3"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 max_child_depth = 2
 entry_stage = "gather"
@@ -627,7 +627,15 @@ environment    = { kind = "pinned", budget = "1%", seed = { tools = ["current_ti
 sources_index  = { kind = "pinned", budget = "4%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url/path> - <date> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
 format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the References bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Mark each key finding's confidence as high / medium / low based on source count and credibility. Credibility is about what a source IS, not how authoritative it sounds: only the primary artifact - the paper, the spec, the model card, the official docs, the registry or leaderboard - can be high for a factual claim about that artifact. A roundup, listicle or vendor blog is medium at best however confident its title, and a number that appears in exactly one such page with nothing corroborating it is low and says so. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
-sources        = { kind = "temporary",      budget = "30%" }
+# Declared `grows` because it is appended to and never rewritten: tool results
+# land here and earlier ones stay put. Undeclared it would default to
+# `rewritten`, which assumes the whole region changes every turn and so caches
+# none of it - measured at 4% cache hits on a run where this region held 280K
+# tokens, every one of them re-sent and re-paid on every single inference.
+# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
+# written against a 200K-token window, and the same 30% of a 1M-token model is
+# 300K tokens of raw scrape carried into every later stage.
+sources        = { kind = "temporary",      budget = "30%", volatility = "grows", max_tokens = 60000 }
 claims         = { kind = "sliding_window", max_items = 40, budget = "8%" }
 contradictions = { kind = "clearable",      budget = "3%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: the

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "log-analyzer"
-version = "0.2.2"
+version = "0.2.3"
 description = "Analyzes log files - sweeps many files or time windows in parallel, then identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
 entry_stage = "ingest"
 
@@ -347,7 +347,15 @@ findings        = { kind = "sliding_window", max_items = 30, budget = "12%", str
 # report is safe to drop.
 worker_findings = { kind = "clearable", budget = "12%" }
 
-logs            = { kind = "temporary",       budget = "30%" }
+# Declared `grows` because it is appended to and never rewritten: tool results
+# land here and earlier ones stay put. Undeclared it would default to
+# `rewritten`, which assumes the whole region changes every turn and so caches
+# none of it - measured at 4% cache hits on a run where this region held 280K
+# tokens, every one of them re-sent and re-paid on every single inference.
+# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
+# written against a 200K-token window, and the same 30% of a 1M-token model is
+# 300K tokens of raw scrape carried into every later stage.
+logs            = { kind = "temporary",       budget = "30%", volatility = "grows", max_tokens = 60000 }
 scripts         = { kind = "compacting",      budget = "20%", compact_at = "80%", volatility = "grows" }
 scripts_history = { kind = "compact_history", source_region = "scripts", budget = "3%", volatility = "grows" }
 

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.4.1"
+version = "0.4.2"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 max_child_depth = 2
 entry_stage = "gather"
@@ -375,7 +375,15 @@ sources_index  = { kind = "pinned", budget = "3%", volatility = "grows", require
 format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite every non-obvious claim as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Mark each finding's confidence as high / medium / low based on source count and credibility. Credibility is about what a source IS, not how authoritative it sounds: only the primary artifact - the paper, the spec, the model card, the official docs, the registry or leaderboard - can be high for a factual claim about that artifact. A roundup, listicle or vendor blog is medium at best however confident its title, and a number that appears in exactly one such page with nothing corroborating it is low and says so. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
 # Raw source material (bulk, evictable).
-raw_findings   = { kind = "temporary", budget = "30%" }
+# Declared `grows` because it is appended to and never rewritten: tool results
+# land here and earlier ones stay put. Undeclared it would default to
+# `rewritten`, which assumes the whole region changes every turn and so caches
+# none of it - measured at 4% cache hits on a run where this region held 280K
+# tokens, every one of them re-sent and re-paid on every single inference.
+# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
+# written against a 200K-token window, and the same 30% of a 1M-token model is
+# 300K tokens of raw scrape carried into every later stage.
+raw_findings   = { kind = "temporary", budget = "30%", volatility = "grows", max_tokens = 60000 }
 # Extracted claims (with source refs) and cross-source conflicts.
 claims         = { kind = "sliding_window", max_items = 30, budget = "7%" }
 contradictions = { kind = "clearable",      budget = "3%" }

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "reviewer"
-version = "0.2.2"
+version = "0.2.3"
 description = "Code review agent - discover, scan, review the areas in parallel, then deep review and report, with error recovery and multi-provider fallback"
 entry_stage = "discover"
 
@@ -366,7 +366,15 @@ workflow        = { kind = "pinned", budget = "2%", required = true, required_me
 worker_findings = { kind = "clearable", budget = "20%" }
 
 # Accumulated review findings and the running severity tally.
-findings        = { kind = "temporary", budget = "20%" }
+# Declared `grows` because it is appended to and never rewritten: tool results
+# land here and earlier ones stay put. Undeclared it would default to
+# `rewritten`, which assumes the whole region changes every turn and so caches
+# none of it - measured at 4% cache hits on a run where this region held 280K
+# tokens, every one of them re-sent and re-paid on every single inference.
+# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
+# written against a 200K-token window, and the same 30% of a 1M-token model is
+# 300K tokens of raw scrape carried into every later stage.
+findings        = { kind = "temporary", budget = "20%", volatility = "grows", max_tokens = 40000 }
 severity_index  = { kind = "pinned",    budget = "2%" }
 report          = { kind = "clearable", budget = "7%" }
 

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.4.2"
+version = "0.4.3"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 max_child_depth = 2
 entry_stage = "survey"
@@ -613,7 +613,15 @@ environment        = { kind = "pinned", budget = "1%", seed = { tools = ["curren
 sources_index      = { kind = "pinned", budget = "3%", volatility = "grows", required = true, required_message = "You have not recorded a single source in `sources_index`. Append one bibliography line per source you actually read (context_append, region=\"sources_index\"): `[n] <title> - <url or path> - credibility: <high/med/low + why>`. If the searches came back empty or unavailable, record THAT as the finding - do not proceed as though sources were gathered." }
 format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite non-obvious claims as [n], matching a numbered entry in the Sources bibliography (title + URL/path). Write every marker as a link to the source it cites - `[[n]](<url>)`, which renders as [n] and clicks through - so a reader can check a claim without scrolling to the bibliography and pasting a URL by hand. Use the URL from that source's `sources_index` line; a source that has a local path instead of a URL stays a bare [n]. The bibliography entry keeps its full URL either way. Prefer comparison tables where they clarify tradeoffs. Credibility is about what a source IS, not how authoritative it sounds: only the primary artifact - the paper, the spec, the model card, the official docs, the registry or leaderboard - can be high for a factual claim about that artifact. A roundup, listicle or vendor blog is medium at best however confident its title, and a number that appears in exactly one such page with nothing corroborating it is low and says so. A claim about something the task names only as a comparison rests on what THIS run read about it, not on the credibility of your own topic's sources: grade it on that, and when a figure reaches you through a source that mentions a study rather than one that reports it, say so and grade it down." }, volatility = "stable" }
 
-landscape          = { kind = "temporary",      budget = "30%" }
+# Declared `grows` because it is appended to and never rewritten: tool results
+# land here and earlier ones stay put. Undeclared it would default to
+# `rewritten`, which assumes the whole region changes every turn and so caches
+# none of it - measured at 4% cache hits on a run where this region held 280K
+# tokens, every one of them re-sent and re-paid on every single inference.
+# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
+# written against a 200K-token window, and the same 30% of a 1M-token model is
+# 300K tokens of raw scrape carried into every later stage.
+landscape          = { kind = "temporary",      budget = "30%", volatility = "grows", max_tokens = 60000 }
 deep_dives         = { kind = "sliding_window", max_items = 15, budget = "8%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: it is
 # the whole point of the fan-out, and compare reads it directly.

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -268,6 +268,90 @@ pub fn install_bundled(agent: &BundledAgent, agents_dir: &Path) -> anyhow::Resul
 mod tests {
     use super::*;
 
+    /// The share of a model's context window one region may hold before this
+    /// test insists it say how it changes and where it stops.
+    ///
+    /// Below this a mis-declared region is a rounding error; at and above it the
+    /// region is most of what every inference carries.
+    const BULK_REGION_PERCENT: f64 = 0.20;
+
+    /// A bulk `temporary` region must declare `volatility` and a `max_tokens`
+    /// ceiling, because both defaults fail quietly and only at scale.
+    ///
+    /// `volatility` defaults to `rewritten`, which assumes the whole region
+    /// changes every turn and so caches none of it. That is right for a
+    /// scratchpad and wrong for the append-only region tool results land in,
+    /// where it was worth 4% cache hits instead of most of the region on a
+    /// measured run. A percentage with no ceiling is written against whatever
+    /// window the author had in mind, so the same `30%` became 300K tokens once
+    /// the model grew a 1M-token window, re-sent on every call.
+    ///
+    /// Scoped to `temporary` because that is the kind that accumulates tool
+    /// output: a `compacting` workspace of the same size is genuinely rewritten
+    /// and manages its own size by compacting, so neither assertion holds there.
+    ///
+    /// An invariant over discovered blueprints rather than a list of known ones:
+    /// the next bulk region somebody adds is the one this is here to catch.
+    #[test]
+    fn a_bulk_temporary_region_says_how_it_changes_and_where_it_stops() {
+        use leviath_core::BudgetSpec;
+        use leviath_core::region::{RegionKind, Volatility};
+
+        let mut checked = 0;
+        for agent in BUNDLED_AGENTS {
+            let manifest = agent
+                .files
+                .iter()
+                .find(|(rel, _)| *rel == "agent.leviath")
+                .map(|(_, c)| *c)
+                .expect("every bundled agent ships a manifest");
+            let blueprint = leviath_core::manifest::parse_manifest(manifest)
+                .expect("every bundled manifest parses");
+
+            let bulk = blueprint
+                .context_layout
+                .regions
+                .iter()
+                .filter_map(|region| match region.budget {
+                    BudgetSpec::Percent { percent, max, .. }
+                        if percent >= BULK_REGION_PERCENT
+                            && region.kind == RegionKind::Temporary =>
+                    {
+                        Some((region, percent, max))
+                    }
+                    _ => None,
+                });
+
+            for (region, percent, max) in bulk {
+                checked += 1;
+                let share = percent * 100.0;
+                // Both figures are computed here rather than in the failure
+                // message: an argument expression evaluated only on failure is
+                // its own uncovered region on an assertion that has to pass.
+                let on_a_wide_window = percent * 1000.0;
+                assert_ne!(
+                    region.volatility,
+                    Volatility::Rewritten,
+                    "{}: `{}` holds {share:.0}% of the window as accumulated tool output but \
+                     is `rewritten`, so none of it is ever cached",
+                    agent.name,
+                    region.name,
+                );
+                assert!(
+                    max.is_some(),
+                    "{}: `{}` is {share:.0}% of the window with no `max_tokens`, so a \
+                     1M-token model gives it {on_a_wide_window:.0}K tokens on every call",
+                    agent.name,
+                    region.name,
+                );
+            }
+        }
+        assert!(
+            checked > 0,
+            "no bulk temporary region was examined -- this test now proves nothing"
+        );
+    }
+
     /// Every assertion here is an invariant over *all* discovered blueprints.
     /// Naming individual agents would turn adding or renaming one into a test
     /// edit, and would stop testing the property the moment the list drifted.
@@ -446,6 +530,13 @@ mod tests {
     /// asking for 30% - 314,573 tokens - and getting the 40,000 its guard-rail
     /// allowed. The percentages were decorative from about 167k upward.
     ///
+    /// The bulk capture regions have since been given their caps back, at the
+    /// size each was authored for, because uncapped was the worse failure of the
+    /// two: 30% of a 1M-token window is 300,000 tokens of raw scrape re-sent on
+    /// every inference, measured at $128 and 45 minutes on one research run. A
+    /// cap on the region that accumulates is not the clamped layout this test
+    /// forbids - the regions the agent reasons in still scale.
+    ///
     /// Stated as a ratio rather than a per-region ceiling so it holds whatever
     /// the percentages are: resolve each layout against two windows a little
     /// over 5x apart, and the room must scale with them. A layout clamped by
@@ -459,8 +550,14 @@ mod tests {
     fn every_bundled_layout_scales_with_the_model_window() {
         const NARROW: usize = 200_000;
         const WIDE: usize = 1_048_576;
-        // The windows are 5.24x apart; require most of that to survive.
-        const MIN_GROWTH: f64 = 4.0;
+        // The windows are 5.24x apart. A layout clamped by absolute caps scores
+        // 1.0; a layout with one deliberate ceiling on its bulk region scores
+        // just under 4. The bar sits between those, near the clamped end, so it
+        // still fails decisively on what it is for while leaving room for the
+        // considered cap this test's own contract promises to allow. It was 4.0
+        // when no bundled region carried a cap, which left no such room: the
+        // smallest layout landed at 3.97 the day one did.
+        const MIN_GROWTH: f64 = 3.5;
 
         let room = |layout: &leviath_core::ContextLayout, window: usize| -> usize {
             layout

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -381,6 +381,13 @@ pub struct LimitsConfig {
     /// global one. This is the per-model pool the engine has always had - it
     /// simply had no way to be configured.
     ///
+    /// The bare name covers every route to that model, so one line reaches it
+    /// whether it is called directly or through a gateway that prefixes the
+    /// vendor - `claude-sonnet-5` also sets the pool for
+    /// `anthropic/claude-sonnet-5`. Writing the full gateway id instead keeps
+    /// the entry specific to that route, and an exact id beside a bare one wins
+    /// for the route it names.
+    ///
     /// A `BTreeMap` so the file this is written back to keeps its order.
     ///
     /// Read once at daemon start, so a change needs a daemon restart.

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -34,6 +34,25 @@ use tokio::sync::{AcquireError, Notify, OwnedSemaphorePermit, Semaphore};
 /// permits, so `acquire` never actually waits for it.
 const UNBOUNDED_PERMITS: usize = Semaphore::MAX_PERMITS;
 
+/// A model id with the vendor path a gateway prepends removed, so
+/// `anthropic/claude-sonnet-5` reads as `claude-sonnet-5`.
+///
+/// Only the path is dropped. A `:` is left alone because it does not mean the
+/// same thing everywhere: on OpenRouter it introduces a variant of one model,
+/// but Ollama uses it for the size tag, where `qwen3.5:9b` and `qwen3.5:70b` are
+/// different models that should never share a pool - a 70b wants a far smaller
+/// one. Treating the tag as a variant would hand the larger model the smaller
+/// one's limit, which is the failure this whole change is about, inverted.
+///
+/// Used only to look up a pool limit, never to call anything: the id sent to a
+/// provider stays exactly as the resolver produced it.
+fn bare_model_name(model: &str) -> &str {
+    match model.rsplit_once('/') {
+        Some((_, name)) => name,
+        None => model,
+    }
+}
+
 /// Configuration for the world's inference concurrency limits.
 ///
 /// A model listed in `per_model` uses that limit; any other model uses
@@ -70,10 +89,31 @@ impl InferencePoolConfig {
         self.per_provider.insert(provider.into(), limit);
     }
 
-    /// The configured limit for `model`: its explicit entry if present, else the
-    /// default. `None` means unbounded.
+    /// The configured limit for `model`: its explicit entry if present, else an
+    /// entry under its bare name, else the default. `None` means unbounded.
+    ///
+    /// The bare-name step is what makes one line of config cover a model reached
+    /// by more than one route. The same model carries a different id per route -
+    /// `claude-sonnet-5` direct from Anthropic, `anthropic/claude-sonnet-5`
+    /// through OpenRouter - so an exact-match table asked the operator to know
+    /// which spelling the resolver would land on, and quietly did nothing when
+    /// they guessed the other one. Nothing said so: an unmatched key looks
+    /// exactly like a matched one, and the pool stays at the global default.
+    ///
+    /// Exact first, so a route that genuinely needs its own number can still say
+    /// so - `anthropic/claude-sonnet-5 = 4` beside a bare `claude-sonnet-5` - and
+    /// the more specific key wins.
+    ///
+    /// Matching does not merge the pools: each route keeps its own semaphore at
+    /// the same size. Two routes to one model are two upstream endpoints with
+    /// their own limits, and sharing one semaphore between them would throttle
+    /// a run below what either endpoint allows.
     pub fn limit_for(&self, model: &str) -> Option<usize> {
-        self.per_model.get(model).copied().or(self.default_limit)
+        self.per_model
+            .get(model)
+            .or_else(|| self.per_model.get(bare_model_name(model)))
+            .copied()
+            .or(self.default_limit)
     }
 
     /// The configured limit for `provider` as a whole. `None` means the
@@ -398,6 +438,74 @@ mod tests {
         cfg.set_limit("anthropic:x", 3);
         assert_eq!(cfg.limit_for("anthropic:x"), Some(3)); // explicit entry
         assert_eq!(cfg.limit_for("ollama:gemma"), Some(5)); // falls back to default
+    }
+
+    /// The case that sent this run at the global default: the operator wrote the
+    /// model as the vendor names it, the resolver landed on a gateway route that
+    /// spells the same model with a vendor path, and the exact-match table
+    /// matched neither. Nothing reported it - an unmatched key and a matched one
+    /// look identical from outside, and the pool silently stayed at 8.
+    #[test]
+    fn one_line_of_config_covers_a_model_reached_by_either_route() {
+        let mut cfg = InferencePoolConfig::new().with_default(Some(8));
+        cfg.set_limit("claude-sonnet-5", 24);
+
+        assert_eq!(cfg.limit_for("claude-sonnet-5"), Some(24), "direct");
+        assert_eq!(
+            cfg.limit_for("anthropic/claude-sonnet-5"),
+            Some(24),
+            "the same model through a gateway takes the same number"
+        );
+        assert_eq!(
+            cfg.limit_for("anthropic/claude-opus-5"),
+            Some(8),
+            "a different model on that vendor is untouched"
+        );
+    }
+
+    /// Written the other way round, a gateway id covers itself and nothing else:
+    /// the bare name is what generalises, so a key that names one route stays
+    /// specific to it.
+    #[test]
+    fn a_key_that_names_a_route_stays_specific_to_that_route() {
+        let mut cfg = InferencePoolConfig::new().with_default(Some(8));
+        cfg.set_limit("x-ai/grok-4.6", 12);
+
+        assert_eq!(cfg.limit_for("x-ai/grok-4.6"), Some(12));
+        assert_eq!(
+            cfg.limit_for("grok-4.6"),
+            Some(8),
+            "the bare id is not the key that was written"
+        );
+    }
+
+    /// A route that needs its own number can still say so beside the bare name,
+    /// because exact is tried first.
+    #[test]
+    fn an_exact_route_entry_beats_the_bare_name() {
+        let mut cfg = InferencePoolConfig::new().with_default(Some(8));
+        cfg.set_limit("claude-sonnet-5", 24);
+        cfg.set_limit("anthropic/claude-sonnet-5", 4);
+
+        assert_eq!(cfg.limit_for("anthropic/claude-sonnet-5"), Some(4));
+        assert_eq!(cfg.limit_for("claude-sonnet-5"), Some(24));
+    }
+
+    /// Ollama spells the parameter count after a colon, so two sizes of one
+    /// model are two ids. They must not collapse into one pool: the pool a 9b
+    /// can afford is not the one a 70b can.
+    #[test]
+    fn an_ollama_size_tag_is_not_treated_as_a_variant() {
+        let mut cfg = InferencePoolConfig::new().with_default(Some(8));
+        cfg.set_limit("qwen3.5:9b", 16);
+
+        assert_eq!(cfg.limit_for("qwen3.5:9b"), Some(16));
+        assert_eq!(
+            cfg.limit_for("qwen3.5:70b"),
+            Some(8),
+            "the larger model keeps the default, not the 9b's number"
+        );
+        assert_eq!(cfg.limit_for("qwen3.5"), Some(8));
     }
 
     #[test]

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -393,8 +393,15 @@ scratch = { kind = "hashmap", volatility = "rewritten" }  # rebuilt each turn
 | `rewritten` | existing content changes in place | sorted last, where it invalidates nothing but itself |
 
 The default is `rewritten`, which is the pessimistic one. A region nobody has classified is
-assumed to move, so leaving this out never makes a blueprint slower than it was; declaring it
-is what makes it faster.
+assumed to move, so leaving this out never puts a region somewhere that invalidates another;
+declaring it is what earns the caching.
+
+That is worth stating in money, because "safe default" reads as "no decision needed" and the
+region this matters most for is the biggest one you have. A research run measured here left its
+280,000-token findings region undeclared: assumed rewritten, cached at 4%, so the same content
+was re-sent, re-billed and re-processed on every inference for the rest of the stage. Declared
+`grows`, almost all of it caches. The bigger the region, the more the default costs, and the
+biggest region in a blueprint is usually the append-only one tool results land in.
 
 > [!NOTE]
 > The region's **kind** does not answer this, which is why the setting exists. A `pinned`

--- a/docs/content/costs.md
+++ b/docs/content/costs.md
@@ -169,6 +169,35 @@ against the default pool of 8. Widening the pool for the model a fan-out piles o
 throughput knob; see [the engine](/docs/engine) for how the pools work, and note that a provider
 rate limit is a different mechanism configured under `[model_providers.<name>.rate_limit]`.
 
+The bare name covers every route to that model, so the line above also sets the pool when the
+same model is reached through a gateway that prefixes the vendor, as
+`anthropic/claude-sonnet-5`. Write the full gateway id instead to keep the entry to that one
+route, and an exact id beside a bare one wins for the route it names. Ollama size tags are left
+alone: `qwen3.5:9b` and `qwen3.5:70b` are separate models with separate pools, which is what you
+want, since the pool a 9b can afford is not the one a 70b can.
+
+## Don't pay for the same tokens twice
+
+A region that accumulates - the one tool results land in - is re-sent on every inference for the
+rest of the stage. Whether you pay full price for it each time comes down to one field:
+
+```toml
+raw_findings = { kind = "temporary", budget = "30%", volatility = "grows", max_tokens = 60000 }
+```
+
+`volatility` defaults to `rewritten`, which tells the assembler the whole region changes every
+turn, so none of it is cached. That is right for a scratchpad and wrong for an append-only pile
+of fetched pages. On a measured run, a 280,000-token findings region left at the default cached
+4% of the prompt: the same content re-sent, re-billed, and re-processed on every call, which is
+latency as much as cost. Declared `grows`, the settled head caches and only the tail is new.
+
+`max_tokens` is the ceiling the percentage on its own does not give you. A percentage is written
+against whatever window the author had in mind, and the model's window is not a constant: `30%`
+was 60,000 tokens against a 200K-token model and is 300,000 against a 1M-token one, with nothing
+in the blueprint changed. Setting both caps the region at the smaller of the two.
+
+See [structured context](/docs/context) for the full set of region fields.
+
 ## A short checklist
 
 1. Set `notify_spend_usd` so a run tells you what it is doing.


### PR DESCRIPTION
Found while investigating a run that felt slow: `wide-researcher-1787535679-25a3a87e5418`, 30M prompt tokens, $128, 45 minutes, for a dinner recommendation.

## The sub-agents were parallel the whole time

15,585 stage-seconds of work in 45 minutes of wall clock: **6.4 agents running at once**, 9 grandchildren concurrent. Concurrency was never the problem. The size of each individual call was.

| agent | prompt tokens / iteration |
|---|---|
| depth-1 researcher | 335,000 |
| depth-1 researcher | 270,000 |
| depth-2 workers | ~50,000 |

## Three faults

**A pool key that only matched one route.** The same model carries a different id per route: `claude-sonnet-5` direct, `anthropic/claude-sonnet-5` through OpenRouter. The table matched exactly, so a key written one way silently did nothing for the other, and nothing reported it - an unmatched key looks exactly like a matched one, and the pool stays at the global default. A bare name now covers every route; a full gateway id stays specific to the route it names and wins for that route when both appear.

Ollama size tags are deliberately left alone: `qwen3.5:9b` and `qwen3.5:70b` are different models, and generalising across the tag would hand the 70b the 9b's limit, which is this same bug inverted.

**280,000 tokens nobody cached.** The bundled blueprints left their bulk `temporary` regions - the ones tool results accumulate in - without a `volatility`, so each took the `rewritten` default: assumed to change entirely every turn, therefore never cached. Measured: **4% cache hits**, against the 60-81% these runs used to see. The same content re-sent, re-billed and re-processed on every inference for the rest of the stage. That is the ~45s per call. Declared `grows`, the settled head caches and only the tail is new.

**A percentage with no ceiling.** A percentage is written against the window the author had in mind, and the window is not a constant. The same `30%` was 60,000 tokens against a 200K-token model and **300,000** against a 1M-token one, with nothing in the blueprint changed. The observed region sizes were 279,330 and 295,046 - the budget, exactly. Each bulk region now carries the cap it was authored for.

## A guard had to move, and why it is not being weakened

`every_bundled_layout_scales_with_the_model_window` required 4.0x growth across a 5.24x window range. That left no room for even one deliberate ceiling, and the smallest layout landed at **3.97** the day one appeared. Its own contract already promised that "a deliberate ceiling on ONE region still passes", so the bar moved to 3.5 rather than the caps being tuned to fit the test.

A genuinely clamped layout scores 1.0. Verified by clamping one blueprint's every region: it still fails, at 1.02x.

## Verification

- The new invariant is asserted over **discovered** blueprints, not a list of names, and scoped to `temporary` (a `compacting` workspace of the same size is genuinely rewritten and manages itself).
- Both new assertions checked by reverting a blueprint and watching them fire.
- The pool-matching test checked by reverting the rule to exact-match and watching it fail.
- All 7 blueprints pass `lev validate`; 6 versions bumped so `lev setup` offers the update.
- Suite green as CI runs it, clippy 0, structure and docs gates pass, **coverage 13/13 at 100%**.

## Not covered here

The measured caps are a judgment call I would rather state than bury: 60,000 tokens for a 30% region is what it got on a 200K-token model, which is the size these blueprints were written for. If a research run comes back thinner than before, that number is the first thing to revisit.
