### PR TITLE
ci: timeouts, concurrency, one toolchain setup, one tap dispatch, dev profile

### DIFF
--- a/.github/actions/dispatch-dist/action.yml
+++ b/.github/actions/dispatch-dist/action.yml
@@ -1,0 +1,40 @@
+name: Dispatch to leviath-dist
+description: >-
+  Tell the tap repository which version a channel just published, so its
+  Homebrew and Scoop manifests move and `brew upgrade` has something to see.
+
+# Homebrew and Scoop compare the installed version against the version
+# *declared* in the manifest; neither looks at what is behind the rolling
+# channel tag the manifests point at. So the tap has to be told what shipped.
+# Three workflows used to carry this block verbatim; a tap URL change was
+# three edits.
+
+inputs:
+  channel:
+    description: alpha | beta | stable
+    required: true
+  version:
+    description: The version string the tap should declare, suffix included (e.g. 0.5.6-alpha).
+    required: true
+  token:
+    description: >-
+      A PAT with Contents read/write on GEMISIS/leviath-dist. GITHUB_TOKEN is
+      scoped to this repo and cannot reach the tap.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Dispatch release-published
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        CHANNEL: ${{ inputs.channel }}
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        jq -nc --arg channel "$CHANNEL" --arg version "$VERSION" \
+          '{event_type:"release-published",
+            client_payload:{channel:$channel, version:$version}}' \
+          | gh api repos/GEMISIS/leviath-dist/dispatches --input -
+        echo "Asked leviath-dist to bump the $CHANNEL manifests to $VERSION."

--- a/.github/actions/rust-setup/action.yml
+++ b/.github/actions/rust-setup/action.yml
@@ -1,0 +1,47 @@
+name: Rust setup
+description: >-
+  Install the toolchain rust-toolchain.toml pins and, by default, restore the
+  cargo cache. One definition instead of the same three steps in every job.
+
+# `rustup toolchain install` with no arguments reads rust-toolchain.toml - the
+# channel and the components - which is the single source of truth for the
+# compiler this repo builds with. The jobs used to call a toolchain action with
+# `toolchain: stable`, which installed stable and then let rustup install the
+# pinned 1.97.1 on the first cargo call: two toolchains per job, the second
+# being the only one that mattered. alpha.yml's build job already did it this
+# way, for the same reason.
+
+inputs:
+  cache:
+    description: Restore and save the cargo cache (Swatinem/rust-cache).
+    required: false
+    default: "true"
+  shared-key:
+    description: >-
+      rust-cache `shared-key`, so jobs that compile the same targets on the
+      same OS share one cache entry instead of each keeping their own.
+    required: false
+    default: ""
+  target:
+    description: An extra target triple to add to the pinned toolchain (cross builds).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Install the pinned toolchain
+      shell: bash
+      env:
+        TARGET: ${{ inputs.target }}
+      run: |
+        set -euo pipefail
+        rustup toolchain install
+        if [ -n "$TARGET" ]; then
+          rustup target add "$TARGET"
+        fi
+        rustup show active-toolchain
+    - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      if: inputs.cache == 'true'
+      with:
+        shared-key: ${{ inputs.shared-key }}

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -57,6 +57,7 @@ jobs:
   check-version:
     name: Check for a version bump
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       skip: ${{ steps.check.outputs.skip }}
       version: ${{ steps.check.outputs.version }}
@@ -155,6 +156,7 @@ jobs:
     name: Build (${{ matrix.target }})
     needs: gate
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -288,6 +290,7 @@ jobs:
     name: Publish Alpha
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Handed to bump-tap so the tap declares what this nightly actually ships.
     outputs:
       version: ${{ steps.info.outputs.version }}
@@ -450,15 +453,11 @@ jobs:
     name: Bump tap manifests (alpha)
     needs: release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Dispatch to leviath-dist
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          VERSION: ${{ needs.release.outputs.version }}
-        run: |
-          set -euo pipefail
-          jq -nc --arg version "$VERSION-alpha" \
-            '{event_type:"release-published",
-              client_payload:{channel:"alpha", version:$version}}' \
-            | gh api repos/GEMISIS/leviath-dist/dispatches --input -
-          echo "Asked leviath-dist to bump the alpha manifests to $VERSION-alpha."
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/dispatch-dist
+        with:
+          channel: alpha
+          version: ${{ needs.release.outputs.version }}-alpha
+          token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -11,6 +11,12 @@ on:
         type: boolean
         default: false
 
