### PR TITLE
fix: a run settled its candidate list from one index and never asked what it left out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,29 @@ same list.
 
 ## Unreleased
 
+- Fixed: `deep-researcher` carried the same ceiling just lifted from
+  `researcher` - its report is written from `claims`, and `claims` was a 40-item
+  sliding window, so a run above a fan-out of up to twelve workers could deliver
+  forty findings however much they handed back. Every worker's findings funnel
+  through those slots, which makes it the level where the ceiling cost most.
+- Fixed: the research blueprints told the model to find "the authoritative index
+  for the domain" and stopped there, so a run settled its whole candidate list
+  from one index without ever learning what that index leaves out. Every index
+  has an inclusion rule, and the rule is invisible from inside: a category
+  listing looks like a list of everything, because the things it excludes are
+  the ones it does not mention. On a measured run every candidate came from
+  category listings, and a well-regarded subject filed under a different
+  category was never a candidate at all - it appeared twice in 32M tokens, both
+  times as page furniture. The survey stages now require crossing two
+  structurally different kinds of index and asking what would have to be true of
+  something for it to appear in neither.
+- Changed: `wide-researcher`'s overview no longer asks the model to "write
+  concisely". Density is worth asking for and brevity is not: the entries a
+  shorter draft drops first are the unfamiliar ones that take a sentence more to
+  explain, which are also the ones the reader could not have found alone. It now
+  asks for coverage, and for the long tail to arrive with what makes it
+  different.
+
 - Fixed: `wide-researcher`'s adversarial pass told the model to go through
   `claims`, `contradictions` and `analysis` - three regions that belong to
   `deep-researcher`, which is where the stage had been copied from. Nothing

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.4.3"
+version = "0.4.4"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 max_child_depth = 2
 entry_stage = "gather"
@@ -46,6 +46,27 @@ authoritative references, not a broad skim.
   sources, not one of them a model card, and every hard number resting on a
   single page nobody else corroborates. Go to the artifact itself for anything
   you are going to state as a number.
+
+  One index is one filter. Every index - a registry, a leaderboard, a category
+  listing, a "best of" roundup - has an inclusion rule, and whatever sits outside
+  that rule is not ranked low in it, it is absent from it entirely, so reading
+  further down will never surface it. The rule is invisible from inside: a
+  category listing looks like a list of everything, because the things it leaves
+  out are the things it does not mention.
+
+  So cross at least two indexes of DIFFERENT KINDS before settling the list, and
+  record which kinds in `sources_index`. Different kinds means structurally
+  different: a category listing and a second category listing are one index twice.
+  Reach for what a category filter cannot reach - awards and guides, a
+  professional body's own roster, the "related" and "see also" edges out of a page
+  you already trust, the venue or umbrella an entry belongs to rather than the
+  type it is filed under, and what the primary source claims to be itself.
+
+  Then ask the question that catches the filter: what would something in this
+  field have to be for it NOT to appear in the indexes I used? Name one such thing
+  and go looking for it specifically. A run that finds nothing there has spent one
+  search confirming its coverage; a run that skips the question cannot tell a
+  complete landscape from a well-filtered one, and neither can its reader.
 - Run a focused first round of web_search calls across the distinct facets of the
   question, then web_fetch the most authoritative results for detail. Prefer
   primary sources (papers, standards, official docs) over summaries. read_file for
@@ -636,7 +657,13 @@ format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite ever
 # written against a 200K-token window, and the same 30% of a 1M-token model is
 # 300K tokens of raw scrape carried into every later stage.
 sources        = { kind = "temporary",      budget = "30%", volatility = "grows", max_tokens = 60000 }
