### PR TITLE
feat(providers): ask a provider what its models hold, and say when nobody asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,34 @@ same list.
 
 ## Unreleased
 
+- Fixed: `GET /api/models` published a guess for every provider whose real
+  answer is a network call away. It built a registry and listed straight away,
+  never priming, so the token limits it reported came from a table matched
+  against each model's name. Measured against a running server: Ollama reported
+  131,072 for a model its own server serves at 262,144, and all 418 OpenRouter
+  models carried compiled figures despite that provider having fetched the real
+  ones for some time. The route now primes first, with a five second budget, and
+  a provider that does not answer in time keeps its table and says so.
+- Added: Google reports its own token limits to the runtime. The native
+  `/v1beta/models` listing has always read `inputTokenLimit` and
+  `outputTokenLimit` and handed them to the model picker, while `capabilities()`
+  - which is what percentage region budgets resolve against - answered from
+  family defaults matched off the model's name. The authoritative numbers were
+  being fetched and thrown away.
+- Added: Ollama asks `/api/ps` before `/api/show`. That endpoint reports the
+  window the runner actually allocated for a loaded model, which is the only
+  figure that is an observation rather than an inference: `num_ctx` is what a
+  Modelfile asked for, and the architecture length in `model_info` is what the
+  weights allow rather than what the server will serve. A model nothing has
+  called yet still falls back to `num_ctx`.
+- Added: `limits_source` on every `GET /api/models` entry - `api`, `builtin` or
+  `override` - so a client can tell a limit the provider reported from one this
+  build matched off a model's name. They look identical once printed and are not
+  worth the same: a window that is wrong by a factor of two makes every
+  percentage region in the run wrong by the same factor, and nothing downstream
+  can tell. Anthropic and OpenAI report `builtin` and always will: neither
+  `/models` endpoint carries token limits at all.
+
 - Fixed: the research blueprints crossed to the right index and then asked it
   the wrong question. Told to reach past category listings, a survey searched an
   awards guide - exactly the kind a category filter cannot reach - and appended

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -1,6 +1,7 @@
 //! `lev models` - Inspect available models and their capabilities.
 
 use clap::{Args, Subcommand};
+use leviath_providers::LimitsSource;
 use leviath_providers::{ModelCapabilities, ModelInfo};
 
 use super::run::build_provider_registry_from_config;
@@ -162,6 +163,7 @@ fn builtin_table() -> Vec<BuiltinEntry> {
                     supports_system_prompt: true,
                     max_context_tokens: $ctx,
                     max_output_tokens: $out,
+                    limits_source: LimitsSource::Builtin,
                 },
             }
         };
@@ -1075,6 +1077,7 @@ mod tests {
             supports_system_prompt: true,
             max_context_tokens: 100_000,
             max_output_tokens: 8_192,
+            limits_source: LimitsSource::Builtin,
         };
         // Should not panic
         print_model_detail("test-model", Some("Test Model"), "test", &caps, false);
@@ -1531,6 +1534,7 @@ mod tests {
             supports_system_prompt: false,
             max_context_tokens: 1000,
             max_output_tokens: 500,
+            limits_source: LimitsSource::Builtin,
         };
         // Should not panic with all features disabled
         print_model_detail("test-model", Some("Test"), "test", &caps, false);
@@ -2412,6 +2416,7 @@ mod tests {
                         supports_system_prompt: false,
                         max_context_tokens: 1,
                         max_output_tokens: 1,
+                        limits_source: LimitsSource::Builtin,
                     }
                     .into(),
                 );
@@ -2451,6 +2456,7 @@ mod tests {
                         supports_system_prompt: false,
                         max_context_tokens: 1,
                         max_output_tokens: 1,
+                        limits_source: LimitsSource::Builtin,
                     }
                     .into(),
                 );

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -346,6 +346,7 @@ fn script_provider_spec(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use leviath_providers::LimitsSource;
 
     #[test]
     fn build_provider_registry_with_empty_config() {
@@ -891,6 +892,7 @@ mod tests {
                 supports_system_prompt: true,
                 max_context_tokens: 9999,
                 max_output_tokens: 999,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );
@@ -939,6 +941,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 99,
                 max_output_tokens: 99,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -197,6 +197,13 @@ pub(super) async fn validate_config_key(Json(req): Json<ValidateKeyReq>) -> Json
     Json(ValidateKeyResp { valid, message })
 }
 
+/// How long the models route waits for a provider to describe its own models.
+///
+/// Shorter than the daemon's start-up prime: this is a page load, and a limit
+/// that arrives after the page has rendered is worth less than a fast answer
+/// that admits which numbers are guesses.
+const MODELS_PRIME_TIMEOUT_SECS: u64 = 5;
+
 pub(super) async fn get_models(State(state): State<AppState>) -> Json<Vec<ModelEntry>> {
     models_with(&state, &leviath_providers::provider::build_http_client).await
 }
@@ -246,6 +253,26 @@ pub(super) async fn list_models_from_config(
     ) else {
         return Vec::new();
     };
+    // Ask each provider what its models are before asking what they can hold.
+    //
+    // Without this the route published the compiled-in guess for every provider
+    // whose real answer is a network call away - which is most of them, and
+    // includes the two that had learned to fetch it. Measured against a running
+    // server: Ollama reported a name-matched 131,072 for a model whose server
+    // says 262,144, and OpenRouter reported builtin limits for all 418 of its
+    // models. Only Google looked right, and only because its listing reads the
+    // limits inline rather than through the primed table.
+    //
+    // The route already makes one network call per provider to list at all, so
+    // this is a second bounded one, not a new class of cost. A provider that
+    // does not answer in time keeps its compiled table and says so through
+    // `limits_source`.
+    registry
+        .prime_capabilities(
+            std::time::Duration::from_secs(MODELS_PRIME_TIMEOUT_SECS),
+            None,
+        )
+        .await;
     let mut models = Vec::new();
 
     for provider_name in registry.resolvable_names() {
@@ -265,6 +292,7 @@ pub(super) async fn list_models_from_config(
                     display_name: m.display_name,
                     max_context_tokens: m.capabilities.max_context_tokens,
                     max_output_tokens: m.capabilities.max_output_tokens,
+                    limits_source: limits_source_label(m.capabilities.limits_source),
                     supports_tools: m.capabilities.supports_tools,
                 });
             }
@@ -272,6 +300,36 @@ pub(super) async fn list_models_from_config(
     }
 
     models
