### PR TITLE
feat(update): answer "is there anything newer", once, for both callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ same list.
   `[model_providers.<name>] serves` list for a script that has none. Per-stage
   models are unaffected: this decides the route, so a tiered blueprint keeps
   each stage on the model its author picked.
+- Added: `GET /api/update` reports `latest`, `update_available` and `checked_at`
+  alongside the install method and command, so a console can tell whether an
+  update is worth mentioning instead of inferring it. It was comparing the
+  daemon's version against a number baked into the site at deploy time, which
+  only knows the stable channel and is as stale as the last build - so a daemon
+  on `alpha` or `beta` was unjudgeable, and the people most likely to want an
+  update prompt were the ones who could not have one. All three are `null`
+  together when the check has not run, could not reach the network, or had no
+  channel to ask about, which is the "cannot tell" a client already renders.
+- Added: `lev update` says whether the version you have is the newest on your
+  channel, from the same lookup the API uses and through the same
+  `plan_json`, so the terminal and the console cannot disagree about the same
+  binary. The route answers from the daemon's cached result and never waits on
+  a network call: asking on every page load costs nothing and at most starts a
+  lookup for whoever asks next.
+
 - Fixed: a turn in which the model only wrote to its own context left no trace
   in the stage log. Those calls are resolved by the dispatcher rather than the
   tool lane, and the lane is where `[tool]` lines are written, so a batch made

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,12 @@ same list.
   `plan_json`, so the terminal and the console cannot disagree about the same
   binary. The route answers from the daemon's cached result and never waits on
   a network call: asking on every page load costs nothing and at most starts a
