### PR TITLE
fix: size the accumulating regions by their percentage and nothing else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ same list.
   now, and a taken port says so and names `--port`. The startup line reports the
   address the socket actually got, so `--port 0` prints the port the system
   chose instead of `:0`.
+- Changed: the accumulating regions in the bundled blueprints are sized by their
+  percentage again, rather than by an absolute cap that overrode it. Capping a
+  `30%` region at 60,000 tokens stopped it ballooning on a large model, but the
+  cap then decided the size on every model above 200K and the percentage decided
+  nothing across the whole range anyone runs on. Each is now a lower percentage
+  with guard-rails either side: `min_tokens` so a small window does not resolve
+  the region below one fetched page, and `max_tokens` set far enough above what
+  the percentage yields to be a backstop for a window nobody ships yet. A
+  `raw_findings` region now resolves to 16K at 200K, 83K at 1M and 150K at 2M,
+  where before it was 60K at every one of them.
+- Changed: the test behind those regions is keyed on the region's kind rather
+  than on how large its percentage looks. It previously examined only regions at
+  20% or more, which stopped covering anything the moment those percentages were
+  lowered - it caught its own blind spot through the vacuity check rather than
+  passing on an empty set.
 
 - Fixed: `deep-researcher` carried the same ceiling just lifted from
   `researcher` - its report is written from `claims`, and `claims` was a 40-item

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,20 +36,20 @@ same list.
   now, and a taken port says so and names `--port`. The startup line reports the
   address the socket actually got, so `--port 0` prints the port the system
   chose instead of `:0`.
-- Changed: the accumulating regions in the bundled blueprints are sized by their
-  percentage again, rather than by an absolute cap that overrode it. Capping a
-  `30%` region at 60,000 tokens stopped it ballooning on a large model, but the
-  cap then decided the size on every model above 200K and the percentage decided
-  nothing across the whole range anyone runs on. Each is now a lower percentage
-  with guard-rails either side: `min_tokens` so a small window does not resolve
-  the region below one fetched page, and `max_tokens` set far enough above what
-  the percentage yields to be a backstop for a window nobody ships yet. A
-  `raw_findings` region now resolves to 16K at 200K, 83K at 1M and 150K at 2M,
-  where before it was 60K at every one of them.
-- Changed: the test behind those regions is keyed on the region's kind rather
-  than on how large its percentage looks. It previously examined only regions at
-  20% or more, which stopped covering anything the moment those percentages were
-  lowered - it caught its own blind spot through the vacuity check rather than
+- Fixed: the accumulating regions in the bundled blueprints are sized by their
+  percentage alone again. An absolute `max_tokens` had been added alongside the
+  percentage to stop a `30%` region resolving to 300,000 tokens on a 1M-token
+  model, but a ceiling low enough to do that binds on every model above the
+  window it was picked for, so from 200K upward the cap decided the size and the
+  percentage decided nothing. A region that resolves to the same number on a
+  200K model and a 1M one is not percentage-sized. The size was not the fault:
+  280,000 tokens re-sent at 4% cached is expensive and the same 280,000 mostly
+  cached is not, and the `volatility` declaration is what changed that.
+- Changed: the test behind those regions asserts the `volatility` declaration
+  and no longer requires an absolute ceiling, and is keyed on the region's kind
+  rather than on how large its percentage looks. It previously examined only
+  regions at 20% or more, which stopped covering anything the moment those
+  percentages moved - it reported that through its vacuity check rather than
   passing on an empty set.
 
 - Fixed: `deep-researcher` carried the same ceiling just lifted from

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -309,15 +309,13 @@ caveats       = { kind = "pinned", budget = "2%", volatility = "grows" }
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# The percentage is what sizes it, and it is lower than it looks: this region is
-# re-sent on every inference for the rest of the stage, so its size multiplies
-# cost and latency rather than being paid once. 30% was written against a
-# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
-# which is where a measured run spent most of $137. `min_tokens` keeps a small
-# window from resolving to less than one fetched page; `max_tokens` is a
-# backstop for a window nobody ships yet, deliberately far above the percentage
-# so that the percentage, not the cap, is what decides on every model in use.
-raw_sources   = { kind = "temporary", budget = "7%", volatility = "grows", min_tokens = 14000, max_tokens = 125000 }
+# Sized by the percentage alone. An absolute ceiling was tried here and removed:
+# it bound on every model above 200K, so the percentage - which is the whole
+# mechanism for scaling with the model in front of you - decided nothing across
+# the range anyone runs on. The size was never the fault anyway. 280K tokens
+# re-sent at 4% cached is expensive; the same 280K mostly cached is not, and the
+# `volatility` above is what makes the difference.
+raw_sources   = { kind = "temporary", budget = "25%", volatility = "grows" }
 # The workers' consolidated rows, on the way into the merge. Its budget is what
 # each worker's share is divided from, so it gets the largest slice here.
 worker_rows   = { kind = "clearable", budget = "40%" }