+}
+
+/// The wire spelling of a [`LimitsSource`].
+///
+/// Written out here rather than serialized from the enum so the API's
+/// vocabulary is visible at the boundary that publishes it: a rename in the
+/// providers crate should not silently change what a console reads.
+fn limits_source_label(source: leviath_providers::LimitsSource) -> String {
+    match source {
+        leviath_providers::LimitsSource::Api => "api",
+        leviath_providers::LimitsSource::Builtin => "builtin",
+        leviath_providers::LimitsSource::Override => "override",
+    }
+    .to_string()
+}
+
+#[cfg(test)]
+mod limits_source_label_tests {
+    use super::limits_source_label;
+    use leviath_providers::LimitsSource;
+
+    /// The three spellings a client switches on. Pinned here because they are
+    /// the wire vocabulary: renaming the enum in the providers crate must not
+    /// quietly change what a console reads, and only this test would notice.
+    #[test]
+    fn every_source_has_its_wire_spelling() {
+        assert_eq!(limits_source_label(LimitsSource::Api), "api");
+        assert_eq!(limits_source_label(LimitsSource::Builtin), "builtin");
+        assert_eq!(limits_source_label(LimitsSource::Override), "override");
+    }
 }
 
 #[cfg(test)]

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1063,6 +1063,14 @@ pub(super) struct ModelEntry {
     pub(super) display_name: Option<String>,
     pub(super) max_context_tokens: usize,
     pub(super) max_output_tokens: usize,
+    /// Where the two limits above came from: `api`, `builtin` or `override`.
+    ///
+    /// Published because they are numbers a client acts on and the two kinds
+    /// are not worth the same. `api` is what the provider says; `builtin` is
+    /// this build matching the model's name against a compiled table, which is
+    /// the only answer available for a provider whose API does not report
+    /// limits at all, and is a guess that can be wrong by a factor of two.
+    pub(super) limits_source: String,
     pub(super) supports_tools: bool,
 }
 

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -1,9 +1,9 @@
 //! Anthropic Claude provider implementation.
 
 use crate::provider::{
-    FinishReason, InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride,
-    ModelInfo, Provider, ProviderConfig, ProviderError, Result, StreamChunk, TokenUsage, ToolCall,
-    ToolCallDelta,
+    FinishReason, InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities,
+    ModelCapabilityOverride, ModelInfo, Provider, ProviderConfig, ProviderError, Result,
+    StreamChunk, TokenUsage, ToolCall, ToolCallDelta,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -339,6 +339,7 @@ impl AnthropicProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 128_000,
+                limits_source: LimitsSource::Builtin,
             };
         }
         // Sonnet 5 - 1M context, 128K output, no temperature
@@ -350,6 +351,7 @@ impl AnthropicProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 128_000,
+                limits_source: LimitsSource::Builtin,
             };
         }
         // Fable 5 / Mythos 5 - top-tier, 1M context, 128K output, no temperature
@@ -361,6 +363,7 @@ impl AnthropicProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 128_000,
+                limits_source: LimitsSource::Builtin,
             };
         }
         // Opus 4.8 / 4.7 - 1M context, 128K output, no temperature
@@ -372,6 +375,7 @@ impl AnthropicProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 128_000,
+                limits_source: LimitsSource::Builtin,
             };
         }
         // Opus 4.6 - 1M context, 128K output, temperature supported
@@ -383,6 +387,7 @@ impl AnthropicProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 128_000,
+                limits_source: LimitsSource::Builtin,
             };
         }
         // Sonnet 4.6 - 1M context, 128K output, temperature supported
@@ -394,6 +399,7 @@ impl AnthropicProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 128_000,
+                limits_source: LimitsSource::Builtin,
             };
         }
         // Haiku 4.5 - 200K context, 64K output, temperature supported
@@ -405,6 +411,7 @@ impl AnthropicProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 200_000,
                 max_output_tokens: 64_000,
+                limits_source: LimitsSource::Builtin,
             };
         }
         // Generic Claude 4.x fallback (e.g. older 4.5 snapshots)
@@ -419,6 +426,7 @@ impl AnthropicProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 32_768,
+                limits_source: LimitsSource::Builtin,
             };
         }
         ModelCapabilities::default()
@@ -1758,6 +1766,7 @@ mod tests {
                 supports_system_prompt: true,
                 max_context_tokens: 1_000_000,
                 max_output_tokens: 32_768,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );
@@ -2471,6 +2480,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 42,
                 max_output_tokens: 10,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );

--- a/crates/leviath-providers/src/capabilities.rs
+++ b/crates/leviath-providers/src/capabilities.rs
@@ -26,6 +26,46 @@ pub struct ModelCapabilities {
 
     /// Maximum number of output tokens
     pub max_output_tokens: usize,
+
+    /// Where the two token limits above came from.
+    ///
+    /// Carried beside them because they are published - `GET /api/models` and
+    /// `lev models` both print them - and a number read from the provider and a
+    /// number matched off a substring of the model's name look identical once
+    /// printed. They are not worth the same: percentage region budgets resolve
+    /// against `max_context_tokens`, so a guess that is wrong by 2x makes every
+    /// region in the run wrong by 2x, and nothing downstream can tell.
+    #[serde(default)]
+    pub limits_source: LimitsSource,
+}
+
+/// How a model's token limits were arrived at.
+///
+/// Ordered by how much it is worth trusting, least first, so `max` picks the
+/// better of two answers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LimitsSource {
+    /// Matched from the model's name against a table compiled into this build.
+    ///
+    /// The default, and the honest answer for a provider whose API does not
+    /// report limits at all: Anthropic's and OpenAI's `/models` both return an
+    /// id and a display name and nothing about size. It is also the answer when
+    /// a provider that *could* say has not been asked yet, since
+    /// `prime_capabilities` runs at daemon start-up and a short-lived command
+    /// may not have waited for it.
+    #[default]
+    Builtin,
+
+    /// Read from the provider's own API for this model.
+    Api,
+
+    /// Set by the operator in `[model_capabilities]`.
+    ///
+    /// Ranked above the API because someone who wrote the number down is
+    /// correcting something, and the usual something is an API answer that did
+    /// not match what the endpoint actually served.
+    Override,
 }
 
 impl Default for ModelCapabilities {
@@ -37,6 +77,7 @@ impl Default for ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 8192,
             max_output_tokens: 4096,
+            limits_source: LimitsSource::Builtin,
         }
     }
 }
@@ -101,7 +142,20 @@ impl ModelCapabilityOverride {
                 .unwrap_or(base.supports_system_prompt),
             max_context_tokens: self.max_context_tokens.unwrap_or(base.max_context_tokens),
             max_output_tokens: self.max_output_tokens.unwrap_or(base.max_output_tokens),
+            // Only a limit the operator actually named makes this theirs. An
+            // entry that corrects `supports_temperature` and says nothing about
+            // size would otherwise relabel an API-read window as hand-set, and
+            // the label is there to say how much the number is worth.
+            limits_source: match self.names_a_limit() {
+                true => LimitsSource::Override,
+                false => base.limits_source,
+            },
         }
