### PR TITLE
feat(editor): drag a stage's models into priority order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ same list.
 
 ## Unreleased
 
+- Added: a stage's model chain can be reordered with the mouse in the agent
+  editor. Each model row carries a `⠿` grip; press it, drag up or down the
+  chain, and let go. The rows reorder as you drag, so the drop is what you
+  saw, and the document is only written on release - one undo entry for the
+  whole move, and none at all for a drop back where it started. The grip is a
+  small target on purpose: dragging anywhere else on the row still selects
+  text, so a model id stays something you can highlight and copy. `←` `→` on a
+  model row still move it a place at a time.
+- Changed: moving a model in the chain lifts and inserts rather than swapping
+  with its neighbour. The two agree for the single step the arrow keys make,
+  but a drag crosses several rows at once, and swapping the ends of such a
+  move would fling the entry the pointer had just passed back to where the
+  dragged one started.
 - Fixed: deleting a run now deletes the sub-agent runs beneath it. A fan-out
   worker or a `sub_agent` spawn is a run of its own, but it exists because
   something started it and it is drawn nested under that run, so deleting the

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
@@ -126,6 +126,9 @@ pub(in crate::commands::dashboard) struct Editor {
     /// each field, and the column span of each stage tab, so a click lands
     /// on the right one.
     pub(in crate::commands::dashboard) hit: InspectorHits,
+    /// A model entry the mouse has picked up by its grip, if one is in the
+    /// air. See [`ModelDrag`].
+    pub(in crate::commands::dashboard) model_drag: Option<ModelDrag>,
 }
 
 /// What the inspector drew last, for the mouse.
@@ -137,6 +140,29 @@ pub(in crate::commands::dashboard) struct InspectorHits {
     pub(in crate::commands::dashboard) rows: Vec<u16>,
     /// The screen row of the stage tab bar, and each tab's `[x0, x1)`.
     pub(in crate::commands::dashboard) tabs: Option<(u16, Vec<(u16, u16)>)>,
+    /// The drag grip drawn beside each model entry: its place in the chain,
+    /// and the cells that pick it up.
+    ///
+    /// A grip rather than the whole row, so pressing on a model's *name*
+    /// still starts a text selection the way pressing on any other value
+    /// does. Dragging the row itself would mean the only way to copy a model
+    /// id out of the inspector was to not touch the row it is on.
+    pub(in crate::commands::dashboard) grips: Vec<(usize, ratatui::layout::Rect)>,
+}
+
+/// A model entry held by the mouse: where it came from in the chain, and
+/// where it would land if the button came up now.
+///
+/// The document is not touched until the drop. Mid-drag the inspector simply
+/// *draws* the chain in `to` order, so what the pointer is over is the answer
+/// rather than a preview of it, and the whole gesture lands on the undo stack
+/// as one entry instead of one per row crossed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::commands::dashboard) struct ModelDrag {
+    /// The entry's index in the chain when it was picked up.
+    pub(in crate::commands::dashboard) from: usize,
+    /// The index it would take on release.
+    pub(in crate::commands::dashboard) to: usize,
 }
 
 /// Snapshots kept for undo.
@@ -407,6 +433,7 @@ impl Dashboard {
             models,
             tools,
             hit: InspectorHits::default(),
+            model_drag: None,
         };
         editor.apply_flags();
         self.agents().editor = Some(editor);

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_keys.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_keys.rs
@@ -6,7 +6,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent,
 use ratatui::layout::Rect;
 
 use super::super::state::Dashboard;
-use super::editor::{Focus, Overlay, PickerFor};
+use super::editor::{Focus, ModelDrag, Overlay, PickerFor};
 use super::inspector::{Panel, StageTab};
 use crate::tui::flowgraph::CanvasEvent;
 use crate::tui::widgets::line_edit::{EditOutcome, LineEdit};
