### PR TITLE
fix(validate): check a model against the provider that would serve it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## Unreleased
+
+- Fixed: a stage naming a model its provider does not carry is now a validation
+  error and a refused spawn, instead of a run on some other model. Nothing had
+  ever checked a model id against the provider that would serve it: pinned
+  `provider/model` pairs were taken on trust at resolution, and `lev validate`
+  only compared them to a table compiled into the build covering Anthropic,
+  OpenAI and Google. A custom Rhai provider was therefore never checked at all,
+  so a stage pinned to `groq/llama-3.1-70b` on a `groq.rhai` that serves nothing
+  of that name validated clean, spawned clean, and quietly ran on whatever the
+  fallback chain reached. `lev validate` now asks each provider the blueprint
+  pins what it serves, using the same primed registry the runtime resolves
+  against, and reports `unserved-model` as an error - which `--json` carries and
+  the exit code reflects. The daemon refuses such a spawn with the provider and
+  model named.
+- Added: `catalog-unchecked`, a warning naming a script provider that loaded but
+  has neither a `list_models(state)` function nor a `[model_providers.<name>]
+  serves` list, so it has never said what it takes and its model ids went
+  unchecked. `serves` is read from `config.toml` with no network and no key,
+  which makes it the way to get a script provider checked in CI.
+- Changed: `no-reachable-provider` now judges an entry that names a model and no
+  provider, which is the form every bundled blueprint is written in. It used to
+  skip any stage holding one, because it had no registry to ask which providers
+  serve a bare name; it now has the resolver's own answer. A stage naming a
+  single misspelled model produced no finding at all before this and now says so.
+  Its message lists entries the way the blueprint writes them, bare or
+  `provider/model`, rather than provider names alone.
+- Changed: a fallback whose provider says it does not carry that model is
+  dropped from a stage's failover chain rather than left in it, so a failover
+  cannot spend a step dispatching to a pair the API will reject.
+
 ## 0.5.1 - 2026-08-26
 
 - Changed: `lev ps`, the TUI and the HTTP API describe a run's time the same

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -1455,6 +1455,11 @@ mod tests {
             available_providers: None,
             read_paths: None,
             safe_commands_granted: None,
+            // No machine to ask, which is the point: this test asserts what a
+            // bundled blueprint says about itself, not what one install happens
+            // to have configured.
+            provider_catalogs: std::collections::HashMap::new(),
+            unrouted_models: std::collections::HashSet::new(),
             model_windows: crate::commands::models::builtin_model_windows(),
         }
     }

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -270,7 +270,7 @@ pub(super) async fn list_models_from_config(
     registry
         .prime_capabilities(
             std::time::Duration::from_secs(MODELS_PRIME_TIMEOUT_SECS),
-            None,
+            &[],
         )
         .await;
     let mut models = Vec::new();

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -429,6 +429,13 @@ fn execute_reporting_outcome(
         env = env
             .with_providers(&checked.blueprint, config)
             .with_read_paths(&checked.blueprint, config, &workdir);
+        // The primed registry, not a fresh one. A provider that has not been
+        // asked what it serves has no catalogue to report, and a check reading
+        // an empty catalogue would call every model wrong - so this is the one
+        // builder that takes the registry the caller already warmed.
+        if let Some(registry) = registry {
+            env = env.with_provider_catalogs(&checked.blueprint, config, registry);
+        }
     }
     let findings = lint_manifest(&checked.content, &checked.blueprint, &env);
     let (errors, warnings) = match args.json {
@@ -746,8 +753,34 @@ fn print_global_script_report_in(
 /// an install with no reachable provider.
 async fn primed_registry(
     config: Option<&crate::config::Config>,
+    pinned: &[String],
 ) -> Option<leviath_runtime::ProviderRegistry> {
-    primed_registry_with(config, &leviath_providers::provider::build_http_client).await
+    primed_registry_with(
+        config,
+        pinned,
+        &leviath_providers::provider::build_http_client,
+    )
+    .await
+}
+
+/// Every provider the blueprint pins by name, deduplicated.
+///
+/// A script provider is compiled on demand, so one that is neither configured
+/// nor the machine default is never primed and has no catalogue to report -
+/// which would leave the very entries that named it unchecked. Priming exactly
+/// the ones this blueprint mentions costs a compile of a script the author is
+/// already using.
+fn pinned_providers(blueprint: &leviath_core::Blueprint) -> Vec<String> {
+    let mut names: Vec<String> = blueprint
+        .stages
+        .iter()
+        .flat_map(|s| s.model.models.iter())
+        .filter(|e| !e.provider.is_empty())
+        .map(|e| e.provider.clone())
+        .collect();
+    names.sort_unstable();
+    names.dedup();
+    names
 }
 
 /// [`primed_registry`], with client construction injected.
@@ -760,19 +793,24 @@ async fn primed_registry(
 ///     crate::commands::run::build_provider_registry_from_config_with
 async fn primed_registry_with(
     config: Option<&crate::config::Config>,
+    pinned: &[String],
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
 ) -> Option<leviath_runtime::ProviderRegistry> {
     let config = config?;
     let registry =
         crate::commands::run::build_provider_registry_from_config_with(config, build_client)
             .ok()?;
+    // The machine's default, so `lev validate` reports the model a run would
+    // really use on a machine whose default is a script provider rather than
+    // the one it would have used before that provider could answer. Plus every
+    // provider this blueprint pins, so the catalogue check has something to
+    // check against - see `pinned_providers`.
+    let mut also: Vec<&str> = vec![config.default_provider.as_str()];
+    also.extend(pinned.iter().map(String::as_str));
     registry
         .prime_capabilities(
             std::time::Duration::from_secs(VALIDATE_PRIME_TIMEOUT_SECS),
-            // So `lev validate` reports the model a run would really use on a
-            // machine whose default is a script provider, rather than the one
-            // it would have used before that provider could answer.
-            Some(config.default_provider.as_str()),
+            &also,
         )
         .await;
     Some(registry)
@@ -805,7 +843,13 @@ pub async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
     // table until it is asked. Without this, `validate` and the daemon disagree
     // about which model a stage runs, and the tool whose job is saying what will
     // happen is the one that does not know.
-    let registry = primed_registry(config.as_ref()).await;
+    // Parsed here only to learn which providers to prime; the real parse, with
+    // its error reporting, happens inside `execute_reporting_outcome`. A
+    // manifest that will not parse primes nothing extra and is reported there.
+    let pinned = check_manifest(std::path::Path::new(&args.path))
+        .map(|c| pinned_providers(&c.blueprint))
+        .unwrap_or_default();
+    let registry = primed_registry(config.as_ref(), &pinned).await;
 
     match execute_reporting_outcome(&args, config.as_ref(), registry.as_ref())? {
         ValidateOutcome::Success => Ok(()),
@@ -898,7 +942,7 @@ system_prompt = "hi"
     #[tokio::test]
     async fn no_config_means_no_registry_to_prime() {
         assert!(
-            primed_registry(None).await.is_none(),
+            primed_registry(None, &[]).await.is_none(),
             "nothing to build a registry from"
         );
     }
@@ -930,7 +974,7 @@ system_prompt = "hi"
         // version passed on macOS and failed on Linux.
         let no_client = |_: Option<u64>| Err(leviath_providers::provider::malformed_url_error());
         assert!(
-            primed_registry_with(Some(&config), &no_client)
+            primed_registry_with(Some(&config), &[], &no_client)
                 .await
                 .is_none(),
             "no client, so no providers, so nothing to say"

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -173,7 +173,7 @@ pub async fn setup_daemon_host_with(
             // answer what it serves and win an open route (issue #598). No
             // effect when the default is a native provider, which is already
             // in the list.
-            Some(config.default_provider.as_str()),
+            &[config.default_provider.as_str()],
         )
         .await;
     // MCP connections are shared across agents; the workdir here only seeds the

--- a/crates/leviath-cli/src/lint/checks.rs
+++ b/crates/leviath-cli/src/lint/checks.rs
@@ -5,6 +5,7 @@
 //! agent work" and those answer "should this agent be allowed to".
 
 use super::*;
+use leviath_runtime::pipeline::model_key;
 
 /// Fields the stage left to a default: `mode`, `model`, and `max_iterations`.
 pub(super) fn lint_declarations(stage: &leviath_core::Stage, keys: StageKeys) -> Vec<LintFinding> {
@@ -555,11 +556,80 @@ pub(super) fn lint_graph(blueprint: &Blueprint) -> Vec<LintFinding> {
     findings
 }
 
+/// A few names out of a catalogue, for a message that has to fit on a line.
+///
+/// The count is worth carrying even when the list is short: "it lists 2" and
+/// "it lists 340" send someone to different places, the first to a typo in the
+/// script's own `list_models` and the second to a typo in the blueprint.
+fn sample_catalog(ids: &[String]) -> String {
+    const SHOWN: usize = 3;
+    let head: Vec<&str> = ids.iter().take(SHOWN).map(String::as_str).collect();
+    match ids.len() > SHOWN {
+        true => format!("{} and {} more", head.join(", "), ids.len() - SHOWN),
+        false => head.join(", "),
+    }
+}
+
 /// Models and providers the install cannot resolve.
 pub(super) fn lint_models(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<LintFinding> {
     let mut findings = Vec::new();
 
     for entry in &stage.model.models {
+        // What the provider itself said, when this install asked it. It beats
+        // every check below: a live catalogue knows about models released after
+        // this build, and about a script provider's models that no build could
+        // know.
+        match env.provider_catalogs.get(&entry.provider) {
+            Some(ProviderCatalog::Complete(ids)) => {
+                let key = model_key(&entry.model);
+                if !ids.iter().any(|id| model_key(id) == key) {
+                    findings.push(
+                        LintFinding::new(
+                            LintSeverity::Error,
+                            "unserved-model",
+                            format!(
+                                "names {}/{}, which provider '{}' does not serve (it lists {})",
+                                entry.provider,
+                                entry.model,
+                                entry.provider,
+                                sample_catalog(ids),
+                            ),
+                        )
+                        .in_stage(&stage.name)
+                        .with_fix(format!(
+                            "run `lev models list --provider {}` and name one of those",
+                            entry.provider
+                        )),
+                    );
+                }
+                // Checked against the provider's own answer, so the compiled
+                // table below has nothing left to add and would only put a
+                // second, weaker finding on the same entry.
+                continue;
+            }
+            Some(ProviderCatalog::ScriptSaidNothing) => {
+                findings.push(
+                    LintFinding::new(
+                        LintSeverity::Warning,
+                        "catalog-unchecked",
+                        format!(
+                            "names {}/{}, and provider '{}' does not say which models \
+                             it serves, so the name went unchecked",
+                            entry.provider, entry.model, entry.provider
+                        ),
+                    )
+                    .in_stage(&stage.name)
+                    .with_fix(format!(
+                        "give {}.rhai a `list_models(state)`, or list its models under \
+                         `[model_providers.{}] serves`",
+                        entry.provider, entry.provider
+                    )),
+                );
+                continue;
+            }
+            None => {}
+        }
+
         // A provider with no catalog here is open-ended (Ollama serves whatever
         // is pulled, OpenRouter's list runs to hundreds, a script provider
         // defines its own). Checking a model against a catalog that does not
@@ -594,38 +664,56 @@ pub(super) fn lint_models(stage: &leviath_core::Stage, env: &LintEnv) -> Vec<Lin
     // saying is that *nothing* in the list does, which is the shape that
     // reaches the runtime as "no usable provider" at spawn.
     //
-    // An entry that pins no provider is not evidence either way here. It names a
-    // model and leaves the route open, and which providers serve that model is a
-    // question for the resolver, which has a registry; this check does not. So an
-    // open entry counts as reachable rather than as a provider named and missing
-    // - before that, a blueprint written entirely in the current form failed this
-    // check every time and was told it would "fall back to your default model",
-    // having tried providers it never named.
-    let pinned: Vec<&str> = stage
-        .model
-        .models
-        .iter()
-        .filter(|e| !e.provider.is_empty())
-        .map(|e| e.provider.as_str())
-        .collect();
-    if let Some(available) = &env.available_providers
+    // An entry is reachable when this install can actually run it: a pinned one
+    // needs its provider registered, an open one needs something that serves
+    // its model.
+    //
+    // That second half used to be unanswerable here. The check had no registry,
+    // so it counted an open entry as reachable on the grounds that the resolver
+    // knew better, and skipped itself entirely on any stage holding one - the
+    // form every bundled blueprint is written in. It now has the resolver's own
+    // answer in `unrouted_models`, so a stage whose every entry names something
+    // this machine cannot run is reported whichever form its entries take.
+    //
+    // `unrouted_models` is empty both when nobody asked and when everything
+    // routes, and both read as reachable here. That is the safe direction: a
+    // question nobody asked must not turn into a finding.
+    let reachable = |e: &leviath_core::blueprint::ModelEntry| match e.provider.is_empty() {
+        true => !env.unrouted_models.contains(&e.model),
+        false => env
+            .available_providers
+            .as_ref()
+            .is_some_and(|a| a.contains(&e.provider)),
+    };
+    if env.available_providers.is_some()
         && !stage.model.models.is_empty()
-        && pinned.len() == stage.model.models.len()
-        && !pinned.iter().any(|p| available.contains(&p.to_string()))
+        && !stage.model.models.iter().any(reachable)
     {
-        let tried: Vec<&str> = pinned.clone();
+        // Written the way the blueprint writes them, so the list in the message
+        // can be found in the file: a bare name for an entry that left the route
+        // open, `provider/model` for one that pinned it. Rendering an open entry
+        // as `/gpt-5.5` would show a route it does not claim to have.
+        let tried: Vec<String> = stage
+            .model
+            .models
+            .iter()
+            .map(|e| match e.provider.is_empty() {
+                true => e.model.clone(),
+                false => format!("{}/{}", e.provider, e.model),
+            })
+            .collect();
         findings.push(
             LintFinding::new(
                 LintSeverity::Warning,
                 "no-reachable-provider",
                 format!(
-                    "names no provider this install can reach (tried {}), so it \
+                    "names nothing this install can run (tried {}), so it \
                      falls back to your default model",
                     tried.join(", ")
                 ),
             )
             .in_stage(&stage.name)
-            .with_fix("run `lev setup` to configure one of them, or add a provider you have"),
+            .with_fix("run `lev setup` to configure one of them, or name a model you have"),
         );
     }
 

--- a/crates/leviath-cli/src/lint/mod.rs
+++ b/crates/leviath-cli/src/lint/mod.rs
@@ -120,6 +120,28 @@ impl LintFinding {
     }
 }
 
+/// What one provider answered when asked what models it takes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProviderCatalog {
+    /// It named everything it carries. A model outside this list is a model it
+    /// will refuse, so naming one is a fault in the blueprint rather than a
+    /// fact about the machine.
+    Complete(Vec<String>),
+
+    /// It is reachable but would not say what it carries, and it is a script
+    /// provider - one with neither a `list_models` function nor a
+    /// `[model_providers.<name>] serves` list.
+    ///
+    /// Only script providers are recorded this way. Every built-in whose
+    /// catalogue this build cannot see is either covered by the compiled-in
+    /// table that `unknown-model` reads (Anthropic, OpenAI, Google) or has an
+    /// open catalogue where silence is the correct answer (Ollama serves
+    /// whatever has been pulled). A script provider is the one case where the
+    /// silence is the author's to fix, and where saying nothing is what let a
+    /// wrong model id reach a run unremarked.
+    ScriptSaidNothing,
+}
+
 /// Facts about the machine the blueprint will run on, which the manifest alone
 /// cannot supply.
 ///
@@ -160,6 +182,31 @@ pub struct LintEnv {
     /// or not at all.
     pub safe_commands_granted: Option<bool>,
 
+    /// What each provider the blueprint names says it serves, read off the same
+    /// primed registry the runtime resolves against.
+    ///
+    /// A provider absent from this map was not asked - either nobody built a
+    /// registry (the daemon's offline lint) or this install cannot reach it -
+    /// and its entries go unchecked. See [`ProviderCatalog`] for what the two
+    /// present states mean.
+    pub provider_catalogs: HashMap<String, ProviderCatalog>,
+
+    /// Bare model names the blueprint leaves unrouted: it names the model and
+    /// no provider, and nothing this install can reach claims to serve it.
+    ///
+    /// Asked of the registry exactly as [`resolve_stage_candidates`] asks it,
+    /// so this is the set of entries resolution silently drops. It is what
+    /// lets `no-reachable-provider` judge an open entry at all: without it that
+    /// check had to assume every open entry was fine, and so skipped itself on
+    /// every blueprint written in the form they are all written in.
+    ///
+    /// Empty when nobody asked, which is indistinguishable from "everything
+    /// routes". Both mean the same thing to the check that reads it - treat the
+    /// entry as reachable - so an unasked question cannot become a finding.
+    ///
+    /// [`resolve_stage_candidates`]: leviath_runtime::pipeline::resolve_stage_candidates
+    pub unrouted_models: HashSet<String>,
+
     /// Context-window size per `(provider, model)`, for the models this build
     /// ships a capability row for.
     ///
@@ -195,6 +242,14 @@ impl LintEnv {
             available_providers: None,
             read_paths: None,
             safe_commands_granted: None,
+            // Both empty for the same reason `available_providers` is `None`:
+            // reading a provider's catalogue means building and priming a
+            // registry, which is a network call per provider, and the daemon
+            // already refuses a spawn that names a model its provider will not
+            // serve. Doing it again here would cost every agent a round of
+            // priming to say something the spawn says louder a moment later.
+            provider_catalogs: HashMap::new(),
+            unrouted_models: HashSet::new(),
             model_windows: crate::commands::models::builtin_model_windows(),
         }
     }
@@ -213,6 +268,77 @@ impl LintEnv {
                 .filter(|p| registry.as_ref().is_ok_and(|r| r.has(p)))
                 .collect(),
         );
+        self
+    }
+
+    /// Add what each provider the blueprint pins says it serves, and which of
+    /// the blueprint's unpinned model names nothing here routes.
+    ///
+    /// Takes the registry the caller already built and primed rather than
+    /// building another. `with_providers` builds its own because it only needs
+    /// a name lookup; this needs the *primed* one, since an unprimed provider
+    /// has no catalogue to report and would turn every check below into a
+    /// shrug. `lev validate` primes once, at `primed_registry`, and hands the
+    /// same registry here.
+    pub fn with_provider_catalogs(
+        mut self,
+        blueprint: &Blueprint,
+        config: &crate::config::Config,
+        registry: &leviath_runtime::ProviderRegistry,
+    ) -> Self {
+        use leviath_runtime::pipeline::model_key;
+
+        let entries = || blueprint.stages.iter().flat_map(|s| s.model.models.iter());
+
+        for name in entries()
+            .map(|e| e.provider.as_str())
+            .filter(|p| !p.is_empty())
+        {
+            if self.provider_catalogs.contains_key(name) {
+                continue;
+            }
+            // Not reachable here is not the same question, and
+            // `no-reachable-provider` already answers it. Leaving the name out
+            // of the map is what keeps a machine that simply lacks a provider
+            // from being told its blueprint is wrong.
+            let Some(provider) = registry.get(name) else {
+                continue;
+            };
+            let catalog = match provider.served_catalog() {
+                Some(models) => ProviderCatalog::Complete(models),
+                // Only a script provider's silence is worth reporting - see
+                // `ProviderCatalog::ScriptSaidNothing`. `script_provider_named`
+                // answers `None` for a native provider of the same name, which
+                // is exactly the distinction wanted.
+                None if registry.script_provider_named(name).is_some() => {
+                    ProviderCatalog::ScriptSaidNothing
+                }
+                None => continue,
+            };
+            self.provider_catalogs.insert(name.to_string(), catalog);
+        }
+
+        // The open entries, asked the way the resolver asks: does *any*
+        // registered provider claim this model. A script provider is not in
+        // `native_providers`, so the machine's default is offered the question
+        // too, matching `resolve_stage_candidates`.
+        let default_script = registry.script_provider_named(&config.default_provider);
+        for model in entries()
+            .filter(|e| e.provider.is_empty())
+            .map(|e| &e.model)
+        {
+            let key = model_key(model);
+            let routed = registry
+                .native_providers()
+                .iter()
+                .any(|(_, p)| p.serves_model(key).is_some())
+                || default_script
+                    .as_ref()
+                    .is_some_and(|p| p.serves_model(key).is_some());
+            if !routed {
+                self.unrouted_models.insert(model.clone());
+            }
+        }
         self
     }
 

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -880,6 +880,183 @@ max_iterations = 10
     assert!(lint(&toml, &env).is_empty());
 }
 
+/// A provider that published its whole catalogue and does not list the model:
+/// the one case where naming a model is provably a fault in the blueprint
+/// rather than a fact about the machine, so it is an error.
+///
+/// This is what a Rhai provider with a `list_models` answers, and what nothing
+/// checked before: `known_models` covers three built-in providers, so a stage
+/// pinned to a script provider's model was never looked at, validated clean,
+/// spawned clean and ran on whatever the fallback chain reached.
+#[test]
+fn a_model_outside_a_complete_catalog_is_an_error() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "groq", model = "llama-3.1-70b" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        provider_catalogs: HashMap::from([(
+            "groq".to_string(),
+            ProviderCatalog::Complete(vec![
+                "llama-4-scout".to_string(),
+                "llama-4-maverick".to_string(),
+            ]),
+        )]),
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    assert_eq!(codes(&findings), ["unserved-model"]);
+    assert!(findings[0].is_error(), "{findings:?}");
+    // The message carries what the provider does list, because "not that one"
+    // without "these instead" sends someone back to the same guess.
+    assert!(
+        findings[0]
+            .message
+            .contains("llama-4-scout, llama-4-maverick"),
+        "{findings:?}"
+    );
+}
+
+/// A catalogue too long to print is summarised with a count, because "it lists
+/// 2" and "it lists 340" send someone to different places: the first to a typo
+/// in the script's own `list_models`, the second to a typo in the blueprint.
+#[test]
+fn a_long_catalog_is_summarised_with_a_count() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "gateway", model = "nope" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        provider_catalogs: HashMap::from([(
+            "gateway".to_string(),
+            ProviderCatalog::Complete(
+                (0..10)
+                    .map(|i| format!("model-{i}"))
+                    .collect::<Vec<String>>(),
+            ),
+        )]),
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    assert_eq!(codes(&findings), ["unserved-model"]);
+    assert!(
+        findings[0]
+            .message
+            .contains("model-0, model-1, model-2 and 7 more"),
+        "{findings:?}"
+    );
+}
+
+/// A gateway namespaces its ids and a blueprint names the model, so the two are
+/// compared by model key. Comparing the raw strings would call every gateway
+/// route a model the gateway refuses.
+#[test]
+fn a_namespaced_catalog_id_answers_for_a_bare_model_name() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "openrouter", model = "gpt-5.5" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        provider_catalogs: HashMap::from([(
+            "openrouter".to_string(),
+            ProviderCatalog::Complete(vec!["openai/gpt-5.5".to_string()]),
+        )]),
+        ..LintEnv::default()
+    };
+    assert!(lint(&toml, &env).is_empty());
+}
+
+/// A script provider with neither a `list_models` nor a `serves` list has said
+/// nothing, and nothing is not a refusal. A warning, because the alternative -
+/// staying silent - is what makes "checked and fine" and "never checked" look
+/// identical.
+#[test]
+fn a_script_provider_that_names_no_models_warns_rather_than_errors() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "quiet", model = "anything-at-all" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        provider_catalogs: HashMap::from([(
+            "quiet".to_string(),
+            ProviderCatalog::ScriptSaidNothing,
+        )]),
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    assert_eq!(codes(&findings), ["catalog-unchecked"]);
+    assert!(!findings[0].is_error(), "{findings:?}");
+    // The fix names both ways out, since the author picks by what their script
+    // can do rather than by preference.
+    let fix = findings[0].fix.as_deref().unwrap_or_default();
+    assert!(
+        fix.contains("list_models") && fix.contains("serves"),
+        "{fix}"
+    );
+}
+
+/// The provider's own catalogue is better evidence than a table compiled into
+/// this build, so a live answer settles the entry and the compiled table is not
+/// asked again. Two findings on one entry, one calling it wrong and one calling
+/// it merely unrecognised, is a report nobody can act on.
+#[test]
+fn a_live_catalogue_supersedes_the_compiled_table() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "anthropic", model = "claude-sonnet-9" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        // The table this build ships has not heard of it...
+        known_models: vec![("anthropic".to_string(), "claude-sonnet-5".to_string())],
+        // ...but the provider itself says it serves it, which is the newer fact.
+        provider_catalogs: HashMap::from([(
+            "anthropic".to_string(),
+            ProviderCatalog::Complete(vec!["claude-sonnet-9".to_string()]),
+        )]),
+        ..LintEnv::default()
+    };
+    assert!(
+        lint(&toml, &env).is_empty(),
+        "the live catalogue answered, so unknown-model has nothing to add"
+    );
+}
+
+/// A provider absent from the map was never asked, and an unasked question is
+/// not a finding. This is the machine that simply does not have that provider,
+/// which `no-reachable-provider` speaks to instead.
+#[test]
+fn a_provider_nobody_asked_about_is_not_checked() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = [{ provider = "groq", model = "llama-3.1-70b" }] }
+max_iterations = 10
+"#,
+    );
+    assert!(lint(&toml, &LintEnv::default()).is_empty());
+}
+
 #[test]
 fn a_model_present_in_the_catalog_passes() {
     let env = LintEnv {
@@ -897,8 +1074,12 @@ fn a_model_present_in_the_catalog_passes() {
 /// every time, and was told it would "fall back to your default model" having
 /// "tried" a list of empty strings: `(tried , )`.
 ///
-/// Which providers serve a bare model is a question for the resolver, which has
-/// a registry. This check does not, so an open entry is not evidence either way.
+/// Which providers serve a bare model is a question for a registry, and this
+/// env has none: `unrouted_models` is empty, which is a question nobody asked
+/// rather than an answer of "nothing serves these". So an open entry counts as
+/// reachable and the check stays quiet - see
+/// [`an_open_entry_nothing_serves_is_warned_about`] for what happens once
+/// something has actually asked.
 #[test]
 fn a_stage_naming_models_without_providers_is_not_warned_about() {
     let toml = manifest(
@@ -920,8 +1101,9 @@ max_iterations = 10
     );
 }
 
-/// A stage that pins every route and has none of them is still warned about,
-/// which is the case the check exists for.
+/// One open entry among pinned ones leaves the stage undecided, as long as
+/// nobody has said whether that entry routes. The open entry might be served
+/// here; an empty `unrouted_models` is not the claim that it is not.
 #[test]
 fn a_stage_pinning_only_unreachable_providers_is_still_warned_about() {
     let toml = manifest(
@@ -940,6 +1122,63 @@ max_iterations = 10
     assert!(
         !codes(&findings).contains(&"no-reachable-provider"),
         "one open entry is enough to leave this undecided: {findings:?}"
+    );
+}
+
+/// The case an empty `unrouted_models` could never reach: something did ask
+/// the registry, and the answer was that nothing here serves the one model the
+/// stage names.
+///
+/// This is the shape a typo makes. Before the registry's answer reached this
+/// check, a stage naming a single misspelled model produced no finding at all:
+/// the old test required every entry to pin a provider, and this one pins none.
+#[test]
+fn an_open_entry_nothing_serves_is_warned_about() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = ["gorq-turbo-9"] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        available_providers: Some(known_tools(&["ollama"])),
+        unrouted_models: known_tools(&["gorq-turbo-9"]),
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    assert_eq!(codes(&findings), ["no-reachable-provider"]);
+    // Rendered bare, the way the blueprint wrote it. `/gorq-turbo-9` would show
+    // a route the entry does not claim to have.
+    assert!(
+        findings[0].message.contains("tried gorq-turbo-9"),
+        "{findings:?}"
+    );
+}
+
+/// One entry that routes is enough, however the others are written. The list is
+/// an ordered set of fallbacks, and a machine declining some of the options is
+/// the normal case rather than a fault.
+#[test]
+fn one_routable_open_entry_keeps_the_stage_quiet() {
+    let toml = manifest(
+        r#"
+[stages.main]
+mode = "autonomous"
+model = { models = ["gorq-turbo-9", "qwen3.5:9b", { provider = "openai", model = "gpt-5.5" }] }
+max_iterations = 10
+"#,
+    );
+    let env = LintEnv {
+        available_providers: Some(known_tools(&["ollama"])),
+        unrouted_models: known_tools(&["gorq-turbo-9"]),
+        ..LintEnv::default()
+    };
+    let findings = lint(&toml, &env);
+    assert!(
+        !codes(&findings).contains(&"no-reachable-provider"),
+        "qwen3.5:9b routes, so the stage has somewhere to run: {findings:?}"
     );
 }
 
@@ -962,7 +1201,9 @@ max_iterations = 10
     let findings = lint(&toml, &env);
     assert_eq!(codes(&findings), ["no-reachable-provider"]);
     assert!(
-        findings[0].message.contains("anthropic, openai"),
+        findings[0]
+            .message
+            .contains("anthropic/claude-sonnet-5, openai/gpt-5.5"),
         "{findings:?}"
     );
 }
@@ -2372,4 +2613,199 @@ fn an_unenforceable_required_region_is_named_once_across_stages() {
         .filter(|c| *c == "required-region-unenforceable")
         .count();
     assert_eq!(hits, 1);
+}
+
+// ─── with_provider_catalogs ───────────────────────────────────────────────────
+
+/// A blueprint pinning `<provider>/<model>` on its one stage, for the builder
+/// tests below.
+fn blueprint_pinning(pairs: &[(&str, &str)]) -> leviath_core::Blueprint {
+    let listed = pairs
+        .iter()
+        .map(|(p, m)| format!("{{ provider = \"{p}\", model = \"{m}\" }}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let toml = manifest(&format!(
+        "[stages.main]\nmode = \"autonomous\"\n\
+         model = {{ models = [{listed}] }}\nmax_iterations = 10\n"
+    ));
+    leviath_core::manifest::parse_manifest(&toml).expect("the fixture parses")
+}
+
+/// A blueprint naming models and leaving every route open.
+fn blueprint_open(models: &[&str]) -> leviath_core::Blueprint {
+    let listed = models
+        .iter()
+        .map(|m| format!("\"{m}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let toml = manifest(&format!(
+        "[stages.main]\nmode = \"autonomous\"\n\
+         model = {{ models = [{listed}] }}\nmax_iterations = 10\n"
+    ));
+    leviath_core::manifest::parse_manifest(&toml).expect("the fixture parses")
+}
+
+/// A registry holding one script provider, written to disk so the layer
+/// compiles it the way it would in production.
+///
+/// `list_models` returns a fixed array rather than calling out, so the
+/// catalogue is real without the test touching the network.
+fn script_registry(
+    name: &str,
+    serves: Option<&[&str]>,
+) -> (leviath_runtime::ProviderRegistry, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let body = match serves {
+        Some(models) => {
+            let entries = models
+                .iter()
+                .map(|m| {
+                    format!(
+                        "#{{ id: \"{m}\", display_name: \"{m}\", \
+                         max_context_tokens: 8192, max_output_tokens: 1024 }}"
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("fn list_models(state) {{ [{entries}] }}\n")
+        }
+        None => String::new(),
+    };
+    std::fs::write(
+        dir.path().join(format!("{name}.rhai")),
+        format!(
+            "fn initialize(config) {{ #{{}} }}\n\
+             fn inference(state, request) {{ #{{ content: \"x\" }} }}\n{body}"
+        ),
+    )
+    .expect("the script writes");
+    let layer = leviath_runtime::script_provider::ScriptProviderLayer::new(
+        dir.path().to_path_buf(),
+        HashMap::new(),
+        HashMap::new(),
+        None,
+        Vec::new(),
+    );
+    let registry =
+        leviath_runtime::ProviderRegistry::new().with_script_layer(std::sync::Arc::new(layer));
+    (registry, dir)
+}
+
+/// The case the whole check exists for: a Rhai provider that answers
+/// `list_models` publishes a complete catalogue, and the blueprint's model is
+/// then checkable.
+#[tokio::test]
+async fn a_script_providers_catalogue_reaches_the_lint() {
+    let (registry, _dir) = script_registry("groq", Some(&["llama-4-scout"]));
+    registry
+        .prime_capabilities(std::time::Duration::from_secs(5), &["groq"])
+        .await;
+    let bp = blueprint_pinning(&[("groq", "llama-3.1-70b")]);
+
+    let env = LintEnv::default().with_provider_catalogs(
+        &bp,
+        &crate::config::Config::default(),
+        &registry,
+    );
+
+    assert_eq!(
+        env.provider_catalogs.get("groq"),
+        Some(&ProviderCatalog::Complete(vec![
+            "llama-4-scout".to_string()
+        ]))
+    );
+    assert!(
+        lint_manifest("", &bp, &env)
+            .iter()
+            .any(|f| f.code == "unserved-model"),
+        "the catalogue is what makes the model checkable"
+    );
+}
+
+/// A script provider with no `list_models` is recorded as having said nothing,
+/// which is a warning rather than a refusal.
+#[tokio::test]
+async fn a_silent_script_provider_is_recorded_as_such() {
+    let (registry, _dir) = script_registry("quiet", None);
+    registry
+        .prime_capabilities(std::time::Duration::from_secs(5), &["quiet"])
+        .await;
+    let bp = blueprint_pinning(&[("quiet", "anything")]);
+
+    let env = LintEnv::default().with_provider_catalogs(
+        &bp,
+        &crate::config::Config::default(),
+        &registry,
+    );
+
+    assert_eq!(
+        env.provider_catalogs.get("quiet"),
+        Some(&ProviderCatalog::ScriptSaidNothing)
+    );
+}
+
+/// A provider this install cannot reach is left out of the map entirely, so its
+/// entries go unchecked. That is `no-reachable-provider`'s question, and
+/// answering it here as well would tell a machine that simply lacks a provider
+/// that its blueprint is wrong.
+#[tokio::test]
+async fn an_unreachable_provider_is_left_out_of_the_map() {
+    let (registry, _dir) = script_registry("groq", Some(&["llama-4-scout"]));
+    let bp = blueprint_pinning(&[("nobody-has-this", "some-model")]);
+
+    let env = LintEnv::default().with_provider_catalogs(
+        &bp,
+        &crate::config::Config::default(),
+        &registry,
+    );
+
+    assert!(
+        env.provider_catalogs.is_empty(),
+        "{:?}",
+        env.provider_catalogs
+    );
+}
+
+/// The same provider named twice in a stage's list is asked once. Asking again
+/// would compile the script a second time for an answer already in hand.
+#[tokio::test]
+async fn a_provider_named_twice_is_asked_once() {
+    let (registry, _dir) = script_registry("groq", Some(&["llama-4-scout"]));
+    registry
+        .prime_capabilities(std::time::Duration::from_secs(5), &["groq"])
+        .await;
+    let bp = blueprint_pinning(&[("groq", "llama-4-scout"), ("groq", "llama-3.1-70b")]);
+
+    let env = LintEnv::default().with_provider_catalogs(
+        &bp,
+        &crate::config::Config::default(),
+        &registry,
+    );
+
+    assert_eq!(env.provider_catalogs.len(), 1);
+}
+
+/// An open entry is answered the way the resolver answers it, so the machine's
+/// default script provider is asked too. Without that, a local box serving
+/// exactly the model the blueprint named would be reported as unrouted.
+#[tokio::test]
+async fn an_open_entry_is_routed_through_the_default_script_provider() {
+    let (registry, _dir) = script_registry("spark", Some(&["local-fast"]));
+    registry
+        .prime_capabilities(std::time::Duration::from_secs(5), &["spark"])
+        .await;
+    let bp = blueprint_open(&["local-fast", "nobody-serves-this"]);
+    let config = crate::config::Config {
+        default_provider: "spark".to_string(),
+        ..crate::config::Config::default()
+    };
+
+    let env = LintEnv::default().with_provider_catalogs(&bp, &config, &registry);
+
+    assert_eq!(
+        env.unrouted_models,
+        known_tools(&["nobody-serves-this"]),
+        "the default script provider serves local-fast, so only the other is unrouted"
+    );
 }

--- a/crates/leviath-cli/src/lint/tests.rs
+++ b/crates/leviath-cli/src/lint/tests.rs
@@ -2646,6 +2646,39 @@ fn blueprint_open(models: &[&str]) -> leviath_core::Blueprint {
     leviath_core::manifest::parse_manifest(&toml).expect("the fixture parses")
 }
 
+/// A natively registered provider serving a fixed set of models, for the open
+/// entries: a script provider is resolved on demand and so is never in
+/// `native_providers`, which is the list the resolver asks first.
+struct NativeProvider(Vec<String>);
+
+#[async_trait::async_trait]
+impl leviath_providers::Provider for NativeProvider {
+    async fn infer(
+        &self,
+        _r: &leviath_providers::InferenceRequest,
+    ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
+        Err(leviath_providers::ProviderError::Other("t".to_string()))
+    }
+    async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+        1
+    }
+    fn max_context_tokens(&self, _m: &str) -> usize {
+        1000
+    }
+    fn name(&self) -> &str {
+        "native"
+    }
+    fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
+        leviath_providers::ModelCapabilities::default()
+    }
+    fn serves_model(&self, model_key: &str) -> Option<String> {
+        self.0
+            .iter()
+            .any(|m| m == model_key)
+            .then(|| model_key.to_string())
+    }
+}
+
 /// A registry holding one script provider, written to disk so the layer
 /// compiles it the way it would in production.
 ///
@@ -2807,5 +2840,63 @@ async fn an_open_entry_is_routed_through_the_default_script_provider() {
         env.unrouted_models,
         known_tools(&["nobody-serves-this"]),
         "the default script provider serves local-fast, so only the other is unrouted"
+    );
+}
+
+/// The ordinary shape: a natively registered provider answers the open-route
+/// question, exactly as `resolve_stage_candidates` asks it.
+///
+/// The script-provider tests above cannot reach this path at all - a script
+/// provider is compiled on demand and so is never in `native_providers` - so
+/// without a native provider in the registry the loop that asks them runs zero
+/// times.
+#[test]
+fn a_native_provider_answers_the_open_route_question() {
+    let mut registry = leviath_runtime::ProviderRegistry::new();
+    registry.register(
+        "anthropic".to_string(),
+        std::sync::Arc::new(NativeProvider(vec!["claude-sonnet-5".to_string()])),
+    );
+    let bp = blueprint_open(&["claude-sonnet-5", "nobody-serves-this"]);
+
+    let env = LintEnv::default().with_provider_catalogs(
+        &bp,
+        &crate::config::Config::default(),
+        &registry,
+    );
+
+    assert_eq!(
+        env.unrouted_models,
+        known_tools(&["nobody-serves-this"]),
+        "anthropic serves one of the two, so only the other is unrouted"
+    );
+    assert!(
+        env.provider_catalogs.is_empty(),
+        "an open entry pins no provider, so there is no catalogue to record"
+    );
+}
+
+/// A native provider that publishes nothing is left unchecked rather than
+/// reported. Only a script provider's silence is worth naming: every built-in
+/// is either covered by the compiled-in table `unknown-model` reads or has a
+/// genuinely open catalogue.
+#[test]
+fn a_silent_native_provider_is_not_reported_as_unchecked() {
+    let mut registry = leviath_runtime::ProviderRegistry::new();
+    registry.register(
+        "anthropic".to_string(),
+        std::sync::Arc::new(NativeProvider(vec!["claude-sonnet-5".to_string()])),
+    );
+    let bp = blueprint_pinning(&[("anthropic", "claude-sonnet-5")]);
+
+    let env = LintEnv::default().with_provider_catalogs(
+        &bp,
+        &crate::config::Config::default(),
+        &registry,
+    );
+
+    assert!(
+        env.provider_catalogs.is_empty(),
+        "a native provider that publishes nothing is not `catalog-unchecked`"
     );
 }

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -789,6 +789,15 @@ impl Provider for OllamaProvider {
         Ok(())
     }
 
+    // No `served_catalog` here, deliberately. `/api/tags` reports what this
+    // machine has **pulled**, not what Ollama serves: `ollama run` fetches a
+    // model on demand, so a name the listing omits is one nobody has downloaded
+    // yet rather than one that does not exist. Publishing it as a complete
+    // catalogue would make every bundled blueprint - all of which end with an
+    // Ollama entry so a local box can use it - fail validation on a machine
+    // that has not pulled that model. The default `None` keeps those entries
+    // unchecked, which is the honest answer.
+
     async fn prime_capabilities(&self) -> Result<()> {
         let windows = self.learn_model_windows().await?;
         let count = windows.len();

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -771,6 +771,19 @@ impl Provider for OpenRouterProvider {
         })
     }
 
+    /// The gateway's own listing, once priming has read it.
+    ///
+    /// Only the primed catalogue counts. The compiled-in table that
+    /// [`Self::serves_model`] falls back to lists a few dozen of the hundreds
+    /// this gateway carries, so reporting it here would call every model it
+    /// does not happen to mention a model OpenRouter refuses - which is the
+    /// opposite of true. An empty catalogue is "not asked yet", not "serves
+    /// nothing".
+    fn served_catalog(&self) -> Option<Vec<String>> {
+        let windows = leviath_core::sync::lock(&self.api_windows);
+        (!windows.is_empty()).then(|| windows.keys().cloned().collect())
+    }
+
     fn pricing(&self, model: &str) -> Option<crate::ModelPricing> {
         leviath_core::sync::lock(&self.api_pricing)
             .get(model)
@@ -2112,6 +2125,30 @@ mod tests {
              offers it rather than degrading to nothing"
         );
         assert_eq!(provider.serves_model("nobody-has-heard-of-this"), None);
+    }
+
+    /// The gateway may publish a catalogue only once it has read one. The
+    /// compiled-in table `serves_model` falls back to lists a few dozen of the
+    /// hundreds this gateway carries, so reporting it as complete would call
+    /// every model it does not mention a model OpenRouter refuses.
+    #[tokio::test]
+    async fn only_a_primed_gateway_publishes_a_catalogue() {
+        let unprimed = provider_with_url("http://127.0.0.1:1".to_string());
+        assert_eq!(
+            unprimed.served_catalog(),
+            None,
+            "an unprimed gateway has read no catalogue, and its table is not one"
+        );
+
+        let body = br#"{"data":[{"id":"openai/gpt-5.5","context_length":400000}]}"#;
+        let url = spawn_mock_server(200, "OK", body).await;
+        let provider = provider_with_url(url);
+        provider.prime_capabilities().await.expect("primes");
+
+        assert_eq!(
+            provider.served_catalog(),
+            Some(vec!["openai/gpt-5.5".to_string()])
+        );
     }
 
     /// An entry with no `id` cannot be looked up by one, so it is skipped.

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -989,6 +989,27 @@ pub trait Provider: Send + Sync {
         self.serves_model_from_table(model_key)
     }
 
+    /// Every model id this provider will accept, when it is in a position to
+    /// say so.
+    ///
+    /// The difference between this and [`Self::serves_model`] is what a `None`
+    /// means. `serves_model` answers `None` both for a model a provider has
+    /// definitely never heard of and for one it simply cannot check, and a
+    /// caller holding the two together cannot refuse anything: refusing on
+    /// "cannot check" would deny a model that works. So the two are separated
+    /// here. `Some` is a **complete** list, and a name outside it is a name
+    /// this provider will reject. `None` is "cannot say" and every caller
+    /// treats it as "do not check", never as a refusal.
+    ///
+    /// Defaults to `None`, which is the right answer for a provider whose
+    /// catalogue is open (Ollama serves whatever has been pulled, and a name
+    /// missing from that is a model nobody has fetched yet rather than a model
+    /// that does not exist), and for one whose catalogue this build only knows
+    /// from a compiled-in table that may be older than the API.
+    fn served_catalog(&self) -> Option<Vec<String>> {
+        None
+    }
+
     /// [`Self::serves_model`] answered from the compiled-in capability table.
     ///
     /// Split out so an override can fall back to it: a gateway answers from its
@@ -2183,6 +2204,20 @@ mod tests {
         let provider = MinimalProvider;
         let models = provider.list_models().await.unwrap();
         assert!(models.is_empty());
+    }
+
+    /// A provider that has not implemented `served_catalog` says "cannot say",
+    /// never "serves nothing". The difference decides whether a caller may
+    /// refuse a model, and the default has to be the one that refuses nothing -
+    /// an empty `Some(vec![])` here would make every model named against every
+    /// unimplemented provider wrong.
+    ///
+    /// Contrast `serves_model` just above, which answers `None` for both "not
+    /// mine" and "cannot say". Separating the two is the whole point of this
+    /// method existing.
+    #[test]
+    fn default_served_catalog_says_nothing_rather_than_nothing_served() {
+        assert_eq!(MinimalProvider.served_catalog(), None);
     }
 
     /// A provider that has not implemented `pricing` reports no rates, and that

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -586,6 +586,29 @@ impl Provider for RhaiProvider {
         None
     }
 
+    /// The catalogue this script publishes, when it publishes one.
+    ///
+    /// The same two sources [`Self::serves_model`] consults, in the same order,
+    /// but reported as a whole so a caller can tell "this provider says it
+    /// does not serve that" from "this provider has not been asked". A script
+    /// with a `list_models` that primed, or a `[model_providers.<name>] serves`
+    /// list, has named everything it takes; a script with neither has said
+    /// nothing, and `None` keeps it unchecked rather than having every model
+    /// named against it called wrong.
+    ///
+    /// `[model_capabilities]` entries are deliberately left out. One of those
+    /// is somebody describing a model, which `serves_model` reads as a claim to
+    /// serve it, but a handful of described models is not a statement that the
+    /// rest are refused.
+    fn served_catalog(&self) -> Option<Vec<String>> {
+        let served = leviath_core::sync::lock(&self.served_models);
+        if !served.is_empty() {
+            return Some(served.clone());
+        }
+        drop(served);
+        (!self.declared_models.is_empty()).then(|| (*self.declared_models).clone())
+    }
+
     /// Ask the script what it serves, once, so [`Self::serves_model`] can answer
     /// on the synchronous resolve path.
     ///

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -1128,3 +1128,57 @@ async fn priming_a_script_without_list_models_is_a_no_op() {
     p.prime_capabilities().await.expect("nothing to do is fine");
     assert_eq!(p.serves_model("deepseek-v4-flash"), None);
 }
+
+/// `served_catalog` is what separates "this script says it does not serve that"
+/// from "this script has not been asked", and only the first may refuse
+/// anything. Before priming a script with a `list_models` has said nothing yet,
+/// so it publishes nothing.
+#[tokio::test]
+async fn a_script_publishes_its_catalogue_only_once_it_has_answered() {
+    let src = "// @provider mock\n\
+               fn initialize(config) { #{} }\n\
+               fn inference(state, request) { #{ content: \"x\" } }\n\
+               fn list_models(state) { [ #{ id: \"llama-4-scout\", \
+               display_name: \"Scout\", max_context_tokens: 131072, \
+               max_output_tokens: 8192 } ] }";
+    let p = build(src, Arc::new(FakeExecutor::default())).expect("it compiles");
+
+    assert_eq!(p.served_catalog(), None, "unprimed says nothing");
+
+    p.prime_capabilities().await.expect("list_models answers");
+
+    assert_eq!(p.served_catalog(), Some(vec!["llama-4-scout".to_string()]));
+}
+
+/// A script with neither `list_models` nor a `serves` list has said nothing at
+/// all, and nothing must not read as "serves nothing" - that would make every
+/// model named against it wrong.
+#[tokio::test]
+async fn a_script_that_names_no_models_publishes_no_catalogue() {
+    let p = build(GOOD_PROVIDER, Arc::new(FakeExecutor::default())).expect("it compiles");
+    p.prime_capabilities().await.expect("nothing to do is fine");
+    assert_eq!(p.served_catalog(), None);
+}
+
+/// `[model_providers.<name>] serves` is a complete catalogue too, and a static
+/// one: it answers with no priming and no network, which is what lets a script
+/// with no `list_models` still be checked.
+#[test]
+fn a_declared_serves_list_is_a_catalogue_without_priming() {
+    let p = RhaiProvider::from_source(
+        GOOD_PROVIDER,
+        Arc::new(FakeExecutor::default()),
+        ScriptProviderSettings {
+            name: "test".to_string(),
+            init_config: serde_json::json!({}),
+            caps: HashMap::new(),
+            serves: vec!["only-this-one".to_string()],
+            rate_limit: None,
+            request_timeout_secs: None,
+            env_allowlist: no_env_allowlist(),
+        },
+    )
+    .expect("it compiles");
+
+    assert_eq!(p.served_catalog(), Some(vec!["only-this-one".to_string()]));
+}

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -76,7 +76,12 @@ pub fn resolve_stage_model(
 /// The last segment is the model; anything before it is the vendor namespace a
 /// gateway prefixes. A local model with no slash (`qwen3.5:9b`) is already its
 /// own key.
-fn model_key(model: &str) -> &str {
+///
+/// Public because every layer that compares two model names has to compare them
+/// the same way. `lev validate` and the provider registry both grew their own
+/// copy of this rule, and three copies of "what counts as the same model" would
+/// not have stayed equal.
+pub fn model_key(model: &str) -> &str {
     model.rsplit('/').next().unwrap_or(model)
 }
 
@@ -301,10 +306,16 @@ pub fn resolve_stage_candidates(
     // unregistered one is not a fallback but a phantom that parks the run on
     // `StallReason::ProviderMissing`. `user_default_model` hands one back
     // whenever a bare `--model` override is in play, so filter here.
+    //
+    // A pair whose provider is here and says it does not carry that model is a
+    // phantom of the same kind: the failover step lands on it, the API refuses
+    // the id, and the run has spent a step going nowhere. The head is not
+    // filtered here - `resolve_stages` refuses it outright, because a stage
+    // silently running the next model down is the thing being fixed.
     let tail: Vec<ModelEntry> = candidates
         .split_off(1)
         .into_iter()
-        .filter(|e| registry.has(&e.provider))
+        .filter(|e| registry.has(&e.provider) && !registry.refuses_model(&e.provider, &e.model))
         .collect();
     candidates.extend(tail);
     candidates
@@ -645,6 +656,25 @@ pub fn resolve_stages(
                     providers_tried(&stage.model, model_override, defaults)
                 ));
             }
+            // The provider is here and says it does not carry this model. That
+            // is a different failure from the one above and needs its own end:
+            // the provider answers, so nothing fails over, and the run would
+            // spend its whole life posting a model id the API rejects.
+            //
+            // Refused rather than skipped on purpose. Dropping the head and
+            // promoting the next entry is what the blueprint author cannot see
+            // - a stage they pinned to one model quietly running another - and
+            // it is the behaviour this check exists to end. Only a provider
+            // that published a complete catalogue can get here, so the answer
+            // is evidence rather than an absence of it (`refuses_model`).
+            if registry.refuses_model(&head.provider, &head.model) {
+                return Err(format!(
+                    "stage '{}' names {}/{}, which provider '{}' does not serve. \
+                     Run `lev models list --provider {}` to see what it carries, \
+                     then name one of those in the stage's models list.",
+                    stage.name, head.provider, head.model, head.provider, head.provider,
+                ));
+            }
             // Empty `available_tools` exposes no tools; otherwise filter the full
             // set by name (alias-resolved). A name matching nothing (a typo, or an
             // MCP tool whose server isn't installed) is simply omitted. An
@@ -770,7 +800,7 @@ mod tests {
     async fn a_script_provider_named_as_default_wins_an_open_route() {
         let (registry, _dir) = registry_with_script_default(&["local-fast"]);
         registry
-            .prime_capabilities(std::time::Duration::from_secs(5), Some("spark"))
+            .prime_capabilities(std::time::Duration::from_secs(5), &["spark"])
             .await;
         let defaults = ModelDefaults {
             provider: "spark".to_string(),
@@ -797,7 +827,7 @@ mod tests {
     async fn preferring_a_script_provider_keeps_each_stage_on_its_own_model() {
         let (registry, _dir) = registry_with_script_default(&["cheap-model", "costly-model"]);
         registry
-            .prime_capabilities(std::time::Duration::from_secs(5), Some("spark"))
+            .prime_capabilities(std::time::Duration::from_secs(5), &["spark"])
             .await;
         let defaults = ModelDefaults {
             provider: "spark".to_string(),
@@ -819,7 +849,7 @@ mod tests {
     async fn a_stage_that_refuses_the_user_default_does_not_get_the_script() {
         let (registry, _dir) = registry_with_script_default(&["local-fast"]);
         registry
-            .prime_capabilities(std::time::Duration::from_secs(5), Some("spark"))
+            .prime_capabilities(std::time::Duration::from_secs(5), &["spark"])
             .await;
         let defaults = ModelDefaults {
             provider: "spark".to_string(),
@@ -853,6 +883,7 @@ mod tests {
                 (*name).to_string(),
                 Arc::new(FakeProvider {
                     serves: models.iter().map(|m| (*m).to_string()).collect(),
+                    catalog: None,
                 }),
             );
         }
@@ -864,6 +895,10 @@ mod tests {
         /// Models this provider claims. Empty is the ordinary fixture: the
         /// resolver only asks `has()` for a route-pinned entry.
         serves: Vec<String>,
+        /// The complete catalogue this provider publishes, if it publishes one.
+        /// `None` is the ordinary fixture and means "will not say", which no
+        /// caller may read as a refusal.
+        catalog: Option<Vec<String>>,
     }
     #[async_trait::async_trait]
     impl leviath_providers::Provider for FakeProvider {
@@ -893,6 +928,25 @@ mod tests {
                 .any(|m| m == model_key)
                 .then(|| model_key.to_string())
         }
+        fn served_catalog(&self) -> Option<Vec<String>> {
+            self.catalog.clone()
+        }
+    }
+
+    /// A registry whose providers each publish a complete catalogue, for the
+    /// checks that may only refuse a pair on a definite no.
+    fn registry_publishing(providers: &[(&str, &[&str])]) -> ProviderRegistry {
+        let mut r = ProviderRegistry::new();
+        for (name, models) in providers {
+            r.register(
+                (*name).to_string(),
+                Arc::new(FakeProvider {
+                    serves: models.iter().map(|m| (*m).to_string()).collect(),
+                    catalog: Some(models.iter().map(|m| (*m).to_string()).collect()),
+                }),
+            );
+        }
+        r
     }
 
     #[tokio::test]
@@ -1139,6 +1193,81 @@ mod tests {
         assert!(err.contains("plan"), "names the stage: {err}");
         assert!(err.contains("ghost"), "names what it tried: {err}");
         assert!(err.contains("lev setup"), "says what to do: {err}");
+    }
+
+    /// A provider that is here and says it does not carry the model.
+    ///
+    /// Distinct from "no usable provider" above: this provider answers, so
+    /// nothing fails over and the run would spend its life posting a model id
+    /// the API rejects. Refused rather than skipped on purpose - promoting the
+    /// next entry is the silent substitution this check exists to end.
+    #[test]
+    fn resolve_stages_refuses_a_model_the_provider_does_not_carry() {
+        let stage = leviath_core::Stage::new(
+            "plan".to_string(),
+            model_cfg(vec![("groq", "llama-3.1-70b")]),
+        );
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
+
+        let err = resolve_stages(
+            &bp,
+            None,
+            &ModelDefaults::default(),
+            &registry_publishing(&[("groq", &["llama-4-scout"])]),
+            catalog(&[]),
+            false,
+            None,
+        )
+        .expect_err("groq published a catalogue and this model is not in it");
+
+        assert!(err.contains("plan"), "names the stage: {err}");
+        assert!(err.contains("groq/llama-3.1-70b"), "names the pair: {err}");
+        assert!(err.contains("lev models list"), "says what to do: {err}");
+    }
+
+    /// The same shape, against a provider that publishes nothing. A provider
+    /// that will not say what it serves cannot refuse anything, so the stage
+    /// resolves exactly as it did before this check existed.
+    #[test]
+    fn resolve_stages_allows_a_model_an_unpublishing_provider_never_denied() {
+        let stage = leviath_core::Stage::new(
+            "plan".to_string(),
+            model_cfg(vec![("groq", "llama-3.1-70b")]),
+        );
+        let layout = leviath_core::layout::ContextLayout::new(vec![], 1000);
+        let bp = Blueprint::new("t".to_string(), "d".to_string(), vec![stage], layout);
+
+        let resolved = resolve_stages(
+            &bp,
+            None,
+            &ModelDefaults::default(),
+            &registry_with(&["groq"]),
+            catalog(&[]),
+            false,
+            None,
+        )
+        .expect("silence is not a refusal");
+
+        assert_eq!(resolved[0].model, "llama-3.1-70b");
+    }
+
+    /// A fallback the provider will refuse is dropped rather than kept, so a
+    /// failover cannot spend a step landing on it. The head is not filtered
+    /// this way - `resolve_stages` refuses it outright instead.
+    #[test]
+    fn a_fallback_the_provider_refuses_is_dropped_from_the_chain() {
+        let cfg = model_cfg(vec![
+            ("groq", "llama-4-scout"),
+            ("groq", "llama-3.1-70b"),
+            ("groq", "llama-4-maverick"),
+        ]);
+        let registry = registry_publishing(&[("groq", &["llama-4-scout", "llama-4-maverick"])]);
+
+        let picked = resolve_stage_candidates(&cfg, None, &ModelDefaults::default(), &registry);
+
+        let models: Vec<&str> = picked.iter().map(|e| e.model.as_str()).collect();
+        assert_eq!(models, ["llama-4-scout", "llama-4-maverick"], "{picked:?}");
     }
 
     #[test]

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -59,13 +59,14 @@ impl ProviderRegistry {
     /// rather than however long a connect takes to give up.
     ///
     /// Script providers are consulted only when `also` names one - in practice
-    /// the machine's `default_provider`. `get` compiles them on demand, so
+    /// the machine's `default_provider`, and for `lev validate` the providers
+    /// the blueprint in front of it pins. `get` compiles them on demand, so
     /// priming the lot would compile every `.rhai` provider on disk whether or
-    /// not a run touches one; priming the one a machine has actually chosen
-    /// costs a single compile of a script that is about to be used anyway, and
-    /// it is what lets that provider answer [`Provider::serves_model`] and so
-    /// win an open route (issue #598).
-    pub async fn prime_capabilities(&self, timeout: std::time::Duration, also: Option<&str>) {
+    /// not a run touches one; priming the ones a caller has actually named
+    /// costs a compile of a script that is about to be used anyway, and it is
+    /// what lets that provider answer [`Provider::serves_model`] and so win an
+    /// open route (issue #598).
+    pub async fn prime_capabilities(&self, timeout: std::time::Duration, also: &[&str]) {
         let mut targets: Vec<(String, Arc<dyn Provider>)> = self
             .providers
             .iter()
@@ -86,7 +87,11 @@ impl ProviderRegistry {
             .as_ref()
             .map(|l| l.configured_names())
             .unwrap_or_default();
-        for name in configured.iter().map(String::as_str).chain(also) {
+        for name in configured
+            .iter()
+            .map(String::as_str)
+            .chain(also.iter().copied())
+        {
             // Only when it is not already registered natively: a native provider
             // of the same name wins everywhere else, and priming it twice would
             // be a second network call for one answer. Nor twice over, for one
@@ -184,6 +189,31 @@ impl ProviderRegistry {
                 .is_some_and(|l| l.get_or_load(name).is_some())
     }
 
+    /// Whether `provider` is registered here and can prove it does not serve
+    /// `model`.
+    ///
+    /// `false` is the answer to three different questions - there is no such
+    /// provider, it serves the model, or it will not say what it serves - and
+    /// they are folded together on purpose. Every caller of this is deciding
+    /// whether to refuse something, and all three mean "do not refuse". Only a
+    /// provider that published a complete catalogue can put a name outside it,
+    /// so a `true` here is always evidence rather than an absence of it.
+    ///
+    /// Compared by [`crate::pipeline::model_key`], so a gateway's namespaced
+    /// `openai/gpt-5.5` answers for a blueprint that wrote `gpt-5.5`.
+    pub fn refuses_model(&self, provider: &str, model: &str) -> bool {
+        let Some(p) = self.get(provider) else {
+            return false;
+        };
+        let Some(catalog) = p.served_catalog() else {
+            return false;
+        };
+        let key = crate::pipeline::model_key(model);
+        !catalog
+            .iter()
+            .any(|id| crate::pipeline::model_key(id) == key)
+    }
+
     /// Get all *natively-registered* provider names. Script providers are
     /// resolved on demand and so are not enumerated here - see
     /// [`resolvable_names`](Self::resolvable_names) for the set that includes
@@ -266,6 +296,10 @@ mod tests {
         outcome: PrimeOutcome,
         /// Every list this stub was handed to warm, in order.
         warmed: Arc<std::sync::Mutex<Vec<Vec<String>>>>,
+        /// The catalogue this stub publishes, if it publishes one. `None` is
+        /// the ordinary fixture and means "will not say", which no caller may
+        /// read as a refusal.
+        catalog: Option<Vec<String>>,
     }
 
     impl StubProvider {
@@ -274,6 +308,15 @@ mod tests {
                 primed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
                 outcome,
                 warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
+                catalog: None,
+            }
+        }
+
+        /// The same stub, publishing a complete catalogue.
+        fn publishing(models: &[&str]) -> Self {
+            Self {
+                catalog: Some(models.iter().map(|m| (*m).to_string()).collect()),
+                ..Self::new(PrimeOutcome::Ok)
             }
         }
     }
@@ -328,6 +371,47 @@ mod tests {
         fn capabilities(&self, _model: &str) -> ModelCapabilities {
             ModelCapabilities::default()
         }
+        fn served_catalog(&self) -> Option<Vec<String>> {
+            self.catalog.clone()
+        }
+    }
+
+    /// `refuses_model` folds three different "no" answers into `false`, because
+    /// every caller of it is deciding whether to refuse and all three mean "do
+    /// not". Only a published catalogue can produce a `true`.
+    #[test]
+    fn refuses_model_only_says_yes_on_a_published_catalogue() {
+        let mut reg = ProviderRegistry::new();
+        reg.register(
+            "groq".to_string(),
+            Arc::new(StubProvider::publishing(&["llama-4-scout"])),
+        );
+        // A native provider that publishes nothing: silence, never a refusal.
+        reg.register("quiet".to_string(), mock());
+
+        assert!(
+            reg.refuses_model("groq", "llama-3.1-70b"),
+            "not in the list"
+        );
+        assert!(!reg.refuses_model("groq", "llama-4-scout"), "in the list");
+        assert!(!reg.refuses_model("quiet", "anything"), "published nothing");
+        assert!(!reg.refuses_model("absent", "anything"), "no such provider");
+    }
+
+    /// A gateway namespaces its ids and a blueprint names the model, so the two
+    /// are compared by model key. Comparing raw strings would make every
+    /// gateway route look like a model the gateway refuses.
+    #[test]
+    fn refuses_model_compares_by_model_key() {
+        let mut reg = ProviderRegistry::new();
+        reg.register(
+            "openrouter".to_string(),
+            Arc::new(StubProvider::publishing(&["openai/gpt-5.5"])),
+        );
+
+        assert!(!reg.refuses_model("openrouter", "gpt-5.5"));
+        assert!(!reg.refuses_model("openrouter", "openai/gpt-5.5"));
+        assert!(reg.refuses_model("openrouter", "gpt-4"));
     }
 
     /// What an *enumeration* needs, and what `provider_names` cannot give it:
@@ -378,11 +462,7 @@ mod tests {
     }
 
     fn mock() -> Arc<dyn Provider> {
-        Arc::new(StubProvider {
-            primed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            outcome: PrimeOutcome::Ok,
-            warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
-        })
+        Arc::new(StubProvider::new(PrimeOutcome::Ok))
     }
 
     #[test]
@@ -407,8 +487,7 @@ mod tests {
         (
             Arc::new(StubProvider {
                 primed: primed.clone(),
-                outcome,
-                warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
+                ..StubProvider::new(outcome)
             }),
             primed,
         )
@@ -482,7 +561,7 @@ mod tests {
         reg.register("prime".to_string(), p);
         reg.register("other".to_string(), mock());
 
-        reg.prime_capabilities(std::time::Duration::from_secs(5), None)
+        reg.prime_capabilities(std::time::Duration::from_secs(5), &[])
             .await;
         assert_eq!(primed.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
@@ -494,7 +573,7 @@ mod tests {
         let mut reg = ProviderRegistry::new();
         let (bad, bad_calls) = priming(PrimeOutcome::Fails);
         reg.register("bad".to_string(), bad);
-        reg.prime_capabilities(std::time::Duration::from_secs(5), None)
+        reg.prime_capabilities(std::time::Duration::from_secs(5), &[])
             .await;
         assert_eq!(bad_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
@@ -508,7 +587,7 @@ mod tests {
         // With the clock paused this returns as soon as the timeout is the only
         // thing left to wait on, so a regression here fails by hanging the
         // suite rather than by sleeping through it.
-        reg.prime_capabilities(std::time::Duration::from_secs(10), None)
+        reg.prime_capabilities(std::time::Duration::from_secs(10), &[])
             .await;
         assert_eq!(calls.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
@@ -676,7 +755,7 @@ mod tests {
         let reg = ProviderRegistry::new().with_script_layer(Arc::new(layer));
 
         // The default is something else entirely, which is the whole point.
-        reg.prime_capabilities(std::time::Duration::from_secs(5), Some("openrouter"))
+        reg.prime_capabilities(std::time::Duration::from_secs(5), &["openrouter"])
             .await;
 
         assert_eq!(
@@ -721,7 +800,7 @@ mod tests {
             None
         );
 
-        reg.prime_capabilities(std::time::Duration::from_secs(5), Some("spark"))
+        reg.prime_capabilities(std::time::Duration::from_secs(5), &["spark"])
             .await;
 
         assert_eq!(
@@ -740,7 +819,7 @@ mod tests {
         let (p, primed) = priming(PrimeOutcome::Ok);
         reg.register("prime".to_string(), p);
 
-        reg.prime_capabilities(std::time::Duration::from_secs(5), Some("prime"))
+        reg.prime_capabilities(std::time::Duration::from_secs(5), &["prime"])
             .await;
         assert_eq!(primed.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
@@ -750,17 +829,13 @@ mod tests {
     #[tokio::test]
     async fn naming_a_provider_that_does_not_resolve_is_harmless() {
         let reg = ProviderRegistry::new();
-        reg.prime_capabilities(std::time::Duration::from_secs(5), Some("nope"))
+        reg.prime_capabilities(std::time::Duration::from_secs(5), &["nope"])
             .await;
     }
 
     #[tokio::test]
     async fn stub_provider_methods_are_exercised() {
-        let p = StubProvider {
-            primed: Arc::new(std::sync::atomic::AtomicUsize::new(0)),
-            outcome: PrimeOutcome::Ok,
-            warmed: Arc::new(std::sync::Mutex::new(Vec::new())),
-        };
+        let p = StubProvider::new(PrimeOutcome::Ok);
         assert_eq!(p.name(), "stub");
         assert_eq!(p.count_tokens("abcd", "m").await, 4);
         assert_eq!(p.max_context_tokens("m"), 8192);

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -161,6 +161,7 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 | error | `unparseable-safe-command` | A `[safe_commands] shell` entry no call can ever match. See below |
 | error | `output-missing-submit-tool` | A stage must produce an output and has no way to submit one. See below |
 | error | `orphan-stage-permission` | A `[stages.X.tool_permissions]` key names a tool the stage never granted. It reads as a grant and is not one. |
+| error | `unserved-model` | A stage names a model the provider that would run it does not carry. See below |
 | warning | `stage-missing-model` | No `[stages.X.model]` block, so the stage runs on whatever your `default_provider` is. |
 | warning | `stage-missing-mode` | No `mode`, so the stage runs as `autonomous`. |
 | warning | `stage-missing-max-iterations` | Unbounded unless `[limits] default_max_iterations` is set. Fan-out stages are exempt. |
@@ -169,7 +170,8 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 | warning | `blocking-tool-in-autonomous-stage` | An autonomous stage grants a tool that waits for a person. See below |
 | warning | `implicit-shell-policy` | A shell grant with no policy behind it. See below |
 | warning | `unknown-model` | A model this build has not heard of. See below |
-| warning | `no-reachable-provider` | Nothing in the stage's models list is configured here, so it falls through to your default model. |
+| warning | `catalog-unchecked` | A script provider that will not say which models it serves, so a name against it went unchecked. See below |
+| warning | `no-reachable-provider` | Nothing in the stage's models list can run here, so it falls through to your default model. See below |
 | warning | `compact-summarizes-deliverable` | A `compact` edge would hand a `required` region to the summarizer. See below |
 | warning | `unreachable-stage`, `cycle-without-max-revisits`, `broad-read-path` | Graph and `[read_paths]` shape. |
 | warning | `dead-end-possible` | Every route out of a stage can run out of budget. See below |
@@ -180,7 +182,7 @@ in three levels: an **error** exits non-zero, a **warning** does not, and a **no
 | note | `safe-commands-declared` | The blueprint declares `[safe_commands]`. Declaring is not granting. See below |
 | note | `command-seed`, `read-paths-declared` | Things worth knowing before you run the blueprint. See below |
 
-Thirteen of those findings need more than a phrase.
+Fifteen of those findings need more than a phrase.
 
 **`unknown-tool`** means the name matches no built-in, no sub-agent tool, and no `tools/*.rhai`
 file. The stage then advertises one tool fewer, so the model is told a tool it was meant to have
@@ -203,8 +205,36 @@ killed. Set `allow_blocking_tools = true` on the stage to say you meant it.
 **`implicit-shell-policy`** matters because the default is `ask`. An unattended run waits on that
 prompt rather than being denied.
 
-**`unknown-model`** is checked only against providers with a closed catalog. Ollama, OpenRouter and
-script providers are never checked.
+**`unserved-model`** is the one model finding that fails the command, because it is the one that can
+be proved. The provider is configured here, it published the full list of what it carries, and the
+model the stage names is not on it. That is a typo or a renamed model rather than anything about your
+machine, so a stage naming one is refused at spawn too. The message carries a few of the ids the
+provider does list; `lev models list --provider <name>` prints the rest.
+
+A provider publishes its list either by answering `list_models` (a Rhai provider, or a gateway whose
+catalogue Leviath has read) or by having one written down under `[model_providers.<name>] serves`.
+The `serves` route needs no network and no key, which makes it the way to get a script provider
+checked in CI.
+
+**`catalog-unchecked`** is the same question with no answer: the script provider loaded, but it has
+neither a `list_models(state)` function nor a `serves` list, so it has never said what it takes and
+nothing here can tell a good model id from a bad one. It is a warning rather than an error because
+saying nothing is not a refusal. It exists so that "checked and fine" and "never checked" stop
+looking identical. Only script providers are named this way; a built-in that keeps quiet is either
+covered by `unknown-model` below or has a genuinely open catalog.
+
+**`unknown-model`** is the older, weaker check: the table of models compiled into this build, which
+covers Anthropic, OpenAI and Google. It is skipped for any provider that answered for itself, since
+a live catalog knows about models released after this build was cut. A provider that neither
+publishes a catalog nor appears in that table is not checked at all, which is what keeps an open
+catalog (Ollama serves whatever you have pulled) from raising false alarms.
+
+**`no-reachable-provider`** means every entry in the stage's list names something this install cannot
+run: a pinned entry whose provider is not configured, or a bare model name nothing here serves. One
+entry that works is enough to keep the stage quiet, since the list is an ordered set of fallbacks and
+a machine declining some of the options is the normal case. This is also the check that catches a
+misspelled model in a stage that names only one: nothing serves `claude-sonet-5`, so the stage would
+have fallen through to your default model without saying so.
 
 **`compact-summarizes-deliverable`** means a later stage reads a paraphrase of a region you marked
 `required`. Set `summarizable = false` on the region.

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -402,6 +402,23 @@ and the provider answered.
 > `lev doctor -m <name>/<model>` goes one step further and bills a real inference. Both exit
 > non-zero on failure.
 
+Once the script is wired in, `lev validate` checks the model ids against it. A script that answers
+`list_models` has named everything it takes, so a stage pinning `<name>/<model>` for a model outside
+that list is an `unserved-model` error and a refused spawn rather than a run on some other model. A
+script with no `list_models` can be checked the same way by writing the list down:
+
+```toml
+[model_providers.groq]
+script = "groq"
+serves = ["llama-4-scout", "llama-4-maverick"]
+```
+
+`serves` is read straight from the file, so this works with no network and no key, which is what
+makes it usable in CI. A script that offers neither is reported as `catalog-unchecked`: it loaded,
+but it has never said what it takes, so nothing can tell a good model id from a bad one. A script
+that will not compile is a provider that is not there at all, and that stays
+`no-reachable-provider`.
+
 If `lev serve` is running, `POST /api/scripts/validate` with `kind: "provider"` answers the same
 question without a run and without a key: it compiles the text and checks that `initialize(config)`
 and `inference(state, request)` are both there. The rest of the [scripts


### PR DESCRIPTION
## The problem

Nothing ever compared a blueprint's model id against what its provider actually carries.

- `resolve.rs:136` took a pinned `provider/model` pair on trust, in as many words. The model was never checked against anything.
- The `unknown-model` lint only knew a table compiled into the build, covering `anthropic`, `openai` and `google`. Ollama, OpenRouter and **every Rhai script provider** were skipped by design.
- The open-route case (`models = ["some-name"]`) warned to `daemon.log` and fell through to the next entry. A pinned entry whose provider was missing was skipped with no line at all.

So a stage pinned to `groq/llama-3.1-70b`, on a `groq.rhai` whose `list_models` names nothing of the sort, validated clean, spawned clean, and ran on whatever the fallback chain reached.

`lev validate` already built **and primed** a full `ProviderRegistry`. It just handed it to a prose block that `--json` suppresses entirely, so no finding — and therefore no exit code — had ever depended on live provider data.

### Before

```console
$ lev validate .
✓ Blueprint 'probe' is valid.
...
  research         groq/llama-4-scout
                     blueprint order: groq/llama-3.1-70b
$ echo $?
0
```

`--json` said `"valid": true`, `"findings": []`. Meanwhile `lev models list --provider groq` printed the real catalogue perfectly well.

### After

```console
$ lev validate .
  ERR  stage 'research': names groq/llama-3.1-70b, which provider 'groq' does not
       serve (it lists llama-4-scout, llama-4-maverick) [unserved-model]
       run `lev models list --provider groq` and name one of those
Error: ✗ Blueprint has 1 error
$ echo $?
1

$ lev run .
Error: spawn failed: stage 'research' names groq/llama-3.1-70b, which provider
'groq' does not serve. Run `lev models list --provider groq` to see what it
carries, then name one of those in the stage's models list.
```

## The design

Everything hangs off one new question a provider can answer:

```rust
/// Every model id this provider will accept, when it is in a position to say so.
fn served_catalog(&self) -> Option<Vec<String>> { None }
```

`None` is "cannot say" and every caller treats it as *skip*, never as a refusal. Separating that from `serves_model` — which answers `None` both for "not mine" and for "never asked" — is what makes refusing anything possible at all: only a published catalogue can put a name outside itself, so a `true` is always evidence rather than an absence of it.

**Who publishes one.** `RhaiProvider` from a primed `list_models`, or from `[model_providers.<name>] serves` (static, so it needs no network and no key — usable in CI). OpenRouter from its primed catalogue. Everything else keeps the default `None`.

**Ollama deliberately does not.** `/api/tags` reports what this machine has *pulled*, not what Ollama serves — `ollama run` fetches on demand. Publishing it as complete would fail every bundled blueprint, all of which end with an Ollama entry, on a machine that has not pulled that model.

## The rule

| Situation | Severity | Why |
|---|---|---|
| Provider is here, published its list, model is not on it | **error** `unserved-model` | Provable: a typo or a renamed model |
| Script provider is here but publishes nothing | warning `catalog-unchecked` | Cannot prove either way, and silence hides that nothing was checked |
| Provider not configured here | unchanged | A fact about the machine, not a fault in the blueprint |

`unserved-model` is also a spawn refusal, in `resolve_stages`, so a blueprint that was never validated cannot silently run on the wrong model. Head only: promoting the next entry is the silent substitution being removed. A *fallback* the provider will refuse is dropped from the chain instead, so a failover cannot spend a step dispatching to a pair the API rejects.

## `no-reachable-provider` grows the half it could never answer

It used to skip itself on any stage holding an entry that named a model and no provider — the form every bundled blueprint is written in — because it had no registry to ask who serves a bare name. Its own comment said so. It now has the resolver's answer, so:

```console
# models = ["gorq-turbo-9"]  -- produced no finding whatever before this
  WARN stage 'research': names nothing this install can run (tried gorq-turbo-9),
       so it falls back to your default model [no-reachable-provider]
```

Its message now lists entries the way the blueprint writes them (bare, or `provider/model`) rather than provider names alone.

An earlier draft of this added a separate per-entry `unrouted-model` warning. It fired 3-4 times per stage on every bundled blueprint, which is exactly the fault-list noise `model_resolution_lines` already documents avoiding, so it was dropped in favour of fixing the existing check.

## Verification

The probe was run against the **unfixed** tree first and confirmed to report clean — otherwise it proves nothing. Isolated `LEVIATH_HOME`, a `groq.rhai` with a fixed `list_models`, a blueprint pinning a model outside it.

- clean + exit 0 before; `unserved-model` + exit 1 after, and `"valid": false` under `--json`
- `lev run` refused at spawn, with the provider and model named
- a static `serves = [...]` list catches it with no network and no key
- a script with neither reports `catalog-unchecked`, a warning, exit 0
- a provider absent from `config.toml` reports only `no-reachable-provider`
- **all 7 bundled blueprints still exit 0** on a machine with one provider configured — the regression the Ollama exemption exists for

`cargo xtask coverage`: all 13 packages at 100%. Clippy, `cargo xtask docs` and the full suite clean.

Docs updated: the `lev validate` findings table and prose in `cli.md`, and the TIP in `rhai-providers.md` that said a broken provider script is silently skipped, which is now only half true.
