### PR TITLE
fix(pipeline): a turn spent writing to context left no trace of itself (#595)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ same list.
 
 ## Unreleased
 
+- Fixed: a turn in which the model only wrote to its own context left no trace
+  in the stage log. Those calls are resolved by the dispatcher rather than the
+  tool lane, and the lane is where `[tool]` lines are written, so a batch made
+  entirely of them went straight past the only place that records what ran -
+  while still counting towards the run's tool-call total. A run could report
+  tool calls beside a log holding none of them, which reads as a lost log
+  rather than as an agent that spent its turn taking notes.
 - Added: `GET /api/update` reports how this copy of Leviath was installed and
   the command that upgrades it, as the same JSON `lev update --check --json`
   prints. The browser console had no way to ask, so it printed one hard-coded

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -4094,6 +4094,17 @@ async fn dispatch_all_inline_batch_is_not_journaled() {
     // A batch the dispatcher fully resolves inline never reaches the lane; its
     // results land in the window, which the snapshot path persists - a batch
     // record would be pure noise.
+    //
+    // Deliberate, and worth stating why, because it looks like an omission:
+    // `restore_pending_batch` replays a journaled batch by landing its recorded
+    // results in the conversation, and it does *not* re-apply a context tool's
+    // write. Journaling this batch would mean a crash between the append and
+    // the next snapshot restores a turn saying `context_write: ok` over a
+    // region that never got the content - a silent divergence far worse than
+    // the missing record. Unjournaled, the batch is simply re-issued.
+    //
+    // The observability half of that gap is closed by the `[tool]` lines the
+    // test below asserts, which carry no recovery meaning at all.
     let (jtx, mut jrx) = mpsc::unbounded_channel();
     let (ptx, mut prx) = mpsc::unbounded_channel();
     let mut world = World::new();
@@ -4116,6 +4127,82 @@ async fn dispatch_all_inline_batch_is_not_journaled() {
     assert!(world.get::<ReadyToInfer>(e).is_some());
     assert!(jrx.try_recv().is_err());
     assert!(prx.try_recv().is_err(), "no batch record for inline-only");
+}
+
+/// A batch of only inline-resolved calls still says what it did.
+///
+/// It returns before `collect_tools`, which is where every other batch gets its
+/// `[tool]` lines, so it used to leave no trace a person could read: nothing in
+/// `logs.log`, nothing in the journal, and yet `meta.tool_calls` counted it. A
+/// run could report 45 tool calls beside a stage log holding none of them,
+/// which is how an empty activity panel read as a dropped-log bug rather than
+/// as the model having only written to its own context (issues #589, #595).
+#[tokio::test]
+async fn dispatch_logs_an_all_inline_batch_it_would_otherwise_swallow() {
+    let (jtx, _jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let e = world
+        .spawn((
+            agent_state(),
+            infer_with(vec![
+                ctx_call("c1", "notes", "hi"),
+                ctx_call("c2", "notes", "there"),
+            ]),
+            notes_window(),
+            StageCursor { index: 2 },
+            StageIoBuffer::default(),
+            ReadyForTools,
+        ))
+        .id();
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    assert!(world.get::<ReadyToInfer>(e).is_some(), "nothing to await");
+    let buf = world
+        .get::<StageIoBuffer>(e)
+        .expect("the buffer is still there");
+    // One line per call, on the stage the run is actually on, in call order.
+    assert_eq!(buf.logs.len(), 2, "one line per call: {:?}", buf.logs);
+    assert!(buf.logs.iter().all(|(idx, _)| *idx == 2));
+    assert!(
+        buf.logs[0].1.starts_with("[tool] context_write:"),
+        "{:?}",
+        buf.logs[0]
+    );
+    assert!(
+        buf.logs[1].1.starts_with("[tool] context_write:"),
+        "{:?}",
+        buf.logs[1]
+    );
+    // The readable output stream stays empty: the model said nothing here, and
+    // claiming otherwise is what made the other panel misleading.
+    assert!(buf.output.is_empty());
+}
+
+/// The same batch on an agent with no buffer (a `lev run` world, or a test)
+/// dispatches exactly as before rather than panicking on the missing component.
+#[tokio::test]
+async fn dispatch_all_inline_without_a_buffer_still_advances() {
+    let (jtx, _jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let e = world
+        .spawn((
+            agent_state(),
+            infer_with(vec![ctx_call("c1", "notes", "hi")]),
+            notes_window(),
+            StageCursor { index: 0 },
+            ReadyForTools,
+        ))
+        .id();
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+    assert!(world.get::<ReadyToInfer>(e).is_some());
 }
 
 #[tokio::test]

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -291,6 +291,9 @@ type DispatchToolsQuery = (
     (
         Option<&'static RunMetadata>,
         Option<&'static crate::pipeline::response::StageProgress>,
+        // Only for the all-inline batch below, which returns before
+        // `collect_tools` (the usual writer of `[tool]` lines) ever sees it.
+        Option<&'static mut crate::pipeline::response::StageIoBuffer>,
     ),
     Option<&'static crate::components::OutputValidators>,
     // For the submit_output guard: a submission that is exactly the name of a
@@ -369,7 +372,7 @@ pub fn dispatch_tools(
         auto_gate,
         in_flight,
         cursor,
-        (metadata, stage_progress),
+        (metadata, stage_progress, mut io_buffer),
         validators,
         blueprint,
     ) in agents.iter_mut()
@@ -692,6 +695,25 @@ pub fn dispatch_tools(
         if lane_calls.is_empty() {
             // Nothing async to run - apply the context results now and loop back.
             let merged = merge_in_call_order(&result.tool_calls, &context_results);
+            // Log the calls here, because this batch never reaches
+            // `collect_tools` - the usual writer of `[tool]` lines - and so
+            // left no trace anywhere a person can read. A batch of only
+            // inline-resolved calls (context tools, a refusal, a gate denial)
+            // still counts towards `meta.tool_calls`, so a run could report
+            // tool calls next to a stage log that recorded none of them, which
+            // is exactly how an empty activity panel came to look like a
+            // dropped-log bug (issues #589, #595). A mixed batch is already
+            // covered: `collect_tools` zips over every call, inline ones
+            // included.
+            if let Some(buffer) = io_buffer.as_deref_mut() {
+                let idx = cursor.map_or(0, |c| c.index);
+                for (call, (_id, tool_result)) in result.tool_calls.iter().zip(merged.iter()) {
+                    buffer.logs.push((
+                        idx,
+                        format!("[tool] {}: {}", call.name, one_line(tool_result, 200)),
+                    ));
+                }
+            }
             apply_tool_results(
                 &mut window,
                 &result.response,


### PR DESCRIPTION
Closes #595, with a correction to how it was filed.

The observation held: a batch made entirely of calls the dispatcher resolves itself — context tools, a refusal, a gate denial — never reaches the tool lane, and the lane is where `[tool]` lines are written. So such a turn produced no log line, no journal record, and yet `meta.tool_calls` counted every call. That is the shape that made #589's empty activity panel read as a lost log rather than as an agent that spent its turn taking notes.

**The remedy I proposed in the issue is the half I did not do.** The existing test asserting an inline batch is unjournaled turns out to be right for a reason it never stated: `restore_pending_batch` replays a journaled batch by landing its recorded results in the conversation, and it does *not* re-apply a context tool's write. Journaling it would mean a crash between the append and the next snapshot restores a turn saying `context_write: ok` over a region that never received the content — the model then reasons from notes it can see it wrote and cannot find. Unjournaled, the batch is simply re-issued, which is correct for a call whose whole effect is a window mutation. The test now says so.

The journal's under-count against `meta.tool_calls` therefore stays, and is inert: `FoldedRun::tool_call_count` has no production caller.

What is fixed is the half that costs someone an evening — the log. The early-return path writes its `[tool]` lines first, so those calls are visible where every other call is. Mixed batches already worked; this is only the all-inline case. `[tool]` lines carry no recovery meaning, which is exactly why this half is safe to change and the other is not.

## Verification

Live, against the shipped 0.4.0 binary as a control, driving an agent that calls `context_write` on its own:

| | `meta.tool_calls` | `stages/0/logs.log` |
|---|---|---|
| before | 1 | `[Tokens: 10 in, 5 out]` — the call is invisible |
| after | 1 | `[tool] context_write: Stored in 'notes' section.` |

The new test was run against the unfixed code first and fails there with an empty log. `cargo xtask coverage`: all 13 packages at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)