### PR TITLE
fix(providers): a local model you named as your default is now reachable (#598)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ same list.
 
 ## Unreleased
 
+- Fixed: naming a script provider as `default_provider` did not send any stage
+  to it. A blueprint entry that names a model and no provider is resolved by
+  asking the configured providers which of them serves it, and script providers
+  were not among those asked - they are compiled the first time they are used
+  rather than enumerated. So a machine with a local model serving exactly what
+  the blueprint asked for sent every stage somewhere else, and setting
+  `default_provider` changed nothing. The provider named as the default is now
+  asked too, which is one script compiled rather than every script on disk. It
+  answers from its own `list_models`, or from a new
+  `[model_providers.<name>] serves` list for a script that has none. Per-stage
+  models are unaffected: this decides the route, so a tiered blueprint keeps
+  each stage on the model its author picked.
 - Fixed: a turn in which the model only wrote to its own context left no trace
   in the stage log. Those calls are resolved by the dispatcher rather than the
   tool lane, and the lane is where `[tool]` lines are written, so a batch made

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -339,6 +339,7 @@ fn script_provider_spec(
         script: mp.script.clone(),
         rate_limit: mp.rate_limit.clone(),
         init_config: serde_json::Value::Object(cfg),
+        serves: mp.serves.clone(),
     }
 }
 
@@ -571,6 +572,7 @@ mod tests {
                 requests_per_minute: 30,
                 tokens_per_minute: 1000,
             }),
