### PR TITLE
fix: saturating arithmetic wherever a hostile number reaches a sum

### DIFF
--- a/crates/leviath-cli/src/tui/widgets/markdown_edit/mod.rs
+++ b/crates/leviath-cli/src/tui/widgets/markdown_edit/mod.rs
@@ -621,7 +621,7 @@ impl MarkdownEdit {
         let width = area.width.saturating_sub(4).clamp(12, 56);
         let height = 6u16.min(area.height);
         let popup = Rect {
-            x: area.x + (area.width - width) / 2,
+            x: area.x + area.width.saturating_sub(width) / 2,
             y: area.y + area.height.saturating_sub(height) / 2,
             width,
             height,
@@ -1836,5 +1836,15 @@ mod tests {
         );
         // A zero-width pane must not divide by zero on the way to nowhere.
         assert_eq!(wrapped_rows(&lines, 0), 21);
+    }
+
+    /// The prompt popup clamps its width to at least 12 columns, so in a
+    /// narrower terminal `area.width - width` went below zero - a panic with
+    /// `overflow-checks` on, which is how release builds ship.
+    #[test]
+    fn the_link_prompt_draws_in_a_ten_column_terminal() {
+        let mut md = edit("hi");
+        md.prompt = Some(Prompt::Link(LinkPrompt::new("hi")));
+        let _ = draw(&mut md, 10, 8);
     }
 }

--- a/crates/leviath-core/src/duration.rs
+++ b/crates/leviath-core/src/duration.rs
@@ -54,8 +54,11 @@ pub fn precise(secs: u64) -> String {
 /// The clamp is not paranoia about arithmetic: these are wall-clock stamps from
 /// a machine whose clock can be corrected, and a run whose `started_at` lands
 /// after `now` should read as brand new rather than as `u64::MAX` seconds old.
+/// The saturating subtraction *is* about arithmetic: `from` is read from a
+/// `meta.json` on disk, and a corrupted or hand-edited `i64::MIN` there would
+/// otherwise overflow before the clamp could apply.
 pub fn between(from: i64, to: i64) -> u64 {
-    (to - from).max(0) as u64
+    to.saturating_sub(from).max(0) as u64
 }
 
 /// The JSON key carrying a run's age in seconds, on every API that serves runs.
@@ -130,5 +133,13 @@ mod tests {
         assert_eq!(between(100, 145), 45);
         assert_eq!(between(100, 100), 0);
         assert_eq!(between(200, 100), 0);
+    }
+
+    /// A hand-edited or corrupted `started_at` of `i64::MIN` overflowed the
+    /// subtraction before the clamp could apply.
+    #[test]
+    fn between_survives_a_timestamp_at_the_edge_of_the_range() {
+        assert_eq!(between(i64::MIN, 0), i64::MAX as u64);
+        assert_eq!(between(0, i64::MIN), 0);
     }
 }

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -244,7 +244,10 @@ impl ContextLayout {
             return Ok(());
         }
 
-        let total_max: usize = self.regions.iter().map(|r| r.max_tokens).sum();
+        let total_max = self
+            .regions
+            .iter()
+            .fold(0usize, |acc, r| acc.saturating_add(r.max_tokens));
         if total_max > self.total_budget_tokens {
             tracing::warn!(
                 "Sum of region max tokens ({}) exceeds total budget ({})",
@@ -274,8 +277,7 @@ impl ContextLayout {
                         }
                 )
             })
-            .map(|r| r.max_tokens)
-            .sum();
+            .fold(0usize, |acc, r| acc.saturating_add(r.max_tokens));
         // Only enforce the absolute working-budget floor on realistically-sized
         // layouts. Tiny illustrative layouts (toy examples, unit-test fixtures)
         // have small budgets by design and are not real agent runs; applying an