-claims         = { kind = "sliding_window", max_items = 40, budget = "8%" }
+# The report is written FROM this region, so anything evicted here is a finding
+# the run paid for and cannot deliver. 40 items bounds the report long before the
+# reading is done - and this blueprint sits above a fan-out of up to 12 workers,
+# so it is the level where the ceiling costs most: every worker's findings funnel
+# through these slots. Wide enough now that the budget is what limits it, which
+# is a limit that scales with the model.
+claims         = { kind = "sliding_window", max_items = 150, budget = "15%", volatility = "grows", max_tokens = 30000 }
 contradictions = { kind = "clearable",      budget = "3%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: the
 # analysis stage reads it directly and it is the point of the fan-out.

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.4.3"
+version = "0.4.4"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 max_child_depth = 2
 entry_stage = "gather"
@@ -43,6 +43,27 @@ Be efficient - do not search exhaustively:
    none: the model cards, the leaderboard, the vendor's docs, the registry.
    Searching the question as asked returns roundups; go to the artifact itself
    for anything you will state as a number.
+
+   One index is one filter. Every index - a registry, a leaderboard, a category
+   listing, a "best of" roundup - has an inclusion rule, and whatever sits outside
+   that rule is not ranked low in it, it is absent from it entirely, so reading
+   further down will never surface it. The rule is invisible from inside: a
+   category listing looks like a list of everything, because the things it leaves
+   out are the things it does not mention.
+
+   So cross at least two indexes of DIFFERENT KINDS before settling the list, and
+   record which kinds in `sources_index`. Different kinds means structurally
+   different: a category listing and a second category listing are one index twice.
+   Reach for what a category filter cannot reach - awards and guides, a
+   professional body's own roster, the "related" and "see also" edges out of a page
+   you already trust, the venue or umbrella an entry belongs to rather than the
+   type it is filed under, and what the primary source claims to be itself.
+
+   Then ask the question that catches the filter: what would something in this
+   field have to be for it NOT to appear in the indexes I used? Name one such thing
+   and go looking for it specifically. A run that finds nothing there has spent one
+   search confirming its coverage; a run that skips the question cannot tell a
+   complete landscape from a well-filtered one, and neither can its reader.
 1. Run a FOCUSED first round of 3-5 web_search calls covering the distinct
    sub-topics of the question (not many rephrasings of the same query).
 2. web_fetch only the 2-3 most promising sources for detail; the search snippets

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.4.4"
+version = "0.4.5"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 max_child_depth = 2
 entry_stage = "survey"
@@ -54,6 +54,27 @@ A "which one should I use" question has an index too, even when it names none:
 the model cards, the leaderboard, the vendor's own docs, the package registry.
 Searching the question as asked returns roundups and listicles; go to the
 artifact itself for anything you are going to state as a number.
+
+One index is one filter. Every index - a registry, a leaderboard, a category
+listing, a "best of" roundup - has an inclusion rule, and whatever sits outside
+that rule is not ranked low in it, it is absent from it entirely, so reading
+further down will never surface it. The rule is invisible from inside: a
+category listing looks like a list of everything, because the things it leaves
+out are the things it does not mention.
+
+So cross at least two indexes of DIFFERENT KINDS before settling the list, and
+record which kinds in `sources_index`. Different kinds means structurally
+different: a category listing and a second category listing are one index twice.
+Reach for what a category filter cannot reach - awards and guides, a
+professional body's own roster, the "related" and "see also" edges out of a page
+you already trust, the venue or umbrella an entry belongs to rather than the
+type it is filed under, and what the primary source claims to be itself.
+
+Then ask the question that catches the filter: what would something in this
+field have to be for it NOT to appear in the indexes I used? Name one such thing
+and go looking for it specifically. A run that finds nothing there has spent one
+search confirming its coverage; a run that skips the question cannot tell a
+complete landscape from a well-filtered one, and neither can its reader.
 
 Today's date is in the `environment` region. Treat it as authoritative over
 anything you remember: your training has a cutoff and this run does not. Judge
@@ -378,8 +399,21 @@ citing `sources_index` per the rules in `format`. Include:
 Every `[n]` in the prose is a link to its source - `[[n]](<url>)` - so the
 reader can click through from the claim.
 
-Write concisely - the reader wants the lay of the land quickly. Cite sources for
-non-obvious claims.
+Write densely, not briefly. The reader wants the lay of the land quickly, and
+that is a reason to cut throat-clearing, restated questions and summaries of
+summaries - it is not a reason to cover fewer candidates. Coverage is the
+deliverable here: a survey that names four of the twelve things the run
+investigated has thrown away most of what it was asked for, and the reader has
+no way to tell that the other eight were ever looked at.
+
+The long tail is where this stage earns its keep. The obvious entries are the
+ones the reader could have found alone in ten minutes; the one they could not is
+usually the one a shorter draft drops first, because it is unfamiliar and takes
+a sentence more to explain. If the run gathered something that does not fit the
+main recommendation, it goes in with what makes it different rather than being
+cut for tidiness.
+
+Cite sources for non-obvious claims.
 
 A qualifier travels with the claim it qualifies. If the evidence says "yes, with
 offload" or "tight", or the figure came from one uncorroborated page, the


### PR DESCRIPTION
The last three narrowings from the fan-out investigation. Each is in a different place and all point the same way: the run gathered far more than it delivered.

## `deep-researcher` still had the ceiling

Its report is written from `claims`, and `claims` was a 40-item sliding window - the same bug lifted from `researcher` in #591, in the blueprint that sits above a fan-out of **up to twelve** workers. Every worker's findings funnelled through forty slots, which makes this the level where the bound cost most. Now bounded by the token budget, which scales with the model.

## The survey stages settled the list from one index

They told the model to find *"the authoritative index for the domain"* and stopped there. That is good advice which quietly assumes one index sees everything.

Every index has an inclusion rule, and the rule is invisible from inside: a category listing reads as a list of everything, because whatever it excludes is precisely what it does not mention.

Measured on the run that started this:

- all **7** discovery queries were category-framed (`best steakhouse…`, `best seafood restaurants…`, `best family friendly restaurants…`)
- every candidate came from a category listing - the top fetched domains were Tripadvisor (628), Yelp (469), OpenTable (386), all category index pages
- a Forbes Five-Star subject with 140 Yelp reviews, filed under a *different* category, was never a candidate. It appears twice in 32M tokens, both times as page furniture - a "you might have missed" sidebar and an unrendered `<option>` - and never once as a result

The stages now require crossing two **structurally different** kinds of index before settling the list (a category listing plus a second category listing is one index twice), name the kinds a category filter cannot reach, and end with the question that catches the filter: *what would something have to be for it to appear in neither of the indexes I used?*

A run that looks and finds nothing has spent one search confirming its coverage. A run that skips the question cannot tell a complete landscape from a well-filtered one, and neither can whoever reads it.

Applied to all three research blueprints, since all three have a discovery stage.

## The overview asked for concision

Density is worth asking for; brevity is not. The entries a shorter draft drops first are the unfamiliar ones that need a sentence more to explain - which are the same entries the reader could not have found alone in ten minutes. It now asks for coverage, and for the long tail to arrive with what makes it different.

## What proves this

Honestly: a run, not a test. These are prompt and region changes with no code behind them, so CI can only show that nothing regressed.

- ghost-region and layout-scaling invariants still hold
- all 7 blueprints pass `lev validate`
- the 3 changed ones are version-bumped, so `lev setup` will offer them
- suite green as CI runs it, clippy 0, docs gate passes, **coverage 13/13 at 100%**

## Still deliberately out

The fan-out caps, unchanged since #591 for the same reason: raising them multiplies agents that each return one summary. The hand-off had to widen first, and whether it did is a question for the next live run.
