### PR TITLE
fix: three of the five issues filed on 2026-08-24 (#586, #587, #588)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ same list.
 
 ## Unreleased
 
+- Fixed: `lev serve` announced itself before it had the port. A machine where
+  something else already held 3000 saw `Leviath API server listening on
+  http://127.0.0.1:3000` and then a bare `os error 48`, which reads as a server
+  that started and crashed rather than one that never started. It binds first
+  now, and a taken port says so and names `--port`. The startup line reports the
+  address the socket actually got, so `--port 0` prints the port the system
+  chose instead of `:0`.
+
 - Fixed: `deep-researcher` carried the same ceiling just lifted from
   `researcher` - its report is written from `claims`, and `claims` was a 40-item
   sliding window, so a run above a fan-out of up to twelve workers could deliver
@@ -65,7 +73,6 @@ same list.
   going back to `survey` is available and when to take it. Both already had that
   edge and neither used it; an edge a transition prompt does not mention is one
   the model does not weigh.
-
 - Fixed: a per-model inference pool configured under the model's own name did
   nothing when the resolver reached that model through a gateway. The same model
   carries a different id per route - `claude-sonnet-5` direct,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ same list.
 
 ## Unreleased
 
+- Added: `GET /api/update` reports how this copy of Leviath was installed and
+  the command that upgrades it, as the same JSON `lev update --check --json`
+  prints. The browser console had no way to ask, so it printed one hard-coded
+  `brew upgrade` at everyone, including the Windows users it could never work
+  for. Read-only, available without `--allow-admin`, and announced as the
+  `update.plan` capability.
 - Fixed: a run could be named with the model's scratch instead of a title. The
   check that was meant to catch this was a length check, on the reasoning that
   reasoning is longer than a title, so anything short got through: a chat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ same list.
 
 ## Unreleased
 
+- Fixed: a run could be named with the model's scratch instead of a title. The
+  check that was meant to catch this was a length check, on the reasoning that
+  reasoning is longer than a title, so anything short got through: a chat
+  template's stop token (`<|end_of|`), the model reading the instruction back
+  ("drafting a short title (max 8 words, no quotes)"), and a model stuck
+  repeating itself ("response. response. response.") were all stored and shown
+  to people as the names of their runs. A title is now cut at the first control
+  token, and refused if it loops or paraphrases the instruction. A refused
+  reply leaves the run with no title, which is already how it falls back to
+  showing the task, and the reason is recorded on the run.
 - Fixed: `lev serve` announced itself before it had the port. A machine where
   something else already held 3000 saw `Leviath API server listening on
   http://127.0.0.1:3000` and then a bare `os error 48`, which reads as a server

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -153,6 +153,13 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // re-implementing the parser's defaults.
     "blueprints.fan_outs",
     "tools.list",
+    // `GET /api/update`: how this copy was installed, and the command that
+    // upgrades it. Announced because the fallback is guessing, and the console
+    // guessed wrong for every user who was not on a Mac - it printed one
+    // hard-coded `brew upgrade` at everybody. A client with this asks; a client
+    // without it should send people to the install docs rather than pick a
+    // package manager on their behalf.
+    "update.plan",
     "scripts.read",
     // Announced whether or not `--allow-admin` was passed, which is a narrower
     // claim than the others on this list: it says this build serves the write

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -402,17 +402,27 @@ async fn execute_with_shutdown(
 
     let addr: SocketAddr = format!("{}:{}", args.host, args.port).parse()?;
     let scheme = tls::scheme(tls.as_ref());
-    tracing::info!("Listening on {}://{}", scheme, addr);
-    println!("Leviath API server listening on {scheme}://{addr}");
 
-    let listener = tokio::net::TcpListener::bind(addr).await?;
+    // Bound before anything says it is listening. Announcing first meant a
+    // taken port printed "Leviath API server listening on http://127.0.0.1:3000"
+    // and *then* died on a bare `os error 48`, which reads as a server that
+    // started and crashed rather than one that never started (issue #586).
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .map_err(|e| bind_error(&e, &args.host, args.port))?;
+    // The address the socket actually got, not the one that was asked for:
+    // `--port 0` means "you pick", and the port it picked is the only useful
+    // thing to print.
+    let bound = listener
+        .local_addr()
+        .expect("infallible: a freshly bound TcpListener always has a local address");
+    tracing::info!("Listening on {}://{}", scheme, bound);
+    println!("Leviath API server listening on {scheme}://{bound}");
+
     if let Some(ready) = ready {
         // A test-only observer failing to receive (e.g. it already gave up
         // after a timeout) shouldn't stop the server from starting for real.
-        let local_addr = listener
-            .local_addr()
-            .expect("infallible: a freshly bound TcpListener always has a local address");
-        let _ = ready.send(local_addr);
+        let _ = ready.send(bound);
     }
 
     match tls_config {
@@ -427,6 +437,31 @@ async fn execute_with_shutdown(
     }
 
     Ok(())
+}
+
+/// Turn a failed bind into something a person can act on.
+///
+/// The default port is 3000, which collides with most of the JavaScript world
+/// and a fair number of agent runtimes, so "the port is taken" is the ordinary
+/// failure here rather than an exotic one. It used to surface as a bare
+/// `os error 48` / `os error 10048` with no mention of the flag that fixes it.
+///
+/// Deliberately does not fall back to another port. The console at
+/// leviath.dev polls a fixed `http://127.0.0.1:3000`, so a server that quietly
+/// moved would be a server it can never find: a clear error beats a silent
+/// no-connect. `--port 0` remains the way to ask the OS to choose, and the
+/// startup line then reports what it chose.
+fn bind_error(err: &std::io::Error, host: &str, port: u16) -> anyhow::Error {
+    match err.kind() {
+        std::io::ErrorKind::AddrInUse => anyhow::anyhow!(
+            "port {port} on {host} is already in use, so the API server could not start. \
+             Pass `--port <port>` to listen somewhere else, or `--port 0` to let the \
+             system pick a free one (the port it picks is printed on startup). \
+             To find what holds it: `lsof -i :{port}` on macOS and Linux, \
+             `netstat -ano | findstr :{port}` on Windows."
+        ),
+        _ => anyhow::anyhow!("could not listen on {host}:{port}: {err}"),
+    }
 }
 
 /// Serve over TLS on an already-bound listener, until `shutdown` resolves.
@@ -688,6 +723,25 @@ mod tests {
     #[should_panic(expected = "execute should fail when port is already in use")]
     fn assert_execute_failed_on_port_in_use_panics_when_ok() {
         assert_execute_failed_on_port_in_use(&Ok(()));
+    }
+
+    /// See [`assert_execute_failed_on_malformed_config`] - same rationale, for
+    /// the region that checks a bind failure explains itself.
+    fn assert_error_says(result: &anyhow::Result<()>, expected: &str) {
+        let message = match result {
+            Err(e) => e.to_string(),
+            Ok(()) => String::from("<the call succeeded>"),
+        };
+        assert!(
+            message.contains(expected),
+            "bind error should mention {expected}"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "bind error should mention --port")]
+    fn assert_error_says_panics_when_the_message_is_missing() {
+        assert_error_says(&Ok(()), "--port");
     }
 
     /// See [`assert_execute_failed_on_malformed_config`] - same rationale,
@@ -1761,12 +1815,13 @@ system_prompt = "Run"
     }).await;
     }
 
