### PR TITLE
fix(update): take out the `serves = []` older builds wrote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ same list.
 
 ## Unreleased
 
+- Fixed: `lev update` removes the `serves = []` that older builds wrote into
+  every `[model_providers.*]` block. The line never meant anything - `serves` is
+  the fallback list a script provider with no `list_models` uses, and an empty
+  one is the same as no entry - but it reads as a declaration that the provider
+  serves nothing, which is exactly what a provider whose `list_models` was never
+  asked looks like from outside. So it took the blame for a routing failure it
+  had no part in.
+- Changed: `serves` distinguishes "not mentioned" from "mentioned as empty".
+  They were one empty `Vec`, which is what made the stale line unremovable: a
+  save-back writes whatever the field holds, and an empty `Vec` writes as
+  `serves = []` however it got there.
+
 - Added: providers are asked to get a run's models ready before it starts, through
   a new `Provider::warm_models` that defaults to doing nothing. Ollama implements
   it, because it is the one provider where "ready" is a state the machine has to

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -339,7 +339,7 @@ fn script_provider_spec(
         script: mp.script.clone(),
         rate_limit: mp.rate_limit.clone(),
         init_config: serde_json::Value::Object(cfg),
-        serves: mp.serves.clone(),
+        serves: mp.serves.clone().unwrap_or_default(),
     }
 }
 
@@ -573,7 +573,7 @@ mod tests {
                 requests_per_minute: 30,
                 tokens_per_minute: 1000,
             }),