--- a/crates/leviath-cli/agents/data-analyst/agent.leviath
+++ b/crates/leviath-cli/agents/data-analyst/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "data-analyst"
-version = "0.1.3"
+version = "0.1.4"
 description = "Data analyst - searches the web for data on a subject, builds a clean CSV of it, and hands back a ready-to-use summary of what the numbers say"
 entry_stage = "scope"
 
@@ -309,10 +309,15 @@ caveats       = { kind = "pinned", budget = "2%", volatility = "grows" }
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
-# written against a 200K-token window, and the same 30% of a 1M-token model is
-# 300K tokens of raw scrape carried into every later stage.
-raw_sources   = { kind = "temporary", budget = "25%", volatility = "grows", max_tokens = 50000 }
+# The percentage is what sizes it, and it is lower than it looks: this region is
+# re-sent on every inference for the rest of the stage, so its size multiplies
+# cost and latency rather than being paid once. 30% was written against a
+# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
+# which is where a measured run spent most of $137. `min_tokens` keeps a small
+# window from resolving to less than one fetched page; `max_tokens` is a
+# backstop for a window nobody ships yet, deliberately far above the percentage
+# so that the percentage, not the cap, is what decides on every model in use.
+raw_sources   = { kind = "temporary", budget = "7%", volatility = "grows", min_tokens = 14000, max_tokens = 125000 }
 # The workers' consolidated rows, on the way into the merge. Its budget is what
 # each worker's share is divided from, so it gets the largest slice here.
 worker_rows   = { kind = "clearable", budget = "40%" }

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -653,24 +653,20 @@ format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite ever
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# The percentage is what sizes it, and it is lower than it looks: this region is
-# re-sent on every inference for the rest of the stage, so its size multiplies
-# cost and latency rather than being paid once. 30% was written against a
-# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
-# which is where a measured run spent most of $137. `min_tokens` keeps a small
-# window from resolving to less than one fetched page; `max_tokens` is a
-# backstop for a window nobody ships yet, deliberately far above the percentage
-# so that the percentage, not the cap, is what decides on every model in use.
-sources        = { kind = "temporary",      budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
+# Sized by the percentage alone. An absolute ceiling was tried here and removed:
+# it bound on every model above 200K, so the percentage - which is the whole
+# mechanism for scaling with the model in front of you - decided nothing across
+# the range anyone runs on. The size was never the fault anyway. 280K tokens
+# re-sent at 4% cached is expensive; the same 280K mostly cached is not, and the
+# `volatility` above is what makes the difference.
+sources        = { kind = "temporary",      budget = "30%", volatility = "grows" }
 # The report is written FROM this region, so anything evicted here is a finding
 # the run paid for and cannot deliver. 40 items bounds the report long before the
 # reading is done - and this blueprint sits above a fan-out of up to 12 workers,
 # so it is the level where the ceiling costs most: every worker's findings funnel
 # through these slots. Wide enough now that the budget is what limits it, which
-# is a limit that scales with the model - a percentage low enough that what the
-# region holds is bounded by what a run can afford to re-send, not by what the
-# window could technically fit.
-claims         = { kind = "sliding_window", max_items = 150, budget = "5%", volatility = "grows", min_tokens = 10000, max_tokens = 75000 }
+# is a limit that scales with the model.
+claims         = { kind = "sliding_window", max_items = 150, budget = "15%", volatility = "grows" }
 contradictions = { kind = "clearable",      budget = "3%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: the
 # analysis stage reads it directly and it is the point of the fan-out.

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.4.4"
+version = "0.4.5"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 max_child_depth = 2
 entry_stage = "gather"
@@ -653,17 +653,24 @@ format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite ever
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
-# written against a 200K-token window, and the same 30% of a 1M-token model is
-# 300K tokens of raw scrape carried into every later stage.
-sources        = { kind = "temporary",      budget = "30%", volatility = "grows", max_tokens = 60000 }
+# The percentage is what sizes it, and it is lower than it looks: this region is
+# re-sent on every inference for the rest of the stage, so its size multiplies
+# cost and latency rather than being paid once. 30% was written against a
+# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
+# which is where a measured run spent most of $137. `min_tokens` keeps a small
+# window from resolving to less than one fetched page; `max_tokens` is a
+# backstop for a window nobody ships yet, deliberately far above the percentage
+# so that the percentage, not the cap, is what decides on every model in use.
+sources        = { kind = "temporary",      budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
 # The report is written FROM this region, so anything evicted here is a finding
 # the run paid for and cannot deliver. 40 items bounds the report long before the
 # reading is done - and this blueprint sits above a fan-out of up to 12 workers,
 # so it is the level where the ceiling costs most: every worker's findings funnel
 # through these slots. Wide enough now that the budget is what limits it, which
-# is a limit that scales with the model.
-claims         = { kind = "sliding_window", max_items = 150, budget = "15%", volatility = "grows", max_tokens = 30000 }
+# is a limit that scales with the model - a percentage low enough that what the
+# region holds is bounded by what a run can afford to re-send, not by what the
+# window could technically fit.
+claims         = { kind = "sliding_window", max_items = 150, budget = "5%", volatility = "grows", min_tokens = 10000, max_tokens = 75000 }
 contradictions = { kind = "clearable",      budget = "3%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: the
 # analysis stage reads it directly and it is the point of the fan-out.

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -57,10 +57,10 @@ authoritative references, not a broad skim.
   So cross at least two indexes of DIFFERENT KINDS before settling the list, and
   record which kinds in `sources_index`. Different kinds means structurally
   different: a category listing and a second category listing are one index twice.
-  Reach for what a category filter cannot reach - awards and guides, a
-  professional body's own roster, the "related" and "see also" edges out of a page
-  you already trust, the venue or umbrella an entry belongs to rather than the
-  type it is filed under, and what the primary source claims to be itself.
+  Reach for what a category filter cannot reach: awards and guides, a
+  professional body's own roster, the "related" and "see also" edges out of a
+  page you already trust, whatever an entry sits inside rather than the type it
+  is filed under, and what the primary source says it is in its own words.
 
   Then ask the question that catches the filter: what would something in this
   field have to be for it NOT to appear in the indexes I used? Name one such thing

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -352,15 +352,13 @@ worker_findings = { kind = "clearable", budget = "12%" }
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# The percentage is what sizes it, and it is lower than it looks: this region is
-# re-sent on every inference for the rest of the stage, so its size multiplies
-# cost and latency rather than being paid once. 30% was written against a
-# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
-# which is where a measured run spent most of $137. `min_tokens` keeps a small
-# window from resolving to less than one fetched page; `max_tokens` is a
-# backstop for a window nobody ships yet, deliberately far above the percentage
-# so that the percentage, not the cap, is what decides on every model in use.
-logs            = { kind = "temporary",       budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
+# Sized by the percentage alone. An absolute ceiling was tried here and removed:
+# it bound on every model above 200K, so the percentage - which is the whole
+# mechanism for scaling with the model in front of you - decided nothing across
+# the range anyone runs on. The size was never the fault anyway. 280K tokens
+# re-sent at 4% cached is expensive; the same 280K mostly cached is not, and the
+# `volatility` above is what makes the difference.
+logs            = { kind = "temporary",       budget = "30%", volatility = "grows" }
 scripts         = { kind = "compacting",      budget = "20%", compact_at = "80%", volatility = "grows" }
 scripts_history = { kind = "compact_history", source_region = "scripts", budget = "3%", volatility = "grows" }
 

--- a/crates/leviath-cli/agents/log-analyzer/agent.leviath
+++ b/crates/leviath-cli/agents/log-analyzer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "log-analyzer"
-version = "0.2.3"
+version = "0.2.4"
 description = "Analyzes log files - sweeps many files or time windows in parallel, then identifies anomalies, trends, and error patterns via a scripted analyze⇄script loop, maintaining a severity-ranked findings index"
 entry_stage = "ingest"
 
@@ -352,10 +352,15 @@ worker_findings = { kind = "clearable", budget = "12%" }
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
-# written against a 200K-token window, and the same 30% of a 1M-token model is
-# 300K tokens of raw scrape carried into every later stage.
-logs            = { kind = "temporary",       budget = "30%", volatility = "grows", max_tokens = 60000 }
+# The percentage is what sizes it, and it is lower than it looks: this region is
+# re-sent on every inference for the rest of the stage, so its size multiplies
+# cost and latency rather than being paid once. 30% was written against a
+# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
+# which is where a measured run spent most of $137. `min_tokens` keeps a small
+# window from resolving to less than one fetched page; `max_tokens` is a
+# backstop for a window nobody ships yet, deliberately far above the percentage
+# so that the percentage, not the cap, is what decides on every model in use.
+logs            = { kind = "temporary",       budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
 scripts         = { kind = "compacting",      budget = "20%", compact_at = "80%", volatility = "grows" }
 scripts_history = { kind = "compact_history", source_region = "scripts", budget = "3%", volatility = "grows" }
 

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -413,25 +413,23 @@ format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite ever
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# The percentage is what sizes it, and it is lower than it looks: this region is
-# re-sent on every inference for the rest of the stage, so its size multiplies
-# cost and latency rather than being paid once. 30% was written against a
-# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
-# which is where a measured run spent most of $137. `min_tokens` keeps a small
-# window from resolving to less than one fetched page; `max_tokens` is a
-# backstop for a window nobody ships yet, deliberately far above the percentage
-# so that the percentage, not the cap, is what decides on every model in use.
-raw_findings   = { kind = "temporary", budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
+# Sized by the percentage alone. An absolute ceiling has been tried here twice
+# and removed twice - once at 40,000 with the note that "the percentages were
+# decorative from about 167k upward", once at 60,000 for the same reason found
+# again. A cap low enough to matter binds on every model above the window it was
+# chosen for, so from there up it decides the size and the percentage - the whole
+# mechanism for scaling with the model in front of you - decides nothing. The size was never the fault anyway. 280K tokens
+# re-sent at 4% cached is expensive; the same 280K mostly cached is not, and the
+# `volatility` above is what makes the difference.
+raw_findings   = { kind = "temporary", budget = "30%", volatility = "grows" }
 # Extracted claims (with source refs) and cross-source conflicts.
 # The report is written FROM this region, so anything evicted here is a finding
 # the run paid for and cannot deliver. At 30 items that bound was reached long
 # before the reading was: on one measured run an agent read 8.8M tokens, spent
 # $35, and handed back 2,596 bytes - fewer than one that read 462K and spent
 # $2.41, because both filled the same 30 slots. Wide enough now that the budget
-# is what limits it, which is a limit that scales with the model - a percentage
-# low enough that what the region holds is bounded by what a run can afford to
-# re-send, not by what the window could technically fit.
-claims         = { kind = "sliding_window", max_items = 150, budget = "5%", volatility = "grows", min_tokens = 10000, max_tokens = 75000 }
+# is what limits it, which is a limit that scales with the model.
+claims         = { kind = "sliding_window", max_items = 150, budget = "15%", volatility = "grows" }
 contradictions = { kind = "clearable",      budget = "3%" }
 
 # Synthesis workspace (compacts to a running history when it grows).

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.4.4"
+version = "0.4.5"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 max_child_depth = 2
 entry_stage = "gather"
@@ -413,18 +413,25 @@ format         = { kind = "pinned", budget = "1%", seed = { literal = "Cite ever
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
-# written against a 200K-token window, and the same 30% of a 1M-token model is
-# 300K tokens of raw scrape carried into every later stage.
-raw_findings   = { kind = "temporary", budget = "30%", volatility = "grows", max_tokens = 60000 }
+# The percentage is what sizes it, and it is lower than it looks: this region is
+# re-sent on every inference for the rest of the stage, so its size multiplies
+# cost and latency rather than being paid once. 30% was written against a
+# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
+# which is where a measured run spent most of $137. `min_tokens` keeps a small
+# window from resolving to less than one fetched page; `max_tokens` is a
+# backstop for a window nobody ships yet, deliberately far above the percentage
+# so that the percentage, not the cap, is what decides on every model in use.
+raw_findings   = { kind = "temporary", budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
 # Extracted claims (with source refs) and cross-source conflicts.
 # The report is written FROM this region, so anything evicted here is a finding
 # the run paid for and cannot deliver. At 30 items that bound was reached long
 # before the reading was: on one measured run an agent read 8.8M tokens, spent
 # $35, and handed back 2,596 bytes - fewer than one that read 462K and spent
 # $2.41, because both filled the same 30 slots. Wide enough now that the budget
-# is what limits it, which is a limit that scales with the model.
-claims         = { kind = "sliding_window", max_items = 150, budget = "15%", volatility = "grows", max_tokens = 30000 }
+# is what limits it, which is a limit that scales with the model - a percentage
+# low enough that what the region holds is bounded by what a run can afford to
+# re-send, not by what the window could technically fit.
+claims         = { kind = "sliding_window", max_items = 150, budget = "5%", volatility = "grows", min_tokens = 10000, max_tokens = 75000 }
 contradictions = { kind = "clearable",      budget = "3%" }
 
 # Synthesis workspace (compacts to a running history when it grows).

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -54,10 +54,10 @@ Be efficient - do not search exhaustively:
    So cross at least two indexes of DIFFERENT KINDS before settling the list, and
    record which kinds in `sources_index`. Different kinds means structurally
    different: a category listing and a second category listing are one index twice.
-   Reach for what a category filter cannot reach - awards and guides, a
-   professional body's own roster, the "related" and "see also" edges out of a page
-   you already trust, the venue or umbrella an entry belongs to rather than the
-   type it is filed under, and what the primary source claims to be itself.
+   Reach for what a category filter cannot reach: awards and guides, a
+   professional body's own roster, the "related" and "see also" edges out of a
+   page you already trust, whatever an entry sits inside rather than the type it
+   is filed under, and what the primary source says it is in its own words.
 
    Then ask the question that catches the filter: what would something in this
    field have to be for it NOT to appear in the indexes I used? Name one such thing

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "reviewer"
-version = "0.2.3"
+version = "0.2.4"
 description = "Code review agent - discover, scan, review the areas in parallel, then deep review and report, with error recovery and multi-provider fallback"
 entry_stage = "discover"
 
@@ -371,10 +371,15 @@ worker_findings = { kind = "clearable", budget = "20%" }
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
-# written against a 200K-token window, and the same 30% of a 1M-token model is
-# 300K tokens of raw scrape carried into every later stage.
-findings        = { kind = "temporary", budget = "20%", volatility = "grows", max_tokens = 40000 }
+# The percentage is what sizes it, and it is lower than it looks: this region is
+# re-sent on every inference for the rest of the stage, so its size multiplies
+# cost and latency rather than being paid once. 30% was written against a
+# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
+# which is where a measured run spent most of $137. `min_tokens` keeps a small
+# window from resolving to less than one fetched page; `max_tokens` is a
+# backstop for a window nobody ships yet, deliberately far above the percentage
+# so that the percentage, not the cap, is what decides on every model in use.
+findings        = { kind = "temporary", budget = "6%", volatility = "grows", min_tokens = 12000, max_tokens = 100000 }
 severity_index  = { kind = "pinned",    budget = "2%" }
 report          = { kind = "clearable", budget = "7%" }
 

--- a/crates/leviath-cli/agents/reviewer/agent.leviath
+++ b/crates/leviath-cli/agents/reviewer/agent.leviath
@@ -371,15 +371,13 @@ worker_findings = { kind = "clearable", budget = "20%" }
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# The percentage is what sizes it, and it is lower than it looks: this region is
-# re-sent on every inference for the rest of the stage, so its size multiplies
-# cost and latency rather than being paid once. 30% was written against a
-# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
-# which is where a measured run spent most of $137. `min_tokens` keeps a small
-# window from resolving to less than one fetched page; `max_tokens` is a
-# backstop for a window nobody ships yet, deliberately far above the percentage
-# so that the percentage, not the cap, is what decides on every model in use.
-findings        = { kind = "temporary", budget = "6%", volatility = "grows", min_tokens = 12000, max_tokens = 100000 }
+# Sized by the percentage alone. An absolute ceiling was tried here and removed:
+# it bound on every model above 200K, so the percentage - which is the whole
+# mechanism for scaling with the model in front of you - decided nothing across
+# the range anyone runs on. The size was never the fault anyway. 280K tokens
+# re-sent at 4% cached is expensive; the same 280K mostly cached is not, and the
+# `volatility` above is what makes the difference.
+findings        = { kind = "temporary", budget = "20%", volatility = "grows" }
 severity_index  = { kind = "pinned",    budget = "2%" }
 report          = { kind = "clearable", budget = "7%" }
 

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -65,10 +65,10 @@ out are the things it does not mention.
 So cross at least two indexes of DIFFERENT KINDS before settling the list, and
 record which kinds in `sources_index`. Different kinds means structurally
 different: a category listing and a second category listing are one index twice.
-Reach for what a category filter cannot reach - awards and guides, a
-professional body's own roster, the "related" and "see also" edges out of a page
-you already trust, the venue or umbrella an entry belongs to rather than the
-type it is filed under, and what the primary source claims to be itself.
+Reach for what a category filter cannot reach: awards and guides, a
+professional body's own roster, the "related" and "see also" edges out of a
+page you already trust, whatever an entry sits inside rather than the type it
+is filed under, and what the primary source says it is in its own words.
 
 Then ask the question that catches the filter: what would something in this
 field have to be for it NOT to appear in the indexes I used? Name one such thing
@@ -541,9 +541,10 @@ the report is going to assert, ask the uncomfortable question:
 - Is anything MISSING? Read `sources_index` and ask what kind of source is not
   in it. A survey that found its candidates through category listings has only
   what that category is indexed under, and the best answer is often filed
-  somewhere else - a different category, an award or a guide, a venue rather
-  than its type. Name what is absent and where it would be found: absence is a
-  finding, and this is the last stage that can still go and get it.
+  somewhere else: a different category, an award or a guide, whatever it sits
+  inside rather than the type it is. Name what is absent and where it would be
+  found. Absence is a finding, and this is the last stage that can still go and
+  get it.
 
 Write each challenge to `challenges` (context_append) as one line:
 `[!] <the claim> - <what is wrong with the support> - <what would settle it>`

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.4.5"
+version = "0.4.6"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 max_child_depth = 2
 entry_stage = "survey"
@@ -695,10 +695,15 @@ format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite 
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# `max_tokens` is the ceiling the percentage alone stopped providing: 30% was
-# written against a 200K-token window, and the same 30% of a 1M-token model is
-# 300K tokens of raw scrape carried into every later stage.
-landscape          = { kind = "temporary",      budget = "30%", volatility = "grows", max_tokens = 60000 }
+# The percentage is what sizes it, and it is lower than it looks: this region is
+# re-sent on every inference for the rest of the stage, so its size multiplies
+# cost and latency rather than being paid once. 30% was written against a
+# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
+# which is where a measured run spent most of $137. `min_tokens` keeps a small
+# window from resolving to less than one fetched page; `max_tokens` is a
+# backstop for a window nobody ships yet, deliberately far above the percentage
+# so that the percentage, not the cap, is what decides on every model in use.
+landscape          = { kind = "temporary",      budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
 deep_dives         = { kind = "sliding_window", max_items = 15, budget = "8%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: it is
 # the whole point of the fan-out, and compare reads it directly.

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -695,15 +695,13 @@ format             = { kind = "pinned", budget = "1%", seed = { literal = "Cite 
 # `rewritten`, which assumes the whole region changes every turn and so caches
 # none of it - measured at 4% cache hits on a run where this region held 280K
 # tokens, every one of them re-sent and re-paid on every single inference.
-# The percentage is what sizes it, and it is lower than it looks: this region is
-# re-sent on every inference for the rest of the stage, so its size multiplies
-# cost and latency rather than being paid once. 30% was written against a
-# 200K-token window and became 300K tokens of raw scrape on a 1M-token model,
-# which is where a measured run spent most of $137. `min_tokens` keeps a small
-# window from resolving to less than one fetched page; `max_tokens` is a
-# backstop for a window nobody ships yet, deliberately far above the percentage
-# so that the percentage, not the cap, is what decides on every model in use.
-landscape          = { kind = "temporary",      budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
+# Sized by the percentage alone. An absolute ceiling was tried here and removed:
+# it bound on every model above 200K, so the percentage - which is the whole
+# mechanism for scaling with the model in front of you - decided nothing across
+# the range anyone runs on. The size was never the fault anyway. 280K tokens
+# re-sent at 4% cached is expensive; the same 280K mostly cached is not, and the
+# `volatility` above is what makes the difference.
+landscape          = { kind = "temporary",      budget = "30%", volatility = "grows" }
 deep_dives         = { kind = "sliding_window", max_items = 15, budget = "8%" }
 # What the parallel researcher workers hand back, one entry each. Pinned: it is
 # the whole point of the fan-out, and compare reads it directly.

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -373,15 +373,16 @@ mod tests {
         );
     }
 
-    /// The share of a model's context window one region may hold before this
-    /// test insists it say how it changes and where it stops.
+    /// A `temporary` region on a percentage budget must declare `volatility` and
+    /// a `max_tokens` ceiling, because both defaults fail quietly and only at
+    /// scale.
     ///
-    /// Below this a mis-declared region is a rounding error; at and above it the
-    /// region is most of what every inference carries.
-    const BULK_REGION_PERCENT: f64 = 0.20;
-
-    /// A bulk `temporary` region must declare `volatility` and a `max_tokens`
-    /// ceiling, because both defaults fail quietly and only at scale.
+    /// Keyed on the kind rather than on how large the percentage looks. An
+    /// earlier version of this test only examined regions at 20% or more, on the
+    /// reasoning that a smaller one could not matter - which stopped being true
+    /// the moment those percentages were lowered and their guard-rails did the
+    /// scaling instead. The percentage is not what makes a region worth checking;
+    /// accumulating tool output is, and `temporary` is the kind that does it.
     ///
     /// `volatility` defaults to `rewritten`, which assumes the whole region
     /// changes every turn and so caches none of it. That is right for a
@@ -419,8 +420,7 @@ mod tests {
                 .iter()
                 .filter_map(|region| match region.budget {
                     BudgetSpec::Percent { percent, max, .. }
-                        if percent >= BULK_REGION_PERCENT
-                            && region.kind == RegionKind::Temporary =>
+                        if region.kind == RegionKind::Temporary =>
                     {
                         Some((region, percent, max))
                     }
@@ -453,7 +453,7 @@ mod tests {
         }
         assert!(
             checked > 0,
-            "no bulk temporary region was examined -- this test now proves nothing"
+            "no temporary region on a percentage budget was examined -- this test now proves nothing"
         );
     }
 

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -373,16 +373,27 @@ mod tests {
         );
     }
 
-    /// A `temporary` region on a percentage budget must declare `volatility` and
-    /// a `max_tokens` ceiling, because both defaults fail quietly and only at
-    /// scale.
+    /// A `temporary` region must declare its `volatility`, because the default
+    /// fails quietly and only at scale.
     ///
-    /// Keyed on the kind rather than on how large the percentage looks. An
-    /// earlier version of this test only examined regions at 20% or more, on the
-    /// reasoning that a smaller one could not matter - which stopped being true
-    /// the moment those percentages were lowered and their guard-rails did the
-    /// scaling instead. The percentage is not what makes a region worth checking;
-    /// accumulating tool output is, and `temporary` is the kind that does it.
+    /// `rewritten` - the default - says the whole region changes every turn, so
+    /// none of it is cached. That is right for a scratchpad and wrong for the
+    /// append-only region tool results land in, where it was worth 4% cache hits
+    /// instead of most of the region on a measured run. A region re-sent in full
+    /// on every inference for the rest of a stage is the single largest thing a
+    /// blueprint can get wrong about its own cost.
+    ///
+    /// Keyed on the kind, not on how large the percentage is. An earlier version
+    /// checked only regions at 20% or more, on the reasoning that a smaller one
+    /// could not matter; it stopped covering anything the moment those
+    /// percentages changed. Accumulating tool output is what makes a region worth
+    /// checking and `temporary` is the kind that does it.
+    ///
+    /// Deliberately NOT asserting an absolute ceiling alongside the percentage.
+    /// One was tried and removed: it bound on every model above 200K, which left
+    /// the percentage - the entire mechanism for scaling to the model in front of
+    /// you - deciding nothing over the range anyone runs on. Size was never the
+    /// fault; uncached size was.
     ///
     /// `volatility` defaults to `rewritten`, which assumes the whole region
     /// changes every turn and so caches none of it. That is right for a
@@ -399,7 +410,7 @@ mod tests {
     /// An invariant over discovered blueprints rather than a list of known ones:
     /// the next bulk region somebody adds is the one this is here to catch.
     #[test]
-    fn a_bulk_temporary_region_says_how_it_changes_and_where_it_stops() {
+    fn a_temporary_region_says_how_its_contents_change() {
         use leviath_core::BudgetSpec;
         use leviath_core::region::{RegionKind, Volatility};
 
@@ -419,33 +430,23 @@ mod tests {
                 .regions
                 .iter()
                 .filter_map(|region| match region.budget {
-                    BudgetSpec::Percent { percent, max, .. }
-                        if region.kind == RegionKind::Temporary =>
-                    {
-                        Some((region, percent, max))
+                    BudgetSpec::Percent { percent, .. } if region.kind == RegionKind::Temporary => {
+                        Some((region, percent))
                     }
                     _ => None,
                 });
 
-            for (region, percent, max) in bulk {
+            for (region, percent) in bulk {
                 checked += 1;
+                // Computed here rather than in the failure message: an argument
+                // expression evaluated only on failure is its own uncovered
+                // region on an assertion that has to pass.
                 let share = percent * 100.0;
-                // Both figures are computed here rather than in the failure
-                // message: an argument expression evaluated only on failure is
-                // its own uncovered region on an assertion that has to pass.
-                let on_a_wide_window = percent * 1000.0;
                 assert_ne!(
                     region.volatility,
                     Volatility::Rewritten,
                     "{}: `{}` holds {share:.0}% of the window as accumulated tool output but \
                      is `rewritten`, so none of it is ever cached",
-                    agent.name,
-                    region.name,
-                );
-                assert!(
-                    max.is_some(),
-                    "{}: `{}` is {share:.0}% of the window with no `max_tokens`, so a \
-                     1M-token model gives it {on_a_wide_window:.0}K tokens on every call",
                     agent.name,
                     region.name,
                 );

--- a/docs/content/costs.md
+++ b/docs/content/costs.md
@@ -123,10 +123,10 @@ inference after it grows. [Structured context](/docs/context) is where this is g
 - An edge `transform` decides what crosses a stage boundary. A `clear` on a region the next
   stage does not read is the cheapest change available: a report-rewriting stage does not need
   the transcript of the research that produced it.
-- `max_tokens` on a region is a ceiling, not a reservation, and `min_tokens` a floor. Alongside a
-  percentage budget they bound what it resolves to rather than replacing it. Keep the ceiling
-  well above what the percentage yields on the models you run, or it, and not the percentage, is
-  what sizes the region.
+- `max_tokens` on a region is a ceiling, not a reservation. Alongside a percentage budget it
+  caps what that percentage resolves to - so on every model where it binds, it and not the
+  percentage is what sizes the region. Reach for it only when the region's useful size does not
+  grow with the window.
 
 ## Know what you actually paid
 
@@ -184,7 +184,7 @@ A region that accumulates - the one tool results land in - is re-sent on every i
 rest of the stage. Whether you pay full price for it each time comes down to one field:
 
 ```toml
-raw_findings = { kind = "temporary", budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
+raw_findings = { kind = "temporary", budget = "30%", volatility = "grows" }
 ```
 
 `volatility` defaults to `rewritten`, which tells the assembler the whole region changes every
@@ -193,19 +193,18 @@ of fetched pages. On a measured run, a 280,000-token findings region left at the
 4% of the prompt: the same content re-sent, re-billed, and re-processed on every call, which is
 latency as much as cost. Declared `grows`, the settled head caches and only the tail is new.
 
-The percentage is the number to get right, and for an accumulating region it should be lower
-than feels natural. This region is re-sent on every inference for the rest of the stage, so its
-size multiplies cost and latency instead of being paid once. `30%` sounds like a third of the
-budget; against a 1M-token model it is 300,000 tokens carried into every call, which is where a
-measured run spent most of $137.
+Size the region with the percentage and leave it there. A percentage is the mechanism for
+scaling to the model in front of you: 30% is 60,000 tokens on a 200K-token model and 300,000 on
+a 1M-token one, and both are 30% of what that model can hold.
 
-`min_tokens` and `max_tokens` are guard-rails on that percentage, not replacements for it. The
-floor keeps a small-context model from resolving the region below one fetched page. The ceiling
-is a backstop for a window nobody ships yet, and it is deliberately set far above what the
-percentage yields today: a cap that binds on the models you actually run makes the percentage
-decorative, which is the failure mode in the other direction. If your region resolves to the
-same number on a 200K model and a 1M one, the cap is doing the deciding and the percentage is
-not.
+It is tempting to add an absolute `max_tokens` alongside it as insurance. Resist it unless you
+mean the cap to be the real limit, because that is what it becomes: a ceiling low enough to
+matter binds on every model above the window it was chosen for, and from there up the percentage
+decides nothing. A region that resolves to the same number on a 200K model and a 1M one is not
+percentage-sized at all. If your region is too big, the percentage is the number to change.
+
+The exception is a region whose useful size genuinely does not grow with the window - a fixed
+list, a seeded constant. Those are the ones `max_tokens` is for.
 
 See [structured context](/docs/context) for the full set of region fields.
 

--- a/docs/content/costs.md
+++ b/docs/content/costs.md
@@ -123,8 +123,10 @@ inference after it grows. [Structured context](/docs/context) is where this is g
 - An edge `transform` decides what crosses a stage boundary. A `clear` on a region the next
   stage does not read is the cheapest change available: a report-rewriting stage does not need
   the transcript of the research that produced it.
-- `max_tokens` on a region is a ceiling, not a reservation. Setting one alongside a percentage
-  budget caps the region at the smaller of the two.
+- `max_tokens` on a region is a ceiling, not a reservation, and `min_tokens` a floor. Alongside a
+  percentage budget they bound what it resolves to rather than replacing it. Keep the ceiling
+  well above what the percentage yields on the models you run, or it, and not the percentage, is
+  what sizes the region.
 
 ## Know what you actually paid
 
@@ -182,7 +184,7 @@ A region that accumulates - the one tool results land in - is re-sent on every i
 rest of the stage. Whether you pay full price for it each time comes down to one field:
 
 ```toml
-raw_findings = { kind = "temporary", budget = "30%", volatility = "grows", max_tokens = 60000 }
+raw_findings = { kind = "temporary", budget = "8%", volatility = "grows", min_tokens = 16000, max_tokens = 150000 }
 ```
 
 `volatility` defaults to `rewritten`, which tells the assembler the whole region changes every
@@ -191,10 +193,19 @@ of fetched pages. On a measured run, a 280,000-token findings region left at the
 4% of the prompt: the same content re-sent, re-billed, and re-processed on every call, which is
 latency as much as cost. Declared `grows`, the settled head caches and only the tail is new.
 
-`max_tokens` is the ceiling the percentage on its own does not give you. A percentage is written
-against whatever window the author had in mind, and the model's window is not a constant: `30%`
-was 60,000 tokens against a 200K-token model and is 300,000 against a 1M-token one, with nothing
-in the blueprint changed. Setting both caps the region at the smaller of the two.
+The percentage is the number to get right, and for an accumulating region it should be lower
+than feels natural. This region is re-sent on every inference for the rest of the stage, so its
+size multiplies cost and latency instead of being paid once. `30%` sounds like a third of the
+budget; against a 1M-token model it is 300,000 tokens carried into every call, which is where a
+measured run spent most of $137.
+
+`min_tokens` and `max_tokens` are guard-rails on that percentage, not replacements for it. The
+floor keeps a small-context model from resolving the region below one fetched page. The ceiling
+is a backstop for a window nobody ships yet, and it is deliberately set far above what the
+percentage yields today: a cap that binds on the models you actually run makes the percentage
+decorative, which is the failure mode in the other direction. If your region resolves to the
+same number on a 200K model and a 1M one, the cap is doing the deciding and the percentage is
+not.
 
 See [structured context](/docs/context) for the full set of region fields.
 


### PR DESCRIPTION
#590 added an absolute `max_tokens` alongside these percentages, to stop a `30%` region resolving to 300,000 tokens on a 1M-token model. It worked, and it was the wrong fix.

A ceiling low enough to do that **binds on every model above the window it was picked for**. From 200K upward the cap decided the size and the percentage decided nothing. A region that resolves to the same number on a 200K model and a 1M one is not percentage-sized at all - and the percentage is the entire mechanism for scaling to the model in front of you.

## The size was never the fault

280,000 tokens re-sent at **4% cached** is expensive. The same 280,000 mostly cached is not. The `volatility = "grows"` declaration beside these regions - the other half of #590 - is what changed that, and it is doing the work the cap was brought in for.

So the ceilings are gone and the percentages are back where they were authored:

| region | 200K | 1M | 2M |
|---|---|---|---|
| `raw_findings` / `landscape` / `sources` / `logs` | 60K | 314K | 600K |
| `comparisons` / `raw_sources` | 50K | 262K | 500K |
| `thread_findings` / `findings` | 40K | 209K | 400K |
| `claims` | 30K | 157K | 300K |

Each is the percentage of what that model can hold, and nothing overrides it.

## The test moves with them

It now asserts the `volatility` declaration, which is the fix, and no longer requires a ceiling, which was not.

It keeps one thing from the discarded attempt: it is keyed on the region's **kind** rather than on how large its percentage looks. The earlier version only examined regions at 20% or more, and when those percentages moved it covered nothing - which it reported through its vacuity check rather than passing on an empty set. That re-keying was right for its own reasons and would otherwise have to be rediscovered.

## Docs

`docs/content/costs.md` said to combine a percentage with guard-rails. It now says to size these with the percentage and leave it there, and names the one case an absolute ceiling is actually for: a region whose useful size genuinely does not grow with the window - a fixed list, a seeded constant.

## Verification

- Resolved sizes computed across 200K / 1M / 2M for every percentage region in every bundled blueprint and checked against the table above.
- Layouts validate at every window in the existing range check, and layout growth clears its bar - now at the full 5.24x, since nothing clamps.
- All 7 blueprints pass `lev validate`; the 6 changed ones are version-bumped.
- Suite green as CI runs it, clippy 0, structure and docs gates pass, **coverage 13/13 at 100%**.

## History worth keeping

`researcher` had a 40,000 cap on `raw_findings` once before. It was deleted with the note that *"the percentages were decorative from about 167k upward"* - the same conclusion, reached the same way, before I reintroduced it. That note is now in the region comment so the next person to reach for a ceiling here finds the reason it was removed twice.
