### PR TITLE
feat(serve): a route that carries out the update, not only describes it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,9 +882,9 @@ checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -855,6 +855,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon(),
@@ -882,6 +883,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![agents.path().to_path_buf()],
                 ..Default::default()
@@ -1143,6 +1145,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: paths,
                 ..Default::default()
@@ -2968,6 +2971,7 @@ system_prompt = "Plan the work"
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,
@@ -3025,6 +3029,7 @@ system_prompt = "Plan the work"
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -593,6 +593,7 @@ system_prompt = "do it"
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![dir.path().to_path_buf()],
                 ..Default::default()
@@ -826,6 +827,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![path],
                 ..Default::default()

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -366,6 +366,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 ollama_base_url: Some("http://127.0.0.1:1".to_string()),
                 providers: crate::config::ProviderConfig {
@@ -386,6 +387,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -398,6 +400,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 providers: crate::config::ProviderConfig {
                     anthropic_api_key: Some("sk-ant-test".to_string()),
@@ -536,6 +539,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 agent_paths: vec![
                     std::path::PathBuf::from("/my/agents"),
@@ -572,6 +576,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 providers: crate::config::ProviderConfig {
                     anthropic_base_url: None,
@@ -744,6 +749,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -763,6 +769,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: Arc::new(crate::daemon::config_reload::ConfigReloader::new(
                 path.clone(),
                 Config::default(),
@@ -1237,6 +1244,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config {
                 providers: crate::config::ProviderConfig {
                     anthropic_api_key: Some("test-key".to_string()),

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -170,6 +170,14 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // without it should send people to the install docs rather than pick a
     // package manager on their behalf.
     "update.plan",
+    // `POST /api/update` and `GET /api/update/jobs/{id}`: carrying the plan out
+    // rather than only printing it, with the step-by-step on the websocket.
+    // Announced whether or not `--allow-admin` was passed, the same narrower
+    // claim `scripts.write` makes below - it says this build serves the route,
+    // and whether this daemon mounts it is something a client finds out by
+    // calling it and reading the status. Worth announcing anyway: without it a
+    // console has to offer a button that might 404, or offer none at all.
+    "update.apply",
     "scripts.read",
     // Announced whether or not `--allow-admin` was passed, which is a narrower
     // claim than the others on this list: it says this build serves the write

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -85,6 +85,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: leviath_runtime::control_socket::ControlClient::new(

--- a/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
@@ -171,6 +171,7 @@ async fn stand_up(runs_dir: &std::path::Path) -> Seam {
     let (event_tx, _) = broadcast::channel(256);
     let state = AppState {
         update_check: Default::default(),
+        update_jobs: Default::default(),
         config: crate::commands::serve::testutil::fixed_config(Config::default()),
         event_tx,
         control: control.clone(),

--- a/crates/leviath-cli/src/commands/serve/events.rs
+++ b/crates/leviath-cli/src/commands/serve/events.rs
@@ -215,6 +215,45 @@ pub enum ServerEvent {
         /// The result, flattened to one line and truncated.
         summary: String,
     },
+    /// A step of an update started by `POST /api/update` changed.
+    ///
+    /// About the machine rather than about a run, like
+    /// [`DaemonLink`](Self::DaemonLink) - so a per-run subscription does not
+    /// receive one, and `/ws` does.
+    ///
+    /// Sent as it happens, because that is the whole reason the route answers
+    /// with a job id instead of holding the request open: a `brew upgrade` is a
+    /// download and an install, and a console that can only say "updating" for
+    /// a minute is a console that cannot say whether anything is happening.
+    UpdateProgress {
+        /// The job this is about, as `POST /api/update` answered with.
+        job_id: String,
+        /// `binary`, `agents` or `migrations`.
+        step: String,
+        /// `running`, `done`, `skipped`, `advised` or `failed`.
+        status: String,
+        /// One line about what just happened, ready to print.
+        detail: String,
+    },
+    /// An update started by `POST /api/update` reached a terminal status.
+    ///
+    /// Carries the whole job record rather than a summary, so a client that
+    /// connected mid-run or dropped a frame renders the result without a
+    /// follow-up request.
+    UpdateFinished {
+        /// The job that finished.
+        job_id: String,
+        /// `complete` if every step that ran succeeded, `failed` otherwise.
+        status: String,
+        /// Whether the binary on disk is now newer than the processes serving
+        /// this. Both this server and the daemon keep running the old build
+        /// until they are restarted, so a console that reported the version it
+        /// can see would be telling the truth in the least useful way possible.
+        restart_required: bool,
+        /// The same record `GET /api/update/jobs/{id}` returns.
+        job: serde_json::Value,
+    },
+
     /// This server's own link to the daemon changed.
     ///
     /// Sent when the daemon's event stream drops and when it is back, and once
@@ -243,8 +282,8 @@ pub enum ServerEvent {
 
 impl ServerEvent {
     /// The run id this event belongs to, for per-run subscription filtering.
-    /// Every event names one except [`DaemonLink`](Self::DaemonLink), which is
-    /// about the server's own connection rather than any run.
+    /// Every event names one except the three about the machine rather than a
+    /// run - [`DaemonLink`](Self::DaemonLink), and the two an update sends.
     pub fn run_id(&self) -> &str {
         match self {
             ServerEvent::AgentStatus { run_id, .. }
@@ -259,12 +298,20 @@ impl ServerEvent {
             | ServerEvent::ToolCallStarted { run_id, .. }
             | ServerEvent::ToolCallFinished { run_id, .. }
             | ServerEvent::AgentSpend { run_id, .. } => run_id,
-            ServerEvent::DaemonLink { .. } => "",
+            ServerEvent::DaemonLink { .. }
+            | ServerEvent::UpdateProgress { .. }
+            | ServerEvent::UpdateFinished { .. } => "",
         }
     }
 
     /// Whether a subscription filtered to `run_id` should receive this event:
     /// its own run's events, and the ones about no run at all.
+    ///
+    /// The update frames are deliberately not in that second group. A link
+    /// event explains why a run's events stopped arriving, which is something
+    /// a per-run subscriber has to know; an update happening on the machine is
+    /// not about the run it is watching, and `/ws` is where a console watches
+    /// for it.
     pub fn is_for_run(&self, run_id: &str) -> bool {
         matches!(self, ServerEvent::DaemonLink { .. }) || self.run_id() == run_id
     }

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -283,6 +283,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon_client(),

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -136,6 +136,7 @@ mod tests {
         let (tx, _) = broadcast::channel(16);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control,

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -363,6 +363,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -758,6 +759,7 @@ for line in sys.stdin:
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -813,6 +815,7 @@ for line in sys.stdin:
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -26,6 +26,7 @@ mod tree;
 mod types;
 mod update;
 mod update_cache;
+mod update_job;
 mod websocket;
 
 #[cfg(test)]
@@ -61,11 +62,25 @@ impl<T> Drop for AbortOnDrop<T> {
 }
 
 /// Run `lev serve`: expose the HTTP + WebSocket API over the daemon.
+///
+/// `upgrade` is how `POST /api/update` runs a package manager. Injected rather
+/// than built here for the same reason `lev update`'s is: spawning a process is
+/// the one part of an update with nothing to unit-test it against, so it lives
+/// in the binary's composition root and everything that decides *whether* and
+/// *what* to spawn is testable without one.
 pub async fn execute(
     args: ServeArgs,
     control: leviath_runtime::control_socket::ControlClient,
+    upgrade: crate::commands::update::CommandRunner,
 ) -> anyhow::Result<()> {
-    execute_with_shutdown(args, control, Box::pin(std::future::pending()), None).await
+    execute_with_shutdown(
+        args,
+        control,
+        upgrade,
+        Box::pin(std::future::pending()),
+        None,
+    )
+    .await
 }
 
 /// Every API route with its production handlers - the single route table,
@@ -247,6 +262,7 @@ fn routes_in(source: &str) -> Vec<(String, String)> {
 async fn execute_with_shutdown(
     args: ServeArgs,
     control: leviath_runtime::control_socket::ControlClient,
+    upgrade: crate::commands::update::CommandRunner,
     shutdown: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
     ready: Option<tokio::sync::oneshot::Sender<SocketAddr>>,
 ) -> anyhow::Result<()> {
@@ -274,6 +290,7 @@ async fn execute_with_shutdown(
 
     let state = AppState {
         update_check: Default::default(),
+        update_jobs: update_job::UpdateJobs::with_runner(upgrade),
         config: Arc::new(crate::daemon::config_reload::ConfigReloader::new(
             Config::config_path(),
             cfg,
@@ -359,6 +376,13 @@ async fn execute_with_shutdown(
             // Config-write persists provider secrets to disk, so it is gated the
             // same way as MCP admin: unmounted (404) unless --allow-admin.
             .route("/api/config", put(config::put_config))
+            // Carrying out the update the GET half only describes: it runs a
+            // package manager, replaces the blueprints in the agents directory
+            // and rewrites the config. Same category of act as the three above,
+            // and gated the same way - the read half stays open, so a console
+            // without admin still shows what to type.
+            .route("/api/update", post(update::post_update))
+            .route("/api/update/jobs/{id}", get(update::get_update_job))
             // A `.rhai` file is executable code every agent then runs, so
             // writing one is the same category of act as adding an MCP server
             // rather than the same category as saving a blueprint. Unmounted
@@ -526,6 +550,37 @@ async fn status_page() -> axum::response::Html<&'static str> {
          <h1>Leviath is running.</h1>\
          <p>The API needs a token; this page does not serve it.</p>",
     )
+}
+
+/// The upgrade runner a server test carries.
+///
+/// A refusal rather than a no-op: a server test that reached the upgrade path
+/// by accident should fail loudly, not quietly report having run a package
+/// manager it never ran. A named function rather than a closure per call site
+/// so there is one body to cover rather than one per test.
+#[cfg(test)]
+fn no_upgrade_in_tests(_argv: &[String]) -> anyhow::Result<()> {
+    anyhow::bail!("no upgrade command runs in a server test")
+}
+
+/// [`execute_with_shutdown`] for a test that is not exercising the update
+/// route, with a runner that refuses to spawn anything.
+///
+#[cfg(test)]
+async fn serve_for_test(
+    args: ServeArgs,
+    control: leviath_runtime::control_socket::ControlClient,
+    shutdown: std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send>>,
+    ready: Option<tokio::sync::oneshot::Sender<SocketAddr>>,
+) -> anyhow::Result<()> {
+    execute_with_shutdown(
+        args,
+        control,
+        Arc::new(no_upgrade_in_tests),
+        shutdown,
+        ready,
+    )
+    .await
 }
 
 // ─── Tests ──────────────────────────────────────────────────────────────────
@@ -791,6 +846,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon_control(),
@@ -1384,7 +1440,7 @@ system_prompt = "Run"
                     tls_key: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-                let handle = tokio::spawn(execute_with_shutdown(
+                let handle = tokio::spawn(serve_for_test(
                     args,
                     no_daemon_control(),
                     Box::pin(std::future::pending()),
@@ -1459,7 +1515,7 @@ system_prompt = "Run"
                 tls_key: Some(key),
             };
             let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-            let handle = tokio::spawn(execute_with_shutdown(
+            let handle = tokio::spawn(serve_for_test(
                 args,
                 no_daemon_control(),
                 Box::pin(std::future::pending()),
@@ -1541,7 +1597,7 @@ system_prompt = "Run"
                     tls_cert: Some(cert.clone()),
                     ..base.clone()
                 };
-                let err = execute_with_shutdown(
+                let err = serve_for_test(
                     lone,
                     no_daemon_control(),
                     Box::pin(std::future::pending()),
@@ -1560,7 +1616,7 @@ system_prompt = "Run"
                     tls_key: Some(key),
                     ..base
                 };
-                let err = execute_with_shutdown(
+                let err = serve_for_test(
                     unreadable,
                     no_daemon_control(),
                     Box::pin(std::future::pending()),
@@ -1606,7 +1662,7 @@ system_prompt = "Run"
                 };
                 let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-                let server = tokio::spawn(execute_with_shutdown(
+                let server = tokio::spawn(serve_for_test(
                     args,
                     no_daemon_control(),
                     Box::pin(async move {
@@ -1654,7 +1710,7 @@ system_prompt = "Run"
                     tls_key: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-                let handle = tokio::spawn(execute_with_shutdown(
+                let handle = tokio::spawn(serve_for_test(
                     args,
                     no_daemon_control(),
                     Box::pin(std::future::pending()),
@@ -1708,7 +1764,7 @@ system_prompt = "Run"
                     tls_key: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
-                let handle = tokio::spawn(execute_with_shutdown(
+                let handle = tokio::spawn(serve_for_test(
                     args,
                     no_daemon_control(),
                     Box::pin(std::future::pending()),
@@ -1743,7 +1799,7 @@ system_prompt = "Run"
                 tls_cert: None,
                 tls_key: None,
             };
-            let result = execute(args, no_daemon_control()).await;
+            let result = execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
             assert!(result.is_err());
         })
         .await;
@@ -1781,7 +1837,8 @@ system_prompt = "Run"
                     tls_cert: None,
                     tls_key: None,
                 };
-                let result = execute(args, no_daemon_control()).await;
+                let result =
+                    execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
                 assert_execute_failed_on_malformed_config(&result);
             },
         )
@@ -1820,7 +1877,7 @@ system_prompt = "Run"
         };
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
 
-        let handle = tokio::spawn(execute_with_shutdown(
+        let handle = tokio::spawn(serve_for_test(
             args,
             no_daemon_control(),
             Box::pin(shutdown_fut),
@@ -1867,7 +1924,8 @@ system_prompt = "Run"
                     tls_cert: None,
                     tls_key: None,
                 };
-                let result = execute(args, no_daemon_control()).await;
+                let result =
+                    execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
                 assert_execute_failed_on_port_in_use(&result);
                 // Names the address it could not have, rather than leaving the
                 // reader with a bare errno.
@@ -1904,7 +1962,8 @@ system_prompt = "Run"
                     tls_cert: None,
                     tls_key: None,
                 };
-                let result = execute(args, no_daemon_control()).await;
+                let result =
+                    execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
                 assert_execute_failed_on_port_in_use(&result);
                 assert_error_says(
                     &result,
@@ -1932,7 +1991,7 @@ system_prompt = "Run"
                 tls_cert: None,
                 tls_key: None,
             };
-            let result = execute(args, no_daemon_control()).await;
+            let result = execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
             assert!(result.is_err(), "must refuse to start unauthenticated");
         })
         .await;
@@ -1963,7 +2022,7 @@ system_prompt = "Run"
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
 
-                let handle = tokio::spawn(execute_with_shutdown(
+                let handle = tokio::spawn(serve_for_test(
                     args,
                     no_daemon_control(),
                     Box::pin(shutdown_fut),
@@ -2012,7 +2071,7 @@ system_prompt = "Run"
                     let _ = shutdown_rx.await;
                 };
 
-                let handle = tokio::spawn(execute_with_shutdown(
+                let handle = tokio::spawn(serve_for_test(
                     args,
                     no_daemon_control(),
                     Box::pin(shutdown_fut),
@@ -2060,7 +2119,7 @@ system_prompt = "Run"
             async fn starts(cors: Option<&str>) {
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
-                let server = tokio::spawn(execute_with_shutdown(
+                let server = tokio::spawn(serve_for_test(
                     args_with(cors),
                     no_daemon_control(),
                     Box::pin(async move {
@@ -2084,7 +2143,7 @@ system_prompt = "Run"
 
             // A malformed origin fails before binding, so this can be awaited
             // directly rather than raced against a `ready` signal.
-            let err = execute_with_shutdown(
+            let err = serve_for_test(
                 args_with(Some("not a valid\nheader")),
                 no_daemon_control(),
                 Box::pin(std::future::pending()),
@@ -2122,7 +2181,7 @@ system_prompt = "Run"
                     tls_cert: None,
                     tls_key: None,
                 };
-                let server = tokio::spawn(execute_with_shutdown(
+                let server = tokio::spawn(serve_for_test(
                     args,
                     no_daemon_control(),
                     Box::pin(async move {
@@ -2154,6 +2213,108 @@ system_prompt = "Run"
                 let _ = server.await;
             }
         })
+        .await;
+    }
+
+    /// The runner every server test here carries refuses, so a test that
+    /// reached the upgrade path by accident fails loudly rather than reporting
+    /// a package manager it never ran.
+    #[test]
+    fn a_server_test_cannot_run_an_upgrade_command() {
+        let e = no_upgrade_in_tests(&["brew".to_string()]).expect_err("it refuses");
+        assert!(e.to_string().contains("no upgrade command runs"), "{e}");
+    }
+
+    /// The update routes that *do* something are mounted only with
+    /// `--allow-admin`. The `GET` half stays mounted either way, so a console
+    /// without admin still shows what to type - which is the whole point of it
+    /// being a separate route.
+    ///
+    /// The request deliberately asks for the binary step alone. The runner
+    /// `serve_for_test` supplies refuses to spawn anything, so nothing runs;
+    /// asking for the blueprint step would point a real install at whatever
+    /// `~/.leviath/agents` this test happens to run beside.
+    #[tokio::test]
+    async fn the_update_admin_routes_are_mounted_only_with_allow_admin() {
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-update",
+            |_fake_dir| async move {
+                for allow_admin in [false, true] {
+                    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+                    let args = ServeArgs {
+                        port: 0,
+                        host: "127.0.0.1".to_string(),
+                        cors: None,
+                        token: Some("t".to_string()),
+                        allow_admin,
+                        workdir_root: None,
+                        no_remote_yolo: false,
+                        tls_cert: None,
+                        tls_key: None,
+                    };
+                    let server = tokio::spawn(serve_for_test(
+                        args,
+                        no_daemon_control(),
+                        Box::pin(async move {
+                            let _ = stop_rx.await;
+                        }),
+                        Some(ready_tx),
+                    ));
+                    let addr = ready_rx.await.expect("bound");
+                    let client = reqwest::Client::new();
+
+                    let apply = client
+                        .post(format!("http://{addr}/api/update"))
+                        .bearer_auth("t")
+                        .json(&serde_json::json!({
+                            "binary": true, "agents": false, "migrations": false
+                        }))
+                        .send()
+                        .await
+                        .expect("request")
+                        .status()
+                        .as_u16();
+                    let job = client
+                        .get(format!("http://{addr}/api/update/jobs/never"))
+                        .bearer_auth("t")
+                        .send()
+                        .await
+                        .expect("request")
+                        .status()
+                        .as_u16();
+                    // 405 is the signature of "this path exists for GET but POST is
+                    // not mounted"; the jobs path has nothing else on it, so it is
+                    // a 404 when unmounted and a 404-for-a-real-reason when mounted
+                    // - which is why that one is checked as "not 405" from the
+                    // other side: an unknown id.
+                    match allow_admin {
+                        false => {
+                            assert_eq!(apply, 405, "POST must not be mounted");
+                            assert_eq!(job, 404, "the jobs route must not be mounted");
+                        }
+                        true => {
+                            assert_eq!(apply, 202, "POST must be mounted and answer at once");
+                            assert_eq!(job, 404, "mounted, and that id really is unknown");
+                        }
+                    }
+
+                    // The read half answers either way.
+                    let plan = client
+                        .get(format!("http://{addr}/api/update"))
+                        .bearer_auth("t")
+                        .send()
+                        .await
+                        .expect("request")
+                        .status()
+                        .as_u16();
+                    assert_eq!(plan, 200, "the read half is never gated");
+
+                    let _ = stop_tx.send(());
+                    let _ = server.await;
+                }
+            },
+        )
         .await;
     }
 
@@ -2189,7 +2350,7 @@ system_prompt = "Run"
                     tls_cert: None,
                     tls_key: None,
                 };
-                let server = tokio::spawn(execute_with_shutdown(
+                let server = tokio::spawn(serve_for_test(
                     args,
                     no_daemon_control(),
                     Box::pin(async move {

--- a/crates/leviath-cli/src/commands/serve/polling.rs
+++ b/crates/leviath-cli/src/commands/serve/polling.rs
@@ -521,6 +521,7 @@ mod tests {
         (
             AppState {
                 update_check: Default::default(),
+                update_jobs: Default::default(),
                 config: crate::commands::serve::testutil::fixed_config(Config::default()),
                 event_tx: tx,
                 control,

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -127,6 +127,9 @@ pub struct AppState {
     /// On the state rather than in a `static` so two servers in one process -
     /// or two tests - cannot write into each other's answer.
     pub(super) update_check: super::update_cache::UpdateCheckCache,
+    /// The update runs `POST /api/update` has started, and the machine to start
+    /// another on. On the state for the same reason the cache above is.
+    pub(super) update_jobs: super::update_job::UpdateJobs,
 }
 
 impl AppState {

--- a/crates/leviath-cli/src/commands/serve/update.rs
+++ b/crates/leviath-cli/src/commands/serve/update.rs
@@ -1,12 +1,18 @@
-//! `GET /api/update` - "am I current, and what do I type to fix it".
+//! The update routes: what an update would do, and doing it.
 //!
-//! Answers with exactly what `lev update --check --json` prints, from the same
-//! [`crate::commands::update::plan`], so the console and the CLI can never
-//! disagree about how this copy was installed.
+//! `GET /api/update` answers with exactly what `lev update --check --json`
+//! prints, from the same [`crate::commands::update::plan`], so the console and
+//! the CLI can never disagree about how this copy was installed. `POST
+//! /api/update` carries that plan out, behind `--allow-admin`; the machinery
+//! for it is in [`super::update_job`].
 
-use axum::response::Json;
+use axum::extract::{Path as AxumPath, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Json};
 
 use super::config_types::API_VERSION;
+use super::types::{AppState, err};
+use super::update_job::{ApplyRequest, parse_request};
 use crate::commands::update::{UpdateArgs, UpdateEnv, plan, plan_json};
 
 /// `GET /api/update`: how this copy was installed, and the command that
@@ -31,9 +37,7 @@ use crate::commands::update::{UpdateArgs, UpdateEnv, plan, plan_json};
 /// Cannot fail, which is why it returns a bare `Json`. Every step of the
 /// discovery degrades to worse detection rather than to an error - a copy this
 /// build cannot place is `unknown` with advice, an answer rather than a 500.
-pub(super) async fn get_update(
-    axum::extract::State(state): axum::extract::State<super::types::AppState>,
-) -> Json<serde_json::Value> {
+pub(super) async fn get_update(State(state): State<AppState>) -> Json<serde_json::Value> {
     // `--check` is implied: this route only ever plans. The other fields are
     // defaults, which is what a caller who is not choosing a channel means.
     let args = UpdateArgs {
@@ -58,6 +62,78 @@ pub(super) async fn get_update(
     Json(plan_json(&plan, API_VERSION, &state.update_check.peek()))
 }
 
+/// `POST /api/update`: carry the plan out.
+///
+/// Answers `202 Accepted` with a job id and lets the work run behind it. The
+/// alternative is a request held open for a `brew update && brew upgrade`,
+/// which is a download and an install: a minute on a good day, and a console
+/// showing "downloading" for a request that has not returned is a console
+/// showing a spinner it made up. Every step change goes out on `/ws` as
+/// `update_progress`, the last as `update_finished`, and
+/// [`get_update_job`] answers the same record for a client that would rather
+/// poll.
+///
+/// Behind `--allow-admin`, which is the line this route crosses and
+/// `GET /api/update` does not: that one plans and acts on nothing, this one
+/// runs a package manager and rewrites the agents directory and the config.
+///
+/// `409` while another update is going. Two package-manager upgrades of the
+/// same binary racing each other is not a state to debug, and a double-clicked
+/// button means one update.
+pub(super) async fn post_update(
+    State(state): State<AppState>,
+    body: axum::body::Bytes,
+) -> axum::response::Response {
+    let req = match parse_request(&body) {
+        Ok(req) => req,
+        Err(message) => return err(StatusCode::BAD_REQUEST, message).into_response(),
+    };
+    match state.update_jobs.spawn(req, &state.event_tx) {
+        Ok(job_id) => (StatusCode::ACCEPTED, Json(started(&job_id, req))).into_response(),
+        Err(running) => err(
+            StatusCode::CONFLICT,
+            format!("update {running} is already running"),
+        )
+        .into_response(),
+    }
+}
+
+/// The `202` body: the id to watch, and the request as it was read.
+///
+/// Echoing the three flags back is not decoration. Every one defaults to on, so
+/// a caller that sent nothing, or sent a body this route read differently than
+/// it meant, learns which update it actually started at the moment it starts -
+/// rather than from the steps that turn out to be `skipped`.
+fn started(job_id: &str, req: ApplyRequest) -> serde_json::Value {
+    serde_json::json!({
+        "job_id": job_id,
+        "status": "running",
+        "applying": {
+            "binary": req.binary,
+            "agents": req.agents,
+            "migrations": req.migrations,
+        },
+    })
+}
+
+/// `GET /api/update/jobs/{id}`: where one update run got to.
+///
+/// The websocket says it sooner; this is for a client that connected late,
+/// dropped a frame, or does not hold a socket open at all. Same record either
+/// way, so there is no second shape to keep in step.
+///
+/// The last few runs are kept, so an operator who reads back after the fact
+/// finds the job rather than a 404 that means nothing in particular.
+pub(super) async fn get_update_job(
+    State(state): State<AppState>,
+    AxumPath(id): AxumPath<String>,
+) -> axum::response::Response {
+    match state.update_jobs.get(&id) {
+        Some(job) => Json(job).into_response(),
+        None => err(StatusCode::NOT_FOUND, format!("no update job {id}")).into_response(),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -68,7 +144,7 @@ mod tests {
     use axum::body::Body;
     use axum::http::Request;
     use axum::http::StatusCode;
-    use axum::routing::get;
+    use axum::routing::{get, post};
     use tower::ServiceExt;
 
     /// A state with nothing behind it but the update cache, which is all this
@@ -87,6 +163,7 @@ mod tests {
             update_check: super::super::update_cache::UpdateCheckCache::with_fetcher(
                 std::sync::Arc::new(declines),
             ),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(crate::config::Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -132,6 +209,7 @@ mod tests {
         let (tx, _) = tokio::sync::broadcast::channel(64);
         let state = super::super::types::AppState {
             update_check: super::super::update_cache::UpdateCheckCache::with_fetcher(counting),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(crate::config::Config {
                 update_check: false,
                 ..crate::config::Config::default()
@@ -286,5 +364,171 @@ mod tests {
         let from_route: serde_json::Value =
             serde_json::from_slice(&bytes).expect("the handler serializes a plan");
         assert_eq!(from_route, from_cli);
+    }
+
+    // ─── POST /api/update, and reading a job back ────────────────────────────
+
+    /// A state whose update jobs act on a temp directory, so a route test
+    /// cannot install a blueprint into the developer's own agents directory or
+    /// run a package manager.
+    fn applying_state() -> (tempfile::TempDir, super::super::types::AppState) {
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let (agents_dir, config_path) = (dir.path().join("agents"), dir.path().join("config.toml"));
+        let jobs = super::super::update_job::UpdateJobs::with_env(std::sync::Arc::new(move || {
+            crate::commands::update::UpdateEnv {
+                // Nowhere an installer writes, so the binary step is advice and
+                // no command is ever handed to the runner.
+                exe: std::path::PathBuf::from("/nowhere/at/all/lev"),
+                agents_dir: agents_dir.clone(),
+                config_path: config_path.clone(),
+                ..crate::commands::update::UpdateEnv::for_planning()
+            }
+        }));
+        let state = super::super::types::AppState {
+            update_jobs: jobs,
+            ..test_state()
+        };
+        (dir, state)
+    }
+
+    /// The two routes as production mounts them, so a test cannot pass against
+    /// a path production does not serve.
+    fn update_app(state: super::super::types::AppState) -> Router {
+        Router::new()
+            .route("/api/update", post(post_update))
+            .route("/api/update/jobs/{id}", get(get_update_job))
+            .with_state(state)
+    }
+
+    /// The status and body of one request.
+    async fn call(app: Router, request: Request<Body>) -> (StatusCode, serde_json::Value) {
+        let resp = app
+            .oneshot(request)
+            .await
+            .expect("the router is infallible");
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("the body is a small JSON document");
+        let body = serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null);
+        (status, body)
+    }
+
+    /// A `POST` with a body.
+    fn post_with(body: &'static str) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/api/update")
+            .body(Body::from(body))
+            .expect("a POST with a body always builds")
+    }
+
+    /// The route answers at once with an id to watch, and the request as it
+    /// read it - so a caller learns which update it started rather than
+    /// inferring it from the steps that turn out skipped.
+    #[tokio::test]
+    async fn post_update_answers_202_with_a_job_id_and_what_it_is_applying() {
+        let (_dir, state) = applying_state();
+        let jobs = state.update_jobs.clone();
+        let (status, body) = call(update_app(state), post_with(r#"{"agents": false}"#)).await;
+
+        assert_eq!(status, StatusCode::ACCEPTED);
+        let id = body["job_id"].as_str().expect("a job id is a string");
+        assert_eq!(body["status"], "running");
+        assert_eq!(body["applying"]["binary"], true);
+        assert_eq!(body["applying"]["agents"], false);
+        assert_eq!(body["applying"]["migrations"], true);
+        assert!(jobs.get(id).is_some(), "the job is readable straight away");
+    }
+
+    /// An empty body is the whole plan, which is what a console's plain
+    /// "update" button sends.
+    #[tokio::test]
+    async fn post_update_with_no_body_applies_everything() {
+        let (_dir, state) = applying_state();
+        let (status, body) = call(update_app(state), post_with("")).await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        for part in ["binary", "agents", "migrations"] {
+            assert_eq!(body["applying"][part], true, "{part}");
+        }
+    }
+
+    /// A body this route cannot read is a 400 that says so, rather than a
+    /// silent default that would run an update the caller did not ask for.
+    #[tokio::test]
+    async fn post_update_refuses_a_body_it_cannot_read() {
+        let (_dir, state) = applying_state();
+        let (status, body) = call(update_app(state), post_with(r#"{"agent": false}"#)).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            body["error"]
+                .as_str()
+                .is_some_and(|e| e.contains("could not read the request body")),
+            "{body}"
+        );
+    }
+
+    /// One update at a time, and the refusal names the one already going so a
+    /// console can watch that instead of starting a second package manager over
+    /// the same binary.
+    #[tokio::test]
+    async fn post_update_refuses_a_second_while_one_is_running() {
+        let (_dir, state) = applying_state();
+        let running = state
+            .update_jobs
+            .start()
+            .expect("nothing is running to begin with");
+        let (status, body) = call(update_app(state), post_with("")).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            body["error"]
+                .as_str()
+                .is_some_and(|e| e.contains(&running) && e.contains("already running")),
+            "{body}"
+        );
+    }
+
+    /// The poll route answers the same record the finish frame carries.
+    #[tokio::test]
+    async fn a_job_can_be_read_back_by_id() {
+        let (_dir, state) = applying_state();
+        let id = state.update_jobs.start().expect("nothing is running");
+        let request = Request::builder()
+            .uri(format!("/api/update/jobs/{id}"))
+            .body(Body::empty())
+            .expect("a GET with no body always builds");
+        let (status, body) = call(update_app(state), request).await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["id"], id);
+        assert_eq!(body["status"], "running");
+        assert_eq!(body["restart_required"], false);
+        assert_eq!(body["finished_at"], serde_json::Value::Null);
+        let steps: Vec<&str> = body["steps"]
+            .as_array()
+            .expect("steps is a list")
+            .iter()
+            .map(|step| step["step"].as_str().expect("a step names itself"))
+            .collect();
+        assert_eq!(steps, vec!["binary", "agents", "migrations"]);
+    }
+
+    /// An id nobody minted is a 404 that names it, not an empty 200 a client
+    /// would render as a job that did nothing.
+    #[tokio::test]
+    async fn an_unknown_job_id_is_a_404() {
+        let (_dir, state) = applying_state();
+        let request = Request::builder()
+            .uri("/api/update/jobs/update-never-1")
+            .body(Body::empty())
+            .expect("a GET with no body always builds");
+        let (status, body) = call(update_app(state), request).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(
+            body["error"]
+                .as_str()
+                .is_some_and(|e| e.contains("update-never-1")),
+            "{body}"
+        );
     }
 }

--- a/crates/leviath-cli/src/commands/serve/update_job.rs
+++ b/crates/leviath-cli/src/commands/serve/update_job.rs
@@ -1,0 +1,593 @@
+//! `POST /api/update` - carrying out the plan `GET /api/update` prints.
+//!
+//! The read route answers "am I current, and what do I type to fix it". This is
+//! the half that does it: it runs `binary.commands`, installs the blueprints the
+//! plan marks `preselected`, and applies the config migrations - the same three
+//! steps `lev update` runs, from the same [`plan`], so the console and the
+//! terminal cannot carry out different updates (issue #638).
+//!
+//! # Why it is a job rather than a request
+//!
+//! A `brew update && brew upgrade` is a download and an install. It takes a
+//! minute on a good day and can fail halfway, and an HTTP request held open for
+//! it tells a console nothing until it is over - so the button would say
+//! "updating" with no way to know whether anything was happening. The route
+//! answers `202` with a job id immediately, the work runs behind it, and every
+//! step change goes out on the websocket as it happens. A client that missed a
+//! frame, or connected late, polls `GET /api/update/jobs/{id}` for the same
+//! record.
+//!
+//! # What it will not do
+//!
+//! A `cargo install` copy is `binary.action == "advise"`, and stays advice: the
+//! step is recorded as advised, with the plan's own sentence, and no compile is
+//! started. Same for a binary in a directory no installer writes to. A blueprint
+//! the user edited is never installed either - [`install_bundled`] removes the
+//! destination directory first, so a bulk yes would take their edits and any
+//! file they added with it, which is why `lev update` asks about each one on its
+//! own and no flag covers it. There is nobody to ask over HTTP, so the answer
+//! is no, said out loud in the step's detail.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::broadcast;
+
+use super::events::ServerEvent;
+use crate::bundled::install_bundled;
+use crate::commands::update::{
+    BinaryStep, CommandRunner, ConfigState, UpdateArgs, UpdateEnv, UpdatePlan, plan,
+    render_commands,
+};
+
+// ─── The record ──────────────────────────────────────────────────────────────
+
+/// How many jobs to remember. An update is a thing somebody does once and
+/// watches, so the history is for the console that reconnected mid-run and the
+/// operator reading back what happened - not an audit log.
+const KEEP_JOBS: usize = 8;
+
+/// The three steps, in the order they run. `binary` first because the other two
+/// are decided by what the *new* binary ships.
+pub(super) const STEPS: [&str; 3] = ["binary", "agents", "migrations"];
+
+/// A step that has not been reached yet.
+const PENDING: &str = "pending";
+/// A step that is happening now.
+const RUNNING: &str = "running";
+/// A step that did what it set out to.
+const DONE: &str = "done";
+/// A step the request did not ask for, or that had nothing to do.
+const SKIPPED: &str = "skipped";
+/// A step that is the reader's to carry out, with the reason in its detail.
+/// The one status that is neither success nor failure: nothing was done and
+/// nothing went wrong.
+const ADVISED: &str = "advised";
+/// A step that tried and did not manage it.
+const FAILED: &str = "failed";
+/// Every step is finished and none failed.
+const COMPLETE: &str = "complete";
+
+/// What became of one step of an update run.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub(super) struct UpdateStep {
+    /// One of [`STEPS`].
+    pub(super) step: &'static str,
+    /// `pending`, `running`, `done`, `skipped`, `advised` or `failed`.
+    pub(super) status: &'static str,
+    /// One line a console can print under the step's name.
+    pub(super) detail: String,
+}
+
+/// One run of `POST /api/update`, as the poll route and the finish frame report
+/// it.
+#[derive(Debug, Clone, Serialize)]
+pub(super) struct UpdateJob {
+    /// What `POST /api/update` answered with, and what the frames carry.
+    pub(super) id: String,
+    /// `running`, `complete` or `failed`.
+    pub(super) status: &'static str,
+    /// Every step, always all three, so a client renders a fixed list rather
+    /// than one that grows under it.
+    pub(super) steps: Vec<UpdateStep>,
+    /// Whether the binary on disk is newer than the processes serving this.
+    ///
+    /// Set only when the binary step actually ran and succeeded. `lev serve`
+    /// and the daemon it talks to are both still the old build until they
+    /// restart, so a console that reports the version it can see would be
+    /// telling the truth in the least useful way possible.
+    pub(super) restart_required: bool,
+    /// What to say about that, present exactly when `restart_required` is.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) restart_hint: Option<String>,
+    /// When the job started, in unix seconds.
+    pub(super) started_at: u64,
+    /// When it reached a terminal status, or `null` while it is still going.
+    pub(super) finished_at: Option<u64>,
+}
+
+impl UpdateJob {
+    /// A job that has not started any of its steps.
+    fn new(id: String, started_at: u64) -> Self {
+        Self {
+            id,
+            status: RUNNING,
+            steps: STEPS
+                .iter()
+                .map(|step| UpdateStep {
+                    step,
+                    status: PENDING,
+                    detail: String::new(),
+                })
+                .collect(),
+            restart_required: false,
+            restart_hint: None,
+            started_at,
+            finished_at: None,
+        }
+    }
+}
+
+/// The sentence a console shows when the binary moved under it.
+const RESTART_HINT: &str = "the new binary is on disk, but this server and the \
+     daemon it talks to are still running the old one. Restart `lev serve` (and \
+     `lev daemon restart`) to be on the version that was just installed.";
+
+// ─── The request ─────────────────────────────────────────────────────────────
+
+/// Which parts of the plan to carry out.
+///
+/// Every field defaults to on, so an empty body means "everything `lev update`
+/// would do". Naming them is how a console offers the same three checkboxes the
+/// command's own prompts do - somebody who installed the new binary their own
+/// way still wants the blueprints.
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub(super) struct ApplyRequest {
+    /// Run `binary.commands`, where the plan has any.
+    #[serde(default = "asked_for")]
+    pub(super) binary: bool,
+    /// Install the blueprints the plan marks `preselected`.
+    #[serde(default = "asked_for")]
+    pub(super) agents: bool,
+    /// Apply the config migrations the plan lists.
+    #[serde(default = "asked_for")]
+    pub(super) migrations: bool,
+}
+
+/// The default for every field of [`ApplyRequest`]: a part not mentioned is a
+/// part the caller wants.
+fn asked_for() -> bool {
+    true
+}
+
+impl Default for ApplyRequest {
+    fn default() -> Self {
+        Self {
+            binary: true,
+            agents: true,
+            migrations: true,
+        }
+    }
+}
+
+/// Read a `POST /api/update` body.
+///
+/// An empty body is the whole plan rather than an error: "update me" is the
+/// ordinary request, and making a console send `{}` to express it would be a
+/// ceremony with no meaning behind it. `deny_unknown_fields` is the other half
+/// of that - a body that names `agent` instead of `agents` is a caller asking
+/// for something this route did not do, and silently running the default would
+/// be the worst possible answer.
+pub(super) fn parse_request(body: &[u8]) -> Result<ApplyRequest, String> {
+    if body.iter().all(|b| b.is_ascii_whitespace()) {
+        return Ok(ApplyRequest::default());
+    }
+    serde_json::from_slice(body).map_err(|e| format!("could not read the request body: {e}"))
+}
+
+// ─── The store ───────────────────────────────────────────────────────────────
+
+/// Every update run this server has done, and the machine to do another on.
+///
+/// On the app state rather than in a `static` for the same reason the update
+/// cache is: two servers in one process, or two tests, must not write into each
+/// other's answer.
+#[derive(Clone)]
+pub(super) struct UpdateJobs {
+    /// Oldest first, capped at [`KEEP_JOBS`].
+    jobs: Arc<Mutex<Vec<UpdateJob>>>,
+    /// The environment a job acts on: where the blueprints and the config are,
+    /// and how to run a command. A seam, so a test drives the whole thing
+    /// against a temp directory and a runner that spawns nothing.
+    env: Arc<dyn Fn() -> UpdateEnv + Send + Sync>,
+    /// Current unix time; a fn so a long-lived server stays current.
+    clock: fn() -> u64,
+    /// Distinguishes two jobs started in the same second.
+    seq: Arc<AtomicU64>,
+}
+
+impl std::fmt::Debug for UpdateJobs {
+    /// Hand-written because a closure has no `Debug`. Prints the jobs, which is
+    /// the part anyone reading a state dump wants.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpdateJobs")
+            .field("jobs", &self.all())
+            .finish_non_exhaustive()
+    }
+}
+
+impl Default for UpdateJobs {
+    /// The real machine, with a runner that refuses everything.
+    ///
+    /// Refusing rather than spawning: the spawn belongs to the binary's
+    /// composition root like every other one, and `lev serve` passes it in.
+    /// A no-op default would let a server built without one report a
+    /// successful update that ran nothing.
+    fn default() -> Self {
+        Self::with_runner(Arc::new(no_runner))
+    }
+}
+
+/// The runner a store built without one carries.
+fn no_runner(_argv: &[String]) -> anyhow::Result<()> {
+    anyhow::bail!("this server was built without a way to run an upgrade command")
+}
+
+/// Real unix time in seconds.
+fn system_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+impl UpdateJobs {
+    /// The real machine, running upgrade commands the given way.
+    pub(super) fn with_runner(runner: CommandRunner) -> Self {
+        Self::with_env(Arc::new(move || {
+            UpdateEnv::for_applying(Arc::clone(&runner))
+        }))
+    }
+
+    /// A store over an environment a caller built itself. Tests point this at a
+    /// temp home; production points it at the real one.
+    pub(super) fn with_env(env: Arc<dyn Fn() -> UpdateEnv + Send + Sync>) -> Self {
+        Self {
+            jobs: Arc::new(Mutex::new(Vec::new())),
+            env,
+            clock: system_now,
+            seq: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Every job, oldest first.
+    pub(super) fn all(&self) -> Vec<UpdateJob> {
+        self.jobs
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// One job by id.
+    pub(super) fn get(&self, id: &str) -> Option<UpdateJob> {
+        self.all().into_iter().find(|job| job.id == id)
+    }
+
+    /// Record a new job and return its id, or the id of the one already going.
+    ///
+    /// `pub(super)` for [`Self::spawn`]'s own tests, which need a job parked in
+    /// `running` without a task behind it to prove the route refuses a second.
+    ///
+    /// One update at a time: two package-manager upgrades of the same binary
+    /// racing each other is not a state anybody wants to debug, and a console
+    /// that double-clicked the button meant one update. The check and the
+    /// insert are one locked step on purpose - two requests arriving together
+    /// would both see "nothing running" if they were two.
+    pub(super) fn start(&self) -> Result<String, String> {
+        let mut jobs = self.jobs.lock().unwrap_or_else(PoisonError::into_inner);
+        if let Some(running) = jobs.iter().find(|job| job.status == RUNNING) {
+            return Err(running.id.clone());
+        }
+        let now = (self.clock)();
+        let id = format!(
+            "update-{now}-{}",
+            self.seq.fetch_add(1, Ordering::SeqCst) + 1
+        );
+        jobs.push(UpdateJob::new(id.clone(), now));
+        // Oldest first, so trimming from the front drops the oldest.
+        while jobs.len() > KEEP_JOBS {
+            jobs.remove(0);
+        }
+        Ok(id)
+    }
+
+    /// Change one step of a job, and announce it.
+    ///
+    /// A job that has been trimmed out from under a running task is left alone
+    /// rather than re-inserted: it aged out because seven newer ones arrived,
+    /// and resurrecting it would put a stale record back at the front.
+    fn step(
+        &self,
+        id: &str,
+        step: &'static str,
+        status: &'static str,
+        detail: String,
+        events: &broadcast::Sender<ServerEvent>,
+    ) {
+        {
+            let mut jobs = self.jobs.lock().unwrap_or_else(PoisonError::into_inner);
+            let Some(job) = jobs.iter_mut().find(|job| job.id == id) else {
+                return;
+            };
+            let Some(slot) = job.steps.iter_mut().find(|slot| slot.step == step) else {
+                return;
+            };
+            slot.status = status;
+            slot.detail = detail.clone();
+        }
+        // Send outside the lock: a subscriber's slow socket must not hold up the
+        // update it is watching.
+        let _ = events.send(ServerEvent::UpdateProgress {
+            job_id: id.to_string(),
+            step: step.to_string(),
+            status: status.to_string(),
+            detail,
+        });
+    }
+
+    /// Close a job out, and announce the whole record.
+    ///
+    /// The finish frame carries the record rather than a summary so a console
+    /// that connected mid-run, or dropped a frame, needs no follow-up request
+    /// to render the result.
+    fn finish(&self, id: &str, restart_required: bool, events: &broadcast::Sender<ServerEvent>) {
+        let finished = {
+            let mut jobs = self.jobs.lock().unwrap_or_else(PoisonError::into_inner);
+            let Some(job) = jobs.iter_mut().find(|job| job.id == id) else {
+                return;
+            };
+            job.status = match job.steps.iter().any(|step| step.status == FAILED) {
+                true => FAILED,
+                false => COMPLETE,
+            };
+            job.restart_required = restart_required;
+            job.restart_hint = restart_required.then(|| RESTART_HINT.to_string());
+            job.finished_at = Some((self.clock)());
+            job.clone()
+        };
+        let _ = events.send(ServerEvent::UpdateFinished {
+            job_id: finished.id.clone(),
+            status: finished.status.to_string(),
+            restart_required: finished.restart_required,
+            job: serde_json::to_value(&finished)
+                .expect("an update job is plain data and always serializes"),
+        });
+    }
+
+    /// Start a job and carry `req` out on a blocking thread.
+    ///
+    /// Returns the id the caller answers `202` with. The work is
+    /// `spawn_blocking` because all of it is: a package manager subprocess, a
+    /// directory rewrite, and a config save.
+    pub(super) fn spawn(
+        &self,
+        req: ApplyRequest,
+        events: &broadcast::Sender<ServerEvent>,
+    ) -> Result<String, String> {
+        let id = self.start()?;
+        let (store, events, job_id) = (self.clone(), events.clone(), id.clone());
+        tokio::task::spawn_blocking(move || store.apply(&job_id, req, &events));
+        Ok(id)
+    }
+
+    /// The three steps, in order, against a freshly read plan.
+    ///
+    /// The plan is built here rather than passed in: a caller that planned,
+    /// waited for a queue, and then acted on the older answer is exactly the
+    /// surprise `lev update` prints its plan to avoid.
+    fn apply(&self, id: &str, req: ApplyRequest, events: &broadcast::Sender<ServerEvent>) {
+        let env = (self.env)();
+        let plan = plan(&UpdateArgs::default(), &env);
+        let installed = self.binary_step(id, req, &plan, &env, events);
+        self.agents_step(id, req, &plan, &env, events, installed);
+        self.migrations_step(id, req, &plan, &env, events, installed);
+        self.finish(id, matches!(installed, Binary::Installed), events);
+    }
+
+    /// What the binary step did, which the two steps after it need to know.
+    fn binary_step(
+        &self,
+        id: &str,
+        req: ApplyRequest,
+        plan: &UpdatePlan,
+        env: &UpdateEnv,
+        events: &broadcast::Sender<ServerEvent>,
+    ) -> Binary {
+        let step = STEPS[0];
+        if !req.binary {
+            self.step(id, step, SKIPPED, "not asked for".to_string(), events);
+            return Binary::Untouched;
+        }
+        let commands = match &plan.binary {
+            // Advice stays advice. A `cargo install` copy is a full rebuild of
+            // the workspace, which is minutes of somebody's CPU, and a binary
+            // nowhere an installer writes is not something to guess at - both
+            // are the reader's call, and this route says so rather than
+            // starting one.
+            BinaryStep::Advise(message) => {
+                self.step(id, step, ADVISED, message.clone(), events);
+                return Binary::Untouched;
+            }
+            BinaryStep::Run(commands) => commands,
+        };
+        let shown = render_commands(commands);
+        self.step(id, step, RUNNING, format!("running `{shown}`"), events);
+        for argv in commands {
+            if let Err(e) = (env.runner)(argv) {
+                self.step(id, step, FAILED, e.to_string(), events);
+                return Binary::Failed;
+            }
+        }
+        self.step(id, step, DONE, format!("ran `{shown}`"), events);
+        Binary::Installed
+    }
+
+    /// The bundled blueprints, as far as consent reaches.
+    fn agents_step(
+        &self,
+        id: &str,
+        req: ApplyRequest,
+        plan: &UpdatePlan,
+        env: &UpdateEnv,
+        events: &broadcast::Sender<ServerEvent>,
+        binary: Binary,
+    ) {
+        let step = STEPS[1];
+        let Some(()) = self.reached(id, step, req.agents, binary, events) else {
+            return;
+        };
+        // `preselect` rather than `is_change`, which is the whole difference:
+        // a blueprint the user edited is a change this route must not make.
+        let (offered, edited): (Vec<_>, Vec<_>) = plan
+            .agents
+            .iter()
+            .filter(|(_, action)| action.is_change())
+            .partition(|(_, action)| action.preselect());
+        if offered.is_empty() && edited.is_empty() {
+            let detail = "every bundled blueprint is up to date".to_string();
+            self.step(id, step, SKIPPED, detail, events);
+            return;
+        }
+
+        let mut said = Vec::new();
+        let mut failed = Vec::new();
+        if !offered.is_empty() {
+            self.step(
+                id,
+                step,
+                RUNNING,
+                format!("installing {} blueprint(s)", offered.len()),
+                events,
+            );
+            let mut installed = Vec::new();
+            for (agent, _) in &offered {
+                match install_bundled(agent, &env.agents_dir) {
+                    Ok(()) => installed.push(agent.name),
+                    Err(e) => failed.push(format!("{}: {e}", agent.name)),
+                }
+            }
+            if !installed.is_empty() {
+                said.push(format!("installed {}", installed.join(", ")));
+            }
+            // A failed install is reported, not fatal - the same reason
+            // `lev setup` treats it that way. Most of the blueprints plus a
+            // named failure is a better place to leave somebody than a step
+            // that gave up in the middle.
+            if !failed.is_empty() {
+                said.push(format!("could not install {}", failed.join(", ")));
+            }
+        }
+        if !edited.is_empty() {
+            said.push(format!(
+                "{} left alone because you edited them - installing removes the \
+                 directory first, so that is yours to do",
+                edited.len()
+            ));
+        }
+        // Nothing offered means nothing was attempted, however much there was to
+        // say about the ones that were passed over.
+        let status = match (failed.is_empty(), offered.is_empty()) {
+            (false, _) => FAILED,
+            (true, true) => SKIPPED,
+            (true, false) => DONE,
+        };
+        self.step(id, step, status, said.join("; "), events);
+    }
+
+    /// The config migrations the plan found.
+    fn migrations_step(
+        &self,
+        id: &str,
+        req: ApplyRequest,
+        plan: &UpdatePlan,
+        env: &UpdateEnv,
+        events: &broadcast::Sender<ServerEvent>,
+        binary: Binary,
+    ) {
+        let step = STEPS[2];
+        let Some(()) = self.reached(id, step, req.migrations, binary, events) else {
+            return;
+        };
+        let config = match &plan.config {
+            ConfigState::Unreadable(e) => {
+                let detail = format!("the config could not be read, so it was left alone: {e}");
+                self.step(id, step, SKIPPED, detail, events);
+                return;
+            }
+            ConfigState::Loaded(config) => config,
+        };
+        if plan.migrations.is_empty() {
+            self.step(id, step, SKIPPED, "nothing to migrate".to_string(), events);
+            return;
+        }
+        self.step(
+            id,
+            step,
+            RUNNING,
+            format!("applying {} migration(s)", plan.migrations.len()),
+            events,
+        );
+        let mut config = config.as_ref().clone();
+        let mut changed = Vec::new();
+        for migration in &plan.migrations {
+            for line in (migration.apply)(&mut config) {
+                changed.push(format!("{}: {line}", migration.name));
+            }
+        }
+        match config.save_to_path_public(&env.config_path) {
+            Ok(()) => self.step(id, step, DONE, changed.join("; "), events),
+            Err(e) => self.step(id, step, FAILED, e.to_string(), events),
+        }
+    }
+
+    /// Whether a step runs at all, recording why when it does not.
+    ///
+    /// `Some(())` to carry on, `None` when the step has already been closed out.
+    /// A binary step that failed stops the two after it for the same reason
+    /// `lev update` stops there: the blueprints and the config that matter are
+    /// the ones the *new* binary ships, and applying the old one's over a failed
+    /// upgrade is half a job done twice.
+    fn reached(
+        &self,
+        id: &str,
+        step: &'static str,
+        asked_for: bool,
+        binary: Binary,
+        events: &broadcast::Sender<ServerEvent>,
+    ) -> Option<()> {
+        let reason = match (asked_for, binary) {
+            (false, _) => "not asked for",
+            (true, Binary::Failed) => "the binary step failed, so this was left alone",
+            (true, _) => return Some(()),
+        };
+        self.step(id, step, SKIPPED, reason.to_string(), events);
+        None
+    }
+}
+
+/// What the binary step left behind.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Binary {
+    /// New commands ran and every one of them succeeded.
+    Installed,
+    /// Nothing was run: not asked for, or advice this route will not act on.
+    Untouched,
+    /// A command was run and it failed.
+    Failed,
+}
+
+#[cfg(test)]
+#[path = "update_job_tests.rs"]
+mod tests;

--- a/crates/leviath-cli/src/commands/serve/update_job_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/update_job_tests.rs
@@ -1,0 +1,814 @@
+//! Tests for the update job machinery.
+//!
+//! Every one of these drives the real [`UpdateJobs::apply`] against a temp
+//! directory: a real agents dir, a real config file, and a runner that records
+//! the argv it was handed instead of spawning it. Nothing here reaches a
+//! package manager, and nothing writes outside the temp dir.
+
+use super::*;
+
+use std::sync::atomic::AtomicUsize;
+
+use crate::commands::update::{Channel, InstallMethod, MIGRATIONS, binary_step};
+
+/// A runner that records the argv it was handed instead of spawning it, and
+/// can be told to fail on the nth call or to do something to the filesystem
+/// while it "runs".
+#[derive(Clone)]
+struct Recorder {
+    ran: Arc<Mutex<Vec<Vec<String>>>>,
+    /// Which call to fail on, counting from one. `0` never fails.
+    fail_at: usize,
+    calls: Arc<AtomicUsize>,
+    /// Run on the first call. An upgrade takes a minute of wall clock, and the
+    /// machine can change under it - which is the only way to reach the arm
+    /// where a config that read fine no longer saves.
+    during: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl Default for Recorder {
+    fn default() -> Self {
+        Self {
+            ran: Arc::default(),
+            fail_at: 0,
+            calls: Arc::default(),
+            during: Arc::new(|| {}),
+        }
+    }
+}
+
+impl Recorder {
+    fn runner(&self) -> CommandRunner {
+        let me = self.clone();
+        Arc::new(move |argv: &[String]| {
+            let nth = me.calls.fetch_add(1, Ordering::SeqCst) + 1;
+            me.ran
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .push(argv.to_vec());
+            if nth == 1 {
+                (me.during)();
+            }
+            match nth == me.fail_at {
+                true => anyhow::bail!("`{}` exited with 1", argv.join(" ")),
+                false => Ok(()),
+            }
+        })
+    }
+
+    fn ran(&self) -> Vec<Vec<String>> {
+        self.ran
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+}
+
+/// The machine an update runs against in these tests.
+struct Fixture {
+    _dir: tempfile::TempDir,
+    agents_dir: std::path::PathBuf,
+    config_path: std::path::PathBuf,
+    recorder: Recorder,
+    jobs: UpdateJobs,
+    events: broadcast::Sender<ServerEvent>,
+    rx: broadcast::Receiver<ServerEvent>,
+}
+
+impl Fixture {
+    /// A fixture whose plan detects the given install method, with the config
+    /// text written as given.
+    fn new(exe: std::path::PathBuf, config: &str, fail_at: usize) -> Self {
+        Self::with_side_effect(exe, config, fail_at, Arc::new(|| {}))
+    }
+
+    /// [`Self::new`], with something for the runner to do to the filesystem
+    /// while the binary step is "running".
+    fn with_side_effect(
+        exe: std::path::PathBuf,
+        config: &str,
+        fail_at: usize,
+        during: Arc<dyn Fn() + Send + Sync>,
+    ) -> Self {
+        let dir = tempfile::tempdir().expect("a temp dir");
+        let agents_dir = dir.path().join("agents");
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, config).expect("the temp config writes");
+        let recorder = Recorder {
+            fail_at,
+            during,
+            ..Recorder::default()
+        };
+        let (env_agents, env_config, runner) =
+            (agents_dir.clone(), config_path.clone(), recorder.runner());
+        let jobs = UpdateJobs::with_env(Arc::new(move || UpdateEnv {
+            exe: exe.clone(),
+            agents_dir: env_agents.clone(),
+            config_path: env_config.clone(),
+            ..UpdateEnv::for_applying(Arc::clone(&runner))
+        }));
+        let (events, rx) = broadcast::channel(256);
+        Self {
+            _dir: dir,
+            agents_dir,
+            config_path,
+            recorder,
+            jobs,
+            events,
+            rx,
+        }
+    }
+
+    /// A fixture whose binary step is a `Run`, because the exe sits in a Scoop
+    /// layout. Scoop rather than Homebrew so the same path detects the same way
+    /// on every runner: `detect` asks the real `brew --prefix` for the Homebrew
+    /// arms, and a temp path is not under it on a machine that has one either.
+    fn runnable(config: &str, fail_at: usize) -> Self {
+        Self::new(
+            std::path::PathBuf::from("/opt/scoop/apps/leviath/current/lev.exe"),
+            config,
+            fail_at,
+        )
+    }
+
+    /// A fixture whose binary step is `Advise`, because nothing claims the path.
+    fn advising(config: &str) -> Self {
+        Self::new(std::path::PathBuf::from("/nowhere/at/all/lev"), config, 0)
+    }
+
+    /// Run one apply to completion, on this thread.
+    fn apply(&self, req: ApplyRequest) -> UpdateJob {
+        let id = self.jobs.start().expect("nothing else is running");
+        self.jobs.apply(&id, req, &self.events);
+        self.jobs.get(&id).expect("the job it just ran")
+    }
+
+    /// Every frame sent so far.
+    fn frames(&mut self) -> Vec<ServerEvent> {
+        let mut out = Vec::new();
+        while let Ok(event) = self.rx.try_recv() {
+            out.push(event);
+        }
+        out
+    }
+}
+
+/// One step out of a finished job.
+fn step<'a>(job: &'a UpdateJob, name: &str) -> &'a UpdateStep {
+    job.steps
+        .iter()
+        .find(|step| step.step == name)
+        .expect("every job carries all three steps")
+}
+
+// ─── The request body ─────────────────────────────────────────────────────────
+
+/// An empty body is "do everything", because that is the ordinary request and
+/// making a console send `{}` to say it would be ceremony.
+#[test]
+fn an_empty_body_asks_for_the_whole_plan() {
+    assert_eq!(
+        parse_request(b"").expect("empty is fine"),
+        ApplyRequest {
+            binary: true,
+            agents: true,
+            migrations: true,
+        }
+    );
+    assert_eq!(
+        parse_request(b"  \n\t ").expect("whitespace is empty"),
+        ApplyRequest::default()
+    );
+}
+
+/// A body that names some parts leaves the rest on, which is what makes the
+/// three fields a console's checkboxes rather than an all-or-nothing switch.
+#[test]
+fn a_partial_body_leaves_the_parts_it_does_not_name_alone() {
+    let req = parse_request(br#"{"binary": false}"#).expect("valid JSON");
+    assert!(!req.binary);
+    assert!(req.agents);
+    assert!(req.migrations);
+}
+
+/// A misspelled field is refused rather than silently running the default.
+/// `{"agent": false}` is somebody asking for something this route did not do.
+#[test]
+fn a_body_with_a_field_this_route_does_not_know_is_refused() {
+    let e = parse_request(br#"{"agent": false}"#).expect_err("unknown fields are refused");
+    assert!(e.contains("could not read the request body"), "{e}");
+    assert!(parse_request(b"not json at all").is_err());
+}
+
+// ─── The binary step ──────────────────────────────────────────────────────────
+
+/// The commands the plan named are the commands that ran, in order, and the
+/// job says a restart is needed afterwards.
+#[test]
+fn a_runnable_binary_step_runs_the_planned_commands_in_order() {
+    let fixture = Fixture::runnable("", 0);
+    let job = fixture.apply(ApplyRequest {
+        binary: true,
+        agents: false,
+        migrations: false,
+    });
+
+    let planned = match binary_step(&InstallMethod::Scoop {
+        package: "leviath".to_string(),
+    }) {
+        BinaryStep::Run(commands) => commands,
+        BinaryStep::Advise(text) => unreachable!("a scoop path plans commands, not {text}"),
+    };
+    assert_eq!(fixture.recorder.ran(), planned);
+    assert_eq!(step(&job, "binary").status, DONE);
+    assert_eq!(job.status, COMPLETE);
+    assert!(job.restart_required);
+    assert!(
+        job.restart_hint
+            .as_deref()
+            .is_some_and(|hint| hint.contains("still running the old one")),
+        "{:?}",
+        job.restart_hint
+    );
+    assert!(job.finished_at.is_some());
+}
+
+/// Advice stays advice. A `cargo install` copy - or a binary nowhere an
+/// installer writes - is the reader's to rebuild, and this route says so with
+/// the plan's own sentence rather than starting a compile nobody asked for.
+#[test]
+fn an_advising_binary_step_says_so_and_runs_nothing() {
+    let fixture = Fixture::advising("");
+    let job = fixture.apply(ApplyRequest::default());
+
+    assert!(fixture.recorder.ran().is_empty());
+    let binary = step(&job, "binary");
+    assert_eq!(binary.status, ADVISED);
+    assert!(
+        binary.detail.contains("not where any installer"),
+        "{binary:?}"
+    );
+    // Advice is neither success nor failure, so the job as a whole completed -
+    // and the steps after it still ran.
+    assert_eq!(job.status, COMPLETE);
+    assert!(!job.restart_required);
+    assert_eq!(job.restart_hint, None);
+    assert_ne!(step(&job, "agents").status, SKIPPED);
+}
+
+/// A binary step that fails stops the two after it, the same way `lev update`
+/// stops there: the blueprints worth installing are the ones the *new* binary
+/// ships.
+#[test]
+fn a_failed_binary_step_stops_the_steps_after_it() {
+    let fixture = Fixture::runnable("", 1);
+    let job = fixture.apply(ApplyRequest::default());
+
+    assert_eq!(fixture.recorder.ran().len(), 1, "it stopped at the failure");
+    let binary = step(&job, "binary");
+    assert_eq!(binary.status, FAILED);
+    assert!(binary.detail.contains("exited with 1"), "{binary:?}");
+    for later in ["agents", "migrations"] {
+        assert_eq!(step(&job, later).status, SKIPPED);
+        assert!(
+            step(&job, later).detail.contains("the binary step failed"),
+            "{:?}",
+            step(&job, later)
+        );
+    }
+    assert_eq!(job.status, FAILED);
+    assert!(!job.restart_required, "nothing was installed");
+    // The blueprints the failed run did not install are still absent.
+    assert!(!fixture.agents_dir.exists());
+}
+
+/// The second command failing is still a failure, which is the whole reason the
+/// step is a sequence: a `scoop update` that worked and a `scoop update leviath`
+/// that did not is not an update.
+#[test]
+fn a_failure_part_way_through_the_sequence_fails_the_step() {
+    let fixture = Fixture::runnable("", 2);
+    let job = fixture.apply(ApplyRequest {
+        binary: true,
+        agents: false,
+        migrations: false,
+    });
+    assert_eq!(fixture.recorder.ran().len(), 2);
+    assert_eq!(step(&job, "binary").status, FAILED);
+    assert!(!job.restart_required);
+}
+
+// ─── What the request asked for ───────────────────────────────────────────────
+
+/// A part the caller turned off is skipped and says why, rather than being
+/// absent from the record: a console renders the same three rows every time.
+#[test]
+fn a_step_the_request_turned_off_is_skipped_and_says_so() {
+    let fixture = Fixture::runnable("", 0);
+    let job = fixture.apply(ApplyRequest {
+        binary: false,
+        agents: false,
+        migrations: false,
+    });
+
+    assert!(fixture.recorder.ran().is_empty());
+    assert_eq!(job.steps.len(), 3);
+    for name in STEPS {
+        assert_eq!(step(&job, name).status, SKIPPED);
+        assert_eq!(step(&job, name).detail, "not asked for");
+    }
+    assert_eq!(job.status, COMPLETE);
+    assert!(!job.restart_required);
+}
+
+// ─── The blueprints ───────────────────────────────────────────────────────────
+
+/// An empty agents directory is every bundled blueprint waiting to be
+/// installed, and they land where the environment says.
+#[test]
+fn the_agents_step_installs_the_blueprints_the_plan_preselects() {
+    let fixture = Fixture::advising("");
+    let job = fixture.apply(ApplyRequest {
+        binary: false,
+        agents: true,
+        migrations: false,
+    });
+
+    let agents = step(&job, "agents");
+    assert_eq!(agents.status, DONE, "{agents:?}");
+    assert!(agents.detail.starts_with("installed "), "{agents:?}");
+    // Assert over what was discovered rather than over a list of names: the
+    // bundled set changes, and a test that enumerated it would only ever be a
+    // second copy of the list.
+    let installed: Vec<_> = std::fs::read_dir(&fixture.agents_dir)
+        .expect("the agents dir was created")
+        .map(|e| e.expect("a readable entry").file_name())
+        .collect();
+    assert!(!installed.is_empty());
+    for entry in &installed {
+        assert!(
+            agents.detail.contains(&entry.to_string_lossy().to_string()),
+            "{agents:?} does not name {entry:?}"
+        );
+    }
+}
+
+/// Run twice and the second time has nothing to do - which is a skip, not a
+/// failure, and not a silent success either.
+#[test]
+fn an_agents_step_with_nothing_to_install_skips() {
+    let fixture = Fixture::advising("");
+    let only_agents = ApplyRequest {
+        binary: false,
+        agents: true,
+        migrations: false,
+    };
+    fixture.apply(only_agents);
+    let job = fixture.apply(only_agents);
+
+    let agents = step(&job, "agents");
+    assert_eq!(agents.status, SKIPPED);
+    assert_eq!(agents.detail, "every bundled blueprint is up to date");
+    assert_eq!(job.status, COMPLETE);
+}
+
+/// A blueprint the user edited is left alone and named as left alone.
+///
+/// `install_bundled` removes the destination directory first, so installing
+/// over an edited copy takes the edits and any file they added with them. `lev
+/// update` asks about each one on its own and no flag covers it; there is
+/// nobody to ask over HTTP, so the answer is no.
+#[test]
+fn an_edited_blueprint_is_left_alone_and_the_step_says_why() {
+    let fixture = Fixture::advising("");
+    let only_agents = ApplyRequest {
+        binary: false,
+        agents: true,
+        migrations: false,
+    };
+    fixture.apply(only_agents);
+
+    // Edit one of whatever was installed, without naming it.
+    let edited = std::fs::read_dir(&fixture.agents_dir)
+        .expect("the agents dir exists")
+        .next()
+        .expect("at least one blueprint was installed")
+        .expect("a readable entry")
+        .path();
+    let marker = edited.join("agent.leviath");
+    let original = std::fs::read_to_string(&marker).expect("a bundled blueprint has a manifest");
+    std::fs::write(&marker, format!("{original}\n# mine\n")).expect("the edit writes");
+
+    let job = fixture.apply(only_agents);
+    let agents = step(&job, "agents");
+    assert_eq!(agents.status, SKIPPED, "{agents:?}");
+    assert_eq!(
+        agents.detail,
+        "1 left alone because you edited them - installing removes the \
+         directory first, so that is yours to do"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&marker).expect("still readable"),
+        format!("{original}\n# mine\n"),
+        "the edit survived"
+    );
+}
+
+/// An install that cannot be written is reported and does not stop the run -
+/// the same reason `lev setup` treats it as a warning. Most of the blueprints
+/// plus a named failure beats a step that gave up in the middle.
+#[test]
+fn an_install_that_fails_is_named_and_the_run_carries_on() {
+    let fixture = Fixture::advising("");
+    // A file where the agents directory should be: every install fails, and
+    // nothing about the failure is this test's to arrange per blueprint.
+    std::fs::write(&fixture.agents_dir, "not a directory").expect("the blocker writes");
+
+    let job = fixture.apply(ApplyRequest {
+        binary: false,
+        agents: true,
+        migrations: false,
+    });
+    let agents = step(&job, "agents");
+    assert_eq!(agents.status, FAILED, "{agents:?}");
+    assert!(agents.detail.contains("could not install"), "{agents:?}");
+    assert_eq!(job.status, FAILED);
+    // The step after it still ran.
+    assert_ne!(step(&job, "migrations").status, PENDING);
+}
+
+// ─── The config ───────────────────────────────────────────────────────────────
+
+/// A config with a migration due is migrated, and the step names what changed.
+#[test]
+fn the_migrations_step_applies_what_the_plan_found_and_writes_it() {
+    // `serves = []` is what the one shipped migration removes. Written through
+    // the real config path so the plan reads it the way production does.
+    let fixture = Fixture::advising(
+        "[model_providers.demo]\nbase_url = \"https://example.invalid\"\nserves = []\n",
+    );
+    assert!(!MIGRATIONS.is_empty(), "this test needs one to apply");
+
+    let job = fixture.apply(ApplyRequest {
+        binary: false,
+        agents: false,
+        migrations: true,
+    });
+    let migrations = step(&job, "migrations");
+    assert_eq!(migrations.status, DONE, "{migrations:?}");
+    assert!(
+        migrations.detail.contains("stale-empty-serves"),
+        "{migrations:?}"
+    );
+    let written = std::fs::read_to_string(&fixture.config_path).expect("the config was rewritten");
+    assert!(!written.contains("serves"), "{written}");
+}
+
+/// A config with nothing due is a skip, so a console does not report a write
+/// that never happened.
+#[test]
+fn a_config_with_nothing_to_migrate_skips() {
+    let fixture = Fixture::advising("");
+    let job = fixture.apply(ApplyRequest {
+        binary: false,
+        agents: false,
+        migrations: true,
+    });
+    let migrations = step(&job, "migrations");
+    assert_eq!(migrations.status, SKIPPED);
+    assert_eq!(migrations.detail, "nothing to migrate");
+}
+
+/// A config that will not parse is left alone and said so, rather than
+/// overwritten with the defaults - which is what "migrate" would otherwise mean
+/// for a file nothing could read.
+#[test]
+fn a_config_that_will_not_parse_is_left_exactly_as_it_is() {
+    let fixture = Fixture::advising("this is not [ toml");
+    let job = fixture.apply(ApplyRequest {
+        binary: false,
+        agents: false,
+        migrations: true,
+    });
+    let migrations = step(&job, "migrations");
+    assert_eq!(migrations.status, SKIPPED);
+    assert!(
+        migrations.detail.contains("could not be read"),
+        "{migrations:?}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&fixture.config_path).expect("still there"),
+        "this is not [ toml"
+    );
+}
+
+/// A save that cannot land fails the step rather than reporting a write that
+/// did not happen.
+///
+/// The config is read when the plan is built and written a minute later, after
+/// a package manager has had its turn - so "it read fine and then would not
+/// save" is a real interval, not a contrived one. Here the directory holding it
+/// is replaced by a file while the binary step runs.
+#[test]
+fn a_config_that_cannot_be_written_fails_the_step() {
+    let dir = tempfile::tempdir().expect("a temp dir");
+    let home = dir.path().join("home");
+    std::fs::create_dir(&home).expect("the config dir is a directory to begin with");
+    let config_path = home.join("config.toml");
+    let during = {
+        let home = home.clone();
+        Arc::new(move || {
+            std::fs::remove_dir_all(&home).expect("the directory goes");
+            std::fs::write(&home, "a file where the directory was")
+                .expect("a file takes its place");
+        })
+    };
+    let fixture = Fixture::with_side_effect(
+        std::path::PathBuf::from("/opt/scoop/apps/leviath/current/lev.exe"),
+        "",
+        0,
+        during,
+    );
+    // The config the plan reads is the one about to become unwritable.
+    std::fs::write(
+        &config_path,
+        "[model_providers.demo]\nbase_url = \"https://example.invalid\"\nserves = []\n",
+    )
+    .expect("the config writes");
+    let jobs = UpdateJobs::with_env({
+        let (agents, runner, config_path) = (
+            fixture.agents_dir.clone(),
+            fixture.recorder.runner(),
+            config_path.clone(),
+        );
+        Arc::new(move || UpdateEnv {
+            exe: std::path::PathBuf::from("/opt/scoop/apps/leviath/current/lev.exe"),
+            agents_dir: agents.clone(),
+            config_path: config_path.clone(),
+            ..UpdateEnv::for_applying(Arc::clone(&runner))
+        })
+    });
+    let id = jobs.start().expect("nothing else is running");
+    jobs.apply(
+        &id,
+        ApplyRequest {
+            binary: true,
+            agents: false,
+            migrations: true,
+        },
+        &fixture.events,
+    );
+    let job = jobs.get(&id).expect("the job it just ran");
+
+    assert_eq!(
+        step(&job, "binary").status,
+        DONE,
+        "the upgrade itself worked"
+    );
+    let migrations = step(&job, "migrations");
+    assert_eq!(migrations.status, FAILED, "{migrations:?}");
+    assert!(!migrations.detail.is_empty(), "the failure says something");
+    assert_eq!(job.status, FAILED);
+    // A failed migration is not a reason to say the new binary is not there.
+    assert!(job.restart_required);
+}
+
+// ─── The frames ───────────────────────────────────────────────────────────────
+
+/// Every step change goes out as it happens, and the last frame carries the
+/// whole record - which is what a console that connected mid-run reads.
+#[tokio::test]
+async fn every_step_is_announced_and_the_last_frame_carries_the_record() {
+    let mut fixture = Fixture::runnable("", 0);
+    let job = fixture.apply(ApplyRequest {
+        binary: true,
+        agents: false,
+        migrations: false,
+    });
+
+    let frames = fixture.frames();
+    let progress: Vec<_> = frames
+        .iter()
+        .filter_map(|event| match event {
+            ServerEvent::UpdateProgress {
+                job_id,
+                step,
+                status,
+                ..
+            } => Some((job_id.clone(), step.clone(), status.clone())),
+            _ => None,
+        })
+        .collect();
+    // running then done for the binary, and one each for the two skips.
+    assert_eq!(
+        progress,
+        vec![
+            (job.id.clone(), "binary".to_string(), RUNNING.to_string()),
+            (job.id.clone(), "binary".to_string(), DONE.to_string()),
+            (job.id.clone(), "agents".to_string(), SKIPPED.to_string()),
+            (
+                job.id.clone(),
+                "migrations".to_string(),
+                SKIPPED.to_string()
+            ),
+        ]
+    );
+
+    let last = frames.last().expect("a job always finishes");
+    let ServerEvent::UpdateFinished {
+        job_id,
+        status,
+        restart_required,
+        job: record,
+    } = last
+    else {
+        unreachable!("the last frame is the finish, not {last:?}")
+    };
+    assert_eq!(job_id, &job.id);
+    assert_eq!(status, COMPLETE);
+    assert!(restart_required);
+    assert_eq!(record["id"], job.id);
+    assert_eq!(record["steps"][0]["status"], DONE);
+    assert!(record["restart_hint"].is_string());
+}
+
+/// The update frames are about the machine, not about a run: `/ws` gets them
+/// and a per-run subscription does not.
+#[test]
+fn an_update_frame_belongs_to_no_run() {
+    let progress = ServerEvent::UpdateProgress {
+        job_id: "update-1-1".to_string(),
+        step: "binary".to_string(),
+        status: RUNNING.to_string(),
+        detail: "running `scoop update`".to_string(),
+    };
+    assert_eq!(progress.run_id(), "");
+    assert!(!progress.is_for_run("run-1"));
+    let finished = ServerEvent::UpdateFinished {
+        job_id: "update-1-1".to_string(),
+        status: COMPLETE.to_string(),
+        restart_required: false,
+        job: serde_json::json!({}),
+    };
+    assert_eq!(finished.run_id(), "");
+    assert!(!finished.is_for_run("run-1"));
+    let json = serde_json::to_value(&finished).expect("a frame serializes");
+    assert_eq!(json["type"], "update_finished");
+}
+
+// ─── The store ────────────────────────────────────────────────────────────────
+
+/// One update at a time. The second request is told which one is going rather
+/// than starting a second package-manager upgrade of the same binary.
+#[test]
+fn a_second_update_is_refused_while_one_is_running() {
+    let fixture = Fixture::runnable("", 0);
+    let first = fixture.jobs.start().expect("the first starts");
+    let refused = fixture.jobs.start().expect_err("the second is refused");
+    assert_eq!(refused, first);
+    // Once it finishes, another may start.
+    fixture.jobs.finish(&first, false, &fixture.events);
+    let second = fixture.jobs.start().expect("the next one starts");
+    assert_ne!(second, first);
+}
+
+/// Ids are distinct even within one second, which is the case a wall clock
+/// alone gets wrong.
+#[test]
+fn two_jobs_started_in_the_same_second_get_different_ids() {
+    let fixture = Fixture::runnable("", 0);
+    let mut ids = Vec::new();
+    for _ in 0..3 {
+        let id = fixture.jobs.start().expect("nothing is running");
+        fixture.jobs.finish(&id, false, &fixture.events);
+        ids.push(id);
+    }
+    let unique: std::collections::HashSet<_> = ids.iter().collect();
+    assert_eq!(unique.len(), ids.len(), "{ids:?}");
+}
+
+/// The history is bounded, and it is the oldest that goes.
+#[test]
+fn the_job_history_is_capped_and_drops_the_oldest_first() {
+    let fixture = Fixture::runnable("", 0);
+    let mut ids = Vec::new();
+    for _ in 0..KEEP_JOBS + 2 {
+        let id = fixture.jobs.start().expect("nothing is running");
+        fixture.jobs.finish(&id, false, &fixture.events);
+        ids.push(id);
+    }
+    let kept = fixture.jobs.all();
+    assert_eq!(kept.len(), KEEP_JOBS);
+    assert!(fixture.jobs.get(&ids[0]).is_none(), "the oldest aged out");
+    assert!(
+        fixture
+            .jobs
+            .get(ids.last().expect("there are ids"))
+            .is_some(),
+        "the newest is kept"
+    );
+}
+
+/// An id nobody minted has no job, which is what the poll route turns into a
+/// 404.
+#[test]
+fn an_unknown_job_id_is_not_found() {
+    let fixture = Fixture::runnable("", 0);
+    assert!(fixture.jobs.get("update-never-1").is_none());
+}
+
+/// A job that aged out from under its own running task is left alone rather
+/// than re-inserted: it went because newer ones arrived, and putting a stale
+/// record back would be worse than losing it.
+#[test]
+fn a_job_that_aged_out_is_not_resurrected_by_its_own_task() {
+    let fixture = Fixture::runnable("", 0);
+    fixture.jobs.step(
+        "update-gone-1",
+        STEPS[0],
+        DONE,
+        "x".to_string(),
+        &fixture.events,
+    );
+    fixture.jobs.finish("update-gone-1", true, &fixture.events);
+    assert!(fixture.jobs.all().is_empty());
+}
+
+/// A step name that is not one of the three changes nothing. Unreachable from
+/// the route, which only ever passes [`STEPS`]; asserted so the guard cannot be
+/// removed as dead.
+#[test]
+fn a_step_name_the_job_does_not_carry_changes_nothing() {
+    let fixture = Fixture::runnable("", 0);
+    let id = fixture.jobs.start().expect("nothing is running");
+    fixture
+        .jobs
+        .step(&id, "not-a-step", DONE, "x".to_string(), &fixture.events);
+    let job = fixture.jobs.get(&id).expect("still there");
+    assert!(job.steps.iter().all(|step| step.status == PENDING));
+}
+
+/// `spawn` hands back an id straight away and the work happens behind it. That
+/// is the whole reason the route answers `202`.
+#[tokio::test]
+async fn spawn_answers_with_an_id_and_runs_the_work_behind_it() {
+    let mut fixture = Fixture::runnable("", 0);
+    let id = fixture
+        .jobs
+        .spawn(
+            ApplyRequest {
+                binary: true,
+                agents: false,
+                migrations: false,
+            },
+            &fixture.events,
+        )
+        .expect("nothing else is running");
+    // The record exists the moment the route answers, whether or not the work
+    // behind it has got anywhere yet - which is what a console polls.
+    assert!(
+        fixture.jobs.get(&id).is_some(),
+        "recorded before it is done"
+    );
+    let finished = loop {
+        match fixture.rx.recv().await.expect("the sender is alive") {
+            ServerEvent::UpdateFinished { job_id, status, .. } => break (job_id, status),
+            _ => continue,
+        }
+    };
+    assert_eq!(finished, (id.clone(), COMPLETE.to_string()));
+    assert_eq!(fixture.jobs.get(&id).expect("still there").status, COMPLETE);
+    assert_eq!(fixture.recorder.ran().len(), 2, "both planned commands ran");
+}
+
+/// A store built without a runner refuses to run anything, loudly. A no-op
+/// default would let such a server report a successful update that ran nothing.
+#[tokio::test]
+async fn the_default_store_cannot_run_an_upgrade_command() {
+    let jobs = UpdateJobs::default();
+    assert!(format!("{jobs:?}").contains("UpdateJobs"));
+    let env = (jobs.env)();
+    let e = (env.runner)(&["scoop".to_string()]).expect_err("it refuses");
+    assert!(e.to_string().contains("without a way to run"), "{e}");
+}
+
+/// The channel a plan-less caller names still reaches the planner: asserted so
+/// the fixture's Scoop path is the method it claims to be, rather than a path
+/// that happens to detect as something else on some runner.
+#[test]
+fn the_fixture_path_detects_as_the_method_its_test_assumes() {
+    let method = crate::commands::update::detect(
+        std::path::Path::new("/opt/scoop/apps/leviath/current/lev.exe"),
+        None,
+        None,
+        Some(Channel::Stable),
+    );
+    assert_eq!(method.id(), "scoop");
+    let nowhere = crate::commands::update::detect(
+        std::path::Path::new("/nowhere/at/all/lev"),
+        None,
+        None,
+        None,
+    );
+    assert_eq!(nowhere.id(), "unknown");
+}

--- a/crates/leviath-cli/src/commands/serve/websocket.rs
+++ b/crates/leviath-cli/src/commands/serve/websocket.rs
@@ -219,6 +219,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -665,6 +666,7 @@ mod tests {
         let (tx, _) = broadcast::channel(64);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: daemon.client.clone(),
@@ -826,6 +828,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(2);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx.clone(),
             control: crate::commands::serve::testutil::no_daemon_client(),
@@ -954,6 +957,7 @@ mod tests {
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         let state = AppState {
             update_check: Default::default(),
+            update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx.clone(),
             control: crate::commands::serve::testutil::no_daemon_client(),

--- a/crates/leviath-cli/src/commands/update.rs
+++ b/crates/leviath-cli/src/commands/update.rs
@@ -724,6 +724,50 @@ pub struct UpdateArgs {
 /// `SeedCommandRunner` seams.
 pub type CommandRunner = Arc<dyn Fn(&[String]) -> anyhow::Result<()> + Send + Sync>;
 
+/// What to make of an upgrade command a caller ran with its output captured
+/// rather than letting it draw on a terminal.
+///
+/// `lev update` hands the package manager the terminal it inherited, because a
+/// progress bar is most of what makes the wait bearable. `POST /api/update` has
+/// no terminal to hand over and a console on the other end of a socket, so the
+/// command is run captured and whatever it printed is the only evidence of
+/// *why* that ever reaches the person who pressed the button.
+///
+/// Split from the spawn so the decision is testable: the spawn itself lives in
+/// the binary's composition root, beside the terminal-inheriting one.
+pub fn captured_outcome(
+    argv: &[String],
+    output: std::io::Result<std::process::Output>,
+) -> anyhow::Result<()> {
+    let shown = argv.join(" ");
+    let output = output.map_err(|e| anyhow::anyhow!("could not run `{shown}`: {e}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    // stderr first, then stdout: a package manager that failed usually says so
+    // on stderr, but `sh -c "curl ... | sh"` is a pipeline whose useful last
+    // word can land on either. The exit status alone is the last resort - it
+    // names no cause, and "exited with 1" is what sent people to run the
+    // command by hand to find out.
+    match last_line(&output.stderr).or_else(|| last_line(&output.stdout)) {
+        Some(line) => anyhow::bail!("`{shown}` failed: {line}"),
+        None => anyhow::bail!("`{shown}` exited with {} and said nothing", output.status),
+    }
+}
+
+/// The last line of captured output with anything on it.
+///
+/// The last rather than the first: a build log's opening lines are the tool
+/// announcing itself, and the sentence that explains the failure is at the
+/// bottom.
+fn last_line(bytes: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .map(|line| line.trim().to_string())
+}
+
 /// Asks the user a yes/no question. Injected for the same reason: a unit test
 /// has no terminal, and which questions a flag answers on the user's behalf -
 /// and, for a blueprint they edited, which ones no flag answers - is something
@@ -791,6 +835,27 @@ impl UpdateEnv {
         Self {
             latest: std::sync::Arc::new(decline_update_check),
             ..Self::for_planning()
+        }
+    }
+
+    /// The real machine, wired for a caller that will carry the plan out but
+    /// will never stop to ask a question.
+    ///
+    /// `POST /api/update` is the caller: the request body is the consent, so
+    /// there is nobody to prompt and no terminal to prompt on. `confirm` is a
+    /// refusal rather than a yes for the same reason [`Self::for_planning`]
+    /// carries refusals - the executing paths that ask are the ones this caller
+    /// must not reach, and a `true` here would make reaching one look like
+    /// permission.
+    ///
+    /// The update check is off: the route answers "is there anything newer"
+    /// from its own cache, and an apply that blocked on a release feed would
+    /// turn a step that runs a package manager into one that first waits on
+    /// GitHub.
+    pub fn for_applying(runner: CommandRunner) -> Self {
+        Self {
+            latest: std::sync::Arc::new(decline_update_check),
+            ..Self::real(runner, std::sync::Arc::new(say_no))
         }
     }
 

--- a/crates/leviath-cli/src/commands/update/tests.rs
+++ b/crates/leviath-cli/src/commands/update/tests.rs
@@ -1683,3 +1683,125 @@ fn the_stale_serves_migration_does_not_apply_to_a_clean_config() {
         &config, &raw
     ));
 }
+
+// ─── Running a command with its output captured ───────────────────────────────
+
+/// An `ExitStatus` that did or did not succeed.
+///
+/// Borrowed from a real spawn of the test binary for the same reason
+/// [`output_with`] does it: `ExitStatus` cannot be constructed portably, and a
+/// `#[cfg(unix)]` construction would leave the Windows build with an untested
+/// arm. Listing no tests succeeds; a flag libtest does not know does not.
+fn spawned_status(succeeds: bool) -> std::process::ExitStatus {
+    let mut command = std::process::Command::new(std::env::current_exe().expect("the test binary"));
+    match succeeds {
+        true => command.arg("--list").arg("a_filter_that_matches_nothing"),
+        false => command.arg("--a-flag-libtest-does-not-know"),
+    };
+    command
+        .output()
+        .expect("spawning the test binary to borrow an ExitStatus")
+        .status
+}
+
+/// An `Output` with the given streams and a status that did or did not succeed.
+fn captured(succeeds: bool, stdout: &str, stderr: &str) -> std::io::Result<std::process::Output> {
+    Ok(std::process::Output {
+        status: spawned_status(succeeds),
+        stdout: stdout.as_bytes().to_vec(),
+        stderr: stderr.as_bytes().to_vec(),
+    })
+}
+
+/// A command that worked is a plain `Ok`, whatever it printed.
+#[test]
+fn a_captured_command_that_succeeded_is_a_success() {
+    let argv = vec!["scoop".to_string(), "update".to_string()];
+    assert!(captured_outcome(&argv, captured(true, "noise", "warnings")).is_ok());
+}
+
+/// The failure a console shows is the command's own last word, because "exited
+/// with 1" is what sent people to run it by hand to find out.
+#[test]
+fn a_captured_failure_carries_the_last_thing_the_command_said() {
+    let argv = vec![
+        "scoop".to_string(),
+        "update".to_string(),
+        "leviath".to_string(),
+    ];
+
+    let stderr = captured_outcome(&argv, captured(false, "", "warming up\nno such bucket\n"))
+        .expect_err("it failed");
+    assert_eq!(
+        stderr.to_string(),
+        "`scoop update leviath` failed: no such bucket"
+    );
+
+    // stdout is read when stderr said nothing: a `sh -c "curl ... | sh"` is a
+    // pipeline whose useful last word can land on either.
+    let stdout = captured_outcome(&argv, captured(false, "step 1\ncould not fetch\n", "  \n"))
+        .expect_err("it failed");
+    assert!(
+        stdout.to_string().ends_with("failed: could not fetch"),
+        "{stdout}"
+    );
+
+    // Nothing on either stream still names the command, since the exit status
+    // alone is not something to hand a reader on its own.
+    let silent = captured_outcome(&argv, captured(false, "", "")).expect_err("it failed");
+    assert!(
+        silent.to_string().contains("scoop update leviath"),
+        "{silent}"
+    );
+    assert!(silent.to_string().contains("said nothing"), "{silent}");
+}
+
+/// A command that could not be spawned at all names itself, so "scoop is not
+/// installed" does not read as "scoop failed".
+#[test]
+fn a_command_that_could_not_be_spawned_says_which_one() {
+    let argv = vec!["scoop".to_string(), "update".to_string()];
+    let e = captured_outcome(
+        &argv,
+        Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "not found",
+        )),
+    )
+    .expect_err("it did not run");
+    assert!(
+        e.to_string().starts_with("could not run `scoop update`"),
+        "{e}"
+    );
+}
+
+/// The environment the API applies an update through: a real machine, the
+/// caller's runner, and nothing that asks a question or reaches the network.
+///
+/// The refusals matter. `POST /api/update` never prompts - the request body was
+/// the consent - so a `confirm` that answered yes would make an executing path
+/// that stopped to ask look like permission, and the update check belongs to
+/// the route's own cache rather than to a step that runs a package manager.
+#[test]
+fn the_applying_environment_asks_nothing_and_checks_nothing() {
+    let ran = Arc::new(Mutex::new(Vec::new()));
+    let env = UpdateEnv::for_applying({
+        let ran = Arc::clone(&ran);
+        Arc::new(move |argv: &[String]| {
+            ran.lock().expect("not poisoned").push(argv.to_vec());
+            Ok(())
+        })
+    });
+
+    (env.runner)(&["scoop".to_string()]).expect("the caller's runner is the one that runs");
+    assert_eq!(
+        *ran.lock().expect("not poisoned"),
+        vec![vec!["scoop".to_string()]]
+    );
+    assert!(!(env.confirm)("anything?"), "nothing is agreed to");
+    assert!(
+        (env.latest)("https://example.invalid").is_err(),
+        "nothing is looked up"
+    );
+    assert_eq!(env.migrations.len(), MIGRATIONS.len());
+}

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -145,7 +145,12 @@ impl RiskyExecutors for RealExecutors {
         // The HTTP API is a gateway to the shared-world daemon: ensure it's
         // running, then serve, routing agent actions through its control socket.
         ensure_daemon_running().await?;
-        commands::serve::execute(args, long_lived_control_client()?).await
+        commands::serve::execute(
+            args,
+            long_lived_control_client()?,
+            std::sync::Arc::new(run_upgrade_captured),
+        )
+        .await
     }
 
     async fn agent_client(
@@ -261,6 +266,25 @@ fn run_upgrade(argv: &[String]) -> anyhow::Result<()> {
         true => Ok(()),
         false => anyhow::bail!("`{}` exited with {status}", argv.join(" ")),
     }
+}
+
+/// Run an upgrade command for `POST /api/update`.
+///
+/// The opposite of [`run_upgrade`] in all three ways that matter: there is no
+/// terminal for a package manager to draw on, no stdin for it to block the
+/// server on waiting for an answer nobody will type, and the console that
+/// pressed the button only ever sees what this function puts in the error - so
+/// the output is captured and [`commands::update::captured_outcome`], which is
+/// where the judgement lives, folds it in.
+fn run_upgrade_captured(argv: &[String]) -> anyhow::Result<()> {
+    let Some((program, rest)) = argv.split_first() else {
+        anyhow::bail!("no upgrade command to run");
+    };
+    let output = leviath_sys::child_command(program)
+        .args(rest)
+        .stdin(std::process::Stdio::null())
+        .output();
+    commands::update::captured_outcome(argv, output)
 }
 
 /// Ask a yes/no question on the real terminal.

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -47,6 +47,7 @@ a test, so a client generator or an agent can consume the contract directly.
   | `PUT /api/config` | 405, because `GET /api/config` is mounted |
   | `POST /api/mcp/servers` | 405, because `GET /api/mcp/servers` is mounted |
   | `DELETE /api/mcp/servers/{name}` | 404, because nothing else is mounted on that path |
+  | `POST /api/update` | 405, because `GET /api/update` is mounted |
 - **`--workdir-root`** confines agent workdirs; **`--no-remote-yolo`** forbids `"yolo": true` and
   `"allow": [...]` on spawn, which are one lever rather than two.
 
@@ -179,6 +180,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
 | `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
 | `GET /api/update` | Whether anything newer exists, how this copy was installed, and the command that upgrades it. See [below](#asking-how-to-upgrade) |
+| `POST /api/update` *(admin)* · `GET /api/update/jobs/{id}` | Carry that plan out, and read where it got to. See [below](#pressing-the-button) |
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
 | `POST /api/fs/dirs` | Make one directory: `{"path": "<absolute parent>", "name": "<one segment>"}` → `201 {"path", "parent"}`. The same fence as the `GET`; `409` if it already exists. Announced as `fs.mkdir` |
 | `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
@@ -678,6 +680,98 @@ The route is read-only and available without `--allow-admin`. It works out what 
 do and does none of it, makes no network call on the request path, and cannot run a command even
 if asked.
 
+## Pressing the button
+
+`POST /api/update` carries out the plan the `GET` prints: it runs `binary.commands` in order,
+installs the blueprints the plan marks `preselected`, and applies the migrations. It needs
+`lev serve --allow-admin`, which is the line it crosses and the read half does not - it runs a
+package manager, replaces the blueprints in your agents directory and rewrites your config.
+
+The body names which parts to do. Every field defaults to `true`, so an empty body is the whole
+plan and a body naming one part leaves the others on. A field this route does not know is a `400`
+rather than a silent default:
+
+```json
+{ "binary": true, "agents": true, "migrations": false }
+```
+
+It answers `202` straight away, with the id to watch:
+
+```json
+{
+  "job_id": "update-1787438706-1",
+  "status": "running",
+  "applying": { "binary": true, "agents": true, "migrations": false }
+}
+```
+
+An upgrade is a download and an install - a minute on a good day, and it can fail halfway - so the
+request does not stay open for it. Watch `/ws`, where each step change arrives as it happens:
+
+```json
+{ "type": "update_progress", "job_id": "update-1787438706-1", "step": "binary",
+  "status": "running", "detail": "running `scoop update && scoop update leviath`" }
+```
+
+`step` is `binary`, `agents` or `migrations`, always in that order, and `status` is one of
+`running`, `done`, `skipped`, `advised` or `failed`. The last frame is `update_finished`, carrying
+the whole record so a client that connected mid-run needs no follow-up request. Both frames are
+about the machine rather than a run, so `/ws` receives them and a per-run subscription does not.
+
+`GET /api/update/jobs/{id}` answers that same record, for a client that would rather poll than
+hold a socket open:
+
+```json
+{
+  "id": "update-1787438706-1",
+  "status": "complete",
+  "steps": [
+    { "step": "binary", "status": "done", "detail": "ran `scoop update && scoop update leviath`" },
+    { "step": "agents", "status": "done", "detail": "installed researcher, coder" },
+    { "step": "migrations", "status": "skipped", "detail": "not asked for" }
+  ],
+  "restart_required": true,
+  "restart_hint": "the new binary is on disk, but this server and the daemon it talks to are still running the old one...",
+  "started_at": 1787438706,
+  "finished_at": 1787438771
+}
+```
+
+The last few runs are kept, so reading back after the fact finds the job rather than a `404`.
+One update runs at a time: a second `POST` while one is going is a `409` naming the job already
+running, not a second package manager over the same binary.
+
+### What it will not do
+
+`binary.action == "advise"` stays advice. A `cargo install` copy is a full rebuild of the
+workspace, and a binary somewhere no installer writes is not something to guess at - both are
+yours to do, so the step is recorded as `advised` with the plan's own sentence and no compile is
+started. That is neither a success nor a failure: the job carries on to the other two steps and
+still finishes `complete`.
+
+A blueprint you edited locally is never installed. Installing removes the destination directory
+first, so it would take your edits and any file you added with them; `lev update` asks about each
+one on its own and no flag covers it, and there is nobody to ask over HTTP. The `agents` step says
+how many it left alone and why.
+
+A binary step that *fails* stops the two after it, the same way `lev update` stops there: the
+blueprints and the config worth having are the ones the new binary ships. A failed blueprint
+install does not - it is named in the step's detail and the run carries on, because most of the
+blueprints plus a named failure is a better place to be left than a step that gave up in the
+middle.
+
+### The restart
+
+Upgrading replaces the binary on disk. The daemon answering the request is the old one and stays
+the old one, and so does `lev serve`, until each restarts - so a console that updates and then
+reports the version it can see has told the truth in the least useful way possible.
+
+`restart_required` is `true` when the binary step actually ran and succeeded, and `restart_hint`
+carries the sentence to show. Say it; do not report the running version as the result of the
+update. Restarting `lev serve` picks up the new binary, and `lev daemon restart` does the same for
+the daemon - which any `lev` command also does on its own, since the daemon's build marker is
+checked before a run is spawned.
+
 ## Tools and scripts
 
 `GET /api/tools` answers what an agent on **this** machine can call, which is not a question a
@@ -807,6 +901,7 @@ than that feature, not broken.
 | `blueprints.fan_outs` | `fan_outs` on the detail route. See [fan-out limits](#fan-out-limits) |
 | `tools.list` | `GET /api/tools?agent=`, what an agent here can actually call |
 | `update.plan` | `GET /api/update`, how this copy was installed and the command that upgrades it. See [asking how to upgrade](#asking-how-to-upgrade) |
+| `update.apply` | `POST /api/update` and `GET /api/update/jobs/{id}`, carrying that plan out. Says this build serves them; whether *this* daemon mounts them is `--allow-admin`, which you find out by calling one. See [pressing the button](#pressing-the-button) |
 | `scripts.read` | The `GET` half of the scripts routes |
 | `scripts.write` | That this build serves the write half. Whether *this* daemon mounts it is `--allow-admin`, which you find out by calling one and reading the status |
 | `scripts.providers` | `provider` as a fifth script `kind`, the machine's drop-in model providers |

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1051,6 +1051,74 @@
             "$ref": "#/components/responses/Ok"
           }
         }
+      },
+      "post": {
+        "tags": [
+          "diagnostics"
+        ],
+        "summary": "Carry out the update the GET half describes",
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because it runs a package manager, rewrites the agents directory and rewrites the config. Answers 202 with a `job_id` and runs the work behind it: an upgrade is a download and an install, so every step change is sent on `/ws` as `update_progress`, the last as `update_finished`, and `GET /api/update/jobs/{id}` answers the same record for a client that would rather poll. The body names which parts to do - `binary`, `agents`, `migrations`, each defaulting to true, so an empty body is the whole plan. A `binary.action` of `advise` stays advice: the step is recorded as `advised` with the reason and no compile is started. A blueprint you edited locally is never installed. 409 while another update is running.",
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "binary": {
+                    "type": "boolean"
+                  },
+                  "agents": {
+                    "type": "boolean"
+                  },
+                  "migrations": {
+                    "type": "boolean"
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "409": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
+      }
+    },
+    "/api/update/jobs/{id}": {
+      "get": {
+        "tags": [
+          "diagnostics"
+        ],
+        "summary": "Where one update run got to",
+        "description": "Admin only, mounted alongside `POST /api/update`. The same record the `update_finished` frame carries: `status` of `running`, `complete` or `failed`; a `steps` list with one entry per step (`binary`, `agents`, `migrations`), each `pending`, `running`, `done`, `skipped`, `advised` or `failed` with a line of detail; and `restart_required`, set when the binary was replaced - this server and the daemon keep running the old build until they are restarted. The last few runs are kept, so a client that reads back after the fact finds the job.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "An update job id, as returned by POST /api/update."
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          }
+        }
       }
     },
     "/api/fs/dirs": {


### PR DESCRIPTION
Closes #638.

`GET /api/update` answers "am I current, and what do I type to fix it". `POST /api/update` is the half that does it.

## The route

Behind `--allow-admin`, alongside MCP admin, config write and script write - it runs a package manager, replaces the blueprints in the agents directory and rewrites the config. The read half stays open, so a console without admin still shows what to type.

It runs the plan the `GET` prints, from the same planner. The body names which parts to do:

```json
{ "binary": true, "agents": true, "migrations": false }
```

Every field defaults to `true`, so an empty body is the whole plan. A field the route does not know is a `400` rather than a silent default.

## Progress, not a hang

An upgrade is a download and an install - a minute on a good day, and it can fail halfway - so the request does not stay open for it:

```
202 { "job_id": "update-1787855700-1", "status": "running",
      "applying": { "binary": true, "agents": true, "migrations": true } }
```

Each step change goes out on `/ws` as it happens, with `update_finished` last carrying the whole record so a client that connected mid-run needs no follow-up request. `GET /api/update/jobs/{id}` answers that same record for a client that would rather poll; the last eight runs are kept. A second `POST` while one is going is a `409` naming the job already running, not a second package manager over the same binary.

## What it will not do

`binary.action == "advise"` stays advice - a `cargo install` copy is a full rebuild, a binary nowhere an installer writes is not something to guess at. Both are recorded as `advised` with the plan's own sentence and no compile is started; that is neither success nor failure, so the other two steps still run.

A blueprint you edited locally is never installed. Installing removes the destination directory first, `lev update` asks about each one on its own and no flag covers it, and there is nobody to ask over HTTP - so the step says how many it left alone and why.

## The restart

Reported, not performed. Upgrading replaces the binary on disk and both `lev serve` and the daemon keep running the old one until they restart, so a console that updated and then reported the version it can see would be telling the truth in the least useful way possible. `restart_required` and `restart_hint` say so.

Re-execing the server is the shape that makes the button mean what a reader thinks it means, and it is deliberately not here: it replaces a process mid-request and has no `exec` on Windows. That is its own change rather than a rider on this one.

## Live, against a real `lev serve --allow-admin`

Isolated `HOME`/`LEVIATH_HOME`, no API key, three runs - the advise path, a `run` path with no `scoop` on `PATH`, and a `run` path with a stub that succeeds.

The successful one:

```json
{
  "id": "update-1787855700-1",
  "status": "complete",
  "steps": [
    { "step": "binary", "status": "done", "detail": "ran `scoop update && scoop update leviath`" },
    { "step": "agents", "status": "done", "detail": "installed coder, data-analyst, deep-researcher, log-analyzer, researcher, reviewer, wide-researcher" },
    { "step": "migrations", "status": "skipped", "detail": "nothing to migrate" }
  ],
  "restart_required": true,
  "restart_hint": "the new binary is on disk, but this server and the daemon it talks to are still running the old one. Restart `lev serve` (and `lev daemon restart`) to be on the version that was just installed."
}
```

The one with no `scoop`, which is also the whole run-and-fail path through the real spawn:

```json
[
  { "step": "binary", "status": "failed", "detail": "could not run `scoop update`: No such file or directory (os error 2)" },
  { "step": "agents", "status": "skipped", "detail": "the binary step failed, so this was left alone" },
  { "step": "migrations", "status": "skipped", "detail": "the binary step failed, so this was left alone" }
]
```

Nothing was written in that case, which is the point of stopping there: the blueprints worth installing are the ones the new binary ships.

`400`, `409` and `404` were all exercised the same way, and the websocket frames arrived in order.

## Also

- `update.apply` announced in `API_CAPABILITIES`, documented in `docs/content/api.md` (a new "Pressing the button" section) and in `docs/schema/openapi.json`.
- The spawn lives in `main.rs` beside the terminal-inheriting one. `POST /api/update` has no terminal to hand a package manager and no stdin for it to block the server on, so the command runs captured and `captured_outcome` folds its last line into the error - "`scoop update leviath` failed: no such bucket" rather than "exited with 1", which is what sent people to run it by hand to find out.
- `cargo xtask coverage`: all 13 packages at 100%.
