### PR TITLE
fix(agents): ask an index what is on it, not whether it has what you have

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## Unreleased
+
+- Fixed: the research blueprints crossed to the right index and then asked it
+  the wrong question. Told to reach past category listings, a survey searched an
+  awards guide - exactly the kind a category filter cannot reach - and appended
+  three entries it already had to the query, which turns "what is on this list"
+  into "confirm these are on this list". The entry it was missing sits third in
+  the results for the same search without those three names, on that guide's own
+  page for it. The survey stages now say not to name what you already have in an
+  index query. This is the failure that survives crossing indexes properly,
+  because the query still looks like the right one.
+
 ## 0.5.0 - 2026-08-24
 
 - Fixed: naming a script provider as `default_provider` did not send any stage

--- a/crates/leviath-cli/agents/deep-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/deep-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "deep-researcher"
-version = "0.4.5"
+version = "0.4.6"
 description = "Thorough single-topic investigation - searches, follows citation chains, cross-checks claims, and produces a structured cited report"
 max_child_depth = 2
 entry_stage = "gather"
@@ -61,6 +61,15 @@ authoritative references, not a broad skim.
   professional body's own roster, the "related" and "see also" edges out of a
   page you already trust, whatever an entry sits inside rather than the type it
   is filed under, and what the primary source says it is in its own words.
+
+  Ask an index what is ON it. Do not name the entries you already have in the
+  query: adding the three you know turns "what is on this list" into "confirm these
+  are on this list", and the answer comes back about them. This is the failure mode
+  that survives crossing indexes properly, because the query still looks like the
+  right query. Measured: a run searched an awards guide - exactly the kind a
+  category listing cannot reach - and appended three names it already had. The
+  top-rated entry it was missing sits third in the results for the same search with
+  those three names removed, on that guide's own page for it.
 
   Then ask the question that catches the filter: what would something in this
   field have to be for it NOT to appear in the indexes I used? Name one such thing

--- a/crates/leviath-cli/agents/researcher/agent.leviath
+++ b/crates/leviath-cli/agents/researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "researcher"
-version = "0.4.5"
+version = "0.4.6"
 description = "Research assistant - gather, analyze, and summarize with a gather↔analyze refinement loop, error recovery, and multi-provider fallback"
 max_child_depth = 2
 entry_stage = "gather"
@@ -58,6 +58,15 @@ Be efficient - do not search exhaustively:
    professional body's own roster, the "related" and "see also" edges out of a
    page you already trust, whatever an entry sits inside rather than the type it
    is filed under, and what the primary source says it is in its own words.
+
+   Ask an index what is ON it. Do not name the entries you already have in the
+   query: adding the three you know turns "what is on this list" into "confirm these
+   are on this list", and the answer comes back about them. This is the failure mode
+   that survives crossing indexes properly, because the query still looks like the
+   right query. Measured: a run searched an awards guide - exactly the kind a
+   category listing cannot reach - and appended three names it already had. The
+   top-rated entry it was missing sits third in the results for the same search with
+   those three names removed, on that guide's own page for it.
 
    Then ask the question that catches the filter: what would something in this
    field have to be for it NOT to appear in the indexes I used? Name one such thing

--- a/crates/leviath-cli/agents/wide-researcher/agent.leviath
+++ b/crates/leviath-cli/agents/wide-researcher/agent.leviath
@@ -1,6 +1,6 @@
 [agent]
 name = "wide-researcher"
-version = "0.4.6"
+version = "0.4.7"
 description = "Broad multi-topic survey - cast a wide net, research the threads in parallel, compare approaches, and produce a landscape overview"
 max_child_depth = 2
 entry_stage = "survey"
@@ -69,6 +69,15 @@ Reach for what a category filter cannot reach: awards and guides, a
 professional body's own roster, the "related" and "see also" edges out of a
 page you already trust, whatever an entry sits inside rather than the type it
 is filed under, and what the primary source says it is in its own words.
+
+Ask an index what is ON it. Do not name the entries you already have in the
+query: adding the three you know turns "what is on this list" into "confirm these
+are on this list", and the answer comes back about them. This is the failure mode
+that survives crossing indexes properly, because the query still looks like the
+right query. Measured: a run searched an awards guide - exactly the kind a
+category listing cannot reach - and appended three names it already had. The
+top-rated entry it was missing sits third in the results for the same search with
+those three names removed, on that guide's own page for it.
 
 Then ask the question that catches the filter: what would something in this
 field have to be for it NOT to appear in the indexes I used? Name one such thing


### PR DESCRIPTION
Follow-up to the discovery-framing change, from the run that tested it.

## The last fix worked, and was not enough

Told to cross index kinds, the survey went from **7 searches to 51** and genuinely reached past category listings: Michelin, Hale ʻAina Awards, Forbes/AAA Five Diamond, official Hawaii tourism, plus a "not touristy / local" angle.

It still missed the same entry. The query was:

```
Forbes Travel Guide AAA Five Diamond Waikiki restaurants La Mer Orchids Azure
```

The right index — asked to confirm three entries the run already had.

Run the same search **without those three names** and the missing entry is the **third result**, on that guide's own page for it.

## Why this one is worse than the failure before it

The query looks right in the log. "Cross a different kind of index" is satisfied by a search that structurally cannot return anything new: naming what you have turns a question about the list into a question about your existing answers, and the results come back about them.

So the blueprints now say: **ask an index what is ON it, and do not name the entries you already have.** Placed after the crossing instruction and before the question about what would appear in neither index, since it is what makes both of those worth doing.

## Verification, stated honestly

**Not verified by a run.** A prompt change is proven by a run and this one has not had one yet.

What *is* verified is the mechanism: the same search with the three names removed returns the missing entry third. That is the whole claim.

- All 7 blueprints pass `lev validate`; the 3 changed ones are version-bumped
- Ghost-region and layout invariants hold
- Suite green as CI runs it, docs gate passes

## From the same run, for context

The other half of the previous change did land: report **4,911B → 7,587B**, working citations **0 → 20**, source domains **97 → 143**, cache hit rate **6.2% → 61%**, cost per agent **$8.54 → $4.04** while running nearly twice as many agents.