@@ -1264,5 +1266,20 @@ mod tests {
         with_tracing(|| {
             assert!(layout.validate().is_ok());
         });
+    }
+
+    /// `validate` sums every region's ceiling to warn when they exceed the
+    /// budget. Two saturated ceilings used to overflow that sum and abort
+    /// instead of warning.
+    #[test]
+    fn validate_does_not_abort_when_region_ceilings_sum_past_usize_max() {
+        let layout = ContextLayout::new(
+            vec![
+                RegionDefinition::new("a".to_string(), RegionKind::Pinned, usize::MAX),
+                RegionDefinition::new("b".to_string(), RegionKind::Pinned, usize::MAX),
+            ],
+            1_000,
+        );
+        let _ = layout.validate();
     }
 }

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -128,7 +128,7 @@ pub(super) fn parse_region_layout(
                     // for percentage regions (resolved later), else the legacy
                     // absolute `max_tokens * 8 / 10`.
                     (None, None, true) => usize::MAX,
-                    (None, None, false) => provisional_max_tokens * 8 / 10,
+                    (None, None, false) => provisional_max_tokens.saturating_mul(8) / 10,
                 };
                 RegionKind::Compacting {
                     threshold_tokens: threshold,
@@ -265,7 +265,7 @@ pub(super) fn parse_region_layout(
         // Percentage regions contribute their (unknown) size at resolution, so
         // only absolute budgets add to the summed total here.
         if percent.is_none() {
-            total_tokens += provisional_max_tokens;
+            total_tokens = total_tokens.saturating_add(provisional_max_tokens);
         }
 
         let mut def = RegionDefinition::new(region_name.clone(), kind, provisional_max_tokens)

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -5436,3 +5436,36 @@ hide = ["sources"]
         .expect_err("routed into a hidden region");
     assert!(err.to_string().contains("sources"), "{err}");
 }
+
+// ─── Arithmetic on hostile numbers ─────────────────────────────────────
+
+/// `max_tokens = -1` became `usize::MAX` through `as usize`, and the default
+/// compaction threshold (`max_tokens * 8 / 10`) then overflowed. With
+/// `overflow-checks` on in release that aborted the daemon on load, taking
+/// every running agent with it. Loading must not panic; whether it should be
+/// refused is a separate question (it will be).
+#[test]
+fn a_negative_max_tokens_on_a_compacting_region_does_not_abort() {
+    let toml = r#"
+[agent]
+name = "neg"
+
+[context.regions]
+notes = { kind = "compacting", max_tokens = -1 }
+"#;
+    let _ = parse_manifest(toml);
+}
+
+/// Two such regions overflowed the summed total instead.
+#[test]
+fn two_negative_budgets_do_not_abort_the_total() {
+    let toml = r#"
+[agent]
+name = "neg"
+
+[context.regions]
+a = { kind = "pinned", max_tokens = -1 }
+b = { kind = "pinned", max_tokens = -1 }
+"#;
+    let _ = parse_manifest(toml);
+}

--- a/crates/leviath-core/src/region/mod.rs
+++ b/crates/leviath-core/src/region/mod.rs
@@ -949,17 +949,17 @@ impl Region {
                     while self.content.len() > max && self.remove_oldest().is_some() {}
                 }
                 EvictionStrategy::Bulk { overflow } => {
-                    if self.content.len() > max + overflow {
+                    if self.content.len() > max.saturating_add(overflow) {
                         while self.content.len() > max && self.remove_oldest().is_some() {}
                     }
                 }
                 EvictionStrategy::Compact { compact_count } => {
-                    if self.content.len() > max + compact_count * 2 {
+                    if self.content.len() > max.saturating_add(compact_count.saturating_mul(2)) {
                         // Fallback: runtime hasn't compacted, bulk-evict to prevent
                         // unbounded growth.
                         while self.content.len() > max && self.remove_oldest().is_some() {}
                         self.needs_message_compaction = false;
-                    } else if self.content.len() > max + compact_count {
+                    } else if self.content.len() > max.saturating_add(compact_count) {
                         self.needs_message_compaction = true;
                     }
                 }
@@ -3670,5 +3670,30 @@ mod tests {
             Some("two"),
             "the oldest rolled off as it always did"
         );
+    }
+
+    /// A `max_items` of `usize::MAX` is what a negative manifest value used to
+    /// resolve to. The bulk-eviction check added `overflow` to it on the first
+    /// write and aborted the daemon mid-run.
+    #[test]
+    fn a_saturated_window_does_not_abort_on_its_first_write() {
+        let mut region = Region::new(
+            "w".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: usize::MAX,
+                eviction_strategy: EvictionStrategy::Bulk { overflow: 10 },
+            },
+            100,
+        );
+        region.add_entry("x".to_string(), 1).unwrap();
+        let mut region = Region::new(
+            "w".to_string(),
+            RegionKind::SlidingWindow {
+                max_items: usize::MAX,
+                eviction_strategy: EvictionStrategy::Compact { compact_count: 10 },
+            },
+            100,
+        );
+        region.add_entry("x".to_string(), 1).unwrap();
     }
 }

