### PR TITLE
fix(runtime): leave the window room for a prompt that costs more than estimated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ requests since the previous version. A channel publishes only when the version
 below it has moved, so the headings here and the releases on GitHub are the
 same list.
 
+## Unreleased
+
+- Fixed: a stage whose model can answer at nearly the width of its own context
+  window could be rejected outright for asking. The reply budget was everything
+  the window had left after the prompt, and "what the prompt costs" there is
+  `estimate_tokens`, bytes over four, while the provider counts with its own
+  tokenizer and counts the tool schemas besides. Measured on a wide-researcher
+  run against grok-4.6 (500k window, 450k output cap): the window put the prompt
+  at 106,172 tokens and asked for the other 393,828 back, the provider counted
+  the same prompt at 108,277, and the call died on `maximum context length is
+  500000 tokens. However, you requested about 502105 tokens`. The budget now
+  keeps a sixteenth of the prompt back as headroom, which costs nothing anywhere
+  the model's own cap is the smaller number and is the difference between a
+  shorter answer and a dead stage where it is not.
+
 ## 0.5.4 - 2026-08-27
 
 - Fixed: a tool call streamed from the native Anthropic provider arrived as two

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -110,6 +110,26 @@ pub(crate) fn hint_blocks(
 /// and the warning beside it says so.
 const MIN_OUTPUT_TOKENS: usize = 1;
 
+/// The share of the prompt held back from the answer when the window, and not
+/// the model's own cap, is what limits the reply. One sixteenth.
+///
+/// The window is shared between the prompt and the answer, and only one of the
+/// two is a measurement: the prompt is [`leviath_core::estimate_tokens`], bytes
+/// over four, while the provider counts with its own tokenizer and counts the
+/// tool schemas and its own message framing besides.
+/// [`PromptCalibration`](crate::pipeline::PromptCalibration) corrects that from
+/// what earlier calls were charged, but it can only correct by what it has
+/// already seen, and a stage's first call carries schemas nothing has measured
+/// yet. Asking for every token the estimate says is left means any remaining
+/// light spot is not a shorter answer but a rejected request.
+///
+/// This is not the guessed margin the calibration module argues against. That
+/// one would hold context back from every workload; this one only ever shortens
+/// a reply, only when the window is the binding constraint - where the model's
+/// cap is the smaller number the `min` below already leaves the difference as
+/// slack - and it is proportional because the error it covers is.
+const PROMPT_ESTIMATE_HEADROOM: usize = 16;
+
 /// What earlier calls in this run taught us, carried into the next request.
 ///
 /// Three pieces of evidence with one thing in common: none of them can be
@@ -184,7 +204,10 @@ pub(crate) fn build_request(
         true => output_cap.max(caps.max_output_tokens),
         false => output_cap,
     };
-    let max_tokens = remaining.min(output_cap).max(MIN_OUTPUT_TOKENS);
+    // What is left of the window for the answer, less the headroom the estimate
+    // behind `remaining` needs. See [`PROMPT_ESTIMATE_HEADROOM`].
+    let room_for_answer = remaining.saturating_sub(spent / PROMPT_ESTIMATE_HEADROOM);
+    let max_tokens = room_for_answer.min(output_cap).max(MIN_OUTPUT_TOKENS);
     if remaining < MIN_OUTPUT_TOKENS {
         // The prompt has filled the window and left nothing to answer with.
         // Said out loud because the request still goes out, and a reply capped

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -87,6 +87,89 @@ fn provider(supports_temperature: bool, max_output: usize) -> Arc<dyn Provider> 
 
 // ── build_request branch coverage ──
 
+/// The answer is asked for with room to spare, not for every token the window
+/// estimate says is left.
+///
+/// Regression: `max_tokens` was `window - estimated_prompt`, which is only
+/// right if the estimate is never light. It is bytes-over-four, and the
+/// provider counts with its own tokenizer, so a prompt costing more than
+/// estimated put `real_prompt + max_tokens` over the window and the provider
+/// rejected the request outright. Measured on a wide-researcher run against
+/// grok-4.6 (500k window, 450k output cap): the window believed the prompt was
+/// 106,172 tokens and asked for the other 393,828 back, the provider counted
+/// the same prompt at 108,277, and the call died with "maximum context length
+/// is 500000 tokens. However, you requested about 502105 tokens".
+///
+/// Only models whose output cap approaches their context window can reach it:
+/// anywhere the cap is the smaller number, the `min` below already leaves the
+/// difference as slack.
+#[test]
+fn build_request_leaves_the_window_room_for_an_underestimated_prompt() {
+    const WINDOW: usize = 500_000;
+    const ESTIMATE: usize = 106_172;
+    // What the provider's own tokenizer made of the same prompt.
+    const REAL: usize = 108_277;
+
+    let mut w = ContextWindow::new(WINDOW);
+    w.add_region(Region::new("sys".to_string(), RegionKind::Pinned, WINDOW));
+    w.add_to_region("sys", "the prompt".to_string(), ESTIMATE)
+        .unwrap();
+
+    let si = stage("grok-4.6", vec![], None);
+    let req = build_request(
+        &w,
+        None,
+        &si,
+        // A model that will answer with almost its whole window, which is what
+        // stops the output cap from providing the slack by itself.
+        &provider(true, 450_000),
+        "challenge",
+        0,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+
+    assert!(
+        REAL + req.max_tokens <= WINDOW,
+        "asked for {} output tokens on top of a {REAL}-token prompt, which is \
+         {} over the {WINDOW}-token window",
+        req.max_tokens,
+        (REAL + req.max_tokens).saturating_sub(WINDOW),
+    );
+    // The room given up is headroom, not the whole answer: a stage that has
+    // most of its window free still gets most of it back.
+    assert!(
+        req.max_tokens > (WINDOW - ESTIMATE) * 3 / 4,
+        "gave up too much of the window: {}",
+        req.max_tokens
+    );
+}
+
+/// The headroom comes off the window, not off a cap the model already fits
+/// inside. A stage whose model answers in 4k on a 500k window still gets its
+/// full 4k.
+#[test]
+fn build_request_does_not_shave_an_output_cap_the_window_already_fits() {
+    let mut w = ContextWindow::new(500_000);
+    w.add_region(Region::new("sys".to_string(), RegionKind::Pinned, 500_000));
+    w.add_to_region("sys", "the prompt".to_string(), 100_000)
+        .unwrap();
+
+    let si = stage("m", vec![], None);
+    let req = build_request(
+        &w,
+        None,
+        &si,
+        &provider(true, 4_096),
+        "test-stage",
+        0,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+
+    assert_eq!(req.max_tokens, 4_096);
+}
+
 #[test]
 fn build_request_threads_stage_meta_into_custom_region_render() {
     // The custom region's script echoes the stage metadata build_request
@@ -1870,7 +1953,9 @@ fn the_completion_budget_never_falls_below_the_provider_minimum() {
 }
 
 /// And the clamp must not overshoot: a provider rejects `prompt + completion`
-/// past the window just as readily, so the budget stays inside what is left.
+/// past the window just as readily, so the budget stays inside what is left -
+/// and inside the headroom held back from it, because what is "left" is an
+/// estimate of the prompt rather than a measurement of it.
 #[test]
 fn the_completion_budget_stays_inside_what_the_window_has_left() {
     let mut w = window();
@@ -1888,7 +1973,32 @@ fn the_completion_budget_stays_inside_what_the_window_has_left() {
     )
     .0;
 
-    assert_eq!(req.max_tokens, 10, "10 left means 10 asked for");
+    assert!(
+        req.max_tokens <= 10,
+        "10 left is the most that can be asked for, got {}",
+        req.max_tokens
+    );
+
+    // Half the window free, and the ask is the rest of it less the headroom -
+    // near enough all of it that a stage with room to answer still has it.
+    let mut roomy = window();
+    roomy.current_tokens = roomy.max_tokens / 2;
+    let req = build_request(
+        &roomy,
+        None,
+        &si,
+        &provider(true, 100_000),
+        "implement",
+        1,
+        crate::pipeline::inference::PriorCalls::default(),
+    )
+    .0;
+    let left = roomy.max_tokens - roomy.current_tokens;
+    assert!(
+        req.max_tokens < left && req.max_tokens > left * 3 / 4,
+        "expected most of the {left} left, got {}",
+        req.max_tokens
+    );
 }
 
 // ─── estimator calibration (issue #485) ───


### PR DESCRIPTION
Found while looking at run `wide-researcher-1787845097-1032a730f2eb`, which dropped into `error_recovery` from `challenge` with this:

```
maximum context length is 500000 tokens. However, you requested about
502105 tokens (107585 of text input, 692 of tool input, 393828 in the output)
```

The interesting number is the last one. It was not the model that ran long, it was us asking for a 393,828-token reply.

## What was wrong

The reply budget is everything the window has left after the prompt:

```rust
let remaining = window.max_tokens.saturating_sub(spent);
let max_tokens = remaining.min(output_cap);
```

`spent` is `estimate_tokens` - bytes over four - corrected by what earlier calls in the run were charged. The provider counts with its own tokenizer, and counts the tool schemas and its own framing besides, so the two agree only by luck. Asking for every token the estimate says is left turns any light spot into a rejected request rather than a shorter answer.

On this run, grok-4.6 with a 500k window and a 450k output cap:

| | tokens |
|---|---|
| window believed the prompt was | 106,172 |
| so it asked for the rest | 393,828 |
| provider counted the same prompt at | 108,277 |
| total | **502,105** against a 500,000 window |

2,105 tokens, and the stage was dead. A 400 does not read as transient, so the retry resent the same doomed request and the run fell through to `error_recovery`.

## The fix

The budget keeps a sixteenth of the prompt back as headroom. Proportional on purpose, because the error it covers is: drift in bytes-over-four grows with the content.

This is not the guessed margin `calibration.rs` argues against. That one would hold context back from every workload; this only ever shortens a reply, and only where the window is the binding constraint. Anywhere the model's own cap is the smaller number the `min` already leaves the difference as slack and nothing changes.

## Why it took this long to show up

Only a model whose output cap approaches its context window can reach it. The same run on a stage capped at 64k of output had 400k of slack it never used. grok-4.6 reports `context_length: 500000, max_completion_tokens: 450000`, so the cap stops covering for the estimate.

## Tests

Three, all failing on `main`:

- the measured case: 500k window, 450k cap, prompt estimated at 106,172 and really 108,277 - `main` asks for 393,828 and goes 2,105 over
- a model capped at 4,096 on a 500k window still gets its full 4,096
- the existing `the_completion_budget_stays_inside_what_the_window_has_left` now says what it means: never more than what is left, and most of it when there is room
