### PR TITLE
feat(providers): get a run's models ready before it sizes its context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,27 @@ same list.
 
 ## Unreleased
 
+- Added: providers are asked to get a run's models ready before it starts, through
+  a new `Provider::warm_models` that defaults to doing nothing. Ollama implements
+  it, because it is the one provider where "ready" is a state the machine has to
+  be put into: it serves a model out of memory and can only report the window it
+  truly allocated for one it has resident. A run whose first inference loads the
+  model had already sized its context regions against a guess from the model's
+  name by then, and percentage budgets resolve once, at spawn, into absolute
+  numbers - so that guess was not corrected later, it was what the whole run used.
+  Measured on a developer machine: 7.9 seconds for a cold 32B-class model and 0.2
+  seconds for one already resident, so the cost is paid once rather than per run.
+  Script providers can implement `warm_models(state, models)` too.
+- Fixed: a bare `--model` override put pairs in the fallback list that nobody
+  asked for and nothing serves. The override replaces the model on every entry
+  while leaving each entry's provider alone, so `--model gpt-5.5` against a stage
+  listing `{provider = "anthropic", ...}` produced `anthropic/gpt-5.5`, which sat
+  there until a failover reached it and moved the run onto a route that cannot
+  answer. A renamed pair is now dropped when some provider serves that model and
+  this one does not. Only on a definite no: a provider that claims nothing cannot
+  tell us the pair is wrong, and treating silence as rejection would throw away
+  every route to it.
+
 - Added: `decode_base64` for Rhai scripts, and `encode_base64` for tool scripts,
   which had neither. The provider engine has offered `encode_base64` for some
   time with no way to read a value back, and the tool engine offered no base64

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -275,6 +275,10 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // install can't fan out unbounded requests against provider rate limits),
     // alongside the per-model overrides and the per-provider caps.
     let pool_config = parts.config.limits.inference_pools();
