### PR TITLE
refactor(core): one now_secs, one default_true, one char-truncate

### DIFF
--- a/crates/leviath-cli/src/approvals.rs
+++ b/crates/leviath-cli/src/approvals.rs
@@ -142,7 +142,7 @@ pub struct SafeCommands {
     /// already `allow` while `cat file` prompts, and closing that incoherence is
     /// most of what this setting is for.
     ///
-    #[serde(default = "default_true")]
+    #[serde(default = "leviath_core::default_true")]
     pub defaults: bool,
     /// Tools that need no prompt whatever their arguments. Built-in names, or
     /// MCP names in their advertised form (`server__tool`).
@@ -154,12 +154,8 @@ pub struct SafeCommands {
     pub shell: Vec<String>,
 }
 
-fn default_true() -> bool {
-    true
-}
-
 /// Hand-written rather than derived, because `#[derive(Default)]` would give
-/// `defaults: false` while `#[serde(default = "default_true")]` gives `true` for
+/// `defaults: false` while `#[serde(default = "leviath_core::default_true")]` gives `true` for
 /// the same absent section. That split is invisible and load-bearing: a user
 /// with no config file at all goes through `Default`, a user with a config file
 /// and no `[safe_commands]` section goes through serde, and they must land on
@@ -167,7 +163,7 @@ fn default_true() -> bool {
 impl Default for SafeCommands {
     fn default() -> Self {
         Self {
-            defaults: default_true(),
+            defaults: leviath_core::default_true(),
             tools: Vec::new(),
             shell: Vec::new(),
         }

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -147,7 +147,7 @@ pub(super) async fn list_agents(
     // signing secret this handler would otherwise hand out whole, and what
     // gives these runs the same `age_secs`/`working_secs` that `/api/runs`
     // reports for the very same run.
-    let now = now_secs();
+    let now = leviath_core::duration::now_secs();
     Json(runs.iter().map(|m| run_json(m, now)).collect())
 }
 
@@ -155,7 +155,7 @@ pub(super) async fn get_agent(
     AxumPath(id): AxumPath<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
     runstate::read_meta(&id)
-        .map(|m| Json(run_json(&m, now_secs())))
+        .map(|m| Json(run_json(&m, leviath_core::duration::now_secs())))
         .map_err(|_| {
             (
                 StatusCode::NOT_FOUND,
@@ -167,7 +167,7 @@ pub(super) async fn get_agent(
 }
 
 pub(super) async fn agent_children(AxumPath(id): AxumPath<String>) -> Json<Vec<serde_json::Value>> {
-    let now = now_secs();
+    let now = leviath_core::duration::now_secs();
     let children: Vec<serde_json::Value> = runstate::list_runs()
         .into_iter()
         .filter(|r| r.parent_run_id.as_deref() == Some(&id))
@@ -337,14 +337,12 @@ pub(super) async fn agent_context_history(
         });
 
     let items = collected.into_iter().map(|(_, point)| point).collect();
-    Ok(Json(Page::new(items, next_cursor, Some(total), now_secs())))
-}
-
-fn now_secs() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
+    Ok(Json(Page::new(
+        items,
+        next_cursor,
+        Some(total),
+        leviath_core::duration::now_secs(),
+    )))
 }
 
 /// `GET /api/agents/{id}/logs`: what a run has written, by stage.

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -266,15 +266,8 @@ pub(super) async fn list_blueprints(
         remaining,
         next_cursor,
         Some(total),
-        now_secs(),
+        leviath_core::duration::now_secs(),
     )))
-}
-
-fn now_secs() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
 }
 
 /// `GET /api/blueprints/{name}`: one blueprint, with its manifest text.

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -449,7 +449,7 @@ pub(super) async fn list_runs(
     Query(query): Query<RunsQuery>,
 ) -> Result<Json<Page<RunItem>>, ApiError> {
     let resolved = resolve(&query)?;
-    let server_time = now_secs();
+    let server_time = leviath_core::duration::now_secs();
 
     // A batch fetch reads exactly the named runs, rather than scanning the
     // whole directory and filtering it down to them.
@@ -512,13 +512,6 @@ pub(super) async fn list_runs(
     let mut page = Page::new(items, next_cursor, total, server_time);
     page.scan_truncated = scan_truncated;
     Ok(Json(page))
-}
-
-fn now_secs() -> i64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
 }
 
 /// Order by `(sort value, run_id)`, with the tie-break following the primary
@@ -884,7 +877,7 @@ pub(super) fn run_json(meta: &RunMeta, now: i64) -> serde_json::Value {
 /// The spans go on before the projection, so `?fields=working_secs` selects one
 /// the way it selects any other key.
 fn build_item(meta: &RunMeta, resolved: &Resolved, highlights: Option<Vec<Highlight>>) -> RunItem {
-    let mut value = run_json(meta, now_secs());
+    let mut value = run_json(meta, leviath_core::duration::now_secs());
     if let (Some(fields), serde_json::Value::Object(map)) = (&resolved.fields, &mut value) {
         map.retain(|key, _| fields.contains(key));
     }

--- a/crates/leviath-cli/src/commands/stages.rs
+++ b/crates/leviath-cli/src/commands/stages.rs
@@ -74,7 +74,7 @@ fn print_ledger(stages: &[StageRecord], with_regions: bool, with_visits: bool) {
     for stage in stages {
         println!(
             "{:<20} {:<10} {:>10} {:>10} {:>10} {:>10} {:>11}",
-            truncate(&stage.name, 20),
+            leviath_core::truncate_chars(&stage.name, 20),
             format!("{:?}", stage.status).to_lowercase(),
             stage.prompt_tokens,
             stage.completion_tokens,
@@ -116,7 +116,11 @@ fn print_ledger(stages: &[StageRecord], with_regions: bool, with_visits: bool) {
             let mut regions: Vec<(&String, &usize)> = stage.region_tokens.iter().collect();
             regions.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
             for (name, tokens) in regions {
-                println!("  {:<18} {:>42}", truncate(name, 18), tokens);
+                println!(
+                    "  {:<18} {:>42}",
+                    leviath_core::truncate_chars(name, 18),
+                    tokens
+                );
             }
         }
     }
@@ -149,16 +153,6 @@ fn print_ledger(stages: &[StageRecord], with_regions: bool, with_visits: bool) {
 
 /// `s` cut to `width` **characters**.
 ///
-/// Counted in characters rather than bytes because the width is a column count
-/// in a table, and a byte cut would both misalign the column and land
-/// mid-codepoint on any non-ASCII stage or region name.
-fn truncate(s: &str, width: usize) -> String {
-    match s.chars().count() > width {
-        true => s.chars().take(width).collect(),
-        false => s.to_string(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -228,14 +222,6 @@ mod tests {
         r.region_tokens.insert("alpha".to_string(), 42);
         r.region_tokens.insert("beta".to_string(), 42);
         print_ledger(&[r], true, false);
-    }
-
-    /// A long stage name is cut rather than breaking the columns, and cut on a
-    /// char boundary - region and stage names are author-supplied text.
-    #[test]
-    fn a_long_name_is_truncated_on_a_char_boundary() {
-        assert_eq!(truncate("short", 20), "short");
-        assert_eq!(truncate(&"é".repeat(30), 5).chars().count(), 5);
     }
 
     /// A run whose ledger is on disk, in an isolated runs dir.

--- a/crates/leviath-cli/src/commands/timeline.rs
+++ b/crates/leviath-cli/src/commands/timeline.rs
@@ -339,7 +339,7 @@ fn print_run(run: &RunTimeline, with_calls: bool) {
     for s in &run.stages {
         println!(
             "{:<20} {:>9} {:>6} {:>10} {:>10}",
-            truncate(&s.name, 20),
+            leviath_core::truncate_chars(&s.name, 20),
             hms(s.secs),
             s.calls,
             s.output_tokens,
@@ -359,9 +359,9 @@ fn print_run(run: &RunTimeline, with_calls: bool) {
                 format!("+{}", hms(c.started_at - t0)),
                 hms(c.secs()),
                 c.kind,
-                truncate(&c.stage, 16),
+                leviath_core::truncate_chars(&c.stage, 16),
                 c.iteration,
-                truncate(&c.model, 30),
+                leviath_core::truncate_chars(&c.model, 30),
                 c.prompt_tokens,
                 c.cached_tokens,
                 c.completion_tokens
@@ -385,7 +385,7 @@ fn print_tree(runs: &[RunTimeline]) {
     for r in runs {
         println!(
             "{:<44} {:>5} {:>9} {:>9} {:>9} {:>9}",
-            truncate(&r.run_id, 44),
+            leviath_core::truncate_chars(&r.run_id, 44),
             r.depth,
             hms(r.totals.wall),
             hms(r.totals.inference),
@@ -396,7 +396,11 @@ fn print_tree(runs: &[RunTimeline]) {
     println!();
     println!("{:<40} {:>10}", "MODEL", "PEAK CALLS");
     for (model, peak) in peak_in_flight(runs) {
-        println!("{:<40} {:>10}", truncate(&model, 40), peak);
+        println!(
+            "{:<40} {:>10}",
+            leviath_core::truncate_chars(&model, 40),
+            peak
+        );
     }
 }
 
@@ -438,15 +442,6 @@ fn hms(secs: i64) -> String {
     match h {
         0 => format!("{m}:{sec:02}"),
         _ => format!("{h}:{m:02}:{sec:02}"),
-    }
-}
-
-/// `s` cut to `width` **characters**, so a long id or model name cannot break
-/// the columns or land mid-codepoint.
-fn truncate(s: &str, width: usize) -> String {
-    match s.chars().count() > width {
-        true => s.chars().take(width).collect(),
-        false => s.to_string(),
     }
 }
 

--- a/crates/leviath-cli/src/commands/timeline/tests.rs
+++ b/crates/leviath-cli/src/commands/timeline/tests.rs
@@ -280,8 +280,13 @@ fn durations_read_as_clock_time() {
     assert_eq!(hms(65), "1:05");
     assert_eq!(hms(3_725), "1:02:05");
     assert_eq!(hms(-5), "0:00");
-    assert_eq!(truncate("short", 20), "short");
-    assert_eq!(truncate(&"é".repeat(30), 5).chars().count(), 5);
+    assert_eq!(leviath_core::truncate_chars("short", 20), "short");
+    assert_eq!(
+        leviath_core::truncate_chars(&"é".repeat(30), 5)
+            .chars()
+            .count(),
+        5
+    );
 }
 
 #[test]

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -221,7 +221,7 @@ pub struct Config {
     /// setting `batch_tool_hint = false` in their `[agent]` / `[stages.<name>]`
     /// blocks; when this global is `false`, they opt back *in* by setting it to
     /// `true` at the narrower scope.
-    #[serde(default = "default_true")]
+    #[serde(default = "leviath_core::default_true")]
     pub batch_tool_hint: bool,
 
     /// Global master switch for the platform shell hint.
@@ -234,7 +234,7 @@ pub struct Config {
     /// on Linux and macOS this toggle costs nothing either way. Individual
     /// agents or stages override it with `shell_hint` in their `[agent]` /
     /// `[stages.<name>]` blocks.
-    #[serde(default = "default_true")]
+    #[serde(default = "leviath_core::default_true")]
     pub shell_hint: bool,
 
     /// Machine-wide defaults for the empty-response nudge (`[nudge]`): the
@@ -1014,16 +1014,6 @@ fn set_dir_permissions_with(
     if let Err(e) = secure(path) {
         tracing::warn!("Failed to set config directory permissions: {}", e);
     }
-}
-
-/// Serde default for a flag that ships on.
-///
-/// Shared by `[security]`, `[limits]` and `Config` itself, so it lives here
-/// rather than in whichever section happened to need it first: serde resolves
-/// a `default = "..."` path in the module the struct is defined in, so a helper
-/// three sections use has to be reachable from all three.
-pub(crate) fn default_true() -> bool {
-    true
 }
 
 /// The update check is on when the key is absent.

--- a/crates/leviath-cli/src/config/security.rs
+++ b/crates/leviath-cli/src/config/security.rs
@@ -7,8 +7,6 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::default_true;
-
 /// One agent's entry in `[agent_read_paths.<name>]`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReadPathGrants {
@@ -49,7 +47,7 @@ pub struct SecurityConfig {
     /// `[limits] script_shell_timeout_secs`. Set this to `false` to refuse them
     /// machine-wide, or pass `--no-seed-commands` for a single run. Inspect an
     /// agent's command seeds before installing it with `lev validate <path>`.
-    #[serde(default = "default_true")]
+    #[serde(default = "leviath_core::default_true")]
     pub allow_seed_commands: bool,
 
     /// Whether agent-driven fetches may reach loopback, private, and link-local

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -28,7 +28,6 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 // The plain run-state data types (RunMeta, RunStatus, the snapshot structs, and
 // the per-stage records) live in `leviath_core::run_meta`. Re-exported here so
@@ -245,13 +244,6 @@ pub fn context_history(run_id: &str) -> Vec<leviath_core::run_archive::RunPoint>
         .collect()
 }
 
-fn now_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
-}
-
 /// Inner implementation of `runs_dir`, parameterised so it can be tested
 /// without touching the process-global env. All callers go through `runs_dir`.
 ///
@@ -412,7 +404,12 @@ pub fn new_run_id(agent_name: &str) -> String {
     use rand::RngExt as _;
     let entropy: u64 = rand::rng().random::<u64>() >> (u64::BITS - RUN_ID_ENTROPY_BITS);
     let safe_name = agent_name.replace(|c: char| !c.is_ascii_alphanumeric() && c != '-', "-");
-    format!("{}-{}-{:012x}", safe_name, now_secs(), entropy)
+    format!(
+        "{}-{}-{:012x}",
+        safe_name,
+        leviath_core::duration::now_secs(),
+        entropy
+    )
 }
 
 /// Create the run directory and write initial metadata.
@@ -567,7 +564,7 @@ impl ForceCancelOutcome {
 /// Force a run's on-disk metadata to `Cancelled`, in the runs dir resolved from
 /// the environment. See [`force_cancel_in`].
 pub fn force_cancel(run_id: &str) -> ForceCancelOutcome {
-    force_cancel_in(&run_dir(run_id), now_secs())
+    force_cancel_in(&run_dir(run_id), leviath_core::duration::now_secs())
 }
 
 /// Force the run in `run_dir` to `Cancelled`, stamping `updated_at` with `now`.

--- a/crates/leviath-core/src/blueprint/stage.rs
+++ b/crates/leviath-core/src/blueprint/stage.rs
@@ -561,7 +561,7 @@ pub struct Stage {
     /// Whether this stage accepts mid-run user messages.
     /// When true, messages sent to the agent are injected into context
     /// between inference calls. Default: true.
-    #[serde(default = "default_true")]
+    #[serde(default = "crate::default_true")]
     pub accepts_messages: bool,
 
     /// Whether the LLM may end the run at this stage instead of naming a
@@ -661,11 +661,6 @@ pub struct Stage {
     /// and nothing about the scripting engine is touched for this stage.
     #[serde(default, skip_serializing_if = "StageHooks::is_empty")]
     pub hooks: StageHooks,
-}
-
-/// Default value for bool fields that should default to true.
-fn default_true() -> bool {
-    true
 }
 
 impl Stage {

--- a/crates/leviath-core/src/config.rs
+++ b/crates/leviath-core/src/config.rs
@@ -7,10 +7,6 @@
 
 use serde::{Deserialize, Serialize};
 
-fn default_true() -> bool {
-    true
-}
-
 /// Configuration for auto-generating a short human-readable run title.
 ///
 /// Example config:
@@ -23,7 +19,7 @@ fn default_true() -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TitleConfig {
     /// Whether to generate titles at all (default: true).
-    #[serde(default = "default_true")]
+    #[serde(default = "crate::default_true")]
     pub enabled: bool,
 
     /// Provider to use for title generation.

--- a/crates/leviath-core/src/duration.rs
+++ b/crates/leviath-core/src/duration.rs
@@ -61,6 +61,18 @@ pub fn between(from: i64, to: i64) -> u64 {
     to.saturating_sub(from).max(0) as u64
 }
 
+/// The current Unix time in whole seconds, as the run records store it.
+///
+/// Zero if the clock is before 1970, which `SystemTime` can report on a
+/// machine whose clock is unset; every consumer treats zero as "unknown"
+/// rather than as a date. Five crates had their own copy of these four lines.
+pub fn now_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 /// The JSON key carrying a run's age in seconds, on every API that serves runs.
 pub const AGE_SECS_KEY: &str = "age_secs";
 
@@ -141,5 +153,13 @@ mod tests {
     fn between_survives_a_timestamp_at_the_edge_of_the_range() {
         assert_eq!(between(i64::MIN, 0), i64::MAX as u64);
         assert_eq!(between(0, i64::MIN), 0);
+    }
+
+    #[test]
+    fn now_secs_is_a_plausible_unix_time() {
+        // After 2024-01-01 and before 2100-01-01: catches a millisecond or a
+        // zero slipping in, without pinning the test to today.
+        let now = now_secs();
+        assert!((1_704_067_200..4_102_444_800).contains(&now), "{now}");
     }
 }

--- a/crates/leviath-core/src/interaction.rs
+++ b/crates/leviath-core/src/interaction.rs
@@ -55,7 +55,7 @@ pub struct InteractionRequest {
     /// For ToolApproval: the tool arguments (JSON).
     pub tool_arguments: Option<serde_json::Value>,
     /// Whether an answer is mandatory (empty/cancel not allowed).
-    #[serde(default = "default_true")]
+    #[serde(default = "crate::default_true")]
     pub required: bool,
     /// Stage name that triggered this request.
     pub stage_name: String,
@@ -65,10 +65,6 @@ pub struct InteractionRequest {
     /// Format of the body content.
     #[serde(default)]
     pub body_format: BodyFormat,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 impl InteractionRequest {

--- a/crates/leviath-core/src/layout.rs
+++ b/crates/leviath-core/src/layout.rs
@@ -30,11 +30,6 @@ use serde::{Deserialize, Serialize};
 /// exactly, so this costs no existing agent anything.
 pub const STAGE_INSTRUCTIONS_REGION: &str = "stage_instructions";
 
-/// Serde default for a flag that is on unless a blueprint turns it off.
-fn default_true() -> bool {
-    true
-}
-
 /// How a region's token ceiling is expressed before it is resolved against a
 /// concrete model context window.
 ///
@@ -651,7 +646,7 @@ pub struct RegionDefinition {
     /// Setting this false protects the region wherever it is used, rather than
     /// at each of the N edges that might touch it. `clear` still applies - this
     /// says "do not paraphrase my content", not "keep it forever".
-    #[serde(default = "default_true")]
+    #[serde(default = "crate::default_true")]
     pub summarizable: bool,
 
     /// What this region does when a write does not fit.

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -74,4 +74,14 @@ pub use taint::{
     GateDecision, GateDecisionSource, GateEvent, RegionTaint, SecurityConfig, TaintLevel,
     ToolClassification, ToolDirection,
 };
-pub use text::{estimate_tokens, floor_char_boundary, truncate_at_boundary};
+pub use text::{estimate_tokens, floor_char_boundary, truncate_at_boundary, truncate_chars};
+
+/// Serde default for a flag that is on unless a file turns it off.
+///
+/// `#[serde(default)]` on a `bool` is `false`, so every "on by default" field
+/// needs a named function, and eight modules across two crates had written
+/// this one. Name it as `default = "crate::default_true"` inside this crate and
+/// `"leviath_core::default_true"` outside it; serde pastes the path as written.
+pub fn default_true() -> bool {
+    true
+}

--- a/crates/leviath-core/src/region/mod.rs
+++ b/crates/leviath-core/src/region/mod.rs
@@ -430,7 +430,7 @@ pub struct Region {
     /// Carried from the region's declaration so the transform can consult it
     /// without the layout: `transform = "compact"` summarizes by region *kind*,
     /// and kind cannot tell a transcript from a table of results (#369).
-    #[serde(default = "crate::region::default_true")]
+    #[serde(default = "crate::default_true")]
     pub summarizable: bool,
 
     /// What this region does when a write does not fit. See [`Admission`].
@@ -468,11 +468,6 @@ pub struct Region {
 mod schema;
 
 pub use schema::{ContentFormat, RegionSchema, Validator};
-
-/// Serde default for a flag that is on unless a blueprint turns it off.
-pub(crate) fn default_true() -> bool {
-    true
-}
 
 impl Region {
     /// Create a new region with the specified configuration.

--- a/crates/leviath-core/src/run_meta.rs
+++ b/crates/leviath-core/src/run_meta.rs
@@ -8,7 +8,6 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 mod stage_ledger;
 
@@ -787,7 +786,7 @@ impl RunMeta {
         workdir: String,
         num_stages: usize,
     ) -> Self {
-        let now = now_secs();
+        let now = crate::duration::now_secs();
         Self {
             run_id,
             agent_name,
@@ -880,7 +879,7 @@ impl RunMeta {
     /// persistence heartbeat calls this, and a run that is wedged must not look
     /// like one that just moved. See [`RunMeta::last_progress_at`].
     pub fn touch(&mut self) {
-        self.updated_at = now_secs();
+        self.updated_at = crate::duration::now_secs();
     }
 }
 
@@ -965,12 +964,6 @@ pub struct ContextSnapshot {
 }
 
 /// Current Unix time in seconds (saturating to 0 before the epoch).
-fn now_secs() -> i64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0)
-}
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/leviath-core/src/sandbox.rs
+++ b/crates/leviath-core/src/sandbox.rs
@@ -57,7 +57,7 @@ pub struct ToolSandboxConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine: Option<String>,
     /// Whether the sandbox has network access. `false` isolates the network.
-    #[serde(default = "default_true")]
+    #[serde(default = "crate::default_true")]
     pub network: bool,
     /// Extra host paths to bind-mount into the sandbox. The agent's workdir is
     /// always mounted regardless of this list.
@@ -70,10 +70,6 @@ pub struct ToolSandboxConfig {
     /// What to do when the runtime is unavailable.
     #[serde(default)]
     pub on_unavailable: OnUnavailable,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 /// How much a kind actually isolates, for comparison.

--- a/crates/leviath-core/src/text.rs
+++ b/crates/leviath-core/src/text.rs
@@ -133,6 +133,19 @@ pub fn estimate_tokens(s: &str) -> usize {
     s.len().div_ceil(4)
 }
 
+/// The first `width` characters of `s`, whole characters only.
+///
+/// For fixed-width table cells over author-supplied names: counts characters
+/// rather than bytes, so a name of accented letters is cut where the column
+/// ends and never inside a character. No ellipsis; a cell that wants one
+/// appends it. Two commands had this as a private helper each.
+pub fn truncate_chars(s: &str, width: usize) -> String {
+    match s.chars().count() > width {
+        true => s.chars().take(width).collect(),
+        false => s.to_string(),
+    }
+}
+
 /// Substitute `{name}` placeholders in a template.
 ///
 /// Plain sequential `str::replace`, the same scheme `CompactionConfig`'s
@@ -215,6 +228,17 @@ mod snippet_tests {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn truncate_chars_counts_characters_not_bytes() {
+        assert_eq!(truncate_chars("short", 20), "short");
+        assert_eq!(truncate_chars("exactly", 7), "exactly");
+        assert_eq!(truncate_chars("longer than that", 6), "longer");
+        // Each `é` is two bytes; five characters is five characters.
+        let cut = truncate_chars(&"é".repeat(30), 5);
+        assert_eq!(cut.chars().count(), 5);
+        assert_eq!(cut, "ééééé");
+    }
     use super::*;
 
     #[test]


### PR DESCRIPTION
## What

Three helpers defined once in `leviath-core` instead of many times. Pure consolidation; byte-identical bodies.

| helper | was | now |
|---|---|---|
| `now_secs() -> i64` | 5 identical copies (`runstate.rs`, `serve/{runs,blueprints,agents}.rs`, `run_meta.rs`) | `leviath_core::duration::now_secs` |
| `default_true() -> bool` (serde default) | 8 definitions across core and cli | `leviath_core::default_true`, referenced as `default = "crate::default_true"` / `"leviath_core::default_true"` |
| `truncate(s, width)` (char-counted, no ellipsis) | identical in `stages.rs` and `timeline.rs` | `leviath_core::truncate_chars` |

Deliberately **not** merged, with the reason in the commit: `update/latest.rs::now_secs` (`u64`, documented), `pipeline/stall.rs` (a `chrono` seam), `dashboard/helpers.rs::truncate` (trims, bytes, `…`), `commands/test.rs::truncate_str` (bytes, `...`), `blueprint/stage.rs::default_true_val` (different name, two callers).

## Verification

New core tests for each helper (coverage is per package). `cargo test -p leviath-core` 901, `-p leviath-cli --lib` 4,022; clippy and rustdoc `-D warnings` on both.
