### PR TITLE
fix: the adversarial pass was reading regions that did not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,36 @@ same list.
 
 ## Unreleased
 
+- Fixed: `wide-researcher`'s adversarial pass told the model to go through
+  `claims`, `contradictions` and `analysis` - three regions that belong to
+  `deep-researcher`, which is where the stage had been copied from. Nothing
+  failed: the stage ran, found nothing to attack because it was looking for
+  regions that were not there, and passed the report through unchallenged. It
+  now reads the regions this blueprint actually has, and a test asserts over
+  every bundled blueprint that a stage prompt never names a region its own
+  blueprint does not declare.
+- Fixed: the `deep_dive` stage wrote nothing. On a measured run it spent 77
+  seconds, made no tool call, and left its `deep_dives` region empty, while
+  `compare` next door - which gates its edge on having written `comparisons` -
+  filled its region every pass. The edge out of `deep_dive` is now gated the
+  same way, so a focused read that records nothing cannot be mistaken for one
+  that never happened.
+- Fixed: a research report is written from the `claims` region, and `claims` was
+  a 30-item sliding window, so claim 31 evicted claim 1 and no run could deliver
+  more than 30 findings however much it read. Measured: an agent that consumed
+  8.8M tokens and cost $35 handed back 2,596 bytes, fewer than one that consumed
+  462K and cost $2.41, because both filled the same 30 slots. The window is now
+  wide enough that the token budget is what bounds it.
+- Changed: the researcher's summarize stage no longer asks for a "concise"
+  report. Concision is right for a report a person reads and wrong for one
+  another agent reads, and this blueprint is both - as a fan-out worker its
+  report IS the hand-off, so anything left out is deleted from the run. Length
+  now follows the material.
+- Added: `deep_dive` and `challenge` state in their transition prompts that
+  going back to `survey` is available and when to take it. Both already had that
+  edge and neither used it; an edge a transition prompt does not mention is one
+  the model does not weigh.
+
 - Fixed: a per-model inference pool configured under the model's own name did
   nothing when the resolver reached that model through a gateway. The same model
   carries a different id per route - `claude-sonnet-5` direct,

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.4.2"
+version = "0.4.3"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 max_child_depth = 2
 entry_stage = "gather"
@@ -202,7 +202,7 @@ transform = "direct"
 [stages.summarize]
 mode = "autonomous"
 model = { models = ["claude-sonnet-5", "gpt-5.4-mini", "gemini-3.5-flash", { provider = "ollama", model = "qwen3.5:9b" }] }
-description = "Create a concise, well-organized summary"
+description = "Write up everything found, organized by theme"
 available_tools = ["write_file", "read_file"]
 max_iterations = 10
 system_prompt = """
@@ -224,8 +224,20 @@ Structure:
 - Open questions.
 - Sources - the numbered bibliography from `sources_index`.
 
-Keep it tight and skimmable. Every non-obvious claim must carry a linked
-`[[n]](<url>)` citation.
+Length follows the material: every claim in `claims` that bears on the question
+gets its line, and a claim is dropped only because it is irrelevant or
+unsupported, never to keep the page short. Be dense rather than brief - no
+throat-clearing, no restating the question, no summary of the summary - but do
+not compress by leaving findings out.
+
+This matters most when you are a worker in a fan-out. Then this report is not
+read by a person, it IS the hand-off: whatever you leave out is deleted from the
+run, because the agent that reads it cannot see your sources, your `claims`, or
+anything you decided was not worth the space. It has only this. A worker that
+returns a tidy page while its region holds five times as much has thrown away
+what it was paid to find.
+
+Every non-obvious claim must carry a linked `[[n]](<url>)` citation.
 
 A qualifier travels with the claim it qualifies. If the evidence says "yes, with
 offload" or "tight", or the figure came from one uncorroborated page, the
@@ -385,7 +397,13 @@ format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite ever
 # 300K tokens of raw scrape carried into every later stage.
 raw_findings   = { kind = "temporary", budget = "30%", volatility = "grows", max_tokens = 60000 }
 # Extracted claims (with source refs) and cross-source conflicts.
-claims         = { kind = "sliding_window", max_items = 30, budget = "7%" }
+# The report is written FROM this region, so anything evicted here is a finding
+# the run paid for and cannot deliver. At 30 items that bound was reached long
+# before the reading was: on one measured run an agent read 8.8M tokens, spent
+# $35, and handed back 2,596 bytes - fewer than one that read 462K and spent
+# $2.41, because both filled the same 30 slots. Wide enough now that the budget
+# is what limits it, which is a limit that scales with the model.
+claims         = { kind = "sliding_window", max_items = 150, budget = "15%", volatility = "grows", max_tokens = 30000 }
 contradictions = { kind = "clearable",      budget = "3%" }
 
 # Synthesis workspace (compacts to a running history when it grows).

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.4.3"
+version = "0.4.4"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 max_child_depth = 2
 entry_stage = "survey"
@@ -312,6 +312,16 @@ best sources on JUST that thread, read them, and append the findings to
 source refs) and a bibliography line to `sources_index`. Then hand back to compare.
 Stay on the flagged thread - this is depth on one item, not a new broad survey.
 """
