### PR TITLE
chore(release): 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## 0.5.4 - 2026-08-27
+
+- Fixed: a tool call streamed from the native Anthropic provider arrived as two
+  calls, and the second one had no id, so the turn after it was rejected before
+  the model saw it: `messages.N.content.M.tool_use.id: String should match
+  pattern '^[a-zA-Z0-9_-]+$'`. `content_block_start` numbered the call and then
+  advanced the counter, so every `input_json_delta` after it - that call's own
+  arguments - was filed one index further on, and the collector, which keys by
+  index, built one call carrying an id and no arguments and a second carrying
+  arguments and an empty id. Any streamed run that called a tool on that
+  provider died on its next turn, which is every run of a bundled agent whose
+  stage names a Claude model on a machine holding an Anthropic key. The same
+  models served through OpenRouter were never affected: that is an
+  OpenAI-shaped stream and a different parser, which is why this reached a
+  release.
+
 ## 0.5.3 - 2026-08-27
 
 - Fixed: `lev dash` no longer reads every run's context window on every tick.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2427,7 +2427,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leviath"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "leviath-agent-client",
  "leviath-core",
@@ -2443,7 +2443,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-agent-client"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "leviath-core",
  "serde",
@@ -2452,7 +2452,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-alloc"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "libmimalloc-sys",
  "temp-env",
@@ -2460,7 +2460,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2523,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "chrono",
  "dirs",
@@ -2543,7 +2543,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-mcp"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2570,7 +2570,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-net"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "reqwest",
  "tokio",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-package"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-providers"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2625,7 +2625,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-runtime"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-trait",
  "bevy_ecs",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-scripting"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "base64 0.23.1",
  "leviath-core",
@@ -2665,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-sys"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "fs4",
  "keyring",
@@ -2681,7 +2681,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-telemetry"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "leviath-core",
  "leviath-testkit",
@@ -2697,7 +2697,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-testkit"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "tokio",
  "tracing",
@@ -2705,7 +2705,7 @@ dependencies = [
 
 [[package]]
 name = "leviath-tools"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2024"
 license = "MIT"
 authors = ["Gerald McAlister <gemisis@users.noreply.github.com>"]
@@ -96,18 +96,18 @@ allow_attributes_without_reason = "deny"
 # `leviath-testkit` stays path-only ON PURPOSE: cargo strips path-only
 # dev-dependencies when publishing, which is what keeps the testkit private
 # to the repo while every crate that dev-depends on it still publishes.
-leviath = { path = "crates/leviath", version = "0.5.3" }
-leviath-core = { path = "crates/leviath-core", version = "0.5.3" }
-leviath-net = { path = "crates/leviath-net", version = "0.5.3" }
-leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.3" }
-leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.3" }
-leviath-providers = { path = "crates/leviath-providers", version = "0.5.3" }
-leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.3" }
-leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.3" }
-leviath-package = { path = "crates/leviath-package", version = "0.5.3" }
-leviath-tools = { path = "crates/leviath-tools", version = "0.5.3" }
-leviath-sys = { path = "crates/leviath-sys", version = "0.5.3" }
-leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.3" }
+leviath = { path = "crates/leviath", version = "0.5.4" }
+leviath-core = { path = "crates/leviath-core", version = "0.5.4" }
+leviath-net = { path = "crates/leviath-net", version = "0.5.4" }
+leviath-agent-client = { path = "crates/leviath-agent-client", version = "0.5.4" }
+leviath-runtime = { path = "crates/leviath-runtime", version = "0.5.4" }
+leviath-providers = { path = "crates/leviath-providers", version = "0.5.4" }
+leviath-mcp = { path = "crates/leviath-mcp", version = "0.5.4" }
+leviath-scripting = { path = "crates/leviath-scripting", version = "0.5.4" }
+leviath-package = { path = "crates/leviath-package", version = "0.5.4" }
+leviath-tools = { path = "crates/leviath-tools", version = "0.5.4" }
+leviath-sys = { path = "crates/leviath-sys", version = "0.5.4" }
+leviath-telemetry = { path = "crates/leviath-telemetry", version = "0.5.4" }
 leviath-testkit = { path = "crates/leviath-testkit" }
 
 # External dependencies

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -37,7 +37,7 @@ mimalloc-allocator = ["dep:mimalloc", "dep:leviath-alloc", "leviath-alloc/mimall
 # table on purpose: only the composition-root binary should pick an allocator,
 # never a library crate.
 mimalloc = { version = "0.1", optional = true }
-leviath-alloc = { path = "../leviath-alloc", version = "0.5.3", optional = true }
+leviath-alloc = { path = "../leviath-alloc", version = "0.5.4", optional = true }
 leviath-core = { workspace = true }
 # The outbound-request policy (SSRF checks + the shared client).
 leviath-net = { workspace = true }

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Leviath HTTP API",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "description": "The REST and WebSocket surface `lev serve` puts in front of the shared-world daemon. Every route requires a bearer token. Paths here are checked against the router in crates/leviath-cli/src/commands/serve/mod.rs by a test in that file, so a route added without a spec entry fails the build. See https://leviath.dev/docs/api.",
     "license": {
       "name": "MIT"


### PR DESCRIPTION
Emergency cut over #636 alone.

0.5.3 shipped a streaming tool-call regression: a tool call streamed from the native Anthropic provider arrived as two calls, the second with an empty id, and Anthropic rejected the following turn on the pattern its ids have to match:

```
HTTP 400 messages.N.content.M.tool_use.id:
String should match pattern '^[a-zA-Z0-9_-]+$'
```

Every streamed run that called a tool on that provider died on its second or third turn, which on a stock install is every run of a bundled agent whose stage names a Claude model. The same models through OpenRouter were unaffected, so the blast radius is anyone holding an Anthropic key.

0.5.3 is the only release carrying it: streaming landed in that version.

Verified on the bundled researcher against the real API before and after the fix - see #636 for both runs.
