### PR TITLE
ci(deps): move Dependabot to Thursday afternoon

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,18 @@ version: 2
 # - `github-actions` - the actions that build and publish releases. These run
 #   with `contents: write` on the release path, so a compromised action is a
 #   compromised release.
+#
+# Both run Thursday afternoon, a few hours after the Thursday 9am prod cut, so a
+# dependency bump lands with a whole weekend to be reviewed and integrated
+# before the next Monday beta goes out.
 updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: thursday
+      time: "13:00"
+      timezone: America/Los_Angeles
     open-pull-requests-limit: 5
     groups:
       # One PR for the routine churn, so security updates stand out instead of
@@ -31,7 +37,9 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      day: monday
+      day: thursday
+      time: "13:00"
+      timezone: America/Los_Angeles
     labels:
       - dependencies
       - ci


### PR DESCRIPTION
Dependabot was opening its weekly PRs on Monday, which is also when the beta
cut goes out (`beta.yml`, Mondays 16:00 UTC). That put dependency bumps and a
release on the same morning, so bumps either sat unreviewed through the release
or got rushed in next to it.

This moves both ecosystems to Thursday 1pm Pacific, a few hours after the
Thursday 9am prod cut (`prod.yml`, Thursdays 16:00 UTC), leaving the weekend to
review and integrate anything worth taking before Monday's beta.

Also pins the time and timezone explicitly - without them Dependabot picks its
own time of day, so "Thursday" alone could still land at an awkward hour.