+    }
+
+    /// Whether this entry sets either token limit.
+    pub fn names_a_limit(&self) -> bool {
+        self.max_context_tokens.is_some() || self.max_output_tokens.is_some()
     }
 }
 

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -127,6 +127,7 @@ impl ClaudeCodeProvider {
             supports_system_prompt: true,
             max_context_tokens: 200_000 - INJECTION_RESERVE_TOKENS,
             max_output_tokens: max_output,
+            limits_source: LimitsSource::Builtin,
         }
     }
 
@@ -564,6 +565,7 @@ mod tests {
                 supports_system_prompt: true,
                 max_context_tokens: 100_000,
                 max_output_tokens: 8_000,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -6,8 +6,8 @@ use crate::openai_compat::{
 #[cfg(test)]
 use crate::provider::FinishReason;
 use crate::provider::{
-    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
-    Provider, ProviderConfig, ProviderError, Result, StreamChunk,
+    InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderConfig, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -82,6 +82,17 @@ pub struct GeminiProvider {
     /// Rate limiter
     rate_limiter: Option<RateLimiter>,
 
+    /// Per-model limits as the native API reported them, filled by
+    /// [`Provider::prime_capabilities`].
+    ///
+    /// The listing has always read these - `inputTokenLimit` and
+    /// `outputTokenLimit` off `/v1beta/models` - and only ever handed them to
+    /// the model picker. The runtime sizes percentage region budgets through
+    /// the sync `capabilities()` path, which could not await a fetch and so
+    /// answered from a table of family defaults matched off the model's name.
+    /// The authoritative numbers were being fetched and thrown away.
+    api_limits: std::sync::Arc<std::sync::Mutex<HashMap<String, (usize, usize)>>>,
+
     /// Per-model capability overrides
     capability_overrides: HashMap<String, ModelCapabilityOverride>,
 }
@@ -94,6 +105,7 @@ impl GeminiProvider {
             api_key,
             base_url: "https://generativelanguage.googleapis.com/v1beta/openai".to_string(),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         }
     }
@@ -108,6 +120,7 @@ impl GeminiProvider {
                 "https://generativelanguage.googleapis.com/v1beta/openai".to_string()
             }),
             rate_limiter,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         }
     }
@@ -125,6 +138,7 @@ impl GeminiProvider {
             base_url: "https://generativelanguage.googleapis.com/v1beta/openai".to_string(),
             rate_limiter: rate_limit.map(crate::rate_limit::RateLimiter::new),
             capability_overrides: overrides,
+            api_limits: Default::default(),
         }
     }
 
@@ -172,6 +186,26 @@ impl GeminiProvider {
             supports_system_prompt: true,
             max_context_tokens,
             max_output_tokens,
+            limits_source: LimitsSource::Builtin,
+        }
+    }
+
+    /// `base` with the token limits the API reported, when it has reported any.
+    ///
+    /// Only the two sizes. The rest of `ModelCapabilities` is about how a
+    /// request must be shaped - whether tools work, whether temperature is
+    /// accepted - and the listing describes what a model is, not the quirks of
+    /// talking to it. Same split as the Ollama provider makes, for the same
+    /// reason: each source answers the question it can answer.
+    fn api_corrected(&self, model: &str, base: ModelCapabilities) -> ModelCapabilities {
+        match leviath_core::sync::lock(&self.api_limits).get(model) {
+            Some(&(max_context_tokens, max_output_tokens)) => ModelCapabilities {
+                max_context_tokens,
+                max_output_tokens,
+                limits_source: LimitsSource::Api,
+                ..base
+            },
+            None => base,
         }
     }
 
