### PR TITLE
feat(tui): draw the run's path, not its blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,24 @@ same list.
 - Changed: a fallback whose provider says it does not carry that model is
   dropped from a stage's failover chain rather than left in it, so a failover
   cannot spend a step dispatching to a pair the API will reject.
+- Changed: the dashboard's detail view draws the run's path instead of its
+  blueprint. One box per stage visit, in the order the run walked them, snaking
+  across rows so it stays compact and grows a row at a time while you watch:
+  three passes through `implement` are three boxes, `implement`,
+  `implement (2)` and `implement (3)`, each with the time it was entered and
+  the iterations it took. Before this the band painted the run onto the whole
+  blueprint, which answers a different question - the visited stages kept their
+  blueprint layer and slot, so a path read as a sparse slice of a big picture
+  with the revisits collapsed into a `×3` badge, and the band usually had to pan
+  to show any of it. The rows alternate direction so the last box of a row sits
+  directly above the first box of the next, which turns the hand-off between
+  them into a short vertical hop; the band grows a row taller when the path
+  wraps and pans past that, keeping the current stage on screen. `t` swaps the
+  band to the whole blueprint and back, boxes drag and the canvas pans, and `R`
+  re-snakes a path you have rearranged. The stage explorer on `g` now opens on
+  the whole blueprint rather than the path, since the band beside it is already
+  the path; `t` there still narrows it to the path and the options. This is the
+  same pair of pictures The Lair shows on the web.
 
 ## 0.5.1 - 2026-08-26
 

--- a/crates/leviath-cli/src/commands/dashboard/detail_band.rs
+++ b/crates/leviath-cli/src/commands/dashboard/detail_band.rs
@@ -1,13 +1,25 @@
-//! The detail view's graph band: the blueprint's stage graph in the rows the
-//! flat tab strip used to have, drawn by the same canvas as the explorer.
+//! The detail view's graph band: the run's path through its blueprint, drawn
+//! in the rows the flat tab strip used to have by the same canvas as the
+//! explorer.
 //!
-//! The strip said "3 of 7" and which stage was selected; the band says the
-//! same and also where the run has been, where it is, and how the stages
-//! connect. The selection on the canvas is the stage tab: `←`/`→` move it
-//! through the graph, `1`-`9` jump to a stage by number, a click picks a
-//! box, and the content panes below follow. Boxes drag, the canvas pans,
-//! and `g` opens the full-screen explorer. On a terminal too short to give
-//! it its rows the strip stays.
+//! The strip said "3 of 7" and which stage was selected. The band says where
+//! the run has actually been: one box per stage *visit*, in order, snaking
+//! across rows so it stays compact and grows a row at a time while the run is
+//! still going (see [`crate::tui::flowgraph::path`]). Three passes through
+//! `implement` are three boxes - `implement`, `implement (2)`,
+//! `implement (3)` - not one with a `×3` badge, because the order is the
+//! story. Painting the run onto the whole blueprint instead answers a
+//! different question ("what could it do"), and buries this one in the
+//! stages it never went near.
+//!
+//! The blueprint is still a keypress away: `t` swaps the band to it and back,
+//! and `g` opens it full screen. The selection on the canvas is the stage
+//! tab: `←`/`→` move it along the path, `1`-`9` jump to a stage by number, a
+//! click picks a box, and the content panes below follow. Boxes drag and the
+//! canvas pans; `R` re-snakes, throwing away an arrangement made by hand. On
+//! a terminal too short to give it its rows the strip stays.
+
+use std::sync::Arc;
 
 use ratatui::Frame;
 use ratatui::layout::Rect;
@@ -15,35 +27,134 @@ use ratatui::style::Style;
 use ratatui::text::Span;
 use ratatui::widgets::{Block, BorderType, Borders};
 
+use super::history::clock;
 use super::state::Dashboard;
 use super::theme::*;
 use super::types::*;
-use crate::tui::flowgraph::{FlowView, Selection};
+use crate::tui::flowgraph::path::{self, Visit};
+use crate::tui::flowgraph::{
+    FlowView, LiveOverlay, Selection, StageGraph, snake_per_row, snake_row_pitch,
+};
 
-/// Rows the band takes: a border, a row of boxes, and lanes for the loops.
+/// Rows the band takes for a path that fits on one row: a border, a row of
+/// boxes, and the gutter a hand-off to the next row runs down.
 pub(super) const BAND_HEIGHT: u16 = 12;
+
+/// Rows it will grow to for a path that has wrapped. Past this the canvas
+/// pans, and the stage the run is in is kept on screen instead - a band tall
+/// enough for every path would leave nothing for the panes below.
+pub(super) const BAND_MAX_HEIGHT: u16 = 18;
 
 /// The detail area must be at least this tall for the band to replace the
 /// three-row strip; below it every other pane needs the rows more.
 pub(super) const BAND_MIN_AREA_HEIGHT: u16 = 36;
 