-            serves: Vec::new(),
+            serves: None,
             extra,
         };
         let spec = script_provider_spec(&mp);

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -1093,7 +1093,7 @@ mod tests {
                 api_key: Some("sk-secret-value".to_string()),
                 base_url: Some("https://api.groq.com".to_string()),
                 rate_limit: None,
-                serves: Vec::new(),
+                serves: None,
                 extra: [(
                     "signing_secret".to_string(),
                     toml::Value::String("hunter2".to_string()),

--- a/crates/leviath-cli/src/commands/update.rs
+++ b/crates/leviath-cli/src/commands/update.rs
@@ -351,11 +351,45 @@ pub struct Migration {
     pub apply: fn(&mut Config) -> Vec<String>,
 }
 
+/// Why `serves = []` is worth a migration at all.
+///
+/// It never meant anything. `serves` is the model list a script provider with no
+/// `list_models` falls back to, and an empty one is the same as no entry - so the
+/// line has always been inert. It got written because the field serialized even
+/// when empty, and a save-back writes every field, so `lev setup` and every
+/// config migration stamped it into each `[model_providers.*]` block.
+///
+/// Inert is not harmless once somebody is debugging. It reads as a declaration
+/// that the provider serves nothing, which is exactly what a provider whose
+/// `list_models` was never asked looks like from outside - so it got the blame
+/// for a routing failure it had no part in. The real fault was priming, fixed
+/// separately; this removes the thing that pointed at the wrong culprit.
+///
 /// The migrations this build knows about, oldest first.
 ///
-/// Empty, and honestly so: nothing in a released `config.toml` has to change to
-/// work with this version. Adding one is adding an entry here.
-pub const MIGRATIONS: &[Migration] = &[];
+/// Adding one is adding an entry here.
+pub const MIGRATIONS: &[Migration] = &[Migration {
+    name: "stale-empty-serves",
+    description: "remove `serves = []` from [model_providers.*] - it never meant anything",
+    applies: |config, _raw| {
+        config
+            .model_providers
+            .values()
+            .any(|p| p.serves.as_ref().is_some_and(Vec::is_empty))
+    },
+    apply: |config| {
+        let mut done = Vec::new();
+        for (name, provider) in &mut config.model_providers {
+            if provider.serves.as_ref().is_some_and(Vec::is_empty) {
+                provider.serves = None;
+                done.push(format!(
+                    "removed empty `serves` from [model_providers.{name}]"
+                ));
+            }
+        }
+        done
+    },
+}];
 
 // ─── The plan ─────────────────────────────────────────────────────────────────
 

--- a/crates/leviath-cli/src/commands/update/tests.rs
+++ b/crates/leviath-cli/src/commands/update/tests.rs
@@ -634,11 +634,35 @@ fn a_migration_is_selected_by_its_predicate_over_the_config_and_the_raw_toml() {
     assert!(plan(&UpdateArgs::default(), &env).migrations.is_empty());
 }
 
+/// Every shipped migration is named, described, and does nothing to a config
+/// that has already taken it.
+///
+/// This replaced an assertion that the list was empty, which was true until a
+/// released `config.toml` first had something in it worth changing. Emptiness
+/// was never the property worth holding - these are, because a migration ships
+/// forever and runs on every `lev update` after the one that needed it.
 #[test]
-fn the_shipped_migration_list_is_empty_and_that_is_deliberate() {
-    // No released config.toml has to change to work with this build. The list
-    // is the place a future one goes; the tests above prove it would run.
-    assert!(MIGRATIONS.is_empty());
+fn every_shipped_migration_is_named_and_idempotent() {
+    assert!(
+        !MIGRATIONS.is_empty(),
+        "the machinery is exercised by what ships, not only by a sample"
+    );
+    for migration in MIGRATIONS {
+        assert!(!migration.name.is_empty(), "a migration needs a name");
+        assert!(
+            !migration.description.is_empty(),
+            "{}: needs a line saying what it changes",
+            migration.name
+        );
+        // A default config has taken every migration by construction: it is
+        // what a fresh install writes.
+        let fresh = crate::config::Config::default();
+        assert!(
+            !(migration.applies)(&fresh, &toml::Table::new()),
+            "{}: applies to a config that never needed it",
+            migration.name
+        );
+    }
 }
 
 // ─── Rendering ────────────────────────────────────────────────────────────────
@@ -1593,4 +1617,69 @@ fn a_copy_that_is_behind_still_runs_the_upgrade() {
             "a copy that is behind is offered the upgrade"
         );
     });
+}
+
+/// The migration on the shape it was written for: a real config carrying the
+/// stale line, run through `applies` and `apply`, and saved.
+#[test]
+fn the_stale_serves_migration_removes_the_line_and_leaves_the_rest() {
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let path = dir.path().join("config.toml");
+    std::fs::write(
+        &path,
+        "default_provider = \"openrouter\"\n\n\
+         [model_providers.cerebras]\n\
+         base_url = \"https://api.cerebras.ai/v1\"\n\
+         serves = []\n\n\
+         [model_providers.keeps-its-list]\n\
+         serves = [\"a-model\"]\n",
+    )
+    .expect("writes");
+
+    let mut config =
+        crate::config::Config::load_from_path_public(&path).expect("the fixture parses");
+    let raw: toml::Table =
+        toml::from_str(&std::fs::read_to_string(&path).expect("reads")).expect("parses");
+
+    let migration = &crate::commands::update::MIGRATIONS[0];
+    assert!(
+        (migration.applies)(&config, &raw),
+        "a config carrying the stale line needs it"
+    );
+
+    let done = (migration.apply)(&mut config);
+    assert_eq!(done.len(), 1, "one provider changed, not both: {done:?}");
+    assert!(done[0].contains("cerebras"), "{done:?}");
+
+    config.save_to_path_public(&path).expect("saves");
+    let written = std::fs::read_to_string(&path).expect("reads back");
+
+    assert!(
+        !written.contains("serves = []"),
+        "the empty one is gone:\n{written}"
+    );
+    assert!(
+        written.contains("a-model"),
+        "and a real list is untouched:\n{written}"
+    );
+    assert!(
+        written.contains("cerebras"),
+        "as is the provider itself:\n{written}"
+    );
+
+    // Run again and it has nothing to do, which is what makes it safe to keep
+    // shipping after everyone has taken it.
+    let after = crate::config::Config::load_from_path_public(&path).expect("still parses");
+    let raw_after: toml::Table = toml::from_str(&written).expect("parses");
+    assert!(!(migration.applies)(&after, &raw_after));
+}
+
+/// A config that never had the line is left alone entirely.
+#[test]
+fn the_stale_serves_migration_does_not_apply_to_a_clean_config() {
+    let config = crate::config::Config::default();
+    let raw = toml::Table::new();
+    assert!(!(crate::commands::update::MIGRATIONS[0].applies)(
+        &config, &raw
+    ));
 }

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -2712,7 +2712,7 @@ google_api_key = "AIza-existing"
             api_key: Some("gsk-SECRET-VALUE".to_string()),
             base_url: Some("https://api.groq.example".to_string()),
             rate_limit: None,
-            serves: Vec::new(),
+            serves: None,
             extra: HashMap::from([
                 (
                     "org_token".to_string(),

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -161,17 +161,21 @@ pub struct ModelProviderConfig {
     /// the provider claims no models and can only be reached by a blueprint
     /// that pins it, which is what made a local model unreachable however the
     /// machine set `default_provider` (issue #598).
-    /// Serialized even when empty, deliberately. Skipping it would tidy the
-    /// `serves = []` a save-back writes into every provider block - but
-    /// `Config::unknown_config_keys` decides whether a key is read by
-    /// round-tripping the file through serde, on the stated invariant that "a
-    /// field they set is a field that serializes". A field that vanishes when
-    /// empty breaks that: `lev doctor` would report a correctly-spelled
-    /// `serves = []` as a key read by nothing. The line is inert, not harmful -
-    /// what made this provider unreachable was priming, fixed separately - so it
-    /// is not worth breaking that invariant to remove.
-    #[serde(default)]
-    pub serves: Vec<String>,
+    /// `None` when the file does not mention it, `Some` when it does - including
+    /// `Some(vec![])` for an explicit `serves = []`.
+    ///
+    /// The two are different states and were conflated as one empty `Vec`, which
+    /// is what made the stale `serves = []` unremovable: a save-back writes
+    /// whatever the field holds, and an empty `Vec` writes as `serves = []`
+    /// however it got there. `None` writes nothing, which is what lets the
+    /// `stale-empty-serves` migration take the line out.
+    ///
+    /// Skipping `None` does not break the invariant `Config::unknown_config_keys`
+    /// rests on - "a field they set is a field that serializes". A field they set
+    /// is `Some`, and `Some` always serializes, `serves = []` included. `None` is
+    /// the field they did *not* set, which was never in the file to be reported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub serves: Option<Vec<String>>,
 
     /// Any additional keys, forwarded verbatim into the script's `initialize`.
     #[serde(flatten)]


### PR DESCRIPTION
The clean route for the `serves = []` cleanup, after the `skip_serializing_if` version was reverted in #611 for breaking `lev doctor`.

## Why not just stop writing it

`Config::unknown_config_keys` decides whether a key is read by round-tripping the file through serde, on a stated invariant:

> a field they set is a field that serializes

A field that vanishes when empty breaks it — `lev doctor` would report a correctly-spelled `serves = []` as *"read by nothing — check the spelling."* Trading a real diagnostic for a tidy file.

## What actually fixes it

`serves` now distinguishes **"not mentioned"** from **"mentioned as empty."** Those were conflated as one empty `Vec`, and that conflation is what made the line unremovable: a save-back writes whatever the field holds, and an empty `Vec` writes as `serves = []` however it got there.

`None` writes nothing, so a migration can take it out. The invariant still holds — a field they set is `Some`, and `Some` always serializes, `serves = []` included.

Then the migration itself, the first entry in a list that has been empty since it was built.

## Verified on a real config, not a fixture

```
$ lev update --check
  config   1 migration(s)
             stale-empty-serves - remove `serves = []` from [model_providers.*]

$ lev update --yes
    - stale-empty-serves: removed empty `serves` from [model_providers.cerebras]
  wrote ~/.leviath/config.toml
```

The text diff showed a `[model_capabilities.*]` block had **moved**, which is TOML serialization order rather than data movement — so I compared parsed keys instead of lines:

```
keys lost:      1   (model_providers.cerebras.serves)
keys gained:    0
values changed: 0
total:          73 → 72
```

The API key, base URL and model on that provider are all intact.

## A test whose premise expired

`the_shipped_migration_list_is_empty_and_that_is_deliberate` asserted `MIGRATIONS.is_empty()`, with a comment saying no released config had to change. That stopped being true here.

Emptiness was never the property worth holding. It now asserts what is: every shipped migration is **named, described, and does nothing to a config that has already taken it** — which matters because a migration ships forever and runs on every `lev update` after the one that needed it. Idempotency is also checked directly on the real fixture.

## Gates

Suite green as CI runs it, clippy clean, structure and docs gates pass, **coverage 13/13 at 100%** on the first pass.