--- a/crates/leviath-providers/src/pricing.rs
+++ b/crates/leviath-providers/src/pricing.rs
@@ -68,11 +68,18 @@ impl TokenUsage {
     ///
     /// The one constructor for a parsed response, so a provider cannot ship a
     /// total that disagrees with its parts.
+    ///
+    /// Saturating: every count arrives from a provider's response body, and
+    /// `overflow-checks` is on in release, so a gateway reporting a nonsense
+    /// `prompt_tokens` would otherwise abort the daemon rather than one call.
     pub fn new(fresh: usize, cached: usize, cache_write: usize, completion: usize) -> Self {
         Self {
             prompt_tokens: fresh,
             completion_tokens: completion,
-            total_tokens: fresh + cached + cache_write + completion,
+            total_tokens: fresh
+                .saturating_add(cached)
+                .saturating_add(cache_write)
+                .saturating_add(completion),
             cached_tokens: cached,
             cache_write_tokens: cache_write,
             reported_cost_usd: None,
@@ -87,7 +94,9 @@ impl TokenUsage {
 
     /// All input tokens, however they were billed.
     pub fn input_tokens(&self) -> usize {
-        self.prompt_tokens + self.cached_tokens + self.cache_write_tokens
+        self.prompt_tokens
+            .saturating_add(self.cached_tokens)
+            .saturating_add(self.cache_write_tokens)
     }
 
     /// What this one call cost, or `None` when nothing can price it.
@@ -606,5 +615,14 @@ mod cost_tests {
         totals.add(&computed, None);
         assert_eq!(computed.priced_cost(None), None);
         assert_eq!(totals.unpriced_calls, 1);
+    }
+
+    /// Every count arrives from a provider response. A gateway reporting a
+    /// nonsense `prompt_tokens` used to abort the daemon in the constructor.
+    #[test]
+    fn token_usage_saturates_instead_of_aborting() {
+        let usage = TokenUsage::new(usize::MAX, 1, 1, 1);
+        assert_eq!(usage.total_tokens, usize::MAX);
+        assert_eq!(usage.input_tokens(), usize::MAX);
     }
 }

--- a/crates/leviath-providers/src/provider/stream.rs
+++ b/crates/leviath-providers/src/provider/stream.rs
@@ -123,10 +123,12 @@ impl PartialToolCall {
 /// once.
 fn merge_usage(into: TokenUsage, chunk: TokenUsage) -> TokenUsage {
     TokenUsage::new(
-        into.prompt_tokens + chunk.prompt_tokens,
-        into.cached_tokens + chunk.cached_tokens,
-        into.cache_write_tokens + chunk.cache_write_tokens,
-        into.completion_tokens + chunk.completion_tokens,
+        into.prompt_tokens.saturating_add(chunk.prompt_tokens),
+        into.cached_tokens.saturating_add(chunk.cached_tokens),
+        into.cache_write_tokens
+            .saturating_add(chunk.cache_write_tokens),
+        into.completion_tokens
+            .saturating_add(chunk.completion_tokens),
     )
     .with_reported_cost(chunk.reported_cost_usd.or(into.reported_cost_usd))
 }
@@ -318,5 +320,16 @@ mod tests {
         let err = collect_stream(stream).await.expect_err("the stream failed");
 
         assert_eq!(err.failure_kind(), Some(FailureKind::Timeout));
+    }
+
+    /// Chunk counts accumulate across a stream; two large reports must clamp
+    /// rather than overflow the running total.
+    #[test]
+    fn merged_usage_saturates_instead_of_aborting() {
+        let a = TokenUsage::new(usize::MAX, 0, 0, 0);
+        let b = TokenUsage::new(1, 0, 0, 1);
+        let merged = merge_usage(a, b);
+        assert_eq!(merged.prompt_tokens, usize::MAX);
+        assert_eq!(merged.total_tokens, usize::MAX);
     }
 }

--- a/crates/leviath-providers/src/rate_limit.rs
+++ b/crates/leviath-providers/src/rate_limit.rs
@@ -68,16 +68,23 @@ impl RateLimiter {
             let now = Instant::now();
             let mut state = self.state.lock().await;
 
-            // Prune old entries outside the 1-minute window
-            let cutoff = now - window;
+            // Prune old entries outside the 1-minute window. `duration_since`
+            // rather than `now - window`: an `Instant` cannot go before the
+            // platform's epoch, and `Instant - Duration` panics when it would -
+            // on Linux the epoch is boot, so a daemon started under a service
+            // manager within 60s of boot hit that on its first request.
             while state
                 .request_timestamps
                 .front()
-                .is_some_and(|t| *t < cutoff)
+                .is_some_and(|t| now.duration_since(*t) > window)
             {
                 state.request_timestamps.pop_front();
             }
-            while state.token_counts.front().is_some_and(|(t, _)| *t < cutoff) {
+            while state
+                .token_counts
+                .front()
+                .is_some_and(|(t, _)| now.duration_since(*t) > window)
+            {
                 state.token_counts.pop_front();
             }
 
@@ -113,9 +120,12 @@ impl RateLimiter {
         let window = Duration::from_secs(60);
         let mut state = self.state.lock().await;
 
-        // Prune old entries
-        let cutoff = now - window;
-        while state.token_counts.front().is_some_and(|(t, _)| *t < cutoff) {
+        // Prune old entries; see `acquire` for why this is not `now - window`.
+        while state
+            .token_counts
+            .front()
+            .is_some_and(|(t, _)| now.duration_since(*t) > window)
+        {
             state.token_counts.pop_front();
         }
 


### PR DESCRIPTION
## What

`overflow-checks = true` in release is the right call, and it means every arithmetic on a number that came from outside the process must be unable to overflow. Ten sites were not, and each was a daemon abort (every running agent lost), not a bad number:

| site | input | before |
|---|---|---|
| `manifest/regions.rs` compacting default threshold `* 8 / 10` | `max_tokens = -1` in a blueprint (`as usize` → `usize::MAX`) | abort on load |
| `manifest/regions.rs` summed total `+=` | two such regions | abort on load |
| `layout.rs::validate` two `.sum()`s over region ceilings | same | abort at spawn |
| `region/mod.rs` `max + overflow`, `max + compact_count * 2`, `max + compact_count` | `max_items = -1` | abort on the region's **first write**, mid-run |
| `pricing.rs` `TokenUsage::new`, `input_tokens` | counts from a provider/gateway response body | abort on a nonsense `prompt_tokens` |
| `provider/stream.rs::merge_usage` | same, accumulated across chunks | abort |
| `rate_limit.rs` `now - window` on an `Instant` (twice) | wall clock | panics if the result precedes the platform epoch; on Linux that is boot, so a daemon started under systemd within 60 s of boot died on its first request |
| `duration.rs::between` `to - from` | `started_at` read from `meta.json` | abort on `i64::MIN` |
| `markdown_edit` `area.width - width` after `.clamp(12, ..)` | terminal narrower than 12 columns with a prompt open | dashboard panic |

Each now saturates (the rate limiter asks `now.duration_since(t) > window`, which is the same predicate with no subtraction).

## Behaviour

None observable short of the panic: a count that would have overflowed clamps at `usize::MAX`/`u64::MAX`; a narrow terminal renders clipped. A negative in a blueprint still **loads** (as a saturated ceiling); refusing it is a separate, behaviour-changing PR (Phase 5.7 of the cleanup plan).

## Verification

Seven regression tests, each run first against the unfixed code and shown to panic there (`attempt to subtract with overflow` and the like), then green after the fix. `cargo test -p leviath-core` 904, `-p leviath-providers` 907, clippy `-D warnings` on core/providers/cli. No new branches, so the coverage gate is unaffected.