-/// The band's canvas, kept between frames so the viewport survives a
+/// Which picture the band is showing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BandMode {
+    /// The run's path: where it has been, in order.
+    Path,
+    /// The whole blueprint: everything it could do.
+    Blueprint,
+}
+
+/// The band's canvases, kept between frames so the viewport survives a
 /// redraw. Rebuilt when the selected run changes.
 #[derive(Debug)]
 pub(super) struct DetailBand {
     pub(super) run_id: String,
-    pub(super) view: FlowView,
+    pub(super) mode: BandMode,
+    /// The run's path, snaked.
+    path: FlowView,
+    /// The whole blueprint, built the first time `t` asks for it - most runs
+    /// are watched from start to finish without anyone asking.
+    blueprint: Option<FlowView>,
+    /// What the path was built from: how many visits, and the stage the run
+    /// is in. The canvas is only rebuilt when one of them moves.
+    signature: (usize, String),
+}
+
+impl DetailBand {
+    /// The canvas on show.
+    pub(super) fn view(&self) -> &FlowView {
+        match (self.mode, &self.blueprint) {
+            (BandMode::Blueprint, Some(view)) => view,
+            _ => &self.path,
+        }
+    }
+
+    pub(super) fn view_mut(&mut self) -> &mut FlowView {
+        match (self.mode, &mut self.blueprint) {
+            (BandMode::Blueprint, Some(view)) => view,
+            _ => &mut self.path,
+        }
+    }
+}
+
+/// The band's title: what is on show and how to move around it, in as many
+/// words as the width allows.
+///
+/// Only the keys the band actually answers to are advertised. `r` and `e`
+/// belong to the canvas but never reach it here - in the detail view they
+/// resume the run and jump to the end of the pane below - so the full screen
+/// is where the title points for those.
+fn band_title(width: u16, mode: BandMode, visits: usize, stage: usize, stages: usize) -> String {
+    let other = match mode {
+        BandMode::Path => "blueprint",
+        BandMode::Blueprint => "path",
+    };
+    if width < 100 {
+        let what = match mode {
+            BandMode::Path => format!("Path · {visits}"),
+            BandMode::Blueprint => "Blueprint".to_string(),
+        };
+        return format!(" {what} · {stage}/{stages} · t:{other} · [g] ");
+    }
+    let what = match mode {
+        BandMode::Path => format!(
+            "Path · {visits} visit{} · stage {stage}/{stages}",
+            if visits == 1 { "" } else { "s" }
+        ),
+        BandMode::Blueprint => format!("Blueprint · stage {stage}/{stages}"),
+    };
+    let arrange = match mode {
+        BandMode::Path => "  [R] re-snake",
+        BandMode::Blueprint => "",
+    };
+    format!(" {what}  ·  ←/→ select  1-9 jump  ·  [t] {other}{arrange}  [g] full screen ")
 }
 
 impl Dashboard {
     /// How tall the stage row of the detail view is: the band when the area
     /// is tall enough and the run has a graph, the flat strip otherwise.
-    pub(super) fn stage_row_height(area_height: u16, agent: &DashboardAgent) -> u16 {
-        if area_height >= BAND_MIN_AREA_HEIGHT && agent.graph.is_some() {
-            BAND_HEIGHT
-        } else {
-            3
+    ///
+    /// A path that has wrapped asks for the rows its later rows need, up to
+    /// [`BAND_MAX_HEIGHT`]; a run still on its first row leaves them to the
+    /// panes below. Assumes the caller has loaded the run's history - without
+    /// it the path is one box and the band opens short, then jumps a frame
+    /// later.
+    pub(super) fn stage_row_height(&self, area: Rect, agent: &DashboardAgent) -> u16 {
+        if area.height < BAND_MIN_AREA_HEIGHT || agent.graph.is_none() {
+            return 3;
         }
+        let visits = self.path_visits(agent);
+        if visits.is_empty() {
+            return 3;
+        }
+        // The widest box the path could ask for, ordinal included, so the
+        // rows it needs are counted against the same width the canvas will
+        // settle on.
+        let longest = visits
+            .iter()
+            .map(|v| v.stage.chars().count() + " (99)".len())
+            .max()
+            .unwrap_or(0);
+        let rows = visits.len().div_ceil(snake_per_row(longest, area.width));
+        u16::try_from(rows.saturating_sub(1))
+            .unwrap_or(u16::MAX)
+            .saturating_mul(snake_row_pitch())
+            .saturating_add(BAND_HEIGHT)
+            .min(BAND_MAX_HEIGHT)
     }
 
     /// Whether the band drew last frame, so the stage keys go through it.
@@ -53,14 +164,21 @@ impl Dashboard {
             .any(|(id, _)| *id == PaneId::DetailBand)
     }
 
+    /// The blueprint stage a box on the band stands for: a path box carries
+    /// the visit's ordinal, which is not part of the stage's name.
+    fn band_stage_of(&self, id: &str) -> String {
+        path::stage_of(id, self.selected_agent().and_then(|a| a.graph.as_deref()))
+    }
+
     /// The tab index of a stage on the band: the ledger's position when it
     /// has one, the blueprint's order otherwise.
     fn band_stage_index(&self, name: &str) -> Option<usize> {
+        let name = self.band_stage_of(name);
         self.selected_agent().and_then(|a| {
             a.stages
                 .iter()
                 .position(|s| s.name == name)
-                .or_else(|| a.graph.as_ref().and_then(|g| g.stage_index(name)))
+                .or_else(|| a.graph.as_ref().and_then(|g| g.stage_index(&name)))
         })
     }
 
@@ -78,7 +196,7 @@ impl Dashboard {
     /// The band's selection is the stage tab: adopt it, and reset what a
     /// tab change resets.
     pub(super) fn adopt_band_selection(&mut self) {
-        let picked = match self.detail_band.as_ref().map(|b| b.view.selection()) {
+        let picked = match self.detail_band.as_ref().map(|b| b.view().selection()) {
             Some(Selection::Node(id)) => self.band_stage_index(&id),
             _ => None,
         };
@@ -98,71 +216,181 @@ impl Dashboard {
     /// the graph and follow it.
     pub(super) fn band_key(&mut self, code: crossterm::event::KeyCode) {
         if let Some(band) = self.detail_band.as_mut() {
-            band.view.handle_key(code);
+            band.view_mut().handle_key(code);
         }
         self.adopt_band_selection();
     }
 
-    /// The tab was set by number: point the band at it.
-    pub(super) fn band_select_tab(&mut self, index: usize) {
-        if let Some(name) = self.band_stage_name(index)
-            && let Some(band) = self.detail_band.as_mut()
-        {
-            band.view.select_stage(&name);
+    /// `t`: swap the band between the run's path and the whole blueprint.
+    ///
+    /// On the explorer `t` filters the picture on show; here it changes which
+    /// picture that is, which is the same question asked of a pane with room
+    /// for only one of them.
+    pub(super) fn toggle_band_mode(&mut self) {
+        let blueprint = self
+            .selected_agent()
+            .and_then(|a| a.graph.clone())
+            .map(|graph| {
+                // `t` was asked for the whole blueprint. Opening it filtered
+                // down to the path the band was already showing would answer
+                // with the same picture in a worse layout.
+                let mut view = FlowView::new(graph, false);
+                view.set_show_all(true);
+                view
+            });
+        let Some(band) = self.detail_band.as_mut() else {
+            return;
+        };
+        band.mode = match band.mode {
+            BandMode::Path => BandMode::Blueprint,
+            BandMode::Blueprint => BandMode::Path,
+        };
+        if band.mode == BandMode::Blueprint && band.blueprint.is_none() {
+            band.blueprint = blueprint;
+        }
+        // The tab the panes below are on is the box the new picture opens on.
+        self.band_select_tab(self.selected_stage);
+    }
+
+    /// `R`: throw away an arrangement made by hand and lay the band out
+    /// again.
+    pub(super) fn reset_band_layout(&mut self) {
+        if let Some(band) = self.detail_band.as_mut() {
+            band.view_mut().reset_layout();
         }
     }
 
-    /// Draw the band into `area`. Returns `false` when the run has no graph
-    /// to draw, so the caller can fall back to the strip.
+    /// The tab was set by number: point the band at it. On a path that is the
+    /// *last* box of that stage - the pass the run is on, or ended on.
+    pub(super) fn band_select_tab(&mut self, index: usize) {
+        let Some(name) = self.band_stage_name(index) else {
+            return;
+        };
+        let ids: Vec<String> = self
+            .detail_band
+            .as_ref()
+            .map(|b| b.view().graph().ids().map(str::to_string).collect())
+            .unwrap_or_default();
+        let pick = ids.into_iter().rfind(|id| self.band_stage_of(id) == name);
+        if let Some(id) = pick
+            && let Some(band) = self.detail_band.as_mut()
+        {
+            band.view_mut().select_stage(&id);
+        }
+    }
+
+    /// The run's path as the band draws it: what the archive recorded, plus
+    /// the stage the run is in now.
+    fn path_visits(&self, agent: &DashboardAgent) -> Vec<Visit> {
+        let visits: Vec<Visit> = self
+            .history
+            .as_ref()
+            .filter(|h| h.run_id == agent.id)
+            .map(|h| {
+                h.visits
+                    .iter()
+                    .map(|v| Visit {
+                        stage: v.stage.clone(),
+                        at: Some(clock(v.entered_at)),
+                        iterations: v.iterations,
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+        path::path_visits(&visits, &agent.stage)
+    }
+
+    /// The path graph and the overlay that paints it.
+    fn run_path_for(&self, agent: &DashboardAgent) -> (Arc<StageGraph>, LiveOverlay, usize) {
+        let visits = self.path_visits(agent);
+        let errored: Vec<String> = agent
+            .stages
+            .iter()
+            .filter(|s| s.status == leviath_core::run_meta::StageRunStatus::Error)
+            .map(|s| s.name.clone())
+            .collect();
+        let graph = path::run_path(agent.graph.as_deref(), &visits);
+        let mut live = path::path_overlay(
+            &visits,
+            &errored,
+            super::explorer::run_phase(&agent.status),
+            self.tick_count,
+        );
+        live.workers = self.worker_counts_for(agent);
+        (Arc::new(graph), live, visits.len())
+    }
+
+    /// Draw the band into `area`. Returns `false` when the run has nothing to
+    /// draw, so the caller can fall back to the strip.
     pub(super) fn draw_stage_band(
         &mut self,
         frame: &mut Frame,
         area: Rect,
         agent: &DashboardAgent,
     ) -> bool {
+        if agent.graph.is_none() {
+            return false;
+        }
+        // The path (and the visit counts behind it) comes from the archive.
+        self.ensure_history(&agent.id);
+        let (graph, live, visits) = self.run_path_for(agent);
+        if visits == 0 {
+            return false;
+        }
+        let signature = (visits, agent.stage.clone());
+        let longest = graph.ids().map(|id| id.chars().count()).max().unwrap_or(0);
+        let per_row = snake_per_row(longest, area.width);
+
         let stale = self
             .detail_band
             .as_ref()
             .is_none_or(|b| b.run_id != agent.id);
         if stale {
-            let Some(graph) = agent.graph.clone() else {
-                return false;
-            };
             self.detail_band = Some(DetailBand {
                 run_id: agent.id.clone(),
-                view: FlowView::new(graph, false),
+                mode: BandMode::Path,
+                path: FlowView::new_path(graph, per_row),
+                blueprint: None,
+                signature,
             });
             // A fresh canvas starts on the tab that is open.
             self.band_select_tab(self.selected_stage);
         } else {
             // A click since the last frame picked a box: that is the tab now.
             self.adopt_band_selection();
+            let band = self
+                .detail_band
+                .as_mut()
+                .expect("not stale, so the band is there");
+            // The path grows a box at a time, and rebuilding the canvas for a
+            // frame that added none would throw the camera away every tick.
+            if band.signature != signature {
+                band.signature = signature;
+                band.path.replace_path(graph);
+            }
         }
-        // Visits (the taken edges, the counts) come from the archive.
-        self.ensure_history(&agent.id);
-        let live = self.live_overlay_for(agent);
         let stage_count = agent
             .stages
             .len()
             .max(agent.graph.as_ref().map(|g| g.stage_count()).unwrap_or(0))
             .max(1);
         let selected = self.selected_stage.min(stage_count - 1);
+        let blueprint_live = self.live_overlay_for(agent);
         let band = self
             .detail_band
             .as_mut()
             .expect("built above when missing or stale");
-        band.view.apply_live(&live);
-        let title = format!(
-            " Stages ←/→ select  1-9 jump  stage {}/{}  ·  [g] graph  ·  click, drag ",
-            selected + 1,
-            stage_count
-        );
+        band.path.apply_live(&live);
+        if let Some(view) = band.blueprint.as_mut() {
+            view.apply_live(&blueprint_live);
+        }
+        let title = band_title(area.width, band.mode, visits, selected + 1, stage_count);
         let block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(C_BORDER_FOCUS))
             .title(Span::styled(title, Style::default().fg(C_DIM)));
-        let canvas = band.view.render(frame, area, block);
+        let canvas = band.view_mut().render(frame, area, block);
         self.pane_rects.push((PaneId::DetailBand, canvas));
         true
     }
@@ -173,6 +401,7 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::commands::dashboard::history::{RunHistoryCache, derive_visits};
     use crate::commands::dashboard::test_support::{
         make_test_dashboard, rendered_buffer, style_at_text,
     };
@@ -241,6 +470,46 @@ condition = "llm_choice"
         }
     }
 
+    /// Give `run` an archived path: one point per stage named, in order, so
+    /// `derive_visits` sees them as consecutive stays.
+    fn seed(dash: &mut Dashboard, run_id: &str, stages: &[&str]) {
+        let points: Vec<leviath_core::run_archive::RunPoint> = stages
+            .iter()
+            .enumerate()
+            .map(|(i, stage)| {
+                let mut meta = leviath_core::run_meta::RunMeta::new(
+                    run_id.to_string(),
+                    "grapher".to_string(),
+                    "/p".to_string(),
+                    "t".to_string(),
+                    None,
+                    "/w".to_string(),
+                    4,
+                );
+                meta.current_stage = (*stage).to_string();
+                meta.iteration = 2;
+                leviath_core::run_archive::RunPoint {
+                    meta,
+                    context: leviath_core::run_meta::ContextSnapshot {
+                        stage_name: (*stage).to_string(),
+                        total_tokens: 0,
+                        max_tokens: 100,
+                        regions: vec![],
+                    },
+                    at: 1000 + i as i64 * 10,
+                }
+            })
+            .collect();
+        dash.history = Some(RunHistoryCache {
+            run_id: run_id.to_string(),
+            visits: derive_visits(&points),
+            points,
+            // Far enough ahead that the TTL never reloads it over a stub
+            // loader that would hand back nothing.
+            loaded_at_tick: u64::MAX,
+        });
+    }
+
     fn draw(dash: &mut Dashboard, w: u16, h: u16) -> Terminal<TestBackend> {
         let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
         terminal.draw(|f| dash.draw(f)).unwrap();
@@ -266,42 +535,48 @@ condition = "llm_choice"
         r
     }
 
-    /// A run at implement that came through plan: the ledger names both.
-    fn run_at_implement(id: &str) -> DashboardAgent {
+    /// A run at its second pass through implement, having come through plan
+    /// and review: the ledger names the three, the archive has the order.
+    fn looped_run(dash: &mut Dashboard, id: &str) {
         let mut run = agent(id);
         run.stages = vec![
             record("plan", 0, true),
             record("implement", 1, true),
-            record("review", 2, false),
+            record("review", 2, true),
             record("done", 3, false),
         ];
-        run
+        dash.agents.push(run);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        seed(dash, id, &["plan", "implement", "review", "implement"]);
     }
 
     #[test]
-    fn a_tall_detail_view_draws_the_band_with_the_current_stage_lit_and_the_tab_selected() {
+    fn the_band_draws_one_box_per_visit_with_the_latest_pass_numbered() {
         let mut dash = make_test_dashboard();
-        dash.agents.push(run_at_implement("run-1"));
-        dash.update_display_indices();
-        dash.detail_view = true;
+        looped_run(&mut dash, "run-1");
         dash.selected_stage = 0;
         let terminal = draw(&mut dash, 160, 40);
         let text = rendered_buffer(&terminal);
-        assert!(text.contains("stage 1/4"), "{text}");
-        assert!(text.contains("click, drag"), "{text}");
-        // The same picture as the explorer: the path so far and what comes
-        // next, in boxes; done hangs off review and waits for its turn.
+
+        // Four visits, four boxes: the second pass through implement is its
+        // own box, numbered, not a `×2` badge on the first.
+        assert!(text.contains("Path · 4 visits"), "{text}");
+        assert!(text.contains("implement (2)"), "{text}");
+        assert!(!text.contains("implement ×2"), "{text}");
         for stage in ["plan", "implement", "review"] {
-            assert!(text.contains(&format!(" {stage} ")), "{stage}: {text}");
+            assert!(text.contains(stage), "{stage}: {text}");
         }
+        // A stage the run never reached is not on its path at all.
         assert!(!text.contains(" done "), "{text}");
-        // The stage the run is in is drawn in the active colour; the selected
-        // tab (plan, the open one) has the thick frame; review is dim.
-        assert_eq!(style_at_text(&terminal, "implement").fg, Some(C_ACTIVE));
+        // The box the run is in is the last one, in the active colour; an
+        // earlier pass through the same stage is done.
+        assert_eq!(style_at_text(&terminal, "implement (2)").fg, Some(C_ACTIVE));
+        assert_eq!(style_at_text(&terminal, "plan").fg, Some(C_WHITE));
+        // The selected tab (plan, the open one) has the thick frame.
         assert_eq!(style_at_text(&terminal, "┏").fg, Some(C_BORDER_FOCUS));
-        assert_eq!(style_at_text(&terminal, "review").fg, Some(C_DIM));
         assert_eq!(
-            dash.detail_band.as_ref().unwrap().view.selection(),
+            dash.detail_band.as_ref().unwrap().view().selection(),
             Selection::Node("plan".into())
         );
         assert!(
@@ -315,39 +590,90 @@ condition = "llm_choice"
     }
 
     #[test]
-    fn a_short_detail_view_keeps_the_flat_strip() {
+    fn a_stage_the_ledger_calls_errored_is_red_on_the_pass_that_failed() {
+        let mut dash = make_test_dashboard();
+        looped_run(&mut dash, "run-1");
+        let mut failed = record("review", 2, true);
+        failed.status = leviath_core::run_meta::StageRunStatus::Error;
+        dash.agents[0].stages[2] = failed;
+        let terminal = draw(&mut dash, 160, 40);
+        assert_eq!(style_at_text(&terminal, "review").fg, Some(C_ERROR));
+        // The stages that did not fail are untouched.
+        assert_eq!(style_at_text(&terminal, "plan").fg, Some(C_WHITE));
+    }
+
+    #[test]
+    fn a_run_with_no_archive_yet_still_gets_the_stage_it_is_in() {
         let mut dash = make_test_dashboard();
         dash.agents.push(agent("run-1"));
         dash.update_display_indices();
         dash.detail_view = true;
+        seed(&mut dash, "run-1", &[]);
+        let terminal = draw(&mut dash, 160, 40);
+        let text = rendered_buffer(&terminal);
+        assert!(text.contains("Path · 1 visit ·"), "singular: {text}");
+        assert!(text.contains("implement"), "{text}");
+        assert!(!text.contains("implement (2)"), "{text}");
+    }
+
+    #[test]
+    fn a_short_detail_view_keeps_the_flat_strip() {
+        let mut dash = make_test_dashboard();
+        looped_run(&mut dash, "run-1");
         let terminal = draw(&mut dash, 160, 24);
         let text = rendered_buffer(&terminal);
         assert!(text.contains("stage 1/4"), "{text}");
-        assert!(!text.contains("click, drag"), "{text}");
+        assert!(!text.contains("Path ·"), "{text}");
         assert!(dash.detail_band.is_none());
         assert!(!dash.band_shown());
-        assert_eq!(Dashboard::stage_row_height(24, &agent("run-1")), 3);
-        assert_eq!(
-            Dashboard::stage_row_height(40, &agent("run-1")),
-            BAND_HEIGHT
-        );
+
+        let area = |h: u16| Rect::new(0, 0, 160, h);
+        let run = dash.agents[0].clone();
+        assert_eq!(dash.stage_row_height(area(24), &run), 3);
+        assert_eq!(dash.stage_row_height(area(40), &run), BAND_HEIGHT);
         let mut no_graph = agent("run-2");
         no_graph.graph = None;
-        assert_eq!(Dashboard::stage_row_height(40, &no_graph), 3);
+        assert_eq!(dash.stage_row_height(area(40), &no_graph), 3);
+        // Nothing to draw at all: no archive and no current stage.
+        let mut nowhere = agent("run-3");
+        nowhere.stage = String::new();
+        dash.history = None;
+        assert_eq!(dash.stage_row_height(area(40), &nowhere), 3);
+    }
+
+    #[test]
+    fn the_band_grows_a_row_when_the_path_wraps_and_stops_growing() {
+        let mut dash = make_test_dashboard();
+        looped_run(&mut dash, "run-1");
+        let run = dash.agents[0].clone();
+        let area = |w: u16| Rect::new(0, 0, w, 60);
+        // Four visits at 160 cells fit one row of four.
+        assert_eq!(dash.stage_row_height(area(160), &run), BAND_HEIGHT);
+        // The same four on a narrow canvas wrap, and the band grows for it.
+        assert_eq!(
+            dash.stage_row_height(area(70), &run),
+            BAND_HEIGHT + snake_row_pitch()
+        );
+        // A long path stops at the ceiling and pans instead.
+        let many: Vec<&str> = std::iter::repeat_n(["plan", "implement"], 12)
+            .flatten()
+            .collect();
+        seed(&mut dash, "run-1", &many);
+        assert_eq!(dash.stage_row_height(area(160), &run), BAND_MAX_HEIGHT);
     }
 
     #[test]
     fn the_band_rebuilds_when_the_selected_run_changes_and_declines_without_a_graph() {
         let mut dash = make_test_dashboard();
-        dash.agents.push(agent("run-1"));
+        looped_run(&mut dash, "run-1");
         let mut other = agent("run-2");
         other.stage = "review".to_string();
         dash.agents.push(other);
         dash.update_display_indices();
-        dash.detail_view = true;
         draw(&mut dash, 160, 40);
         assert_eq!(dash.detail_band.as_ref().unwrap().run_id, "run-1");
         dash.selected = 1;
+        seed(&mut dash, "run-2", &["plan", "review"]);
         draw(&mut dash, 160, 40);
         assert_eq!(dash.detail_band.as_ref().unwrap().run_id, "run-2");
 
@@ -362,9 +688,24 @@ condition = "llm_choice"
             .unwrap();
         assert!(!drew);
         assert!(rendered_buffer(&terminal).trim().is_empty());
+        // A run with a graph but nowhere to be declines too.
+        let mut nowhere = agent("run-4");
+        nowhere.stage = String::new();
+        dash.history = None;
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        terminal
+            .draw(|f| drew = dash.draw_stage_band(f, f.area(), &nowhere))
+            .unwrap();
+        assert!(!drew);
+
         // The selected stage is clamped to what the run has.
         dash.selected = 0;
         dash.selected_stage = 40;
+        seed(
+            &mut dash,
+            "run-1",
+            &["plan", "implement", "review", "implement"],
+        );
         let terminal = draw(&mut dash, 160, 40);
         assert!(rendered_buffer(&terminal).contains("stage 4/4"));
         // Opening the detail view afresh drops the canvas, so the selection
@@ -374,49 +715,79 @@ condition = "llm_choice"
     }
 
     #[test]
+    fn a_growing_path_keeps_its_canvas_until_it_actually_grows() {
+        let mut dash = make_test_dashboard();
+        looped_run(&mut dash, "run-1");
+        draw(&mut dash, 160, 40);
+        let before = dash.detail_band.as_ref().unwrap().view().graph().clone();
+        // A frame that adds no visit redraws the same graph, not a new one.
+        draw(&mut dash, 160, 40);
+        assert!(Arc::ptr_eq(
+            &before,
+            dash.detail_band.as_ref().unwrap().view().graph()
+        ));
+        // One more visit and the path is rebuilt, a box longer.
+        seed(
+            &mut dash,
+            "run-1",
+            &["plan", "implement", "review", "implement", "review"],
+        );
+        let terminal = draw(&mut dash, 160, 40);
+        assert!(!Arc::ptr_eq(
+            &before,
+            dash.detail_band.as_ref().unwrap().view().graph()
+        ));
+        assert!(rendered_buffer(&terminal).contains("review (2)"));
+    }
+
+    #[test]
     fn the_selection_is_the_stage_tab_both_ways() {
         let mut dash = make_test_dashboard();
-        dash.agents.push(run_at_implement("run-1"));
-        dash.update_display_indices();
-        dash.detail_view = true;
+        looped_run(&mut dash, "run-1");
         dash.selected_stage = 0;
         draw(&mut dash, 160, 40);
-        // `→` walks the graph and the tab follows, resetting the scrolls.
+        // `→` walks the path and the tab follows, resetting the scrolls.
         dash.detail_scroll = 5;
         dash.handle_key(key(KeyCode::Right));
-        assert_eq!(dash.selected_stage, 1);
+        assert_eq!(dash.selected_stage, 1, "implement");
         assert_eq!(dash.detail_scroll, 0);
         assert_eq!(
-            dash.detail_band.as_ref().unwrap().view.selection(),
+            dash.detail_band.as_ref().unwrap().view().selection(),
             Selection::Node("implement".into())
         );
         dash.handle_key(key(KeyCode::Right));
         assert_eq!(dash.selected_stage, 2, "review");
-        // Nothing to the right of review on show: the tab stays.
+        // The next box along is the second pass through implement, which is
+        // the same tab as the first.
         dash.handle_key(key(KeyCode::Right));
-        assert_eq!(dash.selected_stage, 2);
-        dash.handle_key(key(KeyCode::Left));
         assert_eq!(dash.selected_stage, 1);
-        // A number jumps the tab and points the canvas at it.
-        dash.handle_key(key(KeyCode::Char('1')));
-        assert_eq!(dash.selected_stage, 0);
         assert_eq!(
-            dash.detail_band.as_ref().unwrap().view.selection(),
-            Selection::Node("plan".into())
+            dash.detail_band.as_ref().unwrap().view().selection(),
+            Selection::Node("implement (2)".into())
+        );
+        dash.handle_key(key(KeyCode::Left));
+        assert_eq!(dash.selected_stage, 2);
+        // A number jumps the tab and points the canvas at the LAST pass
+        // through that stage - where the run is, or ended up.
+        dash.handle_key(key(KeyCode::Char('2')));
+        assert_eq!(dash.selected_stage, 1);
+        assert_eq!(
+            dash.detail_band.as_ref().unwrap().view().selection(),
+            Selection::Node("implement (2)".into())
         );
         // A selection picked on the canvas (a click) is adopted at the next
-        // draw; a selection the ledger does not know is left alone.
+        // draw; one the ledger does not know is left alone.
         dash.detail_band
             .as_mut()
             .unwrap()
-            .view
+            .view_mut()
             .select_stage("review");
         draw(&mut dash, 160, 40);
         assert_eq!(dash.selected_stage, 2);
         dash.detail_band
             .as_mut()
             .unwrap()
-            .view
+            .view_mut()
             .select_stage("nowhere");
         dash.adopt_band_selection();
         assert_eq!(dash.selected_stage, 2);
@@ -424,33 +795,70 @@ condition = "llm_choice"
         dash.detail_band = None;
         dash.band_key(KeyCode::Left);
         dash.band_select_tab(0);
+        dash.reset_band_layout();
+        dash.toggle_band_mode();
         assert_eq!(dash.selected_stage, 2);
-        // A run whose ledger is empty falls back to the blueprint's order.
+    }
+
+    #[test]
+    fn a_run_with_no_ledger_falls_back_to_the_blueprints_stage_order() {
         let mut dash = make_test_dashboard();
         dash.agents.push(agent("run-1"));
         dash.update_display_indices();
         dash.detail_view = true;
+        seed(&mut dash, "run-1", &["plan", "implement", "review"]);
         dash.selected_stage = 2;
         draw(&mut dash, 160, 40);
         assert_eq!(
-            dash.detail_band.as_ref().unwrap().view.selection(),
+            dash.detail_band.as_ref().unwrap().view().selection(),
             Selection::Node("review".into())
         );
         dash.detail_band
             .as_mut()
             .unwrap()
-            .view
+            .view_mut()
             .select_stage("implement");
         dash.adopt_band_selection();
         assert_eq!(dash.selected_stage, 1);
     }
 
     #[test]
-    fn the_band_takes_the_mouse_and_ticks() {
+    fn t_swaps_the_band_between_the_path_and_the_whole_blueprint() {
         let mut dash = make_test_dashboard();
-        dash.agents.push(run_at_implement("run-1"));
-        dash.update_display_indices();
-        dash.detail_view = true;
+        looped_run(&mut dash, "run-1");
+        dash.selected_stage = 0;
+        let text = rendered_buffer(&draw(&mut dash, 160, 40));
+        assert!(text.contains("[t] blueprint"), "{text}");
+
+        dash.handle_key(key(KeyCode::Char('t')));
+        let text = rendered_buffer(&draw(&mut dash, 160, 40));
+        assert_eq!(dash.detail_band.as_ref().unwrap().mode, BandMode::Blueprint);
+        // The whole blueprint: `done` is on it now, and the ordinals are not.
+        assert!(text.contains("Blueprint · stage"), "{text}");
+        assert!(text.contains("[t] path"), "{text}");
+        assert!(text.contains(" done "), "{text}");
+        assert!(!text.contains("implement (2)"), "{text}");
+        // The run is still painted on it - the revisit count comes back as a
+        // badge, which is what a blueprint has room to say.
+        assert!(text.contains("implement ×2"), "{text}");
+        // Re-snaking a blueprint is not offered.
+        assert!(!text.contains("re-snake"), "{text}");
+
+        dash.handle_key(key(KeyCode::Char('t')));
+        let text = rendered_buffer(&draw(&mut dash, 160, 40));
+        assert_eq!(dash.detail_band.as_ref().unwrap().mode, BandMode::Path);
+        assert!(text.contains("implement (2)"), "{text}");
+        // With no band on screen `t` is somebody else's key.
+        dash.detail_view = false;
+        dash.pane_rects.clear();
+        dash.handle_key(key(KeyCode::Char('t')));
+        assert_eq!(dash.detail_band.as_ref().unwrap().mode, BandMode::Path);
+    }
+
+    #[test]
+    fn the_band_takes_the_mouse_and_r_puts_a_dragged_box_back() {
+        let mut dash = make_test_dashboard();
+        looped_run(&mut dash, "run-1");
         dash.selected_stage = 1;
         draw(&mut dash, 160, 40);
         // A second draw of the same run keeps the canvas it built.
@@ -466,7 +874,7 @@ condition = "llm_choice"
             .find(|(id, _)| *id == PaneId::DetailBand)
             .map(|(_, r)| *r)
             .expect("the band registered its canvas");
-        let pan = dash.detail_band.as_ref().unwrap().view.pan();
+        let pan = dash.detail_band.as_ref().unwrap().view().pan();
         let (x, y) = (canvas.x + canvas.width - 3, canvas.y + 1);
         dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), x, y));
         assert!(
@@ -475,20 +883,71 @@ condition = "llm_choice"
         );
         dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), x - 10, y));
         dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), x - 10, y));
-        assert_ne!(dash.detail_band.as_ref().unwrap().view.pan(), pan);
+        assert_ne!(dash.detail_band.as_ref().unwrap().view().pan(), pan);
+
+        // Drag a box somewhere else and it stays there while the path grows.
+        // Asserted in world units, not screen cells: growing the path
+        // re-settles the camera, which moves every box on screen whether or
+        // not it moved on the canvas.
+        let at = |dash: &Dashboard| {
+            dash.detail_band
+                .as_ref()
+                .unwrap()
+                .view()
+                .positions()
+                .get("plan")
+                .copied()
+                .expect("plan is on the canvas")
+        };
+        let rect = |dash: &Dashboard| {
+            dash.detail_band
+                .as_ref()
+                .unwrap()
+                .view()
+                .node_rect("plan")
+                .expect("plan is drawn")
+        };
+        let before = at(&dash);
+        let (nx, ny, _, _) = rect(&dash);
+        let (nx, ny) = (nx as u16 + 1, ny as u16 + 1);
+        dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), nx, ny));
+        dash.handle_mouse(mouse(MouseEventKind::Drag(MouseButton::Left), nx, ny + 3));
+        dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), nx, ny + 3));
+        let moved = at(&dash);
+        assert_ne!(moved, before, "the drag moved the box");
+        seed(
+            &mut dash,
+            "run-1",
+            &["plan", "implement", "review", "implement", "review"],
+        );
+        draw(&mut dash, 160, 40);
+        assert_eq!(at(&dash), moved, "a dragged box survives a new visit");
+        // `R` throws the arrangement away and snakes it again.
+        dash.handle_key(key(KeyCode::Char('R')));
+        draw(&mut dash, 160, 40);
+        assert_eq!(at(&dash), before, "re-snaked back to its cell");
+
         // A click on a box picks it, and the tab follows at the next draw.
-        let (nx, ny, _, _) = dash
-            .detail_band
-            .as_ref()
-            .unwrap()
-            .view
-            .node_rect("plan")
-            .expect("plan is drawn");
+        let (nx, ny, _, _) = rect(&dash);
         let (nx, ny) = (nx as u16 + 1, ny as u16 + 1);
         dash.handle_mouse(mouse(MouseEventKind::Down(MouseButton::Left), nx, ny));
         dash.handle_mouse(mouse(MouseEventKind::Up(MouseButton::Left), nx, ny));
         draw(&mut dash, 160, 40);
         assert_eq!(dash.selected_stage, 0);
         dash.tick_graphs(std::time::Duration::from_millis(100));
+    }
+
+    #[test]
+    fn the_title_says_less_on_a_narrow_band() {
+        let wide = band_title(160, BandMode::Path, 4, 2, 4);
+        assert!(wide.contains("Path · 4 visits · stage 2/4"), "{wide}");
+        assert!(wide.contains("[R] re-snake"), "{wide}");
+        let narrow = band_title(80, BandMode::Path, 4, 2, 4);
+        assert!(narrow.len() < wide.len(), "{narrow} / {wide}");
+        assert!(narrow.contains("Path · 4 · 2/4 · t:blueprint"), "{narrow}");
+        let narrow = band_title(80, BandMode::Blueprint, 4, 2, 4);
+        assert!(narrow.contains("Blueprint · 2/4 · t:path"), "{narrow}");
+        let one = band_title(160, BandMode::Path, 1, 1, 4);
+        assert!(one.contains("1 visit ·"), "singular: {one}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/explorer.rs
+++ b/crates/leviath-cli/src/commands/dashboard/explorer.rs
@@ -41,7 +41,16 @@ impl Dashboard {
                 // back as it was: viewport, dragged boxes, direction, toggles.
                 let view = match self.explorer_cache.take() {
                     Some((cached_run, view)) if cached_run == run_id => view,
-                    _ => FlowView::new(graph, false),
+                    _ => {
+                        // The explorer is the map: the whole blueprint, with
+                        // the run lit on it. The band beside it is already
+                        // the path, so opening this on the path too would
+                        // show the same picture twice. A canvas the user has
+                        // been in before comes back as they left it.
+                        let mut view = FlowView::new(graph, false);
+                        view.set_show_all(true);
+                        view
+                    }
                 };
                 self.stage_explorer = Some(ExplorerState::new(run_id, view));
             }
@@ -70,7 +79,7 @@ impl Dashboard {
             explorer.view.tick(elapsed);
         }
         if let Some(band) = self.detail_band.as_mut() {
-            band.view.tick(elapsed);
+            band.view_mut().tick(elapsed);
         }
         if let Some(Ok(view)) = self.new_run_preview.as_mut().map(|p| p.view.as_mut()) {
             view.tick(elapsed);
@@ -193,6 +202,10 @@ impl Dashboard {
                     errored: record.is_some_and(|r| r.status == StageRunStatus::Error),
                     visits: visit_count(visits, &name),
                     last_seen: last_visit(visits, &name).map(|v| clock(v.entered_at)),
+                    // One box per stage here, so a revisited stage has no
+                    // single iteration count; the current one's comes
+                    // through `LiveOverlay::iteration`.
+                    iterations: None,
                     name,
                 }
             })
@@ -203,6 +216,22 @@ impl Dashboard {
             .collect();
         let last_transition = taken.last().cloned();
 
+        LiveOverlay {
+            current: (!agent.stage.is_empty()).then(|| agent.stage.clone()),
+            run: Some(run_phase(&agent.status)),
+            iteration: agent.iteration,
+            stages,
+            workers: self.worker_counts_for(agent),
+            taken,
+            last_transition,
+            tick: self.tick_count,
+        }
+    }
+
+    /// How the children a fan-out stage spawned are getting on, for the box
+    /// of whichever stage the run is in. `None` when the run has no children
+    /// at all, which is every run that has not fanned out.
+    pub(super) fn worker_counts_for(&self, agent: &DashboardAgent) -> Option<WorkerCounts> {
         let mut workers = WorkerCounts::default();
         let mut has_workers = false;
         for child in self
@@ -221,17 +250,7 @@ impl Dashboard {
                 _ => workers.running += 1,
             }
         }
-
-        LiveOverlay {
-            current: (!agent.stage.is_empty()).then(|| agent.stage.clone()),
-            run: Some(run_phase(&agent.status)),
-            iteration: agent.iteration,
-            stages,
-            workers: has_workers.then_some(workers),
-            taken,
-            last_transition,
-            tick: self.tick_count,
-        }
+        has_workers.then_some(workers)
     }
 
     /// Give a graph canvas first refusal on a mouse event. Returns whether the
