### PR TITLE
feat(scripting): base64 that goes both ways, in both engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ same list.
 
 ## Unreleased
 
+- Added: `decode_base64` for Rhai scripts, and `encode_base64` for tool scripts,
+  which had neither. The provider engine has offered `encode_base64` for some
+  time with no way to read a value back, and the tool engine offered no base64
+  at all - so a tool fetching a JSON API that returns a base64 field could not
+  open it, and a provider script could write one it could not read.
+  `decode_base64` fails rather than returning something wrong, and says which of
+  the two failures happened: input that is not valid base64, and input that is
+  valid base64 but decodes to bytes that are not UTF-8. The second is not a typo
+  on the caller's part - base64 carries any bytes and a Rhai string holds text -
+  so the two need different fixes and the message says so.
+- Changed: both engines now call one implementation, the way they already share
+  `encode_uri`. Two functions reachable by the same name from two engines is a
+  difference nobody finds until a script works in one and not the other.
+
 - Fixed: `GET /api/models` published a guess for every provider whose real
   answer is a network call away. It built a registry and listed straight away,
   never priming, so the token limits it reported came from a table matched

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2603,7 +2603,6 @@ name = "leviath-providers"
 version = "0.5.0"
 dependencies = [
  "async-trait",
- "base64 0.23.1",
  "bytes",
  "futures-core",
  "leviath-core",
@@ -2653,6 +2652,7 @@ dependencies = [
 name = "leviath-scripting"
 version = "0.5.0"
 dependencies = [
+ "base64 0.23.1",
  "leviath-core",
  "rhai",
  "serde",

--- a/crates/leviath-providers/Cargo.toml
+++ b/crates/leviath-providers/Cargo.toml
@@ -39,7 +39,6 @@ bytes = "1"
 # a pause and resume restores a window full of ids from the last one.
 rand = { workspace = true }
 rhai = { workspace = true }
-base64 = { workspace = true }
 # The Claude Code transport hands its system prompt to the CLI as a file: an
 # assembled context routinely exceeds Linux's 128 KB cap on a single argv entry.
 tempfile = "3"

--- a/crates/leviath-providers/src/rhai_provider/engine.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine.rs
@@ -4,7 +4,6 @@
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
-use base64::Engine as _;
 use rhai::{Dynamic, Engine, EvalAltResult, FnPtr, Map, NativeCallContext};
 use tokio::sync::{mpsc, oneshot};
 
@@ -85,8 +84,16 @@ fn register_pure_fns(engine: &mut Engine, env_allowlist: Arc<Vec<String>>) {
     engine.register_fn("encode_uri", |s: &str| {
         leviath_scripting::tool::percent_encode(s)
     });
+    // Both from `leviath_scripting::tool`, which is where `encode_uri` above
+    // already comes from and for the same reason: a script reaching a function
+    // by one name in the tool engine and a different implementation of it here
+    // is a difference nobody finds until a `.rhai` works in one and not the
+    // other.
     engine.register_fn("encode_base64", |s: &str| {
-        base64::engine::general_purpose::STANDARD.encode(s)
+        leviath_scripting::tool::encode_base64(s)
+    });
+    engine.register_fn("decode_base64", |s: &str| {
+        leviath_scripting::tool::decode_base64(s)
     });
     engine.register_fn("env_var", move |name: &str| {
         env_var_fn(name, &env_allowlist)

--- a/crates/leviath-providers/src/rhai_provider/engine/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine/tests.rs
@@ -259,6 +259,29 @@ fn to_json_is_valid_json_for_nested_and_scalar_shapes() {
 }
 
 #[test]
+fn decode_base64_round_trips_and_reports_its_failures() {
+    let engine = build_init_engine(no_env_allowlist());
+
+    // A provider script that encodes something can now read it back, and the
+    // implementation is the one the tool engine offers under the same name.
+    let out: String = engine
+        .eval(r#"decode_base64(encode_base64("provider · 🐙"))"#)
+        .expect("round trips");
+    assert_eq!(out, "provider · 🐙");
+
+    // A value written by anything else decodes too.
+    let decoded: String = engine.eval(r#"decode_base64("aGk=")"#).expect("decodes");
+    assert_eq!(decoded, "hi");
+
+    // And a failure is an error the script sees, not an empty string it would
+    // carry on with.
+    let err = engine
+        .eval::<String>(r#"decode_base64("not base64!")"#)
+        .expect_err("refused");
+    assert!(err.to_string().contains("not valid base64"), "{err}");
+}
+
+#[test]
 fn encode_uri_passes_unreserved_and_encodes_rest() {
     let engine = build_init_engine(no_env_allowlist());
     let out: String = engine.eval(r#"encode_uri("Aa0-_.~ /?")"#).unwrap();

--- a/crates/leviath-scripting/Cargo.toml
+++ b/crates/leviath-scripting/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
+base64 = { workspace = true }
 leviath-core = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/leviath-scripting/src/tool.rs
+++ b/crates/leviath-scripting/src/tool.rs
@@ -666,6 +666,12 @@ fn register_host_functions(engine: &mut Engine, host: Arc<dyn ScriptHost>) {
     engine.register_fn("html_to_text", |s: &str| -> HostRes<String> {
         guard_str("html_to_text", &mut || Ok(html_to_text(s)))
     });
+    engine.register_fn("encode_base64", |s: &str| -> HostRes<String> {
+        guard_str("encode_base64", &mut || Ok(encode_base64(s)))
+    });
+    engine.register_fn("decode_base64", |s: &str| -> HostRes<String> {
+        guard_str("decode_base64", &mut || decode_base64(s))
+    });
 }
 
 /// `parse_json(str)` host function: JSON string → Rhai value.
@@ -685,6 +691,48 @@ fn parse_json_fn(s: &str) -> HostRes<Dynamic> {
 fn to_json_fn(v: &Dynamic) -> HostRes<String> {
     let json: serde_json::Value = rhai::serde::from_dynamic(v)?;
     Ok(json.to_string())
+}
+
+/// Standard base64, with padding.
+///
+/// Public for the same reason [`percent_encode`] is: the script *provider*
+/// engine offers scripts a function of this name too, and two encoders reachable
+/// by one name is a difference waiting to be found by whoever writes a `.rhai`
+/// that works in one engine and not the other.
+pub fn encode_base64(input: &str) -> String {
+    use base64::Engine as _;
+    base64::engine::general_purpose::STANDARD.encode(input)
+}
+
+/// Standard base64 back to text.
+///
+/// Errors rather than returning something wrong, in the two ways this can fail:
+/// input that is not valid base64, and input that decodes to bytes that are not
+/// UTF-8. The second is the one worth stating, because it is not a typo on the
+/// caller's part - base64 carries arbitrary bytes, a Rhai string is text, and a
+/// script that decodes a PNG has asked for something this cannot return. The
+/// message says which of the two happened, since the fixes are unrelated.
+pub fn decode_base64(input: &str) -> HostRes<String> {
+    use base64::Engine as _;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(input)
+        .map_err(|e| {
+            Box::new(EvalAltResult::ErrorRuntime(
+                format!("decode_base64: not valid base64: {e}").into(),
+                Position::NONE,
+            ))
+        })?;
+    String::from_utf8(bytes).map_err(|e| {
+        Box::new(EvalAltResult::ErrorRuntime(
+            format!(
+                "decode_base64: decoded {} bytes that are not UTF-8 text ({e}). \
+                 Base64 can carry any bytes; a Rhai string holds text.",
+                e.as_bytes().len()
+            )
+            .into(),
+            Position::NONE,
+        ))
+    })
 }
 
 /// Percent-encode a string for use in a URL query component. Unreserved
@@ -1345,6 +1393,27 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
         assert_eq!(out, "Hi& bye");
     }
 
+    /// Exercises the registered bindings rather than the free functions: a
+    /// script calls both by name and gets its own text back. This is the part
+    /// that was missing - the tool engine offered neither.
+    #[test]
+    fn execute_base64_round_trip_via_script() {
+        let tool = tool_from("// @tool t\ndecode_base64(encode_base64(\"round trip · 🐙\"))");
+        let out = execute(&tool, serde_json::json!({}), FakeHost::arc());
+        assert_eq!(out, "round trip · 🐙");
+    }
+
+    /// A script decoding something that is not base64 gets the error as its
+    /// output, prefixed like any other tool failure, rather than an empty
+    /// string it would carry on with.
+    #[test]
+    fn execute_decode_base64_failure_reaches_the_script() {
+        let tool = tool_from("// @tool t\ndecode_base64(\"not base64!\")");
+        let out = execute(&tool, serde_json::json!({}), FakeHost::arc());
+        assert!(out.starts_with("[error] t:"), "got: {out}");
+        assert!(out.contains("not valid base64"), "got: {out}");
+    }
+
     #[test]
     fn execute_missing_optional_param_reads_as_unit() {
         // Mirrors the issue's `params.count == ()` idiom.
@@ -1731,6 +1800,69 @@ schema = { type = "string", enum = ["json", "yaml"], description = "Output forma
     fn encode_uri_non_ascii() {
         // '€' (U+20AC) is 3 UTF-8 bytes E2 82 AC.
         assert_eq!(percent_encode("€"), "%E2%82%AC");
+    }
+
+    /// Round-trips, including the bytes that make base64 worth having: a
+    /// multi-byte character, and the padding cases at each input length mod 3.
+    #[test]
+    fn base64_round_trips_through_both_directions() {
+        for original in [
+            "",
+            "a",
+            "ab",
+            "abc",
+            "hello, world",
+            "€ · 🐙",
+            "line\nbreak\ttab",
+            "{\"json\": [1, 2, 3]}",
+        ] {
+            let encoded = encode_base64(original);
+            let decoded = decode_base64(&encoded).expect("what we encoded decodes");
+            assert_eq!(decoded, original, "round trip of {original:?}");
+        }
+    }
+
+    /// Standard alphabet with padding, so a script's output matches what any
+    /// other base64 tool produces for the same input.
+    #[test]
+    fn base64_is_the_standard_padded_alphabet() {
+        assert_eq!(encode_base64("a"), "YQ==");
+        assert_eq!(encode_base64("ab"), "YWI=");
+        assert_eq!(encode_base64("abc"), "YWJj");
+        // `?` and `>` are the pair that separate the standard alphabet from the
+        // URL-safe one: standard encodes them with `+` and `/`.
+        assert_eq!(encode_base64("\u{00ff}\u{00fe}"), "w7/Dvg==");
+    }
+
+    /// Input that is not base64 is an error, not a silent empty string.
+    #[test]
+    fn decoding_something_that_is_not_base64_says_so() {
+        let err = decode_base64("not base64 at all!").expect_err("refused");
+        let message = err.to_string();
+        assert!(message.contains("decode_base64"), "{message}");
+        assert!(message.contains("not valid base64"), "{message}");
+    }
+
+    /// Valid base64 carrying bytes that are not text is refused, and the message
+    /// says which of the two failures happened - the fixes are unrelated.
+    #[test]
+    fn decoding_bytes_that_are_not_text_explains_which_failure_it_was() {
+        // A PNG's magic number: valid base64, not valid UTF-8.
+        let png_header = encode_base64_bytes(&[0x89, b'P', b'N', b'G', 0x0d, 0x0a]);
+        let err = decode_base64(&png_header).expect_err("refused");
+        let message = err.to_string();
+        assert!(message.contains("not UTF-8 text"), "{message}");
+        assert!(
+            !message.contains("not valid base64"),
+            "the two failures are told apart: {message}"
+        );
+    }
+
+    /// Encode arbitrary bytes, for the test above. Not offered to scripts: a
+    /// Rhai string is text, so there is nothing for a byte encoder to take.
+    fn encode_base64_bytes(bytes: &[u8]) -> String {
+        use base64::Engine as _;
+        base64::engine::general_purpose::STANDARD.encode(bytes)
     }
 
     #[test]

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -169,7 +169,8 @@ below does. Never assemble the body by joining strings. A model reply routinely 
 a newline or a backslash, and escaping those by hand is where a provider script breaks weeks later
 on one unusual page.
 - Env and encoding: `env_var(name)` (returns a string or `()`), `encode_uri(str)`,
-  `encode_base64(str)`.
+  `encode_base64(str)`, `decode_base64(str)`. The base64 pair is the same implementation
+  [tool scripts get](/docs/rhai-tools), including how `decode_base64` reports a failure.
 - Tokens: `count_tokens_heuristic(text, hint)` where `hint` is `"openai"`, `"anthropic"`,
   `"gemini"`, or `"general"`.
 

--- a/docs/content/rhai-tools.md
+++ b/docs/content/rhai-tools.md
@@ -64,9 +64,15 @@ tool's `@requires` line is not a gate: it only filters which platforms discover 
 
 | Group | Functions |
 |---|---|
-| JSON and encoding | `parse_json`, `to_json`, `encode_uri`, `html_to_text` |
+| JSON and encoding | `parse_json`, `to_json`, `encode_uri`, `encode_base64`, `decode_base64`, `html_to_text` |
 | Strings | `contains`, `starts_with`, `ends_with`, `trim`, `join`, `split` |
 | Content | `count_tokens`, `is_json`, `is_markdown`, `is_mermaid`, `is_empty`, `content_format` |
+
+`decode_base64` fails rather than returning something wrong, in two ways worth telling apart. Input
+that is not valid base64 says so. Input that is valid base64 but decodes to bytes that are not UTF-8
+says *that* - base64 carries any bytes, a Rhai string holds text, so a script decoding an image has
+asked for something the function cannot return. Both reach the model as an `[error]` line naming
+your tool, so a script that hits one stops rather than carrying on with an empty string.
 
 ## A complete tool
 


### PR DESCRIPTION
Half the premise held, and the other half was worse — there are **two** Rhai engines:

| engine | encode | decode |
|---|---|---|
| provider (`.rhai` providers) | ✅ `encode_base64` | ❌ |
| tool (`.rhai` tools) | ❌ | ❌ |

So tool scripts had **neither**. A tool calling a JSON API that returns a base64 field had no way to open it, and a provider script could write a value it could not read back.

## What changed

Both engines register `encode_base64` and `decode_base64`, and both call **one implementation** in `leviath_scripting::tool` — the arrangement `encode_uri` already uses, whose comment already explains why:

> Two encoders that scripts reach by the same name is a difference waiting to be discovered by whoever writes a `.rhai` that works in one and not the other.

## `decode_base64` tells its two failures apart

```
decode_base64: not valid base64: <detail>
decode_base64: decoded 6 bytes that are not UTF-8 text (<detail>).
               Base64 can carry any bytes; a Rhai string holds text.
```

The second is worth stating separately. It isn't a typo on the caller's part — base64 carries arbitrary bytes while a Rhai string holds text, so a script decoding a PNG has asked for something the function cannot return. Different cause, different fix.

Both reach the model as an `[error]` line naming the tool, so a script that hits one stops rather than carrying on with an empty string.

## Verification

Tested **through the engines**, not just as free functions — a script calls both by name and gets its own text back, in each engine, and a failure arrives as the error a tool's caller actually sees:

```rhai
decode_base64(encode_base64("round trip · 🐙"))   // → "round trip · 🐙"
decode_base64("not base64!")                      // → [error] t: ... not valid base64
```

Round-trips cover each padding case (input length mod 3), multi-byte characters, and the alphabet positions where standard base64 differs from URL-safe.

- Suite green as CI runs it, clippy clean, structure and docs gates pass, **coverage 13/13 at 100%**
- Docs updated in both `rhai-tools.md` and `rhai-providers.md`, including how the failures differ

## Housekeeping

`base64` moves from `leviath-providers` to `leviath-scripting` with the code that uses it, rather than staying behind as a dependency nothing calls.