-    /// Covers the `TcpListener::bind(addr).await?` error path deterministically
+    /// Covers the generic (non-`AddrInUse`) arm of [`bind_error`] deterministically
     /// by binding to a reserved TEST-NET-1 address (RFC 5737, `192.0.2.0/24`)
     /// that is never assigned to a local interface, so the bind always fails
     /// with `EADDRNOTAVAIL`. (A prior version reused an already-bound ephemeral
     /// port, which occasionally let the second bind succeed under parallel-test
-    /// load and left this region uncovered - a genuine flake.)
+    /// load and left this region uncovered - a genuine flake. The port-in-use
+    /// case now has its own test below, which binds first on purpose.)
     #[tokio::test]
     async fn execute_with_unbindable_address_returns_bind_error() {
         // Isolated: this reaches `Config::load()`, which reads process-wide
@@ -1787,9 +1842,52 @@ system_prompt = "Run"
                 };
                 let result = execute(args, no_daemon_control()).await;
                 assert_execute_failed_on_port_in_use(&result);
+                // Names the address it could not have, rather than leaving the
+                // reader with a bare errno.
+                assert_error_says(&result, "could not listen on 192.0.2.1:8080");
             },
         )
         .await;
+    }
+
+    /// The failure people actually hit: the default port is 3000, and 3000 is
+    /// taken on a great many developer machines. Holds an ephemeral port for
+    /// the duration so the collision is certain rather than hoped for, then
+    /// asserts the error names the flag that fixes it (issue #586).
+    #[tokio::test]
+    async fn execute_on_a_taken_port_names_the_port_flag() {
+        let held = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("binding an ephemeral loopback port always succeeds");
+        let port = held
+            .local_addr()
+            .expect("a bound listener always has a local address")
+            .port();
+        crate::config::with_isolated_config_path_async(
+            "serve-port-taken",
+            |_fake_dir| async move {
+                let args = ServeArgs {
+                    port,
+                    host: "127.0.0.1".to_string(),
+                    cors: None,
+                    token: Some("test-token".to_string()),
+                    allow_admin: false,
+                    workdir_root: None,
+                    no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
+                };
+                let result = execute(args, no_daemon_control()).await;
+                assert_execute_failed_on_port_in_use(&result);
+                assert_error_says(
+                    &result,
+                    &format!("port {port} on 127.0.0.1 is already in use"),
+                );
+                assert_error_says(&result, "--port <port>");
+            },
+        )
+        .await;
+        drop(held);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -24,6 +24,7 @@ mod tls;
 mod tools;
 mod tree;
 mod types;
+mod update;
 mod websocket;
 
 #[cfg(test)]
@@ -130,6 +131,10 @@ fn api_router() -> Router<AppState> {
         .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
         // Doctor - the same checks `lev doctor` runs, returned as data.
         .route("/api/doctor", get(doctor::run_doctor))
+        // Update - how this copy was installed, and what upgrades it. The
+        // console has no other way to know, and printed a macOS-only command
+        // to everyone because of it.
+        .route("/api/update", get(update::get_update))
         // Filesystem - directory browsing for the console's folder picker,
         // and the "New Folder" a browser cannot get from a native dialog.
         .route("/api/fs/dirs", get(fs::list_dirs).post(fs::create_dir))

--- a/crates/leviath-cli/src/commands/serve/update.rs
+++ b/crates/leviath-cli/src/commands/serve/update.rs
@@ -1,0 +1,126 @@
+//! `GET /api/update` - "am I current, and what do I type to fix it".
+//!
+//! Answers with exactly what `lev update --check --json` prints, from the same
+//! [`crate::commands::update::plan`], so the console and the CLI can never
+//! disagree about how this copy was installed.
+
+use axum::response::Json;
+
+use super::config_types::API_VERSION;
+use crate::commands::update::{UpdateArgs, UpdateEnv, plan, plan_json};
+
+/// `GET /api/update`: how this copy was installed, and the command that
+/// upgrades it.
+///
+/// Exists because the browser console had no way to ask. It printed a single
+/// hard-coded `brew upgrade leviath` at anyone whose Leviath was out of date,
+/// which is an instruction a Windows user cannot carry out and has no
+/// alternative offered for (issue #588) - while `lev update` on the very same
+/// binary already knew to say `scoop update leviath`, or to re-run
+/// `install.ps1`, or that a `cargo install` copy is theirs to rebuild.
+///
+/// Read-only, and so not behind `--allow-admin`: [`plan`] works out what the
+/// command *would* do and does none of it, the environment it is handed cannot
+/// run anything ([`UpdateEnv::for_planning`]), and no network call is made. The
+/// auth token is the boundary here, the same as for every other read route.
+///
+/// The body is `plan_json` unchanged rather than a trimmed "just the command"
+/// shape: one shape means one thing to document, and no drift the day the CLI
+/// gains a field.
+///
+/// Cannot fail, which is why it returns a bare `Json`. Every step of the
+/// discovery degrades to worse detection rather than to an error - a copy this
+/// build cannot place is `unknown` with advice, an answer rather than a 500.
+pub(super) async fn get_update() -> Json<serde_json::Value> {
+    // `--check` is implied: this route only ever plans. The other fields are
+    // defaults, which is what a caller who is not choosing a channel means.
+    let args = UpdateArgs {
+        check: true,
+        ..UpdateArgs::default()
+    };
+    Json(plan_json(
+        &plan(&args, &UpdateEnv::for_planning()),
+        API_VERSION,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::http::StatusCode;
+    use axum::routing::get;
+    use tower::ServiceExt;
+
+    /// The route answers, and answers with the shape the console reads: an
+    /// install method it can name, and a command it can print.
+    #[tokio::test]
+    async fn get_update_reports_the_install_method_and_a_command() {
+        let app = Router::new().route("/api/update", get(get_update));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/update")
+                    .body(Body::empty())
+                    .expect("a GET with no body always builds"),
+            )
+            .await
+            .expect("the router is infallible");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("the body is a small JSON document");
+        let body: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("the handler serializes a plan");
+
+        // The version is this build's, so a console can compare without a
+        // second request.
+        assert_eq!(body["version"], API_VERSION);
+        // Whatever this test machine is, the method is one of the five the CLI
+        // knows and the binary step is one of the two shapes it produces.
+        // Asserting on membership rather than a value is the point: enumerating
+        // "it is homebrew here" would pass on a laptop and fail on a runner.
+        let method = body["install_method"]
+            .as_str()
+            .expect("install_method is always a string");
+        assert!(["homebrew", "scoop", "cargo", "script", "unknown"].contains(&method));
+        let action = body["binary"]["action"]
+            .as_str()
+            .expect("binary.action is always a string");
+        assert!(["run", "advise"].contains(&action));
+    }
+
+    /// The console reads this to decide what to print, so it has to be the same
+    /// answer `lev update --json` gives on the same machine. A route that
+    /// drifted from the CLI would send people a command their own terminal
+    /// disagrees with.
+    #[tokio::test]
+    async fn get_update_agrees_with_what_the_cli_would_print() {
+        let env = UpdateEnv::for_planning();
+        let args = UpdateArgs {
+            check: true,
+            ..UpdateArgs::default()
+        };
+        let from_cli = plan_json(&plan(&args, &env), API_VERSION);
+
+        let app = Router::new().route("/api/update", get(get_update));
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/update")
+                    .body(Body::empty())
+                    .expect("a GET with no body always builds"),
+            )
+            .await
+            .expect("the router is infallible");
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("the body is a small JSON document");
+        let from_route: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("the handler serializes a plan");
+        assert_eq!(from_route, from_cli);
+    }
+}

--- a/crates/leviath-cli/src/commands/update.rs
+++ b/crates/leviath-cli/src/commands/update.rs
@@ -708,6 +708,113 @@ pub struct UpdateEnv {
     pub migrations: &'static [Migration],
 }
 
+impl UpdateEnv {
+    /// The real machine, wired up for a caller that only intends to [`plan`].
+    ///
+    /// `plan` never touches `runner` or `confirm` - it works out what the
+    /// command *would* do and does none of it - so a caller that will not go on
+    /// to `execute_with` has nothing to supply for them. Both are filled with
+    /// refusals rather than no-ops, so a future caller that runs this env
+    /// through the executing path fails loudly instead of silently doing
+    /// nothing.
+    ///
+    /// Resolving the executable is the load-bearing part. A Homebrew `bin/lev`
+    /// is a symlink into the Cellar, and the Cellar path is the only place the
+    /// formula name - and so the channel - is written down, so the link has to
+    /// be followed before [`detect`] can read anything off it.
+    pub fn for_planning() -> Self {
+        Self::real(
+            std::sync::Arc::new(refuse_to_run),
+            std::sync::Arc::new(say_no),
+        )
+    }
+
+    /// The real machine, with the caller's own way to run a command and ask a
+    /// question. `lev update` passes a terminal's; the API passes refusals.
+    ///
+    /// Infallible on purpose. Every step here degrades to worse *detection*
+    /// rather than to an error: no home, no `brew`, or an executable path that
+    /// will not resolve all land in [`detect`]'s `Unknown` arm, which advises
+    /// re-installing. "I could not work out how you installed this" is an
+    /// answer; refusing to answer is not, and a `lev update` that failed
+    /// outright because it could not locate its own binary would be strictly
+    /// less useful than one that says so.
+    pub fn real(runner: CommandRunner, confirm: Confirm) -> Self {
+        let home = dirs::home_dir();
+        // A path that cannot be read, or cannot be canonicalized, is used as
+        // whatever it came out as. An empty one detects as `Unknown`.
+        let exe = std::env::current_exe().unwrap_or_default();
+        let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
+        Self {
+            exe,
+            agents_dir: crate::commands::setup::real_agents_dir(home.as_deref()),
+            home,
+            brew_prefix: brew_prefix(),
+            config_path: crate::config::Config::config_path(),
+            runner,
+            confirm,
+            migrations: MIGRATIONS,
+        }
+    }
+}
+
+/// The `runner` a planning-only environment carries: a loud refusal.
+///
+/// Not a no-op. A no-op runner would let a caller wire this env into
+/// `execute_with`, watch it print every step, and change nothing - a silent
+/// failure dressed as a successful update.
+fn refuse_to_run(_argv: &[String]) -> anyhow::Result<()> {
+    anyhow::bail!("this update environment was built for planning only, and cannot run commands")
+}
+
+/// The `confirm` a planning-only environment carries. Nothing is agreed to by
+/// something that is only working out what it would ask.
+fn say_no(_question: &str) -> bool {
+    false
+}
+
+/// What `brew --prefix` says, when there is a `brew` to ask.
+///
+/// Cached: this used to run once per `lev update`, and now also answers an HTTP
+/// route, where spawning a process per request to learn a thing that cannot
+/// change under a running server would be a waste worth noticing.
+pub fn brew_prefix() -> Option<PathBuf> {
+    static CACHED: std::sync::OnceLock<Option<PathBuf>> = std::sync::OnceLock::new();
+    CACHED
+        .get_or_init(|| {
+            brew_prefix_from(
+                leviath_sys::child_command("brew")
+                    .arg("--prefix")
+                    .output()
+                    .ok(),
+            )
+        })
+        .clone()
+}
+
+/// The part of [`brew_prefix`] that is worth testing: what to make of whatever
+/// `brew --prefix` did or did not say.
+///
+/// Any failure is a `None` - it only ever adds evidence, and a machine without
+/// Homebrew is the ordinary case rather than an error. Empty output is a `None`
+/// for the same reason: an empty prefix would match every path under
+/// [`detect`]'s `starts_with`, which is the opposite of no evidence.
+///
+/// Takes the answer rather than a closure that produces one. A generic seam
+/// would be tidier to read and is measured per instantiation, so the arms this
+/// machine's own `brew` does not take would go uncovered however many closures
+/// the tests passed. The command is spawned once, inside the cache above, so
+/// taking it eagerly costs nothing.
+fn brew_prefix_from(output: Option<std::process::Output>) -> Option<PathBuf> {
+    let output = output?;
+    let prefix = String::from_utf8(output.stdout).ok()?;
+    let prefix = prefix.trim();
+    match prefix.is_empty() {
+        true => None,
+        false => Some(PathBuf::from(prefix)),
+    }
+}
+
 // ─── Execution ────────────────────────────────────────────────────────────────
 
 /// Ask, unless `--yes` has already answered.

--- a/crates/leviath-cli/src/commands/update/tests.rs
+++ b/crates/leviath-cli/src/commands/update/tests.rs
@@ -1265,3 +1265,90 @@ fn agreed_asks_unless_yes_already_answered() {
     assert!(!agreed(&UpdateArgs::default(), &env, "anything?"));
     assert_eq!(fixture.recorder.asked(), vec!["anything?".to_string()]);
 }
+
+// ─── The real machine ─────────────────────────────────────────────────────────
+
+/// An `Output` carrying `stdout`, for the parsing test below. The status is
+/// borrowed from a real spawn because `ExitStatus` cannot be constructed
+/// portably, and it is the one field `brew_prefix_from` never reads.
+#[cfg(test)]
+fn output_with(stdout: &[u8]) -> std::process::Output {
+    let status = std::process::Command::new(std::env::current_exe().expect("the test binary"))
+        .arg("--a-flag-that-lists-no-tests-and-runs-none")
+        .arg("--list")
+        .output()
+        .expect("spawning the test binary to borrow an ExitStatus")
+        .status;
+    std::process::Output {
+        status,
+        stdout: stdout.to_vec(),
+        stderr: Vec::new(),
+    }
+}
+
+/// `brew --prefix` is evidence, never a requirement, so every way of not
+/// answering has to come out as "no evidence" rather than as a failure.
+///
+/// The empty case is the one worth stating outright: an empty prefix is not
+/// merely useless, it is dangerous. [`detect`] asks whether the executable path
+/// `starts_with` the prefix, and every path starts with an empty one - so a
+/// blank answer from `brew` would make every install on the machine look like a
+/// Homebrew install.
+#[test]
+fn brew_prefix_treats_every_non_answer_as_no_evidence() {
+    // No `brew` on this machine at all.
+    assert_eq!(brew_prefix_from(None), None);
+    // A `brew` that answered with nothing, or with only whitespace.
+    assert_eq!(brew_prefix_from(Some(output_with(b""))), None);
+    assert_eq!(brew_prefix_from(Some(output_with(b"  \n "))), None);
+    // Output that is not text.
+    assert_eq!(brew_prefix_from(Some(output_with(&[0xff, 0xfe]))), None);
+    // And the answer it is there for, trailing newline and all.
+    assert_eq!(
+        brew_prefix_from(Some(output_with(b"/opt/homebrew\n"))),
+        Some(PathBuf::from("/opt/homebrew"))
+    );
+}
+
+/// The cached wrapper resolves, and keeps resolving to the same thing. Which
+/// answer it gives is a fact about whatever machine is running the tests, not
+/// about this code - the parsing is pinned above - so this asserts only that
+/// the cache works.
+#[test]
+fn brew_prefix_is_cached_and_stable() {
+    assert_eq!(brew_prefix(), brew_prefix());
+}
+
+/// A planning environment describes this machine and refuses to act on it.
+///
+/// The refusals matter more than they look. `plan` never reaches them, so
+/// nothing today would notice if they were no-ops - and a no-op runner is
+/// exactly how a caller who wired this into `execute_with` would get an update
+/// that looked successful and changed nothing.
+#[test]
+fn a_planning_environment_describes_the_machine_and_refuses_to_change_it() {
+    let env = UpdateEnv::for_planning();
+    assert_eq!(env.migrations.len(), MIGRATIONS.len());
+    assert!(env.config_path.ends_with("config.toml"));
+
+    let refused = (env.runner)(&["brew".to_string(), "upgrade".to_string()]);
+    let message = refused
+        .expect_err("a planning env runs nothing")
+        .to_string();
+    assert!(message.contains("built for planning only"), "{message}");
+    assert!(!(env.confirm)("upgrade?"));
+}
+
+/// Whatever this test binary is, planning against it reaches a verdict rather
+/// than failing. That is what `UpdateEnv::real` is infallible for: a copy in a
+/// place no installer uses is `Unknown` with advice, which is an answer, and
+/// refusing to answer is not.
+#[test]
+fn planning_against_the_real_machine_always_reaches_a_verdict() {
+    let plan = plan(&UpdateArgs::default(), &UpdateEnv::for_planning());
+    assert!(!plan.method.describe().is_empty());
+    match &plan.binary {
+        BinaryStep::Run(commands) => assert!(!commands.is_empty()),
+        BinaryStep::Advise(message) => assert!(!message.is_empty()),
+    }
+}

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -226,47 +226,18 @@ impl RiskyExecutors for RealExecutors {
     }
 }
 
-/// Real `lev update`: the four things the command needs from the machine, wired
-/// into the tested core.
+/// Real `lev update`: this machine, plus a terminal's way to run a command and
+/// ask a question, wired into the tested core.
 ///
-/// Resolving the executable is the load-bearing one. A Homebrew `bin/lev` is a
-/// symlink into the Cellar, and the Cellar path is the only place the formula
-/// name - and so the channel - is written down, so the link has to be followed
-/// before detection can read anything off it.
+/// The machine half lives in `UpdateEnv::real` rather than here, because
+/// `GET /api/update` needs exactly the same discovery and only differs in what
+/// it is willing to do with the answer.
 fn real_update(args: commands::update::UpdateArgs) -> anyhow::Result<()> {
-    let home = dirs::home_dir();
-    let exe = std::env::current_exe()?;
-    // A path that cannot be canonicalized is used as it came: worse detection,
-    // never a failed command.
-    let exe = std::fs::canonicalize(&exe).unwrap_or(exe);
-
-    let env = commands::update::UpdateEnv {
-        exe,
-        agents_dir: commands::setup::real_agents_dir(home.as_deref()),
-        home,
-        brew_prefix: brew_prefix(),
-        config_path: leviath_cli::config::Config::config_path(),
-        runner: std::sync::Arc::new(run_upgrade),
-        confirm: std::sync::Arc::new(ask_yes_no),
-        migrations: commands::update::MIGRATIONS,
-    };
+    let env = commands::update::UpdateEnv::real(
+        std::sync::Arc::new(run_upgrade),
+        std::sync::Arc::new(ask_yes_no),
+    );
     commands::update::execute_with(&args, &env, env!("CARGO_PKG_VERSION"))
-}
-
-/// What `brew --prefix` says, when there is a `brew` to ask. Any failure is a
-/// `None`: it only ever adds evidence, and a machine without Homebrew is the
-/// ordinary case rather than an error.
-fn brew_prefix() -> Option<std::path::PathBuf> {
-    let output = leviath_sys::child_command("brew")
-        .arg("--prefix")
-        .output()
-        .ok()?;
-    let prefix = String::from_utf8(output.stdout).ok()?;
-    let prefix = prefix.trim();
-    match prefix.is_empty() {
-        true => None,
-        false => Some(std::path::PathBuf::from(prefix)),
-    }
 }
 
 /// Run the upgrade command, letting it draw on the terminal it inherits - a

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -347,12 +347,95 @@ fn sanitize_title(raw: &str) -> String {
     // check and was then sliced mid-title.
     stripped
         .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
+        .map(strip_control_tokens)
         .map(|l| l.trim_matches(['"', '\'', '`']).trim().to_string())
-        .find(|l| l.len() <= TITLE_MAX_LEN)
+        .filter(|l| !l.is_empty())
+        .find(|l| l.len() <= TITLE_MAX_LEN && !is_degenerate(l) && !echoes_the_instruction(l))
         .unwrap_or_default()
 }
+
+/// Cut a line at the first chat-template control token.
+///
+/// The length rule above is a length rule, and these are short: `<|end_of|`
+/// is 9 bytes and one line, so it sailed through and was rendered to a user as
+/// the name of their run. Nothing else in the codebase handles these - a
+/// search for `<|` found no other site - because every provider that speaks a
+/// real API strips them. A local llama.cpp or a thin OpenAI-compatible gateway
+/// in front of a GGUF does not always, and that is exactly the setup a title
+/// call is cheap enough to be pointed at.
+///
+/// Cutting rather than deleting: a control token means the model stopped
+/// there, so what follows it is another turn's text, not more of this title.
+/// A line that *starts* with one is left empty and skipped.
+fn strip_control_tokens(line: &str) -> &str {
+    match line.split_once("<|") {
+        Some((before, _)) => before.trim(),
+        None => line.trim(),
+    }
+}
+
+/// Whether a line is the model stuck repeating itself.
+///
+/// "response. response. response." is short, single-line, and passes every
+/// other check here. Degenerate output is not a title, and showing one to a
+/// user is worse than showing them the task they typed.
+///
+/// The rule is deliberately blunt: enough words to judge, and almost all of
+/// them the same word. A real title reuses a word now and then ("Ship the ship
+/// docs"), so this needs a run of them before it will refuse.
+fn is_degenerate(line: &str) -> bool {
+    let words: Vec<String> = line
+        .split_whitespace()
+        .map(|w| {
+            w.trim_matches(|c: char| !c.is_alphanumeric())
+                .to_lowercase()
+        })
+        .filter(|w| !w.is_empty())
+        .collect();
+    if words.len() < DEGENERATE_MIN_WORDS {
+        return false;
+    }
+    let unique: std::collections::HashSet<&String> = words.iter().collect();
+    unique.len() * 2 <= words.len()
+}
+
+/// Below this many words there is not enough of a line to call it a loop:
+/// "Ship it, ship it" is a person being emphatic, not a model wedged. Three is
+/// the smallest that still catches the reported case ("response. response.
+/// response.") while leaving a two-word title alone.
+const DEGENERATE_MIN_WORDS: usize = 3;
+
+/// Whether a line is the model narrating [`TITLE_SYSTEM_PROMPT`] back at us.
+///
+/// A model that is asked for a title and answers "drafting a short title (max
+/// 8 words, no quotes)" has described the job instead of doing it. That reply
+/// is 46 bytes on one line, so the display cap - the whole basis of the
+/// earlier reasoning fix - has nothing to say about it.
+///
+/// Matched on the instruction's own distinctive pairing rather than a list of
+/// words that smell like reasoning. "Title" alone is a legitimate title
+/// ("Title the release notes"); "title" next to this prompt's own constraints
+/// is the model reading the prompt out loud. Being wrong here costs a title
+/// and falls back to the task text, so the bar is set to catch the echo rather
+/// than to be certain about it.
+fn echoes_the_instruction(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    if !lower.contains("title") {
+        return false;
+    }
+    INSTRUCTION_TELLS.iter().any(|tell| lower.contains(tell))
+}
+
+/// Phrases from [`TITLE_SYSTEM_PROMPT`] that a title has no reason to contain,
+/// but a paraphrase of the instruction almost always does.
+const INSTRUCTION_TELLS: [&str; 6] = [
+    "8 words",
+    "eight words",
+    "no quotes",
+    "no explanation",
+    "short title",
+    "the given task",
+];
 
 /// Opening tags a model may wrap its reasoning in, with the closer that ends
 /// each. Ollama returns thinking in its own field and Anthropic in its own
@@ -697,8 +780,12 @@ pub fn collect_title(
         if title.is_empty() {
             record_title_failure(
                 &mut meta,
+                // Not "nothing short enough" any more: length is only one of
+                // the reasons a reply is refused now, and a run whose reply
+                // was a stop token or the instruction read back deserves a
+                // reason that is true of it.
                 format!(
-                    "{}/{} replied with nothing short enough to be a title",
+                    "{}/{} replied with nothing usable as a title",
                     outcome.provider_name, outcome.model
                 ),
             );
@@ -1542,7 +1629,7 @@ mod tests {
         assert_eq!(world.get::<RunMetadata>(e).unwrap().title, None);
         assert_eq!(
             world.get::<RunMetadata>(e).unwrap().title_error.as_deref(),
-            Some("mock/m replied with nothing short enough to be a title"),
+            Some("mock/m replied with nothing usable as a title"),
             "the provider answered, so this is the model's verdict, not the route's"
         );
     }
@@ -1932,6 +2019,92 @@ mod tests {
         // Comfortably inside the cap in bytes, so it is a title.
         let short = "字".repeat(8);
         assert_eq!(sanitize_title(&short), short);
+    }
+
+    /// The three chips from issue #587, verbatim as they were reported from a
+    /// live console, each proving one hole the display cap could not see.
+    ///
+    /// All three are short, single-line, and free of reasoning tags, so the
+    /// earlier fix - "reasoning is longer than a title" - had nothing to say
+    /// about any of them. They were stored, and shown to a user as the names
+    /// of their runs.
+    #[test]
+    fn sanitize_refuses_the_three_replies_that_were_shown_to_a_user() {
+        // A chat-template control token, cut short exactly as it appeared.
+        assert_eq!(sanitize_title("<|end_of|"), "");
+        // The model describing the job instead of doing it.
+        assert_eq!(
+            sanitize_title("drafting a short title (max 8 words, no quotes)"),
+            ""
+        );
+        // The model wedged.
+        assert_eq!(sanitize_title("response. response. response."), "");
+
+        // Every one of them would have passed the cap on its own, which is
+        // the point: the cap was the only check there was.
+        for reply in [
+            "<|end_of|",
+            "drafting a short title (max 8 words, no quotes)",
+            "response. response. response.",
+        ] {
+            assert!(reply.len() <= TITLE_MAX_LEN);
+        }
+    }
+
+    /// A control token ends the turn, so what precedes it is the whole title
+    /// and what follows is another turn's text.
+    #[test]
+    fn sanitize_cuts_a_title_at_a_control_token_rather_than_dropping_it() {
+        assert_eq!(
+            sanitize_title("Cache Warmup<|end_of_text|>"),
+            "Cache Warmup"
+        );
+        assert_eq!(
+            sanitize_title("Queue Drain Fix <|eot_id|>"),
+            "Queue Drain Fix"
+        );
+        assert_eq!(
+            sanitize_title("Ship the parser<|im_end|>\nnot this line"),
+            "Ship the parser"
+        );
+        // Nothing before the token means nothing to show, so the next line
+        // gets its turn rather than the run being left with an empty name.
+        assert_eq!(
+            sanitize_title("<|endoftext|>\nReal Title Here"),
+            "Real Title Here"
+        );
+    }
+
+    /// The repetition check has to leave ordinary titles alone. A person
+    /// writes a repeated word on purpose often enough that refusing on any
+    /// repeat would cost more titles than it saves.
+    #[test]
+    fn sanitize_allows_a_title_that_merely_repeats_a_word() {
+        assert_eq!(sanitize_title("Ship the ship docs"), "Ship the ship docs");
+        assert_eq!(sanitize_title("Run run"), "Run run");
+        assert_eq!(
+            sanitize_title("Fix the fix that broke the fix"),
+            "Fix the fix that broke the fix"
+        );
+    }
+
+    /// "Title" is a perfectly good word for a title to contain. Only the
+    /// instruction's own constraints alongside it mean the model is reading
+    /// the prompt out loud.
+    #[test]
+    fn sanitize_allows_a_title_that_is_genuinely_about_titles() {
+        assert_eq!(
+            sanitize_title("Title the release notes"),
+            "Title the release notes"
+        );
+        assert_eq!(
+            sanitize_title("Fix run title truncation"),
+            "Fix run title truncation"
+        );
+        // And still refuses the paraphrases, whichever way they are worded.
+        assert_eq!(sanitize_title("A short title, at most eight words"), "");
+        assert_eq!(sanitize_title("Writing a title for the given task"), "");
+        assert_eq!(sanitize_title("Title: no explanation, no quotes"), "");
     }
 
     /// `<think>` is not the only spelling. A local GGUF writes its reasoning

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -178,6 +178,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
 | `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
+| `GET /api/update` | How this copy was installed, and the command that upgrades it. See [below](#asking-how-to-upgrade) |
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
 | `POST /api/fs/dirs` | Make one directory: `{"path": "<absolute parent>", "name": "<one segment>"}` → `201 {"path", "parent"}`. The same fence as the `GET`; `409` if it already exists. Announced as `fs.mkdir` |
 | `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
@@ -506,6 +507,44 @@ which are errors rather than quiet fallbacks. The workers still share the daemon
 (`[limits] max_concurrent_inferences`, 8 by default), so an unlimited fan-out queues at the model
 rather than running away.
 
+## Asking how to upgrade
+
+`GET /api/update` answers how this copy of Leviath was installed and what command brings it
+up to date. Like `GET /api/tools`, it exists because the answer is a fact about the machine
+that no client can work out for itself, and guessing it wrong is worse than not saying.
+
+The body is exactly what `lev update --check --json` prints, from the same planner:
+
+```json
+{
+  "version": "0.4.0",
+  "install_method": "scoop",
+  "channel": "stable",
+  "binary": {
+    "action": "run",
+    "commands": [["scoop", "update"], ["scoop", "update", "leviath"]],
+    "command": ["scoop", "update", "leviath"]
+  },
+  "agents": [],
+  "migrations": [],
+  "config_error": null
+}
+```
+
+`install_method` is one of `homebrew`, `scoop`, `cargo`, `script` or `unknown`. `binary.action`
+is either `run`, carrying a `commands` list of argv lists to run in order, or `advise`, carrying
+a `message` to show instead. A `cargo install` copy is always `advise`: rebuilding it is a full
+compile, which is not something to start on someone's behalf. So is a binary sitting somewhere
+no installer puts one, where the honest answer is to point at the install docs.
+
+Render `binary.commands` rather than composing your own. That is the whole point of the route:
+a client that hard-codes one package manager's command is right for the users who happen to
+share its author's machine and wrong for everyone else. Where a daemon does not announce
+`update.plan`, send people to the install page rather than picking a package manager for them.
+
+The route is read-only and available without `--allow-admin`. It works out what an update would
+do and does none of it, makes no network call, and cannot run a command even if asked.
+
 ## Tools and scripts
 
 `GET /api/tools` answers what an agent on **this** machine can call, which is not a question a
@@ -626,6 +665,7 @@ than that feature, not broken.
 | `blueprints.validate.name` | `POST /api/blueprints/validate` accepting an installed name, not only a body |
 | `blueprints.fan_outs` | `fan_outs` on the detail route. See [fan-out limits](#fan-out-limits) |
 | `tools.list` | `GET /api/tools?agent=`, what an agent here can actually call |
+| `update.plan` | `GET /api/update`, how this copy was installed and the command that upgrades it. See [asking how to upgrade](#asking-how-to-upgrade) |
 | `scripts.read` | The `GET` half of the scripts routes |
 | `scripts.write` | That this build serves the write half. Whether *this* daemon mounts it is `--allow-admin`, which you find out by calling one and reading the status |
 | `scripts.providers` | `provider` as a fifth script `kind`, the machine's drop-in model providers |

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -736,7 +736,7 @@ $ lev update --check
 
 lev 0.3.5, installed with Homebrew (formula leviath-beta, beta channel)
 
-  binary   brew upgrade leviath-beta
+  binary   brew update && brew upgrade leviath-beta
   agents   1 of 7 would change
              data-analyst - update 0.0.1 → 0.0.2
   config   nothing to migrate

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1039,6 +1039,20 @@
         }
       }
     },
+    "/api/update": {
+      "get": {
+        "tags": [
+          "diagnostics"
+        ],
+        "summary": "How this copy was installed, and what upgrades it",
+        "description": "The same answer `lev update --check --json` prints, from the same planner, so a client never sends a user a command their own terminal disagrees with. `install_method` is one of `homebrew`, `scoop`, `cargo`, `script`, `unknown`. `binary.action` is `run` with a `commands` list of argv lists to run in order, or `advise` with a `message` to show. Read-only and available without `--allow-admin`: it works out what an update would do and does none of it.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          }
+        }
+      }
+    },
     "/api/fs/dirs": {
       "get": {
         "tags": [


### PR DESCRIPTION
Three of the five issues filed against this repo on 2026-08-24, fixed here. The other two turn out to be bugs in the console rather than in Leviath; they are filed on `leviath.dev` with the exact cause, and the issues here carry a note saying so.

Closes #586. Closes #587. Addresses this repo's half of #588.

## `lev serve` says the port is taken (#586)

The success line and the bind were in the wrong order, so a machine where something already held 3000 saw

```
Leviath API server listening on http://127.0.0.1:3000
Error: Address already in use (os error 48)
```

which reads as a server that started and crashed. Nothing announces itself now until the socket is bound, and a failed bind names the port and `--port`. The startup line reports `listener.local_addr()`, so `--port 0` prints the port it got rather than `:0`.

The issue also asked for an automatic fallback to a free port and a new default. Both are declined, and the reasoning is in the commit: the console's onboarding polls a fixed `http://127.0.0.1:3000`, so a server that quietly relocated is one it can never find, and a silent no-connect is worse than a clear error.

## The title sanitizer is a length check (#587)

The reported chips were the run's **title**, not a live activity feed. Under the misread framing there is a real bug: `sanitize_title` strips three reasoning-tag spellings and takes the first line of 80 bytes or fewer, so anything short was a title by definition. All three reported strings are short:

| reply | before | after |
|---|---|---|
| `<\|end_of\|` | stored as the title | no title, reason recorded |
| `drafting a short title (max 8 words, no quotes)` | stored as the title | no title, reason recorded |
| `response. response. response.` | stored as the title | no title, reason recorded |
| `Adding Two Numbers` | stored | stored |

A title is cut at the first `<\|` control token, and refused if it loops or paraphrases the title instruction. Ordinary titles that repeat a word, or are genuinely about titles, still pass.

## `GET /api/update` (#588)

The console prints one hard-coded `brew upgrade leviath` at everyone, including the Windows users it cannot work for. `lev update` on the same binary already resolves Homebrew / Scoop / cargo / script install from the executable's own path and knows the right command for each, but none of that was reachable over HTTP, so the console had nothing to ask.

The route returns `plan_json` unchanged, so it is byte for byte what `lev update --check --json` prints. Read-only and not behind `--allow-admin`: it plans and does nothing, and the environment it builds cannot run a command even if asked. Announced as the `update.plan` capability.

Two corrections to the issue as filed, for the record: the command is `leviath`, not `leviathan`, and the gate is an API-version comparison against the connected daemon, not a Homebrew check. Only the printed command was wrong.

`UpdateEnv::real` moves the machine discovery out of `main.rs` so the route and the CLI share one construction, and `brew_prefix` is cached rather than spawning `brew --prefix` per request.

## Verification

Everything here was checked against the shipped 0.4.0 binary as a "before" control, not only under test.

- **#586** — held a port, ran both binaries. Before: the listening line, then `os error 48`. After: no listening line, and a message naming `--port`. With `--port 0`: before `:0`, after the real port.
- **#587** — drove a real daemon through a mock provider scripted to return each reported string. Before: all three stored as titles. After: none, with `title_error` set. A fourth, ordinary reply is stored by both, so the refusals do not cost a real title.
- **#588** — the route answers, 401s without a token, and matches `lev update --check --json` on the same binary byte for byte. Checked on two install shapes so it is reading the machine rather than returning a constant.
- The three new sanitizer tests were run against the **unfixed** code first and fail there, returning the reported strings verbatim.
- `cargo xtask coverage`: all 13 packages at 100%.

## Also found, filed separately

`pipeline/tools.rs` returns early when a batch resolves entirely inline, before the journaling block, so those calls never reach `run.lvr` while still incrementing `meta.tool_calls`. Adjacent to #589 but a distinct defect, so it is its own issue rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