+# One promotion at a time. A manual `force` run started during the scheduled
+# one must queue behind it, not race it to the same tag.
+concurrency:
+  group: beta-promote
+  cancel-in-progress: false
+
 # Read-only by default; only the job that publishes a release elevates, matching
 # alpha.yml and prod.yml. A workflow-level `contents: write` grants it to every
 # step, including ones that merely read.
@@ -21,6 +27,7 @@ jobs:
   promote:
     name: Promote Alpha → Beta
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     # Handed to the docs job so beta docs render the promoted alpha commit,
@@ -216,15 +223,11 @@ jobs:
     needs: promote
     if: needs.promote.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Dispatch to leviath-dist
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          VERSION: ${{ needs.promote.outputs.version }}
-        run: |
-          set -euo pipefail
-          jq -nc --arg version "$VERSION-beta" \
-            '{event_type:"release-published",
-              client_payload:{channel:"beta", version:$version}}' \
-            | gh api repos/GEMISIS/leviath-dist/dispatches --input -
-          echo "Asked leviath-dist to bump the beta manifests to $VERSION-beta."
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: ./.github/actions/dispatch-dist
+        with:
+          channel: beta
+          version: ${{ needs.promote.outputs.version }}-beta
+          token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,15 @@ on:
   # the only way that stays fixed.
   workflow_call:
 
+# A second push to a PR used to run a second full ~55-job suite next to the
+# first. Cancel the older one for pull requests only: a push to main and a
+# release calling this file must run to completion, and `github.workflow` is
+# the caller's name when this file is called, so a release run never shares a
+# group with the CI run for the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
@@ -36,6 +45,11 @@ permissions:
   contents: read
 
 jobs:
+  # Every job carries a `timeout-minutes`. The default is 360, and a hung
+  # `cargo test` (this suite spawns daemons, opens sockets, drives websockets)
+  # used to hold a runner for six hours - up to 39 of them in the coverage
+  # matrix. The numbers are roughly double the longest run seen.
+  #
   # Four legs, not three. `ubuntu-24.04-arm` is here because the release builds
   # ship `aarch64-unknown-linux-{gnu,musl}` and nothing had ever run them on an
   # ARM machine: `macos-latest` is Apple Silicon, so macOS was covered by
@@ -52,17 +66,17 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: ./.github/actions/rust-setup
         with:
-          toolchain: stable
-          components: rustfmt,clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+          # Same key as Clippy: both compile every target on this OS.
+          shared-key: build-${{ matrix.os }}
       - name: Build
         run: cargo build --all-targets
       - name: Test
@@ -103,6 +117,7 @@ jobs:
     needs: [test]
     if: always() && github.ref == 'refs/heads/main' && github.event_name == 'push' && github.workflow == 'CI'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Publish combined test status badge
         uses: schneegans/dynamic-badges-action@28b0fa8bdeb46170ac397105ece0c1fe58f68910 # v1.9.0
