### PR TITLE
docs(scripting): list the helpers every script gets, where they are pointed at

### DIFF
--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -50,6 +50,24 @@ by point:
 - Region hooks and policy rules get **nothing**. They are pure data transforms over the `ctx` they
   are handed.
 
+### What every script can call
+
+Available at every extension point, including the ones that get no host access at all, because none
+of these reach outside the process - they only transform values the script already holds:
+
+| Group | Functions |
+|---|---|
+| Strings | `contains`, `starts_with`, `ends_with`, `trim`, `join`, `split` |
+| Content | `count_tokens`, `is_json`, `is_markdown`, `is_mermaid`, `is_empty`, `content_format` |
+| JSON | `parse_json`, `to_json` |
+
+On top of that, tool and provider scripts get `encode_uri`, `encode_base64`, `decode_base64` and
+`html_to_text`, and the host functions that do reach outside - which is what
+[`[tool_script_permissions]`](/docs/configuration#tool_script_permissions) governs. The full list
+per point is on that point's own page: [tools](/docs/rhai-tools),
+[providers](/docs/rhai-providers), [regions](/docs/rhai-regions), [hooks](/docs/rhai-hooks),
+[validators](/docs/rhai-validators).
+
 Names are matched exactly, and the match is enforced. A script missing the function its surface
 needs, or defining it with the wrong arity, fails at spawn with a compile error rather than
 silently never firing. `lev validate` and `lev tools` catch it before a run does.


### PR DESCRIPTION
Audited every registered Rhai function against the docs. All 34 script-facing names are documented — but one link went nowhere useful.

## The gap

`rhai-validators.md` says:

> You get the [standard helpers](/docs/scripting), including `parse_json`.

`/docs/scripting` described the extension points and what kind of access each has, and **listed no functions at all**. Following the link answers a different question than the one that sent you there.

That page now carries the shared set — string, content and JSON helpers available at every point including the ones handed no host access, since none of them reach outside the process — plus a line on what tool and provider scripts get on top, and links to each point's own page.

## Verified, not transcribed

Each of the fourteen was probed through the **output-validator engine** — the most restricted one there is, so anything it can call, every point can — by compiling a validator that calls it and checking the verdict.

That mattered. `parse_json` and `to_json` are **not** in our `register_functions`; they come from Rhai's default packages. Reading the registration sites — which is what I did first — says they're unavailable and the validator docs are wrong. They're available and the docs were right.

```
CLAIM parse_json: Valid
CLAIM to_json: Valid
```

The probe was removed before committing; this is a docs-only change.

## Also confirmed correct

`decode_base64` and `encode_base64` are documented on both `rhai-tools.md` and `rhai-providers.md` from #608, and every other registered function appears on its own page.
