### PR TITLE
chore(release): 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
+## 0.5.1 - 2026-08-26
 
 - Changed: `lev ps`, the TUI and the HTTP API describe a run's time the same
   way. There are three spans and they answer different questions - AGE (how long

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "dirs",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64 0.23.1",
  "leviath-core",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "fs4",
  "keyring",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "tokio",
  "tracing",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.5.0" }
-leviath-core = { path = "crates/leviath-core", version = "0.5.0" }
-leviath-net = { path = "crates/leviath-net", version = "0.5.0" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.0" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.0" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.5.0" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.0" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.0" }
-leviath-package = { path = "crates/leviath-package", version = "0.5.0" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.5.0" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.5.0" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.0" }
+leviath = { path = "crates/leviath", version = "0.5.1" }
+leviath-core = { path = "crates/leviath-core", version = "0.5.1" }
+leviath-net = { path = "crates/leviath-net", version = "0.5.1" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.1" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.1" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.5.1" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.1" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.1" }
+leviath-package = { path = "crates/leviath-package", version = "0.5.1" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.5.1" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.5.1" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.1" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.5.0", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.5.1", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": {
       "name": "MIT"
@@ -1841,6 +1841,27 @@
               "null"
             ],
             "description": "Unix seconds; null until the stage is left."
+          },
+          "active": {
+            "type": [
+              "object",
+              "null"
+            ],
+            "description": "How long this stage actually spent working, as against how long it was the cursor. Null on records written before Leviath kept the clock, which is distinct from a stage that did no work. A stage the run is parked in - paused, or holding a prompt open - is still the cursor stage, so started_at..ended_at counts time nothing spent working.",
+            "properties": {
+              "banked_secs": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Seconds from spans that have already ended."
+              },
+              "since": {
+                "type": [
+                  "integer",
+                  "null"
+                ],
+                "description": "Unix seconds when the span in progress began, or null while the clock is stopped. The working total is banked_secs plus now - since when since is set."
+              }
+            }
           }
         }
       },


### PR DESCRIPTION
Cuts 0.5.1. Merging this publishes the alpha channel; beta follows by dispatch.

`cargo xtask version 0.5.1` wrote all of it: `[workspace.package] version`, the intra-workspace path-dep pins, `Cargo.lock`, the OpenAPI `info.version`, and the CHANGELOG heading (`## Unreleased` → `## 0.5.1 - 2026-08-26`). `cargo xtask version --check` agrees every pin matches and every member is in the publish list and the coverage matrix.

## One non-mechanical change

`StageRecord` in `docs/schema/openapi.json` gained the `active` clock. `GET /api/agents/{id}/stages` has returned that field since #616, and `xtask docs` only checks that routes have spec entries, not that response schemas list every field - so it went unnoticed there. Folded in here rather than held for its own PR: a published spec that omits a field this very release adds is the worse outcome.

The run object itself has no schema in the spec to update, so `age_secs` / `working_secs` have nowhere to land beyond the prose in `docs/content/api.md`, which #616 already covers.

## What 0.5.1 contains

Everything under the heading in the CHANGELOG, which is #616 plus the provider circuit-breaker work that landed before it:

- A run's duration counts only the time it was working. Paused, blocked on a person, or parked until the machine is fixed no longer count; inferring, calling tools, and being held for its own fan-out workers and sub-agents do.
- `lev ps`, the TUI and the HTTP API describe a run's time the same way - `AGE`, `WORK`, `MOVED`, with `age_secs` and `working_secs` computed on every run object the APIs serve.
- A provider that answers slowly keeps its place in the rotation four times longer than one that cannot be reached at all.
- A failed provider call says what actually went wrong, and Rhai providers can supply `failure_kind`.

## Note

Carries `allow-version-bump`, as the `guard-version-bump` required check demands of any PR moving the version.
