### PR TITLE
chore(perf-tools): live harness, measuring sticks and a baseline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,36 @@ cargo llvm-cov --package <crate> --lib --html --open   # browsable per-crate rep
 
 > Branch coverage isn't collected: `cargo llvm-cov --branch` reliably SIGSEGVs inside LLVM's own coverage-mapping code ([open upstream bug](https://github.com/llvm/llvm-project/issues/119558)). See the doc comment atop `xtask/src/coverage.rs` for the full investigation.
 
+## Live-testing against a real daemon
+
+A green test suite and a 100% coverage number are not the same thing as
+"tested": this repository has shipped fixes that a unit test certified and a
+running daemon ignored. Anything that changes what the daemon does on a tool
+call, a spawn or an HTTP request gets driven through a real daemon as well.
+
+`perf-tools/` holds the harness. `perf-tools/harness.sh CMD...` runs `CMD`
+in an isolated environment (`LEVIATH_HOME=/tmp/lv`, the repo `.env` skipped,
+the native OpenAI provider pointed at `perf-tools/mock.py`) and installs a
+one-stage `probe` blueprint. `mock.py` is a stateless OpenAI-compatible server
+that asks for a tool call of your choosing on the first turn; `daemon_drive.py`
+starts everything, spawns runs over `lev serve`, and waits for them to finish:
+
+```sh
+cargo build --release -p leviath-cli
+perf-tools/harness.sh python3 perf-tools/daemon_drive.py \
+    --runs 2 --tool shell --args '{"command":"echo hi > note.txt"}' --yolo --keep
+perf-tools/harness.sh target/release/lev timeline <run-id>
+```
+
+Every "the bad thing did not happen" probe needs a control in the same script
+that makes the good thing happen. A probe whose control is also silent proves
+that the harness is broken, not that the fix works. `mock.py`'s `GET /count`
+exists so "no provider call was made" can be asserted rather than assumed.
+
+The same directory holds the measuring sticks a performance change is gated
+on (`dash_pty.py`, `serve_latency.py`, `binsize.sh`) and the baseline numbers
+under `perf-tools/baselines/`; see `perf-tools/README.md`.
+
 ## Dependencies
 
 Declare a dependency in `[workspace.dependencies]` and reference it from a crate as `{ workspace = true }`. A version written inline in a crate manifest is invisible to anyone reading the root, which is how one crate ends up on a different minor from the rest without anybody deciding that.

--- a/perf-tools/README.md
+++ b/perf-tools/README.md
@@ -21,6 +21,46 @@ metrics on both sides or the comparison is meaningless.
   tab), printing the server's RSS between batches. A per-connection leak shows
   up as a staircase.
 
+## The measuring sticks the cleanup work is gated on
+
+Every performance PR has to move one of the numbers below, measured the same
+way before and after, or it does not merge. The scripts are Python and shell
+on purpose: nothing here is a workspace member, so the 100% coverage gate
+does not apply and no benchmark target pollutes a crate's profile.
+
+- `harness.sh` - the isolated environment every live probe runs in. Wraps a
+  command in `env -i` with a short `LEVIATH_HOME` (`/tmp/lv`), the
+  repo-root `.env` skipped, and the native OpenAI provider pointed at
+  `mock.py`. Use it as a prefix: `perf-tools/harness.sh lev ps`. It also
+  installs `agents/probe/`, a one-stage blueprint that calls whatever tool
+  the mock asks for.
+- `mock.py PORT [TOOL ARGS-JSON]` - a stateless OpenAI-compatible provider.
+  It decides from the request body, never a turn counter (the daemon spends
+  a turn at startup): the tool call is returned until `messages` carries a
+  `role: "tool"` entry, then the reply is `done`. `GET /count` says how many
+  completions it served, which is what makes a "no provider call happened"
+  probe provable rather than silent.
+- `daemon_drive.py --runs K [--tool NAME --args JSON --yolo]` - starts the
+  mock, a daemon and `lev serve`, spawns K runs, waits for them to finish,
+  and prints wall clock plus rusage as JSON. Run it through `harness.sh`.
+- `fake_runs.py --from RUN_DIR --count 750 --out DIR` - copies one real run
+  directory N times with fresh ids. Copies, not stubs: a 200-byte
+  `context.json` would hide exactly the per-frame parsing cost the dashboard
+  numbers exist to catch.
+- `dash_pty.py --bin lev --seconds 30 --keys 'jjj'` - drives `lev dash`
+  over a real pty, accumulating the whole escape stream (a full pty buffer
+  blocks the child and corrupts the measurement), and reports the child's
+  CPU seconds, max RSS, bytes written, repaint count and a normalised hash of
+  the first frame. The hash must match before and after a change; the CPU
+  and the syscall count (`measure.sh`, Linux) must fall.
+- `measure.sh CMD...` - `perf stat` + `strace -c` on Linux, `/usr/bin/time
+  -l` on macOS. Linux is the gate; macOS is corroboration.
+- `binsize.sh [BIN]` - release binary size, package count, `__const` /
+  `.rodata` size, and whether the unreachable tiktoken vocabularies are still
+  linked in.
+- `baselines/` - one JSON per commit the numbers were taken at. Compare
+  against the newest one.
+
 ## Memory metrics: what they mean, and the trap
 
 The single most common benchmarking mistake for long-lived processes is

--- a/perf-tools/agents/probe/agent.leviath
+++ b/perf-tools/agents/probe/agent.leviath
@@ -1,0 +1,18 @@
+[agent]
+name = "probe"
+version = "0.1.0"
+description = "One-stage agent for driving a real daemon against the mock provider"
+entry_stage = "main"
+
+[context.regions]
+task = { kind = "pinned", max_tokens = 2000, required = true, seed = "task" }
+
+[stages.main]
+mode = "autonomous"
+description = "Do whatever the mock provider asks, then finish"
+model = { models = [{ provider = "openai", model = "mock-1" }] }
+available_tools = ["shell", "write_file", "read_file", "current_time"]
+max_iterations = 4
+system_prompt = """
+You are a probe. Call the tool you are asked to call, then reply "done".
+"""

--- a/perf-tools/baselines/2026-08-27-ab079e06.json
+++ b/perf-tools/baselines/2026-08-27-ab079e06.json
@@ -1,0 +1,56 @@
+{
+  "taken_at": "2026-08-28T03:39:21+00:00",
+  "commit": "ab079e06",
+  "branch_head": "d0a4bd49",
+  "machine": "Darwin 25.6.0 arm64",
+  "notes": [
+    "fake-runs corpus: 750 copies of one 28 KB probe run (small context.json); regenerate from a longer run for the dashboard PRs",
+    "dashboard: 30 s over a 200x50 pty, keys jjj, release binary",
+    "serve: 100 sequential requests per route, one connection each, corpus of 750 runs",
+    "drive: 32 probe runs against mock.py with a current_time tool call, --yolo",
+    "mock_completions is cumulative for the mock process and includes the daemon's own warm-up calls"
+  ],
+  "binary": {
+    "binary": "target/release/lev",
+    "bytes": 33309152,
+    "packages": 498,
+    "const_bytes": "8796832",
+    "r50k_vocab": "present"
+  },
+  "dashboard_750_runs_30s": {
+    "cpu_seconds": 4.1188,
+    "max_rss_bytes": 23805952,
+    "bytes_written": 18644,
+    "repaints": 1,
+    "seconds": 30.0,
+    "frame1_sha256": "eaac4a4c2a0f524a2c0697cae3193cba9cf88bd0c6cf49837eaf3a9f3472c282",
+    "exit_status": 0
+  },
+  "serve_750_runs": {
+    "/api/runs?limit=50": {
+      "p50_ms": 8.92,
+      "p99_ms": 14.42,
+      "max_ms": 18.79,
+      "body_bytes": 57243
+    },
+    "/api/agents/tree": {
+      "p50_ms": 9.44,
+      "p99_ms": 11.5,
+      "max_ms": 11.87,
+      "body_bytes": 151501
+    },
+    "/api/agents": {
+      "p50_ms": 12.64,
+      "p99_ms": 14.06,
+      "max_ms": 17.6,
+      "body_bytes": 848085
+    }
+  },
+  "daemon_drive_32_runs": {
+    "runs": 32,
+    "finished": 32,
+    "wall_seconds": 1.421,
+    "mock_completions": 198,
+    "daemon_cpu_seconds": 0.29
+  }
+}

--- a/perf-tools/binsize.sh
+++ b/perf-tools/binsize.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Size facts about the release binary and the dependency graph, as JSON.
+# Run from the workspace root after `cargo build --release -p leviath-cli`.
+set -e
+BIN=${1:-target/release/lev}
+bytes=$(wc -c < "$BIN" | tr -d ' ')
+pkgs=$(cargo tree -p leviath-cli -e normal --prefix none 2>/dev/null | sort -u | wc -l | tr -d ' ')
+# A 64-byte slice unique to the r50k/p50k tiktoken vocabularies: present means
+# the encodings no reachable model selects are still linked in.
+probe=$(python3 - "$BIN" <<'PY'
+import glob, pathlib, sys
+assets = glob.glob(str(pathlib.Path.home() / ".cargo/registry/src/*/tiktoken-rs-*/assets"))
+if not assets:
+    print("no-tiktoken-assets"); sys.exit()
+a = pathlib.Path(sorted(assets)[-1])
+r50 = a.joinpath("r50k_base.tiktoken").read_bytes()
+cl = a.joinpath("cl100k_base.tiktoken").read_bytes()
+o2 = a.joinpath("o200k_base.tiktoken").read_bytes()
+probe = None
+for off in range(100_000, len(r50) - 64, 977):
+    p = r50[off:off + 64]
+    if p not in cl and p not in o2:
+        probe = p; break
+if probe is None:
+    print("no-probe"); sys.exit()
+print("present" if probe in pathlib.Path(sys.argv[1]).read_bytes() else "absent")
+PY
+)
+if command -v size >/dev/null 2>&1 && [ "$(uname)" = "Darwin" ]; then
+  const=$(size -m "$BIN" | awk '/__const/ {print $NF; exit}')
+else
+  const=$(size -A "$BIN" 2>/dev/null | awk '/\.rodata/ {print $2; exit}')
+fi
+printf '{"binary":"%s","bytes":%s,"packages":%s,"const_bytes":"%s","r50k_vocab":"%s"}\n' \
+  "$BIN" "$bytes" "$pkgs" "${const:-unknown}" "$probe"

--- a/perf-tools/daemon_drive.py
+++ b/perf-tools/daemon_drive.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""Drive a real daemon through K runs against mock.py and report the cost.
+
+Runs inside the environment `harness.sh` sets up (call it through the wrapper:
+`harness.sh python3 perf-tools/daemon_drive.py ...`). Starts the mock and the
+daemon itself, spawns the runs over `lev serve`, waits for every run to reach a
+terminal status, then prints one JSON object with wall clock and the daemon's
+rusage. Nothing here inherits the caller's environment beyond what the wrapper
+passed.
+
+    --runs K          how many runs to spawn (default 8)
+    --tool NAME       ask the mock to request this tool on the first turn
+    --args JSON       the tool's arguments
+    --yolo            spawn with yolo (tool calls need no approval)
+    --json PATH       write the measurement here as well as printing it
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.request
+
+LV_BIN = os.environ.get("LV_BIN", "lev")
+MOCK_PORT = int(os.environ.get("LV_MOCK_PORT", "8099"))
+SERVE_PORT = int(os.environ.get("LV_SERVE_PORT", "8199"))
+TOKEN = os.environ["LEVIATH_API_TOKEN"]
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def api(method, path, body=None):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"http://127.0.0.1:{SERVE_PORT}{path}", data=data, method=method,
+                                 headers={"authorization": f"Bearer {TOKEN}",
+                                          "content-type": "application/json"})
+    with urllib.request.urlopen(req, timeout=30) as r:
+        return json.loads(r.read() or b"null")
+
+
+def wait_http(url, seconds=20):
+    deadline = time.monotonic() + seconds
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(url, timeout=1).read()
+            return
+        except Exception:
+            time.sleep(0.1)
+    raise SystemExit(f"nothing answered at {url}")
+
+
+def daemon_cpu_seconds():
+    """The daemon's accumulated CPU time, from `ps`. It is a detached process,
+    so `getrusage(RUSAGE_CHILDREN)` never sees it."""
+    pid_file = os.path.join(os.environ["LEVIATH_HOME"], ".leviath", "daemon.pid")
+    try:
+        pid = open(pid_file).read().strip().split()[0]
+        txt = subprocess.run(["ps", "-o", "cputime=", "-p", pid], capture_output=True, text=True).stdout.strip()
+    except (OSError, IndexError):
+        return None
+    # mm:ss.cc or hh:mm:ss
+    parts = txt.split(":")
+    if not txt:
+        return None
+    secs = 0.0
+    for part in parts:
+        secs = secs * 60 + float(part)
+    return secs
+
+
+def spawn(cmd):
+    # A new session so the shell that started us cannot SIGKILL the group.
+    return subprocess.Popen(cmd, start_new_session=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--runs", type=int, default=8)
+    ap.add_argument("--tool")
+    ap.add_argument("--args", default="{}")
+    ap.add_argument("--yolo", action="store_true")
+    ap.add_argument("--json")
+    ap.add_argument("--keep", action="store_true", help="leave the daemon and mock running")
+    a = ap.parse_args()
+
+    mock_cmd = [sys.executable, os.path.join(HERE, "mock.py"), str(MOCK_PORT)]
+    if a.tool:
+        mock_cmd += [a.tool, a.args]
+    mock = spawn(mock_cmd)
+    wait_http(f"http://127.0.0.1:{MOCK_PORT}/v1/models")
+
+    subprocess.run([LV_BIN, "daemon", "stop"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    subprocess.run([LV_BIN, "daemon", "start"], check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    serve = spawn([LV_BIN, "serve", "--port", str(SERVE_PORT), "--host", "127.0.0.1"])
+    wait_http(f"http://127.0.0.1:{SERVE_PORT}/")
+
+    workdir = os.path.join(os.environ["LEVIATH_HOME"], "work")
+    cpu_before = daemon_cpu_seconds()
+    started = time.monotonic()
+    ids = []
+    for i in range(a.runs):
+        body = {"blueprint": "probe", "task": f"probe run {i}", "workdir": workdir, "yolo": a.yolo}
+        ids.append(api("POST", "/api/agents", body)["run_id"])
+    terminal = {"complete", "complete_interactive", "error", "cancelled"}
+    pending = set(ids)
+    deadline = time.monotonic() + 120
+    while pending and time.monotonic() < deadline:
+        for rid in list(pending):
+            st = api("GET", f"/api/agents/{rid}").get("status", "")
+            if str(st).lower() in terminal:
+                pending.discard(rid)
+        time.sleep(0.2)
+    wall = time.monotonic() - started
+    cpu_after = daemon_cpu_seconds()
+
+    calls = json.loads(urllib.request.urlopen(f"http://127.0.0.1:{MOCK_PORT}/count").read())["count"]
+    out = {
+        "runs": a.runs,
+        "finished": a.runs - len(pending),
+        "wall_seconds": round(wall, 3),
+        "mock_completions": calls,
+        "daemon_cpu_seconds": None if cpu_before is None or cpu_after is None else round(cpu_after - cpu_before, 2),
+        "run_ids": ids,
+    }
+    print(json.dumps(out, indent=2))
+    if a.json:
+        with open(a.json, "w") as f:
+            json.dump(out, f, indent=2)
+    if not a.keep:
+        serve.terminate()
+        subprocess.run([LV_BIN, "daemon", "stop"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        mock.terminate()
+    if pending:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/perf-tools/dash_pty.py
+++ b/perf-tools/dash_pty.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Drive `lev dash` over a pty and measure it.
+
+`lev dash` only enters the real render path with a terminal on stdout, so
+this forks a pty, sets a window size, feeds keys, and accumulates the WHOLE
+output stream. Accumulating everything matters: a full pty buffer blocks the
+child on write, throttles the render loop, and turns the number being measured
+into a measurement of this script.
+
+Reports (JSON):
+    cpu_seconds     ru_utime + ru_stime of the child, exact and portable
+    max_rss_bytes   ru_maxrss, normalised (macOS reports bytes, Linux KiB)
+    bytes_written   total escape-stream bytes (a rendering change that emits
+                    far more is a regression even if CPU falls)
+    repaints        full repaints seen (cursor-home + clear sequences)
+    frame1_sha256   sha256 of the first full frame with whitespace stripped and
+                    clock-shaped tokens masked; must match before/after a change
+
+    --bin PATH --seconds N --cols C --rows R --keys 'jjj' --json OUT --stream OUT.bin
+"""
+import argparse
+import faulthandler
+import fcntl
+import hashlib
+import json
+import os
+import pty
+import re
+import resource
+import select
+import signal
+import struct
+import sys
+import termios
+import time
+
+
+def normalise(frame: bytes) -> bytes:
+    frame = re.sub(rb"\d\d:\d\d(:\d\d)?", b"T", frame)
+    frame = re.sub(rb"\b\d+(\.\d+)?\s?(ms|s|m|h|d)\b", b"D", frame)
+    frame = re.sub(rb"\b\d+ ago\b", b"D ago", frame)
+    return re.sub(rb"\s+", b"", frame)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bin", default=os.environ.get("LV_BIN", "lev"))
+    ap.add_argument("--seconds", type=float, default=30)
+    ap.add_argument("--cols", type=int, default=200)
+    ap.add_argument("--rows", type=int, default=50)
+    ap.add_argument("--keys", default="", help="keys to send after 2s, one per 300ms; \\e for Escape")
+    ap.add_argument("--json")
+    ap.add_argument("--stream", help="write the raw escape stream here")
+    a = ap.parse_args()
+    # A watchdog: if the run overshoots by 30s, dump every thread's stack and
+    # exit non-zero rather than hang a CI job.
+    faulthandler.dump_traceback_later(a.seconds + 30, exit=True)
+
+    pid, fd = pty.fork()
+    if pid == 0:
+        os.execvp(a.bin, [a.bin, "dash"])
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", a.rows, a.cols, 0, 0))
+
+    keys = a.keys.encode().decode("unicode_escape").encode("latin-1")
+    out = bytearray()
+    deadline = time.monotonic() + a.seconds
+    next_key = time.monotonic() + 2.0
+    key_i = 0
+    while time.monotonic() < deadline:
+        r, _, _ = select.select([fd], [], [], 0.05)
+        if r:
+            try:
+                chunk = os.read(fd, 1 << 16)
+            except OSError:
+                break
+            if not chunk:
+                break
+            out.extend(chunk)
+        if key_i < len(keys) and time.monotonic() >= next_key:
+            os.write(fd, keys[key_i:key_i + 1])
+            key_i += 1
+            next_key = time.monotonic() + 0.3
+    # Teardown escalates: `q` (then `y` for a confirm dialog), SIGTERM, SIGKILL.
+    # Keep draining the pty meanwhile so the child never blocks on a full buffer.
+    def reap(grace):
+        end = time.monotonic() + grace
+        while time.monotonic() < end:
+            wpid, status, ru = os.wait4(pid, os.WNOHANG)
+            if wpid == pid:
+                return status, ru
+            r, _, _ = select.select([fd], [], [], 0.05)
+            if r:
+                try:
+                    out.extend(os.read(fd, 1 << 16))
+                except OSError:
+                    pass
+        return None
+    done = None
+    for step in (lambda: os.write(fd, b"q"), lambda: os.write(fd, b"y"),
+                 lambda: os.kill(pid, signal.SIGTERM), lambda: os.kill(pid, signal.SIGKILL)):
+        try:
+            step()
+        except (OSError, ProcessLookupError):
+            pass
+        done = reap(2.0)
+        if done:
+            break
+    if done is None:
+        _, status, ru = os.wait4(pid, 0)
+    else:
+        status, ru = done
+    maxrss = ru.ru_maxrss if sys.platform == "darwin" else ru.ru_maxrss * 1024
+
+    repaints = out.count(b"\x1b[1;1H") + out.count(b"\x1b[H")
+    first = out.find(b"\x1b[2J")
+    second = out.find(b"\x1b[1;1H", first + 1) if first >= 0 else -1
+    frame1 = out[first:second] if first >= 0 and second > first else bytes(out[:4096])
+    result = {
+        "cpu_seconds": round(ru.ru_utime + ru.ru_stime, 4),
+        "max_rss_bytes": maxrss,
+        "bytes_written": len(out),
+        "repaints": repaints,
+        "seconds": a.seconds,
+        "frame1_sha256": hashlib.sha256(normalise(bytes(frame1))).hexdigest(),
+        "exit_status": status,
+    }
+    print(json.dumps(result, indent=2))
+    if a.json:
+        with open(a.json, "w") as f:
+            json.dump(result, f, indent=2)
+    if a.stream:
+        with open(a.stream, "wb") as f:
+            f.write(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/perf-tools/fake_runs.py
+++ b/perf-tools/fake_runs.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Materialise N run directories by copying one real run.
+
+    fake_runs.py --from RUNS_DIR/<run_id> --count 750 --out /tmp/lv-bench/runs
+
+The template is a run the daemon actually wrote (produce one with
+`daemon_drive.py --keep`), so every file has the real on-disk schema and a
+realistic size. A generator that wrote 200-byte `context.json` stubs would hide
+exactly the per-frame parsing cost the dashboard measurements exist to catch.
+
+Only `run_id` (in `meta.json` and the directory name) and the timestamps are
+rewritten; everything else is byte-identical to the template.
+"""
+import argparse
+import json
+import os
+import shutil
+import time
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--from", dest="src", required=True, help="a real run directory")
+    ap.add_argument("--count", type=int, default=750)
+    ap.add_argument("--out", required=True, help="the runs directory to fill")
+    a = ap.parse_args()
+
+    meta_path = os.path.join(a.src, "meta.json")
+    with open(meta_path) as f:
+        meta = json.load(f)
+    base = os.path.basename(a.src.rstrip("/"))
+    prefix = base.rsplit("-", 1)[0] if "-" in base else base
+    now = int(time.time())
+    os.makedirs(a.out, exist_ok=True)
+    for i in range(a.count):
+        rid = f"{prefix}-{i:06x}"
+        dst = os.path.join(a.out, rid)
+        if os.path.exists(dst):
+            shutil.rmtree(dst)
+        shutil.copytree(a.src, dst)
+        m = dict(meta)
+        m["run_id"] = rid
+        for key in ("started_at", "updated_at", "finished_at", "completed_at"):
+            if isinstance(m.get(key), int):
+                m[key] = now - (a.count - i) * 60
+        with open(os.path.join(dst, "meta.json"), "w") as f:
+            json.dump(m, f)
+    print(f"wrote {a.count} runs under {a.out} from {a.src}")
+
+
+if __name__ == "__main__":
+    main()

--- a/perf-tools/harness.sh
+++ b/perf-tools/harness.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# The isolated environment every live probe runs in. Source it, or use it as
+# a wrapper: `harness.sh lev ps`.
+#
+#   LEVIATH_HOME   short path (the Unix control socket has a ~104-byte limit)
+#   LEVIATH_SKIP_DOTENV  the repo-root .env holds a real key; never load it
+#   OPENAI_*       point the native OpenAI provider at mock.py
+#   LV_RUNS_DIR    optional; forwarded as LEVIATH_RUNS_DIR (the fake-runs corpus)
+#
+# Nothing here reads the caller's environment: `env -i` first, then exactly
+# these names, so a probe cannot accidentally reach a real provider.
+: "${LV_HOME:=/tmp/lv}"
+: "${LV_MOCK_PORT:=8099}"
+: "${LV_BIN:=$(cd "$(dirname "$0")/.." && pwd)/target/release/lev}"
+: "${LEVIATH_API_TOKEN:=probe-token}"
+
+mkdir -p "$LV_HOME/.leviath/agents" "$LV_HOME/work"
+if [ ! -e "$LV_HOME/.leviath/agents/probe" ]; then
+  cp -R "$(dirname "$0")/agents/probe" "$LV_HOME/.leviath/agents/probe"
+fi
+
+exec env -i \
+  PATH="/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin" \
+  HOME="$LV_HOME" \
+  LEVIATH_HOME="$LV_HOME" \
+  LEVIATH_SKIP_DOTENV=1 \
+  LEVIATH_API_TOKEN="$LEVIATH_API_TOKEN" \
+  OPENAI_API_KEY=mock \
+  OPENAI_BASE_URL="http://127.0.0.1:$LV_MOCK_PORT/v1" \
+  TERM="${TERM:-xterm-256color}" \
+  ${LV_RUNS_DIR:+LEVIATH_RUNS_DIR="$LV_RUNS_DIR"} \
+  LV_BIN="$LV_BIN" \
+  "$@"

--- a/perf-tools/measure.sh
+++ b/perf-tools/measure.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Wrap a command with the OS's own counters and print them.
+#   Linux: perf stat (instructions, task-clock, page faults) + strace -c
+#   macOS: /usr/bin/time -l (rusage incl. max RSS)
+# The gate numbers in the plan come from Linux; macOS is corroboration.
+set -e
+case "$(uname)" in
+  Linux)
+    if command -v perf >/dev/null 2>&1; then
+      perf stat -e instructions,task-clock,page-faults -- "$@"
+    else
+      /usr/bin/time -v "$@"
+    fi
+    if command -v strace >/dev/null 2>&1; then
+      strace -c -f -e trace=openat,newfstatat,statx,read,pread64 -o /tmp/measure.strace "$@" >/dev/null
+      cat /tmp/measure.strace
+    fi
+    ;;
+  Darwin)
+    /usr/bin/time -l "$@"
+    ;;
+esac

--- a/perf-tools/mock.py
+++ b/perf-tools/mock.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""A stateless OpenAI-compatible mock provider for driving a real daemon.
+
+Usage:
+    mock.py PORT                         # every turn answers "done"
+    mock.py PORT TOOL '{"json":"args"}'  # first turn asks for TOOL, then "done"
+
+The decision is made from the request body, never from a turn counter: the
+daemon spends a turn during startup, so a counter-based script never reaches
+the agent. The tool call is returned until `messages` carries a `role: "tool"`
+entry, then the reply is plain text and the run completes.
+
+Routes:
+    GET  /v1/models          one model, "mock-1"
+    POST /v1/chat/completions  JSON or SSE, depending on `stream`
+    GET  /count              how many completions were served (probe counter)
+    POST /reset              zero the counter
+"""
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PORT = int(sys.argv[1])
+TOOL = sys.argv[2] if len(sys.argv) > 2 else None
+ARGS = sys.argv[3] if len(sys.argv) > 3 else "{}"
+CALLS = [0]
+USAGE = {"prompt_tokens": 12, "completion_tokens": 3, "total_tokens": 15}
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_):
+        pass
+
+    def _json(self, obj, status=200):
+        body = json.dumps(obj).encode()
+        self.send_response(status)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self):
+        if self.path.startswith("/count"):
+            return self._json({"count": CALLS[0]})
+        return self._json({"object": "list", "data": [{"id": "mock-1", "object": "model"}]})
+
+    def do_POST(self):
+        if self.path.startswith("/reset"):
+            CALLS[0] = 0
+            return self._json({"ok": True})
+        n = int(self.headers.get("content-length", "0"))
+        req = json.loads(self.rfile.read(n) or b"{}")
+        CALLS[0] += 1
+        seen_tool = any(m.get("role") == "tool" for m in req.get("messages", []))
+        want_tool = TOOL is not None and not seen_tool
+        if req.get("stream"):
+            return self._sse(want_tool)
+        if want_tool:
+            message = {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "type": "function",
+                                "function": {"name": TOOL, "arguments": ARGS}}],
+            }
+            finish = "tool_calls"
+        else:
+            message = {"role": "assistant", "content": "done"}
+            finish = "stop"
+        self._json({"id": "c1", "object": "chat.completion", "model": "mock-1", "usage": USAGE,
+                    "choices": [{"index": 0, "finish_reason": finish, "message": message}]})
+
+    def _sse(self, want_tool):
+        if want_tool:
+            delta = {"role": "assistant", "tool_calls": [{"index": 0, "id": "call_1", "type": "function",
+                                                          "function": {"name": TOOL, "arguments": ARGS}}]}
+            finish = "tool_calls"
+        else:
+            delta = {"role": "assistant", "content": "done"}
+            finish = "stop"
+        chunks = [
+            {"id": "c1", "object": "chat.completion.chunk", "model": "mock-1",
+             "choices": [{"index": 0, "delta": delta, "finish_reason": None}]},
+            {"id": "c1", "object": "chat.completion.chunk", "model": "mock-1",
+             "choices": [{"index": 0, "delta": {}, "finish_reason": finish}]},
+            {"id": "c1", "object": "chat.completion.chunk", "model": "mock-1", "choices": [], "usage": USAGE},
+        ]
+        body = "".join(f"data: {json.dumps(c)}\n\n" for c in chunks) + "data: [DONE]\n\n"
+        body = body.encode()
+        self.send_response(200)
+        self.send_header("content-type", "text/event-stream")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+if __name__ == "__main__":
+    HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()

--- a/perf-tools/serve_latency.py
+++ b/perf-tools/serve_latency.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Latency percentiles for `lev serve` read routes over a fixed runs corpus.
+
+    serve_latency.py --port 8299 --n 200 [--json OUT]
+
+Hits each route N times sequentially (one connection per request, like a
+console tab would) and prints p50/p99 in milliseconds. Run against a server
+started with the same corpus every time (`LV_RUNS_DIR=... harness.sh lev serve
+--port 8299`), or the numbers are not comparable.
+"""
+import argparse
+import json
+import os
+import statistics
+import time
+import urllib.request
+
+ROUTES = ["/api/runs?limit=50", "/api/agents/tree", "/api/agents"]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=int(os.environ.get("LV_SERVE_PORT", "8299")))
+    ap.add_argument("--n", type=int, default=200)
+    ap.add_argument("--json")
+    a = ap.parse_args()
+    token = os.environ["LEVIATH_API_TOKEN"]
+    out = {}
+    for route in ROUTES:
+        samples = []
+        size = 0
+        for _ in range(a.n):
+            req = urllib.request.Request(f"http://127.0.0.1:{a.port}{route}",
+                                         headers={"authorization": f"Bearer {token}"})
+            t = time.perf_counter()
+            with urllib.request.urlopen(req, timeout=60) as r:
+                size = len(r.read())
+            samples.append((time.perf_counter() - t) * 1000)
+        samples.sort()
+        out[route] = {
+            "p50_ms": round(statistics.median(samples), 2),
+            "p99_ms": round(samples[int(len(samples) * 0.99) - 1], 2),
+            "max_ms": round(samples[-1], 2),
+            "body_bytes": size,
+        }
+    print(json.dumps(out, indent=2))
+    if a.json:
+        with open(a.json, "w") as f:
+            json.dump(out, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

The measuring sticks the cleanup PRs are gated on, and the baseline they compare against. Nothing in the workspace changes; everything lives under `perf-tools/` (Python and shell, not workspace members, so the coverage gate does not apply).

- `harness.sh` wraps a command in an isolated environment (`LEVIATH_HOME=/tmp/lv`, repo `.env` skipped, native OpenAI provider pointed at `mock.py`) and installs a one-stage `probe` blueprint.
- `mock.py` is a stateless OpenAI-compatible provider (JSON and SSE) that asks for a chosen tool on the first turn and counts what it served (`GET /count`), so a "no provider call happened" probe is provable.
- `daemon_drive.py` starts mock + daemon + `lev serve`, spawns K runs, waits, reports wall clock and the daemon's CPU delta (read from `ps`; the daemon is detached so `RUSAGE_CHILDREN` never sees it).
- `fake_runs.py` copies one real run N times (real schema, real sizes).
- `dash_pty.py` drives `lev dash` over a pty: CPU, RSS, bytes written, first-frame hash. Teardown escalates q, y, SIGTERM, SIGKILL; a `faulthandler` watchdog dumps and exits if it overruns.
- `serve_latency.py`, `measure.sh`, `binsize.sh` (with a byte-probe for the r50k/p50k tiktoken vocabularies).
- `baselines/2026-08-27-ab079e06.json`.

## Baseline at main

| number | value |
|---|---|
| release `lev` | 33,309,152 B, 498 packages, `__const` 8.8 MB, r50k vocab present |
| dashboard, 750 runs, 30 s, 200x50 | 4.12 CPU-s (13.7% of a core), 23.8 MB RSS |
| `GET /api/runs?limit=50` p50 / p99 at 750 runs | 8.9 / 14.4 ms |
| `GET /api/agents/tree` p50 / p99 | 9.4 / 11.5 ms |
| `GET /api/agents` p50 / p99 (unpaginated, 848 KB) | 12.6 / 14.1 ms |
| 32 probe runs with one tool call each | 1.42 s wall, 0.29 s daemon CPU |

Caveat recorded in the file: the corpus is 750 copies of a 28 KB probe run, so `context.json` is small; the dashboard PRs should regenerate it from a longer run before claiming a win.

## Also

`CONTRIBUTING.md` gains a "Live-testing against a real daemon" section, including the rule that every negative probe ships a positive control.

## Verified

Smoke-run end to end: 2 and 32 runs through the mock with a `current_time` tool call; the tool result is in the run's stage log. `cargo xtask docs` clean; pre-commit hook passed.