@@ -245,6 +245,9 @@ impl Dashboard {
     /// A click on the inspector: the row under it takes the cursor and the
     /// keys; a click on a stage tab switches to it; a second click on the
     /// row the cursor is on opens it, like Enter.
+    ///
+    /// Pressing a model row's grip picks the entry up instead, and dragging
+    /// moves it along the chain until the button comes up. See [`ModelDrag`].
     pub(in crate::commands::dashboard) fn editor_inspector_mouse(
         &mut self,
         event: MouseEvent,
@@ -254,6 +257,34 @@ impl Dashboard {
         };
         if editor.overlay.is_some() || editor.line.is_some() || editor.add_stage.is_some() {
             return false;
+        }
+        // A drag that began on a grip owns the mouse until it is released,
+        // wherever the pointer wanders. Answering these itself is what stops
+        // the fall-through from starting a text selection over the inspector
+        // half-way through the gesture.
+        if let Some(drag) = editor.model_drag {
+            match event.kind {
+                MouseEventKind::Drag(MouseButton::Left) => {
+                    if let Some((to, _)) = editor
+                        .hit
+                        .grips
+                        .iter()
+                        .find(|(_, cells)| cells.y == event.row)
+                    {
+                        editor.model_drag = Some(ModelDrag { to: *to, ..drag });
+                        editor.cursor = *to;
+                    }
+                    return true;
+                }
+                MouseEventKind::Up(MouseButton::Left) => {
+                    editor.model_drag = None;
+                    // A no-op when it landed where it started, undo stack
+                    // included.
+                    self.editor_reorder_model(drag.from, drag.to);
+                    return true;
+                }
+                _ => {}
+            }
         }
         if event.kind != MouseEventKind::Down(MouseButton::Left) {
             return false;
@@ -279,6 +310,16 @@ impl Dashboard {
             };
             editor.cursor = 0;
             editor.focus = Focus::Inspector;
+            return true;
+        }
+        // The grip is checked before the row it sits on: pressing it picks the
+        // entry up rather than opening the model chooser on a second click.
+        if let Some((m, _)) = hit.grips.iter().find(|(_, cells)| {
+            event.row == cells.y && event.column >= cells.x && event.column < cells.x + cells.width
+        }) {
+            editor.focus = Focus::Inspector;
+            editor.cursor = *m;
+            editor.model_drag = Some(ModelDrag { from: *m, to: *m });
             return true;
         }
         let was = (editor.focus, editor.cursor);

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor_panels.rs
@@ -382,8 +382,28 @@ impl Dashboard {
         }
     }
 
-    /// `←`/`→` on a model entry: move it in the chain.
+    /// `←`/`→` on a model entry: move it one place along the chain.
     pub(super) fn editor_move_model(&mut self, index: usize, delta: isize) {
+        let Some(to) = index.checked_add_signed(delta) else {
+            return;
+        };
+        self.editor_reorder_model(index, to);
+    }
+
+    /// Put the chain's `from`th entry at `to`, the cursor following it.
+    ///
+    /// Lift-and-insert rather than a swap. The two agree for the one-step
+    /// move the arrow keys make, but a drag crosses several rows at once, and
+    /// swapping its ends would fling the entry the pointer had just passed
+    /// all the way back to where the dragged one started.
+    ///
+    /// Out-of-range and standing-still are both no-ops, so a drop back where
+    /// it began costs nothing - not even an undo entry.
+    ///
+    /// The cursor is a field index and `from`/`to` are chain indices; on the
+    /// model tab the chain is drawn first, so the two are the same number and
+    /// the shift applies directly.
+    pub(super) fn editor_reorder_model(&mut self, from: usize, to: usize) {
         let stage = self.editor().panel_stage().expect("a stage field");
         let mut chain = self
             .editor()
@@ -391,16 +411,16 @@ impl Dashboard {
             .stage(&stage)
             .map(|s| s.models)
             .unwrap_or_default();
-        let to = index as isize + delta;
-        if index >= chain.len() || to < 0 || to as usize >= chain.len() {
+        if from >= chain.len() || to >= chain.len() || from == to {
             return;
         }
-        chain.swap(index, to as usize);
+        let entry = chain.remove(from);
+        chain.insert(to, entry);
         // The stage is the one the panel shows, so the write cannot be
-        // refused; the cursor follows the entry.
+        // refused.
         self.editor_mutate(|d| d.set_models(&stage, &chain));
         let editor = self.editor();
-        editor.cursor = (editor.cursor as isize + delta) as usize;
+        editor.cursor = (editor.cursor + to).saturating_sub(from);
     }
 
     /// `←`/`→`/Enter on a segment: the next rule for the region.

--- a/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/inspector.rs
@@ -404,7 +404,7 @@ fn stage_fields(doc: &ManifestDoc, name: &str, tab: StageTab) -> Vec<Field> {
                         FieldId::ModelEntry(i),
                         if i == 0 { "Model" } else { "then" },
                         FieldValue::Row(m.clone()),
-                        "The chain is tried in order. Enter swaps this one, x drops it, ←/→ move it.",
+                        "Tried in order, best first. Enter swaps this one, x drops it, ←/→ or a drag on ⠿ moves it.",
                     )
                 })
                 .collect();

--- a/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/panel_tests.rs
@@ -5,7 +5,7 @@
 
 use crossterm::event::{KeyCode, MouseButton, MouseEventKind};
 
-use super::editor::{Focus, Overlay};
+use super::editor::{Focus, ModelDrag, Overlay};
 use super::inspector::{FieldId, FieldValue, Panel, StageTab};
 use super::prompts::{ExternalEdit, PromptFocus};
 use super::tests::{ctrl, dashboard, draw, key, mouse, open_editor_on, text, type_str};
@@ -1415,6 +1415,170 @@ fn a_click_on_the_inspector_picks_rows_and_tabs() {
     // No editor: not handled.
     dash.close_editor();
     assert!(!dash.editor_inspector_mouse(press(1, 1)));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// The model chain is a priority order, so moving an entry is an edit like
+/// any other - and reaching for the mouse to do it is the obvious thing.
+///
+/// The grip is what makes that safe. Dragging the *row* would mean the only
+/// way to copy a model id out of the inspector was to not touch the row it is
+/// on, so the press has to land on the grip cells to pick anything up.
+#[test]
+fn a_model_is_dragged_along_the_chain_by_its_grip() {
+    let (mut dash, root) = dashboard("model_drag");
+    open_stage(&mut dash, "own", "work", StageTab::Model);
+    let chain = vec![
+        "alfa-model".to_string(),
+        "bravo-model".to_string(),
+        "charlie-model".to_string(),
+    ];
+    assert!(dash.editor_mutate(|d| d.set_models("work", &chain)));
+
+    let _ = draw(&mut dash, 160, 50);
+    let grips = dash.agents().editor.as_ref().unwrap().hit.grips.clone();
+    assert_eq!(
+        grips.iter().map(|(m, _)| *m).collect::<Vec<_>>(),
+        vec![0, 1, 2],
+        "one grip per chain entry, in chain order"
+    );
+    // Only the model rows get one: the tools row below them is not orderable.
+    assert_eq!(
+        grips.len(),
+        3,
+        "the button and the tools row carry no grip: {grips:?}"
+    );
+
+    let at = |kind, cell: ratatui::layout::Rect| mouse(kind, cell.x, cell.y);
+    let down = MouseEventKind::Down(MouseButton::Left);
+    let drag = MouseEventKind::Drag(MouseButton::Left);
+    let up = MouseEventKind::Up(MouseButton::Left);
+
+    // Pick the last entry up. Nothing is written yet - the document is only
+    // touched on the drop, so the whole gesture is one undo entry.
+    assert!(dash.handle_agents_mouse(at(down, grips[2].1)));
+    assert_eq!(
+        models_of(&mut dash, "work"),
+        chain,
+        "the press changed nothing"
+    );
+    assert!(dash.agents().editor.as_ref().unwrap().model_drag.is_some());
+
+    // Drag it over the first row: the chain *draws* in the order a release
+    // would commit, so what is under the pointer is the answer.
+    assert!(dash.handle_agents_mouse(at(drag, grips[0].1)));
+    let screen = text(&mut dash);
+    let seen = |name: &str| {
+        screen
+            .find(name)
+            .unwrap_or_else(|| panic!("{name} is not drawn"))
+    };
+    assert!(
+        seen("charlie-model") < seen("alfa-model"),
+        "the held entry draws where it would land"
+    );
+    assert_eq!(
+        models_of(&mut dash, "work"),
+        chain,
+        "still nothing written mid-drag"
+    );
+
+    // Release: now it is written, and the cursor stayed on the entry.
+    assert!(dash.handle_agents_mouse(at(up, grips[0].1)));
+    assert_eq!(
+        models_of(&mut dash, "work"),
+        vec![
+            "charlie-model".to_string(),
+            "alfa-model".to_string(),
+            "bravo-model".to_string(),
+        ],
+        "lift-and-insert, not a swap: alfa and bravo both shift down one"
+    );
+    assert_eq!(dash.agents().editor.as_ref().unwrap().cursor, 0);
+    assert!(dash.agents().editor.as_ref().unwrap().model_drag.is_none());
+
+    // A drag that ends where it began costs nothing - not even an undo entry,
+    // so one undo still reaches the order from before the first drop.
+    let _ = draw(&mut dash, 160, 50);
+    let grips = dash.agents().editor.as_ref().unwrap().hit.grips.clone();
+    assert!(dash.handle_agents_mouse(at(down, grips[1].1)));
+    assert!(dash.handle_agents_mouse(at(up, grips[1].1)));
+    assert!(dash.agents().editor.as_mut().unwrap().undo());
+    assert_eq!(models_of(&mut dash, "work"), chain);
+
+    // Another button pressed part-way through a drag is not the drag's: it
+    // takes its ordinary meaning and the held entry stays held.
+    assert!(dash.handle_agents_mouse(at(down, grips[2].1)));
+    assert!(!dash.editor_inspector_mouse(mouse(
+        MouseEventKind::Down(MouseButton::Right),
+        grips[0].1.x,
+        grips[0].1.y
+    )));
+    assert!(dash.agents().editor.as_ref().unwrap().model_drag.is_some());
+    assert!(dash.handle_agents_mouse(at(up, grips[2].1)));
+
+    // The rows are rebuilt from the document every frame, and the document can
+    // move under a held button (an undo, a reload). A drag whose indices no
+    // longer fit the chain draws it untouched rather than panicking.
+    dash.agents().editor.as_mut().unwrap().model_drag = Some(ModelDrag { from: 0, to: 9 });
+    let screen = text(&mut dash);
+    let seen = |name: &str| screen.find(name).expect("the chain is drawn");
+    assert!(seen("alfa-model") < seen("bravo-model"), "{screen}");
+    dash.agents().editor.as_mut().unwrap().model_drag = None;
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// The grip is a target, not the row. A press anywhere else on a model row is
+/// the ordinary row click, and the drag machinery stays out of the way of
+/// selecting the model id as text.
+#[test]
+fn pressing_a_model_row_off_its_grip_starts_no_drag() {
+    let (mut dash, root) = dashboard("model_drag_off_grip");
+    open_stage(&mut dash, "own", "work", StageTab::Model);
+    let chain = vec!["alfa-model".to_string(), "bravo-model".to_string()];
+    assert!(dash.editor_mutate(|d| d.set_models("work", &chain)));
+    let _ = draw(&mut dash, 160, 50);
+    let editor = dash.agents().editor.as_ref().unwrap();
+    let grips = editor.hit.grips.clone();
+    let rows = editor.hit.rows.clone();
+    let press = |col: u16, row: u16| mouse(MouseEventKind::Down(MouseButton::Left), col, row);
+
+    // Two cells to the right of the grip is the label, and further right the
+    // value: both are ordinary row picks.
+    let cell = grips[1].1;
+    assert!(dash.handle_agents_mouse(press(cell.x + cell.width, cell.y)));
+    assert!(dash.agents().editor.as_ref().unwrap().model_drag.is_none());
+    assert_eq!(dash.agents().editor.as_ref().unwrap().cursor, 1);
+
+    // A drag with nothing held is not the inspector's: it falls through to
+    // the text selection behind it.
+    assert!(!dash.editor_inspector_mouse(mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        cell.x,
+        cell.y
+    )));
+    assert!(!dash.editor_inspector_mouse(mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        cell.x,
+        cell.y
+    )));
+
+    // A drag off the rows entirely keeps the entry where it was picked up,
+    // so letting go outside the list is a cancel rather than a random move.
+    assert!(dash.handle_agents_mouse(press(cell.x, cell.y)));
+    assert!(dash.handle_agents_mouse(mouse(
+        MouseEventKind::Drag(MouseButton::Left),
+        cell.x,
+        rows[rows.len() - 1] + 1
+    )));
+    assert!(dash.handle_agents_mouse(mouse(
+        MouseEventKind::Up(MouseButton::Left),
+        cell.x,
+        rows[rows.len() - 1] + 1
+    )));
+    assert_eq!(models_of(&mut dash, "work"), chain);
+
     let _ = std::fs::remove_dir_all(&root);
 }
 

--- a/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/render_editor.rs
@@ -13,8 +13,8 @@ use ratatui::widgets::{Block, BorderType, Borders, Clear, Paragraph, Wrap};
 use super::super::state::Dashboard;
 use super::super::theme::*;
 use super::super::types::PaneId;
-use super::editor::{Focus, InspectorHits, Overlay};
-use super::inspector::{Field, FieldValue, Panel, StageTab, panel_title};
+use super::editor::{Focus, InspectorHits, ModelDrag, Overlay};
+use super::inspector::{Field, FieldId, FieldValue, Panel, StageTab, panel_title};
 use crate::blueprint_edit::check::Severity;
 use crate::tui::widgets::footer::{draw_hint_bar, hint};
 use crate::tui::widgets::markdown_edit::{MODE_CHORD, MdAction, chord_label};
@@ -26,6 +26,14 @@ const SIDE_BY_SIDE_MIN_WIDTH: u16 = 110;
 const INSPECTOR_WIDTH: u16 = 58;
 /// Rows the expanded problems list takes.
 const PROBLEMS_ROWS: u16 = 6;
+/// The grip drawn beside a row the mouse can pick up and drag, with the space
+/// that separates it from the label. Braille dots: the widest-supported glyph
+/// that reads as "handle" rather than as content.
+const GRIP: &str = "⠿ ";
+/// Cells [`GRIP`] occupies, and so the width of the column reserved for it on
+/// every row - a grip that shifted its own row two columns right would be a
+/// worse cue than one that lines up with the blanks above it.
+const GRIP_W: u16 = 2;
 
 impl Dashboard {
     /// The editor screen.
@@ -211,11 +219,25 @@ impl Dashboard {
                 Style::default().fg(C_MUTED),
             )));
         }
