### PR TITLE
fix: residual panics, a private dump dir, an honest rate-limit doc

### DIFF
--- a/crates/leviath-cli/src/daemon/sandbox_manager.rs
+++ b/crates/leviath-cli/src/daemon/sandbox_manager.rs
@@ -16,7 +16,6 @@
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
 use std::path::Path;
-use std::process::Command as StdCommand;
 use std::sync::{Mutex as StdMutex, PoisonError};
 
 use leviath_core::sandbox::{OnUnavailable, SandboxKind, ToolSandboxConfig};
@@ -262,10 +261,14 @@ fn unavailable(
 /// Real lifecycle-command runner: spawn synchronously, map a non-zero exit to
 /// its stderr.
 fn real_run(argv: &[String]) -> Result<(), String> {
-    let mut cmd = StdCommand::new(&argv[0]);
-    cmd.args(&argv[1..]);
+    let Some((program, args)) = argv.split_first() else {
+        return Err("empty sandbox command".to_string());
+    };
     // `docker run`/`docker rm` are bookkeeping the operator never watches, so
-    // they get no console window on Windows.
+    // they get no console window on Windows - which is what `child_command`
+    // arranges and a bare `Command::new` did not.
+    let mut cmd = leviath_sys::child_command(program);
+    cmd.args(args);
     let output = cmd.output().map_err(|e| e.to_string())?;
     if output.status.success() {
         Ok(())
@@ -743,4 +746,12 @@ mod tests {
     // The agent's shell runs INSIDE the container (reports `Alpine Linux`, which a
     // non-Alpine host lacks), the bind-mounted workdir is visible, and the
     // container is removed at reap (`docker ps -a` shows no leftover `leviath-*`).
+
+    /// The argv comes from `leviath_sys::container_*_argv`, which is never
+    /// empty, but indexing `argv[0]` on trust is how a refactor becomes a panic.
+    #[test]
+    fn real_run_refuses_an_empty_argv_instead_of_indexing_it() {
+        let err = real_run(&[]).unwrap_err();
+        assert_eq!(err, "empty sandbox command");
+    }
 }

--- a/crates/leviath-mcp/src/auth/store.rs
+++ b/crates/leviath-mcp/src/auth/store.rs
@@ -261,8 +261,13 @@ impl AuthStore {
 /// fallible step to reason about.
 fn create_parent_dir(path: &Path) -> anyhow::Result<()> {
     match path.parent() {
-        Some(parent) if !parent.as_os_str().is_empty() => std::fs::create_dir_all(parent)
-            .map_err(|e| anyhow::anyhow!("Failed to create MCP auth store directory: {}", e)),
+        // Private (0700) like the file inside it: the file mode already keeps
+        // the tokens unreadable, but a world-listable directory around a
+        // `mcp-auth.json` is a map to what is worth stealing.
+        Some(parent) if !parent.as_os_str().is_empty() => {
+            leviath_sys::create_private_dir_all(parent)
+                .map_err(|e| anyhow::anyhow!("Failed to create MCP auth store directory: {}", e))
+        }
         _ => Ok(()),
     }
 }

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -231,16 +231,26 @@ fn dump_request(body: &serde_json::Value, dir: Option<&str>) {
     // contents and `env_var` output included. It was written at the process
     // umask into a directory created the same way, so pointing this at `/tmp` on
     // a shared host handed every local account the conversation.
-    let _ = std::fs::create_dir_all(dir);
-    let _ = leviath_sys::secure_dir_perms(std::path::Path::new(dir));
+    let dir_path = std::path::Path::new(dir);
     // `body` is an already-built `serde_json::Value`, which is infallibly
     // serializable (no NaN/Inf numbers, keys always strings) - `to_string_pretty`
     // only fails on a custom `Serialize` impl that errors, which a `Value` never
     // has. So there is no reachable error arm; `.expect` documents that.
     let pretty = serde_json::to_string_pretty(body)
         .expect("infallible: a serde_json::Value always serializes");
-    if leviath_sys::write_private(&path, pretty.as_bytes()).is_ok() {
-        tracing::info!(request_bytes = bytes, path = %path.display(), "dumped anthropic request body");
+    // Not a fallback to the umask: a dump that cannot be made private is a
+    // dump that must not be written, so the directory, its mode and the
+    // file itself are one chain with one refusal.
+    let written = leviath_sys::create_private_dir_all(dir_path)
+        .and_then(|()| leviath_sys::secure_dir_perms(dir_path))
+        .and_then(|()| leviath_sys::write_private(&path, pretty.as_bytes()));
+    match written {
+        Ok(()) => {
+            tracing::info!(request_bytes = bytes, path = %path.display(), "dumped anthropic request body");
+        }
+        Err(e) => {
+            tracing::warn!(error = %e, dir, "not dumping the request: it could not be written privately");
+        }
     }
 }
 
@@ -1218,6 +1228,23 @@ mod tests {
         assert!(contents.contains("claude-sonnet-5"));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A path that cannot become a private directory (here, an existing
+    /// file) means no dump at all, not a dump at the umask.
+    #[test]
+    fn dump_request_refuses_a_directory_it_cannot_make_private() {
+        let dir =
+            std::env::temp_dir().join(format!("leviath-dumptest-file-{}", std::process::id()));
+        std::fs::write(&dir, b"not a directory").unwrap();
+        let _guard = crate::test_support::always_on_tracing_guard();
+        dump_request(
+            &serde_json::json!({"model": "x"}),
+            Some(dir.to_str().unwrap()),
+        );
+        assert!(dir.is_file(), "the file must be left alone");
+        assert_eq!(std::fs::read(&dir).unwrap(), b"not a directory");
+        std::fs::remove_file(&dir).unwrap();
     }
 
     #[test]

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -970,8 +970,9 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<Result<Strea
                 .and_then(|c| c.as_array())
                 .and_then(|c| c.first());
 
-            // Handle usage-only chunk (no choices)
-            if choice.is_none() {
+            // A usage-only chunk (no choices) carries the totals and nothing
+            // to render; anything else without a choice is skipped.
+            let Some(choice) = choice else {
                 if let Some(usage) = json.get("usage") {
                     let prompt_tokens = usage
                         .get("prompt_tokens")
@@ -1017,9 +1018,7 @@ pub fn parse_openai_sse_event(buffer: &mut String) -> Option<Option<Result<Strea
                     })));
                 }
                 continue;
-            }
-
-            let choice = choice.unwrap();
+            };
             let delta = choice.get("delta").unwrap_or(&serde_json::Value::Null);
 
             let content = delta

--- a/crates/leviath-runtime/src/pipeline/spawn.rs
+++ b/crates/leviath-runtime/src/pipeline/spawn.rs
@@ -247,6 +247,21 @@ pub fn spawn_agent_seeded(world: &mut World, spawn: SeededSpawn) -> Result<Entit
         region_scripts,
     } = spawn;
     let seeds = &seeds;
+    // Everything below indexes `blueprint.stages`, `stages` and the per-stage
+    // vectors built from them by position. `parse_manifest` guarantees at
+    // least one stage, but this is `pub` and an embedder can hand-build a
+    // `Blueprint`; refusing here turns two index panics into the `Err` the
+    // signature already promises.
+    if blueprint.stages.is_empty() {
+        return Err("blueprint declares no stages".to_string());
+    }
+    if stages.len() != blueprint.stages.len() {
+        return Err(format!(
+            "{} resolved stages for a blueprint with {}",
+            stages.len(),
+            blueprint.stages.len()
+        ));
+    }
     // Resolve any percentage region budgets against each stage's model context
     // window (the only place the model - and hence the window - is known). The
     // global layout resolves against the entry stage (stage 0); each per-stage

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -17227,3 +17227,32 @@ fn collect_records_a_cut_off_reply_in_the_stage_ledger() {
     run_collect(&mut world);
     assert!(!world.get::<StageLedger>(plain).unwrap().0[0].output_cap_raised);
 }
+
+/// `spawn_agent_seeded` is `pub`, so a hand-built `Blueprint` can reach it
+/// without `parse_manifest`'s "at least one stage" guarantee. Both invariants
+/// it indexes by are refused up front rather than panicking on `stages[0]`.
+#[test]
+fn spawning_refuses_a_blueprint_with_no_stages_or_a_stage_count_mismatch() {
+    let mut world = World::new();
+    let err = spawn_agent(
+        &mut world,
+        "r".to_string(),
+        blueprint(vec![]),
+        "task",
+        vec![],
+        hints(true),
+    )
+    .unwrap_err();
+    assert!(err.contains("no stages"), "{err}");
+
+    let err = spawn_agent(
+        &mut world,
+        "r".to_string(),
+        blueprint(vec![stage_named("a", None, false, None)]),
+        "task",
+        vec![],
+        hints(true),
+    )
+    .unwrap_err();
+    assert!(err.contains("0 resolved stages"), "{err}");
+}

--- a/crates/leviath-runtime/src/restore.rs
+++ b/crates/leviath-runtime/src/restore.rs
@@ -146,19 +146,23 @@ pub fn restore_agent(
 
     // 2. Jump to the persisted stage, swapping in its inference config and
     //    tool-result routing.
-    if let Some(inf) = world
+    // `stage_index` comes off disk, so both vectors are indexed with `get`:
+    // the two are built together at spawn and agree in practice, but a guard
+    // on one that then indexes the other is a panic waiting for the day they
+    // do not.
+    let inf = world
         .get::<StageInferences>(entity)
         .expect("a spawned agent has stage inferences")
         .0
         .get(stage_index)
-        .cloned()
-    {
-        let setup = &world
-            .get::<StageSetups>(entity)
-            .expect("a spawned agent has stage setups")
-            .0[stage_index];
-        let cfg = setup.inference_config.clone();
-        let routing = setup.routing.clone();
+        .cloned();
+    let setup = world
+        .get::<StageSetups>(entity)
+        .expect("a spawned agent has stage setups")
+        .0
+        .get(stage_index)
+        .map(|s| (s.inference_config.clone(), s.routing.clone()));
+    if let Some((inf, (cfg, routing))) = inf.zip(setup) {
         world.entity_mut(entity).insert((inf, cfg));
         // Mirror `attach_stage_components`' routing arm: present ⇒ insert,
         // absent ⇒ clear the stale one. Without this a reloaded agent kept the

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -621,6 +621,11 @@ requests_per_minute = 50
 tokens_per_minute   = 40000
 ```
 
+Only `requests_per_minute` is enforced today. `tokens_per_minute` is parsed and
+recorded but no code path throttles on it; it is accepted so a config that sets
+it keeps loading, and it will start to apply without a config change once the
+token bucket is wired in.
+
 This shapes request *rate*. `[limits] max_concurrent_inferences` and
 `[limits.max_concurrent_inferences_by_provider]` bound *concurrency*. Both apply. Script providers
 configure their rate limit under `[model_providers.<name>.rate_limit]` instead; their concurrency

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -141,6 +141,7 @@ allow_blueprint = true
 
 [rate_limits.anthropic]
 requests_per_minute = 50
+# Parsed and recorded, not yet enforced: only requests_per_minute throttles.
 tokens_per_minute = 100000
 
 # Every field is optional: name only what you are correcting, and the rest keeps


### PR DESCRIPTION
## What

Small hardenings with no observable behaviour change on any path a user takes today.

| site | before | after |
|---|---|---|
| `runtime/restore.rs` | `StageInferences` guarded with `.get(stage_index)`, then `StageSetups` indexed `[stage_index]` unguarded (index read from `meta.json`) | both `.get`, zipped |
| `runtime/pipeline/spawn.rs` (`pub`) | `stages[0]`, `blueprint.stages[i]`, `ledger.0[0]` on two unstated invariants | one guard returning the `Err` the signature promises; a test per arm |
| `providers/openai_compat.rs` SSE parser | `if choice.is_none() { …; continue }` then `choice.unwrap()` | one `let Some(choice) = choice else { … }` |
| `providers/anthropic.rs::dump_request` | `create_dir_all` at the umask, `secure_dir_perms` result discarded | refuses to write the dump when the directory cannot be made private (test: an existing file as the "directory") |
| `cli/daemon/sandbox_manager.rs::real_run` | `argv[0]` bare index; `std::process::Command` while the comment claimed the Windows no-console behaviour only `leviath_sys::child_command` provides | `split_first` (empty argv is an error, tested) and `child_command` |
| `mcp/auth/store.rs` | directory holding `mcp-auth.json` created with `create_dir_all` (umask) | `leviath_sys::create_private_dir_all` (0700), matching the 0600 file inside |
| `docs/content/configuration.md`, `config.example.toml` | implied `tokens_per_minute` throttles | says it is parsed and recorded but not enforced (`RateLimiter::check_tpm` has no caller); wiring it is a separate behaviour change |

Deliberately **not** in this PR: a byte cap on control-socket replies (the reader type change ripples into the shared auth helper; separate PR if wanted), `installer.rs::list_installed`'s two `expect`s (the function is dead and scheduled for deletion), `claude_code.rs:400`'s temp-file `expect` (documented invariant; no seam to make the error arm testable cheaply).

## Verification

`cargo test -p leviath-providers` 906, runtime spawn/restore tests, CLI sandbox tests; clippy `-D warnings` on runtime/providers/cli/mcp; `cargo xtask docs`. New tests cover every new arm (the coverage gate runs per package in CI).