-  lookup for whoever asks next.
+  lookup for whoever asks next. `update_check = false` in the config turns the
+  lookup off for an install that should make no outbound request nobody asked
+  for; the routes still answer, reporting `null` for whether anything newer
+  exists. On by default, through a named serde default rather than a bare
+  `#[serde(default)]`, which for a bool would have silently switched it off for
+  every config written before the key existed.
 
 - Fixed: a turn in which the model only wrote to its own context left no trace
   in the stage log. Those calls are resolved by the dispatcher rather than the

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -848,6 +848,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon(),
@@ -874,6 +875,7 @@ mod tests {
 
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![agents.path().to_path_buf()],
                 ..Default::default()
@@ -1144,6 +1146,7 @@ mod tests {
     fn test_state_with_agent_paths(paths: Vec<PathBuf>, control: ControlClient) -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: paths,
                 ..Default::default()
@@ -2968,6 +2971,7 @@ system_prompt = "Plan the work"
         use axum::routing::delete;
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,
@@ -3024,6 +3028,7 @@ system_prompt = "Plan the work"
         use axum::routing::post;
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -592,6 +592,7 @@ system_prompt = "do it"
     async fn page(dir: &tempfile::TempDir, extra: &str) -> (StatusCode, serde_json::Value) {
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![dir.path().to_path_buf()],
                 ..Default::default()
@@ -824,6 +825,7 @@ mod tests {
     fn test_state_with_path(path: PathBuf) -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![path],
                 ..Default::default()

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -307,6 +307,7 @@ mod tests {
     fn state_without_a_reachable_ollama() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 ollama_base_url: Some("http://127.0.0.1:1".to_string()),
                 providers: crate::config::ProviderConfig {
@@ -326,6 +327,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -337,6 +339,7 @@ mod tests {
     fn test_state_with_keys() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 providers: crate::config::ProviderConfig {
                     anthropic_api_key: Some("sk-ant-test".to_string()),
@@ -474,6 +477,7 @@ mod tests {
     async fn get_config_agent_paths_included() {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![
                     std::path::PathBuf::from("/my/agents"),
@@ -509,6 +513,7 @@ mod tests {
     fn test_state_listing_models() -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 providers: crate::config::ProviderConfig {
                     anthropic_base_url: None,
@@ -680,6 +685,7 @@ mod tests {
     fn state_with_config_path(path: std::path::PathBuf) -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -698,6 +704,7 @@ mod tests {
     fn state_watching_config_path(path: std::path::PathBuf) -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
+            update_check: Default::default(),
             config: Arc::new(crate::daemon::config_reload::ConfigReloader::new(
                 path.clone(),
                 Config::default(),
@@ -1171,6 +1178,7 @@ mod tests {
         // this test passed while exercising none of what it is named for.
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 providers: crate::config::ProviderConfig {
                     anthropic_api_key: Some("test-key".to_string()),

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -84,6 +84,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: leviath_runtime::control_socket::ControlClient::new(

--- a/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
@@ -170,6 +170,7 @@ async fn stand_up(runs_dir: &std::path::Path) -> Seam {
         ControlClient::for_home(id, dir.path()).with_build(crate::test_support::TEST_BUILD);
     let (event_tx, _) = broadcast::channel(256);
     let state = AppState {
+        update_check: Default::default(),
         config: crate::commands::serve::testutil::fixed_config(Config::default()),
         event_tx,
         control: control.clone(),

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -282,6 +282,7 @@ mod tests {
     fn app_with_root(workdir_root: Option<PathBuf>) -> Router {
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon_client(),

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -135,6 +135,7 @@ mod tests {
     fn app_with(control: ControlClient) -> Router {
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -362,6 +362,7 @@ mod tests {
     ) -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -756,6 +757,7 @@ for line in sys.stdin:
         std::fs::create_dir(&store).unwrap();
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -810,6 +812,7 @@ for line in sys.stdin:
         std::fs::write(&file, b"x").unwrap();
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -25,6 +25,7 @@ mod tools;
 mod tree;
 mod types;
 mod update;
+mod update_cache;
 mod websocket;
 
 #[cfg(test)]
@@ -272,6 +273,7 @@ async fn execute_with_shutdown(
     let (event_tx, _) = broadcast::channel::<ServerEvent>(256);
 
     let state = AppState {
+        update_check: Default::default(),
         config: Arc::new(crate::daemon::config_reload::ConfigReloader::new(
             Config::config_path(),
             cfg,
@@ -788,6 +790,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon_control(),

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -519,6 +519,7 @@ mod tests {
         let (tx, rx) = broadcast::channel(64);
         (
             AppState {
+                update_check: Default::default(),
                 config: crate::commands::serve::testutil::fixed_config(Config::default()),
                 event_tx: tx,
                 control,

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -122,6 +122,11 @@ pub struct AppState {
     /// The spawn-request restrictions from [`ServeArgs`], resolved once at
     /// startup so every handler reads the same decision.
     pub(super) limits: Arc<ServeLimits>,
+    /// The last answer to "is there anything newer", for `GET /api/update`.
+    ///
+    /// On the state rather than in a `static` so two servers in one process -
+    /// or two tests - cannot write into each other's answer.
+    pub(super) update_check: super::update_cache::UpdateCheckCache,
 }
 
 impl AppState {

--- a/crates/leviath-cli/src/commands/serve/update.rs
+++ b/crates/leviath-cli/src/commands/serve/update.rs
@@ -44,11 +44,17 @@ pub(super) async fn get_update(
     // and handing this path a fetcher it is trusted not to call is how a later
     // edit turns a fast route into a slow one with nothing to catch it.
     let plan = plan(&args, &UpdateEnv::for_planning_offline());
-    // Reports what is known now and, if that has gone stale, starts a lookup
-    // for whoever asks next. Never waits on one.
-    state
-        .update_check
-        .read_and_maybe_refresh(plan.method.channel(), API_VERSION);
+    // Reports what is known now and, if that has gone stale, starts a lookup for
+    // whoever asks next. Never waits on one.
+    //
+    // The config is read per request rather than at startup, so turning the
+    // check off takes effect on the next page load instead of on the next
+    // restart - the same way every other setting this server reads behaves.
+    if state.current_config().update_check {
+        state
+            .update_check
+            .read_and_maybe_refresh(plan.method.channel(), API_VERSION);
+    }
     Json(plan_json(&plan, API_VERSION, &state.update_check.peek()))
 }
 
@@ -97,6 +103,80 @@ mod tests {
         let state = test_state();
         assert_eq!(state.update_check.peek(), Default::default());
         assert!(declines("https://example.invalid").is_err());
+    }
+
+    /// With the check switched off in config, the route still answers - it just
+    /// never looks anything up.
+    ///
+    /// The whole route degrading to a 500, or to a missing key, would be worse
+    /// than the guessing this replaced: a client cannot tell "switched off" from
+    /// "this daemon is too old to ask" unless the keys are there and `null`.
+    #[tokio::test]
+    async fn a_config_that_turns_the_check_off_still_answers() {
+        let asked = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let counting = {
+            let asked = std::sync::Arc::clone(&asked);
+            std::sync::Arc::new(move |_: &str| {
+                asked.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(r#"{"name": "9.9.9"}"#.to_string())
+            })
+        };
+        // Called once here so the counter starts from a known, non-zero place.
+        // A fetcher that is never called at all leaves its body unexecuted,
+        // which reads as untested code rather than as the point of the test -
+        // and this way the assertion below is that the count did not MOVE,
+        // which is the same claim without that gap.
+        assert!(counting("https://example.invalid/probe").is_ok());
+        let baseline = asked.load(std::sync::atomic::Ordering::SeqCst);
+
+        let (tx, _) = tokio::sync::broadcast::channel(64);
+        let state = super::super::types::AppState {
+            update_check: super::super::update_cache::UpdateCheckCache::with_fetcher(counting),
+            config: crate::commands::serve::testutil::fixed_config(crate::config::Config {
+                update_check: false,
+                ..crate::config::Config::default()
+            }),
+            event_tx: tx,
+            control: crate::commands::serve::testutil::no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Default::default(),
+        };
+
+        let app = Router::new()
+            .route("/api/update", get(get_update))
+            .with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/update")
+                    .body(Body::empty())
+                    .expect("a GET with no body always builds"),
+            )
+            .await
+            .expect("the router is infallible");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("the body is a small JSON document");
+        let body: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("the route answers with JSON");
+
+        assert_eq!(
+            asked.load(std::sync::atomic::Ordering::SeqCst),
+            baseline,
+            "switched off means the route looked nothing up"
+        );
+        for key in ["latest", "update_available", "checked_at"] {
+            assert_eq!(
+                body.get(key),
+                Some(&serde_json::Value::Null),
+                "`{key}` is present and null, which is an answer a client can render"
+            );
+        }
+        assert!(
+            body.get("install_method").is_some(),
+            "the rest of the answer is unaffected"
+        );
     }
 
     /// The route answers, and answers with the shape the console reads: an

--- a/crates/leviath-cli/src/commands/serve/update.rs
+++ b/crates/leviath-cli/src/commands/serve/update.rs
@@ -31,22 +31,32 @@ use crate::commands::update::{UpdateArgs, UpdateEnv, plan, plan_json};
 /// Cannot fail, which is why it returns a bare `Json`. Every step of the
 /// discovery degrades to worse detection rather than to an error - a copy this
 /// build cannot place is `unknown` with advice, an answer rather than a 500.
-pub(super) async fn get_update() -> Json<serde_json::Value> {
+pub(super) async fn get_update(
+    axum::extract::State(state): axum::extract::State<super::types::AppState>,
+) -> Json<serde_json::Value> {
     // `--check` is implied: this route only ever plans. The other fields are
     // defaults, which is what a caller who is not choosing a channel means.
     let args = UpdateArgs {
         check: true,
         ..UpdateArgs::default()
     };
-    Json(plan_json(
-        &plan(&args, &UpdateEnv::for_planning()),
-        API_VERSION,
-    ))
+    // `for_planning_offline` rather than `for_planning`: planning never fetches,
+    // and handing this path a fetcher it is trusted not to call is how a later
+    // edit turns a fast route into a slow one with nothing to catch it.
+    let plan = plan(&args, &UpdateEnv::for_planning_offline());
+    // Reports what is known now and, if that has gone stale, starts a lookup
+    // for whoever asks next. Never waits on one.
+    state
+        .update_check
+        .read_and_maybe_refresh(plan.method.channel(), API_VERSION);
+    Json(plan_json(&plan, API_VERSION, &state.update_check.peek()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::commands::update::latest::LatestCheck;
 
     use axum::Router;
     use axum::body::Body;
@@ -55,11 +65,47 @@ mod tests {
     use axum::routing::get;
     use tower::ServiceExt;
 
+    /// A state with nothing behind it but the update cache, which is all this
+    /// route reads. The cache declines to look anything up, so these tests
+    /// assert on the route's own shape and never reach the network.
+    /// Stands in for the network in these tests. A refusal rather than a no-op
+    /// that would quietly answer: a route test that reached a real release feed
+    /// would pass or fail on what GitHub happened to be serving.
+    fn declines(_: &str) -> Result<String, String> {
+        Err("no network in tests".to_string())
+    }
+
+    fn test_state() -> super::super::types::AppState {
+        let (tx, _) = tokio::sync::broadcast::channel(64);
+        super::super::types::AppState {
+            update_check: super::super::update_cache::UpdateCheckCache::with_fetcher(
+                std::sync::Arc::new(declines),
+            ),
+            config: crate::commands::serve::testutil::fixed_config(crate::config::Config::default()),
+            event_tx: tx,
+            control: crate::commands::serve::testutil::no_daemon_client(),
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
+            limits: Default::default(),
+        }
+    }
+
+    /// The state these tests serve from must not be able to reach the network,
+    /// so the thing standing in for it is a refusal rather than a no-op that
+    /// would quietly answer.
+    #[test]
+    fn the_test_state_cannot_reach_the_network() {
+        let state = test_state();
+        assert_eq!(state.update_check.peek(), Default::default());
+        assert!(declines("https://example.invalid").is_err());
+    }
+
     /// The route answers, and answers with the shape the console reads: an
     /// install method it can name, and a command it can print.
     #[tokio::test]
     async fn get_update_reports_the_install_method_and_a_command() {
-        let app = Router::new().route("/api/update", get(get_update));
+        let app = Router::new()
+            .route("/api/update", get(get_update))
+            .with_state(test_state());
         let resp = app
             .oneshot(
                 Request::builder()
@@ -93,6 +139,42 @@ mod tests {
         assert!(["run", "advise"].contains(&action));
     }
 
+    /// The three fields a console needs to decide whether to say anything are
+    /// present and answerable, even before any check has run.
+    ///
+    /// Absent keys and `null` keys are different things to a client: `null` is
+    /// "cannot tell", which it already knows how to render, while a missing key
+    /// is indistinguishable from an older daemon and sends it back to guessing
+    /// from the outside, which is what issue #600 is about.
+    #[tokio::test]
+    async fn the_update_check_fields_are_always_present_even_when_unanswered() {
+        let app = Router::new()
+            .route("/api/update", get(get_update))
+            .with_state(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/update")
+                    .body(Body::empty())
+                    .expect("a GET with no body always builds"),
+            )
+            .await
+            .expect("the router is infallible");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("the body is a small JSON document");
+        let body: serde_json::Value =
+            serde_json::from_slice(&bytes).expect("the route answers with JSON");
+
+        for key in ["latest", "update_available", "checked_at"] {
+            assert!(
+                body.get(key).is_some(),
+                "`{key}` is missing, which a client cannot tell from an older daemon"
+            );
+        }
+    }
+
     /// The console reads this to decide what to print, so it has to be the same
     /// answer `lev update --json` gives on the same machine. A route that
     /// drifted from the CLI would send people a command their own terminal
@@ -104,9 +186,11 @@ mod tests {
             check: true,
             ..UpdateArgs::default()
         };
-        let from_cli = plan_json(&plan(&args, &env), API_VERSION);
+        let from_cli = plan_json(&plan(&args, &env), API_VERSION, &LatestCheck::default());
 
-        let app = Router::new().route("/api/update", get(get_update));
+        let app = Router::new()
+            .route("/api/update", get(get_update))
+            .with_state(test_state());
         let resp = app
             .oneshot(
                 Request::builder()

--- a/crates/leviath-cli/src/commands/serve/update_cache.rs
+++ b/crates/leviath-cli/src/commands/serve/update_cache.rs
@@ -1,0 +1,106 @@
+//! The daemon's memory of "is there anything newer".
+//!
+//! `GET /api/update` is asked on every console page load and must never wait on
+//! a network call, so the answer it gives is whatever the last lookup found. The
+//! lookup itself is [`crate::commands::update::latest`], the same code
+//! `lev update` runs, so the console and the terminal cannot come to different
+//! conclusions about the same binary (issue #600).
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use crate::commands::update::latest::{self, LatestCheck, ReleaseFetcher};
+
+/// The last answer, and how to get a new one.
+///
+/// Carried on the app state rather than in a `static` so that two tests, or two
+/// servers in one process, cannot write into each other's answer. The first
+/// version of this was a global and the tests found it immediately: one stored a
+/// version and another read it back, which is the same failure a second `lev
+/// serve` in-process would have hit.
+#[derive(Clone)]
+pub(super) struct UpdateCheckCache {
+    last: Arc<Mutex<LatestCheck>>,
+    fetch: ReleaseFetcher,
+}
+
+impl Default for UpdateCheckCache {
+    fn default() -> Self {
+        Self::with_fetcher(Arc::new(latest::fetch_release))
+    }
+}
+
+impl std::fmt::Debug for UpdateCheckCache {
+    /// Hand-written because a closure has no `Debug`. Prints the answer, which
+    /// is the part anyone reading a state dump wants.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpdateCheckCache")
+            .field("last", &self.peek())
+            .finish_non_exhaustive()
+    }
+}
+
+impl UpdateCheckCache {
+    /// A cache that looks answers up the given way. Tests pass a canned one.
+    pub(super) fn with_fetcher(fetch: ReleaseFetcher) -> Self {
+        Self {
+            last: Arc::new(Mutex::new(LatestCheck::default())),
+            fetch,
+        }
+    }
+
+    /// The stored answer, without looking anything up.
+    pub(super) fn peek(&self) -> LatestCheck {
+        self.last
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// The stored answer, and a refresh started if it has gone stale.
+    ///
+    /// Returns immediately either way: the caller gets what is known now, and a
+    /// later request gets the benefit of the lookup this one started. That is
+    /// the whole contract of the route - a console asking on every page load
+    /// must never trigger a wait, only at most a background lookup.
+    pub(super) fn read_and_maybe_refresh(
+        &self,
+        channel: Option<crate::commands::update::Channel>,
+        running: &str,
+    ) {
+        let now = latest::now_secs();
+        if !self.peek().is_stale(now, latest::CHECK_TTL_SECS) {
+            return;
+        }
+        // A copy whose channel could not be worked out is not asked about. The
+        // only answer available would be the stable release compared against a
+        // build that may not be on that line, which is the wrong-in-both-
+        // directions guess this whole change exists to stop making.
+        let Some(channel) = channel else {
+            return;
+        };
+        let (last, fetch, running) = (
+            Arc::clone(&self.last),
+            Arc::clone(&self.fetch),
+            running.to_string(),
+        );
+        tokio::task::spawn_blocking(move || {
+            store(&last, latest::check_with(channel, &running, &fetch, now));
+        });
+    }
+}
+
+/// Keep an answer, unless there was not one.
+///
+/// A failed lookup is dropped rather than stored. Storing it would stamp
+/// `checked_at`, which makes the failure look like a fresh answer and holds off
+/// the next attempt for the whole hour - so one flaky moment would cost a
+/// console its update prompt for the rest of the hour.
+fn store(last: &Mutex<LatestCheck>, found: LatestCheck) {
+    if found.latest.is_some() {
+        *last.lock().unwrap_or_else(PoisonError::into_inner) = found;
+    }
+}
+
+#[cfg(test)]
+#[path = "update_cache_tests.rs"]
+mod tests;

--- a/crates/leviath-cli/src/commands/serve/update_cache_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/update_cache_tests.rs
@@ -1,0 +1,113 @@
+use super::*;
+
+use crate::commands::update::Channel;
+
+/// A fetcher that answers one release body every time.
+fn answering(body: &'static str) -> ReleaseFetcher {
+    Arc::new(move |_: &str| Ok(body.to_string()))
+}
+
+/// A fresh cache knows nothing, which is an answer a console can render.
+#[test]
+fn a_new_cache_has_no_answer_yet() {
+    let cache = UpdateCheckCache::with_fetcher(answering(r#"{"name": "9.9.9"}"#));
+    assert_eq!(cache.peek(), LatestCheck::default());
+}
+
+/// The refresh runs off the caller's thread and its answer lands in the cache.
+#[tokio::test]
+async fn a_stale_cache_is_refreshed_in_the_background() {
+    let cache = UpdateCheckCache::with_fetcher(answering(r#"{"name": "9.9.9"}"#));
+    cache.read_and_maybe_refresh(Some(Channel::Stable), "0.4.0");
+
+    // The lookup is on a blocking thread, so the answer arrives after this call
+    // has already returned - which is the point of it.
+    leviath_testkit::wait_until("the refresh stores its answer", || {
+        cache.peek().latest.is_some()
+    })
+    .await;
+
+    let found = cache.peek();
+    assert_eq!(found.latest.as_deref(), Some("9.9.9"));
+    assert_eq!(found.update_available, Some(true));
+    assert!(found.checked_at.is_some());
+}
+
+/// A cache holding a current answer does not go and get another one.
+#[tokio::test]
+async fn a_fresh_answer_is_not_looked_up_again() {
+    let asked = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let counting = {
+        let asked = Arc::clone(&asked);
+        Arc::new(move |_: &str| {
+            asked.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(r#"{"name": "9.9.9"}"#.to_string())
+        }) as ReleaseFetcher
+    };
+    let cache = UpdateCheckCache::with_fetcher(counting);
+
+    cache.read_and_maybe_refresh(Some(Channel::Stable), "0.4.0");
+    leviath_testkit::wait_until("the first refresh stores its answer", || {
+        cache.peek().latest.is_some()
+    })
+    .await;
+
+    for _ in 0..5 {
+        cache.read_and_maybe_refresh(Some(Channel::Stable), "0.4.0");
+    }
+    assert_eq!(
+        asked.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "a console asking on every page load must not become a lookup per load"
+    );
+}
+
+/// A copy whose channel is unknown is not asked about at all, rather than being
+/// compared against a channel it may not be on.
+#[tokio::test]
+async fn an_unknown_channel_is_not_looked_up() {
+    let asked = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let counting = {
+        let asked = Arc::clone(&asked);
+        Arc::new(move |_: &str| {
+            asked.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(r#"{"name": "9.9.9"}"#.to_string())
+        }) as ReleaseFetcher
+    };
+    let cache = UpdateCheckCache::with_fetcher(counting);
+
+    cache.read_and_maybe_refresh(None, "0.4.0");
+    assert_eq!(asked.load(std::sync::atomic::Ordering::SeqCst), 0);
+    assert_eq!(cache.peek(), LatestCheck::default());
+}
+
+/// A lookup that could not answer leaves the cache alone, so the next request
+/// tries again instead of being told the failure is a fresh answer.
+#[test]
+fn a_failed_lookup_is_not_stored_as_an_answer() {
+    let last = Mutex::new(LatestCheck::default());
+    store(&last, LatestCheck::default());
+    assert_eq!(
+        *last.lock().expect("not poisoned"),
+        LatestCheck::default(),
+        "nothing was found, so nothing is remembered"
+    );
+
+    let real = LatestCheck {
+        latest: Some("1.2.3".to_string()),
+        update_available: Some(true),
+        checked_at: Some(42),
+    };
+    store(&last, real.clone());
+    assert_eq!(*last.lock().expect("not poisoned"), real);
+}
+
+/// The `Debug` is hand-written because a closure has none; it has to show the
+/// answer rather than fail to compile or print nothing useful.
+#[test]
+fn the_cache_prints_the_answer_it_holds() {
+    let cache = UpdateCheckCache::with_fetcher(answering(r#"{"name": "9.9.9"}"#));
+    let shown = format!("{cache:?}");
+    assert!(shown.contains("UpdateCheckCache"), "{shown}");
+    assert!(shown.contains("last"), "{shown}");
+}

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -218,6 +218,7 @@ mod tests {
     fn test_state() -> AppState {
         let (tx, _) = broadcast::channel(64);
         AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -663,6 +664,7 @@ mod tests {
         daemon.client.list().await.expect("served, and introduced");
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: daemon.client.clone(),
@@ -823,6 +825,7 @@ mod tests {
         // `handle_ws` without needing to fabricate the error directly.
         let (tx, _) = broadcast::channel::<ServerEvent>(2);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx.clone(),
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -950,6 +953,7 @@ mod tests {
     async fn handle_ws_breaks_on_closed_channel_via_server_shutdown() {
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         let state = AppState {
+            update_check: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx.clone(),
             control: crate::commands::serve::testutil::no_daemon_client(),

--- a/crates/leviath-cli/src/commands/update.rs
+++ b/crates/leviath-cli/src/commands/update.rs
@@ -755,8 +755,25 @@ impl UpdateEnv {
     /// trusted not to call.
     pub fn for_planning_offline() -> Self {
         Self {
-            latest: std::sync::Arc::new(|_: &str| Err("check not run on this path".to_string())),
+            latest: std::sync::Arc::new(decline_update_check),
             ..Self::for_planning()
+        }
+    }
+
+    /// [`Self::real`], with the update check switched off when the config says
+    /// so.
+    ///
+    /// Declining rather than skipping: every caller already renders "could not
+    /// find out" honestly, so switching the check off and failing to reach the
+    /// network land in the same place, and there is no second code path where
+    /// one of them could behave differently.
+    pub fn real_with_config(runner: CommandRunner, confirm: Confirm, update_check: bool) -> Self {
+        match update_check {
+            true => Self::real(runner, confirm),
+            false => Self {
+                latest: std::sync::Arc::new(decline_update_check),
+                ..Self::real(runner, confirm)
+            },
         }
     }
 
@@ -989,6 +1006,15 @@ fn migrate_config(args: &UpdateArgs, env: &UpdateEnv, plan: &UpdatePlan) -> anyh
     config.save_to_path_public(&env.config_path)?;
     println!("  wrote {path}");
     Ok(())
+}
+
+/// A fetcher that does not look anything up.
+///
+/// Used both by the path that must not touch the network and by an install that
+/// has turned the check off. One function for both, because "did not ask" is a
+/// single outcome and a caller cannot act on which reason it was.
+fn decline_update_check(_: &str) -> Result<String, String> {
+    Err("the update check is not enabled on this path".to_string())
 }
 
 /// Ask what the newest release on this copy's channel is.

--- a/crates/leviath-cli/src/commands/update.rs
+++ b/crates/leviath-cli/src/commands/update.rs
@@ -594,7 +594,11 @@ pub fn format_plan(plan: &UpdatePlan, version: &str) -> String {
 
 /// The plan as JSON. Built by hand, like `lev tools` and `lev doctor`, so the
 /// shape is explicit and does not move when a type gains a field.
-pub fn plan_json(plan: &UpdatePlan, version: &str) -> serde_json::Value {
+pub fn plan_json(
+    plan: &UpdatePlan,
+    version: &str,
+    latest: &latest::LatestCheck,
+) -> serde_json::Value {
     let binary = match &plan.binary {
         // `commands` is a list of argv lists. The old `command` key held a
         // single argv and is kept alongside it, holding the last command (the
@@ -629,6 +633,13 @@ pub fn plan_json(plan: &UpdatePlan, version: &str) -> serde_json::Value {
         "version": version,
         "install_method": plan.method.id(),
         "channel": plan.method.channel().map(Channel::id),
+        // All three together, and `null` together. "Not checked yet", "switched
+        // off" and "the check failed" are one answer to a client - nothing to
+        // show - and rendering that honestly as "can't tell" is what a console
+        // already does for a channel it cannot judge.
+        "latest": latest.latest,
+        "update_available": latest.update_available,
+        "checked_at": latest.checked_at,
         "binary": binary,
         "agents": agents,
         "migrations": migrations,
@@ -704,6 +715,13 @@ pub struct UpdateEnv {
     pub runner: CommandRunner,
     /// How to ask a yes/no question.
     pub confirm: Confirm,
+    /// How to ask what the newest release on this channel is.
+    ///
+    /// A seam beside `runner` and `confirm` for the same reason: it reaches
+    /// outside the process, so a test has to be able to answer for it. Also the
+    /// switch for turning the check off - an air-gapped install passes one that
+    /// declines, and every caller renders that as "can't tell" already.
+    pub latest: latest::ReleaseFetcher,
     /// The migrations to consider, in order. Production passes [`MIGRATIONS`].
     pub migrations: &'static [Migration],
 }
@@ -727,6 +745,19 @@ impl UpdateEnv {
             std::sync::Arc::new(refuse_to_run),
             std::sync::Arc::new(say_no),
         )
+    }
+
+    /// [`Self::for_planning`], with the update check switched off.
+    ///
+    /// For a caller that must not touch the network on this path at all - the
+    /// API route answers from a cache and refreshes elsewhere, so a fetcher
+    /// that declines is the honest thing to hand it rather than one it is
+    /// trusted not to call.
+    pub fn for_planning_offline() -> Self {
+        Self {
+            latest: std::sync::Arc::new(|_: &str| Err("check not run on this path".to_string())),
+            ..Self::for_planning()
+        }
     }
 
     /// The real machine, with the caller's own way to run a command and ask a
@@ -753,6 +784,7 @@ impl UpdateEnv {
             config_path: crate::config::Config::config_path(),
             runner,
             confirm,
+            latest: std::sync::Arc::new(latest::fetch_release),
             migrations: MIGRATIONS,
         }
     }
@@ -959,20 +991,51 @@ fn migrate_config(args: &UpdateArgs, env: &UpdateEnv, plan: &UpdatePlan) -> anyh
     Ok(())
 }
 
+/// Ask what the newest release on this copy's channel is.
+///
+/// A copy whose channel could not be worked out is not asked about: the answer
+/// would be the stable release compared against a build that may not be on that
+/// line at all, which is exactly the wrong-in-both-directions guess the console
+/// was making before any of this (issue #600).
+fn check_latest(plan: &UpdatePlan, env: &UpdateEnv, version: &str) -> latest::LatestCheck {
+    match plan.method.channel() {
+        Some(channel) => latest::check_with(channel, version, &env.latest, latest::now_secs()),
+        None => latest::LatestCheck::default(),
+    }
+}
+
+/// The one line `lev update` prints about whether the update is worth doing.
+///
+/// Silent when there is nothing to say. A check that could not run prints
+/// nothing rather than "could not check for updates": the command was asked how
+/// to update, it has answered that, and a failed lookup of a thing the user did
+/// not ask for is noise on a terminal.
+fn format_latest(newest: &latest::LatestCheck, running: &str) -> String {
+    match (newest.update_available, &newest.latest) {
+        (Some(true), Some(latest)) => {
+            format!("\n{latest} is available (you have {running}).\n")
+        }
+        (Some(false), _) => format!("\n{running} is the newest on this channel.\n"),
+        _ => String::new(),
+    }
+}
+
 /// Run `lev update` against an injected environment.
 pub fn execute_with(args: &UpdateArgs, env: &UpdateEnv, version: &str) -> anyhow::Result<()> {
     let plan = plan(args, env);
+    let newest = check_latest(&plan, env, version);
 
     if args.json {
         println!(
             "{}",
-            serde_json::to_string_pretty(&plan_json(&plan, version))
+            serde_json::to_string_pretty(&plan_json(&plan, version, &newest))
                 .expect("a plan is plain data and always serializes")
         );
         return Ok(());
     }
 
     print!("{}", format_plan(&plan, version));
+    print!("{}", format_latest(&newest, version));
     if args.check {
         return Ok(());
     }
@@ -985,6 +1048,8 @@ pub fn execute_with(args: &UpdateArgs, env: &UpdateEnv, version: &str) -> anyhow
     migrate_config(args, env, &plan)?;
     Ok(())
 }
+
+pub mod latest;
 
 #[cfg(test)]
 mod tests;

--- a/crates/leviath-cli/src/commands/update/latest.rs
+++ b/crates/leviath-cli/src/commands/update/latest.rs
@@ -1,0 +1,225 @@
+//! "Is there anything newer?" - the question `GET /api/update` could not answer.
+//!
+//! [`crate::commands::update::plan`] works out *how* this copy would update and
+//! deliberately makes no network call, so the route built on it can say what to
+//! type and not whether it is worth typing. The console was left comparing the
+//! daemon's version against a number baked into the site at deploy time, which
+//! only knows the stable channel and is as stale as the last build - so the
+//! people most likely to want an update prompt, the ones on `alpha` and `beta`,
+//! are exactly the ones it has to stay silent for (issue #600).
+//!
+//! The answer comes from the GitHub releases this repo already publishes, one
+//! tag per channel, rather than from the package manager that would install it.
+//! Asking `brew` and `scoop` is the more obvious "forward to the right place",
+//! and it was the first plan here: it fails on the half of the problem that
+//! matters. Their output is a text format per tool per platform, a `cargo
+//! install` copy has nothing to ask at all, and the install script leaves no
+//! record - so Scoop and Windows would answer `null`, which is the gap that
+//! started this. One publish point answers for every channel, on every platform,
+//! for every install method.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::Channel;
+
+/// Where the releases live. One tag per channel: `prod.yml` publishes the
+/// version and `latest`, `beta.yml` publishes `beta`, `alpha.yml` publishes
+/// `alpha`.
+const RELEASES_API: &str = "https://api.github.com/repos/GEMISIS/leviath/releases/tags";
+
+/// How long an answer is good for.
+///
+/// Long because the question is "should I mention an update", which nobody
+/// needs answered to the minute, and because an unauthenticated GitHub client
+/// gets 60 requests an hour per address - a daemon that asked on every page
+/// load would spend that in a minute and start answering `null` to everyone.
+pub const CHECK_TTL_SECS: u64 = 3600;
+
+/// The release tag that carries the newest build on a channel.
+///
+/// Stable reads `latest` rather than a version tag: the version is the thing
+/// being looked up, so a tag named after it cannot be the way in.
+fn tag_for(channel: Channel) -> &'static str {
+    match channel {
+        Channel::Stable => "latest",
+        Channel::Beta => "beta",
+        Channel::Alpha => "alpha",
+    }
+}
+
+/// What the last check found, or that it has not run.
+///
+/// Every field is optional together on purpose. "The check has not happened
+/// yet", "it is switched off" and "it failed" are the same answer to a console -
+/// nothing to show - and a client that renders `null` honestly as "can't tell"
+/// is already the behaviour the site falls back to for pre-release channels.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LatestCheck {
+    /// Newest version on this copy's channel, without a leading `v`.
+    pub latest: Option<String>,
+    /// Whether `latest` is newer than the running build.
+    pub update_available: Option<bool>,
+    /// When the answer was obtained, unix seconds, so a console can say how
+    /// fresh it is rather than presenting an hour-old answer as current.
+    pub checked_at: Option<u64>,
+}
+
+impl LatestCheck {
+    /// Whether this answer is old enough to be worth replacing.
+    ///
+    /// An unchecked cache is stale by definition, which is what makes the first
+    /// request kick off a refresh instead of waiting for a timer.
+    pub fn is_stale(&self, now: u64, ttl: u64) -> bool {
+        match self.checked_at {
+            Some(at) => now.saturating_sub(at) >= ttl,
+            None => true,
+        }
+    }
+}
+
+/// How the check reaches the network, injected so the parsing and the comparing
+/// can be tested without one.
+///
+/// Returns the response body. Any failure is the same as no answer: this
+/// question is never worth surfacing an error for, because the honest rendering
+/// of "the update check failed" and of "the update check has not run" are the
+/// same sentence.
+pub type ReleaseFetcher = Arc<dyn Fn(&str) -> Result<String, String> + Send + Sync>;
+
+/// Ask GitHub what the newest release on `channel` is, and compare it to
+/// `running`.
+///
+/// `running` is the version this binary reports, so the comparison is against
+/// the copy actually being asked about rather than against whatever the caller
+/// last saw.
+pub fn check_with(
+    channel: Channel,
+    running: &str,
+    fetch: &ReleaseFetcher,
+    now: u64,
+) -> LatestCheck {
+    let url = format!("{RELEASES_API}/{}", tag_for(channel));
+    let Ok(body) = fetch(&url) else {
+        return LatestCheck::default();
+    };
+    let Some(latest) = release_version(&body) else {
+        return LatestCheck::default();
+    };
+    let update_available = is_newer(&latest, running);
+    LatestCheck {
+        update_available: Some(update_available),
+        latest: Some(latest),
+        checked_at: Some(now),
+    }
+}
+
+/// The version a release payload names.
+///
+/// Reads `name` before `tag_name`: the channel tags are literally `alpha` and
+/// `beta`, so for two of the three channels the tag is not a version at all and
+/// only the release name carries one.
+fn release_version(body: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(body).ok()?;
+    ["name", "tag_name"]
+        .iter()
+        .filter_map(|k| value.get(*k).and_then(|v| v.as_str()))
+        .find_map(parse_version)
+}
+
+/// The version inside a release name, which is not always only a version:
+/// `prod.yml` tags bare `0.4.2`, while a release may be titled `Leviath 0.4.2`
+/// or `v0.4.2`.
+fn parse_version(text: &str) -> Option<String> {
+    text.split_whitespace()
+        .map(|word| word.trim_start_matches('v'))
+        .find(|word| {
+            let mut parts = word.split('.');
+            let numeric = |p: Option<&str>| {
+                p.is_some_and(|p| !p.is_empty() && p.chars().all(|c| c.is_ascii_digit()))
+            };
+            numeric(parts.next()) && numeric(parts.next()) && parts.next().is_some()
+        })
+        .map(str::to_string)
+}
+
+/// Whether `latest` is a later version than `running`.
+///
+/// Compared field by field as numbers, because a string compare puts `0.10.0`
+/// before `0.9.0` and would tell everyone on 0.10 to downgrade. A pre-release
+/// suffix on either side is ignored for ordering and only breaks a tie: an
+/// equal-numbered `0.5.0` is not an update over `0.5.0-alpha.1`, it is the
+/// release that alpha was building towards, so it counts.
+fn is_newer(latest: &str, running: &str) -> bool {
+    let fields = |v: &str| -> Vec<u64> {
+        v.split('-')
+            .next()
+            .unwrap_or(v)
+            .split('.')
+            .map(|p| p.parse().unwrap_or(0))
+            .collect()
+    };
+    let (l, r) = (fields(latest), fields(running));
+    match l.cmp(&r) {
+        std::cmp::Ordering::Greater => true,
+        std::cmp::Ordering::Less => false,
+        // Same numbers: a plain version beats a pre-release of itself.
+        std::cmp::Ordering::Equal => running.contains('-') && !latest.contains('-'),
+    }
+}
+
+/// Unix seconds now, or 0 on a clock before the epoch.
+///
+/// 0 rather than an error because the only thing this stamps is "how fresh is
+/// this answer", and a machine whose clock is that wrong has a bigger problem
+/// than a stale update prompt.
+pub fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// The real network path: one GET, short timeout, body back as text.
+///
+/// A short timeout because nothing waits on this - the CLI prints its plan
+/// either way and the daemon answers from a cache - so a slow answer is worth
+/// less than a quick "can't tell". Blocking rather than async because the CLI
+/// has no runtime and the daemon calls it off the request path.
+///
+/// GitHub refuses a request with no `User-Agent`, so it carries one naming the
+/// program doing the asking, which is what their guidance asks for.
+pub fn fetch_release(url: &str) -> Result<String, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(std::time::Duration::from_secs(FETCH_TIMEOUT_SECS))
+        .user_agent(concat!("leviath/", env!("CARGO_PKG_VERSION")))
+        // `unwrap_or_default` rather than `?`: a builder given only a timeout
+        // and a user-agent has no failure to report, so the error arm would be
+        // a branch no request can reach. A default client would still make the
+        // call, just without the timeout, and the caller treats a slow failure
+        // and a fast one the same way.
+        .build()
+        .unwrap_or_default();
+    let response = client.get(url).send().map_err(describe)?;
+    // A 404 is an answer - that channel has published nothing - and it arrives
+    // as a body carrying no version, which reads the same as any other unusable
+    // answer. Nothing here separates the failures, because no caller renders
+    // them differently.
+    response.text().map_err(describe)
+}
+
+/// Every failure in [`fetch_release`], flattened to its message.
+///
+/// One named function rather than a closure at each call site: the caller does
+/// not distinguish these failures, and three identical closures would be three
+/// branches that no reachable request can tell apart.
+fn describe(e: impl std::fmt::Display) -> String {
+    e.to_string()
+}
+
+/// How long to wait for GitHub before giving up and reporting nothing.
+const FETCH_TIMEOUT_SECS: u64 = 5;
+
+#[cfg(test)]
+#[path = "latest_tests.rs"]
+mod tests;

--- a/crates/leviath-cli/src/commands/update/latest_tests.rs
+++ b/crates/leviath-cli/src/commands/update/latest_tests.rs
@@ -1,0 +1,198 @@
+use super::*;
+
+/// A fetcher that answers one canned body, and records what it was asked for.
+fn answering(body: &'static str) -> ReleaseFetcher {
+    Arc::new(move |_: &str| Ok(body.to_string()))
+}
+
+/// The three channels read three different tags. Stable reads `latest` rather
+/// than a version tag, because the version is the thing being looked up.
+#[test]
+fn each_channel_asks_for_its_own_tag() {
+    let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let recorder = {
+        let seen = Arc::clone(&seen);
+        Arc::new(move |url: &str| {
+            seen.lock().expect("not poisoned").push(url.to_string());
+            Err("no network".to_string())
+        }) as ReleaseFetcher
+    };
+    for channel in [Channel::Stable, Channel::Beta, Channel::Alpha] {
+        check_with(channel, "0.4.0", &recorder, 1);
+    }
+    let asked = seen.lock().expect("not poisoned").clone();
+    assert!(asked[0].ends_with("/latest"), "stable: {}", asked[0]);
+    assert!(asked[1].ends_with("/beta"), "beta: {}", asked[1]);
+    assert!(asked[2].ends_with("/alpha"), "alpha: {}", asked[2]);
+}
+
+/// The alpha and beta tags are the words `alpha` and `beta`, so the tag is not a
+/// version and only the release name carries one.
+#[test]
+fn a_channel_tag_that_is_not_a_version_reads_the_release_name() {
+    let body = r#"{"tag_name": "alpha", "name": "Leviath 0.5.0-alpha.3"}"#;
+    let got = check_with(Channel::Alpha, "0.4.0", &answering(body), 99);
+    assert_eq!(got.latest.as_deref(), Some("0.5.0-alpha.3"));
+    assert_eq!(got.update_available, Some(true));
+    assert_eq!(got.checked_at, Some(99));
+}
+
+/// A `v` prefix and a title around the number are both things a release name
+/// carries in practice.
+#[test]
+fn a_version_is_read_out_of_the_text_around_it() {
+    for (name, want) in [
+        (r#"{"name": "v0.4.2"}"#, "0.4.2"),
+        (r#"{"name": "Leviath 0.4.2"}"#, "0.4.2"),
+        (r#"{"tag_name": "0.4.2"}"#, "0.4.2"),
+    ] {
+        let got = check_with(Channel::Stable, "0.4.0", &answering(name), 1);
+        assert_eq!(got.latest.as_deref(), Some(want), "from {name}");
+    }
+}
+
+/// The comparison is numeric per field. A string compare puts `0.10.0` before
+/// `0.9.0`, which would tell everyone on the newer build to downgrade.
+#[test]
+fn versions_compare_as_numbers_not_as_text() {
+    let cases = [
+        ("0.10.0", "0.9.0", true),
+        ("0.9.0", "0.10.0", false),
+        ("0.10.0", "0.10.0", false),
+        ("0.4.2", "0.4.0", true),
+        ("1.0.0", "0.99.99", true),
+    ];
+    for (latest, running, want) in cases {
+        let body = format!(r#"{{"name": "{latest}"}}"#);
+        let fetch: ReleaseFetcher = {
+            let body = body.clone();
+            Arc::new(move |_: &str| Ok(body.clone()))
+        };
+        let got = check_with(Channel::Stable, running, &fetch, 1);
+        assert_eq!(
+            got.update_available,
+            Some(want),
+            "latest {latest} against running {running}"
+        );
+    }
+}
+
+/// The release a pre-release was building towards is an update over it, and a
+/// pre-release of the same number is not an update over the release.
+#[test]
+fn a_release_beats_the_pre_release_of_the_same_number() {
+    let released = check_with(
+        Channel::Alpha,
+        "0.5.0-alpha.1",
+        &answering(r#"{"name": "0.5.0"}"#),
+        1,
+    );
+    assert_eq!(released.update_available, Some(true), "0.5.0 over an alpha");
+
+    let backwards = check_with(
+        Channel::Alpha,
+        "0.5.0",
+        &answering(r#"{"name": "0.5.0-alpha.9"}"#),
+        1,
+    );
+    assert_eq!(
+        backwards.update_available,
+        Some(false),
+        "an alpha is not an update over the release"
+    );
+}
+
+/// No network, and a body that is not a release, are the same answer: nothing to
+/// show. A console renders that as "can't tell", which is what it already does.
+#[test]
+fn an_unanswerable_check_reports_nothing_rather_than_a_guess() {
+    let offline: ReleaseFetcher = Arc::new(|_: &str| Err("dns".to_string()));
+    assert_eq!(
+        check_with(Channel::Stable, "0.4.0", &offline, 1),
+        LatestCheck::default()
+    );
+
+    for junk in [r#"{"message": "Not Found"}"#, "not json at all", "{}"] {
+        let got = check_with(Channel::Stable, "0.4.0", &answering_owned(junk), 1);
+        assert_eq!(got, LatestCheck::default(), "from {junk}");
+        assert!(
+            got.checked_at.is_none(),
+            "an answerless check is not a fresh answer"
+        );
+    }
+}
+
+fn answering_owned(body: &str) -> ReleaseFetcher {
+    let body = body.to_string();
+    Arc::new(move |_: &str| Ok(body.clone()))
+}
+
+/// A cache with no answer in it is stale, which is what makes the first request
+/// start a refresh instead of waiting for a timer.
+#[test]
+fn an_unchecked_cache_is_stale_and_a_fresh_one_is_not() {
+    assert!(LatestCheck::default().is_stale(1000, CHECK_TTL_SECS));
+
+    let fresh = LatestCheck {
+        checked_at: Some(1000),
+        ..LatestCheck::default()
+    };
+    assert!(!fresh.is_stale(1000 + CHECK_TTL_SECS - 1, CHECK_TTL_SECS));
+    assert!(fresh.is_stale(1000 + CHECK_TTL_SECS, CHECK_TTL_SECS));
+    assert!(
+        !fresh.is_stale(500, CHECK_TTL_SECS),
+        "a clock that went backwards must not make an answer stale"
+    );
+}
+
+/// The stamp is a real time, not a placeholder, so a console can say how fresh
+/// the answer is.
+#[test]
+fn now_secs_is_a_plausible_wall_clock() {
+    // Any clock later than the day this was written. Asserting a range rather
+    // than a value keeps the test from depending on when it runs.
+    assert!(
+        now_secs() > 1_700_000_000,
+        "unix seconds, not milliseconds or zero"
+    );
+}
+
+/// The real fetcher, against a server that answers, so the client it builds and
+/// the body it reads are exercised rather than only described.
+///
+/// A plain `#[test]`: the fetcher blocks, and blocking inside a tokio runtime
+/// panics. The daemon calls it from `spawn_blocking` for the same reason.
+#[test]
+fn the_real_fetcher_reads_a_body_off_the_wire() {
+    use std::io::{Read, Write};
+
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("a loopback port is available");
+    let addr = listener
+        .local_addr()
+        .expect("a bound listener has an address");
+    let server = std::thread::spawn(move || {
+        let (mut socket, _) = listener.accept().expect("the fetcher connects");
+        // Read just enough to let the client finish sending before answering.
+        let mut buf = [0_u8; 1024];
+        let _ = socket.read(&mut buf);
+        let body = r#"{"name": "1.2.3"}"#;
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nContent-Type: application/json\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = socket.write_all(response.as_bytes());
+    });
+
+    let got = fetch_release(&format!("http://{addr}/releases/tags/latest"));
+    server.join().expect("the server thread does not panic");
+    assert_eq!(got.as_deref(), Ok(r#"{"name": "1.2.3"}"#));
+}
+
+/// A server that is not there is an error, not a hang and not a panic. The
+/// caller turns it into "cannot tell".
+#[test]
+fn the_real_fetcher_reports_a_refused_connection_as_an_error() {
+    // Port 1 needs privileges to bind, so nothing of ours is listening on it.
+    assert!(fetch_release("http://127.0.0.1:1/releases/tags/latest").is_err());
+}

--- a/crates/leviath-cli/src/commands/update/tests.rs
+++ b/crates/leviath-cli/src/commands/update/tests.rs
@@ -1438,3 +1438,45 @@ fn the_offline_env_declines_to_look_anything_up() {
     let env = UpdateEnv::for_planning_offline();
     assert!((env.latest)("https://example.invalid").is_err());
 }
+
+/// The switch is on when nobody has said otherwise, and an existing config
+/// written before the key existed means on.
+///
+/// `#[serde(default)]` on a `bool` is `false`, so getting this wrong would have
+/// silently switched the check off for every install that upgraded into it -
+/// the opposite of what leaving a key out means.
+#[test]
+fn the_update_check_is_on_unless_a_config_turns_it_off() {
+    let absent: crate::config::Config =
+        toml::from_str("").expect("an empty config is a valid config");
+    assert!(absent.update_check, "a config that says nothing means on");
+    assert!(
+        crate::config::Config::default().update_check,
+        "and so does the default"
+    );
+
+    let off: crate::config::Config =
+        toml::from_str("update_check = false").expect("a valid config");
+    assert!(!off.update_check);
+}
+
+/// Switched off, the env declines to look anything up - so the CLI and the API
+/// both report "cannot tell" rather than one of them quietly still asking.
+#[test]
+fn a_config_that_turns_the_check_off_declines_to_ask() {
+    let on =
+        UpdateEnv::real_with_config(Arc::new(|_: &[String]| Ok(())), Arc::new(|_| false), true);
+    let off =
+        UpdateEnv::real_with_config(Arc::new(|_: &[String]| Ok(())), Arc::new(|_| false), false);
+
+    assert!(
+        (off.latest)("https://example.invalid").is_err(),
+        "switched off, nothing is looked up"
+    );
+    // The `on` env carries the real fetcher. Asserting on its identity rather
+    // than calling it: calling it would reach the network from a test.
+    assert!(
+        !std::ptr::addr_eq(Arc::as_ptr(&on.latest), Arc::as_ptr(&off.latest)),
+        "the two envs do not share one fetcher"
+    );
+}

--- a/crates/leviath-cli/src/commands/update/tests.rs
+++ b/crates/leviath-cli/src/commands/update/tests.rs
@@ -63,6 +63,10 @@ impl Fixture {
             exe: PathBuf::from(exe),
             home: Some(PathBuf::from("/home/u")),
             brew_prefix: None,
+            // Declines, so these tests keep asserting on a plan built without a
+            // network call - which is what every one of them was written
+            // against. The lookup has its own tests beside it.
+            latest: Arc::new(|_: &str| Err("no network in tests".to_string())),
             agents_dir: self.dir.path().join("agents"),
             config_path: self.dir.path().join("config.toml"),
             runner: Arc::new(move |argv: &[String]| {
@@ -725,7 +729,11 @@ fn the_json_shape_carries_the_method_channel_command_and_rows() {
     .expect("write the config");
     let env = fixture.env_with("/opt/homebrew/bin/lev", true, true, SAMPLE);
 
-    let json = plan_json(&plan(&UpdateArgs::default(), &env), "0.3.4");
+    let json = plan_json(
+        &plan(&UpdateArgs::default(), &env),
+        "0.3.4",
+        &crate::commands::update::latest::LatestCheck::default(),
+    );
 
     assert_eq!(json["version"], "0.3.4");
     assert_eq!(json["install_method"], "homebrew");
@@ -742,7 +750,11 @@ fn the_json_shape_carries_the_method_channel_command_and_rows() {
         "/home/u/dev/target/release/lev",
         &UpdateArgs::default(),
     );
-    let json = plan_json(&plan, "0.3.4");
+    let json = plan_json(
+        &plan,
+        "0.3.4",
+        &crate::commands::update::latest::LatestCheck::default(),
+    );
     assert_eq!(json["install_method"], "unknown");
     assert_eq!(json["channel"], serde_json::Value::Null);
     assert_eq!(json["binary"]["action"], "advise");
@@ -756,6 +768,7 @@ fn the_json_shape_carries_the_method_channel_command_and_rows() {
     let json = plan_json(
         &plan_for(&broken, "/opt/homebrew/bin/lev", &UpdateArgs::default()),
         "0.3.4",
+        &crate::commands::update::latest::LatestCheck::default(),
     );
     assert!(
         json["config_error"].as_str().is_some_and(|e| !e.is_empty()),
@@ -1351,4 +1364,77 @@ fn planning_against_the_real_machine_always_reaches_a_verdict() {
         BinaryStep::Run(commands) => assert!(!commands.is_empty()),
         BinaryStep::Advise(message) => assert!(!message.is_empty()),
     }
+}
+
+/// The line `lev update` prints about whether the update is worth doing. Silent
+/// when the check could not answer: the command was asked how to update, not
+/// whether to, and a failed lookup of something nobody asked for is noise.
+#[test]
+fn the_update_line_speaks_only_when_it_has_something_to_say() {
+    use crate::commands::update::latest::LatestCheck;
+
+    let available = LatestCheck {
+        latest: Some("0.5.0".to_string()),
+        update_available: Some(true),
+        checked_at: Some(1),
+    };
+    let line = super::format_latest(&available, "0.4.0");
+    assert!(line.contains("0.5.0 is available"), "{line}");
+    assert!(line.contains("0.4.0"), "it says what you have: {line}");
+
+    let current = LatestCheck {
+        latest: Some("0.4.0".to_string()),
+        update_available: Some(false),
+        checked_at: Some(1),
+    };
+    assert!(
+        super::format_latest(&current, "0.4.0").contains("newest on this channel"),
+        "a current copy is told so"
+    );
+
+    assert_eq!(
+        super::format_latest(&LatestCheck::default(), "0.4.0"),
+        "",
+        "an unanswered check prints nothing at all"
+    );
+}
+
+/// A copy whose channel could not be worked out is not asked about. The only
+/// answer available would be the stable release compared against a build that
+/// may not be on that line, which is the guess this exists to stop making.
+#[test]
+fn a_copy_with_no_known_channel_is_not_asked_about() {
+    use crate::commands::update::latest::LatestCheck;
+
+    let asked = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let env = {
+        let asked = Arc::clone(&asked);
+        UpdateEnv {
+            latest: Arc::new(move |_: &str| {
+                asked.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(r#"{"name": "9.9.9"}"#.to_string())
+            }),
+            ..UpdateEnv::for_planning()
+        }
+    };
+
+    // A path no installer uses detects as `Unknown`, which carries no channel.
+    let unknown = plan_for(
+        &Fixture::new(),
+        "/nowhere/at/all/lev",
+        &UpdateArgs::default(),
+    );
+    assert_eq!(
+        super::check_latest(&unknown, &env, "0.4.0"),
+        LatestCheck::default()
+    );
+    assert_eq!(asked.load(std::sync::atomic::Ordering::SeqCst), 0);
+}
+
+/// The offline env's fetcher is a refusal, not a no-op that quietly returns a
+/// stale-looking answer.
+#[test]
+fn the_offline_env_declines_to_look_anything_up() {
+    let env = UpdateEnv::for_planning_offline();
+    assert!((env.latest)("https://example.invalid").is_err());
 }

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -192,6 +192,22 @@ pub struct Config {
     #[serde(default)]
     pub taint_tracking: bool,
 
+    /// Whether this copy may ask whether a newer release exists.
+    ///
+    /// On by default: the question is asked once an hour at most, the answer is
+    /// what stops a console either nagging somebody who is current or staying
+    /// silent for somebody who is not, and a check that reaches nothing simply
+    /// reports that it could not tell.
+    ///
+    /// Set `update_check = false` where reaching out is the problem rather than
+    /// the frequency - an air-gapped install, or a machine that should make no
+    /// outbound request nobody asked for. Off, `lev update` still says how to
+    /// update and `GET /api/update` still answers; both report `null` for
+    /// whether there is anything newer, which every client already renders as
+    /// "cannot tell".
+    #[serde(default = "default_update_check")]
+    pub update_check: bool,
+
     /// Runtime resource limits (inference concurrency + iteration caps).
     #[serde(default)]
     pub limits: LimitsConfig,
@@ -298,6 +314,7 @@ impl Default for Config {
             agent_paths: Vec::new(),
             openrouter_api_key: None,
             ollama_base_url: None,
+            update_check: default_update_check(),
             mcp_servers: Vec::new(),
             default_model: None,
             model_capabilities: HashMap::new(),
@@ -1018,6 +1035,15 @@ pub(crate) fn default_true() -> bool {
 /// table the user has no reason to know about and says nothing about what to
 /// add. Kept in sync with [`Config::default`] by
 /// `an_empty_config_file_parses_to_the_defaults`.
+/// The update check is on when the key is absent.
+///
+/// A named default rather than `#[serde(default)]`, which for a `bool` is
+/// `false` - so an existing config with no `update_check` line would have had
+/// the check switched off, which is the opposite of what leaving it out means.
+fn default_update_check() -> bool {
+    true
+}
+
 pub(crate) fn default_provider_name() -> String {
     "anthropic".to_string()
 }
@@ -3517,6 +3543,7 @@ enabled = false
         tool_perms.insert("bash".to_string(), ToolPolicy::Allow);
 
         let config = Config {
+            update_check: true,
             default_provider: "anthropic".to_string(),
             providers: ProviderConfig {
                 anthropic_api_key: Some("sk-ant-key".to_string()),

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -233,9 +233,16 @@ impl RiskyExecutors for RealExecutors {
 /// `GET /api/update` needs exactly the same discovery and only differs in what
 /// it is willing to do with the answer.
 fn real_update(args: commands::update::UpdateArgs) -> anyhow::Result<()> {
-    let env = commands::update::UpdateEnv::real(
+    // A config that will not load is not a reason to refuse the check: the
+    // default is on, and `lev update` on a machine with a broken config is
+    // exactly when somebody wants to know whether a newer build exists.
+    let update_check = leviath_cli::config::Config::load()
+        .map(|c| c.update_check)
+        .unwrap_or(true);
+    let env = commands::update::UpdateEnv::real_with_config(
         std::sync::Arc::new(run_upgrade),
         std::sync::Arc::new(ask_yes_no),
+        update_check,
     );
     commands::update::execute_with(&args, &env, env!("CARGO_PKG_VERSION"))
 }

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -178,7 +178,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
 | `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
-| `GET /api/update` | How this copy was installed, and the command that upgrades it. See [below](#asking-how-to-upgrade) |
+| `GET /api/update` | Whether anything newer exists, how this copy was installed, and the command that upgrades it. See [below](#asking-how-to-upgrade) |
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
 | `POST /api/fs/dirs` | Make one directory: `{"path": "<absolute parent>", "name": "<one segment>"}` → `201 {"path", "parent"}`. The same fence as the `GET`; `409` if it already exists. Announced as `fs.mkdir` |
 | `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
@@ -527,7 +527,11 @@ The body is exactly what `lev update --check --json` prints, from the same plann
   },
   "agents": [],
   "migrations": [],
-  "config_error": null
+  "config_error": null,
+
+  "latest": "0.4.2",
+  "update_available": true,
+  "checked_at": 1787438706
 }
 ```
 
@@ -542,8 +546,25 @@ a client that hard-codes one package manager's command is right for the users wh
 share its author's machine and wrong for everyone else. Where a daemon does not announce
 `update.plan`, send people to the install page rather than picking a package manager for them.
 
+`latest` is the newest version on this copy's own channel, `update_available` whether that is
+newer than the version it is running, and `checked_at` when the daemon last found out, in unix
+seconds, so you can say how fresh the answer is rather than presenting an hour-old one as
+current. All three are `null` together when the check has not run yet, could not reach the
+network, or had no channel to ask about - one state, "cannot tell", which is the honest thing to
+render. Treat a missing key as an older daemon and a `null` key as an answer.
+
+The daemon looks this up on its own schedule and the route reports whatever the last lookup
+found, so asking on every page load costs nothing and never waits. The lookup runs the same code
+`lev update` does, against the releases published for each channel, so the console and the
+terminal cannot come to different conclusions about the same binary.
+
+Do the comparison with `update_available` rather than against `version` yourself. A client that
+compares against a number it was built with only knows the stable line, so it reports a daemon on
+`alpha` or `beta` as out of date for running something newer.
+
 The route is read-only and available without `--allow-admin`. It works out what an update would
-do and does none of it, makes no network call, and cannot run a command even if asked.
+do and does none of it, makes no network call on the request path, and cannot run a command even
+if asked.
 
 ## Tools and scripts
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -35,6 +35,7 @@ request_timeout_secs = 900           # per-request HTTP timeout to a provider
 taint_tracking       = false         # global master switch, see below
 batch_tool_hint      = true          # global master switch, see below
 shell_hint           = true          # global master switch, see below
+update_check         = true          # ask whether a newer release exists
 ```
 
 | Key | Type | Default | Notes |
@@ -48,6 +49,7 @@ shell_hint           = true          # global master switch, see below
 | `taint_tracking` | bool | `false` | Turns on [taint tracking](/docs/security) for every agent. With it off, an agent can still opt in itself |
 | `batch_tool_hint` | bool | `true` | Adds a short hint telling the model it may batch independent tool calls |
 | `shell_hint` | bool | `true` | Adds a short hint describing the shell a stage will get. Only says anything on Windows today |
+| `update_check` | bool | `true` | Lets this copy ask whether a newer release exists on its own channel, at most once an hour. Set `false` on an air-gapped machine, or anywhere an outbound request nobody asked for is the problem. Off, `lev update` still says how to update and [`GET /api/update`](/docs/api#asking-how-to-upgrade) still answers; both report `null` for whether anything newer exists |
 
 All three of those cascade: a stage setting beats an agent setting, which beats this file.
 


### PR DESCRIPTION
Closes #600.

`GET /api/update` could say *how* this copy would update and not whether it was worth doing, so the console compared the daemon's version against a number baked into the site at deploy time. That number only knows the stable channel, so a daemon on `alpha` or `beta` is legitimately ahead of it and has to be reported as unjudgeable — leaving the people most likely to want an update prompt as the only ones who cannot have one — and it is as stale as the last site build.

## One correction to the issue

It proposed reusing `lev update`'s network path. **There isn't one.** `lev update` shells out to `brew update && brew upgrade` and lets the package manager work out what is newest — which is also why the route could honestly say it made no network call. So this adds the lookup rather than exposing an existing one.

## Why GitHub releases and not `brew` / `scoop`

Asking the package manager is the more obvious "forward to the right place", and it was the first plan here. It fails on the half of the problem that matters: their output is a text format per tool per platform, a `cargo install` copy has nothing to ask, and the install script keeps no record of its channel. Scoop and Windows would answer `null` — which is the gap #588 was about.

One publish point answers for every channel, on every platform, for every install method. `prod.yml` already tags `latest`, `beta.yml` tags `beta`, `alpha.yml` tags `alpha`.

## Unified, as asked

Both callers go through **`plan_json`**, which is where they already met, so the new fields cannot exist on one and not the other:

- `lev update` performs the lookup and prints a line about it
- the route reports the daemon's cached answer and starts a refresh when it has gone stale

A console asking on every page load never waits, and at most starts a lookup for whoever asks next.

```jsonc
{
  "version": "0.4.0", "install_method": "scoop", "channel": "stable",
  "latest": "0.4.2", "update_available": true, "checked_at": 1787438706,
  "binary": { … }, "agents": [ … ], "migrations": [ … ]
}
```

All three are `null` together when the check has not run, could not reach the network, or had no channel to ask about — the "cannot tell" a client already renders.

## Two things the implementation had to get right

**A failed lookup is not cached.** Storing it would stamp `checked_at`, making a failure look like a fresh answer and holding off the next attempt for the whole hour — so one flaky moment would cost a console its prompt until the next one.

**The cache is on the app state, not in a `static`.** It started as a global and the tests found it immediately: one stored a version and another read it back. Two servers in one process would have hit the same thing.

## Verification

- The fetcher is exercised **over a real socket** — a local listener serving one HTTP response — rather than only described, and a refused connection is checked to come back as an error rather than a hang.
- Version ordering is tested per field: `0.10.0` over `0.9.0` is an update. My first draft of that table asserted the opposite and the test caught it.
- A copy with no detectable channel is asserted **not** to be looked up, rather than being compared against a channel it may not be on.
- Suite green as CI runs it, clippy clean, structure and docs gates pass, **coverage 13/13 at 100%**.

## Not in scope

An endpoint that performs the update, per the issue. The route still cannot run a command, is read-only, and needs no `--allow-admin`.

## Turning it off

`update_check = false` in the config, on by default. For a machine where an outbound request nobody asked for is the problem rather than how often it happens.

Off, both callers still answer — `lev update` says how to update, the route returns its usual body — reporting `null` for whether anything newer exists. A client cannot mistake that for a daemon too old to have been asked, because the keys are present.

On by default through a **named** serde default. For a `bool`, a bare `#[serde(default)]` is `false`, so the obvious version would have switched the check off for every config written before the key existed. A test pins it: an empty config parses with the check on.

Switched off, the env carries a fetcher that **declines**, rather than a flag each caller remembers to test. The two ways of not asking are one function, so they cannot drift apart. The route reads the config per request, so the switch takes effect on the next page load rather than the next restart.
