### PR TITLE
chore(release): 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
-## Unreleased
+## 0.5.2 - 2026-08-27
 
 - Fixed: a stage naming a model its provider does not carry is now a validation
   error and a refused spawn, instead of a run on some other model. Nothing had

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "chrono",
  "dirs",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "base64 0.23.1",
  "leviath-core",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "fs4",
  "keyring",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "tokio",
  "tracing",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.5.1" }
-leviath-core = { path = "crates/leviath-core", version = "0.5.1" }
-leviath-net = { path = "crates/leviath-net", version = "0.5.1" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.1" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.1" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.5.1" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.1" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.1" }
-leviath-package = { path = "crates/leviath-package", version = "0.5.1" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.5.1" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.5.1" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.1" }
+leviath = { path = "crates/leviath", version = "0.5.2" }
+leviath-core = { path = "crates/leviath-core", version = "0.5.2" }
+leviath-net = { path = "crates/leviath-net", version = "0.5.2" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.2" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.2" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.5.2" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.2" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.2" }
+leviath-package = { path = "crates/leviath-package", version = "0.5.2" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.5.2" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.5.2" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.2" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.5.1", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.5.2", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": {
       "name": "MIT"


### PR DESCRIPTION
Cuts 0.5.2. `cargo xtask version 0.5.2` across the workspace, plus the
`## Unreleased` heading becoming `## 0.5.2`.

What is in it, since 0.5.1:

- A model id is now checked against the provider that would serve it, in
  `lev validate` and at spawn, so a stage pinned to a model its provider does
  not carry is refused rather than quietly run on the fallback chain. Adds
  `catalog-unchecked`, and `no-reachable-provider` now judges bare model names.
- The dashboard's detail view draws the run's path rather than its blueprint:
  one box per stage visit, snaked across rows.
- Streaming inference is on for any model that offers it, which keeps the
  socket alive through a long turn instead of leaving a proxy to close it.
  Usage, cost and tool calls come back the same way a buffered call reports
  them.
- Network failures: a provider that answered and went quiet is waited out
  longer than one that was never there; a failure at a stage boundary parks
  the run instead of ending it; a failed call says what actually went wrong;
  token counting and model listing no longer inherit the 15-minute deadline.

Merging this cuts the alpha release; beta follows on the weekly workflow.