@@ -299,7 +318,7 @@ impl Dashboard {
                 .as_mut()
                 .filter(|e| e.tab == ExplorerTab::Graph)
                 .map(|e| &mut e.view),
-            PaneId::DetailBand => self.detail_band.as_mut().map(|b| &mut b.view),
+            PaneId::DetailBand => self.detail_band.as_mut().map(|b| b.view_mut()),
             PaneId::NewRunPreview => {
                 let open = self.new_run_screen;
                 self.new_run_preview
@@ -537,6 +556,13 @@ condition = "llm_choice"
             dash.stage_explorer.as_ref().unwrap().view.selection(),
             Selection::Node("plan".into())
         );
+        // The explorer is the map: it opens on the whole blueprint, and `t`
+        // filters it down to the path the run took. (The band beside it is
+        // already the path, so opening on that would say the same thing
+        // twice.)
+        assert!(dash.stage_explorer.as_ref().unwrap().view.show_all());
+        dash.handle_key(key(KeyCode::Char('t')));
+        assert!(!dash.stage_explorer.as_ref().unwrap().view.show_all());
         dash.handle_key(key(KeyCode::Char('t')));
         assert!(dash.stage_explorer.as_ref().unwrap().view.show_all());
         dash.handle_key(key(KeyCode::Char('e')));

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -538,6 +538,11 @@ impl Dashboard {
             KeyCode::Char('g') => {
                 self.open_stage_explorer();
             }
+            // The band's two pictures: the run's path, or the whole
+            // blueprint. (`r` is resume in this view, so re-snaking the path
+            // takes the shifted one.)
+            KeyCode::Char('t') if self.band_shown() => self.toggle_band_mode(),
+            KeyCode::Char('R') if self.band_shown() => self.reset_band_layout(),
             // Home/End are the documented jumps; b/e stay as the historical
             // aliases. (`detail_scroll` counts up from the bottom, so "top of
             // the document" is the maximum offset.)

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -175,7 +175,11 @@ impl Dashboard {
         let info_h: u16 = 4; // task + workdir/stats strip (2 content + 2 border lines)
         // The stage row: the graph band on a tall terminal, the three-row
         // strip otherwise (the band would cost every other pane its rows).
-        let tabs_h: u16 = Self::stage_row_height(area.height, &agent);
+        // The band's height follows the run's path, so the archive has to be
+        // read before the rows are handed out - otherwise a run whose path
+        // has already wrapped opens short and jumps a frame later.
+        self.ensure_history(&agent.id);
+        let tabs_h: u16 = self.stage_row_height(area, &agent);
         let context_h: u16 = if agent.context_snapshot.is_some() || !agent.stages.is_empty() {
             5
         } else {

--- a/crates/leviath-cli/src/tui/flowgraph/layout.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/layout.rs
@@ -42,6 +42,10 @@ pub(crate) struct GraphLayout {
     pub(crate) nodes: Vec<NodeSlot>,
     /// Highest layer index in `nodes`.
     pub(crate) max_layer: usize,
+    /// Set by [`snake`]: how many nodes a row holds before the path wraps.
+    /// With it, `layer` is the node's place in the sequence rather than a
+    /// column, and the whole layout is read as a wrapped grid instead.
+    pub(crate) wrap: Option<usize>,
 }
 
 impl GraphLayout {
@@ -53,6 +57,14 @@ impl GraphLayout {
     /// The layer `name` sits in.
     pub(crate) fn layer_of(&self, name: &str) -> Option<usize> {
         self.slot_of(name).map(|n| n.layer)
+    }
+
+    /// Which row and column `name` sits on, for a snaking layout. `None`
+    /// for a layered one, where a node has a layer and a slot instead.
+    pub(crate) fn cell(&self, name: &str) -> Option<(usize, usize)> {
+        let per_row = self.wrap?;
+        let slot = self.slot_of(name)?;
+        Some(snake_cell(slot.layer, per_row))
     }
 
     /// Node names on `layer`, ordered by slot.
@@ -74,6 +86,25 @@ impl GraphLayout {
         gap_x: f64,
         gap_y: f64,
     ) -> Vec<(String, (f64, f64))> {
+        // A snake is a wrapped grid, not a stack of layers: the sequence
+        // index gives the cell directly, and short rows are NOT centred the
+        // way short layers are. Centring is what makes a diamond read as a
+        // diamond, but here it would shift the last row off the column its
+        // first node has to share with the row above, and that shared column
+        // is the whole point of snaking.
+        if let Some(per_row) = self.wrap {
+            return self
+                .nodes
+                .iter()
+                .map(|node| {
+                    let (row, col) = snake_cell(node.layer, per_row);
+                    (
+                        node.name.clone(),
+                        (col as f64 * (node_w + gap_x), row as f64 * (node_h + gap_y)),
+                    )
+                })
+                .collect();
+        }
         let widest = (0..=self.max_layer)
             .map(|l| self.layer_nodes(l).len())
             .fold(0, usize::max);
@@ -220,7 +251,53 @@ pub(crate) fn layout(graph: &StageGraph) -> GraphLayout {
         })
         .collect();
 
-    GraphLayout { nodes, max_layer }
+    GraphLayout {
+        nodes,
+        max_layer,
+        wrap: None,
+    }
+}
+
+/// Lay `graph`'s nodes out as a snaking path: `per_row` of them left to
+/// right, then the next `per_row` right to left on the row below, and so on.
+///
+/// Nodes are taken in graph order, which for a run's path is the order the
+/// run walked it. The row direction alternates so the last node of a row ends
+/// up directly above the first node of the next one: the hand-off between
+/// rows is then a short vertical hop rather than a full-width jump back
+/// across the canvas, which is what keeps a path readable while it is still
+/// being drawn. (The Lair's run view snakes for the same reason.)
+///
+/// Edges are not consulted at all: the path is a chain, and its shape is its
+/// order.
+pub(crate) fn snake(graph: &StageGraph, per_row: usize) -> GraphLayout {
+    let per_row = per_row.max(1);
+    let nodes: Vec<NodeSlot> = graph
+        .ids()
+        .enumerate()
+        .map(|(index, name)| NodeSlot {
+            name: name.to_string(),
+            layer: index,
+            slot: 0,
+        })
+        .collect();
+    GraphLayout {
+        max_layer: nodes.len().saturating_sub(1),
+        nodes,
+        wrap: Some(per_row),
+    }
+}
+
+/// Which row and column a sequence index lands on for a snake `per_row` wide.
+fn snake_cell(index: usize, per_row: usize) -> (usize, usize) {
+    let row = index / per_row;
+    let in_row = index % per_row;
+    let col = if row.is_multiple_of(2) {
+        in_row
+    } else {
+        per_row - 1 - in_row
+    };
+    (row, col)
 }
 
 #[cfg(test)]
@@ -270,6 +347,77 @@ mod tests {
     }
 
     const P: EdgeClass = EdgeClass::Primary;
+
+    /// A chain of `n` nodes, the shape a run's path always has.
+    fn chain(n: usize) -> StageGraph {
+        let names: Vec<String> = (0..n).map(|i| format!("s{i}")).collect();
+        let refs: Vec<&str> = names.iter().map(String::as_str).collect();
+        let edges: Vec<(&str, &str, EdgeClass, bool)> = refs
+            .windows(2)
+            .map(|pair| (pair[0], pair[1], P, false))
+            .collect();
+        graph("s0", &refs, &edges)
+    }
+
+    #[test]
+    fn a_snake_wraps_every_per_row_and_turns_round() {
+        let l = snake(&chain(10), 4);
+        assert_eq!(l.max_layer, 9);
+        assert_eq!(l.wrap, Some(4));
+        // Sequence index, not a column: every node is its own "layer".
+        assert_eq!(l.layer_of("s7"), Some(7));
+        // Row 0 runs left to right, row 1 right to left, row 2 left again.
+        assert_eq!(l.cell("s0"), Some((0, 0)));
+        assert_eq!(l.cell("s3"), Some((0, 3)));
+        assert_eq!(l.cell("s4"), Some((1, 3)));
+        assert_eq!(l.cell("s7"), Some((1, 0)));
+        assert_eq!(l.cell("s8"), Some((2, 0)));
+        assert_eq!(l.cell("s9"), Some((2, 1)));
+        assert_eq!(l.cell("nope"), None);
+        // A layered layout has no cells to give.
+        assert_eq!(layout(&chain(3)).cell("s0"), None);
+    }
+
+    #[test]
+    fn the_last_box_of_a_row_sits_directly_above_the_first_of_the_next() {
+        // The whole point of snaking: the hand-off between rows is a short
+        // vertical hop, not a jump back across the canvas.
+        let pos = snake(&chain(10), 4).positions(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0);
+        let at = |n: &str| pos.iter().find(|(id, _)| id == n).unwrap().1;
+        assert_eq!(at("s4").0, at("s3").0, "same column across the row change");
+        assert!(at("s4").1 > at("s3").1, "and one row down");
+        assert!(at("s5").0 < at("s4").0, "row 1 runs the other way");
+        assert_eq!(at("s8").0, at("s7").0);
+        assert!(at("s9").0 > at("s8").0, "row 2 runs left to right again");
+        // Columns step by the box plus its gap, rows by the box plus theirs;
+        // a short last row is NOT centred, or it would lose the shared
+        // column above.
+        assert_eq!(at("s0"), (0.0, 0.0));
+        assert_eq!(at("s1"), (14.0, 0.0));
+        assert_eq!(at("s4"), (42.0, 4.0));
+        assert_eq!(at("s8"), (0.0, 8.0));
+        assert_eq!(
+            snake(&chain(10), 4).extent(Direction::LeftToRight, 10.0, 3.0, 4.0, 1.0),
+            (52.0, 11.0)
+        );
+    }
+
+    #[test]
+    fn a_snake_one_wide_is_a_column_and_an_empty_one_lays_out_nothing() {
+        // `per_row` is clamped up: a zero would divide by it.
+        let l = snake(&chain(3), 0);
+        assert_eq!(l.wrap, Some(1));
+        assert_eq!(l.cell("s0"), Some((0, 0)));
+        assert_eq!(l.cell("s1"), Some((1, 0)));
+        assert_eq!(l.cell("s2"), Some((2, 0)));
+        let empty = snake(&graph("a", &[], &[]), 4);
+        assert_eq!(empty.max_layer, 0);
+        assert!(
+            empty
+                .positions(Direction::LeftToRight, 1.0, 1.0, 1.0, 1.0)
+                .is_empty()
+        );
+    }
 
     #[test]
     fn a_linear_chain_gets_one_node_per_layer() {

--- a/crates/leviath-cli/src/tui/flowgraph/mod.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/mod.rs
@@ -8,8 +8,13 @@
 //!
 //! - [`model`] reads a [`leviath_core::Blueprint`] into a [`StageGraph`]:
 //!   both manifest shapes, fan-out hand-offs, self-loops as badges.
-//! - [`layout`] places it on layers, deterministically.
+//! - [`path`] turns a run's visit timeline into a graph of its own: one node
+//!   per visit, chained in the order they happened.
+//! - [`layout`] places it on layers, deterministically, or snakes a path
+//!   across rows.
 //! - [`content`] draws a node and picks an edge stroke.
+//! - [`snake`] is the snaking layout's geometry: row width, box spacing,
+//!   where an edge attaches.
 //! - [`view`] wraps the rataflow canvas: keys, mouse, and the live overlay
 //!   that paints a run onto the blueprint.
 //! - [`text`] renders the same canvas once into plain text.
@@ -17,10 +22,13 @@
 pub(crate) mod content;
 pub(crate) mod layout;
 pub(crate) mod model;
+pub(crate) mod path;
+pub(crate) mod snake;
 pub(crate) mod text;
 pub(crate) mod view;
 
 pub(crate) use content::{RunPhase, WorkerCounts};
 pub(crate) use layout::Direction;
 pub(crate) use model::StageGraph;
+pub(crate) use snake::{snake_per_row, snake_row_pitch};
 pub(crate) use view::{CanvasEvent, FlowView, LiveOverlay, MenuTarget, Selection, StageLive};

--- a/crates/leviath-cli/src/tui/flowgraph/path.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/path.rs
@@ -1,0 +1,384 @@
+//! A run's path as a graph of its own: one node per stage *visit*, in the
+//! order the run walked them.
+//!
+//! The blueprint says what a run *could* do. Painting a run onto it answers
+//! that question, not "what did this run do": the stages it visited keep
+//! their blueprint layer and slot, so the path reads as a sparse slice of a
+//! big picture, and three passes through `implement` collapse into one box
+//! with a `×3` badge, losing the order they happened in.
+//!
+//! So the path gets its own graph. It unrolls the loops: a stage entered
+//! three times is three nodes, `implement`, `implement (2)`, `implement (3)`,
+//! chained in visit order with nothing to branch to. Laid out by
+//! [`super::layout::snake`] it stays compact and grows a row at a time while
+//! the run is still going. The Lair's run view draws the same picture, from
+//! the same data, for the same reasons.
+//!
+//! Free of ratatui and of the dashboard's own types: visits come in as
+//! [`Visit`], which the caller maps from whatever it reads off disk.
+
+use leviath_core::TransitionCondition;
+
+use super::content::RunPhase;
+use super::model::{EdgeClass, NodeKind, StageEdge, StageGraph, StageKind, StageNode};
+use super::view::{LiveOverlay, StageLive};
+
+/// One stay in a stage, as the path cares about it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Visit {
+    pub(crate) stage: String,
+    /// `HH:MM:SS` it was entered, for the box's badge row.
+    pub(crate) at: Option<String>,
+    /// Iterations taken during the visit.
+    pub(crate) iterations: usize,
+}
+
+/// The visits a path draws: what the archive recorded, plus the stage the run
+/// is in now when the archive has not caught up with it.
+///
+/// A run that has just started has written no context yet, so without the
+/// second half its path would be empty until the first checkpoint lands - a
+/// blank band for the first few seconds of every run.
+pub(crate) fn path_visits(visits: &[Visit], current: &str) -> Vec<Visit> {
+    let mut out = visits.to_vec();
+    let already = out.last().is_some_and(|v| v.stage == current);
+    if !current.is_empty() && !already {
+        out.push(Visit {
+            stage: current.to_string(),
+            at: None,
+            iterations: 0,
+        });
+    }
+    out
+}
+
+/// The node id of each visit: the stage name for the first pass through it,
+/// then `name (2)`, `name (3)`, ... . The id is what the box shows, the way
+/// the Lair labels its own path nodes.
+fn visit_ids(visits: &[Visit]) -> Vec<String> {
+    let mut seen: Vec<(&str, usize)> = Vec::new();
+    visits
+        .iter()
+        .map(|visit| {
+            let pass = match seen.iter_mut().find(|(name, _)| *name == visit.stage) {
+                Some((_, count)) => {
+                    *count += 1;
+                    *count
+                }
+                None => {
+                    seen.push((visit.stage.as_str(), 1));
+                    1
+                }
+            };
+            if pass == 1 {
+                visit.stage.clone()
+            } else {
+                format!("{} ({pass})", visit.stage)
+            }
+        })
+        .collect()
+}
+
+/// The stage name a path node id was made from, undoing [`visit_ids`].
+///
+/// The ordinal is only stripped when what is left is a stage `blueprint`
+/// knows, so a blueprint that really does have a stage called `review (2)`
+/// still resolves to itself.
+pub(crate) fn stage_of(id: &str, blueprint: Option<&StageGraph>) -> String {
+    if blueprint.is_some_and(|g| g.node(id).is_some()) {
+        return id.to_string();
+    }
+    id.rsplit_once(" (")
+        .and_then(|(head, tail)| {
+            let digits = tail.strip_suffix(')')?;
+            (!digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())).then_some(head)
+        })
+        .unwrap_or(id)
+        .to_string()
+}
+
+/// The path `visits` walked, as a graph: a chain of one node per visit.
+///
+/// `blueprint` lends each node what the stage is (its mode, its description,
+/// its iteration ceiling); a run whose manifest could not be read still gets
+/// its path, drawn as plain autonomous stages.
+pub(crate) fn run_path(blueprint: Option<&StageGraph>, visits: &[Visit]) -> StageGraph {
+    let ids = visit_ids(visits);
+    let nodes: Vec<StageNode> = ids
+        .iter()
+        .enumerate()
+        .map(|(index, id)| {
+            let stage = blueprint.and_then(|g| g.node(&visits[index].stage));
+            StageNode {
+                id: id.clone(),
+                kind: stage
+                    .map(|s| s.kind.clone())
+                    .unwrap_or(NodeKind::Stage(StageKind::Autonomous)),
+                is_entry: index == 0,
+                // Whether a stage may end the run is the blueprint's to say,
+                // not the path's. Marking the last box terminal because it is
+                // last would badge the stage a running run happens to be in
+                // with "⏹ can end" whether or not it can; where the path
+                // stops is already said by the box the run is in.
+                is_terminal: stage.is_some_and(|s| s.is_terminal),
+                allow_complete: stage.is_some_and(|s| s.allow_complete),
+                // The path has already unrolled every loop; a box that
+                // pointed at itself would be claiming a revisit that is
+                // drawn as the next box along.
+                self_loop: false,
+                max_iterations: stage.and_then(|s| s.max_iterations),
+                max_revisits: None,
+                description: stage.and_then(|s| s.description.clone()),
+            }
+        })
+        .collect();
+    let edges: Vec<StageEdge> = ids
+        .windows(2)
+        .map(|pair| StageEdge {
+            from: pair[0].clone(),
+            to: pair[1].clone(),
+            condition: TransitionCondition::Always,
+            hint: None,
+            transform: "direct",
+            class: EdgeClass::Primary,
+            back_edge: false,
+        })
+        .collect();
+    StageGraph {
+        entry: ids.first().cloned().unwrap_or_default(),
+        nodes,
+        edges,
+        // Nothing on a path branches: it is what happened, not what could.
+        is_branching: false,
+    }
+}
+
+/// Paint the run onto its own path: every node visited, every edge taken,
+/// the last one the stage the run is in.
+///
+/// `errored` names the stages whose ledger says they ended in an error; the
+/// mark lands on the *last* pass through such a stage, since an earlier pass
+/// that was followed by another one plainly did not end the run.
+pub(crate) fn path_overlay(
+    visits: &[Visit],
+    errored: &[String],
+    run: RunPhase,
+    tick: u64,
+) -> LiveOverlay {
+    let ids = visit_ids(visits);
+    let stages: Vec<StageLive> = ids
+        .iter()
+        .enumerate()
+        .map(|(index, id)| {
+            let stage = &visits[index].stage;
+            let last_pass = !visits[index + 1..].iter().any(|v| &v.stage == stage);
+            StageLive {
+                name: id.clone(),
+                entered: true,
+                errored: last_pass && errored.iter().any(|e| e == stage),
+                // One box is one visit, so the `×n` badge has nothing to
+                // count - the `(n)` in the name already says which pass this
+                // is.
+                visits: 1,
+                last_seen: visits[index].at.clone(),
+                iterations: Some(visits[index].iterations),
+            }
+        })
+        .collect();
+    let taken: Vec<(String, String)> = ids
+        .windows(2)
+        .map(|pair| (pair[0].clone(), pair[1].clone()))
+        .collect();
+    LiveOverlay {
+        current: ids.last().cloned(),
+        run: Some(run),
+        iteration: visits.last().map(|v| v.iterations).unwrap_or(0),
+        stages,
+        workers: None,
+        last_transition: taken.last().cloned(),
+        taken,
+        tick,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::manifest::parse_manifest;
+
+    fn blueprint() -> StageGraph {
+        StageGraph::from_blueprint(
+            &parse_manifest(
+                r#"
+[agent]
+name = "grapher"
+[stages.plan]
+description = "think first"
+max_iterations = 4
+[stages.plan.transitions.implement]
+[stages.implement]
+mode = "interactive"
+[stages.implement.transitions.review]
+[stages.review]
+[stages.review.transitions.implement]
+condition = "llm_choice"
+[stages.review.transitions.done]
+[stages.done]
+[stages.done.transitions]
+"#,
+            )
+            .unwrap(),
+        )
+    }
+
+    fn visits(stages: &[&str]) -> Vec<Visit> {
+        stages
+            .iter()
+            .enumerate()
+            .map(|(i, stage)| Visit {
+                stage: (*stage).to_string(),
+                at: Some(format!("10:00:0{i}")),
+                iterations: i,
+            })
+            .collect()
+    }
+
+    fn ids(graph: &StageGraph) -> Vec<&str> {
+        graph.ids().collect()
+    }
+
+    #[test]
+    fn every_visit_is_its_own_box_and_later_passes_are_numbered() {
+        let v = visits(&["plan", "implement", "review", "implement", "review"]);
+        let graph = run_path(Some(&blueprint()), &v);
+        assert_eq!(
+            ids(&graph),
+            ["plan", "implement", "review", "implement (2)", "review (2)"]
+        );
+        // A chain: each box leads to the next and nothing else.
+        assert_eq!(graph.edges.len(), 4);
+        assert_eq!(graph.edges[3].from, "implement (2)");
+        assert_eq!(graph.edges[3].to, "review (2)");
+        assert!(graph.edges.iter().all(|e| e.class == EdgeClass::Primary));
+        assert!(graph.edges.iter().all(|e| !e.back_edge));
+        assert!(!graph.is_branching);
+        assert_eq!(graph.entry, "plan");
+    }
+
+    #[test]
+    fn the_path_starts_where_it_started_and_only_ends_where_it_ended() {
+        let v = visits(&["plan", "implement", "review", "implement"]);
+        let graph = run_path(Some(&blueprint()), &v);
+        let node = |id: &str| graph.node(id).expect("on the path");
+        assert!(node("plan").is_entry);
+        assert!(!node("implement").is_entry);
+        // Whether a stage can end the run is the blueprint's answer, the
+        // same for every pass through it - not "this box is last".
+        assert!(!node("implement").is_terminal);
+        assert!(!node("implement (2)").is_terminal);
+        let ends = run_path(Some(&blueprint()), &visits(&["review", "done"]));
+        assert!(ends.node("done").expect("on the path").is_terminal);
+        // The loop is already unrolled, so no box points at itself.
+        assert!(graph.nodes.iter().all(|n| !n.self_loop));
+        // What the stage is comes from the blueprint, for every pass.
+        assert_eq!(node("plan").description.as_deref(), Some("think first"));
+        assert_eq!(node("plan").max_iterations, Some(4));
+        assert_eq!(node("implement (2)").kind_label(), "interactive");
+    }
+
+    #[test]
+    fn a_path_without_a_blueprint_is_still_a_path() {
+        let graph = run_path(None, &visits(&["plan", "plan"]));
+        assert_eq!(ids(&graph), ["plan", "plan (2)"]);
+        assert_eq!(graph.node("plan").unwrap().kind_label(), "autonomous");
+        assert_eq!(graph.node("plan").unwrap().description, None);
+        // Nothing at all: an empty graph, not a panic.
+        let empty = run_path(None, &[]);
+        assert!(empty.nodes.is_empty());
+        assert!(empty.edges.is_empty());
+        assert_eq!(empty.entry, "");
+    }
+
+    #[test]
+    fn the_stage_the_run_is_in_is_appended_when_the_archive_lags() {
+        // A run that has just moved on: the archive has not caught up, so
+        // the box for where it is now would otherwise be missing.
+        let v = path_visits(&visits(&["plan", "implement"]), "review");
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[2].stage, "review");
+        assert_eq!(v[2].at, None);
+        // Already the last visit: nothing to add.
+        let v = path_visits(&visits(&["plan", "implement"]), "implement");
+        assert_eq!(v.len(), 2);
+        // A run that has written nothing yet is still one box.
+        assert_eq!(path_visits(&[], "plan").len(), 1);
+        // And a run that is nowhere at all is none.
+        assert!(path_visits(&[], "").is_empty());
+    }
+
+    #[test]
+    fn stage_of_undoes_the_ordinal_unless_the_blueprint_really_uses_one() {
+        assert_eq!(stage_of("review", None), "review");
+        assert_eq!(stage_of("review (2)", None), "review");
+        assert_eq!(stage_of("review (12)", None), "review");
+        // Only a trailing ` (<digits>)` is an ordinal.
+        assert_eq!(stage_of("review (draft)", None), "review (draft)");
+        assert_eq!(stage_of("review ()", None), "review ()");
+        assert_eq!(stage_of("review (2", None), "review (2");
+        // A blueprint that really has a stage by that name wins.
+        let odd = run_path(None, &visits(&["review (2)"]));
+        assert_eq!(stage_of("review (2)", Some(&odd)), "review (2)");
+        assert_eq!(stage_of("review (2)", Some(&blueprint())), "review");
+    }
+
+    #[test]
+    fn the_overlay_paints_every_box_visited_and_the_last_one_current() {
+        let v = visits(&["plan", "implement", "review", "implement"]);
+        let live = path_overlay(&v, &[], RunPhase::Active, 7);
+        assert_eq!(live.current.as_deref(), Some("implement (2)"));
+        assert_eq!(live.run, Some(RunPhase::Active));
+        assert_eq!(live.tick, 7);
+        assert_eq!(live.iteration, 3, "the last visit's own count");
+        assert!(live.stages.iter().all(|s| s.entered));
+        // One box is one visit, so nothing carries a `×n` badge, and each
+        // says how long it took on its own.
+        assert!(live.stages.iter().all(|s| s.visits == 1));
+        assert_eq!(live.stages[1].iterations, Some(1));
+        assert_eq!(live.stages[1].last_seen.as_deref(), Some("10:00:01"));
+        // Every hop was taken, and the newest one animates.
+        assert_eq!(
+            live.taken,
+            vec![
+                ("plan".to_string(), "implement".to_string()),
+                ("implement".to_string(), "review".to_string()),
+                ("review".to_string(), "implement (2)".to_string()),
+            ]
+        );
+        assert_eq!(
+            live.last_transition,
+            Some(("review".to_string(), "implement (2)".to_string()))
+        );
+        assert_eq!(live.workers, None);
+        // An empty path has nothing to be current.
+        assert_eq!(path_overlay(&[], &[], RunPhase::Idle, 0).current, None);
+        assert_eq!(path_overlay(&[], &[], RunPhase::Idle, 0).iteration, 0);
+    }
+
+    #[test]
+    fn an_error_marks_the_last_pass_through_the_stage_not_an_earlier_one() {
+        let v = visits(&["implement", "review", "implement"]);
+        let live = path_overlay(&v, &["implement".to_string()], RunPhase::Error, 0);
+        let errored = |name: &str| {
+            live.stages
+                .iter()
+                .find(|s| s.name == name)
+                .expect("on the path")
+                .errored
+        };
+        // The first pass was followed by another one, so it plainly did not
+        // end the run.
+        assert!(!errored("implement"));
+        assert!(errored("implement (2)"));
+        assert!(!errored("review"));
+    }
+}

--- a/crates/leviath-cli/src/tui/flowgraph/snake.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/snake.rs
@@ -1,0 +1,170 @@
+//! The snaking layout's geometry: how wide a row is, how big the boxes and
+//! their gaps are, where an edge attaches, and which handles a box needs.
+//!
+//! A run's path is a chain, and a chain drawn straight runs off the side of
+//! any terminal. Snaking it - `per_row` boxes left to right, then the next
+//! `per_row` right to left on the row below - keeps it on screen, and keeps
+//! the last box of a row directly above the first box of the next, so the
+//! hand-off between rows is a short vertical hop instead of a jump back
+//! across the canvas. Everything that follows from that shape lives here,
+//! away from [`super::view`], which is already the biggest thing in the kit.
+
+use rataflow::{Handle, HandlePosition};
+
+use super::content::{NODE_HEIGHT, node_width};
+
+/// How the boxes are placed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum LayoutMode {
+    /// A blueprint: longest-path layers, running the way that fits.
+    Layered,
+    /// A run's path: a chain snaked across rows `per_row` boxes wide, so it
+    /// stays compact and grows downwards while the run is still going.
+    Snake { per_row: usize },
+}
+
+/// The widest a snake gets before the eye loses the row it was following.
+const MAX_PER_ROW: usize = 6;
+
+/// Box size and gaps: `(node_w, node_h, gap_x, gap_y)`.
+///
+/// A snake is spaced differently from a layered graph: its edges carry no
+/// condition label (every hop on a path is `always`), so the columns can sit
+/// closer together, while the rows need a gutter the vertical hand-off
+/// between them can run down.
+pub(crate) fn metrics(longest_id: usize, snake: bool) -> (f64, f64, f64, f64) {
+    let (gap_x, gap_y) = if snake { (6.0, 2.0) } else { (8.0, 1.0) };
+    (node_width(longest_id), NODE_HEIGHT, gap_x, gap_y)
+}
+
+/// How many boxes a snake fits across a canvas `width` cells wide, given the
+/// longest node id on it.
+///
+/// Shared with the detail band, which sizes itself from the number of rows
+/// this implies: if the two computed it separately they would disagree the
+/// moment one of the constants moved.
+pub(crate) fn snake_per_row(longest_id: usize, width: u16) -> usize {
+    let (node_w, _, gap_x, _) = metrics(longest_id, true);
+    // The same inset the canvas settles inside: the block's border and a cell
+    // of margin each side.
+    let inner = f64::from(width) - 4.0;
+    let fits = ((inner + gap_x) / (node_w + gap_x)).floor();
+    // `fits` is finite and small; a negative one (a canvas narrower than its
+    // own border) clamps to the single-column snake.
+    (fits.max(1.0) as usize).clamp(1, MAX_PER_ROW)
+}
+
+/// How many rows of canvas one row of a snake takes: a box, plus the gutter
+/// below it the hand-off to the next row runs down.
+pub(crate) fn snake_row_pitch() -> u16 {
+    let (_, node_h, _, gap_y) = metrics(0, true);
+    (node_h + gap_y) as u16
+}
+
+/// Which sides an edge leaves and enters on for a snaking path, from the two
+/// cells it joins, as `(source, target, loops_back, stem)`.
+///
+/// Along a row the edge runs the way that row runs, so it leaves the trailing
+/// side and enters the leading one; between rows the two boxes share a column
+/// (that is what the snake is for), so the hand-off drops straight out of the
+/// bottom of one into the top of the next. Both handles are centred, so
+/// neither ever needs a lane beside the boxes.
+pub(crate) fn route_snake(
+    from: (usize, usize),
+    to: (usize, usize),
+) -> (HandlePosition, HandlePosition, bool, f64) {
+    let ((from_row, from_col), (to_row, to_col)) = (from, to);
+    let (src, tgt) = if from_row == to_row {
+        if to_col > from_col {
+            (HandlePosition::Right, HandlePosition::Left)
+        } else {
+            (HandlePosition::Left, HandlePosition::Right)
+        }
+    } else {
+        (HandlePosition::Bottom, HandlePosition::Top)
+    };
+    (src, tgt, false, 1.0)
+}
+
+/// A snake attaches on all four sides, and to both ends of an edge: a row
+/// that runs right to left leaves on the left and enters on the right, which
+/// the layered handle set has no pair for. Every one is centred and hidden -
+/// a path is never edited, so none of them is a port.
+pub(crate) fn handles_snake() -> Vec<Handle> {
+    [
+        HandlePosition::Left,
+        HandlePosition::Right,
+        HandlePosition::Top,
+        HandlePosition::Bottom,
+    ]
+    .into_iter()
+    .flat_map(|side| {
+        [
+            Handle::source(side)
+                .with_id(side.side_name())
+                .with_connectable(false)
+                .with_hidden(true),
+            Handle::target(side)
+                .with_id(side.side_name())
+                .with_connectable(false)
+                .with_hidden(true),
+        ]
+    })
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn snake_edges_run_the_way_their_row_runs_and_drop_between_rows() {
+        // Along a row: out of the trailing side, into the leading one.
+        assert_eq!(
+            route_snake((0, 0), (0, 1)),
+            (HandlePosition::Right, HandlePosition::Left, false, 1.0)
+        );
+        // The next row runs the other way, so the edge does too.
+        assert_eq!(
+            route_snake((1, 3), (1, 2)),
+            (HandlePosition::Left, HandlePosition::Right, false, 1.0)
+        );
+        // Between rows the two boxes share a column: straight down.
+        assert_eq!(
+            route_snake((0, 3), (1, 3)),
+            (HandlePosition::Bottom, HandlePosition::Top, false, 1.0)
+        );
+        // Never a loop and never a lane, whichever way it went.
+        let (_, _, loops_back, stem) = route_snake((1, 0), (2, 0));
+        assert!(!loops_back);
+        assert_eq!(stem, 1.0);
+    }
+
+    #[test]
+    fn snake_per_row_fits_what_it_can_between_one_and_the_ceiling() {
+        // A 28-cell box and a 6-cell gap: 34 to a column, less the border.
+        assert_eq!(snake_per_row(4, 240), MAX_PER_ROW, "capped, not 7");
+        assert_eq!(snake_per_row(4, 200), 5);
+        assert_eq!(snake_per_row(4, 140), 4);
+        assert_eq!(snake_per_row(4, 40), 1);
+        // Narrower than its own border still asks for a column, not none.
+        assert_eq!(snake_per_row(4, 0), 1);
+        // A long stage name makes the boxes wider, so fewer fit.
+        assert!(snake_per_row(60, 240) < snake_per_row(4, 240));
+        // One row of a snake is a box plus the gutter under it.
+        assert_eq!(snake_row_pitch(), 6);
+    }
+
+    #[test]
+    fn a_snake_offers_every_side_as_both_ends_and_a_layered_graph_is_spaced_wider() {
+        let handles = handles_snake();
+        assert_eq!(handles.len(), 8, "four sides, each a source and a target");
+        assert!(handles.iter().all(|h| h.hidden && !h.connectable));
+        // The columns sit closer on a snake and the rows further apart.
+        let (snake_w, snake_h, snake_x, snake_y) = metrics(4, true);
+        let (layered_w, layered_h, layered_x, layered_y) = metrics(4, false);
+        assert_eq!((snake_w, snake_h), (layered_w, layered_h));
+        assert!(snake_x < layered_x);
+        assert!(snake_y > layered_y);
+    }
+}

--- a/crates/leviath-cli/src/tui/flowgraph/view.rs
+++ b/crates/leviath-cli/src/tui/flowgraph/view.rs
@@ -23,12 +23,10 @@ use ratatui::widgets::Block;
 use crate::blueprint_edit::Positions;
 use crate::tui::theme::C_ACCENT;
 
-use super::content::{
-    NODE_HEIGHT, NodeStatus, RunPhase, StageNodeContent, WorkerCounts, edge_style, node_width,
-    palette,
-};
+use super::content::{NodeStatus, RunPhase, StageNodeContent, WorkerCounts, edge_style, palette};
 use super::layout::{self, Direction, GraphLayout};
 use super::model::{EdgeClass, StageEdge, StageGraph};
+use super::snake::{LayoutMode, handles_snake, metrics, route_snake, snake_per_row};
 
 /// What a run has done to one stage, for the overlay.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -42,6 +40,11 @@ pub(crate) struct StageLive {
     pub(crate) visits: usize,
     /// When it was last entered, `HH:MM:SS`.
     pub(crate) last_seen: Option<String>,
+    /// Iterations taken in this stage. On the blueprint that is only known
+    /// for the stage the run is in, and comes through
+    /// [`LiveOverlay::iteration`] instead; on a run's path every box is one
+    /// visit, so each carries its own count.
+    pub(crate) iterations: Option<usize>,
 }
 
 /// Everything the canvas needs to paint a run onto the blueprint, rebuilt
@@ -126,6 +129,7 @@ pub(crate) struct FlowView {
     /// (rataflow treats the press as the start of a pan, and a pan must keep
     /// the selection, so the click is told apart here.)
     pane_press: Option<(u16, u16)>,
+    mode: LayoutMode,
     direction: Direction,
     /// Until the user turns the graph by hand, the first draw picks the
     /// direction that fits.
@@ -154,11 +158,6 @@ pub(crate) struct FlowView {
     max_stem: f64,
 }
 
-/// Box size and gaps: `(node_w, node_h, gap_x, gap_y)`.
-fn metrics(longest_id: usize) -> (f64, f64, f64, f64) {
-    (node_width(longest_id), NODE_HEIGHT, 8.0, 1.0)
-}
-
 /// Put saved positions on the boxes, and any box without one to the right
 /// of the rightmost saved box (the way The Lair appends a new stage), so an
 /// arrangement survives a stage being added.
@@ -169,8 +168,19 @@ fn apply_positions(
     node_h: f64,
     gap_x: f64,
     gap_y: f64,
+    snake: bool,
 ) {
     if positions.is_empty() {
+        return;
+    }
+    // On a snake the boxes that were not moved by hand keep the cell the
+    // layout gave them; only the moved ones are restored. Appending would
+    // put every new visit off to the right of the arrangement instead of on
+    // the next cell of the path.
+    if snake {
+        for (id, (x, y)) in positions {
+            flow.set_node_position(id, (*x, *y));
+        }
         return;
     }
     let mut right = f64::MIN;
@@ -299,6 +309,14 @@ fn handles(direction: Direction, edit: bool) -> Vec<Handle> {
     ]
 }
 
+/// Place `graph`'s boxes the way `mode` asks for.
+fn relayout(graph: &StageGraph, mode: LayoutMode) -> GraphLayout {
+    match mode {
+        LayoutMode::Layered => layout::layout(graph),
+        LayoutMode::Snake { per_row } => layout::snake(graph, per_row),
+    }
+}
+
 /// The canvas for `graph` laid out in `direction`: the nodes, the edges
 /// remembered for live restyling, and the longest lane a visible edge needs.
 fn build(
@@ -315,7 +333,8 @@ fn build(
         .map(|n| n.id.trim_start_matches("ext:").chars().count())
         .max()
         .unwrap_or(0);
-    let (node_w, node_h, gap_x, gap_y) = metrics(longest);
+    let snake = layout.wrap.is_some();
+    let (node_w, node_h, gap_x, gap_y) = metrics(longest, snake);
 
     let nodes: Vec<Node<StageNodeContent>> = graph
         .nodes
@@ -327,7 +346,11 @@ fn build(
                 (node_w, node_h),
                 StageNodeContent::from_node(n),
             )
-            .with_handles(handles(direction, edit))
+            .with_handles(if snake {
+                handles_snake()
+            } else {
+                handles(direction, edit)
+            })
             // An external blueprint is drawn, not edited: nothing connects to
             // it and it cannot be moved.
             .with_connectable(edit && n.kind != super::model::NodeKind::ExternalBlueprint)
@@ -346,7 +369,10 @@ fn build(
         .map(|(i, e)| {
             let from_layer = layout.layer_of(&e.from).unwrap_or(0);
             let to_layer = layout.layer_of(&e.to).unwrap_or(0);
-            let (src, tgt, loops_back, stem) = route(direction, e.class, from_layer, to_layer);
+            let (src, tgt, loops_back, stem) = match (layout.cell(&e.from), layout.cell(&e.to)) {
+                (Some(from), Some(to)) => route_snake(from, to),
+                _ => route(direction, e.class, from_layer, to_layer),
+            };
             if e.class != EdgeClass::Escape {
                 max_stem = max_stem.max(stem);
             }
@@ -389,7 +415,7 @@ fn build(
         .with_deselect_on_pane_click(false)
         .with_locked(locked);
     flow.set_node_positions(layout.positions(direction, node_w, node_h, gap_x, gap_y));
-    apply_positions(&mut flow, positions, node_w, node_h, gap_x, gap_y);
+    apply_positions(&mut flow, positions, node_w, node_h, gap_x, gap_y, snake);
     if edit {
         // A path that exists is not drawn twice, whichever handles a drag
         // would route it through; and a box cannot be wired to itself on
@@ -414,22 +440,42 @@ impl FlowView {
     /// explorer is unlocked, so boxes can be dragged into a better
     /// arrangement and clicked to select.
     pub(crate) fn new(graph: Arc<StageGraph>, locked: bool) -> Self {
-        Self::build_view(graph, locked, false, Positions::new())
+        Self::build_view(graph, locked, false, Positions::new(), LayoutMode::Layered)
+    }
+
+    /// Build the canvas for a run's path (see [`super::path`]): a chain
+    /// snaked `per_row` boxes to a row. Unlocked, so the boxes can be dragged
+    /// into a better arrangement and clicked to select, and never an editor -
+    /// what happened is not editable.
+    pub(crate) fn new_path(graph: Arc<StageGraph>, per_row: usize) -> Self {
+        Self::build_view(
+            graph,
+            false,
+            false,
+            Positions::new(),
+            LayoutMode::Snake { per_row },
+        )
     }
 
     /// Build the canvas as an editor: handles show and connect, boxes drag,
     /// every edge is drawn, and `positions` (from an earlier session) place
     /// the boxes.
     pub(crate) fn new_editor(graph: Arc<StageGraph>, positions: Positions) -> Self {
-        let mut view = Self::build_view(graph, false, true, positions);
+        let mut view = Self::build_view(graph, false, true, positions, LayoutMode::Layered);
         view.show_all = true;
         view.show_escape = true;
         view.sync_visibility();
         view
     }
 
-    fn build_view(graph: Arc<StageGraph>, locked: bool, edit: bool, positions: Positions) -> Self {
-        let layout = layout::layout(&graph);
+    fn build_view(
+        graph: Arc<StageGraph>,
+        locked: bool,
+        edit: bool,
+        positions: Positions,
+        mode: LayoutMode,
+    ) -> Self {
+        let layout = relayout(&graph, mode);
         let (flow, edges, max_stem) = build(
             &graph,
             &layout,
@@ -448,6 +494,7 @@ impl FlowView {
             positions,
             events: Vec::new(),
             pane_press: None,
+            mode,
             direction: Direction::LeftToRight,
             auto_direction: true,
             show_escape: false,
@@ -473,12 +520,42 @@ impl FlowView {
         self.rebuild(self.direction.rotated());
     }
 
+    /// Throw away every box the user dragged and lay the graph out again.
+    ///
+    /// A snake has no other way round to be turned, so `r` re-snakes it
+    /// instead - the Lair's "Re-snake" button by another name.
+    pub(crate) fn reset_layout(&mut self) {
+        self.positions.clear();
+        self.rebuild(self.direction);
+    }
+
+    /// Snake the same path `per_row` boxes to a row. A no-op when it already
+    /// is, so it is safe to call every draw.
+    fn resnake(&mut self, per_row: usize) {
+        if self.mode == (LayoutMode::Snake { per_row }) {
+            return;
+        }
+        self.mode = LayoutMode::Snake { per_row };
+        self.layout = relayout(&self.graph, self.mode);
+        self.rebuild(self.direction);
+    }
+
+    /// Draw a longer path on the same canvas, keeping the boxes the user
+    /// moved by hand where they left them (the Lair merges its own dragged
+    /// nodes over a fresh snake the same way). Everything else takes its new
+    /// cell, so a run that has just reached another stage grows by one box
+    /// rather than rearranging itself.
+    pub(crate) fn replace_path(&mut self, graph: Arc<StageGraph>) {
+        let positions = self.positions.clone();
+        self.replace_graph(graph, positions);
+    }
+
     /// Draw a different graph on the same canvas (the editor after an edit):
     /// selection by id, viewport, direction and toggles carry over;
     /// `positions` place the boxes.
     pub(crate) fn replace_graph(&mut self, graph: Arc<StageGraph>, positions: Positions) {
         self.graph = graph;
-        self.layout = layout::layout(&self.graph);
+        self.layout = relayout(&self.graph, self.mode);
         self.positions = positions;
         let area = self.last_area;
         self.rebuild(self.direction);
@@ -574,6 +651,16 @@ impl FlowView {
         }
     }
 
+    /// The longest node id on the canvas, which is what a box is sized for.
+    fn longest_id(&self) -> usize {
+        self.graph
+            .nodes
+            .iter()
+            .map(|n| n.id.trim_start_matches("ext:").chars().count())
+            .max()
+            .unwrap_or(0)
+    }
+
     /// The longest edge lane, in rows above or below the nodes.
     pub(crate) fn max_stem(&self) -> f64 {
         self.max_stem
@@ -601,6 +688,14 @@ impl FlowView {
     }
 
     /// Switch between the whole graph and the run's path and options.
+    /// Show the whole graph, or only what the run touched. The explorer
+    /// opens on the whole one: it is the map, and the band beside it is
+    /// already the path.
+    pub(crate) fn set_show_all(&mut self, show_all: bool) {
+        self.show_all = show_all;
+        self.sync_visibility();
+    }
+
     pub(crate) fn toggle_all(&mut self) {
         self.show_all = !self.show_all;
         self.sync_visibility();
@@ -681,20 +776,20 @@ impl FlowView {
         // Inside the block's border, less a cell of margin each side.
         let (inner_w, inner_h) = (f64::from(area.width) - 4.0, f64::from(area.height) - 4.0);
         let fits = |(w, h): (f64, f64)| w <= inner_w && h <= inner_h;
+        let longest = self.longest_id();
         let extent = |dir: Direction| {
-            let longest = self
-                .graph
-                .nodes
-                .iter()
-                .map(|n| n.id.trim_start_matches("ext:").chars().count())
-                .max()
-                .unwrap_or(0);
-            let (node_w, node_h, gap_x, gap_y) = metrics(longest);
+            let (node_w, node_h, gap_x, gap_y) = metrics(longest, self.mode != LayoutMode::Layered);
             self.layout.extent(dir, node_w, node_h, gap_x, gap_y)
         };
-        let other = self.direction.rotated();
-        if self.auto_direction && !fits(extent(self.direction)) && fits(extent(other)) {
-            self.rebuild(other);
+        // A path has no other way round to be turned; what it does with a
+        // wider or narrower canvas is fit more or fewer boxes to a row.
+        if self.mode == LayoutMode::Layered {
+            let other = self.direction.rotated();
+            if self.auto_direction && !fits(extent(self.direction)) && fits(extent(other)) {
+                self.rebuild(other);
+            }
+        } else {
+            self.resnake(snake_per_row(longest, area.width));
         }
         if fits(self.world_extent()) {
             self.fit();
@@ -744,7 +839,10 @@ impl FlowView {
             KeyCode::Char('-') => self.flow.zoom_out(),
             KeyCode::Char('0') => self.flow.reset_zoom(),
             KeyCode::Char('f') => self.fit(),
-            KeyCode::Char('r') => self.rotate(),
+            KeyCode::Char('r') => match self.mode {
+                LayoutMode::Layered => self.rotate(),
+                LayoutMode::Snake { .. } => self.reset_layout(),
+            },
             KeyCode::Char('e') => self.toggle_escape(),
             KeyCode::Char('t') => self.toggle_all(),
             _ => return false,
@@ -776,6 +874,18 @@ impl FlowView {
         }
         let response = self.flow.handle_mouse_event(event);
         if !self.edit {
+            // A path is rebuilt every time the run reaches a new stage, so a
+            // box the user dragged somewhere better has to be remembered or
+            // the next visit would snap it back. Kept in memory only: a
+            // visit is not a stage, and there is nothing to save it against.
+            if matches!(self.mode, LayoutMode::Snake { .. })
+                && response
+                    .events()
+                    .iter()
+                    .any(|ev| matches!(ev, rataflow::FlowEvent::NodeDragEnded { .. }))
+            {
+                self.positions = self.positions();
+            }
             return true;
         }
         let at = (event.column, event.row);
@@ -843,7 +953,7 @@ impl FlowView {
                     run: live.run.unwrap_or(RunPhase::Active),
                     times: visits.max(1),
                 };
-                content.iteration = Some(live.iteration);
+                content.iteration = record.and_then(|r| r.iterations).or(Some(live.iteration));
                 if content.kind_label == "fan-out" {
                     content.workers = live.workers;
                 }
@@ -854,6 +964,7 @@ impl FlowView {
                     times: visits.max(1),
                     errored: r.errored,
                 };
+                content.iteration = r.iterations;
             }
         }
 
@@ -1068,6 +1179,41 @@ mode = "output"
         FlowView::new(graph(), false)
     }
 
+    /// A run's path of `n` visits, as the band builds one.
+    fn path_view(n: usize, per_row: usize) -> FlowView {
+        let visits: Vec<super::super::path::Visit> = (0..n)
+            .map(|i| super::super::path::Visit {
+                stage: format!("s{i}"),
+                at: None,
+                iterations: 0,
+            })
+            .collect();
+        FlowView::new_path(
+            Arc::new(super::super::path::run_path(None, &visits)),
+            per_row,
+        )
+    }
+
+    #[test]
+    fn a_path_snakes_and_re_wraps_to_the_canvas_it_gets() {
+        let mut v = path_view(8, 4);
+        // A 140-cell canvas fits four 28-cell boxes and their gaps to a row.
+        draw(&mut v, 140, 40);
+        let row_of = |v: &FlowView, id: &str| v.node_rect(id).expect("drawn").1;
+        assert_eq!(row_of(&v, "s0"), row_of(&v, "s3"), "one row of four");
+        assert!(row_of(&v, "s4") > row_of(&v, "s3"), "and then the next");
+        // Boxes are never shrunk, so a narrow canvas fits fewer to a row and
+        // the path is snaked again rather than zoomed out.
+        draw(&mut v, 80, 40);
+        assert_eq!(v.zoom(), 1.0);
+        assert!(row_of(&v, "s2") > row_of(&v, "s1"), "wrapped sooner");
+        // Turning a path has no meaning, so `r` puts it back instead.
+        let before = v.positions();
+        v.handle_key(KeyCode::Char('r'));
+        assert_eq!(v.direction(), Direction::LeftToRight);
+        assert_eq!(v.positions(), before);
+    }
+
     fn draw(view: &mut FlowView, w: u16, h: u16) -> (Terminal<TestBackend>, String) {
         let mut terminal = Terminal::new(TestBackend::new(w, h)).unwrap();
         terminal
@@ -1186,6 +1332,7 @@ mode = "output"
                     errored: false,
                     visits: 1,
                     last_seen: Some("10:00:00".into()),
+                    iterations: None,
                 },
                 StageLive {
                     name: "implement".into(),
@@ -1193,6 +1340,7 @@ mode = "output"
                     errored: true,
                     visits: 2,
                     last_seen: None,
+                    iterations: None,
                 },
                 StageLive {
                     name: "review".into(),
@@ -1200,6 +1348,7 @@ mode = "output"
                     errored: false,
                     visits: 0,
                     last_seen: None,
+                    iterations: None,
                 },
                 StageLive {
                     name: "done".into(),
@@ -1207,6 +1356,7 @@ mode = "output"
                     errored: false,
                     visits: 0,
                     last_seen: None,
+                    iterations: None,
                 },
             ],
             workers: Some(WorkerCounts {

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -36,9 +36,10 @@ panel and answer. `lev respond` does the same from the shell.
 - **Agent run table**: title and run id, blueprint, stage, status, tokens, and start time, with
   sub-agents nested under their parent. Titles are auto-generated per run. The model, iteration,
   and context-window occupancy live in the detail view.
-- **Detail view**: the blueprint's stage graph as a band under the header (the flat stage tabs
+- **Detail view**: the run's path as a band under the header (the flat stage tabs
   on a short terminal), a context-window visualization, and content panes for **Output**,
-  **Logs**, and **Context** (JSON). Markdown is rendered. `g` opens the graph full screen.
+  **Logs**, and **Context** (JSON). Markdown is rendered. `t` swaps the band to the whole
+  blueprint, and `g` opens the blueprint full screen.
 - **Interactions**: answer an agent's question (free-text, edit, multiple-choice, tool-approval, or
   confirm) or send it a mid-run message.
 - **Agents**: the catalog of agents this machine can run (`a`), and an editor that builds one on
@@ -179,6 +180,8 @@ for a run whose blueprint could not be read, the flat tab strip stays.
 | `Home` / `End` (or `b` / `e`) | Jump to the beginning / end |
 | `l` / `o` / `c` | Switch the pane to Logs / Output / Context |
 | `g` | Open the stage graph explorer |
+| `t` | Swap the band between the run's path and the whole blueprint |
+| `R` | Re-snake the path, undoing boxes you moved by hand |
 | `Enter` / Space | Fold or unfold the row under the Context tree's cursor |
 | `[` / `]` | Jump to the previous / next region in the Context view |
 | `,` / `.` | Step back and forward through context history |
@@ -215,10 +218,27 @@ The one caveat is a *live* run whose region evicts from the front: entry numbers
 expansion, which is already true within a single session and is why this is a convenience rather
 than a promise.
 
+### The path band
+
+The rows under the detail view's header draw the run's path: one box per stage **visit**, in the
+order the run walked them, snaking across rows so it stays compact and grows a row at a time while
+the run is still going. A stage entered three times is three boxes - `implement`, `implement (2)`,
+`implement (3)` - because the order is the story, and each says when it was entered and how many
+iterations it took. The rows alternate direction, so the last box of a row sits directly above the
+first box of the next and the hand-off between them is a short vertical hop rather than a jump back
+across the canvas. The band grows a row taller when the path wraps; past that it pans, keeping the
+stage the run is in on screen. This is the same picture The Lair's run view draws on the web.
+
+`t` swaps the band to the whole blueprint, painted with what the run has done to it, and back
+again. Boxes can be dragged and the canvas panned; a box you move stays where you put it as the
+path grows, and `R` throws the arrangement away and snakes it again. On a terminal too short to
+give the band its rows, the flat stage strip stays.
+
 ### Stage explorer
 
 `g` in the detail view opens the full-screen stage explorer for any run (a linear blueprint is a
-chain; a graph blueprint is a graph):
+chain; a graph blueprint is a graph). Where the band is what the run did, the explorer is the map
+of everything it could do:
 
 - **Graph** draws the blueprint on a canvas: stages are boxes on layers, transitions are routed
   edges. The layers run left to right when that fits the terminal and top to bottom when only that
@@ -227,10 +247,11 @@ chain; a graph blueprint is a graph):
   spins in the run's colour, stages it has been through show a visit count (`×2`) and the time of
   their last visit, the last transition it took is animated while the run is still going, and
   revisit loops run along a lane
-  beside the boxes. While a run is on the canvas the picture is the path and the options: the
-  stages the run has been through and the one it is in, the transitions between them, and the
-  transitions it can take from where it is with the stages they lead to. Everything else waits
-  off screen until `t` shows the whole graph, so a stage never sits there without a line to it.
+  beside the boxes. The whole blueprint is on show, so you can see what the run has not done as
+  well as what it has. `t` narrows it to the path and the options - the stages the run has been
+  through and the one it is in, the transitions between them, and the transitions it can take from
+  where it is with the stages they lead to - and everything else waits off screen, so a stage never
+  sits there without a line to it.
   The escape edges (`error`, `dead_end`, `stuck`, `max_iterations`) are hidden until you ask for
   them, because nearly every stage has one to the same hub; with the path in focus, `e` shows the
   escapes from the current stage. A fan-out stage that is running shows its worker counts.
@@ -249,7 +270,7 @@ chain; a graph blueprint is a graph):
 | `+` / `-` , `0` | Zoom in / out, back to 100% |
 | `f` | Fit the whole graph on screen |
 | `r` | Turn the graph: left to right or top to bottom |
-| `t` | The whole graph, or only the path taken and what comes next |
+| `t` | The whole graph (the default), or only the path taken and what comes next |
 | `e` | Show or hide the escape edges |
 | `Tab` / `Shift-Tab` | Switch between Graph and Timeline |
 | `?` / `F1` | Help |


### PR DESCRIPTION
The detail view's band painted the run onto the whole blueprint. That answers "what could this agent do", and buries "what did this run do" in the stages it never went near: the visited stages keep their blueprint layer and slot, so a path reads as a sparse slice of a big picture, three passes through a stage collapse into one box with a `×3` badge that loses the order they happened in, and the twelve rows the band gets usually have to pan to show any of it.

The Lair has drawn the better pair of pictures on the web for a while: the run view is a compact graph of the stages actually visited, and the full-graph modal is the blueprint with the visits lit. This is the terminal saying the same thing, from the same data.

## The band is now the run's path

One box per stage **visit**, in the order the run walked them:

```
╭ Path · 8 visits · stage 1/4  ·  ←/→ select  1-9 jump  ·  [t] blueprint  [R] re-snake  [g] full screen ─╮
│  ╭ ▶ ✓ plan ───────────────╮   ╭ ✓ implement ────────────╮   ╭ ✓ review ───────────────╮   ╭ ✓ plan (2) ─────────────╮  │
│  │ autonomous · iter 2     │   │ autonomous · iter 2     │   │ autonomous · iter 2     │   │ autonomous · iter 2     │  │
│  │ 16:16:40                │──▶│ 16:16:50                │──▶│ 16:17:00                │──▶│ 16:17:10                │  │
│  ╰─────────────────────────╯   ╰─────────────────────────╯   ╰─────────────────────────╯   ╰─────────────────────────╯  │
│                                                                                                        │               │
│                                                                                                        ▼               │
│  ╭ ⠋ implement (3) ────────╮   ┏ ✓ plan (3) ━━━━━━━━━━━━━┓   ╭ ✓ review (2) ───────────╮   ╭ ✓ implement (2) ────────╮  │
│  │ autonomous · iter 0     │   ┃ autonomous · iter 2     ┃   │ autonomous · iter 2     │   │ autonomous · iter 2     │  │
│  │                         │◀ ─┃ 16:17:40                ┃◀──│ 16:17:30                │◀──│ 16:17:20                │  │
│  ╰─────────────────────────╯   ┗━━━━━━━━━━━━━━━━━━━━━━━━━┛   ╰─────────────────────────╯   ╰─────────────────────────╯  │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

Three passes through `implement` are three boxes, because the order is the story, and each says when it was entered and how many iterations it took. The rows alternate direction, so the last box of a row sits **directly above** the first box of the next and the hand-off is a short vertical hop rather than a jump back across the canvas — which is what keeps a path legible while it is still being drawn.

The band re-snakes to the width it gets (fewer boxes to a row on a narrow terminal, never smaller boxes), grows one row taller when the path wraps, and pans past that with the stage the run is in kept on screen.

## Keys

- `t` swaps the band to the whole blueprint, painted with what the run has done to it, and back.
- Boxes drag and the canvas pans as before. A box moved by hand is now **remembered across the rebuild each new visit triggers**, so an arrangement survives the run moving on; `R` throws it away and snakes it again. Kept in memory only — a visit is not a stage, so there is nothing to save it against.
- `g` opens the explorer on the **whole blueprint** rather than the path, since the band beside it is already the path. `t` there still narrows it to the path and the options.

## How it is built

The data was already there: `derive_visits()` gives an ordered `Vec<StageVisit>` with timestamps and iteration counts, read once per run and TTL-gated.

- **`tui/flowgraph/path.rs`** (new) unrolls the loops into a chain graph — one node per visit, `implement (2)`, `implement (3)` — and the overlay that paints it. Free of ratatui and of the dashboard's own types.
- **`tui/flowgraph/snake.rs`** (new) is the snaking geometry: row width, box spacing, where an edge attaches, which handles a box needs. `view.rs` was at its 1200-line production limit, and this is the concern that wanted its own file.
- **`layout::snake`** places the chain boustrophedon; `GraphLayout` grows a `wrap` field, and `positions()` deliberately skips the centre-the-short-column offset that makes a diamond read as a diamond — on a snake it would shift the last row off the column its first node has to share with the row above.
- **`FlowView`** grows a `LayoutMode`, so one canvas draws either picture: `settle()` re-wraps a snake to the width instead of rotating it, and `r` resets instead of turning.

Two behaviour notes worth a second look:

- **`is_terminal` comes from the blueprint, not from being last.** The first cut marked the path's last box terminal, which badged whatever stage a running run happened to be in with `⏹ can end` whether or not it could. Caught by looking at a rendered frame, not by a test.
- **`R`, not `r`, re-snakes.** `r` is already resume in the detail view.

## Verification

- `cargo test -p leviath-cli` — green. New tests cover the snake cells (mirroring The Lair's own `graphLayout.test.ts` assertions), the path model, snake routing and the band's rendered frames.
- `cargo xtask coverage` — all 13 packages at 100%.
- `cargo xtask docs` — clean; `docs/content/dashboard.md` updated for the band, the new keys and the explorer's new default.
- Frames rendered and read by eye at 160 and 110 columns, for a path on one row, two rows and three: the wrap, the right-to-left second row and the vertical hand-off all draw as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
