### PR TITLE
refactor(dash): poll the daemon off the draw loop

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -99,6 +99,10 @@ impl Dashboard {
         let (mcp_cmd_tx, mcp_cmd_rx) = mpsc::unbounded_channel();
         let (mcp_outcome_tx, mcp_outcome_rx) = mpsc::unbounded_channel();
         let (daemon_outcome_tx, daemon_outcome_rx) = mpsc::unbounded_channel();
+        // The daemon-polling lane. Its whole point is that the draw loop never
+        // waits on the socket: it drains this, and a daemon taking its time
+        // costs a stale run list rather than a frozen terminal.
+        let (daemon_poll_tx, daemon_poll_rx) = mpsc::unbounded_channel();
         // The spawn lane, split the same way: resolving a blueprint and the
         // socket round trip both happen off the draw loop.
         let (spawn_cmd_tx, spawn_cmd_rx) = mpsc::unbounded_channel();
@@ -198,6 +202,8 @@ impl Dashboard {
             spawn_bg_ends: Some((spawn_cmd_rx, spawn_outcome_tx)),
             daemon_outcome_rx,
             daemon_outcome_tx: Some(daemon_outcome_tx),
+            daemon_poll_rx,
+            daemon_poll_tx: Some(daemon_poll_tx),
             daemon_run_ids: None,
             daemon_link: Default::default(),
             clock: system_now_secs,
@@ -233,6 +239,14 @@ impl Dashboard {
         &mut self,
     ) -> Option<mpsc::UnboundedSender<DaemonOutcome>> {
         self.daemon_outcome_tx.take()
+    }
+
+    /// Take the daemon-poll sender, so `init_dashboard` can hand it to
+    /// [`super::daemon_poll_loop`]. Returns `None` if already taken.
+    pub(super) fn take_daemon_poll_tx(
+        &mut self,
+    ) -> Option<mpsc::UnboundedSender<super::types::DaemonPoll>> {
+        self.daemon_poll_tx.take()
     }
     /// The MCP screen's context, for `init_dashboard` to hand to the loop.
     pub(super) fn mcp_context(&self) -> McpContext {

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -46,6 +46,63 @@ use tokio::sync::mpsc;
 use state::Dashboard;
 use types::DaemonCommand;
 
+/// How often the poller asks the daemon what it is holding.
+///
+/// Slower than the 100ms draw tick on purpose. Two socket round trips per
+/// frame was never a rate anything needed - a run's status changes on the
+/// order of seconds - and the old loop only ran at that rate because it was
+/// doing the asking inline.
+const DAEMON_POLL_INTERVAL: Duration = Duration::from_millis(300);
+
+/// Background task that asks the daemon what it is holding, and publishes each
+/// round for the draw loop to pick up.
+///
+/// This exists so the dashboard never waits on the socket. The two questions -
+/// the open interactions and the live run ids - used to be `await`ed inside the
+/// tick, between advancing the frame and drawing it, so a daemon that was busy,
+/// wedged, or part-way through a restart stopped the whole UI: no redraw, no
+/// keys, nothing, until it answered. A control request's deadline is thirty
+/// seconds and there were two per tick.
+///
+/// Every round is sent whether or not the daemon answered, because "it did not
+/// say" is itself information the run list needs: a `None` run set means the
+/// disk view is taken at face value rather than every run being marked stale.
+///
+/// The link bookkeeping this drives - reachable, restarted, build mismatch -
+/// needs nothing sent: `ControlClient` shares it across clones, so the
+/// dashboard's own handle sees what this task's requests learned.
+async fn daemon_poll_loop(
+    control: ControlClient,
+    polls: mpsc::UnboundedSender<types::DaemonPoll>,
+    interval: Duration,
+) {
+    loop {
+        // A closed receiver means the dashboard has exited; nothing to poll for.
+        if polls.send(poll_daemon(&control).await).is_err() {
+            return;
+        }
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// One round of the two questions, each answering `None` when the daemon did
+/// not. Separate from the loop so a test can take a single round against a
+/// socket instead of racing a timer.
+async fn poll_daemon(control: &ControlClient) -> types::DaemonPoll {
+    types::DaemonPoll {
+        interactions: match control.request(&ControlRequest::ListInteractions).await {
+            Ok(ControlResponse::Interactions { interactions }) => Some(interactions),
+            _ => None,
+        },
+        run_ids: match control.request(&ControlRequest::List).await {
+            Ok(ControlResponse::List { runs, .. }) => {
+                Some(runs.into_iter().map(|entry| entry.run_id).collect())
+            }
+            _ => None,
+        },
+    }
+}
+
 /// Background task that forwards the dashboard's control commands (cancel /
 /// answer-interaction / message) to the shared-world daemon over the control
 /// socket. The dashboard is a pure client: it never drives agents itself.
@@ -180,13 +237,12 @@ async fn run_dashboard_loop<B: ratatui::backend::Backend>(
         dashboard.tick_count += 1;
         dashboard.tick_toasts();
 
-        // Pull the daemon's open interactions (best-effort; ignore if the daemon
-        // is unreachable) so waiting agents show their prompt.
-        dashboard.sync_interactions(control).await;
-
-        // …and which runs it actually holds, so a run on disk that nothing is
-        // driving can be shown as stale rather than ACTIVE.
-        dashboard.sync_daemon_runs(control).await;
+        // Take whatever the poller has learned: the daemon's open interactions,
+        // so waiting agents show their prompt, and which runs it actually
+        // holds, so a run on disk that nothing is driving shows as stale rather
+        // than ACTIVE. Drained, never awaited - the socket must not be able to
+        // stop the UI (see `daemon_poll_loop`).
+        dashboard.drain_daemon_polls();
 
         // …and whether those polls reached a daemon at all, and which one.
         dashboard.sync_daemon_link(control);
@@ -281,6 +337,17 @@ fn init_dashboard(control: ControlClient, yank_fn: fn(&str) -> bool) -> Dashboar
         daemon_outcome_tx,
     ));
 
+    // Ask the daemon what it is holding, off the draw loop, for the same
+    // reason: the UI keeps its own time whatever the socket is doing.
+    let daemon_poll_tx = dashboard
+        .take_daemon_poll_tx()
+        .expect("a fresh dashboard has its daemon poll sender");
+    tokio::spawn(daemon_poll_loop(
+        control.clone(),
+        daemon_poll_tx,
+        DAEMON_POLL_INTERVAL,
+    ));
+
     // Run MCP logins/tests off the UI loop. A freshly-built dashboard always
     // has its background channel ends.
     let (mcp_cmd_rx, mcp_outcome_tx) = dashboard
@@ -356,6 +423,36 @@ mod tests {
     #[test]
     fn dashboard_args_can_be_constructed() {
         let _args = DashboardArgs {};
+    }
+
+    /// The poller publishes a round whether or not the daemon answered, and
+    /// stops once nobody is listening.
+    ///
+    /// A round that answered nothing is not a round to skip: `None` run ids
+    /// mean "the daemon did not say", which is what stops the run list
+    /// condemning every run on disk as stale.
+    #[tokio::test]
+    async fn the_poll_loop_publishes_rounds_until_the_dashboard_goes() {
+        use leviath_runtime::control_socket::control_id;
+        let dir = tempfile::tempdir().unwrap();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let control = ControlClient::new(control_id(&dir.path().join("no-daemon")));
+        let task = tokio::spawn(daemon_poll_loop(
+            control,
+            tx,
+            std::time::Duration::from_millis(1),
+        ));
+
+        let round = rx.recv().await.expect("a round is published");
+        assert_eq!(
+            round,
+            types::DaemonPoll::default(),
+            "nothing answered, and the round says so rather than not arriving"
+        );
+
+        // Dropping the receiver is how the dashboard says it has exited.
+        drop(rx);
+        task.await.expect("the loop returns rather than hanging");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -1,6 +1,6 @@
 //! Dashboard state struct and core state-management methods.
 
-use leviath_runtime::control_socket::{ControlClient, ControlRequest, ControlResponse};
+use leviath_runtime::control_socket::ControlClient;
 use ratatui::widgets::TableState;
 use std::collections::HashMap;
 use tokio::sync::mpsc;
@@ -263,6 +263,12 @@ pub(crate) struct Dashboard {
     /// The background loop's sender for [`DaemonOutcome`]s; taken by
     /// `init_dashboard`, retained by tests to inject outcomes.
     pub(super) daemon_outcome_tx: Option<mpsc::UnboundedSender<DaemonOutcome>>,
+    /// Receives each round of daemon polling, drained (never awaited) once a
+    /// tick. See [`Self::drain_daemon_polls`].
+    pub(super) daemon_poll_rx: mpsc::UnboundedReceiver<DaemonPoll>,
+    /// The poll loop's sender; taken by `init_dashboard`, retained by tests to
+    /// inject a round without a daemon.
+    pub(super) daemon_poll_tx: Option<mpsc::UnboundedSender<DaemonPoll>>,
     /// The run ids the daemon currently holds, refreshed each tick. `None` when
     /// the daemon did not answer - the disk view is then taken at face value
     /// rather than declaring every run stale.
@@ -866,31 +872,37 @@ impl Dashboard {
         self.initial_sync_done = true;
     }
 
-    /// Refresh the daemon's open interactions (keyed by agent/run id) so waiting
-    /// agents can show their prompt. Best-effort: on any transport error or an
-    /// unexpected reply the map is left untouched.
-    pub(super) async fn sync_interactions(&mut self, control: &ControlClient) {
-        if let Ok(ControlResponse::Interactions { interactions }) =
-            control.request(&ControlRequest::ListInteractions).await
-        {
+    /// Take whatever the daemon poller has learned since the last tick.
+    ///
+    /// Only the newest round is applied: each carries the whole answer, so an
+    /// older one describes a daemon state that has already been superseded.
+    ///
+    /// The polling itself happens on [`daemon_poll_loop`], not here. It used to
+    /// be two `await`ed control round trips wedged between the tick and the
+    /// draw, which meant a busy or restarting daemon stopped the dashboard
+    /// dead - no redraw, no keys - for as long as it took to answer. Draining
+    /// a channel cannot block, so the UI now keeps its own time whatever the
+    /// daemon is doing.
+    ///
+    /// [`daemon_poll_loop`]: super::daemon_poll_loop
+    pub(super) fn drain_daemon_polls(&mut self) {
+        let mut newest = None;
+        while let Ok(poll) = self.daemon_poll_rx.try_recv() {
+            newest = Some(poll);
+        }
+        let Some(poll) = newest else {
+            return;
+        };
+        // A request that did not come back leaves its state alone: the
+        // best-effort reading both polls always had.
+        if let Some(interactions) = poll.interactions {
             self.pending_interactions = interactions.into_iter().collect();
         }
-    }
-
-    /// Refresh which runs the daemon actually holds.
-    ///
-    /// The dashboard lists runs from disk and the daemon lists them from memory,
-    /// and nothing reconciled the two - so a run whose daemon had died sat at
-    /// ACTIVE with a ticking timer forever. On any transport error this is set
-    /// back to `None`, meaning "unknown", so an unreachable daemon does not make
-    /// every run look dead.
-    pub(super) async fn sync_daemon_runs(&mut self, control: &ControlClient) {
-        self.daemon_run_ids = match control.request(&ControlRequest::List).await {
-            Ok(ControlResponse::List { runs, .. }) => {
-                Some(runs.into_iter().map(|entry| entry.run_id).collect())
-            }
-            _ => None,
-        };
+        // Except this one, where `None` is itself the answer - "the daemon did
+        // not say" is not "the daemon holds nothing", and the difference is
+        // whether every run on disk gets condemned as stale. The poller sends
+        // the `None` deliberately, so it is applied as given.
+        self.daemon_run_ids = poll.run_ids;
     }
 
     /// Notice what this tick's polls learned about the daemon itself, and say
@@ -1138,6 +1150,9 @@ mod tests {
     use super::*;
 
     use crate::commands::dashboard::test_support::make_test_dashboard;
+    // Only the tests speak the control protocol now: the polling itself moved
+    // off the draw loop and onto `daemon_poll_loop`.
+    use leviath_runtime::control_socket::{ControlRequest, ControlResponse};
 
     /// Root agent indices (no parent), in agent order - the input the production
     /// path feeds to `build_tree_order` (there it's the status-sorted roots).
@@ -2771,49 +2786,116 @@ mod tests {
         });
     }
 
-    /// A reachable daemon's run list is recorded; an unreachable one leaves
+    /// A reachable daemon's answers are recorded; an unreachable one leaves
     /// "unknown" rather than an empty set, which would read as "nothing is
     /// running" and flip every healthy run to STALE.
+    ///
+    /// Drives the real polling path: one round against a socket, handed to the
+    /// dashboard the way the background loop hands it over.
     #[tokio::test]
-    async fn sync_daemon_runs_records_the_list_or_unknown() {
+    async fn a_poll_round_records_the_daemons_answers_or_says_it_did_not_answer() {
         use leviath_runtime::control_socket::{bind_control_listener, control_id};
         use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
         let dir = tempfile::tempdir().unwrap();
         let id = control_id(dir.path());
         let mut listener = bind_control_listener(&id).unwrap();
+        // Serialized from the real type: a hand-written interaction body is a
+        // test of my JSON, and the wire shape is the thing under test.
+        let interactions = serde_json::to_string(&ControlResponse::Interactions {
+            interactions: vec![(
+                "run-1".to_string(),
+                interaction::InteractionRequest::free_text("q1", "?", "main", true),
+            )],
+        })
+        .unwrap()
+            + "\n";
+        // Two connections: a round asks two questions, each on its own.
         let server = tokio::spawn(async move {
-            let stream = listener
-                .accept()
-                .await
-                .expect("accept succeeds")
-                .expect("our own connection is admitted");
-            let (read_half, mut write_half) = tokio::io::split(stream);
-            let mut lines = BufReader::new(read_half).lines();
-            let _ = lines.next_line().await;
-            let _ = write_half
-                .write_all(
-                    b"{\"result\":\"list\",\"runs\":[{\"run_id\":\"run-a\",\"status\":\"Active\",\
-                      \"stage\":\"plan\",\"iteration\":1,\"tool_calls\":0}]}\n",
-                )
-                .await;
+            for reply in [
+                interactions.into_bytes(),
+                b"{\"result\":\"list\",\"runs\":[{\"run_id\":\"run-a\",\"status\":\"Active\",\
+                   \"stage\":\"plan\",\"iteration\":1,\"tool_calls\":0}]}\n"
+                    .to_vec(),
+            ] {
+                let stream = listener
+                    .accept()
+                    .await
+                    .expect("accept succeeds")
+                    .expect("our own connection is admitted");
+                let (read_half, mut write_half) = tokio::io::split(stream);
+                let mut lines = BufReader::new(read_half).lines();
+                let _ = lines.next_line().await;
+                let _ = write_half.write_all(&reply).await;
+            }
         });
 
         let mut dash = make_test_dashboard();
-        dash.sync_daemon_runs(&ControlClient::new(id)).await;
+        let polls = dash
+            .take_daemon_poll_tx()
+            .expect("a fresh dashboard has its poll sender");
+        polls
+            .send(super::super::poll_daemon(&ControlClient::new(id)).await)
+            .unwrap();
+        let _ = server.await;
+        dash.drain_daemon_polls();
         assert_eq!(
             dash.daemon_run_ids,
             Some(["run-a".to_string()].into_iter().collect())
         );
-        let _ = server.await;
+        assert_eq!(
+            dash.pending_interactions.get("run-1").map(|r| r.id.clone()),
+            Some("q1".to_string())
+        );
 
-        // No daemon at all → unknown, not "none running".
+        // No daemon at all → unknown, not "none running", and the interactions
+        // already on screen are left where they are rather than blanked.
         let gone = tempfile::tempdir().unwrap();
-        dash.sync_daemon_runs(&ControlClient::new(control_id(
-            &gone.path().join("no-daemon"),
-        )))
-        .await;
+        polls
+            .send(
+                super::super::poll_daemon(&ControlClient::new(control_id(
+                    &gone.path().join("no-daemon"),
+                )))
+                .await,
+            )
+            .unwrap();
+        dash.drain_daemon_polls();
         assert_eq!(dash.daemon_run_ids, None);
+        assert!(
+            dash.pending_interactions.contains_key("run-1"),
+            "a round that did not answer must not blank the prompts on screen"
+        );
+    }
+
+    /// Only the newest round is applied. Each carries the whole answer, so an
+    /// older one describes a daemon state that has already been superseded -
+    /// and applying it would flicker the run list back a step.
+    #[test]
+    fn draining_the_polls_applies_only_the_newest_round() {
+        let mut dash = make_test_dashboard();
+        let polls = dash
+            .take_daemon_poll_tx()
+            .expect("a fresh dashboard has its poll sender");
+        for id in ["old-run", "new-run"] {
+            polls
+                .send(crate::commands::dashboard::types::DaemonPoll {
+                    interactions: None,
+                    run_ids: Some([id.to_string()].into_iter().collect()),
+                })
+                .unwrap();
+        }
+        dash.drain_daemon_polls();
+        assert_eq!(
+            dash.daemon_run_ids,
+            Some(["new-run".to_string()].into_iter().collect())
+        );
+
+        // Nothing queued: the last round stands rather than being cleared.
+        dash.drain_daemon_polls();
+        assert_eq!(
+            dash.daemon_run_ids,
+            Some(["new-run".to_string()].into_iter().collect())
+        );
     }
 
     /// The messages the log pane holds, newest last.
@@ -2841,9 +2923,9 @@ mod tests {
                 assert!(dash.daemon_link.chip().is_none(), "healthy at first");
 
                 // Two failed polls: one announcement.
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
                 assert_eq!(
                     log_messages(&dash),
@@ -2864,9 +2946,9 @@ mod tests {
                             health: Default::default(),
                         }
                     });
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
                 server.await.unwrap();
                 let messages = log_messages(&dash);
@@ -2910,14 +2992,14 @@ mod tests {
                 // The first daemon, met and lost.
                 let (_c, _e, server) =
                     identified_daemon_in(dir.path(), same_code_daemon(1), 1, empty);
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
                 server.await.unwrap();
                 assert!(
                     log_messages(&dash).is_empty(),
                     "meeting the daemon is not news"
                 );
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
                 assert_eq!(log_messages(&dash).len(), 1, "gone");
 
@@ -2925,7 +3007,7 @@ mod tests {
                 let mut newer = same_code_daemon(2);
                 newer.build = "newer-build".to_string();
                 let (_c, _e, server) = identified_daemon_in(dir.path(), newer, 2, empty);
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
                 let messages = log_messages(&dash);
                 assert_eq!(messages.len(), 3, "{messages:?}");
@@ -2942,7 +3024,7 @@ mod tests {
                 assert_eq!(dash.toasts.len(), 3);
 
                 // Said once: another successful poll adds nothing.
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
                 server.await.unwrap();
                 assert_eq!(log_messages(&dash).len(), 3);
@@ -2952,7 +3034,7 @@ mod tests {
                 // the chip comes down without a word.
                 let (_c, _e, server) =
                     identified_daemon_in(dir.path(), same_code_daemon(3), 1, empty);
-                dash.sync_daemon_runs(&poll).await;
+                let _ = poll.request(&ControlRequest::List).await;
                 dash.sync_daemon_link(&poll);
                 server.await.unwrap();
                 assert!(dash.daemon_link.chip().is_none(), "the chip is down");
@@ -3874,51 +3956,6 @@ mod tests {
                 cleanup_run(run_id);
             },
         );
-    }
-
-    #[tokio::test]
-    async fn sync_interactions_populates_map_from_daemon() {
-        use leviath_runtime::control_socket::{
-            ControlClient, ControlResponse, bind_control_listener, control_id,
-        };
-        use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-        let dir = tempfile::tempdir().unwrap();
-        let id = control_id(dir.path());
-        let mut listener = bind_control_listener(&id).unwrap();
-        let server = tokio::spawn(async move {
-            let stream = listener
-                .accept()
-                .await
-                .expect("accept succeeds")
-                .expect("our own connection is admitted");
-            let (r, mut w) = tokio::io::split(stream);
-            let mut lines = BufReader::new(r).lines();
-            let _ = lines.next_line().await.unwrap();
-            let req = interaction::InteractionRequest::free_text("q1", "?", "main", true);
-            let resp = ControlResponse::Interactions {
-                interactions: vec![("run-1".to_string(), req)],
-            };
-            let mut line = serde_json::to_string(&resp).unwrap();
-            line.push('\n');
-            w.write_all(line.as_bytes()).await.unwrap();
-        });
-        let mut dash = make_test_dashboard();
-        dash.sync_interactions(&ControlClient::new(id)).await;
-        server.await.unwrap();
-        assert_eq!(
-            dash.pending_interactions.get("run-1").map(|r| r.id.clone()),
-            Some("q1".to_string())
-        );
-    }
-
-    #[tokio::test]
-    async fn sync_interactions_no_daemon_leaves_map_untouched() {
-        use leviath_runtime::control_socket::{ControlClient, control_id};
-        let dir = tempfile::tempdir().unwrap();
-        let mut dash = make_test_dashboard();
-        dash.sync_interactions(&ControlClient::new(control_id(&dir.path().join("nope"))))
-            .await;
-        assert!(dash.pending_interactions.is_empty());
     }
 
     // ── Marks for group kill / delete ─────────────────────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -445,6 +445,29 @@ pub(super) struct DaemonOutcome {
     pub(super) ok: bool,
 }
 
+/// What one round of daemon polling learned: the open interactions, and which
+/// runs the daemon is actually holding.
+///
+/// Carried on a channel rather than fetched by the draw loop. Both answers
+/// come from control-socket round trips, and the loop used to `await` them
+/// between the tick and the draw - so a daemon that was busy, wedged, or
+/// restarting stopped the dashboard dead. The deadline on a control request is
+/// 30 seconds and there are two of them per tick, which is a very long time to
+/// look like a frozen terminal that ignores keys.
+///
+/// Each field is `None` when that request did not come back, which the
+/// dashboard reads as "no answer this round" and leaves the corresponding
+/// state alone - the same best-effort reading the two polls always had.
+#[derive(Debug, Default, PartialEq)]
+pub(super) struct DaemonPoll {
+    /// The daemon's open interactions, keyed by run id.
+    pub(super) interactions: Option<Vec<(String, interaction::InteractionRequest)>>,
+    /// The runs the daemon reports holding, or `None` for "it did not say" -
+    /// which is not the same as "it holds none", and must not condemn every
+    /// run on disk as stale.
+    pub(super) run_ids: Option<std::collections::HashSet<String>>,
+}
+
 /// The dashboard's view of its link to the daemon, refreshed each tick from
 /// the control client's own bookkeeping.
 ///


### PR DESCRIPTION
> **This is not a fix for the reported UI freeze.** That was the hypothesis, and it did not survive measurement — see below. It is offered as the structural improvement it is.

The dashboard's tick asked the daemon two questions — its open interactions, and which runs it is holding — and `await`ed both between advancing the frame and drawing it. Both now live on a background task that publishes rounds on a channel, which the draw loop drains.

Two things follow:

- **The socket can no longer stall the UI**, whatever the daemon is doing. Worth having by construction rather than by the request deadline happening to be short.
- **The asking drops from twice per 100ms frame to once per 300ms.** A run's status changes on the order of seconds; the old rate was an artifact of doing the asking inline, not something anything needed. That is 20 control round trips per second down to about 3.

A round is published whether or not the daemon answered, because "it did not say" is itself what the run list needs — `None` run ids leave the disk view at face value instead of condemning every run as stale. Only the newest queued round is applied: each carries the whole answer, so an older one describes a state already superseded.

The link bookkeeping (reachable / restarted / build mismatch) stays in the draw loop and needs nothing sent — `ControlClient` shares its `Link` across clones, so the dashboard's handle sees what the poller's requests learned.

## Why this is not the freeze fix

The theory was that a busy or wedged daemon parked the loop for up to the 30-second control deadline, twice a tick. Measured against a real daemon held with `SIGSTOP`:

```
ps, healthy daemon:  0.03s
wedged the daemon
ps, wedged daemon:   0.04s      ← not 30s
```

And driving a real `lev dash` over a pty with its daemon wedged, the run list kept drawing and `s` still cycled the sort — on the build with this change and on the build without it. The reported freeze is still undiagnosed.

## Tests

`sync_interactions` and `sync_daemon_runs` are gone; what replaces them is tested at both ends:

- `a_poll_round_records_the_daemons_answers_or_says_it_did_not_answer` drives a real round against a socket serving both questions, hands it over the channel the way the loop does, and checks that a round which answered nothing leaves the prompts on screen alone while still setting run ids to "unknown".
- `draining_the_polls_applies_only_the_newest_round` covers the coalescing, and that an empty channel leaves the last round standing.
- `the_poll_loop_publishes_rounds_until_the_dashboard_goes` covers the loop: a round is published even when nothing answered, and dropping the receiver ends it.

Full workspace suite green, `cargo xtask coverage --package leviath-cli` at 100%, clippy/fmt/structure clean.
