### PR TITLE
fix: bound the parked log buffer, deadline MCP notifications, reuse the OAuth client

### DIFF
--- a/crates/leviath-cli/src/logging.rs
+++ b/crates/leviath-cli/src/logging.rs
@@ -26,7 +26,7 @@
 //! nothing lands on the screen while somebody is looking at it.
 
 use std::io::Write;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Mutex, OnceLock, PoisonError};
 
 use tracing_subscriber::layer::SubscriberExt;
@@ -45,6 +45,35 @@ static TUI_HOLDS_TERMINAL: AtomicBool = AtomicBool::new(false);
 /// Lines written while the terminal was held, waiting to be flushed.
 static PARKED: Mutex<Vec<u8>> = Mutex::new(Vec::new());
 
+/// The most [`PARKED`] may hold. A long `lev dash` session with `--verbose`
+/// used to accumulate every debug line for the life of the session; past this
+/// the oldest bytes go and the release says how many.
+const PARKED_CAP: usize = 1024 * 1024;
+
+/// Bytes dropped from [`PARKED`] since the last release, reported on release.
+static PARKED_DROPPED: AtomicUsize = AtomicUsize::new(0);
+
+/// Append `buf` to `parked`, keeping at most `cap` bytes by discarding the
+/// oldest, and return how many bytes were discarded.
+///
+/// Pure over its arguments so the arithmetic is tested with a small cap
+/// rather than by writing a megabyte through the global.
+fn park(parked: &mut Vec<u8>, buf: &[u8], cap: usize) -> usize {
+    let total = parked.len().saturating_add(buf.len());
+    let overflow = total.saturating_sub(cap);
+    if overflow == 0 {
+        parked.extend_from_slice(buf);
+        return 0;
+    }
+    // Drop from the front of what is already parked first; only a single
+    // write larger than the whole cap reaches into `buf` itself.
+    let from_parked = overflow.min(parked.len());
+    parked.drain(..from_parked);
+    let from_buf = overflow - from_parked;
+    parked.extend_from_slice(&buf[from_buf..]);
+    overflow
+}
+
 /// Where a log line goes: straight to stderr, or into [`PARKED`] until the
 /// terminal is free.
 ///
@@ -60,10 +89,12 @@ impl Write for TerminalAwareWriter {
             // buffer is still a valid buffer, so it is taken back rather than
             // handled: a logging call is the worst place to raise a second
             // panic, and there is nothing here that a poisoned flag protects.
-            PARKED
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .extend_from_slice(buf);
+            let dropped = park(
+                &mut PARKED.lock().unwrap_or_else(PoisonError::into_inner),
+                buf,
+                PARKED_CAP,
+            );
+            PARKED_DROPPED.fetch_add(dropped, Ordering::Relaxed);
             return Ok(buf.len());
         }
         std::io::stderr().write(buf)
@@ -101,8 +132,15 @@ pub fn hold_for_tui() {
 pub fn release_from_tui() {
     TUI_HOLDS_TERMINAL.store(false, Ordering::Relaxed);
     let parked = std::mem::take(&mut *PARKED.lock().unwrap_or_else(PoisonError::into_inner));
+    let dropped = PARKED_DROPPED.swap(0, Ordering::Relaxed);
     if parked.is_empty() {
         return;
+    }
+    if dropped > 0 {
+        let _ = writeln!(
+            std::io::stderr(),
+            "[log] {dropped} bytes of output were dropped while the terminal was held"
+        );
     }
     let _ = std::io::stderr().write_all(&parked);
     let _ = std::io::stderr().flush();
@@ -240,9 +278,41 @@ mod tests {
             PARKED.lock().expect("uncontended").is_empty(),
             "release hands the buffer to stderr and empties it"
         );
+
+        // Past the cap the oldest bytes go, the count is kept for the release
+        // to report, and the release clears it. Same test, same reason: the
+        // flag and the counter are process-wide.
+        hold_for_tui();
+        let big = vec![b'x'; PARKED_CAP + 16];
+        writer().write_all(&big).expect("a held write is buffered");
+        assert_eq!(PARKED.lock().expect("uncontended").len(), PARKED_CAP);
+        assert_eq!(PARKED_DROPPED.load(Ordering::Relaxed), 16);
+        // Trimmed before the release: releasing the megabyte writes a
+        // megabyte-long line to the process's stderr, and on a CI runner that
+        // line stalled the log pipe for a quarter of an hour and took the whole
+        // test binary with it. A few bytes stay so the release still has
+        // something to write and the dropped-bytes line still prints.
+        PARKED.lock().expect("uncontended").truncate(64);
+        release_from_tui();
+        assert_eq!(PARKED_DROPPED.load(Ordering::Relaxed), 0);
         // Releasing twice is what the panic hook plus `Drop` actually does, and
         // with nothing parked it must stay quiet rather than write an empty
         // line.
         release_from_tui();
+    }
+
+    /// The cap is a ring: dropping comes off the front of what is parked
+    /// first, and only a single write bigger than the cap loses its own head.
+    #[test]
+    fn park_keeps_the_newest_bytes_and_counts_the_rest() {
+        let mut parked = Vec::new();
+        assert_eq!(park(&mut parked, b"abc", 8), 0);
+        assert_eq!(parked, b"abc");
+        // Two over: the two oldest go.
+        assert_eq!(park(&mut parked, b"defghij", 8), 2);
+        assert_eq!(parked, b"cdefghij");
+        // One write larger than the whole cap keeps its own tail.
+        assert_eq!(park(&mut parked, b"0123456789", 8), 10);
+        assert_eq!(parked, b"23456789");
     }
 }