@@ -334,11 +368,47 @@ impl Provider for GeminiProvider {
     }
 
     fn capabilities(&self, model: &str) -> ModelCapabilities {
+        let base = self.api_corrected(model, self.builtin_capabilities(model));
         // Merged, not swapped: an entry names only what it corrects.
         match self.capability_overrides.get(model) {
-            Some(o) => o.apply_to(self.builtin_capabilities(model)),
-            None => self.builtin_capabilities(model),
+            Some(o) => o.apply_to(base),
+            None => base,
         }
+    }
+
+    /// Learn every model's real token limits from the native listing.
+    ///
+    /// Reuses `list_models` rather than fetching separately: it already asks the
+    /// one endpoint that answers this, and a second request shaped slightly
+    /// differently is how the runtime and the model picker come to disagree
+    /// about the same model.
+    ///
+    /// A compat base URL has no native listing, so nothing is learned and the
+    /// family defaults stay in charge - the same outcome as an unreachable API,
+    /// and reported the same way by `limits_source`.
+    async fn prime_capabilities(&self) -> Result<()> {
+        let models = self.list_models().await?;
+        let learned: HashMap<String, (usize, usize)> = models
+            .into_iter()
+            // Only what the API actually reported. `list_models_native` starts
+            // each entry from the family defaults, so an entry the listing said
+            // nothing about would otherwise be stored as if it had - relabelling
+            // a guess as authoritative, which is worse than the guess.
+            .filter(|m| m.capabilities.limits_source == LimitsSource::Api)
+            .map(|m| {
+                (
+                    m.id,
+                    (
+                        m.capabilities.max_context_tokens,
+                        m.capabilities.max_output_tokens,
+                    ),
+                )
+            })
+            .collect();
+        let count = learned.len();
+        *leviath_core::sync::lock(&self.api_limits) = learned;
+        tracing::debug!(models = count, "learned Gemini model token limits");
+        Ok(())
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
@@ -383,11 +453,16 @@ impl GeminiProvider {
                 // Start from the family defaults, then override with the API's
                 // authoritative limits where present.
                 let mut capabilities = self.capabilities(&id);
+                // `limits_source` moves only when the listing supplied a limit,
+                // so an entry that carried neither stays labelled as the guess
+                // it is.
                 if let Some(ctx) = item.get("inputTokenLimit").and_then(|v| v.as_u64()) {
                     capabilities.max_context_tokens = ctx as usize;
+                    capabilities.limits_source = LimitsSource::Api;
                 }
                 if let Some(out) = item.get("outputTokenLimit").and_then(|v| v.as_u64()) {
                     capabilities.max_output_tokens = out as usize;
+                    capabilities.limits_source = LimitsSource::Api;
                 }
                 Some(ModelInfo {
                     id,
@@ -481,6 +556,89 @@ mod tests {
     use crate::test_support::always_on_tracing_guard;
     use leviath_testkit::{spawn_mock_server, spawn_mock_server_truncated_body};
 
+    /// The gap this closes: the native listing has always read the real limits
+    /// and only ever handed them to the model picker, while the runtime sized
+    /// its percentage region budgets from a table matched off the model's name.
+    #[tokio::test]
+    async fn priming_teaches_capabilities_what_the_listing_already_knew() {
+        let body = br#"{"models":[
+            {"name":"models/gemini-3.5-flash","displayName":"Flash",
+             "inputTokenLimit":2000000,"outputTokenLimit":8192}
+        ]}"#;
+        let url = leviath_testkit::spawn_mock_server(200, "OK", body).await;
+        let provider = GeminiProvider::new(reqwest::Client::new(), "k".to_string())
+            .with_base_url(Some(format!("{url}/v1beta/openai")));
+
+        let before = provider.capabilities("gemini-3.5-flash");
+        assert_eq!(
+            before.limits_source,
+            LimitsSource::Builtin,
+            "unprimed, the family default is all there is"
+        );
+
+        provider.prime_capabilities().await.expect("primes");
+
+        let after = provider.capabilities("gemini-3.5-flash");
+        assert_eq!(after.max_context_tokens, 2_000_000);
+        assert_eq!(after.max_output_tokens, 8_192);
+        assert_eq!(after.limits_source, LimitsSource::Api);
+    }
+
+    /// An entry the listing said nothing about is not stored as if it had. The
+    /// listing starts each model from the family defaults, so recording those
+    /// would relabel a guess as authoritative - worse than the guess, because
+    /// nothing downstream would know to doubt it.
+    #[tokio::test]
+    async fn a_model_the_listing_gave_no_limits_for_is_not_learned() {
+        let body = br#"{"models":[{"name":"models/gemini-bare","displayName":"Bare"}]}"#;
+        let url = leviath_testkit::spawn_mock_server(200, "OK", body).await;
+        let provider = GeminiProvider::new(reqwest::Client::new(), "k".to_string())
+            .with_base_url(Some(format!("{url}/v1beta/openai")));
+
+        provider.prime_capabilities().await.expect("primes");
+
+        let caps = provider.capabilities("gemini-bare");
+        assert_eq!(
+            caps.limits_source,
+            LimitsSource::Builtin,
+            "nothing was reported, so nothing is claimed"
+        );
+    }
+
+    /// An operator's entry is the last word, and says so, because someone who
+    /// wrote the number down is usually correcting exactly what the API said.
+    #[tokio::test]
+    async fn an_operator_override_outranks_the_api() {
+        let body = br#"{"models":[
+            {"name":"models/gemini-3.5-flash","inputTokenLimit":2000000,"outputTokenLimit":8192}
+        ]}"#;
+        let url = leviath_testkit::spawn_mock_server(200, "OK", body).await;
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "gemini-3.5-flash".to_string(),
+            ModelCapabilityOverride {
+                max_context_tokens: Some(64_000),
+                ..Default::default()
+            },
+        );
+        let provider = GeminiProvider::with_overrides(
+            reqwest::Client::new(),
+            "k".to_string(),
+            overrides,
+            None,
+        )
+        .with_base_url(Some(format!("{url}/v1beta/openai")));
+
+        provider.prime_capabilities().await.expect("primes");
+
+        let caps = provider.capabilities("gemini-3.5-flash");
+        assert_eq!(caps.max_context_tokens, 64_000, "the operator's number");
+        assert_eq!(
+            caps.max_output_tokens, 8_192,
+            "and the API's for what the operator did not name"
+        );
+        assert_eq!(caps.limits_source, LimitsSource::Override);
+    }
     #[test]
     fn test_provider_name() {
         let provider = GeminiProvider::new(
@@ -583,6 +741,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 1,
                 max_output_tokens: 1,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );
@@ -751,6 +910,7 @@ mod tests {
             api_key: "key".to_string(),
             base_url: "http://127.0.0.1:19997".to_string(),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         }
     }
@@ -778,6 +938,7 @@ mod tests {
             api_key: "key".to_string(),
             base_url: format!("{}/openai", base),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         };
         let tokens = provider.count_tokens("anything", "gemini-3.5-flash").await;
@@ -792,6 +953,7 @@ mod tests {
             api_key: "key".to_string(),
             base_url: format!("{}/openai", base),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         };
         // 8 chars / 4 = 2 (heuristic fallback)
@@ -808,6 +970,7 @@ mod tests {
             api_key: "key".to_string(),
             base_url: "http://127.0.0.1:19997/openai".to_string(),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         };
         let tokens = provider.count_tokens("12345678", "gemini-3.5-flash").await;
@@ -822,6 +985,7 @@ mod tests {
             api_key: "key".to_string(),
             base_url: format!("{}/openai", base),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         };
         let tokens = provider.count_tokens("12345678", "gemini-3.5-flash").await;
@@ -836,6 +1000,7 @@ mod tests {
             api_key: "key".to_string(),
             base_url: format!("{}/openai", base),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         };
         let tokens = provider.count_tokens("12345678", "gemini-3.5-flash").await;
@@ -854,6 +1019,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 42,
                 max_output_tokens: 10,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );
@@ -1097,6 +1263,7 @@ mod tests {
             api_key: "test-key".to_string(),
             base_url: format!("{}/openai", base),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         }
     }
@@ -1151,6 +1318,7 @@ mod tests {
             api_key: "test-key".to_string(),
             base_url: "http://127.0.0.1:19997/openai".to_string(),
             rate_limiter: None,
+            api_limits: Default::default(),
             capability_overrides: HashMap::new(),
         };
         let err = provider.list_models().await.unwrap_err();

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -31,7 +31,7 @@ pub mod tokenizer;
 mod test_support;
 
 pub use anthropic::AnthropicProvider;
-pub use capabilities::{ModelCapabilities, ModelCapabilityOverride};
+pub use capabilities::{LimitsSource, ModelCapabilities, ModelCapabilityOverride};
 pub use claude_code::ClaudeCodeProvider;
 pub use gemini::GeminiProvider;
 pub use ollama::OllamaProvider;

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -3,8 +3,8 @@
 //! Ollama provides local LLM execution via NDJSON streaming.
 
 use crate::provider::{
-    FinishReason, InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride,
-    ModelInfo, Provider, ProviderError, Result, StreamChunk, TokenUsage,
+    FinishReason, InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities,
+    ModelCapabilityOverride, ModelInfo, Provider, ProviderError, Result, StreamChunk, TokenUsage,
 };
 use async_trait::async_trait;
 use futures_core::Stream;