+transition_prompt = """
+Decide the next move:
+- This read exposed something the survey never covered - a name, a category, a
+  kind of source that is absent from `sources_index` - → respond with: survey,
+  naming what to go and get. This is one of only two ways left to widen what the
+  report can draw on, so take it whenever the gap is nameable rather than noting
+  it and moving on.
+- Another flagged thread is still worth a focused read → respond with: compare
+- The threads worth reading have been read → respond with: challenge
+"""
 
 [stages.deep_dive.tool_routing]
 default_region = "conversation"
@@ -334,6 +344,13 @@ transform = "compact"
 [stages.deep_dive.transitions.challenge]
 hint = "Done here - hand to the adversarial pass, which is the only way to the report"
 transform = "compact"
+# Everything leaving this stage for good passes through here, so this is where
+# the region has to exist. Without it the stage produced nothing at all: on one
+# measured run it spent 77 seconds, made no tool call, and left `deep_dives`
+# empty, while `compare` next door - which has a gate - filled its region every
+# pass. A focused read that records nothing is indistinguishable from one that
+# never happened.
+gate = { require_region_updated = "deep_dives", message = "This stage is a focused read and it has to leave a trace. Append what you found to `deep_dives` with context_append: what makes this thread notable, with source refs, and a bibliography line to `sources_index` for anything you opened. If the read changed nothing about your judgment, write THAT and why - a thread that turned out to be ordinary is a finding the report can use." }
 
 [stages.deep_dive.transitions.error_recovery]
 condition = "error"
@@ -476,8 +493,9 @@ system_prompt = """
 You are reading someone else's analysis in order to attack it. You did not
 write it and you owe it nothing.
 
-Go through `claims`, `contradictions` and `analysis`. For each thing the report
-is going to assert, ask the uncomfortable question:
+Go through `thread_findings`, `comparisons` and `deep_dives` - what the workers
+handed back, the judgments compare reached, and any focused read. For each thing
+the report is going to assert, ask the uncomfortable question:
 
 - What single source is this resting on, and would I believe it alone?
 - Is the confidence claimed higher than the evidence supports?
@@ -486,6 +504,12 @@ is going to assert, ask the uncomfortable question:
   what someone said about it?
 - What would have to be true for this conclusion to be wrong, and did anyone
   check that?
+- Is anything MISSING? Read `sources_index` and ask what kind of source is not
+  in it. A survey that found its candidates through category listings has only
+  what that category is indexed under, and the best answer is often filed
+  somewhere else - a different category, an award or a guide, a venue rather
+  than its type. Name what is absent and where it would be found: absence is a
+  finding, and this is the last stage that can still go and get it.
 
 Write each challenge to `challenges` (context_append) as one line:
 `[!] <the claim> - <what is wrong with the support> - <what would settle it>`
@@ -504,8 +528,22 @@ Say when something holds. If a claim is well supported, write
 ever objects is indistinguishable from noise, and the reader cannot tell which
 of your objections to take seriously.
 
-If the analysis is sound throughout, say so and stop. You are not required to
-find fault.
+You are not required to invent fault. You are required to look: read the regions
+named above and say what you found, per claim. "It all looks fine" without that
+reading is the one answer this stage cannot give, because it is also what an
+adversary that never ran would produce, and the two are indistinguishable from
+outside.
+"""
+transition_prompt = """
+Decide the next move:
+- A challenge you just wrote needs evidence nobody has gathered, or you named a
+  kind of source missing from `sources_index` → respond with: survey, naming
+  what to go and get. Going back is the point of this stage existing before the
+  report rather than after it, and it is the ONLY remaining way to add anything
+  the survey missed. Prefer it whenever you named an absence: a gap you record
+  and do not fill is one the report ships with.
+- Every challenge is recorded and each one is either settled or is a caveat the
+  report can state honestly → respond with: summarize
 """
 
 [stages.challenge.transitions.survey]
