### PR TITLE
refactor(tools,cli): one path-confinement function, and four smaller merges

### DIFF
--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -204,10 +204,10 @@ fn relink_tree(world: &mut PipelineWorld, reloaded: &[(RunMeta, Entity)]) {
 }
 
 /// Read + parse `<run_dir>/meta.json`, returning `None` if it is missing or
-/// invalid.
+/// invalid. Recovery treats both the same way: a run it cannot read is a run
+/// it leaves alone.
 fn read_meta(run_dir: &Path) -> Option<RunMeta> {
-    let text = std::fs::read_to_string(run_dir.join("meta.json")).ok()?;
-    serde_json::from_str(&text).ok()
+    crate::runstate::read_meta_from(run_dir).ok()
 }
 
 /// The cumulative token totals recorded in a run's metadata.
@@ -499,7 +499,7 @@ fn reload_one(
     // merely fail to restore the answer, it would erase the one on disk. It
     // also re-arms the required-output gate correctly: a stage that submitted
     // before the restart is not asked to do it again.
-    if let Some(output) = read_final_output_from(run_dir, meta) {
+    if let Some(output) = crate::runstate::read_final_output_in(run_dir, meta) {
         world
             .world_mut()
             .entity_mut(entity)
@@ -532,26 +532,6 @@ fn reload_one(
     }
 
     Ok(entity)
-}
-
-/// Rebuild a run's submitted answer from its descriptor plus the sidecar in
-/// `dir`.
-///
-/// Recovery works from its configured runs directory rather than the home one,
-/// so it cannot use `runstate::read_final_output`, which resolves the path
-/// itself. A missing sidecar yields `None`: a run written before the answer
-/// moved out of `meta.json`, or one whose directory was pruned.
-fn read_final_output_from(dir: &Path, meta: &RunMeta) -> Option<leviath_core::FinalOutput> {
-    let descriptor = meta.final_output.clone()?;
-    let content = std::fs::read_to_string(dir.join(leviath_core::FINAL_OUTPUT_FILE)).ok()?;
-    Some(leviath_core::FinalOutput {
-        content,
-        format: descriptor.format,
-        stage: descriptor.stage,
-        submitted_at: descriptor.submitted_at,
-        truncated: descriptor.truncated,
-        artifacts: descriptor.artifacts,
-    })
 }
 
 #[cfg(test)]
@@ -891,7 +871,7 @@ mod tests {
         );
 
         // No descriptor at all.
-        assert!(read_final_output_from(dir.path(), &meta).is_none());
+        assert!(crate::runstate::read_final_output_in(dir.path(), &meta).is_none());
 
         // A descriptor, but nothing on disk to go with it.
         let answer = leviath_core::output::FinalOutput::new(
@@ -901,7 +881,7 @@ mod tests {
             777,
         );
         meta.final_output = Some(answer.descriptor());
-        assert!(read_final_output_from(dir.path(), &meta).is_none());
+        assert!(crate::runstate::read_final_output_in(dir.path(), &meta).is_none());
 
         // And with both, the answer comes back whole.
         std::fs::write(
@@ -909,7 +889,8 @@ mod tests {
             &answer.content,
         )
         .unwrap();
-        let restored = read_final_output_from(dir.path(), &meta).expect("both halves");
+        let restored =
+            crate::runstate::read_final_output_in(dir.path(), &meta).expect("both halves");
         assert_eq!(restored.content, "already answered");
         assert_eq!(restored.stage, "implement");
     }

--- a/crates/leviath-cli/src/daemon/sandbox_manager.rs
+++ b/crates/leviath-cli/src/daemon/sandbox_manager.rs
@@ -85,13 +85,6 @@ fn sanitize(run_id: &str) -> String {
         .collect()
 }
 
-/// Build the host shell command (no sandbox) - the exact prior behavior.
-fn host_command(shell: &str, flag: &str, command: &str, workdir: &Path) -> TokioCommand {
-    let mut c = leviath_sys::child_command_async(shell);
-    c.arg(flag).arg(command).current_dir(workdir);
-    c
-}
-
 impl SandboxManager {
     /// Build the manager for an agent whose stages resolve (in order) to
     /// `by_index`, bind-mounting `workdir`. `entry_index` selects the initial
@@ -291,7 +284,9 @@ impl ShellExecutor for SandboxManager {
             .unwrap_or_else(PoisonError::into_inner)
             .clone();
         match cfg.kind {
-            SandboxKind::None => host_command(shell, flag, command, workdir),
+            SandboxKind::None => {
+                crate::daemon::script_host::host_shell_command(shell, flag, command, workdir)
+            }
             SandboxKind::Namespace => {
                 if self.namespace_ok {
                     let argv = leviath_sys::namespace_argv(shell, flag, command, cfg.network);
@@ -301,7 +296,7 @@ impl ShellExecutor for SandboxManager {
                 } else {
                     // Warn-fallback build kept the manager alive without a usable
                     // namespace; run on the host.
-                    host_command(shell, flag, command, workdir)
+                    crate::daemon::script_host::host_shell_command(shell, flag, command, workdir)
                 }
             }
             SandboxKind::Container => match self.containers.get(&signature(&cfg)) {
@@ -322,7 +317,9 @@ impl ShellExecutor for SandboxManager {
                     c
                 }
                 // Warn-fallback: the container was never created; run on the host.
-                None => host_command(shell, flag, command, workdir),
+                None => {
+                    crate::daemon::script_host::host_shell_command(shell, flag, command, workdir)
+                }
             },
         }
     }

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -14,7 +14,7 @@
 //! vars) - the same approach the MCP and package-registry tests use.
 
 use std::collections::BTreeMap;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -263,64 +263,15 @@ impl DaemonScriptHost {
     }
 
     /// Resolve a script-supplied file path against the workdir, rejecting both a
-    /// `..` escape and a symlink that leaves the directory (mirrors
-    /// `BuiltinTools::resolve`, which documents the reasoning).
-    fn resolve_in_workdir(&self, requested: &str) -> Result<PathBuf, String> {
-        Self::resolve_in(requested, &self.workdir, leviath_core::resolves_within)
-    }
-
-    /// Core of [`resolve_in_workdir`](Self::resolve_in_workdir) with the
-    /// containment check injected.
+    /// `..` escape and a symlink that leaves the directory.
     ///
-    /// A `fn` pointer (not `impl Fn`) so there is one monomorphization, matching
-    /// the seam idiom used for the browser opener and the socket peer lookup.
-    /// The seam exists because the refusal cannot be reached otherwise on every
-    /// platform: producing the escape needs a real symlink, and creating one on
-    /// Windows requires a privilege CI runners do not have. The `#[cfg(unix)]`
-    /// test still proves the real filesystem behaviour end to end.
-    fn resolve_in(
-        requested: &str,
-        workdir: &Path,
-        within: fn(&Path, &Path) -> bool,
-    ) -> Result<PathBuf, String> {
-        // The null device is not a place, so containment has nothing to say
-        // about it - same reasoning as the built-in tools, which share the
-        // predicate rather than each carrying their own idea of it (#373).
-        if leviath_tools::is_null_device(requested) {
-            return Ok(PathBuf::from(requested));
-        }
-        let raw = if Path::new(requested).is_absolute() {
-            PathBuf::from(requested)
-        } else {
-            workdir.join(requested)
-        };
-        let mut normalized = PathBuf::new();
-        for component in raw.components() {
-            match component {
-                Component::ParentDir => {
-                    if !normalized.pop() {
-                        return Err(format!("path '{requested}' escapes the working directory"));
-                    }
-                }
-                c => normalized.push(c),
-            }
-        }
-        if !normalized.starts_with(workdir) {
-            return Err(format!(
-                "path '{requested}' would escape the working directory ({}). \
-                 Use a path inside the workspace instead - a relative path \
-                 resolves against it.",
-                workdir.display()
-            ));
-        }
-        // The lexical check above is textual only: a symlink inside the workdir
-        // pointing outside it satisfies `starts_with` while reading anywhere.
-        if !within(&normalized, workdir) {
-            return Err(format!(
-                "path '{requested}' resolves outside the working directory through a symlink"
-            ));
-        }
-        Ok(normalized)
+    /// The same function the built-in file tools use, so a script's
+    /// `write_file` and the agent's `write_file` cannot disagree about what a
+    /// path is allowed to be. It used to be a line-for-line copy, error
+    /// strings included.
+    fn resolve_in_workdir(&self, requested: &str) -> Result<PathBuf, String> {
+        leviath_tools::resolve_within(requested, &self.workdir, leviath_core::resolves_within)
+            .map_err(|e| e.to_string())
     }
 }
 
@@ -2020,44 +1971,6 @@ mod tests {
         .unwrap();
         let err = out.expect_err("an endless redirect must be stopped");
         assert!(err.contains("too many redirects"), "got: {err}");
-    }
-
-    /// The containment refusal, driven through the injected predicate so it is
-    /// exercised on every platform. The `#[cfg(unix)]` test below proves the
-    /// same refusal against a real symlink; this one proves the arm fires on
-    /// Windows too, where a test cannot create one.
-    #[test]
-    fn resolve_in_refuses_a_path_that_does_not_resolve_within_the_workdir() {
-        fn escapes(_: &Path, _: &Path) -> bool {
-            false
-        }
-        let dir = tempfile::tempdir().unwrap();
-        let err = DaemonScriptHost::resolve_in("notes.txt", dir.path(), escapes)
-            .expect_err("a path that resolves outside must be refused");
-        assert!(err.contains("symlink"), "{err}");
-    }
-
-    /// The null device is not a place, so containment has nothing to refuse.
-    /// It is returned as written rather than joined onto the workdir, which is
-    /// what makes it a sink instead of a file called `null` in the workspace.
-    #[test]
-    fn resolve_in_admits_the_null_device() {
-        let dir = tempfile::tempdir().unwrap();
-        let resolved =
-            DaemonScriptHost::resolve_in("/dev/null", dir.path(), leviath_core::resolves_within)
-                .expect("the null device is not an escape");
-        assert_eq!(resolved, PathBuf::from("/dev/null"));
-    }
-
-    /// The converse, so the test above is not passing merely because everything
-    /// is refused.
-    #[test]
-    fn resolve_in_admits_an_ordinary_path_within_the_workdir() {
-        let dir = tempfile::tempdir().unwrap();
-        let resolved =
-            DaemonScriptHost::resolve_in("notes.txt", dir.path(), leviath_core::resolves_within)
-                .expect("an ordinary path resolves");
-        assert!(resolved.ends_with("notes.txt"));
     }
 
     /// The script host's own path confinement, mirroring `BuiltinTools`: a

--- a/crates/leviath-cli/src/daemon/seed_tool.rs
+++ b/crates/leviath-cli/src/daemon/seed_tool.rs
@@ -197,7 +197,7 @@ pub fn production_runner(ctx: SeedToolContext, resolve: SeedPolicyResolver) -> S
 /// outcomes are ordinary values. A tool that ran and said it failed is an
 /// `[error]` just as much as one that could not be reached - the seed treats
 /// both as "no block", and the model never sees a failure dressed as data.
-fn mcp_text(result: anyhow::Result<leviath_mcp::execution::ExecutionResult>) -> String {
+pub(super) fn mcp_text(result: anyhow::Result<leviath_mcp::execution::ExecutionResult>) -> String {
     match result {
         Ok(r) if r.success => r.text,
         Ok(r) => format!("[error] {}", r.text),

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -299,11 +299,7 @@ async fn execute_tool(state: &AgentToolState, is_builtin: bool, tc: &ToolCall) -
         result
     } else {
         let mut mcp = state.mcp.lock().await;
-        match mcp.execute(&tc.name, tc.arguments.clone()).await {
-            Ok(r) if r.success => r.text,
-            Ok(r) => format!("[error] {}", r.text),
-            Err(e) => format!("[error] tool error: {e}"),
-        }
+        super::seed_tool::mcp_text(mcp.execute(&tc.name, tc.arguments.clone()).await)
     }
 }
 

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -460,8 +460,19 @@ pub fn read_meta(run_id: &str) -> anyhow::Result<RunMeta> {
 /// build that stored the answer inline, or one whose directory was pruned).
 pub fn read_final_output(run_id: &str) -> Option<leviath_core::FinalOutput> {
     let meta = read_meta(run_id).ok()?;
-    let descriptor = meta.final_output?;
-    let content = std::fs::read_to_string(final_output_path(&run_dir(run_id))).ok()?;
+    read_final_output_in(&run_dir(run_id), &meta)
+}
+
+/// [`read_final_output`] for a run directory the caller already resolved,
+/// with the metadata it already read. The daemon's recovery works from its
+/// configured runs directory rather than the home one, and used to carry a
+/// copy of this for that reason.
+pub(crate) fn read_final_output_in(
+    dir: &std::path::Path,
+    meta: &RunMeta,
+) -> Option<leviath_core::FinalOutput> {
+    let descriptor = meta.final_output.clone()?;
+    let content = std::fs::read_to_string(final_output_path(dir)).ok()?;
     Some(leviath_core::FinalOutput {
         content,
         format: descriptor.format,

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -368,13 +368,7 @@ pub fn escaping_write_refusal(
     let command = arguments.get("command").and_then(|v| v.as_str())?;
     let escaping = crate::shell_keys::write_target_paths(command)
         .into_iter()
-        .find(|target| {
-            let joined = match std::path::Path::new(target).is_absolute() {
-                true => std::path::PathBuf::from(target),
-                false => workdir.join(target),
-            };
-            !leviath_core::resolves_within(&joined, workdir)
-        })?;
+        .find(|target| !leviath_core::resolves_within(&target_path(target, workdir), workdir))?;
     Some(format!(
         "[denied] Shell redirect writes to '{escaping}', which is outside the working directory \
          ({}). The `write_file` tool refuses the same path; a redirect is not a way around it. \
@@ -470,13 +464,20 @@ pub fn measured_write_bytes(
     crate::shell_keys::write_target_paths(command)
         .into_iter()
         .map(|target| {
-            let path = match std::path::Path::new(&target).is_absolute() {
-                true => std::path::PathBuf::from(&target),
-                false => workdir.join(&target),
-            };
-            std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0)
+            std::fs::metadata(target_path(&target, workdir))
+                .map(|m| m.len())
+                .unwrap_or(0)
         })
         .sum()
+}
+
+/// Where a shell redirect target lands: an absolute target as written, a
+/// relative one against the working directory the shell runs in.
+fn target_path(target: &str, workdir: &std::path::Path) -> std::path::PathBuf {
+    match std::path::Path::new(target).is_absolute() {
+        true => std::path::PathBuf::from(target),
+        false => workdir.join(target),
+    }
 }
 
 /// Tools a blueprint may declare *more* permissively than the built-in default

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -42,6 +42,84 @@ fn directory_listing(path: &std::path::Path) -> String {
     out
 }
 
+/// Fold `..` components of `raw` lexically, without touching the filesystem.
+///
+/// `None` when a `..` would climb past the root: that request is unresolvable
+/// whatever any allowlist says. `Path::components` already drops interior
+/// `.`, and every caller passes an absolute path, so no `CurDir` survives.
+/// Shared by [`resolve_within`] and [`BuiltinTools::resolve_outside`], which
+/// used to carry the same loop each.
+fn fold_parents(raw: &Path) -> Option<PathBuf> {
+    let mut normalized = PathBuf::new();
+    for component in raw.components() {
+        match component {
+            Component::ParentDir => {
+                if !normalized.pop() {
+                    return None;
+                }
+            }
+            c => normalized.push(c),
+        }
+    }
+    Some(normalized)
+}
+
+/// Resolve `requested` against `workdir`, refusing anything that leaves it.
+///
+/// The shared definition of "inside the workspace" for every path a tool or
+/// a script hands the daemon: the built-in file tools and the Rhai script
+/// host both go through here, so `write_file` and a script's `write_file`
+/// cannot disagree about what a path is allowed to be.
+///
+/// The `within` predicate is a `fn` pointer (not `impl Fn`) so there is one
+/// monomorphization, matching the seam idiom used elsewhere in the workspace.
+/// The seam exists because the refusal cannot be reached otherwise on every
+/// platform: producing the escape needs a real symlink, and creating one on
+/// Windows requires a privilege CI runners do not have. Injecting the
+/// predicate lets the refusal itself be tested everywhere, while the
+/// `#[cfg(unix)]` tests still prove the real filesystem behaviour end to end.
+pub fn resolve_within(
+    requested: &str,
+    workdir: &Path,
+    within: fn(&Path, &Path) -> bool,
+) -> anyhow::Result<PathBuf> {
+    if is_null_device(requested) {
+        return Ok(PathBuf::from(requested));
+    }
+    let raw = if Path::new(requested).is_absolute() {
+        PathBuf::from(requested)
+    } else {
+        workdir.join(requested)
+    };
+
+    // Normalize by resolving .. and . without requiring the path to exist.
+    let Some(normalized) = fold_parents(&raw) else {
+        anyhow::bail!("path '{}' escapes the working directory", requested);
+    };
+
+    if !normalized.starts_with(workdir) {
+        // Names the workspace and what to do instead. "Denied" on its own
+        // sends an agent looking for a different way out, and it spends
+        // iterations - which the stage's budget is charged for - finding
+        // that there isn't one (#373).
+        anyhow::bail!(
+            "path '{}' would escape the working directory ({}). Use a path \
+             inside the workspace instead - a relative path resolves \
+             against it.",
+            requested,
+            workdir.display()
+        );
+    }
+
+    if !within(&normalized, workdir) {
+        anyhow::bail!(
+            "path '{requested}' resolves outside the working directory through a symlink"
+        );
+    }
+
+    Ok(normalized)
+}
+
 impl BuiltinTools {
     /// Execute a built-in tool by name (resolving aliases), returning the result
     /// as a string.
@@ -131,7 +209,7 @@ impl BuiltinTools {
     /// throughout, which is a larger change; this stops the planted-symlink case,
     /// which is the one an agent can actually arrange.
     pub(crate) fn resolve(&self, requested: &str) -> anyhow::Result<PathBuf> {
-        Self::resolve_within(requested, &self.ctx.workdir, resolves_within)
+        resolve_within(requested, &self.ctx.workdir, resolves_within)
     }
 
     /// Resolve a requested path for a *read-only* tool.
@@ -148,7 +226,7 @@ impl BuiltinTools {
     /// [`resolve`](Self::resolve) so an allowlisted directory can be read but
     /// never written.
     pub(crate) fn resolve_read(&self, requested: &str) -> anyhow::Result<PathBuf> {
-        match Self::resolve_within(requested, &self.ctx.workdir, resolves_within) {
+        match resolve_within(requested, &self.ctx.workdir, resolves_within) {
             Ok(path) => Ok(path),
             Err(workdir_err) => {
                 if !self.ctx.read_paths.is_active() {
@@ -166,7 +244,7 @@ impl BuiltinTools {
 
     /// The out-of-workdir arm of [`resolve_read`](Self::resolve_read), with
     /// the canonicalizer injected (`fn` pointer, same seam idiom as
-    /// [`resolve_within`](Self::resolve_within)) so the fail-closed refusal is
+    /// [`resolve_within`]) so the fail-closed refusal is
     /// testable on every platform.
     ///
     /// The returned path is the *canonicalized* one - the path that was
@@ -189,22 +267,10 @@ impl BuiltinTools {
         };
 
         // Fold `..` lexically; popping past the filesystem root is
-        // unresolvable no matter what any allowlist says. `Path::components`
-        // already drops interior `.`, and `raw` is absolute here (an absolute
-        // request, or a relative one joined onto the canonicalized workdir),
-        // so no `CurDir` survives to this loop - the catch-all mirrors
-        // `resolve_within`.
-        let mut normalized = PathBuf::new();
-        for component in raw.components() {
-            match component {
-                Component::ParentDir => {
-                    if !normalized.pop() {
-                        anyhow::bail!("path '{requested}' cannot be resolved");
-                    }
-                }
-                other => normalized.push(other),
-            }
-        }
+        // unresolvable no matter what any allowlist says.
+        let Some(normalized) = fold_parents(&raw) else {
+            anyhow::bail!("path '{requested}' cannot be resolved");
+        };
 
         // The policy only ever sees the real, symlink-resolved path. A path
         // that cannot be verified is refused, never matched.
@@ -225,65 +291,6 @@ impl BuiltinTools {
                 agent = policy.agent
             ),
         }
-    }
-
-    /// Core of [`resolve`](Self::resolve) with the containment check injected.
-    ///
-    /// A `fn` pointer (not `impl Fn`) so there is one monomorphization, matching
-    /// the seam idiom used elsewhere in the workspace. The seam exists because
-    /// the refusal cannot be reached otherwise on every platform: producing the
-    /// escape needs a real symlink, and creating one on Windows requires a
-    /// privilege CI runners do not have. Injecting the predicate lets the
-    /// refusal itself be tested everywhere, while the `#[cfg(unix)]` tests below
-    /// still prove the real filesystem behaviour end to end.
-    pub(crate) fn resolve_within(
-        requested: &str,
-        workdir: &Path,
-        within: fn(&Path, &Path) -> bool,
-    ) -> anyhow::Result<PathBuf> {
-        if is_null_device(requested) {
-            return Ok(PathBuf::from(requested));
-        }
-        let raw = if Path::new(requested).is_absolute() {
-            PathBuf::from(requested)
-        } else {
-            workdir.join(requested)
-        };
-
-        // Normalize by resolving .. and . without requiring the path to exist.
-        let mut normalized = PathBuf::new();
-        for component in raw.components() {
-            match component {
-                Component::ParentDir => {
-                    if !normalized.pop() {
-                        anyhow::bail!("path '{}' escapes the working directory", requested);
-                    }
-                }
-                c => normalized.push(c),
-            }
-        }
-
-        if !normalized.starts_with(workdir) {
-            // Names the workspace and what to do instead. "Denied" on its own
-            // sends an agent looking for a different way out, and it spends
-            // iterations - which the stage's budget is charged for - finding
-            // that there isn't one (#373).
-            anyhow::bail!(
-                "path '{}' would escape the working directory ({}). Use a path \
-                 inside the workspace instead - a relative path resolves \
-                 against it.",
-                requested,
-                workdir.display()
-            );
-        }
-
-        if !within(&normalized, workdir) {
-            anyhow::bail!(
-                "path '{requested}' resolves outside the working directory through a symlink"
-            );
-        }
-
-        Ok(normalized)
     }
 
     pub(crate) async fn read_file(&self, args: &Value) -> String {

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -18,6 +18,7 @@ mod defs;
 mod env;
 mod exec;
 pub use exec::is_null_device;
+pub use exec::resolve_within;
 mod platform;
 pub mod validate;
 pub use context::*;
@@ -505,7 +506,7 @@ mod tests {
             false
         }
         let dir = tempfile::tempdir().unwrap();
-        let err = BuiltinTools::resolve_within("notes.txt", dir.path(), escapes)
+        let err = resolve_within("notes.txt", dir.path(), escapes)
             .expect_err("a path that resolves outside must be refused");
         assert!(err.to_string().contains("symlink"), "{err}");
     }
@@ -515,9 +516,8 @@ mod tests {
     #[test]
     fn resolve_admits_an_ordinary_path_within_the_workdir() {
         let dir = tempfile::tempdir().unwrap();
-        let resolved =
-            BuiltinTools::resolve_within("notes.txt", dir.path(), leviath_core::resolves_within)
-                .expect("an ordinary path resolves");
+        let resolved = resolve_within("notes.txt", dir.path(), leviath_core::resolves_within)
+            .expect("an ordinary path resolves");
         assert!(resolved.ends_with("notes.txt"));
     }
 


### PR DESCRIPTION
## What

**One path-confinement function.** `leviath_tools::resolve_within` is now the single definition of "inside the workspace" for every path a tool or a Rhai script hands the daemon. It was `pub(crate)` on `BuiltinTools`, which is why `leviath-cli`'s script host carried a line-for-line copy (`DaemonScriptHost::resolve_in`): same `..` fold, same `starts_with`, same injected symlink predicate, same three error strings byte for byte. A security decision duplicated across two crates can drift without anything noticing; now it cannot. The script host maps the shared function's `anyhow` error to its `String` (the rendered text is identical). The `..` fold that `resolve_outside` also repeated is one `fold_parents`.

**Four smaller merges of the same kind:**
- `recovery::read_meta` → `runstate::read_meta_from(dir).ok()`; `recovery::read_final_output_from` → new `runstate::read_final_output_in`, which `runstate::read_final_output` itself now uses.
- `sandbox_manager::host_command` → `script_host::host_shell_command` (identical three lines).
- The absolute-or-join of a shell redirect target in `tools.rs` (twice) → `target_path`.
- The MCP result-to-text `match` in `tool_service` and `seed_tool` → `seed_tool::mcp_text`.

No behaviour change: every message and every arm is the one it was.

## Tests

The three CLI tests that drove the deleted copy directly are removed; `leviath-tools` tests `resolve_within` (refusal via the injected predicate on every OS, the null device, an ordinary path), and the script host's `#[cfg(unix)]` symlink test still exercises the shared function end to end through `resolve_in_workdir`.

## Verification

`cargo test -p leviath-tools` 205, `-p leviath-cli --lib` 4,020; clippy and rustdoc `-D warnings` on both. Coverage: the moved code is exercised by `leviath-tools`' own tests, which is the crate whose gate now owns it.