@@ -197,6 +197,7 @@ impl OllamaProvider {
         match windows.get(model) {
             Some(&max_context_tokens) => ModelCapabilities {
                 max_context_tokens,
+                limits_source: LimitsSource::Api,
                 ..base
             },
             None => base,
@@ -267,6 +268,39 @@ impl OllamaProvider {
     }
 
     /// Ask the server for every installed model's effective window.
+    /// Windows for the models the server currently has loaded, from `/api/ps`.
+    ///
+    /// Never fails the caller: this is an improvement on what `/api/show` can
+    /// say, not a requirement. A server that will not answer, or answers in a
+    /// shape this does not recognise, leaves an empty map and the caller carries
+    /// on with the Modelfile's `num_ctx`.
+    async fn loaded_windows(&self) -> HashMap<String, usize> {
+        let Ok(response) = self
+            .client
+            .get(format!("{}/api/ps", self.base_url))
+            .send()
+            .await
+        else {
+            return HashMap::new();
+        };
+        let Ok(body) = response.json::<serde_json::Value>().await else {
+            return HashMap::new();
+        };
+        body.get("models")
+            .and_then(|m| m.as_array())
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(|entry| {
+                        let name = entry.get("name")?.as_str()?.to_string();
+                        let window = entry.get("context_length")?.as_u64()? as usize;
+                        Some((name, window))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     async fn learn_model_windows(&self) -> Result<HashMap<String, usize>> {
         let tags = self
             .client
@@ -288,8 +322,29 @@ impl OllamaProvider {
             })
             .unwrap_or_default();
 
-        let mut windows = HashMap::with_capacity(names.len());
+        // What is loaded right now, and at what size. `/api/ps` reports the
+        // window the runner actually allocated for a model it has resident,
+        // which is the only answer that is not an inference from configuration:
+        // `num_ctx` is what a Modelfile asked for and the architecture length is
+        // what the weights allow, but this is what the server is serving.
+        //
+        // Measured on a developer machine, `qwen3.8:latest` pins no `num_ctx`
+        // and reports 262144 here, against the 131072 its name was matched to.
+        // Nothing in `/api/show` could have said so: it carries the Modelfile
+        // and the architecture and nothing about the server's own default.
+        //
+        // Loaded models only, which is the whole limitation. A model nothing has
+        // called yet is absent and falls through to `num_ctx` below, so this
+        // helps most on the machine that is actually using Ollama - which is the
+        // machine whose budgets are about to be resolved against the answer.
+        let mut windows = self.loaded_windows().await;
+
         for name in names {
+            // `/api/ps` already answered for this one, from the runner rather
+            // than from configuration. Nothing in `/api/show` outranks that.
+            if windows.contains_key(&name) {
+                continue;
+            }
             let show = self
                 .client
                 .post(format!("{}/api/show", self.base_url))
@@ -322,6 +377,7 @@ impl OllamaProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
+                limits_source: LimitsSource::Builtin,
             }
         // Mistral / Mixtral - tool-capable
         } else if model.contains("mistral") || model.contains("mixtral") {
@@ -332,6 +388,7 @@ impl OllamaProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 32_768,
                 max_output_tokens: 4096,
+                limits_source: LimitsSource::Builtin,
             }
         // Phi-4 - tool-capable, 128K context
         } else if model.contains("phi-4") || model.contains("phi4") {
@@ -342,6 +399,7 @@ impl OllamaProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
+                limits_source: LimitsSource::Builtin,
             }
         // DeepSeek R1 - reasoning, no tool calls
         } else if model.contains("deepseek-r1") {
@@ -352,6 +410,7 @@ impl OllamaProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
+                limits_source: LimitsSource::Builtin,
             }
         // DeepSeek general - tool-capable
         } else if model.contains("deepseek") {
@@ -362,6 +421,7 @@ impl OllamaProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
+                limits_source: LimitsSource::Builtin,
             }
         // Gemma - no tool support
         } else if model.contains("gemma") {
@@ -372,6 +432,7 @@ impl OllamaProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 131_072,
                 max_output_tokens: 8192,
+                limits_source: LimitsSource::Builtin,
             }
         // CodeLlama - no tool support
         } else if model.contains("codellama") {
@@ -382,6 +443,7 @@ impl OllamaProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 16_384,
                 max_output_tokens: 4096,
+                limits_source: LimitsSource::Builtin,
             }
         } else {
             // Conservative fallback for unknown local models
@@ -392,6 +454,7 @@ impl OllamaProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 8192,
                 max_output_tokens: 4096,
+                limits_source: LimitsSource::Builtin,
             }
         }
     }
@@ -961,6 +1024,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 42,
                 max_output_tokens: 10,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );
@@ -1687,6 +1751,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 99,
                 max_output_tokens: 99,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );
@@ -2300,6 +2365,7 @@ mod tests {
                 supports_system_prompt: true,
                 max_context_tokens: 8192,
                 max_output_tokens: 4096,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );
