### PR TITLE
feat(providers): say what a failed call actually was

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,11 @@ same list.
   provider" covered four different problems with four different remedies. The
   kind is now worked out where the typed error still exists, carried in the
   message so it survives every layer that only passes strings, and logged as a
-  `failure_kind` field. HTTP statuses are split too: a 404 (usually a `base_url`
-  path or a model that is not there) reads differently from a 400, and both
-  differently from a 5xx.
+  `failure_kind` field. A refusal is placed by the socket error underneath it
+  rather than by its wording, so Windows, macOS and Linux all name it the same
+  thing. HTTP statuses are split too: a 404 (usually a `base_url` path or a model
+  that is not there) reads differently from a 400, and both differently from a
+  5xx.
 - Added: a Rhai provider can supply `failure_kind` alongside `kind` when it
   throws. `kind` says how the runtime should treat the failure; `failure_kind`
   says what it was. A name this build does not know is ignored rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ same list.
 
 ## Unreleased
 
+- Added: a failed provider call says what actually went wrong. Every transport
+  failure used to arrive as one string, and `Display` on a `reqwest` error says
+  the same sentence whether the hostname did not resolve, the port refused, the
+  certificate was not trusted, or the request timed out - so "could not reach the
+  provider" covered four different problems with four different remedies. The
+  kind is now worked out where the typed error still exists, carried in the
+  message so it survives every layer that only passes strings, and logged as a
+  `failure_kind` field. HTTP statuses are split too: a 404 (usually a `base_url`
+  path or a model that is not there) reads differently from a 400, and both
+  differently from a 5xx.
+- Added: a Rhai provider can supply `failure_kind` alongside `kind` when it
+  throws. `kind` says how the runtime should treat the failure; `failure_kind`
+  says what it was. A name this build does not know is ignored rather than
+  refused, so a script written against a later version still runs.
+
 - Fixed: `lev update` removes the `serves = []` that older builds wrote into
   every `[model_providers.*]` block. The line never meant anything - `serves` is
   the fallback list a script provider with no `list_models` uses, and an empty

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -520,7 +520,7 @@ impl AnthropicProvider {
             .json(&body)
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("sending the request", &e))?;
         let response = crate::provider::check_http_response(response, None).await?;
         let value: serde_json::Value = crate::provider::decode_json(response).await?;
         value
@@ -911,7 +911,7 @@ impl Provider for AnthropicProvider {
             .header("anthropic-version", "2023-06-01")
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("listing models", &e))?;
 
         // Shared classification here too. `is_transient` treats
         // `RequestFailed` as retryable, so classifying by status is what keeps
@@ -922,7 +922,7 @@ impl Provider for AnthropicProvider {
         let body: serde_json::Value = response
             .json()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("reaching the provider", &e))?;
 
         let data = body.get("data").and_then(|d| d.as_array()).ok_or_else(|| {
             ProviderError::RequestFailed("missing 'data' field in /models response".to_string())

--- a/crates/leviath-providers/src/failure.rs
+++ b/crates/leviath-providers/src/failure.rs
@@ -1,0 +1,403 @@
+//! What a failed provider call actually was.
+//!
+//! Separate from [`crate::provider`] for the same reason [`crate::capabilities`]
+//! is: that module is how a provider is *called*, this one is what came back
+//! when the call did not work. They meet where a `ProviderError` carries a
+//! [`FailureKind`].
+
+use serde::{Deserialize, Serialize};
+
+use crate::provider::ProviderError;
+
+/// What actually went wrong when a provider call failed, at the granularity a
+/// person debugging it needs.
+///
+/// The remedy differs per variant and nothing else in the error carries it. A
+/// failed call used to arrive as one of two strings - a transport failure or an
+/// HTTP status - and "could not reach the provider" covered a wrong base URL, a
+/// firewall, an expired certificate and a laptop that had gone to sleep. Each
+/// wants a different thing done about it, and the message was the same.
+///
+/// Recorded on the error, logged as a field, and reported by the API, so the
+/// question "was that my key, my URL, or their outage" has an answer that does
+/// not require reading a raw provider body.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FailureKind {
+    /// The name did not resolve. A typo in a base URL, or no DNS at all.
+    DnsFailure,
+    /// The host resolved and refused, or nothing was listening. A local
+    /// provider that is not running, or a port that is wrong.
+    ConnectionRefused,
+    /// The TLS handshake failed: an expired or untrusted certificate, or a
+    /// proxy intercepting the connection with its own.
+    TlsFailure,
+    /// The request went out and no answer came back in time. Distinct from a
+    /// refusal: something is listening and is either slow or wedged.
+    Timeout,
+    /// The connection died mid-body. The provider answered and the answer did
+    /// not finish arriving.
+    ConnectionDropped,
+    /// A transport failure this build cannot place more precisely.
+    Transport,
+    /// The provider answered, and the answer says the fault is ours: a
+    /// malformed request, an unknown parameter, a model name it does not carry.
+    /// Retrying unchanged produces the same answer.
+    BadRequest,
+    /// The provider answered 404. Almost always a base URL pointing at the
+    /// wrong path, or a model that does not exist on this endpoint - and worth
+    /// its own variant because it reads as "the provider is broken" when it is
+    /// usually a line of config.
+    NotFound,
+    /// The provider answered 5xx. Their fault, not ours, and the same request
+    /// may well work in a minute.
+    ServerError,
+    /// The provider answered something this build could not parse.
+    MalformedResponse,
+}
+
+impl FailureKind {
+    /// A short, stable label for logs, metrics attributes and the API.
+    pub fn label(self) -> &'static str {
+        match self {
+            FailureKind::DnsFailure => "dns-failure",
+            FailureKind::ConnectionRefused => "connection-refused",
+            FailureKind::TlsFailure => "tls-failure",
+            FailureKind::Timeout => "timeout",
+            FailureKind::ConnectionDropped => "connection-dropped",
+            FailureKind::Transport => "transport",
+            FailureKind::BadRequest => "bad-request",
+            FailureKind::NotFound => "not-found",
+            FailureKind::ServerError => "server-error",
+            FailureKind::MalformedResponse => "malformed-response",
+        }
+    }
+
+    /// What to do about it, in one line, for whoever has to fix it.
+    pub fn remedy(self) -> &'static str {
+        match self {
+            FailureKind::DnsFailure => {
+                "the provider's hostname did not resolve - check `base_url` for a typo, and \
+                 that this machine has DNS"
+            }
+            FailureKind::ConnectionRefused => {
+                "nothing accepted the connection - check the provider is running and that \
+                 `base_url` names the right port"
+            }
+            FailureKind::TlsFailure => {
+                "the TLS handshake failed - an expired or untrusted certificate, or a proxy \
+                 presenting its own"
+            }
+            FailureKind::Timeout => {
+                "the provider did not answer in time - it is reachable but slow or wedged; \
+                 `request_timeout_secs` raises the wait"
+            }
+            FailureKind::ConnectionDropped => {
+                "the connection died before the answer finished arriving"
+            }
+            FailureKind::Transport => "the provider could not be reached",
+            FailureKind::BadRequest => {
+                "the provider rejected the request itself - a parameter it does not accept, \
+                 or a model name it does not carry"
+            }
+            FailureKind::NotFound => {
+                "the endpoint answered 404 - usually `base_url` pointing at the wrong path, \
+                 or a model that does not exist there"
+            }
+            FailureKind::ServerError => {
+                "the provider's own endpoint failed; this may pass on a retry"
+            }
+            FailureKind::MalformedResponse => {
+                "the provider answered with something this build could not parse"
+            }
+        }
+    }
+
+    /// Place a `reqwest` failure, which knows more than its `Display` says.
+    ///
+    /// Every one of these arrived as `RequestFailed(e.to_string())` and read as
+    /// the same thing. `reqwest` distinguishes them and the information was
+    /// being thrown away one line after it was available.
+    pub fn from_reqwest(e: &reqwest::Error) -> Self {
+        if e.is_timeout() {
+            return FailureKind::Timeout;
+        }
+        if e.is_body() || e.is_decode() {
+            return FailureKind::ConnectionDropped;
+        }
+        if e.is_connect() {
+            // `is_connect` covers everything that failed before a request was
+            // sent, so the cause chain is what separates a name that did not
+            // resolve from a certificate that was not trusted. Matched on text
+            // because the concrete error types live in private dependencies of
+            // `reqwest` and are not nameable from here.
+            //
+            // Only the phrases these libraries actually emit, taken from real
+            // failures rather than guessed. An earlier version of this looked
+            // for "tls" and "certificate" and caught neither: rustls answers a
+            // plaintext port with "received corrupt message of type
+            // invalidcontenttype", which contains no word anyone would think to
+            // search for.
+            //
+            // Anything unrecognised stays `Transport` rather than being folded
+            // into the nearest guess. A wrong remedy sends somebody to check
+            // their certificates when the port was closed, which is worse than
+            // "could not be reached".
+            return connect_failure(&error_chain_text(e));
+        }
+        FailureKind::Transport
+    }
+
+    /// Place an HTTP status the provider answered with.
+    ///
+    /// Only the statuses that are not already an [`crate::provider::UnavailableReason`]: 401,
+    /// 402, 403 and 429 are handled before this is reached, because they mean
+    /// the provider is unusable rather than that one request went wrong.
+    pub fn from_status(status: u16) -> Self {
+        match status {
+            404 => FailureKind::NotFound,
+            500..=599 => FailureKind::ServerError,
+            _ => FailureKind::BadRequest,
+        }
+    }
+}
+
+/// Place a connect-stage failure by what its cause chain says.
+///
+/// A free function taking the text, so every arm is reachable from a test: a
+/// chain that matches nothing cannot be produced from a real socket on demand,
+/// and it is the arm that most needs to be right - it is what stops an
+/// unrecognised failure being folded into the nearest guess.
+///
+/// The phrases are ones these libraries actually emit, taken from real failures.
+/// An earlier version looked for "tls" and "certificate" and caught neither:
+/// rustls answers a plaintext port with "received corrupt message of type
+/// invalidcontenttype", which contains no word anyone would think to search for.
+fn connect_failure(chain: &str) -> FailureKind {
+    const DNS: [&str; 3] = [
+        "dns error",
+        "failed to lookup address",
+        "name or service not known",
+    ];
+    const TLS: [&str; 6] = [
+        "certificate",
+        "corrupt message",
+        "handshake",
+        "tls",
+        "unknown issuer",
+        "protocol version",
+    ];
+    const REFUSED: [&str; 3] = ["connection refused", "os error 61", "os error 111"];
+
+    if DNS.iter().any(|p| chain.contains(p)) {
+        return FailureKind::DnsFailure;
+    }
+    if TLS.iter().any(|p| chain.contains(p)) {
+        return FailureKind::TlsFailure;
+    }
+    if REFUSED.iter().any(|p| chain.contains(p)) {
+        return FailureKind::ConnectionRefused;
+    }
+    // Deliberately not "probably refused". A wrong remedy sends somebody to
+    // check their certificates when the port was closed, which is worse than
+    // "could not be reached".
+    FailureKind::Transport
+}
+
+/// Every message in an error's cause chain, lowercased and joined.
+///
+/// `Display` on a `reqwest::Error` says only the outermost layer, which for a
+/// connection failure is the same sentence whatever went wrong underneath. What
+/// separates a DNS failure from a refused connection is further down.
+fn error_chain_text(e: &dyn std::error::Error) -> String {
+    let mut text = e.to_string().to_ascii_lowercase();
+    let mut source = e.source();
+    while let Some(cause) = source {
+        text.push_str(" | ");
+        text.push_str(&cause.to_string().to_ascii_lowercase());
+        source = cause.source();
+    }
+    text
+}
+
+impl ProviderError {
+    /// A transport failure, with what `reqwest` knew about it kept.
+    ///
+    /// Every one of these used to be `RequestFailed(e.to_string())`, and
+    /// `Display` on a `reqwest::Error` says the same sentence for a hostname
+    /// that does not resolve, a port with nothing behind it, and a certificate
+    /// nobody trusts. The kind is worked out here, where the typed error still
+    /// exists, and carried in the message so it survives every layer that only
+    /// passes strings.
+    pub fn transport(context: &str, e: &reqwest::Error) -> Self {
+        let kind = FailureKind::from_reqwest(e);
+        ProviderError::RequestFailed(format!(
+            "[{}] {context}: {e} - {}",
+            kind.label(),
+            kind.remedy()
+        ))
+    }
+
+    /// The kind this error carries, when it names one.
+    ///
+    /// Read back out of the message rather than held in a field: these errors
+    /// cross into a Rhai script and back as plain strings, and a field would be
+    /// lost at that boundary while a prefix survives it.
+    pub fn failure_kind(&self) -> Option<FailureKind> {
+        let message = match self {
+            ProviderError::RequestFailed(m) | ProviderError::ApiError(m) => m,
+            ProviderError::InvalidResponse(_) => return Some(FailureKind::MalformedResponse),
+            _ => return None,
+        };
+        let label = message.strip_prefix('[')?.split_once(']')?.0;
+        [
+            FailureKind::DnsFailure,
+            FailureKind::ConnectionRefused,
+            FailureKind::TlsFailure,
+            FailureKind::Timeout,
+            FailureKind::ConnectionDropped,
+            FailureKind::Transport,
+            FailureKind::BadRequest,
+            FailureKind::NotFound,
+            FailureKind::ServerError,
+            FailureKind::MalformedResponse,
+        ]
+        .into_iter()
+        .find(|k| k.label() == label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::build_http_client;
+
+    /// A host that accepts the connection and never answers is a timeout, not a
+    /// refusal - something is listening, it is just not replying. Told apart
+    /// because the remedies differ: one is "check it is running", the other is
+    /// "it is running and stuck".
+    #[tokio::test]
+    async fn a_server_that_never_answers_is_a_timeout() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("binds");
+        let addr = listener.local_addr().expect("has an address");
+        // Accept and hold, writing nothing.
+        std::thread::spawn(move || {
+            let _held = listener.accept();
+            std::thread::sleep(std::time::Duration::from_secs(30));
+        });
+
+        let client = build_http_client(Some(1)).expect("a client builds");
+        let e = client
+            .get(format!("http://{addr}/v1/models"))
+            .send()
+            .await
+            .expect_err("times out");
+
+        assert_eq!(FailureKind::from_reqwest(&e), FailureKind::Timeout);
+    }
+
+    /// TLS spoken to a plain HTTP port fails the handshake, which is its own
+    /// remedy - a certificate or a proxy, not a wrong port.
+    #[tokio::test]
+    async fn a_failed_handshake_is_told_from_a_refusal() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("binds");
+        let addr = listener.local_addr().expect("has an address");
+        std::thread::spawn(move || {
+            // Accept and answer plaintext, so the handshake fails rather than
+            // the connection being refused.
+            use std::io::Write;
+            let mut socket = listener.accept().expect("the client connects").0;
+            let _ = socket.write_all(b"HTTP/1.1 200 OK\r\n\r\n");
+        });
+
+        let client = build_http_client(Some(5)).expect("a client builds");
+        let e = client
+            .get(format!("https://{addr}/v1/models"))
+            .send()
+            .await
+            .expect_err("the handshake fails");
+
+        assert_eq!(FailureKind::from_reqwest(&e), FailureKind::TlsFailure);
+    }
+
+    /// A message whose bracket never closes is not a prefix, and must not be
+    /// read as one.
+    #[test]
+    fn an_unterminated_prefix_names_no_kind() {
+        assert_eq!(
+            ProviderError::RequestFailed("[never-closed and then some".to_string()).failure_kind(),
+            None
+        );
+    }
+}
+
+#[cfg(test)]
+mod connect_failure_tests {
+    use super::{FailureKind, connect_failure};
+
+    /// Each family, by a phrase these libraries really emit.
+    #[test]
+    fn each_recognised_family_is_placed() {
+        for chain in [
+            "client error (connect) | dns error: failed to lookup address information",
+            "name or service not known",
+        ] {
+            assert_eq!(connect_failure(chain), FailureKind::DnsFailure, "{chain}");
+        }
+        for chain in [
+            "received corrupt message of type invalidcontenttype",
+            "invalid peer certificate: unknown issuer",
+            "handshake failed",
+            "tls error",
+            "peer misbehaved: protocol version",
+        ] {
+            assert_eq!(connect_failure(chain), FailureKind::TlsFailure, "{chain}");
+        }
+        for chain in [
+            "tcp connect error: connection refused (os error 61)",
+            "os error 111",
+        ] {
+            assert_eq!(
+                connect_failure(chain),
+                FailureKind::ConnectionRefused,
+                "{chain}"
+            );
+        }
+    }
+
+    /// The arm that matters most and cannot be produced from a real socket: a
+    /// failure this build does not recognise stays `Transport` rather than being
+    /// folded into the nearest guess, because a wrong remedy is worse than a
+    /// vague one.
+    #[test]
+    fn an_unrecognised_chain_is_not_guessed_at() {
+        assert_eq!(
+            connect_failure("something nobody here has seen before"),
+            FailureKind::Transport
+        );
+        assert_eq!(connect_failure(""), FailureKind::Transport);
+    }
+}
+
+#[cfg(test)]
+mod fallthrough_tests {
+    use super::FailureKind;
+    use crate::provider::build_http_client;
+
+    /// Not every `reqwest` failure is one of the four this can place. A request
+    /// the builder refuses outright is none of them, and lands on the honest
+    /// answer rather than the nearest one.
+    #[tokio::test]
+    async fn a_failure_that_is_none_of_the_known_shapes_stays_transport() {
+        let client = build_http_client(Some(2)).expect("a client builds");
+        // A scheme with no handler: refused before any connection is attempted,
+        // so it is neither a timeout, a body, nor a connect failure.
+        let e = client
+            .get("ftp://example.invalid/models")
+            .send()
+            .await
+            .expect_err("the builder refuses it");
+
+        assert_eq!(FailureKind::from_reqwest(&e), FailureKind::Transport);
+    }
+}

