### PR TITLE
ci(deps): say which of the two Thursday schedules drifts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ version: 2
 #   with `contents: write` on the release path, so a compromised action is a
 #   compromised release.
 #
-# Both run Thursday afternoon, a few hours after the Thursday 9am prod cut, so a
-# dependency bump lands with a whole weekend to be reviewed and integrated
-# before the next Monday beta goes out.
+# Both run Thursday at 1pm Pacific, a few hours after the Thursday morning prod
+# cut, so a dependency bump lands with a whole weekend to be reviewed and
+# integrated before the next Monday beta goes out. `time` is read in the
+# `timezone` below rather than UTC, so the hour here is the local one and it
+# holds at 1pm across the daylight-saving change. The prod cron cannot do that -
+# Actions schedules are UTC only - so the gap between the two is four hours in
+# summer and five in winter.
 updates:
   - package-ecosystem: cargo
     directory: /


### PR DESCRIPTION
1pm Pacific stays. No schedule key changes in this PR - the diff is the comment
above them only.

What the comment got wrong: it described the Dependabot run as sitting "a few
hours after the Thursday 9am prod cut", as though that were a fixed offset.
It is not. Dependabot has its own `timezone` key and reads `time` in it, so
1pm holds at 1pm through the daylight-saving change. Actions accepts crons in
UTC only, so prod's `0 16 * * 4` is 9am Pacific in summer and 8am in winter.
The gap is four hours half the year and five the other half, and the comment
now says so.

Worth knowing separately: the Dependabot runs on the night of the 26th were
not the weekly schedule. Pushing a change to `dependabot.yml` makes Dependabot
re-read it immediately, and those two runs fired six seconds after the
Thursday-move commit landed. Merging this will trigger one more immediate
re-read, then it settles onto Thursdays.
