### PR TITLE
ci(prod): give the weekly stable release a second chance to fire

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -4,12 +4,30 @@ on:
   schedule:
     # Every Thursday at 9am PST (4pm UTC)
     - cron: '0 16 * * 4'
+    # Backstop, four hours later. GitHub does not guarantee a scheduled event
+    # is ever delivered, and on 2026-08-27 it dropped the 16:00 dispatch
+    # outright (the nightly alpha ran ten hours late the same day). A weekly
+    # cron with no second chance turns one dropped event into a week with no
+    # stable release. `check-beta` already refuses to ship a version stable
+    # carries, so a redundant run is a fifteen-second no-op.
+    - cron: '0 20 * * 4'
   workflow_dispatch:
     inputs:
       force:
         description: Deploy even if the version was not bumped
         type: boolean
         default: false
+
+# Two scheduled slots plus manual dispatch means two runs can be alive at
+# once. They must not overlap: `check-beta` reads what stable currently
+# carries, so a second run that clears that gate before the first publishes
+# would deploy the same version again, and `Determine version tag` would
+# disambiguate it into a junk `vX.Y.Z+<date>` release. Queued rather than
+# cancelled, because the in-flight run may be midway through a crates.io
+# publish; the queued one re-reads stable afterwards and skips.
+concurrency:
+  group: prod-release
+  cancel-in-progress: false
 
 # Default to read-only; only the deploy job needs to write releases.
 permissions:


### PR DESCRIPTION
## What happened

The Thursday stable release did not go out on 2026-08-27. Nothing was broken:
beta held `0.5.5` at `50e9016d` with all seven archives and a valid
`SHA256SUMS`, stable held `0.4.0`, and `check-beta` would have said
`Version moves 0.4.0 -> 0.5.5. Deploying.` GitHub simply never dispatched the
`0 16 * * 4` cron. There is no run for it, five hours past the slot.

It was not repo-specific. The nightly alpha, which normally fires within
twenty minutes of 09:00 UTC, ran at 19:21 UTC the same day. `gh workflow list`
showed Prod `active`, and every other workflow ran that day, so this was not
the Actions spending cap or a disabled schedule.

A manual `workflow_dispatch` promoted it cleanly in eight minutes:
[run 33119217814](https://github.com/GEMISIS/leviath/actions/runs/33119217814).
`v0.5.5` and the `latest` channel release are published, docs are on stable,
and the tap has been bumped. This PR is the follow-up so it does not need a
human next time.

## The fix

A scheduled event is best-effort. Alpha survives that because it runs daily
and says so in its own comment; a weekly workflow has no second chance, so one
dropped dispatch cost a full week of stable releases.

**Backstop slot** at `0 20 * * 4`, four hours after the intended one.
`check-beta` already refuses to promote a version stable carries, so on any
week the first slot lands the second is a fifteen-second no-op. The 2026-08-20
run is the proof: it skipped in 14s on `Beta SHA matches current prod`.

**Concurrency group**, which is the part that makes the extra slot safe. Two
runs can now be alive at once, and the workflow could not previously survive
that: `check-beta` reads what stable *currently* carries, so a second run that
cleared the gate before the first published would promote the same version
again, and `Determine version tag` would find the tag taken and disambiguate
it into a junk `v0.5.5+20260828` release. Serialising them removes the window.

Queued rather than cancelled (`cancel-in-progress: false`) because an
in-flight run may be midway through the crates.io publish loop, which is not
safe to interrupt. The queued run re-reads stable when it starts and skips.

## Not changed

Beta has the same single-slot weekly exposure. Left alone deliberately: a
missed beta delays a promotion by a week but never leaves users on a stale
stable channel, and it is worth deciding separately.

## Testing

`prod.yml` parses and resolves to the intended shape:

```
crons: [{'cron': '0 16 * * 4'}, {'cron': '0 20 * * 4'}]
concurrency: {'group': 'prod-release', 'cancel-in-progress': False}
jobs: ['check-beta', 'approve', 'deploy', 'publish-crates', 'docs', 'bump-tap']
```

The backstop cannot be exercised before next Thursday. Its no-op path is the
one `check-beta` already runs every week it skips.