@@ -515,6 +553,11 @@ transform = "compact"
 [stages.challenge.transitions.summarize]
 hint = "Challenges are recorded - write the overview"
 transform = "compact"
+# On the edge to the report, not on the one back to `survey`: a pass that found
+# a real gap should be able to go and fill it without first writing up why it is
+# leaving. This is the last edge before the deliverable, so it is where "the
+# adversarial pass actually ran" has to be provable.
+gate = { require_region_updated = "challenges", message = "Write this pass's challenges to `challenges` with context_append, one line each: `[!] <claim> - <what is wrong with the support> - <what would settle it>`, or `[ok] <claim> - <why the support is sufficient>` for the ones that hold. Include at least one line about what is MISSING from `sources_index` rather than wrong in it. The stage is not done until that region has them: a pass that leaves it empty is indistinguishable from one that never read anything." }
 
 [stages.challenge.transitions.error_recovery]
 condition = "error"

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -268,6 +268,111 @@ pub fn install_bundled(agent: &BundledAgent, agents_dir: &Path) -> anyhow::Resul
 mod tests {
     use super::*;
 
+    /// The words a prompt wraps in backticks, which is how these blueprints
+    /// refer to a region.
+    fn backticked_words(prompt: &str) -> Vec<String> {
+        prompt
+            .split('`')
+            .skip(1)
+            .step_by(2)
+            .filter(|w| {
+                !w.is_empty()
+                    && w.chars()
+                        .all(|c| c.is_ascii_lowercase() || c == '_' || c.is_ascii_digit())
+            })
+            .map(str::to_string)
+            .collect()
+    }
+
+    /// A stage prompt must not send the model to a region the blueprint does
+    /// not have.
+    ///
+    /// `wide-researcher`'s adversarial pass told the model to "go through
+    /// `claims`, `contradictions` and `analysis`" - three regions belonging to
+    /// `deep-researcher`, which is where the stage had been copied from. Nothing
+    /// failed. The stage ran, found nothing to attack because it was looking for
+    /// regions that were not there, wrote a token gesture and passed the report
+    /// through unchallenged. A copied stage keeps working right up until it
+    /// mentions a region by name, which is exactly the edit nobody re-reads.
+    ///
+    /// Matched on the backticked names a prompt uses, against the regions the
+    /// blueprint declares plus the ones the runtime supplies. Anything else in
+    /// backticks - a tool, a filename, a TOML key - is not a region and does not
+    /// belong in the comparison, so the check runs against the set of names that
+    /// ARE regions somewhere in the bundled set: a name that is a region in one
+    /// blueprint and undeclared in another is the mistake being caught.
+    #[test]
+    fn no_stage_prompt_names_a_region_its_blueprint_does_not_have() {
+        // Supplied by the runtime rather than declared, so a prompt may name
+        // them anywhere.
+        const RUNTIME_REGIONS: [&str; 4] = [
+            "conversation",
+            "tool_results",
+            "final_output",
+            "stage_instructions",
+        ];
+
+        let parsed: Vec<_> = BUNDLED_AGENTS
+            .iter()
+            .map(|agent| {
+                let manifest = agent
+                    .files
+                    .iter()
+                    .find(|(rel, _)| *rel == "agent.leviath")
+                    .map(|(_, c)| *c)
+                    .expect("every bundled agent ships a manifest");
+                let blueprint = leviath_core::manifest::parse_manifest(manifest)
+                    .expect("every bundled manifest parses");
+                (agent.name, blueprint)
+            })
+            .collect();
+
+        // Every name that is a region in at least one bundled blueprint. A word
+        // in backticks is only held to this if it names a region somewhere.
+        let mut region_vocabulary: std::collections::HashSet<&str> =
+            RUNTIME_REGIONS.into_iter().collect();
+        for (_, blueprint) in &parsed {
+            for region in &blueprint.context_layout.regions {
+                region_vocabulary.insert(region.name.as_str());
+            }
+        }
+
+        let mut checked = 0;
+        for (name, blueprint) in &parsed {
+            let declared: std::collections::HashSet<&str> = blueprint
+                .context_layout
+                .regions
+                .iter()
+                .map(|r| r.name.as_str())
+                .chain(RUNTIME_REGIONS)
+                .collect();
+
+            for stage in &blueprint.stages {
+                let prompts = ["system_prompt", "split_prompt"]
+                    .iter()
+                    .filter_map(|k| stage.config.get(*k).and_then(|v| v.as_str()))
+                    .chain(stage.transition_prompt.as_deref());
+                for named in prompts.flat_map(backticked_words) {
+                    if !region_vocabulary.contains(named.as_str()) {
+                        continue;
+                    }
+                    checked += 1;
+                    assert!(
+                        declared.contains(named.as_str()),
+                        "{name}: stage `{}` tells the model to use region `{named}`, which this \
+                         blueprint does not declare. It is a region in another bundled blueprint, \
+                         so this is a stage copied across without renaming its regions.",
+                        stage.name,
+                    );
+                }
+            }
+        }
+        assert!(
+            checked > 0,
+            "no prompt named a region -- this test now proves nothing"
+        );
+    }
+
     /// The share of a model's context window one region may hold before this
     /// test insists it say how it changes and where it stops.
     ///


### PR DESCRIPTION
Chasing why a $137 run read 32M tokens and delivered a 4,911-byte report. The fan-out count turned out to be the wrong suspect, so this fixes what the measurement actually pointed at.

## The fan-out was not the constraint

| agent | cap | produced |
|---|---|---|
| wide-researcher (parent) | `max_workers=12`, `max_items=30` | **3** |
| researcher (children) | `max_workers=3`, `max_items=3` | exactly 3 |

The parent could have made 30 and chose 3. Nothing was capped there, so raising caps would not have changed it. What bound the run was how little survived each hand-off.

## Three faults

**The adversarial pass was reading regions that do not exist.** `wide-researcher`'s challenge stage told the model to "go through `claims`, `contradictions` and `analysis`". Those are `deep-researcher` regions - the stage had been copied across and its region names never updated. So the pass went looking for three regions this blueprint does not have, found nothing to attack, and passed the report through unchallenged.

Nothing failed and nothing warned. A copied stage keeps working right up until it mentions a region by name, which is exactly the edit nobody re-reads. It now reads the regions this blueprint has, and a test asserts the property over every bundled blueprint.

**`deep_dive` wrote nothing at all** - 77 seconds, no tool call, `deep_dives` empty at every stage of the run. `compare` next door gates its outgoing edge on having written `comparisons`, and filled its region every pass. The difference was the gate. `deep_dive` has one now, on the edge meaning "done here" rather than the ones meaning "I need more", since blocking a pass for moving on honestly is what the compare gate's own note warns against. `challenge` is gated the same way on the edge to the report.

**The hand-off was the largest of the three.** A report is written *from* the `claims` region, and `claims` was a 30-item sliding window - claim 31 evicted claim 1, so no agent could deliver more than 30 findings however much it read. Output size is flat at ~2.5KB while input varies 19x:

| agent | consumed | cost | returned |
|---|---|---|---|
| 55810cce | 462K tokens | $2.41 | 2,612 B |
| ffe68407 | 8.8M tokens | **$35.52** | **2,596 B** |

15x the money, fewer bytes back, because both filled the same 30 slots. The window is now bounded by the token budget instead, and the summarize prompt no longer asks for concision - right for a report a person reads, wrong for one another agent reads, and this blueprint is both. As a fan-out worker its report *is* the hand-off, so anything left out is deleted from the run.

## Both widening edges existed and neither was used

`deep_dive → survey` and `challenge → survey` were already in the blueprint. The run took neither. Both are now named in their stages' transition prompts along with the condition that should trigger them, because an edge a transition prompt does not mention is one the model does not weigh. `challenge` also gained an explicit "is anything missing?" question, since the pass only ever asked whether the claims on hand were well supported, never whether the set was complete.

## Verification

- The ghost-region test was checked against the real bug: restoring `claims`/`contradictions`/`analysis` to the challenge prompt makes it fail with the exact diagnosis.
- It only holds a backticked word to the rule if that word is a region in some bundled blueprint, so tools, filenames and TOML keys are not swept in.
- Gate placement verified by parsing the manifest and reading back which edge carries each gate. The first attempt put `gate` on the stage - the parser rejected it rather than accepting it silently.
- All 7 blueprints pass `lev validate`; the 2 changed ones are version-bumped.
- Suite green as CI runs it, clippy 0, structure and docs gates pass, **coverage 13/13 at 100%**.

## Deliberately not in this PR

The fan-out caps. Raising them multiplies agents that each still return one summary, which buys cost rather than coverage. The right order is to re-measure the hand-off on a live run first and see how much wider it actually got - if sub-agent output moves off its ~2.5KB ceiling, the caps become the next thing worth touching; if it does not, raising them would only have made the bill larger.
