### PR TITLE
docs(integrations): tell people how to run Leviath from OpenClaw

### DIFF
--- a/docs/content/agent-client-protocol.md
+++ b/docs/content/agent-client-protocol.md
@@ -88,12 +88,12 @@ carries no field for it.
 ## Permission handling
 
 Hosts that implement the client-side methods advertise capabilities at `initialize`, and the agent
-surfaces tool approvals as `session/request_permission` requests the host answers. Hosts that send
-no capabilities (Gas City sends none) cannot answer such a request, so instead of deadlocking, the
-question is surfaced as output and the turn stays in flight. Answer it from Leviath's own
-surfaces, `lev respond` or `lev dash`, and the run continues; unanswered, it is denied after
-`[limits] interaction_timeout_secs`. Use `--yolo` (or scoped `--allow` flags) to run unattended
-against such a host.
+surfaces tool approvals as `session/request_permission` requests the host answers. OpenClaw's acpx
+backend answers them. Hosts that send no capabilities (Gas City sends none) cannot answer such a
+request, so instead of deadlocking, the question is surfaced as output and the turn stays in
+flight. Answer it from Leviath's own surfaces, `lev respond` or `lev dash`, and the run continues;
+unanswered, it is denied after `[limits] interaction_timeout_secs`. Use `--yolo` (or scoped
+`--allow` flags) to run unattended against such a host.
 
 ## Connecting a host
 
@@ -104,8 +104,8 @@ streams back as the run progresses.
 lev agent-client --agent coder --yolo
 ```
 
-[Gas City](/docs/gas-city) has a page of its own, with the `city.toml` stanza and the timeouts worth
-adjusting.
+[Gas City](/docs/gas-city) and [OpenClaw](/docs/openclaw) have pages of their own, with the config
+each one wants and the settings worth adjusting.
 
 > [!NOTE]
 > Editor integration is a thin front end over the daemon, exactly like `lev run` and `lev serve`. It

--- a/docs/content/containers.md
+++ b/docs/content/containers.md
@@ -3,7 +3,7 @@ title: Containers and CI
 description: Running Leviath as a container-per-job step, and the one thing to get right, that `lev run` returns before the agent finishes.
 group: Integrations
 group_order: 5
-order: 3
+order: 4
 ---
 
 # Running Leviath in a container or CI job

--- a/docs/content/integrations.md
+++ b/docs/content/integrations.md
@@ -8,9 +8,15 @@ order: 1
 
 # Running Leviath under another tool
 
-If you already use an orchestrator like [Gas City](/docs/gas-city) or
-[OpenHands](https://docs.all-hands.dev/), you have something deciding *which* work happens: which
-issue gets picked up, which repo it runs in, who reviews the result. What you plug into it decides *how* one piece of that work actually gets done.
+If you already use an orchestrator, you have something deciding *which* work happens: which issue
+gets picked up, which repo it runs in, who reviews the result. What you plug into it decides *how*
+one piece of that work actually gets done.
+
+Orchestrators come in two shapes here. [Gas City](/docs/gas-city) and
+[OpenHands](https://docs.all-hands.dev/) coordinate coding workflows across repos and issues.
+[OpenClaw](/docs/openclaw) and [Hermes Agent](https://hermes-agent.nousresearch.com/docs/) are
+always-on gateway agents that reach for a coding harness when a task needs one. Both shapes want
+the same thing from Leviath.
 
 That second job is what Leviath is. Your orchestrator keeps doing the coordinating. Leviath takes
 one task and runs it as a multi-stage agent with structured context, its own tools, and whichever
@@ -18,7 +24,7 @@ models you configured.
 
 ```mermaid
 flowchart TD
-  ORCH["Your orchestrator<br/>Gas City / OpenHands / CI"]
+  ORCH["Your orchestrator<br/>Gas City / OpenClaw / OpenHands / Hermes / CI"]
   ORCH -->|"stdio JSON-RPC"| ACP["lev agent-client"]
   ORCH -->|"one process per job"| RUN["lev run"]
   ORCH -->|"HTTP + WebSocket"| API["lev serve"]