@@ -2906,9 +2972,11 @@ mod tests {
     /// `/api/show` that follows finds nothing listening.
     #[tokio::test]
     async fn priming_reports_a_show_call_that_never_connects() {
-        let (url, _bodies) =
-            leviath_testkit::spawn_mock_sequence(vec![(200, "OK", tags_body(&["qwen3.8:latest"]))])
-                .await;
+        let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (200, "OK", tags_body(&["qwen3.8:latest"])),
+            (200, "OK", ps_body(&[])),
+        ])
+        .await;
         let provider = OllamaProvider::with_base_url(
             crate::provider::build_http_client(None).expect("a test client builds"),
             url,
@@ -2921,6 +2989,7 @@ mod tests {
     async fn priming_reports_a_show_body_that_is_not_json() {
         let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
             (200, "OK", tags_body(&["qwen3.8:latest"])),
+            (200, "OK", ps_body(&[])),
             (200, "OK", b"not json".to_vec()),
         ])
         .await;
@@ -2937,6 +3006,7 @@ mod tests {
     async fn priming_reports_a_show_call_the_server_refuses() {
         let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
             (200, "OK", tags_body(&["qwen3.8:latest"])),
+            (200, "OK", ps_body(&[])),
             (500, "Internal Server Error", b"boom".to_vec()),
         ])
         .await;
@@ -2988,6 +3058,7 @@ mod tests {
     async fn a_guessed_window_is_announced_once_per_model() {
         let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
             (200, "OK", tags_body(&["qwen3.8-32k:latest"])),
+            (200, "OK", ps_body(&[])),
             (200, "OK", show_body(Some(32768))),
         ])
         .await;
@@ -3019,6 +3090,7 @@ mod tests {
     async fn a_window_read_from_the_server_is_not_announced() {
         let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
             (200, "OK", tags_body(&["qwen3.8-32k:latest"])),
+            (200, "OK", ps_body(&[])),
             (200, "OK", show_body(Some(32768))),
         ])
         .await;
@@ -3055,6 +3127,98 @@ mod tests {
     // ─── effective window ───────────────────────────────────────────────────
 
     /// `parameters` is a text block, and `num_ctx` is the line that matters.
+    /// `/api/ps` is the only endpoint that reports the window the runner
+    /// actually allocated, so a model it names is not re-derived from anything
+    /// `/api/show` says.
+    #[tokio::test]
+    async fn a_loaded_model_takes_its_window_from_what_is_running() {
+        let body = br#"{"models":[
+            {"name":"qwen3.8:latest","model":"qwen3.8:latest","context_length":262144},
+            {"name":"gemma3:4b","model":"gemma3:4b","context_length":8192}
+        ]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = OllamaProvider::with_base_url(reqwest::Client::new(), url);
+
+        let loaded = provider.loaded_windows().await;
+        assert_eq!(loaded.get("qwen3.8:latest"), Some(&262_144));
+        assert_eq!(loaded.get("gemma3:4b"), Some(&8_192));
+    }
+
+    /// A field of the wrong shape is skipped like a missing one. `/api/ps` is
+    /// another program's output, so "present but not what it should be" is a
+    /// state worth surviving rather than one worth trusting.
+    #[tokio::test]
+    async fn a_ps_entry_with_wrongly_typed_fields_is_skipped() {
+        let body = br#"{"models":[
+            {"name":42,"context_length":8192},
+            {"name":"bad-window:latest","context_length":"lots"},
+            {"name":"good:latest","context_length":16384}
+        ]}"#;
+        let url = leviath_testkit::spawn_mock_server(200, "OK", body).await;
+        let provider = OllamaProvider::with_base_url(reqwest::Client::new(), url);
+
+        let loaded = provider.loaded_windows().await;
+        assert_eq!(loaded.len(), 1, "only the well-formed entry is kept");
+        assert_eq!(loaded.get("good:latest"), Some(&16_384));
+    }
+
+    /// What the runner has loaded is not re-derived from the Modelfile. A model
+    /// `/api/ps` answered for is skipped entirely when the prime walks the tag
+    /// list, so `/api/show` is not even asked about it.
+    #[tokio::test]
+    async fn a_model_already_answered_by_ps_is_not_asked_about_again() {
+        // Only two responses: the tag list and the `ps` answer. A third request
+        // would find nothing to serve, so this failing to skip shows up as an
+        // error rather than as a wrong number.
+        let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (200, "OK", tags_body(&["warm:latest"])),
+            (200, "OK", ps_body(&[("warm:latest", 262_144)])),
+        ])
+        .await;
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
+
+        provider.prime_capabilities().await.expect("primes");
+
+        assert_eq!(
+            provider.capabilities("warm:latest").max_context_tokens,
+            262_144,
+            "the window the runner allocated"
+        );
+    }
+
+    /// The endpoint is an improvement, not a dependency: a server that will not
+    /// answer it leaves the caller on the Modelfile's `num_ctx` rather than
+    /// failing the prime.
+    #[tokio::test]
+    async fn an_unavailable_ps_endpoint_is_not_an_error() {
+        let url = spawn_mock_server(500, "Server Error", b"nope").await;
+        let provider = OllamaProvider::with_base_url(reqwest::Client::new(), url);
+        assert!(provider.loaded_windows().await.is_empty());
+
+        let garbage = spawn_mock_server(200, "OK", b"not json").await;
+        let provider = OllamaProvider::with_base_url(reqwest::Client::new(), garbage);
+        assert!(provider.loaded_windows().await.is_empty());
+    }
+
+    /// An entry missing either half is skipped rather than half-recorded.
+    #[tokio::test]
+    async fn a_ps_entry_without_a_window_is_skipped() {
+        let body = br#"{"models":[
+            {"name":"no-window:latest"},
+            {"context_length":4096},
+            {"name":"good:latest","context_length":16384}
+        ]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = OllamaProvider::with_base_url(reqwest::Client::new(), url);
+
+        let loaded = provider.loaded_windows().await;
+        assert_eq!(loaded.len(), 1, "only the complete entry is kept");
+        assert_eq!(loaded.get("good:latest"), Some(&16_384));
+    }
+
     #[test]
     fn the_effective_window_comes_from_num_ctx() {
         let show = serde_json::json!({
@@ -3118,6 +3282,18 @@ mod tests {
         .expect("serializes")
     }
 
+    /// An `/api/ps` answer naming the loaded models and their served windows.
+    ///
+    /// Empty is the interesting default: it says nothing is loaded, which is
+    /// what sends the prime on to `/api/show` and the Modelfile's `num_ctx`.
+    fn ps_body(loaded: &[(&str, usize)]) -> Vec<u8> {
+        let models: Vec<serde_json::Value> = loaded
+            .iter()
+            .map(|(n, ctx)| serde_json::json!({ "name": n, "context_length": ctx }))
+            .collect();
+        serde_json::to_vec(&serde_json::json!({ "models": models })).expect("serializes")
+    }
+
     fn tags_body(names: &[&str]) -> Vec<u8> {
         let models: Vec<serde_json::Value> = names
             .iter()
@@ -3132,6 +3308,7 @@ mod tests {
     async fn priming_replaces_the_window_the_name_suggested() {
         let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
             (200, "OK", tags_body(&["qwen3.8-32k:latest"])),
+            (200, "OK", ps_body(&[])),
             (200, "OK", show_body(Some(32768))),
         ])
         .await;
@@ -3168,6 +3345,7 @@ mod tests {
     async fn a_model_naming_no_window_leaves_the_table_in_charge() {
         let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
             (200, "OK", tags_body(&["qwen3.8:latest"])),
+            (200, "OK", ps_body(&[])),
             (200, "OK", show_body(None)),
         ])
         .await;
@@ -3190,6 +3368,7 @@ mod tests {
     async fn an_explicit_override_still_wins_over_the_server() {
         let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
             (200, "OK", tags_body(&["qwen3.8-32k:latest"])),
+            (200, "OK", ps_body(&[])),
             (200, "OK", show_body(Some(32768))),
         ])
         .await;

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -7,8 +7,8 @@ use crate::openai_compat::{
 #[cfg(test)]
 use crate::provider::FinishReason;
 use crate::provider::{
-    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
-    Provider, ProviderConfig, ProviderError, Result, StreamChunk,
+    InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderConfig, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -132,6 +132,7 @@ impl OpenAIProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_050_000,
                 max_output_tokens: 128_000,
+                limits_source: LimitsSource::Builtin,
             }
         // GPT-5.x family (5.4, 5.4-mini, 5.4-nano, 5-mini) - 400K context, 128K output
         } else if model.starts_with("gpt-5") {
@@ -142,6 +143,7 @@ impl OpenAIProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 400_000,
                 max_output_tokens: 128_000,
+                limits_source: LimitsSource::Builtin,
             }
         // GPT-4.1 family - 1M context (must check before generic gpt-4)
         } else if model.starts_with("gpt-4.1") {
@@ -152,6 +154,7 @@ impl OpenAIProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 1_047_576,
                 max_output_tokens: 32_768,
+                limits_source: LimitsSource::Builtin,
             }
         // o-series reasoning models (o3, o4) - no temperature, 200K context
         } else if model.starts_with("o3") || model.starts_with("o4") {
@@ -162,6 +165,7 @@ impl OpenAIProvider {
                 supports_system_prompt: true,
                 max_context_tokens: 200_000,
                 max_output_tokens: 100_000,
+                limits_source: LimitsSource::Builtin,
             }
         } else {
             ModelCapabilities::default()
@@ -761,6 +765,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 1,
                 max_output_tokens: 1,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );
@@ -925,6 +930,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 1,
                 max_output_tokens: 1,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -7,8 +7,8 @@ use crate::openai_compat::{
     OpenAiSseStream, parse_openai_response, send_chat_request, temperature_refused,
 };
 use crate::provider::{
-    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
-    Provider, ProviderConfig, ProviderError, Result, StreamChunk,
+    InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderConfig, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -333,6 +333,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 1_048_576,
             max_output_tokens: 65_536,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── Meta Llama 4 Scout - 10M context ─────────────────────────────────
@@ -344,6 +345,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 10_000_000,
             max_output_tokens: 32_768,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── Meta Llama 4 (Maverick + others) - 1M context ────────────────────
@@ -355,6 +357,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 1_048_576,
             max_output_tokens: 32_768,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── DeepSeek R1 - reasoning-only, no tools, no temperature ───────────
@@ -366,6 +369,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 163_840,
             max_output_tokens: 32_768,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── DeepSeek V4 Pro - 1M context, 384K output ────────────────────────
@@ -377,6 +381,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 1_048_576,
             max_output_tokens: 393_216,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── DeepSeek V4 Flash / V3.x ─────────────────────────────────────────
@@ -388,6 +393,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 1_048_576,
             max_output_tokens: 65_536,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── Mistral Large ─────────────────────────────────────────────────────
@@ -399,6 +405,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 262_144,
             max_output_tokens: 32_768,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── Mistral Medium / Small ────────────────────────────────────────────
@@ -410,6 +417,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 131_072,
             max_output_tokens: 32_768,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── Qwen 3.6+ / Qwen3 Coder - 1M context ────────────────────────────
@@ -421,6 +429,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 1_048_576,
             max_output_tokens: 65_536,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── Qwen3 general ─────────────────────────────────────────────────────
@@ -432,6 +441,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 131_072,
             max_output_tokens: 32_768,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── Anthropic models via OpenRouter - inherit direct-provider flags ───
@@ -447,6 +457,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 1_000_000,
             max_output_tokens: 128_000,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── OpenAI o-series via OpenRouter - no temperature ───────────────────
@@ -458,6 +469,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 200_000,
             max_output_tokens: 100_000,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── OpenAI GPT-5.x via OpenRouter ────────────────────────────────────
@@ -469,6 +481,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
             supports_system_prompt: true,
             max_context_tokens: 1_050_000,
             max_output_tokens: 128_000,
+            limits_source: LimitsSource::Builtin,
         };
     }
     // ── Conservative fallback for unknown OpenRouter models ───────────────
@@ -489,6 +502,7 @@ const FALLBACK_CAPABILITIES: ModelCapabilities = ModelCapabilities {
     supports_system_prompt: true,
     max_context_tokens: 128_000,
     max_output_tokens: 8_192,
+    limits_source: LimitsSource::Builtin,
 };
 
 impl OpenRouterProvider {
@@ -529,6 +543,7 @@ impl OpenRouterProvider {
         ModelCapabilities {
             max_context_tokens: api.context_length,
             max_output_tokens: api.max_completion_tokens.unwrap_or(base.max_output_tokens),
+            limits_source: LimitsSource::Api,
             ..base
         }
     }
@@ -840,8 +855,14 @@ impl Provider for OpenRouterProvider {
 
             let base_caps = self.capabilities(&id);
             let capabilities = ModelCapabilities {
+                // `context_length` is read from this response, so the label
+                // says so. The output fallback is left as it was: changing what
+                // a listing reports for an entry that names no
+                // `max_completion_tokens` is a behaviour change, and this is a
+                // labelling fix.
                 max_context_tokens: context_length,
                 max_output_tokens: max_completion_tokens.unwrap_or(8192),
+                limits_source: LimitsSource::Api,
                 ..base_caps
             };
 
@@ -1241,6 +1262,7 @@ mod tests {
                 supports_system_prompt: false,
                 max_context_tokens: 99,
                 max_output_tokens: 10,
+                limits_source: LimitsSource::Builtin,
             }
             .into(),
         );

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -2,7 +2,7 @@
 
 // Re-exported so `use crate::provider::*` keeps working: the types moved for
 // structural reasons (the 1200-line rule), not as an interface change.
-pub use crate::capabilities::{ModelCapabilities, ModelCapabilityOverride};
+pub use crate::capabilities::{LimitsSource, ModelCapabilities, ModelCapabilityOverride};
 use async_trait::async_trait;
 use futures_core::Stream;
 use serde::{Deserialize, Serialize};
@@ -1158,6 +1158,7 @@ mod tests {
             supports_system_prompt: true,
             max_context_tokens: 400_000,
             max_output_tokens: 64_000,
+            limits_source: LimitsSource::Builtin,
         }
     }
 
@@ -1197,6 +1198,7 @@ mod tests {
             supports_system_prompt: false,
             max_context_tokens: 7,
             max_output_tokens: 9,
+            limits_source: LimitsSource::Builtin,
         });
         let merged = full.apply_to(base());
         assert!(merged.supports_temperature);

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -39,8 +39,8 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::provider::{
-    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
-    Provider, ProviderError, RateLimitConfig, Result, StreamChunk, ToolCallDelta,
+    InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderError, RateLimitConfig, Result, StreamChunk, ToolCallDelta,
 };
 use crate::rate_limit::RateLimiter;
 