+    // Kept before the world takes ownership: the spawn preprocessor warms this
+    // run's models through the same registry the world will infer on, so both
+    // see one set of learned windows rather than two.
+    let pp_providers = parts.providers.clone();
     let mut world = PipelineWorld::new(
         parts.providers,
         tool_service.clone(),
@@ -501,13 +505,22 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // advertises them (they'd otherwise land one turn late - issue #97).
     let pp_pool = parts.mcp_pool.clone();
     let pp_agents_dir = leviath_core::paths::agents_dir();
+    // The models too, and for a reason the MCP warming does not have: a stage's
+    // percentage region budgets resolve once, at spawn, into absolute numbers.
+    // A model whose real window is only knowable once it is loaded - which is
+    // every Ollama model - would otherwise have every region in the run sized
+    // against a guess from its name, and nothing later corrects it.
+    let pp_default_provider = parts.config.default_provider.clone();
     host.set_spawn_preprocessor(Box::new(move |args| {
         let pool = pp_pool.clone();
         let blueprint_path = args.blueprint_path.clone();
         let agents_dir = pp_agents_dir.clone();
+        let providers = pp_providers.clone();
+        let default_provider = pp_default_provider.clone();
         Box::pin(async move {
             warm_blueprint_mcp(&pool, &blueprint_path).await;
             warm_fanout_worker_mcp(&pool, &blueprint_path, agents_dir.as_deref()).await;
+            warm_blueprint_models(&providers, &blueprint_path, &default_provider).await;
         })
     }));
 
@@ -638,6 +651,67 @@ async fn warm_blueprint_mcp(pool: &crate::daemon::mcp_pool::McpPool, blueprint_p
 /// the parent's own blueprint, already warmed by [`warm_blueprint_mcp`], so they
 /// are skipped here. A worker source that can't be read/resolved is skipped.
 /// Extracted from the preprocessor closure so its body is unit-testable.
+/// Every model a blueprint's stages name, bare and deduplicated.
+///
+/// Every entry, not the first of each stage: which one a stage lands on depends
+/// on what this machine has keys for, and that resolution happens later, inside
+/// the spawn. Warming the whole set is what makes the answer right whichever way
+/// it goes, and a provider ignores the names it does not serve, so the extra
+/// ones cost nothing on the providers they are not for.
+///
+/// The provider half of an entry is dropped on purpose. A blueprint may name a
+/// model with no provider at all - that is the point of `models = ["gpt-5.5"]` -
+/// so the name is the only part every entry is guaranteed to have.
+fn blueprint_model_names(blueprint: &leviath_core::Blueprint) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    for stage in &blueprint.stages {
+        for entry in &stage.model.models {
+            if !entry.model.is_empty() {
+                seen.insert(entry.model.clone());
+            }
+        }
+    }
+    seen.into_iter().collect()
+}
+
+/// Warm the models this blueprint's stages name, before the run is built.
+///
+/// A blueprint that will not read or parse warms nothing: the spawn that follows
+/// is about to fail on the same file and say so properly, and a second complaint
+/// from here would only be noise in front of it.
+async fn warm_blueprint_models(
+    providers: &leviath_runtime::ProviderRegistry,
+    blueprint_path: &str,
+    default_provider: &str,
+) {
+    let Ok(content) = std::fs::read_to_string(blueprint_path) else {
+        return;
+    };
+    let Ok(blueprint) = leviath_core::manifest::parse_manifest(&content) else {
+        return;
+    };
+    let models = blueprint_model_names(&blueprint);
+    providers
+        .warm_models(
+            &models,
+            std::time::Duration::from_secs(MODEL_WARM_TIMEOUT_SECS),
+            Some(default_provider),
+        )
+        .await;
+}
+
+/// How long the whole warm-up may take per provider before a run starts anyway.
+///
+/// Generous because it covers a genuinely cold local model - a 32B-class one
+/// measured at 7.9 seconds to load on a developer machine, and a larger one on a
+/// slower disk will take longer. A model already resident answers in about two
+/// tenths of a second, which is the case this is paid in on every run after the
+/// first.
+///
+/// It is a ceiling, not a wait: crossing it means the run starts on the compiled
+/// table rather than that the run is refused.
+const MODEL_WARM_TIMEOUT_SECS: u64 = 90;
+
 async fn warm_fanout_worker_mcp(
     pool: &crate::daemon::mcp_pool::McpPool,
     blueprint_path: &str,
@@ -1206,6 +1280,80 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
         )
         .unwrap();
         manifest
+    }
+
+    /// Every entry across every stage, deduplicated, with the provider half
+    /// dropped: a blueprint may name a model with no provider at all, so the
+    /// name is the only part every entry is guaranteed to have.
+    #[test]
+    fn blueprint_models_are_every_entry_deduplicated() {
+        let manifest = r#"
+[agent]
+name = "m"
+version = "0.1.0"
+entry_stage = "one"
+
+[stages.one]
+system_prompt = "x"
+model = { models = ["shared", { provider = "ollama", model = "local:latest" }] }
+
+[stages.two]
+system_prompt = "y"
+model = { models = ["shared", "other", ""] }
+"#;
+        let blueprint =
+            leviath_core::manifest::parse_manifest(manifest).expect("the fixture parses");
+
+        assert_eq!(
+            blueprint_model_names(&blueprint),
+            vec![
+                "local:latest".to_string(),
+                "other".to_string(),
+                "shared".to_string()
+            ],
+            "sorted and deduplicated, providers dropped, and the empty entry \
+             skipped - no provider serves a nameless model, and passing one \
+             would ask every provider about nothing"
+        );
+    }
+
+    /// A stage that names no model is not a stage with no model: the parser
+    /// fills in the build's default, and that is the one a run would use, so it
+    /// is the one worth warming. Asserted because "names nothing" and "warms
+    /// nothing" read like the same statement and are not.
+    #[test]
+    fn a_stage_naming_no_model_yields_the_default_it_would_run() {
+        let manifest = r#"
+[agent]
+name = "m"
+version = "0.1.0"
+entry_stage = "one"
+
+[stages.one]
+system_prompt = "x"
+"#;
+        let blueprint =
+            leviath_core::manifest::parse_manifest(manifest).expect("the fixture parses");
+        assert_eq!(
+            blueprint_model_names(&blueprint),
+            vec!["claude-sonnet-4-6".to_string()],
+            "the default a model-less stage resolves to is what a run would use"
+        );
+    }
+
+    /// A path that will not read, and a file that will not parse, both warm
+    /// nothing. The spawn that follows fails on the same file and says so
+    /// properly; a second complaint from here would be noise in front of it.
+    #[tokio::test]
+    async fn an_unreadable_or_unparsable_blueprint_warms_nothing() {
+        let registry = leviath_runtime::ProviderRegistry::new();
+
+        warm_blueprint_models(&registry, "/no/such/blueprint.leviath", "anthropic").await;
+
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let bad = dir.path().join("broken.leviath");
+        std::fs::write(&bad, "this is not TOML at all {{{").expect("writes");
+        warm_blueprint_models(&registry, &bad.display().to_string(), "anthropic").await;
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -130,6 +130,15 @@ fn estimated_block_tokens(block: &crate::ContentBlock) -> usize {
     }
 }
 