+            serves: Vec::new(),
             extra,
         };
         let spec = script_provider_spec(&mp);

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -1028,6 +1028,7 @@ mod tests {
                 api_key: Some("sk-secret-value".to_string()),
                 base_url: Some("https://api.groq.com".to_string()),
                 rate_limit: None,
+                serves: Vec::new(),
                 extra: [(
                     "signing_secret".to_string(),
                     toml::Value::String("hunter2".to_string()),

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -682,11 +682,18 @@ async fn primed_registry_with(
     config: Option<&crate::config::Config>,
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
 ) -> Option<leviath_runtime::ProviderRegistry> {
+    let config = config?;
     let registry =
-        crate::commands::run::build_provider_registry_from_config_with(config?, build_client)
+        crate::commands::run::build_provider_registry_from_config_with(config, build_client)
             .ok()?;
     registry
-        .prime_capabilities(std::time::Duration::from_secs(VALIDATE_PRIME_TIMEOUT_SECS))
+        .prime_capabilities(
+            std::time::Duration::from_secs(VALIDATE_PRIME_TIMEOUT_SECS),
+            // So `lev validate` reports the model a run would really use on a
+            // machine whose default is a script provider, rather than the one
+            // it would have used before that provider could answer.
+            Some(config.default_provider.as_str()),
+        )
         .await;
     Some(registry)
 }

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -2686,6 +2686,7 @@ google_api_key = "AIza-existing"
             api_key: Some("gsk-SECRET-VALUE".to_string()),
             base_url: Some("https://api.groq.example".to_string()),
             rate_limit: None,
+            serves: Vec::new(),
             extra: HashMap::from([
                 (
                     "org_token".to_string(),

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -153,6 +153,17 @@ pub struct ModelProviderConfig {
     #[serde(default)]
     pub rate_limit: Option<leviath_providers::RateLimitConfig>,
 
+    /// Model ids this provider serves, so a blueprint entry naming one of them
+    /// with no provider can resolve here.
+    ///
+    /// Only needed by a script with no `list_models`: one that has it is asked
+    /// directly, and its answer is preferred over this list. Without either,
+    /// the provider claims no models and can only be reached by a blueprint
+    /// that pins it, which is what made a local model unreachable however the
+    /// machine set `default_provider` (issue #598).
+    #[serde(default)]
+    pub serves: Vec<String>,
+
     /// Any additional keys, forwarded verbatim into the script's `initialize`.
     #[serde(flatten)]
     pub extra: HashMap<String, toml::Value>,

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -167,7 +167,14 @@ pub async fn setup_daemon_host_with(
     // budget sized against it (#360). Awaited rather than spawned so the first
     // run has the answer instead of racing it; failures are warnings.
     providers
-        .prime_capabilities(std::time::Duration::from_secs(PROVIDER_PRIME_TIMEOUT_SECS))
+        .prime_capabilities(
+            std::time::Duration::from_secs(PROVIDER_PRIME_TIMEOUT_SECS),
+            // The machine's default, so a script provider named there can
+            // answer what it serves and win an open route (issue #598). No
+            // effect when the default is a native provider, which is already
+            // in the list.
+            Some(config.default_provider.as_str()),
+        )
         .await;
     // MCP connections are shared across agents; the workdir here only seeds the
     // (discarded) built-ins - each agent gets its own over its own workdir.

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -30,7 +30,7 @@ mod meta;
 use std::collections::HashMap;
 use std::path::Path;
 use std::pin::Pin;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use futures_core::Stream;
@@ -128,6 +128,18 @@ pub struct RhaiProvider {
     /// script may read via `env_var`. Held so each per-call execution engine is
     /// built with the same policy the init engine was.
     env_allowlist: Arc<Vec<String>>,
+    /// Model ids this script serves, as `list_models` reported them.
+    ///
+    /// Filled by [`Provider::prime_capabilities`] and read by
+    /// [`Provider::serves_model`], which is synchronous and on the resolve path
+    /// so it cannot go and ask. Empty until priming runs, and priming only runs
+    /// for the provider a machine names as its default - a script is compiled
+    /// on demand, and asking every script on disk what it serves is the cost
+    /// the registry exists to avoid.
+    served_models: Arc<Mutex<Vec<String>>>,
+    /// Model ids `[model_providers.<name>] serves` declares, for a script with
+    /// no `list_models` to ask. Static, so it needs no priming.
+    declared_models: Arc<Vec<String>>,
 }
 
 /// What a script provider is configured with, as distinct from the script
@@ -143,6 +155,9 @@ pub struct ScriptProviderSettings {
     pub init_config: serde_json::Value,
     /// Per-model capabilities the config declares.
     pub caps: HashMap<String, ModelCapabilityOverride>,
+    /// `[model_providers.<name>] serves`: model ids this script serves, for one
+    /// that has no `list_models` to be asked. Empty is the ordinary case.
+    pub serves: Vec<String>,
     /// Rate limiting, when configured.
     pub rate_limit: Option<RateLimitConfig>,
     /// Per-request timeout, when configured.
@@ -185,6 +200,7 @@ impl RhaiProvider {
             name,
             init_config,
             caps,
+            serves,
             rate_limit,
             request_timeout_secs,
             env_allowlist,
@@ -224,6 +240,8 @@ impl RhaiProvider {
             has_count_tokens,
             has_list_models,
             env_allowlist,
+            served_models: Arc::new(Mutex::new(Vec::new())),
+            declared_models: Arc::new(serves),
         })
     }
 
@@ -521,6 +539,63 @@ impl Provider for RhaiProvider {
             Some(o) => o.apply_to(base),
             None => base,
         }
+    }
+
+    /// Whether this script serves `model_key`, for resolving an open route.
+    ///
+    /// The default implementation reads the compiled-in capability table, which
+    /// a script provider does not have: [`Self::capabilities`] answers the same
+    /// `base` for every model it has no override for, so the default said "no"
+    /// to everything. A local box serving one fast model could therefore never
+    /// win a blueprint entry that named that model, however the machine set
+    /// `default_provider` (issue #598).
+    ///
+    /// Three sources, cheapest evidence last:
+    ///
+    /// 1. What `list_models` reported, filled by [`Self::prime_capabilities`].
+    ///    Matched on the last path segment as well as whole, because a gateway
+    ///    namespaces its ids (`deepseek/deepseek-v4-flash`) and a blueprint
+    ///    names the model (`deepseek-v4-flash`).
+    /// 2. `[model_providers.<name>] serves`, for a script with no `list_models`
+    ///    to ask. Static, so it works with no priming at all.
+    /// 3. A `[model_capabilities.<model>]` entry, which is someone describing
+    ///    that model for this provider and so saying it serves it.
+    ///
+    /// Deliberately no family-shaped guess. Answering from a default-shaped
+    /// table is how a provider comes to claim every model in existence, which
+    /// [`Provider::serves_model_from_table`] documents having measured.
+    fn serves_model(&self, model_key: &str) -> Option<String> {
+        let served = leviath_core::sync::lock(&self.served_models);
+        if let Some(id) = served
+            .iter()
+            .find(|id| id.as_str() == model_key || id.rsplit('/').next() == Some(model_key))
+        {
+            return Some(id.clone());
+        }
+        drop(served);
+        if self.declared_models.iter().any(|m| m == model_key)
+            || self.capability_overrides.contains_key(model_key)
+        {
+            return Some(model_key.to_string());
+        }
+        None
+    }
+
+    /// Ask the script what it serves, once, so [`Self::serves_model`] can answer
+    /// on the synchronous resolve path.
+    ///
+    /// A script with no `list_models` reports nothing and stays on its
+    /// `serves` list; a script whose call fails leaves the catalogue empty,
+    /// which reads as "claims nothing" rather than as an error - the same
+    /// degradation every other provider's priming has.
+    async fn prime_capabilities(&self) -> Result<()> {
+        if !self.has_list_models {
+            return Ok(());
+        }
+        let models = self.list_models().await?;
+        let ids: Vec<String> = models.into_iter().map(|m| m.id).collect();
+        *leviath_core::sync::lock(&self.served_models) = ids;
+        Ok(())
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -94,6 +94,7 @@ fn build(src: &str, executor: Arc<FakeExecutor>) -> Result<RhaiProvider> {
             name: "test".to_string(),
             init_config: serde_json::json!({}),
             caps: HashMap::new(),
+            serves: Vec::new(),
             rate_limit: None,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -113,6 +114,7 @@ fn build_rl(
             name: "test".to_string(),
             init_config: serde_json::json!({}),
             caps: HashMap::new(),
+            serves: Vec::new(),
             rate_limit,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -150,6 +152,7 @@ fn a_script_model_is_priced_from_config_and_otherwise_not_at_all() {
             name: "test".to_string(),
             init_config: serde_json::json!({}),
             caps,
+            serves: Vec::new(),
             rate_limit: None,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -202,6 +205,7 @@ fn from_source_initialize_receives_config() {
             name: "test".into(),
             init_config: serde_json::json!({ "model": "cfg-model" }),
             caps: HashMap::new(),
+            serves: Vec::new(),
             rate_limit: None,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -223,6 +227,7 @@ fn from_script_reads_missing_file() {
             name: "test".to_string(),
             init_config: serde_json::json!({}),
             caps: HashMap::new(),
+            serves: Vec::new(),
             rate_limit: None,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -251,6 +256,7 @@ fn from_script_loads_real_file() {
             name: "test".to_string(),
             init_config: serde_json::json!({}),
             caps: HashMap::new(),
+            serves: Vec::new(),
             rate_limit: None,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -465,6 +471,7 @@ fn capabilities_and_metadata() {
             name: "test".into(),
             init_config: serde_json::json!({}),
             caps,
+            serves: Vec::new(),
             rate_limit: None,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -753,6 +760,7 @@ fn sample_groq_script_compiles_and_initializes() {
             name: "groq".to_string(),
             init_config: serde_json::json!({ "api_key": "test-key" }),
             caps: HashMap::new(),
+            serves: Vec::new(),
             rate_limit: None,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -817,6 +825,7 @@ fn a_script_sees_each_system_block_region_and_volatility() {
             name: "test".to_string(),
             init_config: serde_json::json!({}),
             caps: HashMap::new(),
+            serves: Vec::new(),
             rate_limit: None,
             request_timeout_secs: None,
             env_allowlist: no_env_allowlist(),
@@ -950,4 +959,127 @@ fn from_source_rejects_a_script_with_no_inference() {
         message.contains("fn inference(state, request)"),
         "{message}"
     );
+}
+
+// ─── Serving an open route ────────────────────────────────────────────────────
+
+/// A script provider that reports nothing claims nothing.
+///
+/// The default `serves_model` reads the compiled-in capability table, which a
+/// script does not have: `capabilities` answers the same base for every model
+/// it has no override for, so the default said "no" to everything and a local
+/// model could never win a blueprint entry that named it (issue #598). Refusing
+/// is still the right answer when there is no evidence - a provider that
+/// claimed every model would be far worse - so this pins that floor.
+#[test]
+fn a_script_with_nothing_to_report_claims_no_models() {
+    let p = build(GOOD_PROVIDER, Arc::new(FakeExecutor::default())).expect("it compiles");
+    assert_eq!(p.serves_model("deepseek-v4-flash"), None);
+    assert_eq!(p.serves_model("anything-at-all"), None);
+}
+
+/// `[model_providers.<name>] serves` is how a script with no `list_models` says
+/// what it answers for. Static, so it needs no priming.
+#[test]
+fn a_declared_serves_list_wins_an_open_route() {
+    let p = RhaiProvider::from_source(
+        GOOD_PROVIDER,
+        Arc::new(FakeExecutor::default()),
+        ScriptProviderSettings {
+            name: "test".to_string(),
+            init_config: serde_json::json!({}),
+            caps: HashMap::new(),
+            serves: vec!["deepseek-v4-flash".to_string()],
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
+    )
+    .expect("the script compiles");
+
+    assert_eq!(
+        p.serves_model("deepseek-v4-flash"),
+        Some("deepseek-v4-flash".to_string())
+    );
+    // And still refuses one it was not told about.
+    assert_eq!(p.serves_model("claude-opus-5"), None);
+}
+
+/// A `[model_capabilities.<model>]` entry is somebody describing that model for
+/// this provider, which is also them saying it serves it.
+#[test]
+fn a_capability_override_is_enough_to_claim_a_model() {
+    let mut caps = HashMap::new();
+    caps.insert(
+        "custom-model".to_string(),
+        ModelCapabilityOverride {
+            max_context_tokens: Some(4096),
+            ..Default::default()
+        },
+    );
+    let p = RhaiProvider::from_source(
+        GOOD_PROVIDER,
+        Arc::new(FakeExecutor::default()),
+        ScriptProviderSettings {
+            name: "test".to_string(),
+            init_config: serde_json::json!({}),
+            caps,
+            serves: Vec::new(),
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
+    )
+    .expect("the script compiles");
+
+    assert_eq!(
+        p.serves_model("custom-model"),
+        Some("custom-model".to_string())
+    );
+    assert_eq!(p.serves_model("some-other-model"), None);
+}
+
+/// Priming asks `list_models` once, so the synchronous resolve path has an
+/// answer without going to the network itself.
+///
+/// The namespace case is the one that matters in practice: a gateway reports
+/// `vendor/model` and a blueprint names `model`, so matching only whole ids
+/// would deny every model a namespacing provider serves.
+#[tokio::test]
+async fn priming_lets_a_script_answer_from_its_own_catalogue() {
+    let src = "// @provider mock\n\
+               fn initialize(config) { #{} }\n\
+               fn inference(state, request) { #{ content: \"x\" } }\n\
+               fn list_models(state) { [ #{ id: \"deepseek/deepseek-v4-flash\", \
+               display_name: \"Flash\", max_context_tokens: 131072, \
+               max_output_tokens: 8192 } ] }";
+    let p = build(src, Arc::new(FakeExecutor::default())).expect("it compiles");
+
+    // Nothing before priming: the catalogue is empty and nothing else claims it.
+    assert_eq!(p.serves_model("deepseek-v4-flash"), None);
+
+    p.prime_capabilities().await.expect("list_models answers");
+
+    // The blueprint's bare name matches the gateway's namespaced id, and the
+    // id handed back is the one to actually send.
+    assert_eq!(
+        p.serves_model("deepseek-v4-flash"),
+        Some("deepseek/deepseek-v4-flash".to_string())
+    );
+    // The whole id works too, for a caller that already has it.
+    assert_eq!(
+        p.serves_model("deepseek/deepseek-v4-flash"),
+        Some("deepseek/deepseek-v4-flash".to_string())
+    );
+    assert_eq!(p.serves_model("claude-opus-5"), None);
+}
+
+/// A script with no `list_models` primes to a no-op rather than an error, so a
+/// provider that simply does not implement the optional entry point is not a
+/// start-up warning every time.
+#[tokio::test]
+async fn priming_a_script_without_list_models_is_a_no_op() {
+    let p = build(GOOD_PROVIDER, Arc::new(FakeExecutor::default())).expect("it compiles");
+    p.prime_capabilities().await.expect("nothing to do is fine");
+    assert_eq!(p.serves_model("deepseek-v4-flash"), None);
 }

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -140,6 +140,19 @@ pub fn resolve_stage_candidates(
         // a named model's routes do.
         let mut candidates_for_model = registry.native_providers();
         candidates_for_model.sort_by_key(|(name, _)| *name != defaults.provider);
+        // A script provider is not in `native_providers` - it is compiled on
+        // demand rather than enumerated - so an open route could never land on
+        // one, and a local box serving one fast model was unreachable however
+        // the machine set `default_provider` (issue #598). The *default*
+        // provider is asked as well, which costs one compile of a script this
+        // machine has explicitly chosen, and leaves every other script on disk
+        // untouched. Put first, because being the default is what it means.
+        if let Some(script) = registry
+            .script_provider_named(&defaults.provider)
+            .filter(|_| model_cfg.allow_user_default)
+        {
+            candidates_for_model.insert(0, (defaults.provider.as_str(), script));
+        }
         let mut routed = false;
         for (name, provider) in candidates_for_model {
             if let Some(id) = provider.serves_model(key) {
@@ -660,6 +673,122 @@ mod tests {
             parameters: HashMap::new(),
             request_timeout_secs: None,
         }
+    }
+
+    /// A registry whose only provider is a script one, named as the default.
+    ///
+    /// Built from a real script on disk because that is the only way to reach
+    /// the lazy-resolve path: a script provider is compiled on demand rather
+    /// than registered, which is exactly why it was invisible to an open route.
+    fn registry_with_script_default(models: &[&str]) -> (ProviderRegistry, tempfile::TempDir) {
+        use crate::script_provider::ScriptProviderLayer;
+        let dir = tempfile::tempdir().unwrap();
+        let listed = models
+            .iter()
+            .map(|m| {
+                format!(
+                    "#{{ id: \"{m}\", display_name: \"{m}\", max_context_tokens: 4096, \
+                     max_output_tokens: 512 }}"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        std::fs::write(
+            dir.path().join("spark.rhai"),
+            format!(
+                "fn initialize(config) {{ #{{}} }}\n\
+                 fn inference(state, request) {{ #{{ content: \"ok\" }} }}\n\
+                 fn list_models(state) {{ [ {listed} ] }}"
+            ),
+        )
+        .unwrap();
+        let layer = ScriptProviderLayer::new(
+            dir.path().to_path_buf(),
+            HashMap::new(),
+            HashMap::new(),
+            None,
+            Vec::new(),
+        );
+        (
+            ProviderRegistry::new().with_script_layer(Arc::new(layer)),
+            dir,
+        )
+    }
+
+    /// The whole of issue #598: a stage naming a model with no provider resolves
+    /// to the script provider the machine named as its default.
+    ///
+    /// Before this, `native_providers` was the only thing asked and it does not
+    /// enumerate script providers, so a local box serving exactly the model the
+    /// blueprint asked for won nothing and the stage went elsewhere.
+    #[tokio::test]
+    async fn a_script_provider_named_as_default_wins_an_open_route() {
+        let (registry, _dir) = registry_with_script_default(&["local-fast"]);
+        registry
+            .prime_capabilities(std::time::Duration::from_secs(5), Some("spark"))
+            .await;
+        let defaults = ModelDefaults {
+            provider: "spark".to_string(),
+            model: None,
+            fallback_order: Vec::new(),
+        };
+
+        let picked = resolve_stage_candidates(
+            &model_cfg_open(vec!["local-fast"]),
+            None,
+            &defaults,
+            &registry,
+        );
+
+        assert_eq!(picked.len(), 1);
+        assert_eq!(picked[0].provider, "spark");
+        assert_eq!(picked[0].model, "local-fast");
+    }
+
+    /// The preference decides the route, not the model, so a blueprint that
+    /// tiers its stages keeps each stage's own model. This is what separates it
+    /// from `default_model`, which pins one model everywhere.
+    #[tokio::test]
+    async fn preferring_a_script_provider_keeps_each_stage_on_its_own_model() {
+        let (registry, _dir) = registry_with_script_default(&["cheap-model", "costly-model"]);
+        registry
+            .prime_capabilities(std::time::Duration::from_secs(5), Some("spark"))
+            .await;
+        let defaults = ModelDefaults {
+            provider: "spark".to_string(),
+            model: None,
+            fallback_order: Vec::new(),
+        };
+
+        for model in ["cheap-model", "costly-model"] {
+            let picked =
+                resolve_stage_candidates(&model_cfg_open(vec![model]), None, &defaults, &registry);
+            assert_eq!(picked[0].provider, "spark");
+            assert_eq!(picked[0].model, model, "each stage keeps its own model");
+        }
+    }
+
+    /// A stage that pins its own provider opts out of the machine's preference,
+    /// and that has to hold for a script provider too.
+    #[tokio::test]
+    async fn a_stage_that_refuses_the_user_default_does_not_get_the_script() {
+        let (registry, _dir) = registry_with_script_default(&["local-fast"]);
+        registry
+            .prime_capabilities(std::time::Duration::from_secs(5), Some("spark"))
+            .await;
+        let defaults = ModelDefaults {
+            provider: "spark".to_string(),
+            model: None,
+            fallback_order: Vec::new(),
+        };
+        let mut cfg = model_cfg_open(vec!["local-fast"]);
+        cfg.allow_user_default = false;
+
+        let picked = resolve_stage_candidates(&cfg, None, &defaults, &registry);
+
+        // Nothing else serves it, so the stage falls through to the blueprint's
+        // own first entry rather than silently landing on the script.
+        assert!(picked.iter().all(|c| c.provider != "spark"), "{picked:?}");
     }
 
     fn registry_with(providers: &[&str]) -> ProviderRegistry {

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -58,11 +58,29 @@ impl ProviderRegistry {
     /// the start-up path, and an unreachable endpoint must cost a bounded wait
     /// rather than however long a connect takes to give up.
     ///
-    /// Script providers are deliberately not consulted. `get` compiles them on
-    /// demand, so priming would compile every `.rhai` provider on disk whether
-    /// or not the run touches one.
-    pub async fn prime_capabilities(&self, timeout: std::time::Duration) {
-        for (name, provider) in &self.providers {
+    /// Script providers are consulted only when `also` names one - in practice
+    /// the machine's `default_provider`. `get` compiles them on demand, so
+    /// priming the lot would compile every `.rhai` provider on disk whether or
+    /// not a run touches one; priming the one a machine has actually chosen
+    /// costs a single compile of a script that is about to be used anyway, and
+    /// it is what lets that provider answer [`Provider::serves_model`] and so
+    /// win an open route (issue #598).
+    pub async fn prime_capabilities(&self, timeout: std::time::Duration, also: Option<&str>) {
+        let mut targets: Vec<(String, Arc<dyn Provider>)> = self
+            .providers
+            .iter()
+            .map(|(name, provider)| (name.clone(), provider.clone()))
+            .collect();
+        // Only when it is not already registered natively: a native provider of
+        // the same name wins everywhere else, and priming it twice would be a
+        // second network call for one answer.
+        if let Some(name) = also
+            && !self.providers.contains_key(name)
+            && let Some(provider) = self.get(name)
+        {
+            targets.push((name.to_string(), provider));
+        }
+        for (name, provider) in targets {
             match tokio::time::timeout(timeout, provider.prime_capabilities()).await {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => tracing::warn!(
@@ -99,6 +117,20 @@ impl ProviderRegistry {
     /// them.
     pub fn provider_names(&self) -> Vec<&str> {
         self.providers.keys().map(|k| k.as_str()).collect()
+    }
+
+    /// The script provider registered under `name`, when there is one and it is
+    /// not shadowed by a native provider of the same name.
+    ///
+    /// The narrow counterpart to [`Self::native_providers`]: it resolves one
+    /// name rather than enumerating, so it compiles exactly the script asked
+    /// for. That is what makes it safe on the resolve path, where enumerating
+    /// would compile every `.rhai` on disk.
+    pub fn script_provider_named(&self, name: &str) -> Option<Arc<dyn Provider>> {
+        if self.providers.contains_key(name) {
+            return None;
+        }
+        self.script_layer.as_ref()?.get_or_load(name)
     }
 
     /// Every natively registered provider, with the name it is registered under.
@@ -286,7 +318,7 @@ mod tests {
         reg.register("prime".to_string(), p);
         reg.register("other".to_string(), mock());
 
-        reg.prime_capabilities(std::time::Duration::from_secs(5))
+        reg.prime_capabilities(std::time::Duration::from_secs(5), None)
             .await;
         assert_eq!(primed.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
@@ -298,7 +330,7 @@ mod tests {
         let mut reg = ProviderRegistry::new();
         let (bad, bad_calls) = priming(PrimeOutcome::Fails);
         reg.register("bad".to_string(), bad);
-        reg.prime_capabilities(std::time::Duration::from_secs(5))
+        reg.prime_capabilities(std::time::Duration::from_secs(5), None)
             .await;
         assert_eq!(bad_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
@@ -312,7 +344,7 @@ mod tests {
         // With the clock paused this returns as soon as the timeout is the only
         // thing left to wait on, so a regression here fails by hanging the
         // suite rather than by sleeping through it.
-        reg.prime_capabilities(std::time::Duration::from_secs(10))
+        reg.prime_capabilities(std::time::Duration::from_secs(10), None)
             .await;
         assert_eq!(calls.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
@@ -350,6 +382,118 @@ mod tests {
         // An unknown name resolves to nothing (layer returns None).
         assert!(!reg.has("nope"));
         assert!(reg.get("nope").is_none());
+    }
+
+    /// The narrow lookup that lets the resolve path reach one script provider
+    /// without enumerating them all.
+    #[test]
+    fn one_script_provider_resolves_by_name_and_a_native_shadows_it() {
+        use crate::script_provider::ScriptProviderLayer;
+        use std::collections::HashMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        for name in ["spark", "other"] {
+            std::fs::write(
+                dir.path().join(format!("{name}.rhai")),
+                "fn initialize(config) { #{} }\n\
+                 fn inference(state, request) { #{ content: \"ok\" } }",
+            )
+            .unwrap();
+        }
+        let layer = ScriptProviderLayer::new(
+            dir.path().to_path_buf(),
+            HashMap::new(),
+            HashMap::new(),
+            None,
+            Vec::new(),
+        );
+        let mut reg = ProviderRegistry::new().with_script_layer(Arc::new(layer));
+
+        // The one asked for, and nothing else.
+        assert!(reg.script_provider_named("spark").is_some());
+        assert!(reg.script_provider_named("nope").is_none());
+
+        // A native provider of the same name shadows the script, so this
+        // answers None rather than handing back a provider `get` would not.
+        reg.register("spark".to_string(), mock());
+        assert!(reg.script_provider_named("spark").is_none());
+    }
+
+    /// A registry with no script layer at all has no script to name.
+    #[test]
+    fn a_registry_without_a_script_layer_names_no_script_provider() {
+        assert!(
+            ProviderRegistry::new()
+                .script_provider_named("spark")
+                .is_none()
+        );
+    }
+
+    /// Priming reaches the script provider a machine names as its default, so
+    /// it can answer what it serves on the synchronous resolve path (#598).
+    #[tokio::test]
+    async fn priming_also_reaches_the_named_script_provider() {
+        use crate::script_provider::ScriptProviderLayer;
+        use std::collections::HashMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("spark.rhai"),
+            "fn initialize(config) { #{} }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { [ #{ id: \"local-fast\", display_name: \"F\", \
+             max_context_tokens: 4096, max_output_tokens: 512 } ] }",
+        )
+        .unwrap();
+        let layer = ScriptProviderLayer::new(
+            dir.path().to_path_buf(),
+            HashMap::new(),
+            HashMap::new(),
+            None,
+            Vec::new(),
+        );
+        let reg = ProviderRegistry::new().with_script_layer(Arc::new(layer));
+
+        // Unprimed it claims nothing, which is the state that made a local
+        // model unreachable.
+        assert_eq!(
+            reg.get("spark")
+                .expect("resolves")
+                .serves_model("local-fast"),
+            None
+        );
+
+        reg.prime_capabilities(std::time::Duration::from_secs(5), Some("spark"))
+            .await;
+
+        assert_eq!(
+            reg.get("spark")
+                .expect("resolves")
+                .serves_model("local-fast"),
+            Some("local-fast".to_string())
+        );
+    }
+
+    /// Naming a provider that is already registered natively does not prime it
+    /// twice: one answer is worth one network call.
+    #[tokio::test]
+    async fn naming_a_native_provider_does_not_prime_it_twice() {
+        let mut reg = ProviderRegistry::new();
+        let (p, primed) = priming(PrimeOutcome::Ok);
+        reg.register("prime".to_string(), p);
+
+        reg.prime_capabilities(std::time::Duration::from_secs(5), Some("prime"))
+            .await;
+        assert_eq!(primed.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    /// Naming something that resolves to nothing is not an error - a machine
+    /// may name a default it has not set up yet.
+    #[tokio::test]
+    async fn naming_a_provider_that_does_not_resolve_is_harmless() {
+        let reg = ProviderRegistry::new();
+        reg.prime_capabilities(std::time::Duration::from_secs(5), Some("nope"))
+            .await;
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -43,6 +43,9 @@ pub struct ScriptProviderSpec {
     /// The `config` map passed to the script's `initialize` (base_url, api_key,
     /// and any extra keys), pre-assembled by the CLI.
     pub init_config: serde_json::Value,
+    /// `serves`: the model ids this script answers for, so it can win an open
+    /// route without a `list_models` to be asked. Empty is the ordinary case.
+    pub serves: Vec<String>,
 }
 
 /// Everything a script-provider load reads out of `config.toml`.
@@ -318,6 +321,7 @@ impl ScriptProviderLayer {
                 name: name.to_string(),
                 init_config,
                 caps: config.default_caps.clone(),
+                serves: spec.map(|s| s.serves.clone()).unwrap_or_default(),
                 rate_limit,
                 request_timeout_secs: config.request_timeout_secs,
                 env_allowlist: config.env_allowlist.clone(),
@@ -465,6 +469,85 @@ mod tests {
             overrides,
             ..Default::default()
         }
+    }
+
+    /// A machine whose `default_provider` is a script provider can win an open
+    /// route, which is the whole of issue #598.
+    ///
+    /// The failing shape: a local box serves one fast model, every bundled
+    /// blueprint names that model with no provider, and the run goes remote
+    /// anyway. `native_providers` does not enumerate script providers - they
+    /// are compiled on demand - so the open route was offered to every built-in
+    /// and never to the one the user had actually chosen. Setting
+    /// `default_provider` changed nothing, because there was no route it was
+    /// eligible to win.
+    #[tokio::test]
+    async fn a_script_provider_named_as_default_can_answer_what_it_serves() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "spark.rhai",
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn list_models(state) { [ #{ id: \"deepseek-v4-flash\" } ] }",
+        );
+        let l = layer(dir.path().to_path_buf());
+        let provider = l.get_or_load("spark").expect("the script loads");
+
+        // Before priming it claims nothing: `serves_model` is synchronous and
+        // on the resolve path, so it cannot go and ask.
+        assert_eq!(provider.serves_model("deepseek-v4-flash"), None);
+
+        provider.prime_capabilities().await.unwrap();
+
+        // After priming it answers for the model its own catalogue reports, and
+        // still refuses one it does not - a provider that claimed everything
+        // would be worse than one that claimed nothing.
+        assert_eq!(
+            provider.serves_model("deepseek-v4-flash"),
+            Some("deepseek-v4-flash".to_string())
+        );
+        assert_eq!(provider.serves_model("claude-opus-5"), None);
+    }
+
+    /// A script with no `list_models` says what it serves in config instead, so
+    /// the feature does not depend on a script implementing an optional entry
+    /// point. Static, so it needs no priming at all.
+    #[tokio::test]
+    async fn a_script_provider_can_declare_what_it_serves_in_config() {
+        let dir = tempfile::tempdir().unwrap();
+        write(
+            dir.path(),
+            "spark.rhai",
+            "fn initialize(config) { #{ ok: true } }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }",
+        );
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "spark".to_string(),
+            ScriptProviderSpec {
+                serves: vec!["deepseek-v4-flash".to_string()],
+                ..Default::default()
+            },
+        );
+        let l = ScriptProviderLayer::with_config_source(
+            dir.path().to_path_buf(),
+            Box::new(move || {
+                Arc::new(ScriptProviderConfig {
+                    overrides: overrides.clone(),
+                    ..Default::default()
+                })
+            }),
+            ScriptProviderLayer::build_executor(None),
+        );
+        let provider = l.get_or_load("spark").expect("the script loads");
+
+        // No priming, and no `list_models` to prime from.
+        assert_eq!(
+            provider.serves_model("deepseek-v4-flash"),
+            Some("deepseek-v4-flash".to_string())
+        );
+        assert_eq!(provider.serves_model("claude-opus-5"), None);
     }
 
     /// The id of the first model `hot` reports - which this script sets to

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -697,6 +697,18 @@ tokens_per_minute   = 100000
 
 Any other key you add is forwarded verbatim to the script's `initialize(config)`.
 
+`serves` is the one key that is not forwarded: it names the models this provider answers for, so a
+blueprint entry naming one of them with no provider can resolve here.
+
+```toml
+[model_providers.spark]
+serves = ["deepseek-v4-flash"]
+```
+
+Only needed by a script with no `list_models`; one that has it is asked directly and its answer
+wins. A provider that reports neither claims no models and can only be reached by a blueprint that
+pins it. See [preferring a script provider](/docs/providers#preferring-a-script-provider).
+
 ## `[[mcp_servers]]`
 
 [MCP](/docs/mcp) tool servers. `lev mcp add` writes these for you.

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -164,6 +164,12 @@ In order:
    not set `allow_user_default = false`. Every entry in the stage's `models` on that provider moves
    to the front, keeping the blueprint's order among them. This is what a preference means: your
    provider first, then whatever the blueprint asked for.
+   An entry that names a model and **no** provider is an *open route*: the providers configured
+   here are asked which of them serves that model, and yours is asked first. That is how the
+   bundled agents run on whichever key you have without ever naming it. A
+   [script provider](/docs/rhai-providers) is asked too when it is the one you named as
+   `default_provider` - see [preferring a script provider](#preferring-a-script-provider) for what
+   it has to report before it can answer.
 3. Your `default_model`, when it is set, first among the entries from step 2. It leads even when the
    blueprint lists that same provider with a different model: `default_provider = "ollama"` with
    `default_model = "qwen3.8:latest"` runs on `qwen3.8:latest`, and the blueprint's own
@@ -224,8 +230,8 @@ OpenRouter serves it as `openai/gpt-5.5`, without the blueprint knowing either i
 
 The [bundled agents](/docs/agent-catalog) name models rather than routes, so any configured key
 works out of the box: whichever provider you set up is asked which of the listed models it serves.
-Each blueprint's own order still decides which model is tried first, and a custom Rhai provider is
-never consulted for an open route. Naming yours as the default is what puts it in front:
+Each blueprint's own order still decides which model is tried first. Naming yours as the default is
+what puts it in front:
 
 ```toml
 default_provider = "openrouter"
@@ -258,6 +264,62 @@ model = { models = ["claude-sonnet-5", { provider = "ollama", model = "qwen3.5:9
 
 A model no configured provider serves is skipped, with a warning naming it, and the stage falls
 through to the next model listed.
+
+### Preferring a script provider
+
+A [script provider](/docs/rhai-providers) is preferred the same way any other is - name it as your
+`default_provider` and stages start there, each on the model its author picked for it:
+
+```toml
+default_provider = "spark"
+```
+
+One extra thing is true of a script provider, and it is worth knowing because the failure is
+silent: it has to be able to say **which models it serves**, or there is nothing for the preference
+to prefer and every stage quietly goes somewhere else.
+
+Two ways it can say so, and the first needs nothing from you:
+
+**Its `list_models`.** A script that implements `list_models(state)` is asked once at start-up and
+claims whatever it reports. Every provider script in [the examples](/docs/rhai-providers) does this
+already.
+
+**Or `serves`, in config.** For a script with no `list_models` to be asked:
+
+```toml
+[model_providers.spark]
+serves = ["deepseek-v4-flash"]
+```
+
+A provider that reports neither claims nothing, and can then only be reached by a blueprint that
+pins it - `{ provider = "spark", model = "..." }` - which is worth knowing before concluding the
+preference is broken.
+
+> [!NOTE]
+> Only the provider you name as `default_provider` is asked. Every other script on disk is left
+> alone, because a script is compiled the first time it is used and asking all of them what they
+> serve would compile every `.rhai` file on the machine before any run started.
+
+Two commands settle whether it worked, and are much faster than a run:
+
+```bash
+lev models list --provider spark   # does it claim the model at all
+lev validate <agent>               # which model each stage would actually use here
+```
+
+`lev validate` is the one that answers the real question. On a machine with `default_provider =
+"spark"` it prints the route per stage, so a tiered blueprint shows its shape intact:
+
+```
+Models this install would use:
+  cheap            spark/deepseek-v4-flash
+  deciding         spark/deepseek-v4-max
+  default_provider = spark, default_model = (unset)
+```
+
+Both stages on your provider, each still on the model its author chose. Add `default_model` and
+that collapses to one model everywhere, with the blueprint's own choice printed underneath as the
+substitution it is.
 
 > [!WARNING]
 > Ollama needs no key, so it is registered whether or not a server is running. Leave


### PR DESCRIPTION
Closes #598.

Set `default_provider` to a script provider serving exactly the model your blueprint asks for, and every stage went somewhere else. Measured against 0.4.0: a stage naming `deepseek-v4-flash` with `default_provider = "spark"` resolved to `ollama/deepseek-v4-flash` and failed — ollama registers without a key, and the script provider was never in the running.

## Two reasons, and fixing either alone changes nothing

**The resolver never asked it.** An entry naming a model with no provider is an *open route*, resolved by asking the configured providers who serves it — via `native_providers`, which deliberately does not enumerate script providers, because they are compiled on first use and enumerating would compile every `.rhai` on disk before a run starts.

**It could not have answered anyway.** `serves_model` fell through to the compiled-in capability table, which a script does not have: `capabilities` returns the same base for every model it has no override for, so the default said no to everything.

## The fix keeps the reason the exclusion existed

Only the provider named as `default_provider` is asked, through a `script_provider_named` that resolves one name rather than enumerating — one compile, of a script this machine chose and is about to use. Every other script on disk is still untouched.

`RhaiProvider` answers `serves_model` from its own `list_models`, primed once for that same provider, matched on the last path segment as well as whole so a gateway's `vendor/model` id answers a blueprint naming `model`. A script with no `list_models` declares `[model_providers.<name>] serves` instead. Reporting neither still claims nothing — a family-shaped guess is how a provider comes to claim every model in existence.

## Route, not model — the tiering survives

```
default_provider = spark                              default_provider = spark, default_model = deepseek-v4-flash
  cheap      spark/deepseek-v4-flash                    cheap      spark/deepseek-v4-flash
  deciding   spark/deepseek-v4-max                      deciding   spark/deepseek-v4-flash
                                                                     blueprint order: deepseek-v4-max
```

That contrast is the point: this is a route preference, which is why `default_model` remains the wrong tool for it.

## Verification

Live against the shipped 0.4.0 binary, with two script providers both serving the model so the reply names whichever route won:

| | result |
|---|---|
| before, `default_provider = spark` | `ollama/deepseek-v4-flash`, **errored** |
| after, `default_provider = spark` | `spark/deepseek-v4-flash`, complete |
| after, `default_provider = remote` | `remote/deepseek-v4-flash` — follows the setting, not a blanket script preference |
| after, `default_provider = ollama` (native) | unchanged |

The key resolver test was run against the unfixed code first and fails there, resolving to `""` instead of `spark`. `cargo xtask coverage`: all 13 packages at 100%.

## Docs

The constraint was documented all along — one clause, mid-paragraph, no consequence and no remedy. I misread it twice, which is its own evidence. It is now in the precedence list where someone looks, plus a section saying what a script provider must report and how to check it did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)