-        let fields = editor.fields();
+        let fields = drag_order(editor.fields(), editor.model_drag);
         let label_w = 23usize;
-        let value_w = (inner.width as usize).saturating_sub(label_w + 3);
+        // Two columns wider than the label and its gutter: the grip sits in
+        // the gap, blank on rows nothing can be done with.
+        let value_w = (inner.width as usize).saturating_sub(label_w + GRIP_W as usize + 3);
         for (i, field) in fields.iter().enumerate() {
-            hits.rows.push(inner.y + lines.len() as u16);
+            let row_y = inner.y + lines.len() as u16;
+            hits.rows.push(row_y);
+            if let FieldId::ModelEntry(m) = field.id {
+                hits.grips.push((
+                    m,
+                    Rect {
+                        x: inner.x + 2,
+                        y: row_y,
+                        width: GRIP_W,
+                        height: 1,
+                    },
+                ));
+            }
             let on = focused && i == editor.cursor;
             let editing = editor.line.as_ref().filter(|(id, _)| *id == field.id);
             let label_style = if !field.enabled {
@@ -225,10 +247,14 @@ impl Dashboard {
             } else {
                 Style::default().fg(C_MUTED)
             };
-            let mut spans = vec![Span::styled(
-                if on { "› " } else { "  " },
-                Style::default().fg(C_ACCENT),
-            )];
+            let grabbable = matches!(field.id, FieldId::ModelEntry(_));
+            let mut spans = vec![
+                Span::styled(if on { "› " } else { "  " }, Style::default().fg(C_ACCENT)),
+                Span::styled(
+                    if grabbable { GRIP } else { "  " },
+                    Style::default().fg(if on { C_ACCENT } else { C_DIM }),
+                ),
+            ];
             // A button is its label: the whole row is the action, so it has
             // no value column.
             let is_button = matches!(field.value, FieldValue::Button);
@@ -268,6 +294,7 @@ impl Dashboard {
         let body_h = inner.height.saturating_sub(3);
         // Rows under the help area are not drawn, so they are not clickable.
         hits.rows.retain(|y| *y < inner.y + body_h);
+        hits.grips.retain(|(_, r)| r.y < inner.y + body_h);
         editor.hit = hits;
         frame.render_widget(
             Paragraph::new(lines).wrap(Wrap { trim: false }),
@@ -377,6 +404,7 @@ impl Dashboard {
                     hint("tab", "canvas"),
                     hint("^z", "undo"),
                     hint("click", "pick a row"),
+                    hint("drag ⠿", "reorder"),
                 ],
             }
         };
@@ -418,6 +446,40 @@ impl Dashboard {
             frame.render_widget(Paragraph::new(lines).scroll((scroll as u16, 0)), inner);
         }
     }
+}
+
+/// The fields as they should be drawn while a model is in the air: the chain's
+/// values permuted into the order a release would commit.
+///
+/// The *values* move and the rows stay, so the labels still read "Model" then
+/// "then" down the list - the first row is whatever the chain would start
+/// with, which is the question the labels are answering. It also keeps the
+/// row under the pointer the row that will hold the entry, so the drop is
+/// what it looked like rather than an inference from a caret.
+///
+/// A drag whose indices no longer fit the chain draws untouched rather than
+/// panicking: the fields are rebuilt from the document every frame, and the
+/// document can change under a held button (an undo, a reload).
+fn drag_order(mut fields: Vec<Field>, drag: Option<ModelDrag>) -> Vec<Field> {
+    let Some(drag) = drag else {
+        return fields;
+    };
+    let rows: Vec<usize> = fields
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| matches!(f.id, FieldId::ModelEntry(_)))
+        .map(|(i, _)| i)
+        .collect();
+    if drag.from >= rows.len() || drag.to >= rows.len() {
+        return fields;
+    }
+    let mut values: Vec<FieldValue> = rows.iter().map(|&i| fields[i].value.clone()).collect();
+    let held = values.remove(drag.from);
+    values.insert(drag.to, held);
+    for (row, value) in rows.into_iter().zip(values) {
+        fields[row].value = value;
+    }
+    fields
 }
 
 /// How a field's value reads on its row (a button reads as its label).

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -202,6 +202,10 @@ fn agent_editor_sections() -> Vec<HelpSection> {
                 ),
                 ("← → on a model", "move it earlier or later in the chain"),
                 (
+                    "drag ⠿",
+                    "pick a model up by its grip and drop it anywhere in the chain; the rest of the row still selects text",
+                ),
+                (
                     "esc",
                     "back: a region or a loop's path returns to where it was opened from, otherwise the canvas",
                 ),

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -319,8 +319,9 @@ hidden, so the panel never reflows under the cursor:
 - **A stage**, on three tabs (`1` `2` `3`). *Behaviour*: how it works, description, tries, revisits,
   whether it may finish the run, the fan-out settings when it fans out, its loop back to itself when it
   has one, the prompts, its place in the file, delete. *Model & tools*: the model chain (the first is
-  tried first; `Enter` swaps an entry, `x` drops it, `←` `→` move it, the last row adds a fallback)
-  and the tools it may use, picked from every tool this install has (`Space` toggles, `Enter` keeps).
+  tried first; `Enter` swaps an entry, `x` drops it, `←` `→` or a drag on its `⠿` grip move it, the
+  last row adds a fallback) and the tools it may use, picked from every tool this install has
+  (`Space` toggles, `Enter` keeps).
   *Context*: whether the stage sees the agent's shared regions or has a layout of its own, the regions
   it sees (`Enter` opens one), a button to give it its own layout or go back to the shared one, where
   tool results land by default, and per-tool routing (`Enter` on a row changes the region, `x` stops
@@ -383,7 +384,16 @@ On the inspector:
 | `x` / `Backspace` | Remove the row: a model from the chain, a tool's routing |
 | `1` `2` `3` | A stage's tabs: behaviour, model & tools, context |
 | `Esc` | Back: a region or a loop's path returns to where it was opened from; otherwise to the graph |
-| mouse | Click a row to pick it (again to open it); click a tab to switch to it |
+| mouse | Click a row to pick it (again to open it); click a tab to switch to it; drag a model's `⠿` grip to move it in the chain |
+
+A stage's model chain is a priority order, and the `⠿` grip at the start of each model row is how
+the mouse changes it: press the grip, drag it up or down the chain, and let go. The rows reorder as
+you drag, so where you drop it is what you saw, and nothing is written until the button comes up --
+one undo entry for the whole move, and a drop back where it started costs not even that.
+
+The grip is deliberately a small target rather than the whole row. Dragging anywhere else on a row
+still selects text the way it does everywhere else in the dashboard, so a model id stays something
+you can highlight and copy.
 
 In the prompts:
 


### PR DESCRIPTION
A stage's model chain is an ordered list, best first — the first model a configured provider serves is the one that runs. The only way to change that order was `←`/`→`, one place at a time.

Each model row now carries a `⠿` grip. Press it, drag up or down the chain, let go.

```
 1 Behaviour  2 Model & tools  3 Context

› ⠿ Model                  alfa-model
  ⠿ then                   bravo-model
  ⠿ then                   charlie-model
    ▸ Add a fallback model
    Tools it may use       (none)
```

## Why a grip and not the row

Dragging the row itself would mean the only way to copy a model id out of the inspector was to not touch the row it is on. The grip is a two-cell target; a press anywhere else on the row still starts the text selection it always did, and still picks the row. The gutter is reserved on *every* row (blank where nothing can be grabbed) so the grips line up with the blanks above them instead of shunting their own row two columns right.

## Nothing is written until the drop

Mid-drag the inspector **draws** the chain in the order a release would commit: the values are permuted, the labels are left alone, so the first row still reads "Model" and holds whatever the chain would start with. Three things follow from that:

- What is under the pointer is the answer, not a caret to infer it from.
- The whole gesture is **one undo entry**, not one per row crossed.
- A drop back where it started costs not even that — `editor_reorder_model` is a no-op when `from == to`.

A drag that began on a grip answers `Drag` and `Up` itself wherever the pointer wanders. That is what stops the fall-through from starting a text selection over the inspector half-way through the gesture, and it means letting go outside the list is a cancel rather than a random move.

## Lift-and-insert, not swap

`editor_move_model` is now one line on top of a new `editor_reorder_model`, so the keyboard and the mouse are the same operation. The two spellings agree for the single step `←`/`→` makes, but a drag crosses several rows at once and swapping the ends would fling the entry the pointer had just passed back to where the dragged one started.

## Verification

The three drag tests were run with the feature switched off first and failed there (`assertion failed: ...model_drag.is_some()`).

Beyond that, a real `lev dash` was driven over a pty with real SGR mouse reports — press the third grip, drag onto the first row — and the screen read back through a VT replay:

```
   the inspector mid-drag                 the inspector after the drop
   › ⠿ Model      charlie-model           › ⠿ Model      charlie-model
     ⠿ then       alfa-model                ⠿ then       alfa-model
     ⠿ then       bravo-model               ⠿ then       bravo-model

   agent.leviath still holds the old      Ctrl-S writes
   order at this point                    models = ["charlie-model", "alfa-model", "bravo-model"]
```

Full workspace suite green, `cargo xtask coverage --package leviath-cli` at 100%, docs/structure/clippy/fmt clean.

## Docs

`docs/content/dashboard.md` gains the grip in the inspector mouse row, a short section on how the drag behaves, and the `←`/`→`-or-drag wording on the Model & tools bullet. The in-app help overlay and the editor hint bar say it too. CHANGELOG under `## Unreleased`.