+/// How long a model warmed for a run stays resident with nothing calling it.
+///
+/// Long enough to cover the gap between warming and the run's first inference,
+/// and to survive the pauses between a run's turns, without pinning memory for
+/// the rest of the day on a machine that ran one agent this morning. Ollama's
+/// own default is five minutes; this says so explicitly rather than depending on
+/// a default that is a server setting somebody may have changed.
+const WARM_KEEP_ALIVE: &str = "5m";
+
 fn effective_window(show: &serde_json::Value) -> Option<usize> {
     let parameters = show.get("parameters")?.as_str()?;
     parameters.lines().find_map(|line| {
@@ -301,7 +310,11 @@ impl OllamaProvider {
             .unwrap_or_default()
     }
 
-    async fn learn_model_windows(&self) -> Result<HashMap<String, usize>> {
+    /// The models this server has pulled, by name.
+    ///
+    /// Sorted, so a caller that walks them asks `/api/show` in a stable order -
+    /// which is what lets a test drive a fixed response sequence.
+    async fn installed_model_names(&self) -> Result<Vec<String>> {
         let tags = self
             .client
             .get(format!("{}/api/tags", self.base_url))
@@ -310,8 +323,7 @@ impl OllamaProvider {
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
         let tags = crate::provider::check_http_response(tags, None).await?;
         let tags: serde_json::Value = crate::provider::decode_json(tags).await?;
-
-        let names: Vec<String> = tags
+        let mut names: Vec<String> = tags
             .get("models")
             .and_then(|m| m.as_array())
             .map(|entries| {
@@ -321,6 +333,54 @@ impl OllamaProvider {
                     .collect()
             })
             .unwrap_or_default();
+        names.sort();
+        Ok(names)
+    }
+
+    /// Load one model into memory without generating anything.
+    ///
+    /// A `/api/generate` carrying a model and no prompt is Ollama's own way to
+    /// say "load this": it answers `done_reason: "load"` having produced no
+    /// tokens. Measured on a developer machine, 7.9s for a cold 32B-class model
+    /// and 0.2s for one already resident - so the cost of doing this before
+    /// every run is paid once, not each time.
+    ///
+    /// Never fails the caller. A model that will not load leaves the run to
+    /// proceed on the compiled table, which is what it would have used anyway;
+    /// refusing to start a run because a warm-up did not work would trade a
+    /// wrong window for no run at all.
+    async fn load_model(&self, model: &str) {
+        let sent = self
+            .client
+            .post(format!("{}/api/generate", self.base_url))
+            .json(&serde_json::json!({ "model": model, "keep_alive": WARM_KEEP_ALIVE }))
+            .send()
+            .await;
+        match sent {
+            Ok(response) if response.status().is_success() => {}
+            Ok(response) => {
+                // Read out before the macro: a field value inside `warn!` is its
+                // own region, evaluated only when the log fires, which leaves it
+                // uncovered even on the test that takes this arm.
+                let status = response.status();
+                tracing::warn!(
+                    model = %model,
+                    %status,
+                    "Ollama refused to load this model, so its context window is \
+                     whatever its name suggests"
+                );
+            }
+            Err(e) => tracing::warn!(
+                model = %model,
+                error = %e,
+                "could not reach Ollama to load this model, so its context \
+                 window is whatever its name suggests"
+            ),
+        }
+    }
+
+    async fn learn_model_windows(&self) -> Result<HashMap<String, usize>> {
+        let names = self.installed_model_names().await?;
 
         // What is loaded right now, and at what size. `/api/ps` reports the
         // window the runner actually allocated for a model it has resident,
@@ -702,6 +762,33 @@ impl Provider for OllamaProvider {
     ///
     /// Failure is a warning upstream, not an error: a daemon whose Ollama is not
     /// running must still start, with the compiled table in charge.
+    async fn warm_models(&self, models: &[String]) -> Result<()> {
+        // Only what this server actually has. Asking it to load a model it does
+        // not hold makes it try to *pull* one, which is a download nobody asked
+        // for at the start of a run.
+        let held = self.installed_model_names().await?;
+        let wanted: Vec<&String> = models.iter().filter(|m| held.contains(m)).collect();
+        if wanted.is_empty() {
+            return Ok(());
+        }
+        for model in &wanted {
+            self.load_model(model).await;
+        }
+        // Re-read now they are resident. This is the point of the exercise: a
+        // loaded model reports through `/api/ps` the window the runner really
+        // allocated, where a cold one leaves only what its Modelfile pins and,
+        // failing that, a guess from its name.
+        let windows = self.learn_model_windows().await?;
+        let learned = windows.len();
+        *leviath_core::sync::lock(&self.api_windows) = windows;
+        tracing::debug!(
+            warmed = wanted.len(),
+            models = learned,
+            "warmed Ollama models and re-read their windows"
+        );
+        Ok(())
+    }
+
     async fn prime_capabilities(&self) -> Result<()> {
         let windows = self.learn_model_windows().await?;
         let count = windows.len();
@@ -3127,6 +3214,146 @@ mod tests {
     // ─── effective window ───────────────────────────────────────────────────
 
     /// `parameters` is a text block, and `num_ctx` is the line that matters.
+    /// The point of the whole thing: a model that is cold reports only what its
+    /// name suggests, and the same model once loaded reports what the runner
+    /// really allocated. Warming is what moves it from the first to the second
+    /// *before* a run sizes its regions.
+    #[tokio::test]
+    async fn warming_a_model_replaces_the_guess_with_what_the_runner_allocated() {
+        let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            // warm_models: what is installed, then the load, then the re-read.
+            (200, "OK", tags_body(&["qwen3.8:latest"])),
+            (200, "OK", br#"{"done":true,"done_reason":"load"}"#.to_vec()),
+            (200, "OK", tags_body(&["qwen3.8:latest"])),
+            (200, "OK", ps_body(&[("qwen3.8:latest", 262_144)])),
+        ])
+        .await;
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
+
+        // Cold: the name is all there is, and the name says 131072.
+        assert_eq!(
+            provider.capabilities("qwen3.8:latest").max_context_tokens,
+            131_072
+        );
+
+        provider
+            .warm_models(&["qwen3.8:latest".to_string()])
+            .await
+            .expect("warms");
+
+        let after = provider.capabilities("qwen3.8:latest");
+        assert_eq!(after.max_context_tokens, 262_144);
+        assert_eq!(after.limits_source, LimitsSource::Api);
+    }
+
+    /// A server that is not there at all is the same as one that refuses: the
+    /// run proceeds on the compiled table. Nothing about a warm-up is worth
+    /// failing a run over.
+    #[tokio::test]
+    async fn a_server_that_cannot_be_reached_does_not_fail_the_warm_up() {
+        // Port 1 needs privileges to bind, so nothing of ours is listening.
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "http://127.0.0.1:1".to_string(),
+        );
+
+        // The tag fetch is the first thing warm_models does, so an unreachable
+        // server surfaces there rather than at the load.
+        assert!(
+            provider
+                .warm_models(&["anything:latest".to_string()])
+                .await
+                .is_err(),
+            "reported to the caller, which logs it and starts the run anyway"
+        );
+
+        // And the load itself, reached directly, is silent about it.
+        provider.load_model("anything:latest").await;
+    }
+
+    /// A model this server has not pulled is not loaded, because asking Ollama
+    /// to load one it does not hold makes it download one - which is not a thing
+    /// to start on somebody's behalf at the beginning of a run.
+    #[tokio::test]
+    async fn a_model_the_server_does_not_have_is_not_pulled() {
+        // One response only: the tag list. A load attempt would find nothing to
+        // serve and fail the test rather than quietly downloading.
+        let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![(
+            200,
+            "OK",
+            tags_body(&["installed:latest"]),
+        )])
+        .await;
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
+
+        provider
+            .warm_models(&["never-pulled:latest".to_string()])
+            .await
+            .expect("returns without loading anything");
+    }
+
+    /// Every provider is handed the whole list, so most of what arrives belongs
+    /// to somebody else. Names this server does not have are simply skipped.
+    #[tokio::test]
+    async fn models_belonging_to_other_providers_are_ignored() {
+        let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (200, "OK", tags_body(&["local:latest"])),
+            (200, "OK", br#"{"done":true,"done_reason":"load"}"#.to_vec()),
+            (200, "OK", tags_body(&["local:latest"])),
+            (200, "OK", ps_body(&[("local:latest", 8_192)])),
+        ])
+        .await;
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
+
+        provider
+            .warm_models(&[
+                "claude-sonnet-5".to_string(),
+                "local:latest".to_string(),
+                "gpt-5.5".to_string(),
+            ])
+            .await
+            .expect("warms only its own");
+
+        assert_eq!(
+            provider.capabilities("local:latest").max_context_tokens,
+            8_192
+        );
+    }
+
+    /// A server that will not load a model does not fail the run. The warm-up is
+    /// an improvement on the compiled table, and refusing to start because it
+    /// did not work would trade a wrong window for no run.
+    #[tokio::test]
+    async fn a_load_that_fails_still_leaves_the_run_startable() {
+        let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (200, "OK", tags_body(&["stubborn:latest"])),
+            (500, "Server Error", b"no".to_vec()),
+            (200, "OK", tags_body(&["stubborn:latest"])),
+            (200, "OK", ps_body(&[])),
+            // Nothing loaded, so the re-read falls through to the Modelfile.
+            (200, "OK", show_body(None)),
+        ])
+        .await;
+        let provider = OllamaProvider::with_base_url(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            url,
+        );
+
+        provider
+            .warm_models(&["stubborn:latest".to_string()])
+            .await
+            .expect("a refused load is not an error to the caller");
+    }
+
     /// `/api/ps` is the only endpoint that reports the window the runner
     /// actually allocated, so a model it names is not re-derived from anything
     /// `/api/show` says.

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -930,6 +930,32 @@ pub trait Provider: Send + Sync {
         Ok(())
     }
 
+    /// Get `models` ready, just before a run that intends to use them starts.
+    ///
+    /// `models` is every model the run's blueprint names, bare (no provider
+    /// prefix) and deduplicated. A provider takes the ones it serves and ignores
+    /// the rest - the caller does not know which are whose, and asking each
+    /// provider is how a model named without a provider still reaches the one
+    /// that has it.
+    ///
+    /// Defaults to doing nothing, which is right for every provider whose models
+    /// are always ready. It exists for the ones where "ready" is a state the
+    /// machine has to be put into: Ollama serves a model out of memory and can
+    /// only report the window it truly allocated for one it has resident, so a
+    /// run whose first inference loads the model has already sized its context
+    /// regions against a guess by then. Percentage budgets resolve once, at
+    /// spawn, into absolute numbers - so that guess is not corrected later, it
+    /// is what the whole run uses.
+    ///
+    /// Called before the run is built, and awaited, because arriving after the
+    /// spawn would be arriving after the only moment it could have helped. It is
+    /// bounded by the caller and its failures are warnings: a run that could not
+    /// be warmed still runs, on whatever the compiled table says.
+    async fn warm_models(&self, models: &[String]) -> Result<()> {
+        let _ = models;
+        Ok(())
+    }
+
     /// List models available from this provider.
     ///
     /// Returns an empty list by default; providers may override to enumerate
@@ -1115,6 +1141,23 @@ mod stream_once {
 mod tests {
 
     use super::*;
+
+    /// Most providers have nothing to get ready, which is what the default is
+    /// for. Exercised through a real one rather than a stub: a stub written for
+    /// this would need four other methods nothing calls, and those would be the
+    /// untested code instead.
+    #[tokio::test]
+    async fn a_provider_that_needs_no_warming_accepts_the_call() {
+        let anthropic = crate::AnthropicProvider::new(
+            build_http_client(None).expect("a test client builds"),
+            "sk-ant-test".to_string(),
+        );
+
+        anthropic
+            .warm_models(&["claude-sonnet-5".to_string()])
+            .await
+            .expect("the default does nothing, successfully, and asks no network");
+    }
 
     /// A temperature reaches the wire as the number that was written.
     ///

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -20,7 +20,8 @@
 //! Required: `initialize(config) -> Map` (runs **offline** - no network host
 //! functions are registered for it) and `inference(state, request) -> Map`.
 //! Optional: `stream(state, request, on_chunk)`, `count_tokens(state, text,
-//! model) -> int`, `list_models(state) -> Array`.
+//! model) -> int`, `list_models(state) -> Array`,
+//! `warm_models(state, models) -> ()`.
 
 mod convert;
 mod engine;
@@ -124,6 +125,7 @@ pub struct RhaiProvider {
     has_stream: bool,
     has_count_tokens: bool,
     has_list_models: bool,
+    has_warm_models: bool,
     /// `[security] allow_env_vars`: credential-shaped environment variables this
     /// script may read via `env_var`. Held so each per-call execution engine is
     /// built with the same policy the init engine was.
@@ -226,6 +228,7 @@ impl RhaiProvider {
         let has_stream = has_fn(&ast, "stream", 3);
         let has_count_tokens = has_fn(&ast, "count_tokens", 3);
         let has_list_models = has_fn(&ast, "list_models", 1);
+        let has_warm_models = has_fn(&ast, "warm_models", 2);
 
         Ok(Self {
             name,
@@ -239,6 +242,7 @@ impl RhaiProvider {
             has_stream,
             has_count_tokens,
             has_list_models,
+            has_warm_models,
             env_allowlist,
             served_models: Arc::new(Mutex::new(Vec::new())),
             declared_models: Arc::new(serves),
@@ -596,6 +600,31 @@ impl Provider for RhaiProvider {
         let models = self.list_models().await?;
         let ids: Vec<String> = models.into_iter().map(|m| m.id).collect();
         *leviath_core::sync::lock(&self.served_models) = ids;
+        Ok(())
+    }
+
+    async fn warm_models(&self, models: &[String]) -> Result<()> {
+        if !self.has_warm_models {
+            return Ok(());
+        }
+        let ast = self.ast.clone();
+        let state = (*self.state).clone();
+        // Handed the whole list, the way every other provider is: a script knows
+        // which of these it serves and the caller does not.
+        let wanted: rhai::Array = models.iter().map(|m| Dynamic::from(m.clone())).collect();
+        // The script's return value is discarded on purpose: warming is what it
+        // did, not what it said.
+        let _ = self
+            .dispatch(
+                self.request_timeout_secs,
+                Box::new(move |engine| {
+                    let mut scope = Scope::new();
+                    engine
+                        .call_fn::<Dynamic>(&mut scope, &ast, "warm_models", (state, wanted))
+                        .map_err(map_rhai_err)
+                }),
+            )
+            .await?;
         Ok(())
     }
 

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -532,6 +532,51 @@ async fn count_tokens_script_non_int_falls_back() {
     assert_eq!(p.count_tokens("abcdefgh", "llama").await, 2);
 }
 
+// ── warm_models ──────────────────────────────────────────────────────────────
+
+/// A script with no `warm_models` is not asked, and says so by succeeding: most
+/// providers have nothing to get ready and should not have to write a stub.
+#[tokio::test]
+async fn warm_models_is_optional() {
+    let src = format!("{NOOP_INIT}fn inference(s, r) {{ #{{}} }}");
+    let p = build(&src, FakeExecutor::new()).unwrap();
+    p.warm_models(&["anything".to_string()]).await.unwrap();
+}
+
+/// A script that defines it is handed the whole list the run named, and decides
+/// for itself which of them are its own - the caller cannot know.
+#[tokio::test]
+async fn warm_models_receives_every_model_the_run_named() {
+    let src = format!(
+        "{NOOP_INIT}fn inference(s, r) {{ #{{}} }}\n\
+         fn warm_models(state, models) {{ \
+           if models.len != 2 {{ throw \"expected two, got \" + models.len }} \
+           if models[0] != \"first\" {{ throw \"wrong first: \" + models[0] }} \
+           if models[1] != \"second\" {{ throw \"wrong second: \" + models[1] }} \
+         }}"
+    );
+    let p = build(&src, FakeExecutor::new()).unwrap();
+    p.warm_models(&["first".to_string(), "second".to_string()])
+        .await
+        .expect("the script saw exactly what the run named");
+}
+
+/// A script that throws while warming reports it, so the caller can log which
+/// provider could not get ready rather than starting the run in silence.
+#[tokio::test]
+async fn a_throwing_warm_models_is_reported() {
+    let src = format!(
+        "{NOOP_INIT}fn inference(s, r) {{ #{{}} }}\n\
+         fn warm_models(state, models) {{ throw \"cannot reach the box\" }}"
+    );
+    let p = build(&src, FakeExecutor::new()).unwrap();
+    let err = p
+        .warm_models(&["m".to_string()])
+        .await
+        .expect_err("the throw reaches the caller");
+    assert!(err.to_string().contains("cannot reach the box"), "{err}");
+}
+
 // ── list_models ──────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -130,8 +130,53 @@ pub fn resolve_stage_candidates(
             .clone()
             .unwrap_or_else(|| entry.model.clone());
         if !entry.provider.is_empty() {
-            if registry.has(&entry.provider) {
+            if !registry.has(&entry.provider) {
+                continue;
+            }
+            // A pinned pair is the author naming a route, and it is taken on
+            // trust: a provider whose catalogue this build cannot see would
+            // otherwise have every pin to it thrown away.
+            //
+            // A *renamed* pair is nobody's route. A bare `--model` override
+            // replaces the model on every entry while leaving each entry's
+            // provider alone, so `--model gpt-5.5` against a stage listing
+            // `{provider = "anthropic", ...}` produces `anthropic/gpt-5.5` - a
+            // pair no one asked for and no provider serves. It sits in the
+            // fallback list until a failover reaches it, and then the run moves
+            // itself onto a route that cannot answer. So a renamed pair has to
+            // earn its place by the same test an open route does.
+            let renamed = override_model.is_some() && model != entry.model;
+            // Dropped only on a definite no. A provider that claims nothing -
+            // one whose catalogue this build cannot see, or a script that never
+            // primed - cannot tell us the pair is wrong, and treating silence as
+            // rejection would throw away every route to it. So the question is
+            // asked of the registry as a whole: if *somebody* serves the renamed
+            // model, then who serves it is knowable, and a provider that does
+            // not is definitively the wrong place to send it. If nobody claims
+            // it, nothing here knows better than the entry already did.
+            let usable = !renamed
+                || !registry
+                    .native_providers()
+                    .into_iter()
+                    .any(|(_, p)| p.serves_model(model_key(&model)).is_some())
+                || registry
+                    .native_providers()
+                    .into_iter()
+                    .find(|(name, _)| *name == entry.provider)
+                    .is_some_and(|(_, provider)| {
+                        provider.serves_model(model_key(&model)).is_some()
+                    });
+            if usable {
                 push(entry.provider.clone(), model);
+            } else {
+                tracing::warn!(
+                    provider = %entry.provider,
+                    model = %model,
+                    listed_model = %entry.model,
+                    "the --model override renamed this entry onto a provider that \
+                     does not serve it, so the pair is skipped rather than left \
+                     for a failover to land on"
+                );
             }
             continue;
         }
@@ -1494,6 +1539,54 @@ mod tests {
         let registry = registry_with(&["anthropic", "openai", "ollama"]);
         let got = resolve_stage_candidates(&cfg, Some("ollama/llama"), &defaults, &registry);
         assert_eq!(pairs(&got), vec![("ollama", "llama")]);
+    }
+
+    /// A bare `--model` override replaces the model on every entry and leaves
+    /// each entry's provider alone, so it invents pairs nobody asked for. One
+    /// that no provider serves used to sit in the fallback list until a failover
+    /// reached it and moved the run onto a route that cannot answer.
+    #[test]
+    fn a_rename_onto_a_provider_that_does_not_serve_it_is_dropped() {
+        let cfg = model_cfg(vec![("anthropic", "sonnet"), ("openrouter", "gpt")]);
+        let registry = registry_serving(&[
+            ("anthropic", &["sonnet", "opus"][..]),
+            ("openrouter", &["gpt", "gpt-5.5"][..]),
+        ]);
+
+        let got =
+            resolve_stage_candidates(&cfg, Some("gpt-5.5"), &ModelDefaults::default(), &registry);
+
+        assert_eq!(
+            pairs(&got),
+            vec![("openrouter", "gpt-5.5")],
+            "anthropic does not serve gpt-5.5, so no failover can land there"
+        );
+    }
+
+    /// The other half of the same rule: silence is not a no. A provider whose
+    /// catalogue this build cannot see keeps its pins, because rejecting a pair
+    /// nothing can vouch for would throw away every route to such a provider.
+    #[test]
+    fn a_rename_is_kept_when_no_provider_can_vouch_for_the_model() {
+        let cfg = model_cfg(vec![("anthropic", "sonnet"), ("openrouter", "gpt")]);
+        // These providers claim nothing at all.
+        let registry = registry_with(&["anthropic", "openrouter"]);
+
+        let got = resolve_stage_candidates(
+            &cfg,
+            Some("some-new-model"),
+            &ModelDefaults::default(),
+            &registry,
+        );
+
+        assert_eq!(
+            pairs(&got),
+            vec![
+                ("anthropic", "some-new-model"),
+                ("openrouter", "some-new-model")
+            ],
+            "nobody could say, so the entries stand as they did before"
+        );
     }
 
     #[test]

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -100,6 +100,61 @@ impl ProviderRegistry {
         }
     }
 
+    /// Get every model a run is about to use ready, before it starts.
+    ///
+    /// `models` is what the blueprint names, bare and deduplicated. Every
+    /// provider is asked and each takes the ones it serves: the caller does not
+    /// know which model belongs to whom, and a blueprint may name a model with
+    /// no provider at all, which is the case this has to keep working.
+    ///
+    /// Bounded per provider and never fatal. A run whose warm-up timed out is a
+    /// run that starts on the compiled table - the same table it would have used
+    /// if this had never been called - so the failure costs accuracy, not the
+    /// run.
+    ///
+    /// `also` names a script provider to include, for the same reason
+    /// [`prime_capabilities`](Self::prime_capabilities) takes one: a script
+    /// provider is compiled on demand, so the ones on disk are not enumerable
+    /// here, and the machine's default is the one worth the compile.
+    pub async fn warm_models(
+        &self,
+        models: &[String],
+        timeout: std::time::Duration,
+        also: Option<&str>,
+    ) {
+        if models.is_empty() {
+            return;
+        }
+        let mut targets: Vec<(String, Arc<dyn Provider>)> = self
+            .providers
+            .iter()
+            .map(|(name, provider)| (name.clone(), provider.clone()))
+            .collect();
+        if let Some(name) = also
+            && !self.providers.contains_key(name)
+            && let Some(provider) = self.get(name)
+        {
+            targets.push((name.to_string(), provider));
+        }
+        for (name, provider) in targets {
+            match tokio::time::timeout(timeout, provider.warm_models(models)).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!(
+                    provider = %name,
+                    error = %e,
+                    "could not warm this provider's models before the run, so any \
+                     it serves are sized from the table compiled into this build"
+                ),
+                Err(_) => tracing::warn!(
+                    provider = %name,
+                    timeout_secs = timeout.as_secs(),
+                    "timed out warming this provider's models before the run, so \
+                     any it serves are sized from the table compiled into this build"
+                ),
+            }
+        }
+    }
+
     /// Check if a provider is available: registered natively, or resolvable
     /// (loadable) as a script provider right now. Used at stage-model selection;
     /// network-free because script `initialize` runs offline.
@@ -191,10 +246,38 @@ mod tests {
     struct StubProvider {
         primed: Arc<std::sync::atomic::AtomicUsize>,
         outcome: PrimeOutcome,
+        /// Every list this stub was handed to warm, in order.
+        warmed: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+    }
+
+    impl StubProvider {
+        fn new(outcome: PrimeOutcome) -> Self {
+            Self {
+                primed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
+                outcome,
+                warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
+            }
+        }
     }
 
     #[async_trait::async_trait]
     impl Provider for StubProvider {
+        async fn warm_models(&self, models: &[String]) -> Result<(), ProviderError> {
+            self.warmed
+                .lock()
+                .expect("not poisoned")
+                .push(models.to_vec());
+            match self.outcome {
+                PrimeOutcome::Ok => Ok(()),
+                PrimeOutcome::Fails => Err(ProviderError::ApiError("no".to_string())),
+                PrimeOutcome::Hangs => {
+                    // Longer than any timeout a test passes.
+                    tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                    Ok(())
+                }
+            }
+        }
+
         async fn prime_capabilities(&self) -> Result<(), ProviderError> {
             self.primed
                 .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -280,6 +363,7 @@ mod tests {
         Arc::new(StubProvider {
             primed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             outcome: PrimeOutcome::Ok,
+            warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
         })
     }
 
@@ -306,9 +390,71 @@ mod tests {
             Arc::new(StubProvider {
                 primed: primed.clone(),
                 outcome,
+                warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
             }),
             primed,
         )
+    }
+
+    /// Every provider is asked, because the caller does not know which model
+    /// belongs to whom - and a blueprint may name one with no provider at all,
+    /// which is the case this has to keep working.
+    #[tokio::test]
+    async fn warming_asks_every_provider_for_the_whole_list() {
+        let a = Arc::new(StubProvider::new(PrimeOutcome::Ok));
+        let b = Arc::new(StubProvider::new(PrimeOutcome::Ok));
+        let mut registry = ProviderRegistry::new();
+        registry.register("a".to_string(), a.clone());
+        registry.register("b".to_string(), b.clone());
+
+        let models = vec!["one".to_string(), "two".to_string()];
+        registry
+            .warm_models(&models, std::time::Duration::from_secs(5), None)
+            .await;
+
+        for stub in [&a, &b] {
+            let seen = stub.warmed.lock().expect("not poisoned").clone();
+            assert_eq!(seen, vec![models.clone()], "asked once, with everything");
+        }
+    }
+
+    /// Nothing to warm means nobody is disturbed - a run whose blueprint names
+    /// no models should not cost a round of provider calls.
+    #[tokio::test]
+    async fn warming_nothing_asks_nobody() {
+        let stub = Arc::new(StubProvider::new(PrimeOutcome::Ok));
+        let mut registry = ProviderRegistry::new();
+        registry.register("a".to_string(), stub.clone());
+
+        registry
+            .warm_models(&[], std::time::Duration::from_secs(5), None)
+            .await;
+
+        assert!(stub.warmed.lock().expect("not poisoned").is_empty());
+    }
+
+    /// A provider that fails or hangs does not stop the run: warming is an
+    /// improvement on the compiled table, and a run that could not be warmed
+    /// still runs on it.
+    #[tokio::test]
+    async fn a_failing_or_hanging_provider_does_not_block_the_run() {
+        let fails = Arc::new(StubProvider::new(PrimeOutcome::Fails));
+        let hangs = Arc::new(StubProvider::new(PrimeOutcome::Hangs));
+        let mut registry = ProviderRegistry::new();
+        registry.register("fails".to_string(), fails.clone());
+        registry.register("hangs".to_string(), hangs.clone());
+
+        // Returns rather than hanging, which is the whole assertion.
+        registry
+            .warm_models(
+                &["m".to_string()],
+                std::time::Duration::from_millis(50),
+                None,
+            )
+            .await;
+
+        assert_eq!(fails.warmed.lock().expect("not poisoned").len(), 1);
+        assert_eq!(hangs.warmed.lock().expect("not poisoned").len(), 1);
     }
 
     #[tokio::test]
@@ -431,6 +577,55 @@ mod tests {
 
     /// Priming reaches the script provider a machine names as its default, so
     /// it can answer what it serves on the synchronous resolve path (#598).
+    /// A script provider is compiled on demand rather than enumerated, so the
+    /// ones on disk are invisible to the loop above. The machine's default is
+    /// reached the same way priming reaches it - otherwise a run whose models
+    /// live on a local script provider warms everything except the one provider
+    /// that needed it.
+    #[tokio::test]
+    async fn warming_also_reaches_the_named_script_provider() {
+        use crate::script_provider::ScriptProviderLayer;
+        use std::collections::HashMap;
+
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("spark.rhai"),
+            "fn initialize(config) { #{} }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn warm_models(state, models) { if models[0] != \"local-fast\" \
+             { throw \"got \" + models[0] } }\n\
+             fn list_models(state) { [ #{ id: \"local-fast\", display_name: \"F\", \
+             max_context_tokens: 4096, max_output_tokens: 512 } ] }",
+        )
+        .unwrap();
+        let layer = ScriptProviderLayer::new(
+            dir.path().to_path_buf(),
+            HashMap::new(),
+            HashMap::new(),
+            None,
+            Vec::new(),
+        );
+        let reg = ProviderRegistry::new().with_script_layer(Arc::new(layer));
+
+        // The script throws unless it is handed exactly this, and a throw is
+        // swallowed as a warning - so the assertion is that the call reached it
+        // at all, which `serves_model` answering afterwards demonstrates.
+        reg.warm_models(
+            &["local-fast".to_string()],
+            std::time::Duration::from_secs(5),
+            Some("spark"),
+        )
+        .await;
+
+        assert_eq!(
+            reg.get("spark")
+                .expect("resolves")
+                .serves_model("local-fast"),
+            None,
+            "warming does not prime; the two are separate questions"
+        );
+    }
+
     #[tokio::test]
     async fn priming_also_reaches_the_named_script_provider() {
         use crate::script_provider::ScriptProviderLayer;
@@ -501,6 +696,7 @@ mod tests {
         let p = StubProvider {
             primed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
             outcome: PrimeOutcome::Ok,
+            warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
         };
         assert_eq!(p.name(), "stub");
         assert_eq!(p.count_tokens("abcd", "m").await, 4);


### PR DESCRIPTION
Closes the gap left by #607: `/api/ps` reports the real window only for a **loaded** model, and a run's first inference is what loads it — by which point the run has already sized its context.

## Why this is locked in, not corrected later

A stage's percentage region budgets resolve **once, at spawn**, into absolute numbers stored on the blueprint. A wrong window there is what the whole run uses. On this machine that was **131,072 guessed against a real 262,144**.

## The hook

`Provider::warm_models(&[String])`, defaulting to doing nothing — right for every provider whose models are always ready. Ollama overrides it, because it's the one where "ready" is a state the machine has to be put into.

Loading is a `/api/generate` carrying a model and **no prompt** — Ollama's own way to say "load this", answering `done_reason: "load"` having produced no tokens. Measured:

| | |
|---|---|
| cold 32B-class model | **7.9s** |
| already resident | **0.2s** |

So blocking the run on it costs the first run and nothing after.

A model the server hasn't pulled is **skipped, not loaded** — asking Ollama to load one it doesn't hold makes it *download* one, which isn't a thing to start on someone's behalf at the start of a run.

## Where it runs

The spawn preprocessor — the existing seam for async work the sync spawner can't do, already used to warm a blueprint's MCP servers. Awaited for the same reason: arriving after the spawn is arriving after the only moment it could help.

Every provider is handed the whole model list and takes what it serves, because the caller doesn't know which model belongs to whom and a blueprint may name one with **no provider at all**. Bounded per provider, never fatal — a run that couldn't be warmed still runs on the table it would have used anyway.

Script providers get `warm_models(state, models)`.

## Also fixed — found while reading the resolver

A bare `--model` override replaces the model on every entry while leaving each entry's provider alone:

```
blueprint: [{anthropic, sonnet}, {openrouter, gpt}]
lev run --model gpt-5.5
        ↓  anthropic/gpt-5.5   ← nobody asked for this; nothing serves it
```

That pair sat in the fallback list until a failover landed on it and moved the run onto a route that cannot answer.

Now dropped — but **only on a definite no**. If some provider serves the renamed model, who serves it is knowable and one that doesn't is the wrong place to send it. If nobody claims it, nothing here knows better than the entry did. My first version rejected on silence too, and two existing tests caught it — including one named `a_bare_override_renames_the_model_on_every_candidate`, which documents that behaviour deliberately.

## Verification

- The load mechanism, the timings, and `done_reason: "load"` were **probed against a live Ollama** before any of this was written
- Warm/cold behaviour, the not-pulled case, a refused load, an unreachable server, and other providers' models being ignored all covered
- The override fix mutation-checked: reverting it fails the new test, and the guard-rail test for the silence case stays green
- Suite green as CI runs it, clippy clean, structure and docs gates pass, **coverage 13/13 at 100%**

## Known limits

Warming happens per top-level spawn. Fan-out children inherit whatever the parent warmed, which is the common case since they usually share models.

`WARM_KEEP_ALIVE` is 5 minutes — long enough to cover the gap to first inference and the pauses between turns, without pinning memory all day.