--- a/crates/leviath-mcp/src/auth/mod.rs
+++ b/crates/leviath-mcp/src/auth/mod.rs
@@ -626,6 +626,9 @@ pub struct StoredTokenRefresher {
     store_path: std::path::PathBuf,
     /// Current Unix time; a fn so a long-lived transport stays current.
     clock: fn() -> u64,
+    /// Built once: every 401 used to construct a fresh `reqwest::Client`,
+    /// with its own connection pool, to make one token request.
+    oauth: OAuthClient,
 }
 
 impl StoredTokenRefresher {
@@ -635,6 +638,7 @@ impl StoredTokenRefresher {
             server_name: server_name.into(),
             store_path,
             clock: system_now_secs,
+            oauth: OAuthClient::new(),
         }
     }
 }
@@ -657,7 +661,7 @@ impl crate::transport::BearerRefresher for StoredTokenRefresher {
                 self.server_name
             )
         })?;
-        let refreshed = OAuthClient::new().refresh(auth, (self.clock)()).await?;
+        let refreshed = self.oauth.refresh(auth, (self.clock)()).await?;
         let value = format!("Bearer {}", refreshed.access_token);
         store.set(&self.server_name, refreshed);
         store.save(&self.store_path)?;
@@ -1586,6 +1590,7 @@ mod tests {
             server_name: "srv".to_string(),
             store_path: dir.join("mcp-auth.json"),
             clock: || 2_000,
+            oauth: OAuthClient::new(),
         }
     }
 

--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -204,6 +204,11 @@ pub(crate) struct HttpTransport {
     session_id: Option<String>,
     protocol_version: Option<String>,
     legacy: Option<LegacyStream>,
+    /// How long a notification's POST may take. `send_request` takes its
+    /// deadline as an argument; the trait gives a notification none, and a
+    /// server that accepts the connection and stalls used to hold it open
+    /// for the full read-stall timeout. A field so a test can shorten it.
+    notification_timeout: Duration,
     /// Re-auths the bearer on a mid-session `401`, if configured.
     refresher: Option<Arc<dyn BearerRefresher>>,
 }
@@ -238,6 +243,7 @@ impl HttpTransport {
             protocol_version: None,
             legacy: None,
             refresher: None,
+            notification_timeout: crate::transport::DEFAULT_REQUEST_TIMEOUT,
         })
     }
 
@@ -707,7 +713,15 @@ impl Transport for HttpTransport {
         let body = serde_json::to_string(req).expect("JsonRpcRequest is always serializable");
 
         // A notification has no reply; anything 2xx (typically 202) is success.
-        self.post_expecting_success(&body).await
+        let timeout = self.notification_timeout;
+        match tokio::time::timeout(timeout, self.post_expecting_success(&body)).await {
+            Ok(result) => result,
+            Err(_) => Err(anyhow::anyhow!(
+                "MCP server did not accept '{}' within {}s",
+                req.method,
+                timeout.as_secs()
+            )),
+        }
     }
 
     async fn close(&mut self) -> anyhow::Result<()> {
@@ -1556,6 +1570,26 @@ mod tests {
             .err()
             .expect("must time out");
         assert!(err.to_string().contains("did not respond"), "got: {err}");
+    }
+
+    /// A notification has no reply to wait for, which is exactly why it had
+    /// no deadline: a server that took the POST and never answered held the
+    /// connection for the whole read-stall timeout.
+    #[tokio::test]
+    async fn a_slow_server_times_out_a_notification_too() {
+        let _guard = always_on_tracing_guard();
+        let app = Router::new().route("/mcp", post(std::future::pending::<()>));
+        let url = format!("{}/mcp", serve(app).await);
+        let mut t = transport(&url);
+        t.notification_timeout = Duration::from_millis(200);
+        let err = t
+            .send_notification(&JsonRpcRequest::notification(
+                "notifications/initialized",
+                serde_json::json!({}),
+            ))
+            .await
+            .expect_err("must time out");
+        assert!(err.to_string().contains("did not accept"), "got: {err}");
     }
 
     // ─── response id matching ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Three unbounded things, each now bounded and tested. No behaviour change on any path a healthy peer takes.

- **Parked log buffer** (`leviath-cli/src/logging.rs`): lines logged while a TUI holds the terminal were appended to a `Vec<u8>` with no ceiling for the life of the session. Now capped at 1 MiB, dropping from the oldest end; the release prints one `[log] N bytes of output were dropped …` line. The ring arithmetic is a pure `park(parked, buf, cap)` tested with an 8-byte cap (including a single write larger than the cap); the global path is asserted inside the existing process-wide test because the flag and counter are static.
- **MCP notification deadline** (`leviath-mcp/src/transport/http.rs`): `send_request` takes a timeout, `send_notification` had none, so a server that accepted the POST and stalled held the connection for the 900 s read-stall timeout. Notifications now get `DEFAULT_REQUEST_TIMEOUT`, kept on a field the test shortens to 200 ms against a never-resolving handler.
- **OAuth client reuse** (`leviath-mcp/src/auth/mod.rs`): `StoredTokenRefresher::refresh` built a new `reqwest::Client` per 401. It holds one `OAuthClient` now.

## Verification

`cargo test -p leviath-mcp` 396, CLI logging tests, clippy `-D warnings` on cli/mcp. Every new arm has a test on all platforms (nothing here is OS-specific).
