### PR TITLE
fix: Debug never prints a secret; drop the dead ProviderConfig

### DIFF
--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -4,8 +4,8 @@ mod stream;
 
 use crate::provider::{
     FinishReason, InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities,
-    ModelCapabilityOverride, ModelInfo, Provider, ProviderConfig, ProviderError, Result,
-    StreamChunk, TokenUsage, ToolCall,
+    ModelCapabilityOverride, ModelInfo, Provider, ProviderError, Result, StreamChunk, TokenUsage,
+    ToolCall,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -299,21 +299,6 @@ impl AnthropicProvider {
         }
     }
 
-    /// Create a new Anthropic provider with full configuration.
-    pub fn with_config(client: reqwest::Client, config: ProviderConfig) -> Self {
-        let rate_limiter = config.rate_limit.as_ref().map(RateLimiter::new);
-        Self {
-            client,
-            api_key: config.api_key,
-            base_url: config
-                .base_url
-                .unwrap_or_else(|| "https://api.anthropic.com/v1".to_string()),
-            rate_limiter,
-            capability_overrides: HashMap::new(),
-            cache_ttl: CacheTtl::default(),
-        }
-    }
-
     /// Create a new Anthropic provider with per-model capability overrides.
     pub fn with_overrides(
         client: reqwest::Client,
@@ -439,9 +424,9 @@ impl AnthropicProvider {
     ///
     /// An enterprise gateway or self-hosted proxy speaks the same API on a
     /// different origin, and every part of that was already here - the struct
-    /// holds a `base_url`, and `with_config` honours one - except a way for
+    /// holds a `base_url`, and the constructors honour one - except a way for
     /// configuration to reach the constructor the registry actually calls.
-    /// `with_config` sets the URL and drops the capability overrides;
+    /// a `base_url` constructor would drop the capability overrides;
     /// `with_overrides` does the reverse, and the registry needs the overrides,
     /// so the URL was the half that got lost.
     ///
@@ -2158,54 +2143,6 @@ mod tests {
     }
 
     #[test]
-    fn test_with_config_default_base_url() {
-        let config = ProviderConfig {
-            api_key: "test-key".to_string(),
-            base_url: None,
-            rate_limit: None,
-            request_timeout_secs: None,
-        };
-        let provider = AnthropicProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert_eq!(provider.base_url, "https://api.anthropic.com/v1");
-    }
-
-    #[test]
-    fn test_with_config_custom_base_url() {
-        let config = ProviderConfig {
-            api_key: "test-key".to_string(),
-            base_url: Some("https://custom.api.com".to_string()),
-            rate_limit: None,
-            request_timeout_secs: None,
-        };
-        let provider = AnthropicProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert_eq!(provider.base_url, "https://custom.api.com");
-    }
-
-    #[test]
-    fn test_with_config_with_rate_limit() {
-        let config = ProviderConfig {
-            api_key: "test-key".to_string(),
-            base_url: None,
-            rate_limit: Some(crate::provider::RateLimitConfig {
-                requests_per_minute: 10,
-                tokens_per_minute: 50000,
-            }),
-            request_timeout_secs: None,
-        };
-        let provider = AnthropicProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert!(provider.rate_limiter.is_some());
-    }
-
-    #[test]
     fn test_builtin_capabilities_opus46() {
         let provider = AnthropicProvider::new(
             crate::provider::build_http_client(None).expect("a test client builds"),
@@ -3035,15 +2972,45 @@ mod tests {
     // without a real network call.
 
     fn provider_with_url(url: String) -> AnthropicProvider {
-        AnthropicProvider::with_config(
+        AnthropicProvider::new(
             crate::provider::build_http_client(None).expect("a test client builds"),
-            ProviderConfig {
-                api_key: "test-key".to_string(),
-                base_url: Some(url),
-                rate_limit: None,
-                request_timeout_secs: None,
-            },
+            "test-key".to_string(),
         )
+        .with_base_url(Some(url))
+    }
+
+    #[test]
+    fn with_base_url_keeps_the_default_when_none_is_given() {
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        )
+        .with_base_url(None);
+        assert_eq!(provider.base_url, "https://api.anthropic.com/v1");
+    }
+
+    #[test]
+    fn with_base_url_replaces_the_default() {
+        let provider = AnthropicProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        )
+        .with_base_url(Some("https://custom.example.com".to_string()));
+        assert_eq!(provider.base_url, "https://custom.example.com");
+    }
+
+    #[test]
+    fn with_overrides_installs_a_rate_limiter_when_given_one() {
+        let provider = AnthropicProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+            HashMap::new(),
+            Some(&crate::provider::RateLimitConfig {
+                requests_per_minute: 10,
+                tokens_per_minute: 50_000,
+            }),
+        );
+        assert!(provider.rate_limiter.is_some());
     }
 
     fn simple_request() -> InferenceRequest {

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -5,7 +5,7 @@ use crate::openai_compat::{
 };
 use crate::provider::{
     InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
-    ModelInfo, Provider, ProviderConfig, ProviderError, Result, StreamChunk,
+    ModelInfo, Provider, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -108,21 +108,6 @@ impl GeminiProvider {
         }
     }
 
-    /// Create a new Gemini provider with full configuration.
-    pub fn with_config(client: reqwest::Client, config: ProviderConfig) -> Self {
-        let rate_limiter = config.rate_limit.as_ref().map(RateLimiter::new);
-        Self {
-            client,
-            api_key: config.api_key,
-            base_url: config.base_url.unwrap_or_else(|| {
-                "https://generativelanguage.googleapis.com/v1beta/openai".to_string()
-            }),
-            rate_limiter,
-            api_limits: Default::default(),
-            capability_overrides: HashMap::new(),
-        }
-    }
-
     /// Create a new Gemini provider with per-model capability overrides.
     pub fn with_overrides(
         client: reqwest::Client,
@@ -144,9 +129,9 @@ impl GeminiProvider {
     ///
     /// An enterprise gateway or self-hosted proxy speaks the same API on a
     /// different origin, and every part of that was already here - the struct
-    /// holds a `base_url`, and `with_config` honours one - except a way for
+    /// holds a `base_url`, and the constructors honour one - except a way for
     /// configuration to reach the constructor the registry actually calls.
-    /// `with_config` sets the URL and drops the capability overrides;
+    /// a `base_url` constructor would drop the capability overrides;
     /// `with_overrides` does the reverse, and the registry needs the overrides,
     /// so the URL was the half that got lost.
     ///
@@ -854,58 +839,6 @@ mod tests {
 
     // ── Additional coverage tests ──────────────────────────────────────────
 
-    #[test]
-    fn test_with_config_default_url() {
-        let config = ProviderConfig {
-            api_key: "key".to_string(),
-            base_url: None,
-            rate_limit: None,
-            request_timeout_secs: None,
-        };
-        let provider = GeminiProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert!(
-            provider
-                .base_url
-                .contains("generativelanguage.googleapis.com")
-        );
-    }
-
-    #[test]
-    fn test_with_config_custom_url() {
-        let config = ProviderConfig {
-            api_key: "key".to_string(),
-            base_url: Some("https://custom.google.com".to_string()),
-            rate_limit: None,
-            request_timeout_secs: None,
-        };
-        let provider = GeminiProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert_eq!(provider.base_url, "https://custom.google.com");
-    }
-
-    #[test]
-    fn test_with_config_with_rate_limit() {
-        let config = ProviderConfig {
-            api_key: "key".to_string(),
-            base_url: None,
-            rate_limit: Some(crate::provider::RateLimitConfig {
-                requests_per_minute: 30,
-                tokens_per_minute: 50000,
-            }),
-            request_timeout_secs: None,
-        };
-        let provider = GeminiProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert!(provider.rate_limiter.is_some());
-    }
-
     /// Provider whose native base is a non-standard URL (no `/openai` suffix),
     /// so `count_tokens` skips the endpoint and uses the local heuristic.
     fn heuristic_only_provider() -> GeminiProvider {
@@ -1082,15 +1015,48 @@ mod tests {
     // ─── HTTP-call-level tests via a raw-TCP mock server ───────────────────
 
     fn provider_with_url(url: String) -> GeminiProvider {
-        GeminiProvider::with_config(
+        GeminiProvider::new(
             crate::provider::build_http_client(None).expect("a test client builds"),
-            ProviderConfig {
-                api_key: "test-key".to_string(),
-                base_url: Some(url),
-                rate_limit: None,
-                request_timeout_secs: None,
-            },
+            "test-key".to_string(),
         )
+        .with_base_url(Some(url))
+    }
+
+    #[test]
+    fn with_base_url_keeps_the_default_when_none_is_given() {
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        )
+        .with_base_url(None);
+        assert_eq!(
+            provider.base_url,
+            "https://generativelanguage.googleapis.com/v1beta/openai"
+        );
+    }
+
+    #[test]
+    fn with_base_url_replaces_the_default() {
+        let provider = GeminiProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        )
+        .with_base_url(Some("https://custom.example.com".to_string()));
+        assert_eq!(provider.base_url, "https://custom.example.com");
+    }
+
+    #[test]
+    fn with_overrides_installs_a_rate_limiter_when_given_one() {
+        let provider = GeminiProvider::with_overrides(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+            HashMap::new(),
+            Some(&crate::provider::RateLimitConfig {
+                requests_per_minute: 10,
+                tokens_per_minute: 50_000,
+            }),
+        );
+        assert!(provider.rate_limiter.is_some());
     }
 
     fn simple_request() -> InferenceRequest {

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -41,7 +41,7 @@ pub use openrouter::OpenRouterProvider;
 pub use pricing::{CostTotals, ModelPricing};
 pub use provider::{
     ContentBlock, DEFAULT_INFERENCE_TIMEOUT_SECS, FailureKind, FinishReason, InferenceRequest,
-    InferenceResponse, Message, MessageContent, ModelInfo, Provider, ProviderConfig, ProviderError,
+    InferenceResponse, Message, MessageContent, ModelInfo, Provider, ProviderError,
     RateLimitConfig, Result, RetryAdvice, SystemBlock, TokenUsage, Tool, ToolCall,
     UnavailableReason, build_http_client, collect_stream,
 };

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -6,7 +6,7 @@ use crate::openai_compat::{
 };
 use crate::provider::{
     InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
-    ModelInfo, Provider, ProviderConfig, ProviderError, Result, StreamChunk,
+    ModelInfo, Provider, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -58,22 +58,6 @@ impl OpenAIProvider {
         }
     }
 
-    /// Create a new OpenAI provider with full configuration.
-    pub fn with_config(client: reqwest::Client, config: ProviderConfig) -> Self {
-        let rate_limiter = config.rate_limit.as_ref().map(RateLimiter::new);
-        Self {
-            client,
-            api_key: config.api_key,
-            base_url: config
-                .base_url
-                .unwrap_or_else(|| "https://api.openai.com/v1".to_string()),
-            rate_limiter,
-            capability_overrides: HashMap::new(),
-            reasoning_effort_none: Default::default(),
-            temperature_unsupported: Default::default(),
-        }
-    }
-
     /// Create a new OpenAI provider with per-model capability overrides.
     pub fn with_overrides(
         client: reqwest::Client,
@@ -96,9 +80,9 @@ impl OpenAIProvider {
     ///
     /// An enterprise gateway or self-hosted proxy speaks the same API on a
     /// different origin, and every part of that was already here - the struct
-    /// holds a `base_url`, and `with_config` honours one - except a way for
+    /// holds a `base_url`, and the constructors honour one - except a way for
     /// configuration to reach the constructor the registry actually calls.
-    /// `with_config` sets the URL and drops the capability overrides;
+    /// a `base_url` constructor would drop the capability overrides;
     /// `with_overrides` does the reverse, and the registry needs the overrides,
     /// so the URL was the half that got lost.
     ///
@@ -845,36 +829,6 @@ mod tests {
         assert_eq!(provider.name(), "openai");
     }
 
-    #[test]
-    fn test_with_config_default_url() {
-        let config = ProviderConfig {
-            api_key: "key".to_string(),
-            base_url: None,
-            rate_limit: None,
-            request_timeout_secs: None,
-        };
-        let provider = OpenAIProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert_eq!(provider.base_url, "https://api.openai.com/v1");
-    }
-
-    #[test]
-    fn test_with_config_custom_url() {
-        let config = ProviderConfig {
-            api_key: "key".to_string(),
-            base_url: Some("https://custom.openai.com".to_string()),
-            rate_limit: None,
-            request_timeout_secs: None,
-        };
-        let provider = OpenAIProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert_eq!(provider.base_url, "https://custom.openai.com");
-    }
-
     #[tokio::test]
     async fn test_count_tokens_uses_tiktoken() {
         let provider = OpenAIProvider::new(
@@ -1004,15 +958,31 @@ mod tests {
     // ─── HTTP-call-level tests via a raw-TCP mock server ───────────────────
 
     fn provider_with_url(url: String) -> OpenAIProvider {
-        OpenAIProvider::with_config(
+        OpenAIProvider::new(
             crate::provider::build_http_client(None).expect("a test client builds"),
-            ProviderConfig {
-                api_key: "test-key".to_string(),
-                base_url: Some(url),
-                rate_limit: None,
-                request_timeout_secs: None,
-            },
+            "test-key".to_string(),
         )
+        .with_base_url(Some(url))
+    }
+
+    #[test]
+    fn with_base_url_keeps_the_default_when_none_is_given() {
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        )
+        .with_base_url(None);
+        assert_eq!(provider.base_url, "https://api.openai.com/v1");
+    }
+
+    #[test]
+    fn with_base_url_replaces_the_default() {
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        )
+        .with_base_url(Some("https://custom.example.com".to_string()));
+        assert_eq!(provider.base_url, "https://custom.example.com");
     }
 
     fn simple_request() -> InferenceRequest {

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -8,7 +8,7 @@ use crate::openai_compat::{
 };
 use crate::provider::{
     InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
-    ModelInfo, Provider, ProviderConfig, ProviderError, Result, StreamChunk,
+    ModelInfo, Provider, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -131,24 +131,6 @@ impl OpenRouterProvider {
         }
     }
 
-    /// Create a new OpenRouter provider with full configuration.
-    pub fn with_config(client: reqwest::Client, config: ProviderConfig) -> Self {
-        let rate_limiter = config.rate_limit.as_ref().map(RateLimiter::new);
-        Self {
-            client,
-            api_key: config.api_key,
-            base_url: config
-                .base_url
-                .unwrap_or_else(|| "https://openrouter.ai/api/v1".to_string()),
-            rate_limiter,
-            capability_overrides: HashMap::new(),
-            warned_unknown: Default::default(),
-            temperature_unsupported: Default::default(),
-            api_windows: Default::default(),
-            api_pricing: Default::default(),
-        }
-    }
-
     /// Create a new OpenRouter provider with per-model capability overrides.
     pub fn with_overrides(
         client: reqwest::Client,
@@ -173,9 +155,9 @@ impl OpenRouterProvider {
     ///
     /// An enterprise gateway or self-hosted proxy speaks the same API on a
     /// different origin, and every part of that was already here - the struct
-    /// holds a `base_url`, and `with_config` honours one - except a way for
+    /// holds a `base_url`, and the constructors honour one - except a way for
     /// configuration to reach the constructor the registry actually calls.
-    /// `with_config` sets the URL and drops the capability overrides;
+    /// a `base_url` constructor would drop the capability overrides;
     /// `with_overrides` does the reverse, and the registry needs the overrides,
     /// so the URL was the half that got lost.
     ///
@@ -1175,36 +1157,6 @@ mod tests {
         assert!(provider.max_context_tokens("meta-llama/llama-4-scout") > 128_000);
     }
 
-    #[test]
-    fn test_with_config_default_url() {
-        let config = ProviderConfig {
-            api_key: "key".to_string(),
-            base_url: None,
-            rate_limit: None,
-            request_timeout_secs: None,
-        };
-        let provider = OpenRouterProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert_eq!(provider.base_url, "https://openrouter.ai/api/v1");
-    }
-
-    #[test]
-    fn test_with_config_custom_url() {
-        let config = ProviderConfig {
-            api_key: "key".to_string(),
-            base_url: Some("https://custom.openrouter.ai".to_string()),
-            rate_limit: None,
-            request_timeout_secs: None,
-        };
-        let provider = OpenRouterProvider::with_config(
-            crate::provider::build_http_client(None).expect("a test client builds"),
-            config,
-        );
-        assert_eq!(provider.base_url, "https://custom.openrouter.ai");
-    }
-
     // ─── The conservative fallback is no longer silent ──────────────────────
 
     #[test]
@@ -1801,15 +1753,31 @@ mod tests {
     // ─── HTTP-call-level tests via a raw-TCP mock server ───────────────────
 
     fn provider_with_url(url: String) -> OpenRouterProvider {
-        OpenRouterProvider::with_config(
+        OpenRouterProvider::new(
             crate::provider::build_http_client(None).expect("a test client builds"),
-            ProviderConfig {
-                api_key: "test-key".to_string(),
-                base_url: Some(url),
-                rate_limit: None,
-                request_timeout_secs: None,
-            },
+            "test-key".to_string(),
         )
+        .with_base_url(Some(url))
+    }
+
+    #[test]
+    fn with_base_url_keeps_the_default_when_none_is_given() {
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        )
+        .with_base_url(None);
+        assert_eq!(provider.base_url, "https://openrouter.ai/api/v1");
+    }
+
+    #[test]
+    fn with_base_url_replaces_the_default() {
+        let provider = OpenRouterProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "test-key".to_string(),
+        )
+        .with_base_url(Some("https://custom.example.com".to_string()));
+        assert_eq!(provider.base_url, "https://custom.example.com");
     }
 
     fn simple_request() -> InferenceRequest {

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -674,25 +674,6 @@ pub struct ToolCallDelta {
     pub thought_signature: Option<String>,
 }
 
-/// Configuration for a provider instance.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ProviderConfig {
-    /// API key for authentication
-    pub api_key: String,
-
-    /// Optional custom base URL
-    pub base_url: Option<String>,
-
-    /// Optional rate limit configuration
-    pub rate_limit: Option<RateLimitConfig>,
-
-    /// Optional request timeout in seconds.
-    /// When set, the reqwest client will abort requests that exceed this duration.
-    /// Default is None (no timeout).
-    #[serde(default)]
-    pub request_timeout_secs: Option<u64>,
-}
-
 /// Rate limit configuration.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RateLimitConfig {
@@ -1930,33 +1911,6 @@ mod tests {
         let back: RateLimitConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(back.requests_per_minute, 60);
         assert_eq!(back.tokens_per_minute, 100_000);
-    }
-
-    #[test]
-    fn provider_config_serde_roundtrip() {
-        let cfg = ProviderConfig {
-            api_key: "sk-test".into(),
-            base_url: Some("https://api.example.com".into()),
-            rate_limit: Some(RateLimitConfig {
-                requests_per_minute: 30,
-                tokens_per_minute: 50_000,
-            }),
-            request_timeout_secs: None,
-        };
-        let json = serde_json::to_string(&cfg).unwrap();
-        let back: ProviderConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.api_key, "sk-test");
-        assert_eq!(back.base_url.as_deref(), Some("https://api.example.com"));
-        assert!(back.rate_limit.is_some());
-    }
-
-    #[test]
-    fn provider_config_optional_fields_default_to_none() {
-        let json = r#"{"api_key":"sk-test"}"#;
-        let cfg: ProviderConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(cfg.api_key, "sk-test");
-        assert!(cfg.base_url.is_none());
-        assert!(cfg.rate_limit.is_none());
     }
 
     // ─── stream_once ────────────────────────────────────────────────────────

--- a/crates/leviath-providers/src/provider/http.rs
+++ b/crates/leviath-providers/src/provider/http.rs
@@ -92,7 +92,7 @@ pub fn apply_request_timeout(
 /// Inference calls are bounded per-request instead (see [`apply_request_timeout`]
 /// and `DEFAULT_INFERENCE_TIMEOUT_SECS`) so each stage can pick its own deadline,
 /// with the dispatch `job_timeout` as the final backstop. `timeout_secs`
-/// (`ProviderConfig::request_timeout_secs`) still applies an optional
+/// (`InferenceRequest::request_timeout_secs`) still applies an optional
 /// client-level hard cap on total request duration for callers that set it; a
 /// per-request timeout, when present, overrides it.
 /// Whether a redirect keeps the request on the origin it started from.

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -22,7 +22,11 @@ pub enum HttpMethod {
 }
 
 /// A single HTTP request a script asked the host to perform.
-#[derive(Debug, Clone)]
+///
+/// `Debug` is hand-written (below): `headers` carries the script provider's
+/// `Authorization` or `x-api-key`, and a derived `Debug` would print it in
+/// full the first time anything logged `?request`.
+#[derive(Clone)]
 pub struct HostRequest {
     /// GET or POST.
     pub method: HttpMethod,
@@ -34,6 +38,32 @@ pub struct HostRequest {
     pub headers: BTreeMap<String, String>,
     /// Per-request wall-clock deadline in seconds (the stage timeout).
     pub timeout_secs: Option<u64>,
+}
+
+impl std::fmt::Debug for HostRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Values are redacted by header *shape*, not by an exact-name list,
+        // so a provider's own credential header (`x-goog-api-key`) is covered
+        // without anyone remembering to add it.
+        let headers: Vec<(&str, String)> = self
+            .headers
+            .iter()
+            .map(|(name, value)| {
+                let shown = match leviath_core::is_secret_header(name) {
+                    true => leviath_core::redact(value),
+                    false => value.clone(),
+                };
+                (name.as_str(), shown)
+            })
+            .collect();
+        f.debug_struct("HostRequest")
+            .field("method", &self.method)
+            .field("url", &self.url)
+            .field("body", &self.body)
+            .field("headers", &headers)
+            .field("timeout_secs", &self.timeout_secs)
+            .finish()
+    }
 }
 
 /// A transport-level error from performing a [`HostRequest`], carrying enough

--- a/crates/leviath-providers/src/rhai_provider/host/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/host/tests.rs
@@ -684,3 +684,32 @@ fn the_executor_survives_losing_only_its_fallback() {
     // moment a script provider is resolved.
     assert!(executor_from_clients(Err(crate::provider::malformed_url_error()), Ok(ok()),).is_err());
 }
+
+/// The one place a script provider's credential could reach a log line.
+#[test]
+fn host_request_debug_never_prints_a_credential_header() {
+    let mut headers = BTreeMap::new();
+    headers.insert(
+        "authorization".to_string(),
+        "Bearer sk-live-abcdefghijklmnop".to_string(),
+    );
+    headers.insert(
+        "x-goog-api-key".to_string(),
+        "AIza-secret-value-1234567890".to_string(),
+    );
+    headers.insert("content-type".to_string(), "application/json".to_string());
+    let request = HostRequest {
+        method: HttpMethod::Post,
+        url: "https://example.com/v1/chat".to_string(),
+        body: Some("{}".to_string()),
+        headers,
+        timeout_secs: Some(30),
+    };
+    let out = format!("{request:?}");
+    assert!(!out.contains("sk-live-abcdefghijklmnop"), "{out}");
+    assert!(!out.contains("AIza-secret-value-1234567890"), "{out}");
+    // Present but redacted, not silently dropped.
+    assert!(out.contains("authorization"), "{out}");
+    assert!(out.contains("x-goog-api-key"), "{out}");
+    assert!(out.contains("application/json"), "{out}");
+}

--- a/crates/leviath-runtime/src/host/types.rs
+++ b/crates/leviath-runtime/src/host/types.rs
@@ -22,7 +22,11 @@ use leviath_core::interaction::{InteractionRequest, InteractionResponse};
 /// The parameters for spawning an agent into the world. The runtime doesn't know
 /// how to load blueprints or resolve tools - that policy lives in the
 /// [`Spawner`] the daemon installs - so this just carries the raw request.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+///
+/// `Debug` is hand-written (below) so `callback_secret` cannot reach a log
+/// line; `Serialize` keeps it, because the secret has to cross the control
+/// socket to the daemon that signs the webhook.
+#[derive(Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct SpawnArgs {
     /// The run id to give the new agent (its directory / control key).
     pub run_id: String,
@@ -90,6 +94,39 @@ pub struct SpawnArgs {
     /// (see [`leviath_core::resolve_output_spec`]).
     #[serde(default)]
     pub output: Option<leviath_core::output::OutputSpec>,
+}
+
+/// Every field, with the webhook secret shown as present-or-absent only.
+///
+/// A `#[derive(Debug)]` here meant one `tracing::debug!(?args)` on the spawn
+/// path - there is none today - would print the HMAC key a caller shares
+/// with the daemon. `provider_creds.rs` does the same for API keys.
+impl std::fmt::Debug for SpawnArgs {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SpawnArgs")
+            .field("run_id", &self.run_id)
+            .field("blueprint_path", &self.blueprint_path)
+            .field("task", &self.task)
+            .field("regions", &self.regions)
+            .field("model", &self.model)
+            .field("workdir", &self.workdir)
+            .field("metadata", &self.metadata)
+            .field("callback_url", &self.callback_url)
+            .field(
+                "callback_secret",
+                match self.callback_secret {
+                    Some(_) => &"<set>",
+                    None => &"<unset>",
+                },
+            )
+            .field("yolo", &self.yolo)
+            .field("no_seed_commands", &self.no_seed_commands)
+            .field("allow", &self.allow)
+            .field("max_depth", &self.max_depth)
+            .field("parent_run_id", &self.parent_run_id)
+            .field("output", &self.output)
+            .finish()
+    }
 }
 
 /// One row of a run listing (`ControlRequest::List`): a live run, its status,
@@ -471,4 +508,25 @@ pub enum ControlOp {
         /// Reply channel.
         reply: oneshot::Sender<bool>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The field is visibly present (so a redacted log still says a secret was
+    /// supplied) and its value is not.
+    #[test]
+    fn spawn_args_debug_never_prints_the_callback_secret() {
+        let args = SpawnArgs {
+            run_id: "r1".to_string(),
+            callback_secret: Some("s3cr3t-callback-hmac-key".to_string()),
+            ..SpawnArgs::default()
+        };
+        let out = format!("{args:?}");
+        assert!(!out.contains("s3cr3t-callback-hmac-key"), "{out}");
+        assert!(out.contains("callback_secret: \"<set>\""), "{out}");
+        let none = format!("{:?}", SpawnArgs::default());
+        assert!(none.contains("callback_secret: \"<unset>\""), "{none}");
+    }
 }


### PR DESCRIPTION
## What

Three types could put a credential into a log line the moment someone wrote `tracing::debug!(?value)`. Nothing does today, which is the cheap moment to make it impossible, following the pattern `provider_creds.rs` already uses for API keys.

- **`SpawnArgs`** (`leviath-runtime/src/host/types.rs`) derived `Debug` over `callback_secret`, the HMAC key a caller shares for webhook signing. Hand-written `Debug` now shows `callback_secret: "<set>"` / `"<unset>"`. `Serialize`/`Deserialize` are unchanged: the secret must cross the control socket.
- **`HostRequest`** (`leviath-providers/src/rhai_provider/host.rs`) derived `Debug` over its headers, which carry a script provider's `Authorization` / `x-api-key` / `x-goog-api-key`. Values are now redacted by header *shape* (`leviath_core::is_secret_header` + `redact`), so a vendor-specific credential header is covered without an exact-name list.
- **`ProviderConfig`** (`leviath-providers/src/provider.rs`) derived `Debug` **and** `Serialize` over a bare `api_key` and had zero production callers (every real construction is `with_overrides` + `with_base_url`). It and the four `with_config` constructors are deleted. The tests that used it are rewritten onto `new(..).with_base_url(..)` and `with_overrides(.., rate_limit)`, the constructors production actually uses, so the base-URL default/override arms and the rate-limiter arm stay covered.

## Behaviour

None at runtime. `leviath-providers` loses one public type and four public constructors; this goes in the release note with the other narrowings.

## Verification

- New tests: `spawn_args_debug_never_prints_the_callback_secret` (asserts the field is *present and redacted*, not dropped) and `host_request_debug_never_prints_a_credential_header` (a bearer token and a Google key are absent from the output; the header names and a non-secret header are present).
- `cargo test -p leviath-providers` 904, runtime host tests, clippy `-D warnings` on providers/runtime/cli, `cargo doc -D warnings`.