@@ -35,7 +41,7 @@ flowchart TD
 
 | You want | Use | Covered in |
 |---|---|---|
-| A host that already speaks the Agent Client Protocol | `lev agent-client` | [Agent Client Protocol](/docs/agent-client-protocol) |
+| A host that already speaks the Agent Client Protocol | `lev agent-client` | [Agent Client Protocol](/docs/agent-client-protocol), [Gas City](/docs/gas-city), [OpenClaw](/docs/openclaw) |
 | One run per job, usually in a container | `lev run` | [CLI reference](/docs/cli) |
 | A long-lived service that several jobs share | `lev serve` | [HTTP API](/docs/api) |
 | Leviath inside your own Rust program | the `leviath` crate | [Embedding](/docs/embedding) |
@@ -45,12 +51,18 @@ JSON-RPC over its stdin and stdout, use `lev agent-client`, because you get stre
 in-turn tool approvals for free. If it thinks in terms of "run this command in this container until
 it exits", use `lev run`.
 
+Not every host can speak it. Hermes Agent implements the
+[Agent Client Protocol as a server](https://hermes-agent.nousresearch.com/docs/user-guide/features/acp)
+rather than a client, so it reaches Leviath the second way, through its terminal tool running
+`lev run`.
+
 ## Three things worth knowing up front
 
 **Approvals need somewhere to go.** By default Leviath asks before a tool call that changes
 something. Under an orchestrator there is usually nobody there to answer, so a run would stop and
 wait indefinitely. Either run with `--yolo`, or list the specific tools you trust with `--allow`.
-The [Gas City page](/docs/gas-city) covers what this looks like in practice.
+The [Gas City](/docs/gas-city) and [OpenClaw](/docs/openclaw) pages cover both cases, the host that
+cannot answer and the host that answers with a default you may not want.
 
 **The daemon outlives your command.** `lev run` hands the agent to a background
 [daemon](/docs/daemon) and returns. In a container that exits as soon as the command finishes, that

--- a/docs/content/openclaw.md
+++ b/docs/content/openclaw.md
@@ -1,0 +1,173 @@
+---
+title: OpenClaw
+description: Wiring Leviath into OpenClaw as a custom acpx harness, so a gateway agent can hand one task to a multi-stage run.
+group: Integrations
+group_order: 5
+order: 3
+---
+
+# Running Leviath from OpenClaw
+
+[OpenClaw](https://docs.openclaw.ai/) is an open-source gateway agent. It runs as a persistent
+daemon, connects to messaging platforms like Slack, Discord, and Telegram, keeps memory across
+sessions, and schedules recurring work. Those are the parts Leviath does not do.
+
+OpenClaw also runs external coding harnesses over the
+[Agent Client Protocol](/docs/agent-client-protocol), which Leviath speaks. So this is a
+configuration change on the OpenClaw side, not an adapter you have to write.
+
+## The vocabulary
+
+Three OpenClaw words show up below. The **gateway** is the single process everything flows through.
+A **harness** is an external coding agent OpenClaw drives instead of answering in its own loop.
+**acpx** is the plugin that talks to those harnesses. OpenClaw's
+[harness documentation](https://docs.openclaw.ai/tools/acp-agents) covers all three properly.
+
+## Register Leviath with acpx
+
+acpx keeps its own registry of harnesses in `~/.acpx/config.json`. Add Leviath to it:
+
+```json
+{
+  "agents": {
+    "leviath": {
+      "command": "lev",
+      "args": ["agent-client", "--agent", "coder"]
+    }
+  }
+}
+```
+
+Per acpx's [custom agents guide](https://github.com/openclaw/acpx/blob/main/docs/custom-agents.md),
+a name you define wins over the built-in registry, so `leviath` is yours to claim. A repository can
+override the same map in its own `.acpxrc.json`.
+
+## Let OpenClaw use it
+
+OpenClaw reads `~/.openclaw/openclaw.json`, in JSON5, so comments and trailing commas are fine. The
+`acp` block decides which harnesses are reachable at all:
+
+```json5
+{
+  acp: {
+    enabled: true,
+    backend: "acpx",
+    defaultAgent: "leviath",
+    allowedAgents: ["leviath"],
+  },
+}
+```
+
+`allowedAgents` is an allowlist. A name missing from it is refused even when acpx knows it. Then
+point an OpenClaw agent at that runtime:
+
+```json5
+{
+  agents: {
+    entries: {
+      builder: {
+        runtime: {
+          type: "acp",
+          acp: { agent: "leviath" },
+        },
+      },
+    },
+  },
+}
+```
+
+`runtime.acp.cwd` sets the directory the session opens in. Leviath takes it as the run's working
+directory, so it is also what the file tools are confined to.
+
+## Approvals have somewhere to go here
+
+By default Leviath asks before a tool call that changes something. Where that question goes depends
+on what the host advertised during the protocol's `initialize` handshake.
+
+acpx answers it. Its [permissions guide](https://github.com/openclaw/acpx/blob/main/docs/permissions.md)
+gives three modes. `--approve-reads` auto-approves reads and prompts for everything else, and is the
+default. `--approve-all` approves everything. `--deny-all` refuses everything.
+
+The default is the one to plan around. Nobody is sitting at a prompt during a gateway turn, so an
+escalated request is denied for that turn. A run that wanted to write a file gets a no and carries
+on without it. acpx exits with code 5 when every request was denied and none approved, which is how
+you spot it from outside.
+
+The fix that travels with your config is on the Leviath side, because it lives in the `args` you
+already declared. Name the tools you are happy to run unattended:
+
+```json
+{
+  "agents": {
+    "leviath": {
+      "command": "lev",
+      "args": [
+        "agent-client", "--agent", "coder",
+        "--allow", "read_file",
+        "--allow", "list_dir",
+        "--allow", "shell"
+      ]
+    }
+  }
+}
+```
+
+`--yolo` in place of those flags approves every tool call instead. Neither one can lift a `deny` in
+your Leviath config, which stays authoritative. Running `acpx` yourself, `--approve-all` gets you
+the same result from the other end.
+
+[Security](/docs/security) covers the policy those flags sit on top of, and
+[Interaction](/docs/interaction) covers what a parked question looks like from Leviath's side.
+
+## Choosing which agent runs
+
+`--agent coder` pins one blueprint for every session using that acpx entry. Declare one entry per
+blueprint when you want the choice to be OpenClaw's:
+
+```json
+{
+  "agents": {
+    "leviath-coder": {
+      "command": "lev",
+      "args": ["agent-client", "--agent", "coder", "--yolo"]
+    },
+    "leviath-reviewer": {
+      "command": "lev",
+      "args": ["agent-client", "--agent", "reviewer", "--yolo"]
+    }
+  }
+}
+```
+
+Add both names to `allowedAgents`, then set `runtime.acp.agent` per OpenClaw agent.
+
+Drop `--agent` entirely and Leviath looks for an `agent.leviath` in the session's working directory
+instead. That is the better default when different projects want different blueprints.
+
+## Checking it works
+
+Three steps, each proving one link in the chain. Run them in order, because a failure at step two
+tells you nothing about step three.
+
+```bash
+lev agent-client --agent coder --yolo   # 1. does Leviath start
+acpx leviath "list the files here"      # 2. does the acpx name resolve
+```
+
+Step one looks like a hang and is not one. The command is waiting for JSON-RPC on stdin, and its
+diagnostics go to stderr, because stdout belongs to the protocol. Stop it with Ctrl-C.
+
+Step three is a prompt from OpenClaw itself, sent to an agent whose `runtime.acp.agent` is
+`leviath`. Output streams back as the run progresses.
+
+If a turn connects and then goes quiet, the run is most likely parked on a tool approval. Answer it
+with `lev respond`, or widen the approvals as described above.
+
+## What Leviath does not bring
+
+OpenClaw keeps doing what it is for, and Leviath does not duplicate it. Leviath has no view of your
+channels, no memory that outlives a run, no scheduler, and no way to reach Slack or Telegram.
+Sub-agents and fan-out happen inside one Leviath run, not across your gateway.
+
+Adding Leviath pays off when the hard part is what happens inside a single task. If the hard part is
+being reachable, remembering, and picking the moment, that is OpenClaw's job and it is better at it.

--- a/docs/content/work-queues.md
+++ b/docs/content/work-queues.md
@@ -3,7 +3,7 @@ title: External work queues
 description: Poll lev ps --all --json to tell a live run from a dead one, without leaking slots or cancelling work that is still going.
 group: Integrations
 group_order: 5
-order: 4
+order: 5
 ---
 
 # Driving Leviath from an external work queue


### PR DESCRIPTION
## What

Adds `docs/content/openclaw.md`, an integration page for [OpenClaw](https://docs.openclaw.ai/), and
widens the integrations hub past Gas City, OpenHands, and CI.

## Why

The hub page named three hosts and only Gas City had a page. OpenClaw and Hermes Agent are a
different shape from those three: always-on gateway agents that reach for a coding harness when a
task needs one. Naming them widens who the page speaks to.

## Can Leviath actually be hooked into either one today

**OpenClaw: yes, with no change on our side.** It runs external coding harnesses over the Agent
Client Protocol through its `acpx` backend, which Leviath already speaks. The wiring is two config
files on OpenClaw's side:

* `~/.acpx/config.json` registers a `leviath` agent pointing at `lev agent-client`. Per [acpx's
  custom agents guide](https://github.com/openclaw/acpx/blob/main/docs/custom-agents.md), a name you
  define wins over the built-in registry.
* `~/.openclaw/openclaw.json` allowlists it with `acp.allowedAgents` and selects it with
  `runtime.acp.agent`, per the [setup
  doc](https://github.com/openclaw/openclaw/blob/main/docs/tools/acp-agents-setup.md).

One thing differs enough from Gas City to get its own section. `acpx` **answers**
`session/request_permission`, and its default `--approve-reads` denies writes for a non-interactive
gateway turn, exiting 5 when everything was denied
([permissions](https://github.com/openclaw/acpx/blob/main/docs/permissions.md)). Gas City sends no
capabilities and the question parks instead. Same protocol, opposite failure mode, so the `--yolo`
advice is restated rather than copied.

**Hermes: not cleanly, and the gap is on our side.** It implements the protocol as a
[server only](https://hermes-agent.nousresearch.com/docs/user-guide/features/acp); client mode is an
open unassigned request (NousResearch/hermes-agent#36057, #5257). Its other clean hook would be MCP,
and `crates/leviath-mcp/` is client-only: no `server.rs`, no `ServerCapabilities`, no request
dispatcher. What works today is its terminal tool running `lev run --json`, the shape
`work-queues.md` already documents. So Hermes gets a mention and a diagram node, not a page.

## One step the upstream docs do not settle

Whether OpenClaw's acpx backend passes an unknown agent id through to `acpx`. Issue
[#40274](https://github.com/openclaw/openclaw/issues/40274) claimed it only accepted built-in ids,
and the PR that would have added an `agentCommand` key was closed unmerged, but the acpx
custom-agent registry postdates both. So "Checking it works" is staged into three commands, and
`acpx leviath "..."` on its own isolates exactly that link before OpenClaw is involved.

## Changes

* `docs/content/openclaw.md`, new, order 3, modelled on `gas-city.md`.
* `integrations.md`: orchestrators split into coding-workflow tools and always-on gateway agents,
  the mermaid node gains OpenClaw and Hermes, and two sourced sentences say how Hermes reaches
  Leviath.
* `agent-client-protocol.md`: notes acpx answers permission requests, and points at both integration
  pages.
* `containers.md` 3 to 4, `work-queues.md` 4 to 5, since `order` is unique per group.

## Verification

* `cargo xtask docs` passes: 40 pages, 3 schemas, no problems.
* `lev agent-client --agent coder --yolo` verified to behave as the page describes: it holds on
  stdin, stdout stays empty, diagnostics go to stderr.
* Every claim about OpenClaw, acpx, and Hermes is sourced to that project's own docs and linked.
* The OpenClaw half of the recipe is for @GEMISIS to try against a real install.

Docs only. No Rust changes.