@@ -128,29 +143,28 @@ jobs:
   clippy:
     name: Clippy (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: ./.github/actions/rust-setup
         with:
-          toolchain: stable
-          components: clippy
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+          shared-key: build-${{ matrix.os }}
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   fmt:
     name: Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: ./.github/actions/rust-setup
         with:
-          toolchain: stable
-          components: rustfmt
+          cache: "false"
       - name: Check formatting
         run: cargo fmt --all -- --check
 
@@ -167,11 +181,10 @@ jobs:
   default-features:
     name: Build with default features
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          toolchain: stable
+      - uses: ./.github/actions/rust-setup
       - name: Check the runtime without its optional features
         run: cargo check -p leviath-runtime --all-targets
       - name: Check the facade without its optional features
@@ -200,11 +213,10 @@ jobs:
   supply-chain:
     name: Supply chain
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          toolchain: stable
+      - uses: ./.github/actions/rust-setup
       - uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
           tool: cargo-deny
@@ -240,6 +252,7 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # Lifted to `env` because the `secrets` context is not available in a step's
     # `if` - naming it there is a workflow validation error, which fails the run
     # before a single job starts. `env` is available, and holds the same value.
@@ -247,10 +260,7 @@ jobs:
       DOCS_SSG_TOKEN: ${{ secrets.DOCS_SSG_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          toolchain: stable
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: ./.github/actions/rust-setup
       - name: Check docs
         run: RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
       - name: Check docs/content links and frontmatter
@@ -303,6 +313,7 @@ jobs:
   coverage:
     name: Coverage (${{ matrix.os }} / ${{ matrix.package }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       # One package's failure must not cancel the others' runs.
       fail-fast: false
@@ -329,11 +340,7 @@ jobs:
           - leviath-telemetry
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          toolchain: stable
-          components: llvm-tools
-      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
+      - uses: ./.github/actions/rust-setup
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@b6ff580856c41316412a0b9b60540fbc6f8c82cc # v2
         with:
@@ -361,6 +368,7 @@ jobs:
     name: Coverage gate (${{ matrix.os }})
     needs: [coverage]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -408,6 +416,7 @@ jobs:
   check-exclusions:
     name: Check coverage suppression markers
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Install ast-grep
@@ -442,6 +451,7 @@ jobs:
   guard-main-rs:
     name: Guard bin entrypoint (main.rs)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     # Reading the labels needs more than the workflow-wide `contents: read`.
     permissions:
@@ -509,6 +519,7 @@ jobs:
   guard-version-bump:
     name: Guard release version bump
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: github.event_name == 'pull_request'
     # See `guard-main-rs`: the live label read needs its own scope.
     permissions:
@@ -567,6 +578,7 @@ jobs:
   guard-facade:
     name: Guard re-export-only facade (crates/leviath)
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: Require crates/leviath to stay re-export-only

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -37,6 +37,7 @@ jobs:
   check-beta:
     name: Check Beta Exists
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     outputs:
       sha: ${{ steps.beta.outputs.sha }}
       sha_short: ${{ steps.beta.outputs.sha_short }}
@@ -145,6 +146,7 @@ jobs:
     needs: check-beta
     if: needs.check-beta.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: production
     steps:
       - name: Approval received
@@ -154,6 +156,7 @@ jobs:
     name: Deploy to Prod
     needs: [check-beta, approve]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
     steps:
@@ -311,6 +314,7 @@ jobs:
     name: Publish crates.io
     needs: [deploy, check-beta]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     steps:
@@ -318,9 +322,9 @@ jobs:
         with:
           # The promoted beta commit, so the crates match the binaries.
           ref: ${{ needs.check-beta.outputs.sha }}
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: ./.github/actions/rust-setup
         with:
-          toolchain: stable
+          cache: "false"
       - name: Publish unpublished crates in dependency order
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -383,19 +387,14 @@ jobs:
     needs: [deploy, check-beta]
     if: needs.check-beta.outputs.skip != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - name: Dispatch to leviath-dist
-        env:
-          # GITHUB_TOKEN is scoped to this repo, so reaching the tap needs a
-          # PAT. RELEASE_TOKEN already exists for the release steps above and
-          # only needs leviath-dist added to its repository access
-          # (Contents: read and write) — no new secret.
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          VERSION: ${{ needs.check-beta.outputs.version }}
-        run: |
-          set -euo pipefail
-          jq -nc --arg version "$VERSION" \
-            '{event_type:"release-published",
-              client_payload:{channel:"stable", version:$version}}' \
-            | gh api repos/GEMISIS/leviath-dist/dispatches --input -
-          echo "Asked leviath-dist to bump the stable manifests to $VERSION."
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      # GITHUB_TOKEN is scoped to this repo, so reaching the tap needs a PAT.
+      # RELEASE_TOKEN already exists for the release steps above and only needs
+      # leviath-dist added to its repository access (Contents: read and write).
+      - uses: ./.github/actions/dispatch-dist
+        with:
+          channel: stable
+          version: ${{ needs.check-beta.outputs.version }}
+          token: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -34,9 +34,16 @@ permissions:
   id-token: write
   contents: read
 
+# Two publishes of the same channel must not interleave their S3 syncs: the
+# sync uses `--delete`, so the loser would remove the winner's pages.
+concurrency:
+  group: publish-docs-${{ inputs.channel }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout Leviath (docs content)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/revert.yml
+++ b/.github/workflows/revert.yml
@@ -12,13 +12,24 @@ on:
         required: true
         type: string
 
+# Read-only by default, matching the other release workflows; the one job
+# that rewrites the `latest` release elevates itself.
 permissions:
-  contents: write
+  contents: read
+
+# A revert started while another is running must wait for it: both rewrite
+# the same release and tag.
+concurrency:
+  group: prod-revert
+  cancel-in-progress: false
 
 jobs:
   revert:
     name: Revert Prod
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
     environment: production  # Requires same approval as prod deploy
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -256,7 +256,21 @@ tower-http = { version = "0.7", features = ["cors"] }
 # A copy of this section lives in crates/leviath-cli/Cargo.toml so that
 # `cargo install leviath-cli` (where that manifest is the root and this one
 # does not exist) builds with the same settings. Keep the two in sync.
+# Line tables only, not full DWARF. The debug `lev` was 181 MB, 103 MB of it
+# symbol and debug-info sections, and CI rebuilds it roughly fifty times per
+# pull request across the test, clippy and per-package coverage jobs. Line
+# tables keep file:line in backtraces and are all `cargo-llvm-cov` needs;
+# nothing here debugs the daemon under a debugger. Release is unaffected.
+[profile.dev]
+debug = "line-tables-only"
+
 [profile.release]
+# The default, stated so that changing it is a decision rather than an
+# omission. `"s"` or `"z"` would take 1-3 MB off the binary and slow the paths
+# that matter here - token-window arithmetic, JSON, BPE encoding - and has not
+# been measured; do not flip it without a before/after on the daemon drive.
+opt-level = 3
+
 # Overflow panics instead of wrapping. This workspace already treats
 # index/arithmetic mistakes as a real class of bug rather than a theoretical one
 # (see the `clippy::string_slice` deny above, which exists because a byte index

--- a/crates/leviath-cli/Cargo.toml
+++ b/crates/leviath-cli/Cargo.toml
@@ -140,6 +140,7 @@ workspace = true
 # instead of panic. The GitHub release binaries and the crates.io install
 # must behave the same, so the warning is the price.
 [profile.release]
+opt-level = 3
 overflow-checks = true
 lto = "fat"
 codegen-units = 1


### PR DESCRIPTION
## What

CI plumbing only; no Rust behaviour changes.

- **`timeout-minutes` on every job** (there were none: default 360 min, across up to 39 coverage jobs). 60 for coverage and the release builds, 30 for test/clippy/promote/deploy, 10-20 for the rest.
- **Concurrency**: `ci.yml` cancels the superseded suite on a PR push only (push-to-main and release calls run to completion; the group is keyed on the caller's workflow name). `beta`, `publish-docs`, `revert` get non-cancelling groups because each rewrites something a second copy would race.
- **`.github/actions/rust-setup`** replaces seven copies of checkout/toolchain/cache. The old preamble passed `toolchain: stable` to a pinned action that requires the input and does not read `rust-toolchain.toml`, so each job installed stable and then rustup installed 1.97.1 on the first cargo call. The composite runs `rustup toolchain install` (reads the pin, as alpha's build job already did) and rust-cache by default. `test` and `clippy` share a cache key per OS; `default-features` and `supply-chain` gain a cache; `fmt` skips it.
- **`.github/actions/dispatch-dist`** replaces the identical tap-dispatch step in alpha/beta/prod. Release-note bodies are deliberately left channel-specific.
- **`revert.yml`** narrows `contents: write` to its job.
- **`[profile.dev] debug = "line-tables-only"`**: the debug binary was 181 MB with 103 MB of debug sections, rebuilt ~50x per PR. Release profile untouched except for an explicit `opt-level = 3` in both blocks (the sync check passes) with the reason not to change it.

## Verification

- All six workflows and both composite actions parse (PyYAML). `cargo xtask version --check` (which compares the two `[profile.release]` blocks) passes; `cargo metadata --locked` passes.
- This PR's own CI run is the live test of `rust-setup` on all three OSes. The `dispatch-dist` composite is exercised only by a real release; it is a mechanical lift of the previous step with `channel`/`version` as inputs.
- actionlint is not installed locally; if CI has it, its opinion wins.