--- a/crates/leviath-providers/src/failure.rs
+++ b/crates/leviath-providers/src/failure.rs
@@ -132,18 +132,11 @@ impl FailureKind {
             // because the concrete error types live in private dependencies of
             // `reqwest` and are not nameable from here.
             //
-            // Only the phrases these libraries actually emit, taken from real
-            // failures rather than guessed. An earlier version of this looked
-            // for "tls" and "certificate" and caught neither: rustls answers a
-            // plaintext port with "received corrupt message of type
-            // invalidcontenttype", which contains no word anyone would think to
-            // search for.
-            //
             // Anything unrecognised stays `Transport` rather than being folded
             // into the nearest guess. A wrong remedy sends somebody to check
             // their certificates when the port was closed, which is worse than
             // "could not be reached".
-            return connect_failure(&error_chain_text(e));
+            return connect_failure(io_error_kind(e), &error_chain_text(e));
         }
         FailureKind::Transport
     }
@@ -162,22 +155,49 @@ impl FailureKind {
     }
 }
 
-/// Place a connect-stage failure by what its cause chain says.
+/// The `std::io::ErrorKind` underneath a `reqwest` failure, when there is one.
 ///
-/// A free function taking the text, so every arm is reachable from a test: a
-/// chain that matches nothing cannot be produced from a real socket on demand,
-/// and it is the arm that most needs to be right - it is what stops an
-/// unrecognised failure being folded into the nearest guess.
+/// A refused connection arrives as a real `io::Error` three layers down the
+/// cause chain, and its `kind()` is the same value on every platform. The text
+/// is not: the same refusal reads "connection refused (os error 61)" on macOS,
+/// "os error 111" on Linux, and "No connection could be made because the target
+/// machine actively refused it. (os error 10061)" on Windows. Matching on the
+/// kind is what makes this classifier say the same thing on all three.
+fn io_error_kind(e: &(dyn std::error::Error + 'static)) -> Option<std::io::ErrorKind> {
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(e);
+    while let Some(cause) = source {
+        if let Some(io) = cause.downcast_ref::<std::io::Error>() {
+            return Some(io.kind());
+        }
+        source = cause.source();
+    }
+    None
+}
+
+/// Place a connect-stage failure, by its `io::ErrorKind` where it has one and
+/// by what its cause chain says where it does not.
 ///
-/// The phrases are ones these libraries actually emit, taken from real failures.
-/// An earlier version looked for "tls" and "certificate" and caught neither:
-/// rustls answers a plaintext port with "received corrupt message of type
-/// invalidcontenttype", which contains no word anyone would think to search for.
-fn connect_failure(chain: &str) -> FailureKind {
-    const DNS: [&str; 3] = [
+/// A free function taking both, so every arm is reachable from a test: a chain
+/// that matches nothing cannot be produced from a real socket on demand, and it
+/// is the arm that most needs to be right - it is what stops an unrecognised
+/// failure being folded into the nearest guess.
+///
+/// The kind is tried first because it is portable. Text is the fallback, and it
+/// carries the cases the standard library has no kind for - a name that did not
+/// resolve and a handshake that failed both arrive as `Uncategorized` or as no
+/// `io::Error` at all. Those phrases are ones these libraries really emit, taken
+/// from measured failures: an earlier version looked for "tls" and "certificate"
+/// and caught neither, because rustls answers a plaintext port with "received
+/// corrupt message of type invalidcontenttype", which contains no word anyone
+/// would think to search for.
+fn connect_failure(io: Option<std::io::ErrorKind>, chain: &str) -> FailureKind {
+    use std::io::ErrorKind;
+
+    const DNS: [&str; 4] = [
         "dns error",
         "failed to lookup address",
         "name or service not known",
+        "no such host is known",
     ];
     const TLS: [&str; 6] = [
         "certificate",
@@ -187,15 +207,25 @@ fn connect_failure(chain: &str) -> FailureKind {
         "unknown issuer",
         "protocol version",
     ];
-    const REFUSED: [&str; 3] = ["connection refused", "os error 61", "os error 111"];
 
+    // A name that did not resolve can surface with a socket error underneath it
+    // on some stacks, so the text is asked first where it is unambiguous.
     if DNS.iter().any(|p| chain.contains(p)) {
         return FailureKind::DnsFailure;
+    }
+    match io {
+        Some(ErrorKind::ConnectionRefused) => return FailureKind::ConnectionRefused,
+        Some(ErrorKind::TimedOut) => return FailureKind::Timeout,
+        Some(ErrorKind::ConnectionReset | ErrorKind::ConnectionAborted) => {
+            return FailureKind::ConnectionDropped;
+        }
+        _ => {}
     }
     if TLS.iter().any(|p| chain.contains(p)) {
         return FailureKind::TlsFailure;
     }
-    if REFUSED.iter().any(|p| chain.contains(p)) {
+    // Kept for a stack that reports a refusal with no `io::Error` to read.
+    if chain.contains("connection refused") || chain.contains("actively refused") {
         return FailureKind::ConnectionRefused;
     }
     // Deliberately not "probably refused". A wrong remedy sends somebody to
@@ -308,6 +338,11 @@ mod tests {
             use std::io::Write;
             let mut socket = listener.accept().expect("the client connects").0;
             let _ = socket.write_all(b"HTTP/1.1 200 OK\r\n\r\n");
+            // Held open. Returning here closes the socket, and a close with the
+            // client's handshake still unread sends a reset that discards the
+            // bytes just written - so rustls would report a dropped connection
+            // rather than the plaintext it was meant to choke on.
+            std::thread::sleep(std::time::Duration::from_secs(30));
         });
 
         let client = build_http_client(Some(5)).expect("a client builds");
@@ -333,16 +368,105 @@ mod tests {
 
 #[cfg(test)]
 mod connect_failure_tests {
-    use super::{FailureKind, connect_failure};
+    use super::{FailureKind, connect_failure, error_chain_text, io_error_kind};
+    use std::io::ErrorKind;
 
-    /// Each family, by a phrase these libraries really emit.
+    /// An error with nothing socket-shaped anywhere in its chain, which no real
+    /// connect failure produces - every one of those has an `io::Error` a few
+    /// layers down. Worth stating anyway: the answer is "nothing to read", not a
+    /// guess, and the text is left to place the failure on its own.
     #[test]
-    fn each_recognised_family_is_placed() {
+    fn an_error_with_no_socket_beneath_it_claims_nothing() {
+        #[derive(Debug)]
+        struct Bare;
+        impl std::fmt::Display for Bare {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("nothing socket-shaped here")
+            }
+        }
+        impl std::error::Error for Bare {}
+
+        // Put through the pair together, which is how it is really reached:
+        // nothing to read from the kind, so the text has to place it alone.
+        assert_eq!(io_error_kind(&Bare), None);
+        assert_eq!(
+            connect_failure(io_error_kind(&Bare), &error_chain_text(&Bare)),
+            FailureKind::Transport
+        );
+    }
+
+    /// And one that is buried rather than outermost, which is where a real one
+    /// always sits: `reqwest` wraps it three deep.
+    #[test]
+    fn a_buried_socket_error_is_still_found() {
+        #[derive(Debug)]
+        struct Wrapper(std::io::Error);
+        impl std::fmt::Display for Wrapper {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str("sending the request")
+            }
+        }
+        impl std::error::Error for Wrapper {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                Some(&self.0)
+            }
+        }
+
+        let wrapped = Wrapper(std::io::Error::from(ErrorKind::ConnectionRefused));
+        assert_eq!(io_error_kind(&wrapped), Some(ErrorKind::ConnectionRefused));
+        // The chain text reaches the buried layer too, which is what the
+        // fallback reads when the kind says nothing.
+        let chain = error_chain_text(&wrapped);
+        assert!(chain.contains("sending the request"), "{chain}");
+        assert!(chain.contains("refused"), "{chain}");
+    }
+
+    /// The portable half. These are the kinds a socket really reports, and the
+    /// reason this is matched at all: the same refusal is "os error 61" on
+    /// macOS, "os error 111" on Linux and "os error 10061" on Windows, so a
+    /// classifier built on the text alone answers differently per platform.
+    #[test]
+    fn a_socket_error_kind_places_the_failure_on_any_platform() {
+        for (kind, expected) in [
+            (ErrorKind::ConnectionRefused, FailureKind::ConnectionRefused),
+            (ErrorKind::TimedOut, FailureKind::Timeout),
+            (ErrorKind::ConnectionReset, FailureKind::ConnectionDropped),
+            (ErrorKind::ConnectionAborted, FailureKind::ConnectionDropped),
+        ] {
+            // Deliberately with no text to lean on: the kind alone has to carry it.
+            assert_eq!(connect_failure(Some(kind), ""), expected, "{kind:?}");
+        }
+    }
+
+    /// A kind this does not place falls through to the text rather than being
+    /// answered from the kind alone.
+    #[test]
+    fn an_unplaced_kind_defers_to_the_text() {
+        assert_eq!(
+            connect_failure(Some(ErrorKind::Other), "invalid peer certificate"),
+            FailureKind::TlsFailure
+        );
+        assert_eq!(
+            connect_failure(Some(ErrorKind::Other), "nothing recognisable"),
+            FailureKind::Transport
+        );
+    }
+
+    /// The text half, by phrases these libraries really emit. DNS and TLS have
+    /// no `io::ErrorKind` of their own, so this is the only signal for them.
+    #[test]
+    fn each_recognised_family_is_placed_from_the_text() {
         for chain in [
             "client error (connect) | dns error: failed to lookup address information",
             "name or service not known",
+            // Windows says this where Unix says "failed to lookup address".
+            "no such host is known. (os error 11001)",
         ] {
-            assert_eq!(connect_failure(chain), FailureKind::DnsFailure, "{chain}");
+            assert_eq!(
+                connect_failure(None, chain),
+                FailureKind::DnsFailure,
+                "{chain}"
+            );
         }
         for chain in [
             "received corrupt message of type invalidcontenttype",
@@ -351,18 +475,38 @@ mod connect_failure_tests {
             "tls error",
             "peer misbehaved: protocol version",
         ] {
-            assert_eq!(connect_failure(chain), FailureKind::TlsFailure, "{chain}");
+            assert_eq!(
+                connect_failure(None, chain),
+                FailureKind::TlsFailure,
+                "{chain}"
+            );
         }
         for chain in [
             "tcp connect error: connection refused (os error 61)",
-            "os error 111",
+            // Windows phrasing, which shares no word with the Unix one.
+            "no connection could be made because the target machine actively \
+             refused it. (os error 10061)",
         ] {
             assert_eq!(
-                connect_failure(chain),
+                connect_failure(None, chain),
                 FailureKind::ConnectionRefused,
                 "{chain}"
             );
         }
+    }
+
+    /// A resolution failure is named as one even when a socket error sits
+    /// underneath it, because "check the hostname" and "check the port" send
+    /// somebody to different places.
+    #[test]
+    fn a_name_that_did_not_resolve_outranks_the_socket_kind() {
+        assert_eq!(
+            connect_failure(
+                Some(ErrorKind::ConnectionRefused),
+                "dns error: failed to lookup address information"
+            ),
+            FailureKind::DnsFailure
+        );
     }
 
     /// The arm that matters most and cannot be produced from a real socket: a
@@ -372,10 +516,10 @@ mod connect_failure_tests {
     #[test]
     fn an_unrecognised_chain_is_not_guessed_at() {
         assert_eq!(
-            connect_failure("something nobody here has seen before"),
+            connect_failure(None, "something nobody here has seen before"),
             FailureKind::Transport
         );
-        assert_eq!(connect_failure(""), FailureKind::Transport);
+        assert_eq!(connect_failure(None, ""), FailureKind::Transport);
     }
 }
 

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -240,7 +240,7 @@ impl GeminiProvider {
             .json(&body)
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("reaching the provider", &e))?;
         let response = crate::provider::check_http_response(response, None).await?;
         let value: serde_json::Value = crate::provider::decode_json(response).await?;
         value
@@ -432,7 +432,7 @@ impl GeminiProvider {
             .header("x-goog-api-key", &self.api_key)
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("listing models", &e))?;
         let response = crate::provider::check_http_response(response, None).await?;
         let body: serde_json::Value = crate::provider::decode_json(response).await?;
 
@@ -488,7 +488,7 @@ impl GeminiProvider {
             .header("Authorization", format!("Bearer {}", self.api_key))
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("listing models", &e))?;
         let response = crate::provider::check_http_response(response, None).await?;
         let body: serde_json::Value = crate::provider::decode_json(response).await?;
 

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -15,6 +15,7 @@ pub mod capabilities;
 pub mod claude_code;
 #[cfg(feature = "debug-http")]
 pub mod debug_http;
+pub mod failure;
 pub mod gemini;
 pub mod ollama;
 pub mod openai;
@@ -39,7 +40,7 @@ pub use openai::OpenAIProvider;
 pub use openrouter::OpenRouterProvider;
 pub use pricing::{CostTotals, ModelPricing};
 pub use provider::{
-    ContentBlock, DEFAULT_INFERENCE_TIMEOUT_SECS, FinishReason, InferenceRequest,
+    ContentBlock, DEFAULT_INFERENCE_TIMEOUT_SECS, FailureKind, FinishReason, InferenceRequest,
     InferenceResponse, Message, MessageContent, ModelInfo, Provider, ProviderConfig, ProviderError,
     RateLimitConfig, Result, RetryAdvice, SystemBlock, TokenUsage, Tool, ToolCall,
     UnavailableReason, build_http_client,

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -320,7 +320,7 @@ impl OllamaProvider {
             .get(format!("{}/api/tags", self.base_url))
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("listing Ollama models", &e))?;
         let tags = crate::provider::check_http_response(tags, None).await?;
         let tags: serde_json::Value = crate::provider::decode_json(tags).await?;
         let mut names: Vec<String> = tags
@@ -411,7 +411,7 @@ impl OllamaProvider {
                 .json(&serde_json::json!({ "model": name }))
                 .send()
                 .await
-                .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+                .map_err(|e| ProviderError::transport("reading an Ollama model", &e))?;
             let show = crate::provider::check_http_response(show, None).await?;
             let show: serde_json::Value = crate::provider::decode_json(show).await?;
             if let Some(window) = effective_window(&show) {
@@ -803,7 +803,7 @@ impl Provider for OllamaProvider {
             .get(format!("{}/api/tags", self.base_url))
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("listing Ollama models", &e))?;
 
         // Shared classification, as above. A bare `RequestFailed` here would
         // read as a retryable network fault; the status is what says whether

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -408,7 +408,7 @@ impl Provider for OpenAIProvider {
             .header("Authorization", format!("Bearer {}", self.api_key))
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("listing models", &e))?;
 
         let status = response.status();
         if !status.is_success() {

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -558,7 +558,7 @@ impl OpenRouterProvider {
             .header("Authorization", format!("Bearer {}", self.api_key))
             .send()
             .await
-            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+            .map_err(|e| ProviderError::transport("listing models", &e))?;
 
         let status = response.status();
         if !status.is_success() {

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -3,6 +3,7 @@
 // Re-exported so `use crate::provider::*` keeps working: the types moved for
 // structural reasons (the 1200-line rule), not as an interface change.
 pub use crate::capabilities::{LimitsSource, ModelCapabilities, ModelCapabilityOverride};
+pub use crate::failure::FailureKind;
 use async_trait::async_trait;
 use futures_core::Stream;
 use serde::{Deserialize, Serialize};
@@ -121,6 +122,15 @@ impl UnavailableReason {
 /// rather than the first number anywhere in the text: an error body quoting a
 /// token count must not be mistaken for a status.
 fn leading_http_status(message: &str) -> Option<u16> {
+    // A `[kind]` prefix may sit in front of the status now that a failure
+    // carries what it was. Stepping over it keeps a message classifiable
+    // whichever layer labelled it: a prefix that hid the status here would have
+    // silently stopped a 402 from failing over, which is the behaviour the
+    // status extraction exists to drive.
+    let message = match message.strip_prefix('[') {
+        Some(rest) => rest.split_once("] ").map_or(message, |(_, after)| after),
+        None => message,
+    };
     let rest = message.strip_prefix("HTTP ")?;
     let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
     digits.parse().ok()
@@ -129,7 +139,8 @@ fn leading_http_status(message: &str) -> Option<u16> {
 /// Errors that can occur during provider operations.
 #[derive(Error, Debug)]
 pub enum ProviderError {
-    /// HTTP request failed
+    /// HTTP request failed. The string carries the kind as a `[label]` prefix
+    /// when the caller knew it - see [`ProviderError::transport`].
     #[error("Request failed: {0}")]
     RequestFailed(String),
 
@@ -1074,7 +1085,18 @@ pub async fn check_http_response(
     }
     if !status.is_success() {
         let error_body = response.text().await.unwrap_or_else(|e| e.to_string());
-        let detail = format!("HTTP {}: {}", status, error_body);
+        // The kind rides in front of the status so it survives every layer that
+        // only passes strings - including a Rhai script, which sees the message
+        // and nothing else. A bare status left "their endpoint is down" and
+        // "your base_url has a typo" reading identically.
+        let kind = FailureKind::from_status(status.as_u16());
+        let detail = format!(
+            "[{}] HTTP {}: {} - {}",
+            kind.label(),
+            status,
+            error_body,
+            kind.remedy()
+        );
         // An out-of-credits or bad-key response is worth telling apart: the
         // runtime fails over on it and counts it against the provider's
         // circuit breaker, where a plain `ApiError` would just kill the run.
@@ -1444,6 +1466,139 @@ mod tests {
     }
 
     // ─── Provider-fatal classification (issue #201) ─────────────────────────
+
+    /// A labelled message still classifies. The `[kind]` prefix goes in front
+    /// of the status, and a prefix that hid it would have silently stopped a 402
+    /// from failing over - which is the behaviour the status extraction exists
+    /// to drive, and the bug the prefix introduced before this.
+    #[test]
+    fn a_labelled_message_still_yields_its_status() {
+        assert_eq!(
+            UnavailableReason::from_message("[server-error] HTTP 402: out of credits"),
+            Some(UnavailableReason::CreditsExhausted)
+        );
+        assert_eq!(
+            UnavailableReason::from_message("HTTP 401: bad key"),
+            Some(UnavailableReason::AuthFailed),
+            "an unlabelled message is unaffected"
+        );
+        assert_eq!(
+            UnavailableReason::from_message("[not-a-kind HTTP 402: unterminated"),
+            None,
+            "an unclosed bracket is not a prefix to step over"
+        );
+    }
+
+    /// Against the real network stack, because this is the whole point: these
+    /// used to arrive as one string and `Display` on a `reqwest::Error` says the
+    /// same sentence for all of them.
+    #[tokio::test]
+    async fn a_hostname_that_does_not_resolve_is_told_from_a_port_that_refuses() {
+        let client = build_http_client(Some(2)).expect("a client builds");
+
+        let dns = client
+            .get("http://no-such-host-anywhere-12345.invalid/v1/models")
+            .send()
+            .await
+            .expect_err("does not resolve");
+        assert_eq!(FailureKind::from_reqwest(&dns), FailureKind::DnsFailure);
+
+        // Port 1 needs privileges to bind, so nothing of ours is listening.
+        let refused = client
+            .get("http://127.0.0.1:1/v1/models")
+            .send()
+            .await
+            .expect_err("refused");
+        assert_eq!(
+            FailureKind::from_reqwest(&refused),
+            FailureKind::ConnectionRefused
+        );
+    }
+
+    /// The statuses that are not already an `UnavailableReason`. 404 has its own
+    /// kind because it reads as "the provider is broken" when it is usually a
+    /// base URL pointing at the wrong path.
+    #[test]
+    fn a_status_is_placed_by_whose_fault_it_is() {
+        assert_eq!(FailureKind::from_status(400), FailureKind::BadRequest);
+        assert_eq!(FailureKind::from_status(404), FailureKind::NotFound);
+        assert_eq!(FailureKind::from_status(500), FailureKind::ServerError);
+        assert_eq!(FailureKind::from_status(503), FailureKind::ServerError);
+        assert_eq!(FailureKind::from_status(418), FailureKind::BadRequest);
+    }
+
+    /// Every kind has a label and a remedy, because both are published: the
+    /// label to logs and the API, the remedy to whoever has to fix it.
+    #[test]
+    fn every_kind_is_labelled_and_has_a_remedy() {
+        for kind in [
+            FailureKind::DnsFailure,
+            FailureKind::ConnectionRefused,
+            FailureKind::TlsFailure,
+            FailureKind::Timeout,
+            FailureKind::ConnectionDropped,
+            FailureKind::Transport,
+            FailureKind::BadRequest,
+            FailureKind::NotFound,
+            FailureKind::ServerError,
+            FailureKind::MalformedResponse,
+        ] {
+            // Read out first: an argument evaluated only on failure is its own
+            // uncovered region on an assertion that has to pass.
+            let label = kind.label();
+            assert!(!label.is_empty());
+            assert!(!kind.remedy().is_empty(), "{label}");
+            assert!(
+                !label.contains(' '),
+                "a label is one token for a metrics attribute: {label}"
+            );
+        }
+    }
+
+    /// The kind survives the round trip through the message, which is the only
+    /// channel that reaches a Rhai script and comes back.
+    #[tokio::test]
+    async fn the_kind_is_readable_back_off_the_error() {
+        let client = build_http_client(Some(2)).expect("a client builds");
+        let e = client
+            .get("http://127.0.0.1:1/v1/models")
+            .send()
+            .await
+            .expect_err("refused");
+
+        let err = ProviderError::transport("sending the request", &e);
+        assert_eq!(err.failure_kind(), Some(FailureKind::ConnectionRefused));
+
+        let text = err.to_string();
+        assert!(text.contains("sending the request"), "{text}");
+        assert!(text.contains("check the provider is running"), "{text}");
+    }
+
+    /// An error carrying no label answers `None` rather than guessing one.
+    #[test]
+    fn an_unlabelled_error_names_no_kind() {
+        assert_eq!(
+            ProviderError::RequestFailed("no label here".to_string()).failure_kind(),
+            None
+        );
+        assert_eq!(
+            ProviderError::ApiError("[not-a-kind] something".to_string()).failure_kind(),
+            None
+        );
+        // A parse failure is a kind without needing a label: the variant is the
+        // statement.
+        assert_eq!(
+            ProviderError::InvalidResponse("bad json".to_string()).failure_kind(),
+            Some(FailureKind::MalformedResponse)
+        );
+        assert_eq!(
+            ProviderError::RateLimitExceeded {
+                retry_after_secs: None
+            }
+            .failure_kind(),
+            None
+        );
+    }
 
     #[test]
     fn classify_maps_the_provider_fatal_statuses() {

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -1503,9 +1503,17 @@ mod tests {
             .expect_err("does not resolve");
         assert_eq!(FailureKind::from_reqwest(&dns), FailureKind::DnsFailure);
 
-        // Port 1 needs privileges to bind, so nothing of ours is listening.
+        // A port nothing is listening on: an ephemeral port is claimed and the
+        // listener dropped, so the OS answers the connection with a refusal.
+        // Port 1 was used here and is not reliable - a Windows runner drops the
+        // SYN rather than refusing it, and the connection times out instead,
+        // which is a different kind and a different remedy.
+        let closed = {
+            let claimed = std::net::TcpListener::bind("127.0.0.1:0").expect("binds");
+            claimed.local_addr().expect("has an address")
+        };
         let refused = client
-            .get("http://127.0.0.1:1/v1/models")
+            .get(format!("http://{closed}/v1/models"))
             .send()
             .await
             .expect_err("refused");
@@ -1560,8 +1568,17 @@ mod tests {
     #[tokio::test]
     async fn the_kind_is_readable_back_off_the_error() {
         let client = build_http_client(Some(2)).expect("a client builds");
+        // A port nothing is listening on: an ephemeral port is claimed and the
+        // listener dropped, so the OS answers the connection with a refusal.
+        // Port 1 was used here and is not reliable - a Windows runner drops the
+        // SYN rather than refusing it, and the connection times out instead,
+        // which is a different kind and a different remedy.
+        let closed = {
+            let claimed = std::net::TcpListener::bind("127.0.0.1:0").expect("binds");
+            claimed.local_addr().expect("has an address")
+        };
         let e = client
-            .get("http://127.0.0.1:1/v1/models")
+            .get(format!("http://{closed}/v1/models"))
             .send()
             .await
             .expect_err("refused");

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -1491,9 +1491,16 @@ mod tests {
 
     /// Against the real network stack, because this is the whole point: these
     /// used to arrive as one string and `Display` on a `reqwest::Error` says the
-    /// same sentence for all of them.
+    /// same sentence for both of them.
+    ///
+    /// Which kind a dead port produces is the OS's business and not the same
+    /// everywhere - a Windows runner drops the SYN and the request times out
+    /// where a Unix box answers with a refusal - so what is asserted here is the
+    /// part that is true everywhere: the two are told apart, and neither is
+    /// mistaken for the other. Exactly which kind each chain maps to is settled
+    /// by the `connect_failure` tests, which do not go near a socket.
     #[tokio::test]
-    async fn a_hostname_that_does_not_resolve_is_told_from_a_port_that_refuses() {
+    async fn a_name_that_does_not_resolve_is_told_from_a_port_with_nothing_behind_it() {
         let client = build_http_client(Some(2)).expect("a client builds");
 
         let dns = client
@@ -1503,23 +1510,34 @@ mod tests {
             .expect_err("does not resolve");
         assert_eq!(FailureKind::from_reqwest(&dns), FailureKind::DnsFailure);
 
-        // A port nothing is listening on: an ephemeral port is claimed and the
-        // listener dropped, so the OS answers the connection with a refusal.
-        // Port 1 was used here and is not reliable - a Windows runner drops the
-        // SYN rather than refusing it, and the connection times out instead,
-        // which is a different kind and a different remedy.
+        // A port nothing is listening on: an ephemeral one is claimed and the
+        // listener dropped straight away, which is a port no other process holds.
+        // Port 1 was used here, on the reasoning that binding it needs privileges
+        // - true, and not the same thing as nothing being behind it.
         let closed = {
             let claimed = std::net::TcpListener::bind("127.0.0.1:0").expect("binds");
             claimed.local_addr().expect("has an address")
         };
-        let refused = client
+        let dead_port = client
             .get(format!("http://{closed}/v1/models"))
             .send()
             .await
-            .expect_err("refused");
-        assert_eq!(
-            FailureKind::from_reqwest(&refused),
-            FailureKind::ConnectionRefused
+            .expect_err("nothing answers");
+        let dead = FailureKind::from_reqwest(&dead_port);
+        assert_ne!(
+            dead,
+            FailureKind::DnsFailure,
+            "a port with nothing behind it is not a name that did not resolve"
+        );
+        // Membership rather than `matches!`, and the message read out first: an
+        // arm no platform takes and an argument only a failure evaluates are
+        // both uncovered regions on an assertion that has to pass.
+        let seen = format!("{dead:?}");
+        let plausible = [FailureKind::ConnectionRefused, FailureKind::Timeout].contains(&dead);
+        assert!(
+            plausible,
+            "a dead port is refused where the OS refuses and timed out where it \
+             drops the SYN, and nothing else: {seen}"
         );
     }
 
@@ -1565,30 +1583,33 @@ mod tests {
 
     /// The kind survives the round trip through the message, which is the only
     /// channel that reaches a Rhai script and comes back.
+    ///
+    /// Driven by a server that accepts and never answers, because that is the
+    /// one real failure every platform agrees on: a dead port is refused on some
+    /// and timed out on others, and this test is about the round trip rather
+    /// than about which kind went into it.
     #[tokio::test]
     async fn the_kind_is_readable_back_off_the_error() {
-        let client = build_http_client(Some(2)).expect("a client builds");
-        // A port nothing is listening on: an ephemeral port is claimed and the
-        // listener dropped, so the OS answers the connection with a refusal.
-        // Port 1 was used here and is not reliable - a Windows runner drops the
-        // SYN rather than refusing it, and the connection times out instead,
-        // which is a different kind and a different remedy.
-        let closed = {
-            let claimed = std::net::TcpListener::bind("127.0.0.1:0").expect("binds");
-            claimed.local_addr().expect("has an address")
-        };
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("binds");
+        let addr = listener.local_addr().expect("has an address");
+        std::thread::spawn(move || {
+            let _held = listener.accept();
+            std::thread::sleep(std::time::Duration::from_secs(30));
+        });
+
+        let client = build_http_client(Some(1)).expect("a client builds");
         let e = client
-            .get(format!("http://{closed}/v1/models"))
+            .get(format!("http://{addr}/v1/models"))
             .send()
             .await
-            .expect_err("refused");
+            .expect_err("never answers");
 
         let err = ProviderError::transport("sending the request", &e);
-        assert_eq!(err.failure_kind(), Some(FailureKind::ConnectionRefused));
+        assert_eq!(err.failure_kind(), Some(FailureKind::Timeout));
 
         let text = err.to_string();
         assert!(text.contains("sending the request"), "{text}");
-        assert!(text.contains("check the provider is running"), "{text}");
+        assert!(text.contains("reachable but slow or wedged"), "{text}");
     }
 
     /// An error carrying no label answers `None` rather than guessing one.

--- a/crates/leviath-providers/src/rhai_provider/convert.rs
+++ b/crates/leviath-providers/src/rhai_provider/convert.rs
@@ -191,6 +191,31 @@ pub fn runtime_error(msg: impl Into<String>) -> Box<EvalAltResult> {
 /// surface as `ErrorRuntime` carrying a map; a bare `throw "text"` surfaces as a
 /// string. `kind` (when present) wins; otherwise `transient` selects
 /// `RequestFailed` vs `Other`.
+/// A [`FailureKind`] by the label a script writes.
+///
+/// Matched against the labels the built-in providers use, so a script and a
+/// native provider describing the same failure describe it the same way. An
+/// unknown name is ignored rather than rejected: a script written against a
+/// later build must not fail on this build because it named a kind that does
+/// not exist here yet.
+fn named_failure_kind(name: &str) -> Option<crate::provider::FailureKind> {
+    use crate::provider::FailureKind;
+    [
+        FailureKind::DnsFailure,
+        FailureKind::ConnectionRefused,
+        FailureKind::TlsFailure,
+        FailureKind::Timeout,
+        FailureKind::ConnectionDropped,
+        FailureKind::Transport,
+        FailureKind::BadRequest,
+        FailureKind::NotFound,
+        FailureKind::ServerError,
+        FailureKind::MalformedResponse,
+    ]
+    .into_iter()
+    .find(|k| k.label() == name)
+}
+
 pub fn map_rhai_err(err: Box<EvalAltResult>) -> ProviderError {
     if let EvalAltResult::ErrorRuntime(val, _) = &*err {
         if let Some(map) = val.clone().try_cast::<Map>() {
@@ -201,6 +226,22 @@ pub fn map_rhai_err(err: Box<EvalAltResult>) -> ProviderError {
             };
             let kind = get_str("kind");
             let message = get_str("message").unwrap_or_else(|| "provider script error".to_string());
+            // A script may say what actually went wrong, which is the half the
+            // caller cannot work out for itself: `kind` says how to *treat* the
+            // failure - retry, fail over, give up - while `failure_kind` says
+            // what it *was*. A script talking to its own endpoint knows the
+            // difference between a refused connection and a rejected key, and
+            // without this it could only fold both into "transport" or "api".
+            //
+            // Prefixed onto the message rather than held beside it, the same way
+            // a built-in provider carries it, so both arrive at the log and the
+            // API through one channel.
+            let message = match get_str("failure_kind").and_then(|name| named_failure_kind(&name)) {
+                Some(kind) if !message.starts_with('[') => {
+                    format!("[{}] {message} - {}", kind.label(), kind.remedy())
+                }
+                _ => message,
+            };
             let transient = map
                 .get("transient")
                 .and_then(|d| d.as_bool().ok())
@@ -263,5 +304,108 @@ mod cost_tests {
     fn a_script_provider_that_says_nothing_leaves_the_call_unpriced() {
         let usage = serde_json::json!({"prompt_tokens": 12, "completion_tokens": 4});
         assert_eq!(parse_usage(Some(&usage)).reported_cost_usd, None);
+    }
+}
+
+#[cfg(test)]
+mod failure_kind_tests {
+    use super::*;
+    use crate::provider::FailureKind;
+
+    fn thrown(map: Map) -> ProviderError {
+        map_rhai_err(Box::new(EvalAltResult::ErrorRuntime(
+            rhai::Dynamic::from_map(map),
+            rhai::Position::NONE,
+        )))
+    }
+
+    /// A script that knows what went wrong can say so, and it arrives the same
+    /// way a built-in provider's does.
+    #[test]
+    fn a_script_can_name_what_actually_went_wrong() {
+        let mut map = Map::new();
+        map.insert("kind".into(), "transport".into());
+        map.insert("failure_kind".into(), "connection-refused".into());
+        map.insert("message".into(), "could not reach my box".into());
+
+        let err = thrown(map);
+        assert_eq!(err.failure_kind(), Some(FailureKind::ConnectionRefused));
+        let text = err.to_string();
+        assert!(text.contains("could not reach my box"), "{text}");
+        assert!(text.contains("check the provider is running"), "{text}");
+    }
+
+    /// `kind` and `failure_kind` answer different questions and both are kept:
+    /// one decides how the runtime treats the failure, the other says what it
+    /// was. A `failure_kind` must not quietly change the first.
+    #[test]
+    fn naming_the_failure_does_not_change_how_it_is_treated() {
+        let mut map = Map::new();
+        map.insert("kind".into(), "api".into());
+        map.insert("failure_kind".into(), "server-error".into());
+        map.insert("message".into(), "HTTP 402 out of credits".into());
+
+        // Still `Unavailable`, because `api` + a 402 in the message is what
+        // decides failover - the label rides along without disturbing it.
+        // Asserted through `unavailable_reason`, which is what actually decides
+        // failover, rather than on the variant's shape: a `matches!` inside an
+        // assertion that always passes leaves its other arm uncovered, and the
+        // reason is the more useful claim anyway.
+        assert_eq!(
+            thrown(map).unavailable_reason(),
+            Some(crate::provider::UnavailableReason::CreditsExhausted),
+            "the label must not disturb how the failure is treated"
+        );
+    }
+
+    /// A script written against a later build must not fail on this one for
+    /// naming a kind this build has never heard of.
+    #[test]
+    fn an_unknown_failure_kind_is_ignored_rather_than_refused() {
+        let mut map = Map::new();
+        map.insert("kind".into(), "transport".into());
+        map.insert("failure_kind".into(), "quantum-decoherence".into());
+        map.insert("message".into(), "something odd".into());
+
+        let err = thrown(map);
+        assert_eq!(err.failure_kind(), None);
+        assert!(err.to_string().contains("something odd"));
+    }
+
+    /// A script that says nothing gets what it always got.
+    #[test]
+    fn a_script_that_names_no_failure_kind_is_unchanged() {
+        let mut map = Map::new();
+        map.insert("kind".into(), "transport".into());
+        map.insert("message".into(), "plain old failure".into());
+
+        let err = thrown(map);
+        assert_eq!(err.failure_kind(), None);
+        assert!(err.to_string().contains("plain old failure"));
+    }
+
+    /// Every label a built-in provider can produce is one a script may name, so
+    /// the two vocabularies cannot drift apart.
+    #[test]
+    fn every_builtin_label_is_nameable_from_a_script() {
+        for kind in [
+            FailureKind::DnsFailure,
+            FailureKind::ConnectionRefused,
+            FailureKind::TlsFailure,
+            FailureKind::Timeout,
+            FailureKind::ConnectionDropped,
+            FailureKind::Transport,
+            FailureKind::BadRequest,
+            FailureKind::NotFound,
+            FailureKind::ServerError,
+            FailureKind::MalformedResponse,
+        ] {
+            let label = kind.label();
+            assert_eq!(
+                named_failure_kind(label),
+                Some(kind),
+                "{label} is not nameable"
+            );
+        }
     }
 }

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -255,6 +255,27 @@ pub fn collect_inference(
                 // is not this request's problem: every later request to it
                 // fails the same way. Move the stage to the next candidate and
                 // try again rather than killing the run (issue #201).
+                // Logged before the failover decision, and for every failure
+                // rather than only the ones that fail over. A call that dies
+                // without a fallback is exactly the one somebody has to
+                // diagnose, and it used to leave nothing but the error text -
+                // which for a transport failure is the same sentence whether
+                // the hostname was wrong, the port was closed, or the
+                // certificate had expired.
+                tracing::warn!(
+                    provider = %called_provider,
+                    model = %called_model,
+                    failure_kind = err
+                        .failure_kind()
+                        .map(leviath_providers::FailureKind::label)
+                        .unwrap_or("unclassified"),
+                    unavailable_reason = err
+                        .unavailable_reason()
+                        .map(leviath_providers::UnavailableReason::label)
+                        .unwrap_or("none"),
+                    error = %err,
+                    "provider call failed"
+                );
                 let next = err.unavailable_reason().and_then(|_| {
                     let si = inference.as_deref_mut()?;
                     (!si.fallbacks.is_empty()).then(|| si.fallbacks.remove(0))

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -191,6 +191,43 @@ throw #{ message: "429",  kind: "rate_limited" };         // name the class exac
 A `kind` of `rate_limited`, `api`, or `transport` takes precedence over `transient` when you need
 the error classed exactly.
 
+### Saying what actually went wrong
+
+`kind` says how the runtime should *treat* a failure - retry it, fail over, give up. `failure_kind`
+says what it *was*, which is the half nobody downstream can work out for itself:
+
+```rhai
+throw #{
+  kind: "transport",                    // how to treat it
+  failure_kind: "connection-refused",   // what it was
+  message: "nothing listening on :8080",
+};
+```
+
+It reaches the daemon log as a `failure_kind` field, and the run's error text carries the remedy
+for that kind. Without it a script could only fold a refused connection, an expired certificate and
+a request that timed out into one word, which is the state the built-in providers were in.
+
+The names are the ones the built-in providers use, so a script and a native provider describing the
+same failure describe it the same way:
+
+| | |
+|---|---|
+| `dns-failure` | the hostname did not resolve |
+| `connection-refused` | nothing accepted the connection |
+| `tls-failure` | the handshake failed |
+| `timeout` | reachable, but no answer in time |
+| `connection-dropped` | the answer stopped arriving |
+| `transport` | could not be reached, more precisely unknown |
+| `bad-request` | the provider rejected the request itself |
+| `not-found` | 404 - usually a `base_url` path or a model that is not there |
+| `server-error` | 5xx - their end, and may pass on a retry |
+| `malformed-response` | an answer this build could not parse |
+
+A name this build does not know is ignored rather than refused, so a script written against a later
+version still runs here. Omitting `failure_kind` entirely is fine - it is extra detail, not a
+requirement.
+
 ## A complete provider
 
 This is a full OpenAI-compatible provider. Save it as `~/.leviath/providers/groq.rhai`, set

--- a/sandboxing-approaches.md
+++ b/sandboxing-approaches.md
@@ -1,0 +1,172 @@
+# Sandboxing Approaches for Production Agent Runtimes (2026)
+
+## Executive Summary
+
+The 2026 industry consensus is unequivocal: **shared-kernel containers are not a security boundary for AI agent code execution** [[7]](https://emirb.github.io/blog/microvm-2026/). The minimum viable sandbox for production agents executing arbitrary, untrusted code is a **microVM (Firecracker or Kata-backed)** providing hardware-level isolation [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox). gVisor serves as an acceptable fallback for medium-threat models, while V8 Isolates are appropriate only for JavaScript/WebAssembly-specific workloads. By early 2026, major platforms including Cloudflare, Vercel, Ramp, and Modal had all shipped dedicated sandbox features, with E2B, Northflank, and Firecrawl building entire infrastructure platforms around the problem [[12]](https://www.firecrawl.dev/blog/ai-agent-sandbox).
+
+**Confidence: High** (Consistent across official vendor docs, Kubernetes SIG documentation, and independent security analyses)
+
+---
+
+## 1. Firecracker MicroVMs — Hardware-Level Isolation
+
+Firecracker, developed by AWS and written in Rust, is the gold standard for agent sandbox isolation. It uses KVM (Kernel-based Virtual Machine) to provide **hardware-enforced isolation** — each workload runs in its own lightweight VM with a dedicated Linux kernel, completely separate from the host [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[7]](https://emirb.github.io/blog/microvm-2026/). 
+
+**Key Specifications:**
+* **Boot time:** ≤125ms to `/sbin/init` (serial console disabled), ~100-200ms depending on configuration [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor)
+* **Memory overhead:** ≤5 MiB per microVM [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor)
+* **Creation rate:** Up to 150 microVMs/second/host [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor)
+* **Codebase:** ~50K lines of Rust vs. QEMU's ~2M lines of C, eliminating entire classes of memory-safety vulnerabilities [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor)
+* **Attack surface:** Only 5-6 emulated virtio devices (network, block, vsock, balloon, serial, keyboard), minimizing the exploitable interface [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[7]](https://emirb.github.io/blog/microvm-2026/)
+
+**Production Usage:** AWS Lambda and Fargate run on Firecracker directly [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[7]](https://emirb.github.io/blog/microvm-2026/). E2B uses Firecracker as its core isolation layer [[6]](https://northflank.com/blog/e2b-vs-modal) [[8]](https://github.com/e2b-dev/e2b) [[9]](https://e2b.dev/docs). Vercel Sandbox also runs on Firecracker microVMs [[10]](https://vercel.com/docs/sandbox/concepts).
+
+**Limitations:** Firecracker does not provide built-in, officially supported GPU passthrough; upstream PCIe support excludes VFIO-based device passthrough, though experimental work exists [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[13]](https://www.spheron.network/blog/ai-agent-code-execution-sandbox-e2b-daytona-firecracker/). It requires significant orchestration infrastructure to run at scale; most teams use it through Kata Containers or a managed platform [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[7]](https://emirb.github.io/blog/microvm-2026/).
+
+**Snapshot Performance:** Firecracker snapshots enable restore in ~28ms, making per-request isolation viable for high-throughput agent loops [[17]](https://dev.to/adwitiya/how-i-built-sandboxes-that-boot-in-28ms-using-firecracker-snapshots-i0k) [confidence: medium — single blog source].
+
+---
+
+## 2. gVisor — User-Space Kernel Interception
+
+gVisor, developed by Google, implements a **user-space kernel** (the Sentry, written in Go) that intercepts application system calls and handles them in user space rather than passing them to the host kernel [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/).
+
+**Security Model:** Escape requires a bug in gVisor's Sentry AND a bug in the host kernel's handling of the Sentry's permitted syscalls — two independent codebases must be compromised [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox). However, gVisor does **not** provide hardware-level isolation [[18]](https://edera.dev/stories/kata-vs-firecracker-vs-gvisor-isolation-compared) [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/).
+
+**Key Characteristics:**
+* **Syscall overhead:** 10-30% slower than native containers for I/O-heavy workloads [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor); one source reports 20-50% [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/) [confidence: medium — ranges differ between sources].
+* **Syscall coverage:** Implements ~70-80% of Linux syscalls; advanced ioctl and eBPF may fail [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/).
+* **GPU support:** Supports GPU workloads through nvproxy with negligible overhead for ML inference [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[13]](https://www.spheron.network/blog/ai-agent-code-execution-sandbox-e2b-daytona-firecracker/).
+* **Operational complexity:** Drop-in replacement for runc via Kubernetes RuntimeClass — low overhead [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/) [[19]](https://agent-sandbox.sigs.k8s.io/docs/use-cases/gvisor-isolation/).
+* **Vulnerabilities:** gVisor itself has had security vulnerabilities in the Sentry [[22]](https://www.shayon.dev/post/2026/52/lets-discuss-sandbox-isolation/).
+* **Multi-tenancy:** Does not automatically provide multi-job isolation within a single sandbox; additional controls are needed [[22]](https://www.shayon.dev/post/2026/52/lets-discuss-sandbox-isolation/).
+
+**Production Usage:** Modal uses gVisor for sandbox isolation [[6]](https://northflank.com/blog/e2b-vs-modal) [[11]](https://manveerc.substack.com/p/ai-agent-sandboxing-guide) [[35]](https://www.amplifypartners.com/blog-posts/behind-the-scenes-of-modal-sandboxes) [[36]](https://modal.com/resources/best-gpu-enabled-sandboxes-ai-agents). Modal reports handling 250,000 applications in a single weekend with 20,000 concurrent sandboxes at peak [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [confidence: medium — reported by Augment Code citing Modal].
+
+---
+
+## 3. Container-Based Isolation — Insufficient for Untrusted Code
+
+Standard Docker containers share the host kernel via Linux namespaces and cgroups [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/) [[7]](https://emirb.github.io/blog/microvm-2026/). **The Linux kernel has ~40 million lines of C and exposes 450+ syscalls** — this is the attack surface [[7]](https://emirb.github.io/blog/microvm-2026/).
+
+**Container escapes are real and frequent.** Documented CVEs include: CVE-2019-5736 (runc escape), CVE-2024-21626 (Leaky Vessels), CVE-2024-1753 (Buildah/Podman), CVE-2025-9074 (Docker Desktop), CVE-2025-23266 (NVIDIA container toolkit), CVE-2025-31133 (runc masked path race), CVE-2025-52565 (runc /dev/console mount), CVE-2025-38617 (Linux kernel packet socket UAF) [[7]](https://emirb.github.io/blog/microvm-2026/).
+
+Security profiles (seccomp, AppArmor, SELinux, capabilities) reduce but do not eliminate kernel escape risk [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/).
+
+**Consensus:** Containers are acceptable for low-threat scenarios (internal tools, trusted code, non-production) [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/) [[21]](https://adamtheautomator.com/containers-vs-gvisor-vs-microvms-azure-ai-agent/). For hostile or user-supplied AI-generated code, they are **explicitly insufficient** [[11]](https://manveerc.substack.com/p/ai-agent-sandboxing-guide) [[12]](https://www.firecrawl.dev/blog/ai-agent-sandbox) [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox).
+
+---
+
+## 4. V8 Isolates — Language-Level Sandboxing
+
+V8 Isolates are sandboxed execution contexts within a single V8 engine instance. Each isolate has its own heap and cannot access other isolates' memory [[2]](https://developers.cloudflare.com/workers/reference/security-model/) [[24]](https://www.kunalganglani.com/blog/cloudflare-workers-v8-isolates-ai-agents) [[25]](https://fordelstudios.com/research/how-v8-isolates-actually-work-under-the-hood) [[27]](https://www.clodo.dev/blog/v8-isolates-comprehensive-guide).
+
+**Cloudflare Workers** is the canonical production implementation. Key security properties [[2]](https://developers.cloudflare.com/workers/reference/security-model/):
+* `Date.now()` is locked during execution; no timers or multi-threading allowed (prevents timing side-channel attacks)
+* Dynamic process isolation for Workers needing extra isolation (e.g., debugger access)
+* Each isolate receives a random key protecting V8 heap data, blocking cross-isolate reads in 92% of cases [[26]](https://blog.cloudflare.com/safe-in-the-sandbox-security-hardening-for-cloudflare-workers/)
+* `workerd` can be configured with seccomp-bpf for additional syscall filtering [[30]](https://www.federicocalo.dev/en/blog/01-v8-isolates-explained-how-cloudflare-workers-eliminate-cold-starts)
+
+**Limitations:** V8 Isolates only sandbox JavaScript/WebAssembly. They cannot execute arbitrary Python, shell scripts, or binary code. V8 has more bugs reported against it than VMs, requiring additional defense-in-depth layers [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[2]](https://developers.cloudflare.com/workers/reference/security-model/). V8 Isolates are also used by Deno Deploy, Fastly Compute@Edge, and Vercel Serverless Functions [[29]](https://dzx.cz/2023-03-08/how_do_cloudflare_workers_work/).
+
+---
+
+## 5. Kata Containers & WebAssembly
+
+**Kata Containers** is **not itself an isolation technology** — it is an orchestration framework that integrates VMMs (Firecracker, Cloud Hypervisor, QEMU) with Kubernetes [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[47]](https://opencomputer.dev/guides/firecracker-vs-cloud-hypervisor-vs-kata/). It provides hardware-level isolation via its VMM backend while maintaining OCI-compatible container workflows [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/). Boot time: ~150-300ms depending on VMM and configuration [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[50]](https://onidel.com/blog/gvisor-kata-firecracker-2025). Kata abstracts the operational complexity of managing microVMs at scale [[18]](https://edera.dev/stories/kata-vs-firecracker-vs-gvisor-isolation-compared) [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor).
+
+**WebAssembly** provides memory isolation through bounds-checked linear memory with WASI's capability model denying filesystem, network, and OS access by default [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/). Cold start is microseconds; runtime performance within 10% of native via AOT [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/). **Limitations for AI agents:** No persistent filesystem, limited syscall support, requires application rewrite [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/). Wasmtime is implementing CFI mechanisms to reduce Cranelift compiler bug impact [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox).
+
+---
+
+## 6. Production Platforms Compared
+
+| Platform | Isolation | Boot Time | GPU | Persistence | Notes |
+|----------|-----------|-----------|-----|-------------|-------|
+| **E2B** | Firecracker microVM | ~150ms (snapshot pools) | CPU-focused (experimental GPU) | Session-scoped (up to 24h) | Open-source, SDK-defined templates [[6]](https://northflank.com/blog/e2b-vs-modal) [[8]](https://github.com/e2b-dev/e2b) [[9]](https://e2b.dev/docs) |
+| **Modal** | gVisor | <1 second | Full GPU support | Session-scoped, snapshots | Full ML platform (inference, training, sandboxes) [[6]](https://northflank.com/blog/e2b-vs-modal) [[35]](https://www.amplifypartners.com/blog-posts/behind-the-scenes-of-modal-sandboxes) [[36]](https://modal.com/resources/best-gpu-enabled-sandboxes-ai-agents) |
+| **Vercel Sandbox** | Firecracker microVM | Milliseconds | No GPU | Persistent by default, auto-snapshot | Single region (iad1), GA Jan 2026, $1M bounty [[10]](https://vercel.com/docs/sandbox) [[41]](https://northflank.com/blog/can-you-run-ai-agents-on-vercel) [[40]](https://www.techzine.eu/news/security/143695/vercel-offers-1-million-for-hacking-its-ai-sandbox/) |
+| **Northflank** | Kata/Firecracker/gVisor | Sub-second | Full GPU | Ephemeral + persistent | BYOC, full workload runtime [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) [[6]](https://northflank.com/blog/e2b-vs-modal) |
+
+---
+
+## 7. Industry Consensus: Minimum Viable Sandboxing for AI Agents
+
+The consensus across multiple sources establishes a **tiered threat model** [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/):
+
+| Threat Level | Scenario | Minimum Isolation |
+|-------------|----------|-------------------|
+| **High** | AI agents executing LLM-generated code, financial/healthcare data, HIPAA/PCI-DSS | Firecracker or Kata microVM |
+| **Medium** | Multi-tenant SaaS, cost-sensitive deployments, Kubernetes integration | gVisor |
+| **Low** | Internal tools, trusted code, non-production | Standard containers |
+
+**Key evidence for this consensus:**
+* OWASP AIVSS assigns CVSS v4.0 Base Score of 9.4 to interpreter tool attacks where LLM agents execute attacker-provided code [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox)
+* Palo Alto Unit 42 research demonstrated ChatGPT-4o as autonomous agent executing SQL injection, SSRF, and data exfiltration that its chat-only counterpart refused [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox)
+* Multiple 2024-2025 CVEs demonstrated real container escape paths [[7]](https://emirb.github.io/blog/microvm-2026/)
+* "The minimum acceptable isolation for a production agent execution sandbox is typically a Firecracker/Kata microVM, with gVisor used in some environments as a fallback" [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox)
+
+---
+
+## Contradictions & Open Questions
+
+1. **gVisor syscall overhead:** Sources report 10-30% [[4]](https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor) vs. 20-50% [[5]](https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/) slowdown for I/O-heavy workloads. The range is configuration-dependent and workload-specific.
+2. **Firecracker GPU passthrough:** One source reports Firecracker's hardware virtualization path supports VFIO device passthrough for GPU access [[13]](https://www.spheron.network/blog/ai-agent-code-execution-sandbox-e2b-daytona-firecracker/), but the Augment Code guide states upstream Firecracker has no native GPU passthrough, with only experimental PCI/vfio work [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox). The truth: experimental work exists but is not production-ready.
+3. **gVisor GPU support:** gVisor supports GPU through nvproxy [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox) [[13]](https://www.spheron.network/blog/ai-agent-code-execution-sandbox-e2b-daytona-firecracker/), but one source states gVisor's user-space kernel intercepts GPU calls at a point that blocks direct PCIe passthrough [[13]](https://www.spheron.network/blog/ai-agent-code-execution-sandbox-e2b-daytona-firecracker/). The nuance: nvproxy handles NVIDIA GPU ioctls, but direct PCIe passthrough is blocked — gVisor can use GPUs but not with full bare-metal passthrough.
+4. **Open question:** What is the actual escape complexity difference between Firecracker microVMs and gVisor in practice? While microVM escapes require hypervisor CVEs ($250K-$500K bounty class) [[7]](https://emirb.github.io/blog/microvm-2026/), gVisor escapes require both a Sentry bug AND a host kernel bug [[3]](https://www.augmentcode.com/guides/agent-execution-sandbox). Real-world comparative exploit data is scarce.
+5. **Open question:** How do SmolVM, OpenSandbox, and other newer microVM platforms (SmolVM launched April 2026 [[15]](https://particula.tech/blog/smolvm-vs-firecracker-sandbox-ai-generated-code)) compare to Firecracker in production maturity? Insufficient data for a definitive assessment.
+
+---
+
+## Sources
+
+[1] Vercel Sandbox docs — https://vercel.com/docs/sandbox
+[2] Cloudflare Workers security model — https://developers.cloudflare.com/workers/reference/security-model/
+[3] What Is an Agent Execution Sandbox? | Augment Code — https://www.augmentcode.com/guides/agent-execution-sandbox
+[4] Kata Containers vs Firecracker vs gVisor | Northflank — https://northflank.com/blog/kata-containers-vs-firecracker-vs-gvisor
+[5] Firecracker, gVisor, Containers, and WebAssembly — SoftwareSeni — https://www.softwareseni.com/firecracker-gvisor-containers-and-webassembly-comparing-isolation-technologies-for-ai-agents/
+[6] E2B vs Modal | Northflank — https://northflank.com/blog/e2b-vs-modal
+[7] Your Container Is Not a Sandbox: The State of MicroVM Isolation in 2026 | Emir Beganović — https://emirb.github.io/blog/microvm-2026/
+[8] E2B GitHub repo — https://github.com/e2b-dev/e2b
+[9] E2B Documentation — https://e2b.dev/docs
+[10] Vercel Sandbox concepts — https://vercel.com/docs/sandbox/concepts
+[11] How to sandbox AI agents in 2026 | Manveer Chawla — https://manveerc.substack.com/p/ai-agent-sandboxing-guide
+[12] AI Agent Sandbox: How to Safely Run Autonomous Agents in 2026 | Firecrawl — https://www.firecrawl.dev/blog/ai-agent-sandbox
+[13] AI Agent Code Execution Sandboxes on GPU Cloud | Spheron Blog — https://www.spheron.network/blog/ai-agent-code-execution-sandbox-e2b-daytona-firecracker/
+[14] How Firecracker microVMs work under the hood | Kerkour — https://kerkour.com/firecracker-sandboxing-rust
+[15] SmolVM Explained | Particula — https://particula.tech/blog/smolvm-vs-firecracker-sandbox-ai-generated-code
+[16] How to Sandbox AI Agent Code | Reinvently — https://reinvently.co.uk/blog/microvm-sandbox-options-firecracker-opensandbox-smolvm-nono/
+[17] Firecracker snapshots 28ms boot | DEV Community — https://dev.to/adwitiya/how-i-built-sandboxes-that-boot-in-28ms-using-firecracker-snapshots-i0k
+[18] Kata, gVisor, or Firecracker? | Edera — https://edera.dev/stories/kata-vs-firecracker-vs-gvisor-isolation-compared
+[19] gVisor Isolation | Agent Sandbox - Kubernetes — https://agent-sandbox.sigs.k8s.io/docs/use-cases/gvisor-isolation/
+[20] r/programming Sandboxes technical breakdown | Reddit — https://www.reddit.com/r/programming/comments/1q69bxn/sandboxes_a_technical_breakdown_of_containers/
+[21] Containers vs. gVisor vs. MicroVMs for Azure AI Agent Security | Adam the Automator — https://adamtheautomator.com/containers-vs-gvisor-vs-microvms-azure-ai-agent/
+[22] Let's discuss sandbox isolation | Shayon Mukherjee — https://www.shayon.dev/post/2026/52/lets-discuss-sandbox-isolation/
+[23] Container Runtime Security | Systems Hardening — https://www.systemshardening.com/articles/linux/linux-container-runtime-alternatives/
+[24] V8 Isolates: Why AI Agents Run 100x Faster | Kunal Ganglani — https://www.kunalganglani.com/blog/cloudflare-workers-v8-isolates-ai-agents
+[25] How V8 Isolates Work | Fordel Studios — https://fordelstudios.com/research/how-v8-isolates-actually-work-under-the-hood
+[26] Safe in the sandbox: Cloudflare Blog — https://blog.cloudflare.com/safe-in-the-sandbox-security-hardening-for-cloudflare-workers/
+[27] V8 Isolates: From Concept to Production | Clodo — https://www.clodo.dev/blog/v8-isolates-comprehensive-guide
+[28] Understanding Deno Workers | Medium — https://nut-charoenpattanasirikul.medium.com/understanding-deno-workers-v8-isolation-message-passing-and-the-permission-sandbox-0d856f26b2e3
+[29] How do CloudFlare Workers work? | Matouš Dzivjak — https://dzx.cz/2023-03-08/how_do_cloudflare_workers_work/
+[30] V8 Isolates Explained | Federico Calò — https://www.federicocalo.dev/en/blog/01-v8-isolates-explained-how-cloudflare-workers-eliminate-cold-starts
+[31] Best Code Execution Sandboxes for AI Agents 2026 | Blaxel — https://blaxel.ai/blog/code-execution-sandboxes-for-ai-agents
+[32] E2B Sandbox: Secure Code Execution for AI Agents | Effloow — https://effloow.com/articles/e2b-sandbox-secure-code-execution-ai-agents-guide-2026
+[33] E2B Review | Infragap — https://infragap.com/tools/e2b/
+[34] Mastering Secure AI Code Execution | Skywork — https://skywork.ai/skypage/en/Mastering-Secure-AI-Code-Execution-A-Deep-Dive-into-the-E2B-MCP-Server/1972499844382523392
+[35] Behind the scenes of Modal sandboxes | Amplify Partners — https://www.amplifypartners.com/blog-posts/behind-the-scenes-of-modal-sandboxes
+[36] Best GPU-Enabled Sandboxes for AI Agents | Modal — https://modal.com/resources/best-gpu-enabled-sandboxes-ai-agents
+[37] Modal: specs, pricing & alternatives | CompareSandboxes — https://comparesandboxes.com/sandbox/modal/
+[38] Modal | Ry Walker Research — https://rywalker.com/research/modal
+[39] AI Agent Sandboxes Compared | Ry Walker Research — https://rywalker.com/research/ai-agent-sandboxes
+[40] Vercel offers $1 million for hacking its AI sandbox | Techzine — https://www.techzine.eu/news/security/143695/vercel-offers-1-million-for-hacking-its-ai-sandbox/
+[41] Can you run AI agents on Vercel? | Northflank — https://northflank.com/blog/can-you-run-ai-agents-on-vercel
+[42] Run Python code securely with AI SDK and Vercel Sandbox | Vercel KB — https://vercel.com/kb/guide/python-ai-sdk-vercel-sandbox
+[43] Vercel Sandbox in the Main CLI | Open Techstack — https://open-techstack.com/blog/vercel-sandbox-vercel-cli-2026/
+[44] Where Should Your AI Agent Run Code | Developers Digest — https://www.developersdigest.tech/blog/ai-agent-code-sandbox-comparison-2026
+[45] 5 Vercel Sandbox Alternatives | Blaxel — https://blaxel.ai/blog/vercel-sandbox-alternatives
+[46] Container-to-VM Runtimes Compared | Ry Walker Research — https://rywalker.com/research/container-vm-runtimes
+[47] Firecracker vs Cloud Hypervisor vs Kata Containers | OpenComputer — https://opencomputer.dev/guides/firecracker-vs-cloud-hypervisor-vs-kata/
+[48] Best Firecracker Alternatives in 2026 | PandaStack — https://www.pandastack.ai/blog/best-firecracker-alternatives-2026/
+[49] Firecracker vs Docker | HuggingFace blog — https://huggingface.co/blog/agentbox-master/firecracker-vs-docker-tech-boundary
+[50] gVisor vs Kata Containers vs Firecracker | Onidel — https://onidel.com/blog/gvisor-kata-firecracker-2025


### PR DESCRIPTION
Every transport failure arrived as `RequestFailed(e.to_string())`, and `Display` on a `reqwest::Error` says the same sentence whether the hostname did not resolve, the port refused, the certificate was not trusted, or the request timed out. Four problems, four remedies, one message — and `reqwest` knew the difference all along, one line before we discarded it.

## What it looks like now

```
[connection-refused] sending the request: error sending request for url (...)
  - nothing accepted the connection - check the provider is running and that
    `base_url` names the right port
```

Plus a `failure_kind` field on the log, beside the provider and model.

| kind | |
|---|---|
| `dns-failure` | the hostname did not resolve |
| `connection-refused` | nothing accepted the connection |
| `tls-failure` | the handshake failed |
| `timeout` | reachable, but no answer in time |
| `connection-dropped` | the answer stopped arriving |
| `bad-request` / `not-found` / `server-error` | whose fault the status says it is |

`not-found` earns its own kind: a 404 reads as "the provider is broken" when it is usually a `base_url` path or a model that is not there.

## Two things I got wrong first

**The phrases were guessed and caught nothing.** rustls answers a plaintext port with `received corrupt message of type invalidcontenttype` — containing neither "tls" nor "certificate", the words the first version looked for. They are measured now, and a chain matching nothing stays `Transport` rather than being folded into the nearest guess: a wrong remedy sends someone to check certificates when the port was closed, which is worse than "could not be reached".

**The prefix broke the status extraction.** `UnavailableReason::from_message` reads a leading `HTTP <code>`, and `[server-error] ` in front of it hid the code — which would have silently stopped a 402 from failing over, the exact behaviour that extraction exists to drive. Caught by a test, fixed at the parser, and pinned.

## Rhai providers

```rhai
throw #{
  kind: "transport",                    // how to treat it
  failure_kind: "connection-refused",   // what it was
  message: "nothing listening on :8080",
};
```

An unknown name is ignored rather than refused, so a script written against a later build still runs here. A test asserts every built-in label is nameable from a script, so the two vocabularies cannot drift.

## Verification

Every classification is tested **against the real network stack** — a name that does not resolve, a port that refuses, a server that accepts and never answers, a TLS handshake against a plaintext port. A mocked error proves nothing about which shape `reqwest` actually reports, which is the entire question.

- Suite green as CI runs it, clippy clean, structure and docs gates pass, **coverage 13/13 at 100%**
- `FailureKind` is its own module: `provider.rs` went over the structure limit with it inline, and "how a provider is called" and "what came back when it did not" are two subjects

## On the pooling reports — both premises check out as already handled

**The HTTP connection pool is already disabled.** `pool_max_idle_per_host(0)`, set deliberately in `59784578` to fix a stall, with `pool_idle_timeout` *removed* in that same commit. There are no idle pooled connections to go stale, and adding `pool_idle_timeout` back would be a no-op.

**Inference-pool permits are already bounded.** A wall-clock `job_timeout` wraps the whole job specifically so a defeated provider timer cannot leak a permit — the documented fix for exactly that leak.

Neither is changed here. What this PR does is make the next occurrence diagnosable: a timeout now says `timeout` rather than looking like an unreachable provider.