@@ -532,6 +532,7 @@ impl Provider for RhaiProvider {
         let base = ModelCapabilities {
             max_context_tokens: self.meta.max_context_tokens,
             max_output_tokens: self.meta.max_output_tokens,
+            limits_source: LimitsSource::Builtin,
             supports_streaming: true,
             ..Default::default()
         };

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -6,6 +6,7 @@ use super::*;
 use crate::inference_pool::{InferencePoolConfig, InferencePools};
 use crate::test_support::hints;
 use leviath_core::{Region, RegionKind};
+use leviath_providers::LimitsSource;
 use tokio::sync::mpsc;
 
 /// A provider whose capabilities can be toggled for the temperature branch.
@@ -46,6 +47,7 @@ impl Provider for Cfg {
         leviath_providers::ModelCapabilities {
             supports_temperature: self.supports_temperature,
             max_output_tokens: self.max_output,
+            limits_source: LimitsSource::Builtin,
             ..Default::default()
         }
     }

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -173,7 +173,7 @@ Base path `/api`; all JSON unless noted.
 | `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question |
 | `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q`; the detail carries the manifest, the regions and the [fan-out limits](#fan-out-limits) |
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
-| `GET /api/models` | Enumerate models |
+| `GET /api/models` | Enumerate models, with each one's token limits and where they came from |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
 | `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
@@ -616,6 +616,13 @@ without an `agent`, since the answer is the same either way.
 
 Each listed provider carries a `provider` object with what its leading `// @` comments declare:
 `description`, `default_model`, `max_context_tokens`, `max_output_tokens` and `supports_streaming`.
+
+Each entry from `GET /api/models` also carries `limits_source`: `api` when the provider reported the
+token limits itself, `builtin` when this build matched them off the model's name, and `override`
+when a `[model_capabilities]` entry set them. Read it before treating a window as a fact - a
+`builtin` figure for a model the table does not know is a guess, and region budgets resolve against
+it. Which providers can report, and from where, is in
+[where a window comes from](/docs/configuration#where-a-window-comes-from).
 That is what lets a console show the catalog without fetching and re-parsing every script. No other
 kind carries the key at all.
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -649,7 +649,9 @@ max_output_tokens    = 4096
 ```
 
 `lev models show <model>` prints the values a run will actually use, with any correction already
-applied.
+applied. `GET /api/models` carries the same numbers plus a `limits_source` of `api`, `builtin` or
+`override`, so a client can tell a figure the provider reported from one this build matched off the
+model's name. The two are not worth the same and they look identical once printed.
 
 ### Where a window comes from
 
@@ -657,11 +659,29 @@ Three sources, narrowest first:
 
 1. A `[model_capabilities]` entry, if you wrote one. Your number is the last word, which is how you
    correct an API that is itself wrong.
-2. What the provider's own API reports, read once when the daemon starts. OpenRouter fronts far more
-   models than any compiled table can name, so its `/models` endpoint is the only current answer for
-   most of them.
-3. The table compiled into this build, and for an OpenRouter model it does not name, a conservative
-   128,000 tokens.
+2. What the provider's own API reports, read once when the daemon starts, and again whenever
+   `GET /api/models` is asked. Which providers can answer, and from where:
+
+   | provider | reads | notes |
+   |---|---|---|
+   | OpenRouter | `/models` | `context_length` and `top_provider.max_completion_tokens`. Fronts far more models than any compiled table can name |
+   | Google | `/v1beta/models` | `inputTokenLimit` and `outputTokenLimit`. Needs the native base URL; an OpenAI-compat one has no such listing |
+   | Ollama | `/api/ps`, then `/api/show` | See below |
+   | Anthropic, OpenAI | nothing | Neither `/models` reports token limits at all, so the compiled table is the only answer available |
+
+3. The table compiled into this build, matched against the model's name, and for an OpenRouter model
+   it does not name, a conservative 128,000 tokens.
+
+Ollama is asked twice because the two endpoints answer different questions. `/api/ps` reports the
+window the runner **actually allocated** for a model it currently has loaded, which is the only
+figure that is an observation rather than an inference, so it is taken as final. For anything not
+loaded, `/api/show` gives the `num_ctx` the model's Modelfile pins. Its `model_info` also carries the
+architecture's maximum, and that is deliberately *not* used: it is what the weights allow rather than
+what the server will serve, and on a model whose Modelfile pins 32 768 against a 262 144 architecture
+it would replace one overestimate with a much larger one.
+
+So a warm Ollama model reports its true window and a cold one that pins no `num_ctx` still falls back
+to the compiled table. Calling a model once is enough to make it warm.
 
 The reason this order matters is that region budgets are percentages of the window. A `budget = "30%"`
 region on a model that really holds 1M tokens is 314,572 tokens if the window is known, and 38,400


### PR DESCRIPTION
Percentage region budgets resolve against `max_context_tokens`, so a window wrong by a factor of two makes every region in a run wrong by the same factor — and nothing downstream can tell. That number was mostly a guess.

## The bug that mattered most

**`GET /api/models` never primed.** It built a registry and listed straight away, so every provider whose real answer is a network call away published its compiled table instead. Measured against a running server:

```
ollama      qwen3.8:latest    ctx=131,072   ← its own server serves 262,144
openrouter  418 models        builtin       ← this provider had fetched real limits for months
```

Only Google looked right, and only because its listing reads limits inline rather than through the primed table — **which is also why every unit test passed while the endpoint was wrong.**

## What each provider can actually answer

| provider | reads | result |
|---|---|---|
| **openrouter** | `/models` | 418/418 `api` |
| **google** | `/v1beta/models` | 50/50 `api` — **new** |
| **ollama** | `/api/ps`, then `/api/show` | 2/2 `api` — **new** |
| **anthropic**, **openai** | — | `builtin`, and always will: neither `/models` carries token limits at all |

**470 of 612 models** now carry provider-reported limits, where that route previously reported effectively none.

**Google** already fetched the right numbers and discarded them. `list_models_native` reads `inputTokenLimit`/`outputTokenLimit` and hands them to the model picker; `capabilities()` — the path budgets resolve through — answered from family defaults matched off the model's name.

**Ollama** now asks `/api/ps`, which reports the window the runner *actually allocated*. That is the only figure here that is an observation rather than an inference: `num_ctx` is what a Modelfile asked for, and `model_info`'s architecture length is what the weights allow rather than what the server serves.

## A revert worth calling out

An earlier draft read `model_info.<arch>.context_length`. A test from **#475** says why that is wrong, and it is right: on a model pinning `num_ctx 32768` against a 262144 architecture it swaps one overestimate for a much larger one. Reverted — `/api/ps` answers the question that field was being asked to answer, without the trap.

The result on a real machine, with both cases represented:

```
qwen3.8:latest       262,144   ← /api/ps, loaded
qwen3.8-32k:latest    32,768   ← num_ctx, not loaded
```

## Provenance, since some numbers are now facts and some are not

`ModelCapabilities` carries `limits_source` — `api`, `builtin`, `override` — and `GET /api/models` publishes it. A provider-reported limit and a substring match look identical once printed and are not worth the same. `override` outranks `api`, because someone who wrote the number down is usually correcting exactly what the API said.

## Verification

Verified against a **live server at each step**, not only compiled. That is what found the missing prime, and what found a mislabel of my own: the bulk edit that added the field stamped OpenRouter's API-read limits as `builtin`. Both were invisible to unit tests — each piece was individually correct.

- Suite green as CI runs it, clippy clean, structure and docs gates pass, **coverage 13/13 at 100%**
- Docs updated: `configuration.md` gains a per-provider table under "where a window comes from" and explains why Ollama is asked twice; `api.md` documents `limits_source`

## Known limitation

`/api/ps` only knows **loaded** models. A cold Ollama model pinning no `num_ctx` still falls back to the compiled table — calling it once is enough to make it warm. Closing that fully means re-priming after first inference, which is a larger change and worth doing separately if the warm case does not cover it in practice.

OpenAI also lists 130 models at the unrecognised-model default of `8192/4096`. Honestly labelled `builtin` now, but that table is thin — separate work.
