### PR TITLE
A slow provider is not a dead one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ same list.
 
 ## Unreleased
 
+- Changed: a provider that answers slowly keeps its place in the rotation four
+  times longer than one that cannot be reached at all, so the default pulls it
+  after twelve consecutive failures rather than three. Both were counted the
+  same, and they do not mean the same thing: nothing listening on the port is a
+  fact about the provider, while a timeout is usually a fact about one request -
+  a large prompt against a busy server. Three of those in a row is an ordinary
+  afternoon on a big run, and pulling a working provider there took it away from
+  every other run for the full five-minute cooldown. Twelve rather than never,
+  because a provider that accepts connections and answers nothing is still one
+  no run should be sent to. `provider_failures_before_open` sets both, so `0`
+  still disables the breaker outright.
+
 - Added: a failed provider call says what actually went wrong. Every transport
   failure used to arrive as one string, and `Display` on a `reqwest` error says
   the same sentence whether the hostname did not resolve, the port refused, the

--- a/crates/leviath-providers/src/failure.rs
+++ b/crates/leviath-providers/src/failure.rs
@@ -141,6 +141,38 @@ impl FailureKind {
         FailureKind::Transport
     }
 
+    /// Whether the provider was reached at all before this went wrong.
+    ///
+    /// A refusal, a name that did not resolve and a failed handshake all say
+    /// the same thing: nothing is serving at that address, and the next request
+    /// fails identically. A timeout or an answer that stopped arriving say the
+    /// opposite - the connection was established, so the provider is there. It
+    /// may be wedged, or it may be one oversized request against a busy server,
+    /// and those are not distinguishable from here.
+    ///
+    /// The circuit breaker asks, because "not there" is worth taking a provider
+    /// out of service over far sooner than "slow".
+    pub fn provider_was_reached(self) -> bool {
+        match self {
+            FailureKind::Timeout | FailureKind::ConnectionDropped => true,
+            // An answer arrived and was rejected, missing or unparseable, so the
+            // provider was plainly reached. None of these are provider-fatal, so
+            // the breaker never sees them, but the answer is still yes.
+            FailureKind::BadRequest
+            | FailureKind::NotFound
+            | FailureKind::ServerError
+            | FailureKind::MalformedResponse => true,
+            // `Transport` is the unrecognised case, and it is counted as not
+            // reached on purpose: the patient threshold is the one that lets a
+            // dead provider keep taking work, so an unknown failure takes the
+            // strict side.
+            FailureKind::DnsFailure
+            | FailureKind::ConnectionRefused
+            | FailureKind::TlsFailure
+            | FailureKind::Transport => false,
+        }
+    }
+
     /// Place an HTTP status the provider answered with.
     ///
     /// Only the statuses that are not already an [`crate::provider::UnavailableReason`]: 401,
@@ -353,6 +385,37 @@ mod tests {
             .expect_err("the handshake fails");
 
         assert_eq!(FailureKind::from_reqwest(&e), FailureKind::TlsFailure);
+    }
+
+    /// Every kind, and which side of the breaker's question it falls on. Stated
+    /// exhaustively because the consequence of getting one wrong is invisible:
+    /// a provider either loses its place in the rotation too early, or keeps it
+    /// long after it stopped serving.
+    #[test]
+    fn every_kind_says_whether_the_provider_was_reached() {
+        for kind in [
+            FailureKind::Timeout,
+            FailureKind::ConnectionDropped,
+            FailureKind::BadRequest,
+            FailureKind::NotFound,
+            FailureKind::ServerError,
+            FailureKind::MalformedResponse,
+        ] {
+            let label = kind.label();
+            assert!(kind.provider_was_reached(), "{label} reached the provider");
+        }
+        for kind in [
+            FailureKind::DnsFailure,
+            FailureKind::ConnectionRefused,
+            FailureKind::TlsFailure,
+            FailureKind::Transport,
+        ] {
+            let label = kind.label();
+            assert!(
+                !kind.provider_was_reached(),
+                "{label} never got to the provider"
+            );
+        }
     }
 
     /// A message whose bracket never closes is not a prefix, and must not be

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -992,6 +992,7 @@ async fn each_re_drive_reports_providers_out_of_service() {
     circuits.record_failure(
         "openrouter",
         leviath_providers::UnavailableReason::CreditsExhausted,
+        None,
         chrono::Utc::now().timestamp(),
         &policy,
     );

--- a/crates/leviath-runtime/src/pipeline/circuit.rs
+++ b/crates/leviath-runtime/src/pipeline/circuit.rs
@@ -21,7 +21,7 @@ use super::*;
 
 use std::collections::HashMap;
 
-use leviath_providers::UnavailableReason;
+use leviath_providers::{FailureKind, UnavailableReason};
 use serde::{Deserialize, Serialize};
 
 /// When to open a provider's circuit, and how long to leave it open.
@@ -44,6 +44,29 @@ pub struct CircuitPolicy {
 /// output tokens than the remaining balance covers, which a smaller request
 /// would survive. Three in a row is an account, not a request.
 pub const DEFAULT_FAILURES_BEFORE_OPEN: u32 = 3;
+
+/// How much more patience a provider gets when it is demonstrably there.
+///
+/// A provider that refuses the connection is out of service after
+/// `failures_before_open`. One that accepts the connection and then answers
+/// slowly, or stops mid-answer, gets this many times that budget before its
+/// circuit opens.
+///
+/// Four rather than one because the two failures do not mean the same thing.
+/// Nothing listening on the port is a fact about the provider and the next
+/// request will fail the same way. A timeout is a fact about *one request*: the
+/// usual cause is an oversized prompt against a busy server, not a dead one, and
+/// three of those in a row is an ordinary afternoon on a large run. Opening the
+/// circuit there takes a working provider away from every run on the box for the
+/// whole cooldown, which is a self-inflicted outage.
+///
+/// Four rather than never because a genuinely wedged provider - accepting
+/// connections and answering nothing - is still one that no run should be sent
+/// to, and without a ceiling every run would keep discovering that the slow way.
+///
+/// Derived from the same knob rather than a second one, so `[limits]` keeps a
+/// single dial and `failures_before_open = 0` still disables the breaker whole.
+pub const SLOW_FAILURE_MULTIPLIER: u32 = 4;
 
 /// Default time an open circuit waits before probing again.
 ///
@@ -93,8 +116,30 @@ pub struct ProviderCircuitState {
 #[derive(Resource, Debug, Clone, Default)]
 pub struct ProviderCircuits(HashMap<String, Circuit>);
 
+impl CircuitPolicy {
+    /// Consecutive failures before a failure of `kind` opens the circuit.
+    ///
+    /// `None` - a provider-fatal failure that carries no kind, such as a 402 the
+    /// provider stated outright - takes the strict threshold. Those are the
+    /// provider telling us about itself, which is exactly what the breaker is
+    /// for.
+    pub fn threshold_for(&self, kind: Option<FailureKind>) -> u32 {
+        match kind {
+            Some(k) if k.provider_was_reached() => self
+                .failures_before_open
+                .saturating_mul(SLOW_FAILURE_MULTIPLIER),
+            _ => self.failures_before_open,
+        }
+    }
+}
+
 impl ProviderCircuits {
     /// Count a provider-fatal failure against `provider`.
+    ///
+    /// `kind` decides how much patience the provider gets: one that accepted the
+    /// connection and then answered slowly is given
+    /// [`SLOW_FAILURE_MULTIPLIER`] times the budget of one that could not be
+    /// reached at all. See [`CircuitPolicy::threshold_for`].
     ///
     /// Returns `true` on the transition into the open state, so the caller can
     /// log and alert exactly once rather than on every subsequent failure.
@@ -102,6 +147,7 @@ impl ProviderCircuits {
         &mut self,
         provider: &str,
         reason: UnavailableReason,
+        kind: Option<FailureKind>,
         now: i64,
         policy: &CircuitPolicy,
     ) -> bool {
@@ -112,11 +158,12 @@ impl ProviderCircuits {
         });
         entry.consecutive_failures = entry.consecutive_failures.saturating_add(1);
         entry.reason = reason;
-        if policy.failures_before_open == 0 {
+        let threshold = policy.threshold_for(kind);
+        if threshold == 0 {
             return false; // breaker disabled; keep counting for the record
         }
         let was_open = entry.opened_at.is_some();
-        if entry.consecutive_failures >= policy.failures_before_open {
+        if entry.consecutive_failures >= threshold {
             // Re-stamp on every failure at or past the threshold: a probe that
             // fails must restart the cooldown, not inherit the old one.
             entry.opened_at = Some(now);
@@ -248,9 +295,106 @@ mod tests {
         circuits.record_failure(
             "openrouter",
             UnavailableReason::CreditsExhausted,
+            None,
             now,
             &policy(),
         )
+    }
+
+    /// A slow provider is one that answered the connection, so it keeps its
+    /// place in the rotation far longer than one that refused it.
+    ///
+    /// This is the whole point of the change: three slow calls in a row is an
+    /// ordinary afternoon on a large run, and opening the circuit there takes a
+    /// working provider away from *every* run on the box for the cooldown.
+    #[test]
+    fn a_timeout_does_not_open_the_circuit_where_a_refusal_would() {
+        let slow = Some(FailureKind::Timeout);
+        let mut circuits = ProviderCircuits::default();
+        for now in 0..3 {
+            assert!(
+                !circuits.record_failure("p", UnavailableReason::Unreachable, slow, now, &policy()),
+                "a timeout must not open the circuit at the strict threshold"
+            );
+        }
+        assert!(
+            !circuits.is_open("p", 3, &policy()),
+            "three slow calls is not an outage"
+        );
+
+        // The same three against a provider that could not be reached at all.
+        let dead = Some(FailureKind::ConnectionRefused);
+        let mut refused = ProviderCircuits::default();
+        assert!(!refused.record_failure("p", UnavailableReason::Unreachable, dead, 0, &policy()));
+        assert!(!refused.record_failure("p", UnavailableReason::Unreachable, dead, 1, &policy()));
+        assert!(
+            refused.record_failure("p", UnavailableReason::Unreachable, dead, 2, &policy()),
+            "nothing listening is a fact about the provider, and opens at three"
+        );
+    }
+
+    /// Patient, not infinite. A provider that accepts connections and answers
+    /// nothing is still one no run should be sent to, so the slow threshold has
+    /// a ceiling rather than being waived.
+    #[test]
+    fn a_wedged_provider_still_opens_its_circuit_eventually() {
+        let slow = Some(FailureKind::Timeout);
+        let mut circuits = ProviderCircuits::default();
+        let threshold = policy().threshold_for(slow);
+        assert_eq!(threshold, 12, "three strict, four times the rope");
+
+        let mut opened_at = None;
+        for now in 0..i64::from(threshold) {
+            if circuits.record_failure("p", UnavailableReason::Unreachable, slow, now, &policy()) {
+                opened_at = Some(now + 1);
+            }
+        }
+        assert_eq!(
+            opened_at,
+            Some(i64::from(threshold)),
+            "it opens on the patient threshold, not before and not never"
+        );
+        assert!(circuits.is_open("p", i64::from(threshold), &policy()));
+    }
+
+    /// A failure the provider stated outright carries no transport kind, and
+    /// takes the strict threshold. Those are the provider telling us about
+    /// itself, which is exactly what the breaker is for.
+    #[test]
+    fn a_stated_failure_keeps_the_strict_threshold() {
+        assert_eq!(policy().threshold_for(None), 3);
+        assert_eq!(
+            policy().threshold_for(Some(FailureKind::ConnectionRefused)),
+            3
+        );
+        assert_eq!(
+            policy().threshold_for(Some(FailureKind::ConnectionDropped)),
+            12
+        );
+    }
+
+    /// Zero disables the breaker whole, and multiplying zero must not quietly
+    /// re-enable it for the slow path.
+    #[test]
+    fn a_disabled_breaker_stays_disabled_for_both_thresholds() {
+        let off = CircuitPolicy {
+            failures_before_open: 0,
+            cooldown_secs: 300,
+        };
+        assert_eq!(off.threshold_for(None), 0);
+        assert_eq!(off.threshold_for(Some(FailureKind::Timeout)), 0);
+
+        let mut circuits = ProviderCircuits::default();
+        for now in 0..20 {
+            assert!(!circuits.record_failure(
+                "p",
+                UnavailableReason::Unreachable,
+                Some(FailureKind::Timeout),
+                now,
+                &off
+            ));
+        }
+        assert!(!circuits.is_open("p", 20, &off));
     }
 
     #[test]
@@ -294,7 +438,7 @@ mod tests {
     fn last_reason_reports_the_most_recent_failure_or_nothing() {
         let mut circuits = ProviderCircuits::default();
         assert_eq!(circuits.last_reason("p"), None);
-        circuits.record_failure("p", UnavailableReason::CreditsExhausted, 0, &policy());
+        circuits.record_failure("p", UnavailableReason::CreditsExhausted, None, 0, &policy());
         assert_eq!(
             circuits.last_reason("p"),
             Some(UnavailableReason::CreditsExhausted),
@@ -355,6 +499,7 @@ mod tests {
             assert!(!circuits.record_failure(
                 "openrouter",
                 UnavailableReason::CreditsExhausted,
+                None,
                 t,
                 &disabled
             ));
@@ -383,7 +528,7 @@ mod tests {
         let mut circuits = ProviderCircuits::default();
         for name in ["openrouter", "anthropic"] {
             for t in 0..3 {
-                circuits.record_failure(name, UnavailableReason::AuthFailed, t, &policy());
+                circuits.record_failure(name, UnavailableReason::AuthFailed, None, t, &policy());
             }
         }
         let open = circuits.open_circuits(10, &policy());
@@ -399,9 +544,9 @@ mod tests {
     #[test]
     fn the_latest_reason_wins() {
         let mut circuits = ProviderCircuits::default();
-        circuits.record_failure("p", UnavailableReason::CreditsExhausted, 0, &policy());
-        circuits.record_failure("p", UnavailableReason::AuthFailed, 1, &policy());
-        circuits.record_failure("p", UnavailableReason::AuthFailed, 2, &policy());
+        circuits.record_failure("p", UnavailableReason::CreditsExhausted, None, 0, &policy());
+        circuits.record_failure("p", UnavailableReason::AuthFailed, None, 1, &policy());
+        circuits.record_failure("p", UnavailableReason::AuthFailed, None, 2, &policy());
         let open = circuits.open_circuits(2, &policy());
         assert_eq!(open[0].reason, UnavailableReason::AuthFailed);
     }
@@ -450,7 +595,13 @@ mod tests {
         let now = chrono::Utc::now().timestamp();
         for name in open {
             for _ in 0..policy().failures_before_open {
-                circuits.record_failure(name, UnavailableReason::CreditsExhausted, now, &policy());
+                circuits.record_failure(
+                    name,
+                    UnavailableReason::CreditsExhausted,
+                    None,
+                    now,
+                    &policy(),
+                );
             }
         }
         world.insert_resource(circuits);
@@ -596,6 +747,7 @@ mod tests {
             circuits.record_failure(
                 "openrouter",
                 UnavailableReason::CreditsExhausted,
+                None,
                 now,
                 &default_policy,
             );

--- a/crates/leviath-runtime/src/pipeline/circuit.rs
+++ b/crates/leviath-runtime/src/pipeline/circuit.rs
@@ -301,6 +301,45 @@ mod tests {
         )
     }
 
+    /// Failures have to be *consecutive*, and a success in between is what
+    /// makes them not.
+    ///
+    /// The existing cover only checked that a success closes an already-open
+    /// circuit. The case that actually happens is quieter: a provider that
+    /// times out now and then, works in between, and never has three bad calls
+    /// in a row. Without the reset those add up over an afternoon and the
+    /// provider is pulled for a fault it does not have.
+    #[test]
+    fn a_success_in_between_means_the_failures_are_not_consecutive() {
+        let mut circuits = ProviderCircuits::default();
+        // The strict threshold, so the count is the only thing under test.
+        let dead = Some(FailureKind::ConnectionRefused);
+        let hit = |c: &mut ProviderCircuits, now: i64| {
+            c.record_failure("p", UnavailableReason::Unreachable, dead, now, &policy())
+        };
+
+        assert!(!hit(&mut circuits, 0));
+        assert!(!hit(&mut circuits, 1));
+        circuits.record_success("p");
+        // Three more failures have now happened in total. Counting them all
+        // would open the circuit here; counting them in a row does not.
+        assert!(!hit(&mut circuits, 2), "the count restarted at the success");
+        assert!(!circuits.is_open("p", 2, &policy()));
+
+        assert!(!hit(&mut circuits, 3));
+        circuits.record_success("p");
+        assert!(!hit(&mut circuits, 4));
+        assert!(
+            !circuits.is_open("p", 4, &policy()),
+            "five failures, never three in a row, and the provider stays in service"
+        );
+
+        // And an actual run of three still opens it, so the reset has not
+        // disarmed the breaker.
+        assert!(!hit(&mut circuits, 5));
+        assert!(hit(&mut circuits, 6), "three in a row is still an outage");
+    }
+
     /// A slow provider is one that answered the connection, so it keeps its
     /// place in the rotation far longer than one that refused it.
     ///

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -150,21 +150,23 @@ pub fn collect_inference(
         // answer at all proves the provider is serving; a provider-fatal one
         // counts against it and may take it out of service for everyone.
         if let Some(circuits) = circuits.as_deref_mut() {
-            match outcome
-                .result
-                .as_ref()
-                .err()
-                .and_then(|e| e.unavailable_reason())
-            {
+            let failed = outcome.result.as_ref().err();
+            match failed.and_then(|e| e.unavailable_reason()) {
                 Some(reason) => {
-                    if circuits.record_failure(&called_provider, reason, now, &policy) {
+                    // The kind travels with the reason now: a provider that
+                    // accepted the connection and then answered slowly is not
+                    // the same as one that refused it, and the breaker gives the
+                    // first far more rope before taking it away from every run.
+                    let kind = failed.and_then(|e| e.failure_kind());
+                    if circuits.record_failure(&called_provider, reason, kind, now, &policy) {
                         // Loud and once, on the transition only. This is the
                         // alert issue #201 asked for: without it, ten dead
                         // runs in a row look like ten unrelated failures.
                         tracing::error!(
                             provider = %called_provider,
                             reason = reason.label(),
-                            failures = policy.failures_before_open,
+                            failure_kind = kind.map_or("unknown", |k| k.label()),
+                            failures = policy.threshold_for(kind),
                             cooldown_secs = policy.cooldown_secs,
                             "provider circuit opened; no run will be dispatched to it \
                              until it recovers"

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -775,6 +775,7 @@ mod tests {
             circuits.record_failure(
                 "ghost",
                 leviath_providers::UnavailableReason::CreditsExhausted,
+                None,
                 NOW - 3 + i,
                 &policy,
             );
@@ -815,6 +816,7 @@ mod tests {
             circuits.record_failure(
                 "ghost",
                 leviath_providers::UnavailableReason::CreditsExhausted,
+                None,
                 NOW - 3 + i,
                 &policy,
             );
@@ -873,7 +875,7 @@ mod tests {
             world.insert_resource(StallTimeout(60));
             let mut circuits = super::super::circuit::ProviderCircuits::default();
             let policy = super::super::circuit::CircuitPolicy::default();
-            circuits.record_failure("ghost", reason, NOW - 1, &policy);
+            circuits.record_failure("ghost", reason, None, NOW - 1, &policy);
             world.insert_resource(circuits);
             let e = spawn_stalled(&mut world, StallReason::ProviderCircuitOpen, 61);
 

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -584,6 +584,7 @@ async fn dispatch_parks_an_agent_whose_provider_circuit_is_open() {
     circuits.record_failure(
         "cfg",
         leviath_providers::UnavailableReason::CreditsExhausted,
+        None,
         chrono::Utc::now().timestamp(),
         &policy,
     );
@@ -621,6 +622,7 @@ async fn dispatch_proceeds_once_the_cooldown_lets_a_probe_through() {
     circuits.record_failure(
         "cfg",
         leviath_providers::UnavailableReason::CreditsExhausted,
+        None,
         chrono::Utc::now().timestamp() - 61,
         &policy,
     );
@@ -1365,6 +1367,66 @@ fn provider_fatal_failures_trip_the_breaker_and_a_success_clears_it() {
         !world
             .resource::<ProviderCircuits>()
             .is_open("dead", now, &policy)
+    );
+}
+
+/// The breaker's two speeds, end to end.
+///
+/// A provider that refused the connection is not serving anyone and the next
+/// request proves it again. One that accepted the connection and then went
+/// quiet is demonstrably there, and the usual cause is an oversized prompt
+/// against a busy server - so it keeps its place four times longer before being
+/// taken away from every run on the box.
+#[test]
+fn a_slow_provider_keeps_its_place_where_a_refused_one_loses_it() {
+    let policy = CircuitPolicy {
+        failures_before_open: 2,
+        cooldown_secs: 300,
+    };
+    let now = chrono::Utc::now().timestamp();
+
+    // The label is the channel: `failure_kind` reads it back off the message,
+    // which is the only thing that survives into a Rhai provider and out again.
+    let fail_with = |label: &str| {
+        leviath_providers::ProviderError::RequestFailed(format!(
+            "[{label}] sending the request: the call did not complete"
+        ))
+    };
+
+    let strikes = |label: &str, count: usize| {
+        let (mut world, tx) = world_with_results();
+        world.insert_resource(ProviderCircuits::default());
+        world.insert_resource(policy);
+        for _ in 0..count {
+            let e = world
+                .spawn((agent_state(), AwaitingInference, stage_with_fallback()))
+                .id();
+            tx.send(InferenceOutcome {
+                latency: std::time::Duration::ZERO,
+                entity: e,
+                result: Err(fail_with(label)),
+                pricing: None,
+            })
+            .unwrap();
+            run_collect(&mut world);
+        }
+        world
+            .resource::<ProviderCircuits>()
+            .is_open("dead", now, &policy)
+    };
+
+    assert!(
+        strikes("connection-refused", 2),
+        "nothing listening is a fact about the provider, and opens at the threshold"
+    );
+    assert!(!strikes("timeout", 2), "two slow answers is not an outage");
+    assert!(
+        !strikes("timeout", 7),
+        "nor is seven, one short of four times the threshold"
+    );
+    assert!(
+        strikes("timeout", 8),
+        "but a provider that has answered nothing eight times running is wedged"
     );
 }
 

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -1370,6 +1370,68 @@ fn provider_fatal_failures_trip_the_breaker_and_a_success_clears_it() {
     );
 }
 
+/// A provider that fails intermittently is not a provider that is failing.
+///
+/// Timeout, success, timeout, success, timeout is three failed calls and no
+/// fault: the provider answered in between, which is the whole definition of
+/// "not consecutive". This drives it through `collect_inference` rather than the
+/// breaker alone, because the reset lives in the wiring - the success arm has to
+/// actually be reached for the count to clear.
+#[test]
+fn a_success_between_failures_clears_the_count_end_to_end() {
+    let policy = CircuitPolicy {
+        failures_before_open: 3,
+        cooldown_secs: 300,
+    };
+    let now = chrono::Utc::now().timestamp();
+    let (mut world, tx) = world_with_results();
+    world.insert_resource(ProviderCircuits::default());
+    world.insert_resource(policy);
+
+    // The strict threshold, so this measures the count and not the patience
+    // added for slow providers.
+    let send = |world: &mut World, ok: bool| {
+        let e = world
+            .spawn((agent_state(), AwaitingInference, stage_with_fallback()))
+            .id();
+        let result = if ok {
+            Ok(resp("hi"))
+        } else {
+            Err(leviath_providers::ProviderError::RequestFailed(
+                "[connection-refused] sending the request: the call did not complete".to_string(),
+            ))
+        };
+        tx.send(InferenceOutcome {
+            latency: std::time::Duration::ZERO,
+            entity: e,
+            result,
+            pricing: None,
+        })
+        .unwrap();
+        run_collect(world);
+    };
+
+    for ok in [false, true, false, true, false] {
+        send(&mut world, ok);
+    }
+    assert!(
+        !world
+            .resource::<ProviderCircuits>()
+            .is_open("dead", now, &policy),
+        "three failures with successes between them is not three in a row"
+    );
+
+    // Two more with nothing in between finally makes a run of three.
+    send(&mut world, false);
+    send(&mut world, false);
+    assert!(
+        world
+            .resource::<ProviderCircuits>()
+            .is_open("dead", now, &policy),
+        "three consecutive failures still opens the circuit"
+    );
+}
+
 /// The breaker's two speeds, end to end.
 ///
 /// A provider that refused the connection is not serving anyone and the next

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -1418,6 +1418,7 @@ mod tests {
         circuits.record_failure(
             "openrouter",
             leviath_providers::UnavailableReason::CreditsExhausted,
+            None,
             chrono::Utc::now().timestamp(),
             &policy,
         );
@@ -1444,6 +1445,7 @@ mod tests {
             circuits.record_failure(
                 "openrouter",
                 leviath_providers::UnavailableReason::AuthFailed,
+                None,
                 chrono::Utc::now().timestamp(),
                 &default_policy,
             );
@@ -2079,6 +2081,7 @@ mod tests {
         circuits.record_failure(
             "openrouter",
             leviath_providers::UnavailableReason::CreditsExhausted,
+            None,
             chrono::Utc::now().timestamp(),
             &policy,
         );

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -284,6 +284,15 @@ or a rejected key, before that provider is taken out of service for every run. T
 because a single payment error can just be one oversized request. `0` disables it and leaves per-run
 failover to cope alone.
 
+A provider that answered the connection and then went quiet gets four times that budget, so the
+default pulls it after twelve rather than three. The two failures do not mean the same thing:
+nothing listening on the port is a fact about the provider, and the next request fails identically,
+while a timeout is usually a fact about one request - a large prompt against a busy server. Three
+slow calls in a row is an ordinary afternoon on a big run, and pulling a working provider there
+takes it away from every other run for the whole cooldown. Twelve rather than never, because a
+provider that accepts connections and answers nothing is still one no run should be sent to. The
+same knob sets both, so `0` still disables the whole thing.
+
 **`inference_retry_attempts`** and **`inference_retry_base_ms`** set how hard a failed model call
 is retried before the agent is failed and its finished work is thrown away. Only a *transient*
 failure is retried at all: a reset connection, a timeout, a 429, a 5xx. A rejected key or an

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -134,6 +134,12 @@ Three rather than one because a single "payment required" can be one request ask
 tokens than the balance covers, which a smaller request would survive. Three in a row is the
 account.
 
+Timeouts are counted on a longer fuse: four times the number above, so twelve by default. A provider
+that refuses the connection is not serving anyone and the next request proves it again, but one that
+accepts the connection and answers slowly is demonstrably there, and the usual cause is a large
+prompt rather than a dead server. Pulling it after three would take a working provider away from
+every run for the cooldown.
+
 While a provider is out, runs move to their next candidate. A run with none left is failed with an
 error saying so, rather than left sitting there looking healthy. Once the cooldown passes, the next
 request goes through as a probe: if it works the provider is back immediately, and if it fails the


### PR DESCRIPTION
The circuit breaker counted every provider-fatal failure the same, so three
timeouts in a row pulled a provider out of service **for every run on the box**
for five minutes. Three timeouts in a row is an ordinary afternoon on a large
run.

## Why they were counted together

They arrived as one indistinguishable string. `Display` on a `reqwest::Error`
says the same sentence for a refused port and a request that timed out, so
counting them the same was the only option available. #614 is what makes the
distinction possible.

## The two failures do not mean the same thing

Nothing listening on the port is a fact about **the provider**, and the next
request fails identically. That is exactly what the breaker is for.

A timeout is usually a fact about **one request** - an oversized prompt against
a busy server. The provider accepted the connection, so it is demonstrably
there.

So a failure that reached the provider (`timeout`, `connection-dropped`) now
gets four times the budget of one that never got there. The default pulls a slow
provider after twelve consecutive failures instead of three.

Four rather than never, because a provider that accepts connections and answers
nothing is still one no run should be sent to, and without a ceiling every run
would keep rediscovering that the slow way.

## Scope

Deliberately narrow. **Failover and the pause-for-resume are untouched**: a
timeout still moves the run to the next provider, and still parks it for
`lev resume` rather than killing it when there is nowhere left to go. Only the
decision to take a provider away from *other* runs is relaxed.

The alternative considered was narrowing `RequestFailed -> Unreachable` so a
timeout is an ordinary error. That was rejected: an ordinary error takes the
stage's `error` edge or terminates the run, so a wedged provider would go from
costing a `lev resume` to costing the whole run.

No new config. The threshold is derived from the existing
`provider_failures_before_open`, so `[limits]` keeps a single dial and `0` still
disables the breaker whole.

## Verification

Every new test was run against the unfixed code first and fails there
(3 of 4 policy tests, plus the end-to-end one; the fourth is the
disabled-breaker guard, which correctly holds either way).

- `provider_was_reached` covers all ten kinds exhaustively
- the breaker's two speeds, driven end to end through `collect_inference`
- `provider_failures_before_open = 0` stays disabled on both paths, since
  multiplying zero must not quietly re-enable it

Local gates: workspace suite green, clippy clean, docs and structure pass,
`leviath-providers` and `leviath-runtime` both at 100% coverage.
