### PR TITLE
refactor(providers): one FramedStream behind the three streaming parsers

### DIFF
--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use futures_core::Stream;
 use std::collections::HashMap;
 use std::pin::Pin;
-use stream::AnthropicSseStream;
+use stream::anthropic_sse_stream;
 
 /// Read the dump directory from the environment and delegate to
 /// [`dump_request`]. See that function for the rationale.
@@ -852,7 +852,7 @@ impl Provider for AnthropicProvider {
         .await?;
 
         let byte_stream = response.bytes_stream();
-        let stream = AnthropicSseStream::new(byte_stream);
+        let stream = anthropic_sse_stream(byte_stream);
 
         Ok(Box::pin(stream))
     }
@@ -958,7 +958,7 @@ impl Provider for AnthropicProvider {
 mod tests {
     // The SSE parser lives in `stream`, and its tests stayed here beside the
     // request-building ones they share fixtures with.
-    use super::stream::{AnthropicSseStream, parse_sse_event};
+    use super::stream::{anthropic_sse_stream, parse_sse_event};
 
     /// Config beats the shipped table, and an unconfigured model still gets the
     /// published rate rather than falling to unpriced.
@@ -3257,7 +3257,7 @@ mod tests {
         assert_eq!(models[0].id, "valid-model");
     }
 
-    // ─── AnthropicSseStream parser (no HTTP needed) ────────────────────────
+    // ─── anthropic_sse_stream parser (no HTTP needed) ──────────────────────
 
     struct StaticByteStream {
         data: Vec<Vec<u8>>,
@@ -3288,7 +3288,7 @@ mod tests {
             data: vec![data],
             idx: 0,
         };
-        let mut sse = AnthropicSseStream::new(stream);
+        let mut sse = anthropic_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
         assert_eq!(chunk.tool_calls.len(), 1);
         assert_eq!(chunk.tool_calls[0].arguments_delta, "{\"a\":1}");
@@ -3306,7 +3306,7 @@ mod tests {
             data: vec![data],
             idx: 0,
         };
-        let mut sse = AnthropicSseStream::new(stream);
+        let mut sse = anthropic_sse_stream(stream);
         assert!(sse.next().await.is_none());
     }
 
@@ -3319,7 +3319,7 @@ mod tests {
             data: vec![data],
             idx: 0,
         };
-        let mut sse = AnthropicSseStream::new(stream);
+        let mut sse = anthropic_sse_stream(stream);
         assert!(sse.next().await.is_none());
     }
 
@@ -3327,7 +3327,7 @@ mod tests {
     async fn infer_stream_body_error_propagates_as_stream_item_error() {
         // Send a Content-Length larger than the actual body and close the
         // connection early - reqwest's body stream then yields a real
-        // Err(reqwest::Error) mid-stream, exercising AnthropicSseStream's
+        // Err(reqwest::Error) mid-stream, exercising the framed stream's
         // Poll::Ready(Some(Err(e))) branch with a genuine error (not a
         // hand-built one - reqwest::Error has no public constructor).
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -3370,7 +3370,7 @@ mod tests {
             data: vec![data],
             idx: 0,
         };
-        let mut sse = AnthropicSseStream::new(stream);
+        let mut sse = anthropic_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");
         assert!(sse.next().await.is_none());
@@ -3387,7 +3387,7 @@ mod tests {
             data: vec![invalid, valid],
             idx: 0,
         };
-        let mut sse = AnthropicSseStream::new(stream);
+        let mut sse = anthropic_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "ok");
     }
@@ -3633,7 +3633,7 @@ mod tests {
             "event: content_block_delta\ndata: {\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"\\\"utc\\\"}\"}}\n\n",
             "event: message_delta\ndata: {\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":9}}\n\n",
         );
-        let stream = AnthropicSseStream::new(StaticByteStream {
+        let stream = anthropic_sse_stream(StaticByteStream {
             data: vec![sse.as_bytes().to_vec()],
             idx: 0,
         });
@@ -3667,7 +3667,7 @@ mod tests {
             "event: content_block_delta\ndata: {\"index\":1,\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"url\\\":\\\"b\\\"}\"}}\n\n",
             "event: message_delta\ndata: {\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":9}}\n\n",
         );
-        let stream = AnthropicSseStream::new(StaticByteStream {
+        let stream = anthropic_sse_stream(StaticByteStream {
             data: vec![sse.as_bytes().to_vec()],
             idx: 0,
         });
@@ -3699,7 +3699,7 @@ mod tests {
             "event: content_block_delta\ndata: {\"delta\":{\"type\":\"input_json_delta\",\"partial_json\":\"{\\\"url\\\":\\\"b\\\"}\"}}\n\n",
             "event: message_delta\ndata: {\"delta\":{\"stop_reason\":\"tool_use\"},\"usage\":{\"output_tokens\":9}}\n\n",
         );
-        let stream = AnthropicSseStream::new(StaticByteStream {
+        let stream = anthropic_sse_stream(StaticByteStream {
             data: vec![sse.as_bytes().to_vec()],
             idx: 0,
         });

--- a/crates/leviath-providers/src/anthropic/stream.rs
+++ b/crates/leviath-providers/src/anthropic/stream.rs
@@ -6,82 +6,28 @@
 //! [`StreamChunk`] the shared collector folds back into one response.
 
 use super::AnthropicProvider;
-use crate::provider::{ProviderError, Result, StreamChunk, TokenUsage, ToolCallDelta};
+use crate::provider::{StreamChunk, TokenUsage, ToolCallDelta};
 use futures_core::Stream;
-use std::pin::Pin;
 
-// The inner byte stream is boxed as a trait object rather than kept generic.
-// In production this is always `reqwest`'s `bytes_stream()`; tests inject
-// dozens of distinct mock stream types via `new`'s generic parameter, and a
-// generic `impl<S> Stream` causes `cargo llvm-cov` to instrument each
-// monomorphized `poll_next` separately, leaving some artificially "uncovered"
-// even though the shared logic is fully exercised. Boxing collapses all of
-// that into a single concrete `poll_next` implementation.
-pub(super) struct AnthropicSseStream {
-    inner: Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>>,
-    buffer: String,
-    /// The tool call the argument deltas arriving now belong to, `None` until
-    /// the first one opens. `content_block_start` carries a call's id and its
-    /// name and each `input_json_delta` after it a slice of its arguments, and
-    /// the collector puts them back together by index, so which block is open
-    /// has to survive from one event to the next.
-    open_tool_block: Option<usize>,
-}
-
-impl AnthropicSseStream {
-    pub(super) fn new<S>(inner: S) -> Self
-    where
-        S: Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
-    {
-        Self {
-            inner: Box::pin(inner),
-            buffer: String::new(),
-            open_tool_block: None,
-        }
-    }
-}
-
-impl Stream for AnthropicSseStream {
-    type Item = Result<StreamChunk>;
-
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        loop {
-            // Check if we have complete SSE events in the buffer
-            if let Some(chunk) = parse_sse_event(&mut this.buffer, &mut this.open_tool_block) {
-                return std::task::Poll::Ready(Some(Ok(chunk)));
-            }
-
-            // Try to get more data
-            match this.inner.as_mut().poll_next(cx) {
-                std::task::Poll::Ready(Some(Ok(bytes))) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        this.buffer.push_str(text);
-                    }
-                }
-                std::task::Poll::Ready(Some(Err(e))) => {
-                    return std::task::Poll::Ready(Some(Err(ProviderError::transport(
-                        "reading the response stream",
-                        &e,
-                    ))));
-                }
-                std::task::Poll::Ready(None) => {
-                    // Stream ended - try to parse any remaining data
-                    if let Some(chunk) =
-                        parse_sse_event(&mut this.buffer, &mut this.open_tool_block)
-                    {
-                        return std::task::Poll::Ready(Some(Ok(chunk)));
-                    }
-                    return std::task::Poll::Ready(None);
-                }
-                std::task::Poll::Pending => return std::task::Poll::Pending,
-            }
-        }
-    }
+/// Wrap a byte stream in Anthropic's server-sent-events framer.
+///
+/// The framer carries the open tool block between events (see
+/// [`parse_sse_event`]), which is why it is a closure over that state rather
+/// than a bare `fn`. `parse_sse_event` answers `None` both for "no complete
+/// event yet" and for an event that carries nothing (`ping`, `message_stop`);
+/// either way the stream polls for more bytes, exactly as it did before.
+pub(super) fn anthropic_sse_stream<S>(inner: S) -> crate::provider::stream::FramedStream
+where
+    S: Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+{
+    let mut open_tool_block: Option<usize> = None;
+    crate::provider::stream::FramedStream::new(
+        inner,
+        Box::new(move |buffer: &mut String| {
+            parse_sse_event(buffer, &mut open_tool_block).map(|chunk| Some(Ok(chunk)))
+        }),
+        None,
+    )
 }
 
 /// The content-block index an event names, when it names one. Anthropic

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -1,7 +1,7 @@
 //! Google Gemini provider implementation (via OpenAI-compatible endpoint).
 
 use crate::openai_compat::{
-    OpenAiSseStream, build_openai_request_body, parse_openai_response, send_chat_request,
+    build_openai_request_body, openai_sse_stream, parse_openai_response, send_chat_request,
 };
 use crate::provider::{
     InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
@@ -304,7 +304,7 @@ impl Provider for GeminiProvider {
         .await?;
 
         let byte_stream = response.bytes_stream();
-        let stream = OpenAiSseStream::new(byte_stream);
+        let stream = openai_sse_stream(byte_stream);
 
         Ok(Box::pin(stream))
     }

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -712,7 +712,7 @@ impl Provider for OllamaProvider {
         .map_err(|e| self.explain_truncation(e, request))?;
 
         let byte_stream = response.bytes_stream();
-        let stream = OllamaNdjsonStream::new(byte_stream);
+        let stream = ollama_ndjson_stream(byte_stream);
 
         Ok(Box::pin(stream))
     }
@@ -849,180 +849,143 @@ impl Provider for OllamaProvider {
     }
 }
 
-// NDJSON stream parser for Ollama's streaming API.
-//
-// The inner byte stream is boxed as a trait object rather than kept generic.
-// In production this is always `reqwest`'s `bytes_stream()`; tests inject
-// dozens of distinct mock stream types via `new`'s generic parameter, and a
-// generic `impl<S> Stream` causes `cargo llvm-cov` to instrument each
-// monomorphized `poll_next` separately, leaving some artificially "uncovered"
-// even though the shared logic is fully exercised. Boxing collapses all of
-// that into a single concrete `poll_next` implementation.
-struct OllamaNdjsonStream {
-    inner: Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>>,
-    buffer: String,
+/// Wrap a byte stream in the NDJSON framer Ollama's `/api/chat` speaks.
+fn ollama_ndjson_stream<S>(inner: S) -> crate::provider::stream::FramedStream
+where
+    S: Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+{
+    crate::provider::stream::FramedStream::new(
+        inner,
+        Box::new(ollama_frame),
+        Some(Box::new(ollama_flush)),
+    )
 }
 
-impl OllamaNdjsonStream {
-    fn new<S>(inner: S) -> Self
-    where
-        S: Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+/// One NDJSON line off the front of the buffer, as a chunk.
+///
+/// Blank lines are skipped; `None` when no newline has arrived yet. A line
+/// that is not JSON is an error the stream delivers rather than a skipped
+/// frame, because with NDJSON there is no other framing to fall back on.
+fn ollama_frame(buffer: &mut String) -> Option<Option<Result<StreamChunk>>> {
+    loop {
+        // Both halves are copied out before the buffer is replaced.
+        let (line, rest) = buffer
+            .split_once('\n')
+            .map(|(line, rest)| (line.to_string(), rest.to_string()))?;
+        *buffer = rest;
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let json: serde_json::Value = match serde_json::from_str(line) {
+            Ok(j) => j,
+            Err(e) => {
+                return Some(Some(Err(ProviderError::InvalidResponse(e.to_string()))));
+            }
+        };
+        return Some(Some(Ok(ollama_chunk(&json))));
+    }
+}
+
+/// A parsed NDJSON object as a chunk: text on every line, tool calls and
+/// usage on the one flagged `done`.
+fn ollama_chunk(json: &serde_json::Value) -> StreamChunk {
+    let done = json.get("done").and_then(|v| v.as_bool()).unwrap_or(false);
+    let message = json.get("message");
+    let content = message
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .unwrap_or("")
+        .to_string();
+    if !done {
+        return StreamChunk {
+            delta: content,
+            tool_calls: Vec::new(),
+            tokens: None,
+            finish_reason: None,
+        };
+    }
+
+    let eval_count = json.get("eval_count").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let prompt_eval_count = json
+        .get("prompt_eval_count")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0) as usize;
+
+    // Parse tool calls from the final chunk's message.tool_calls
+    let mut tool_calls = Vec::new();
+    if let Some(tcs) = message
+        .and_then(|m| m.get("tool_calls"))
+        .and_then(|tc| tc.as_array())
     {
-        Self {
-            inner: Box::pin(inner),
-            buffer: String::new(),
+        for (i, tc) in tcs.iter().enumerate() {
+            let function = tc.get("function").unwrap_or(&serde_json::Value::Null);
+            let name = function
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let arguments = function
+                .get("arguments")
+                .cloned()
+                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
+            tool_calls.push(crate::provider::ToolCallDelta {
+                index: i,
+                id: Some(next_tool_call_id()),
+                name: Some(name),
+                arguments_delta: arguments.to_string(),
+                // Local models sign nothing.
+                thought_signature: None,
+            });
         }
+    }
+
+    let finish_reason = if tool_calls.is_empty() {
+        FinishReason::Complete
+    } else {
+        FinishReason::ToolCall
+    };
+
+    StreamChunk {
+        delta: content,
+        tool_calls,
+        tokens: Some(TokenUsage {
+            prompt_tokens: prompt_eval_count,
+            completion_tokens: eval_count,
+            total_tokens: prompt_eval_count + eval_count,
+            cached_tokens: 0,
+            cache_write_tokens: 0,
+            reported_cost_usd: None,
+        }),
+        finish_reason: Some(finish_reason),
     }
 }
 
-impl Stream for OllamaNdjsonStream {
-    type Item = Result<StreamChunk>;
-
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        loop {
-            // Try to parse a complete JSON line
-            // Split off one complete NDJSON line, if the newline ending it has
-            // arrived. Both halves are copied out before the buffer is replaced.
-            let split = this
-                .buffer
-                .split_once('\n')
-                .map(|(line, rest)| (line.to_string(), rest.to_string()));
-            if let Some((line, rest)) = split {
-                this.buffer = rest;
-
-                let line = line.trim();
-                if line.is_empty() {
-                    continue;
-                }
-
-                let json: serde_json::Value = match serde_json::from_str(line) {
-                    Ok(j) => j,
-                    Err(e) => {
-                        return std::task::Poll::Ready(Some(Err(ProviderError::InvalidResponse(
-                            e.to_string(),
-                        ))));
-                    }
-                };
-
-                // Check for done flag
-                let done = json.get("done").and_then(|v| v.as_bool()).unwrap_or(false);
-
-                let message = json.get("message");
-                let content = message
-                    .and_then(|m| m.get("content"))
-                    .and_then(|c| c.as_str())
-                    .unwrap_or("")
-                    .to_string();
-
-                if done {
-                    let eval_count =
-                        json.get("eval_count").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-                    let prompt_eval_count = json
-                        .get("prompt_eval_count")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0) as usize;
-
-                    // Parse tool calls from the final chunk's message.tool_calls
-                    let mut tool_calls = Vec::new();
-                    if let Some(tcs) = message
-                        .and_then(|m| m.get("tool_calls"))
-                        .and_then(|tc| tc.as_array())
-                    {
-                        for (i, tc) in tcs.iter().enumerate() {
-                            let function = tc.get("function").unwrap_or(&serde_json::Value::Null);
-                            let name = function
-                                .get("name")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or("")
-                                .to_string();
-                            let arguments = function
-                                .get("arguments")
-                                .cloned()
-                                .unwrap_or(serde_json::Value::Object(serde_json::Map::new()));
-                            tool_calls.push(crate::provider::ToolCallDelta {
-                                index: i,
-                                id: Some(next_tool_call_id()),
-                                name: Some(name),
-                                arguments_delta: arguments.to_string(),
-                                // Local models sign nothing.
-                                thought_signature: None,
-                            });
-                        }
-                    }
-
-                    let finish_reason = if tool_calls.is_empty() {
-                        FinishReason::Complete
-                    } else {
-                        FinishReason::ToolCall
-                    };
-
-                    return std::task::Poll::Ready(Some(Ok(StreamChunk {
-                        delta: content,
-                        tool_calls,
-                        tokens: Some(TokenUsage {
-                            prompt_tokens: prompt_eval_count,
-                            completion_tokens: eval_count,
-                            total_tokens: prompt_eval_count + eval_count,
-                            cached_tokens: 0,
-                            cache_write_tokens: 0,
-                            reported_cost_usd: None,
-                        }),
-                        finish_reason: Some(finish_reason),
-                    })));
-                }
-
-                return std::task::Poll::Ready(Some(Ok(StreamChunk {
-                    delta: content,
-                    tool_calls: Vec::new(),
-                    tokens: None,
-                    finish_reason: None,
-                })));
-            }
-
-            // Need more data
-            match this.inner.as_mut().poll_next(cx) {
-                std::task::Poll::Ready(Some(Ok(bytes))) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        this.buffer.push_str(text);
-                    }
-                }
-                std::task::Poll::Ready(Some(Err(e))) => {
-                    return std::task::Poll::Ready(Some(Err(ProviderError::transport(
-                        "reading the response stream",
-                        &e,
-                    ))));
-                }
-                std::task::Poll::Ready(None) => {
-                    // Try remaining buffer
-                    let remaining = this.buffer.trim().to_string();
-                    if !remaining.is_empty() {
-                        this.buffer.clear();
-                        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&remaining) {
-                            let content = json
-                                .get("message")
-                                .and_then(|m| m.get("content"))
-                                .and_then(|c| c.as_str())
-                                .unwrap_or("")
-                                .to_string();
-                            return std::task::Poll::Ready(Some(Ok(StreamChunk {
-                                delta: content,
-                                tool_calls: Vec::new(),
-                                tokens: None,
-                                finish_reason: Some(FinishReason::Complete),
-                            })));
-                        }
-                    }
-                    return std::task::Poll::Ready(None);
-                }
-                std::task::Poll::Pending => return std::task::Poll::Pending,
-            }
-        }
+/// The last line, if the server closed without a trailing newline.
+///
+/// NDJSON promises a newline between records, not after the last one, so a
+/// final `done` record can be sitting in the buffer with nothing to frame
+/// it. It is read as text and the stream is marked complete; the usage on it
+/// is not recovered, which is what the old loop did too.
+fn ollama_flush(buffer: &mut String) -> Option<StreamChunk> {
+    let remaining = buffer.trim().to_string();
+    if remaining.is_empty() {
+        return None;
     }
+    buffer.clear();
+    let json = serde_json::from_str::<serde_json::Value>(&remaining).ok()?;
+    let content = json
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .unwrap_or("")
+        .to_string();
+    Some(StreamChunk {
+        delta: content,
+        tool_calls: Vec::new(),
+        tokens: None,
+        finish_reason: Some(FinishReason::Complete),
+    })
 }
 
 #[cfg(test)]
@@ -2092,7 +2055,7 @@ mod tests {
             idx: 0,
         };
 
-        let ndjson_stream = OllamaNdjsonStream::new(static_stream);
+        let ndjson_stream = ollama_ndjson_stream(static_stream);
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -2147,7 +2110,7 @@ mod tests {
             idx: 0,
         };
 
-        let ndjson_stream = OllamaNdjsonStream::new(static_stream);
+        let ndjson_stream = ollama_ndjson_stream(static_stream);
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -2195,7 +2158,7 @@ mod tests {
             idx: 0,
         };
 
-        let ndjson_stream = OllamaNdjsonStream::new(static_stream);
+        let ndjson_stream = ollama_ndjson_stream(static_stream);
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -2244,7 +2207,7 @@ mod tests {
             idx: 0,
         };
 
-        let ndjson_stream = OllamaNdjsonStream::new(static_stream);
+        let ndjson_stream = ollama_ndjson_stream(static_stream);
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -2291,7 +2254,7 @@ mod tests {
             idx: 0,
         };
 
-        let ndjson_stream = OllamaNdjsonStream::new(static_stream);
+        let ndjson_stream = ollama_ndjson_stream(static_stream);
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -2335,7 +2298,7 @@ mod tests {
             }
         }
 
-        let ndjson_stream = OllamaNdjsonStream::new(PendingThenDataStream {
+        let ndjson_stream = ollama_ndjson_stream(PendingThenDataStream {
             polled_once: false,
             yielded: false,
         });
@@ -2386,7 +2349,7 @@ mod tests {
             idx: 0,
         };
 
-        let ndjson_stream = OllamaNdjsonStream::new(static_stream);
+        let ndjson_stream = ollama_ndjson_stream(static_stream);
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -2443,7 +2406,7 @@ mod tests {
             idx: 0,
         };
 
-        let ndjson_stream = OllamaNdjsonStream::new(static_stream);
+        let ndjson_stream = ollama_ndjson_stream(static_stream);
 
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
@@ -2870,7 +2833,7 @@ mod tests {
     #[test]
     fn ndjson_stream_skips_invalid_utf8_chunk_and_continues() {
         // covers the implicit else of `if let Ok(text) = from_utf8(&bytes)` in
-        // OllamaNdjsonStream::poll_next
+        // the framed stream
         use futures_core::Stream;
         use std::pin::Pin;
         use std::task::{Context, Poll};
@@ -2902,7 +2865,7 @@ mod tests {
             data: vec![invalid_utf8, valid_chunk],
             idx: 0,
         };
-        let ndjson_stream = OllamaNdjsonStream::new(stream);
+        let ndjson_stream = ollama_ndjson_stream(stream);
         let rt = tokio::runtime::Runtime::new().unwrap();
         rt.block_on(async {
             use tokio_stream::StreamExt;

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -1,7 +1,7 @@
 //! OpenAI provider implementation.
 
 use crate::openai_compat::{
-    OpenAiSseStream, TokenLimitField, build_openai_request_body_with, parse_openai_response,
+    TokenLimitField, build_openai_request_body_with, openai_sse_stream, parse_openai_response,
     send_chat_request, temperature_refused, tools_refused_over_reasoning_effort,
 };
 use crate::provider::{
@@ -332,7 +332,7 @@ impl Provider for OpenAIProvider {
         let response = self.post_chat(request, body).await?;
 
         let byte_stream = response.bytes_stream();
-        let stream = OpenAiSseStream::new(byte_stream);
+        let stream = openai_sse_stream(byte_stream);
 
         Ok(Box::pin(stream))
     }

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -10,7 +10,6 @@ use crate::provider::{
 };
 use crate::rate_limit::RateLimiter;
 use futures_core::Stream;
-use std::pin::Pin;
 
 /// Send an OpenAI-compatible chat request and return the checked response.
 ///
@@ -862,71 +861,16 @@ pub fn parse_openai_response(body: &serde_json::Value) -> Result<InferenceRespon
     })
 }
 
-// SSE stream parser for OpenAI-compatible streaming APIs.
-//
-// The inner byte stream is boxed as a trait object rather than kept generic.
-// In production this is always `reqwest`'s `bytes_stream()`; tests inject
-// dozens of distinct mock stream types via `new`'s generic parameter, and a
-// generic `impl<S> Stream` causes `cargo llvm-cov` to instrument each
-// monomorphized `poll_next` separately, leaving some artificially "uncovered"
-// even though the shared logic is fully exercised. Boxing collapses all of
-// that into a single concrete `poll_next` implementation.
-/// SSE stream wrapper that parses OpenAI-compatible server-sent events.
-pub struct OpenAiSseStream {
-    inner: Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>>,
-    buffer: String,
-}
-
-impl OpenAiSseStream {
-    /// Create a new SSE stream wrapper around a byte stream.
-    pub fn new<S>(inner: S) -> Self
-    where
-        S: Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
-    {
-        Self {
-            inner: Box::pin(inner),
-            buffer: String::new(),
-        }
-    }
-}
-
-impl Stream for OpenAiSseStream {
-    type Item = Result<StreamChunk>;
-
-    fn poll_next(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-
-        loop {
-            // Check for complete SSE events
-            if let Some(chunk) = parse_openai_sse_event(&mut this.buffer) {
-                return std::task::Poll::Ready(chunk);
-            }
-
-            match this.inner.as_mut().poll_next(cx) {
-                std::task::Poll::Ready(Some(Ok(bytes))) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        this.buffer.push_str(text);
-                    }
-                }
-                std::task::Poll::Ready(Some(Err(e))) => {
-                    return std::task::Poll::Ready(Some(Err(ProviderError::transport(
-                        "reading the response stream",
-                        &e,
-                    ))));
-                }
-                std::task::Poll::Ready(None) => {
-                    if let Some(chunk) = parse_openai_sse_event(&mut this.buffer) {
-                        return std::task::Poll::Ready(chunk);
-                    }
-                    return std::task::Poll::Ready(None);
-                }
-                std::task::Poll::Pending => return std::task::Poll::Pending,
-            }
-        }
-    }
+/// Wrap a byte stream in the OpenAI-compatible server-sent-events framer.
+///
+/// The one framer shared by OpenAI, Gemini's OpenAI-compatible endpoint and
+/// OpenRouter, which is what makes a gateway's mid-stream error envelope
+/// (see [`parse_openai_sse_event`]) handled the same way on all three.
+pub(crate) fn openai_sse_stream<S>(inner: S) -> crate::provider::stream::FramedStream
+where
+    S: Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+{
+    crate::provider::stream::FramedStream::new(inner, Box::new(parse_openai_sse_event), None)
 }
 
 /// Parse a single SSE event from the buffer.
@@ -1294,6 +1238,7 @@ mod tests {
 
     use super::*;
     use crate::provider::{InferenceRequest, Message, SystemBlock, Tool};
+    use std::pin::Pin;
 
     fn sample_request() -> InferenceRequest {
         InferenceRequest {
@@ -2331,7 +2276,7 @@ mod tests {
         assert!(result.is_none());
     }
 
-    // ─── OpenAiSseStream (Stream-level, not just parse_openai_sse_event) ───
+    // ─── openai_sse_stream (Stream-level, not just parse_openai_sse_event) ───
 
     struct StaticByteStream {
         data: Vec<Vec<u8>>,
@@ -2362,7 +2307,7 @@ mod tests {
             data: vec![data],
             idx: 0,
         };
-        let mut sse = OpenAiSseStream::new(stream);
+        let mut sse = openai_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");
     }
@@ -2375,7 +2320,7 @@ mod tests {
             data: vec![data],
             idx: 0,
         };
-        let mut sse = OpenAiSseStream::new(stream);
+        let mut sse = openai_sse_stream(stream);
         assert!(sse.next().await.is_none());
     }
 
@@ -2388,7 +2333,7 @@ mod tests {
             data: vec![data],
             idx: 0,
         };
-        let mut sse = OpenAiSseStream::new(stream);
+        let mut sse = openai_sse_stream(stream);
         assert!(sse.next().await.is_none());
     }
 
@@ -2403,7 +2348,7 @@ mod tests {
             ],
             idx: 0,
         };
-        let mut sse = OpenAiSseStream::new(stream);
+        let mut sse = openai_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "ok");
     }
@@ -2424,7 +2369,7 @@ mod tests {
             data: vec![data],
             idx: 0,
         };
-        let mut sse = OpenAiSseStream::new(stream);
+        let mut sse = openai_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "hi");
         assert!(sse.next().await.is_none());
@@ -2441,7 +2386,7 @@ mod tests {
             ],
             idx: 0,
         };
-        let mut sse = OpenAiSseStream::new(stream);
+        let mut sse = openai_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
         assert_eq!(chunk.delta, "ok");
     }
@@ -3327,7 +3272,7 @@ mod tests {
         let client = reqwest::Client::new();
         let resp = client.get(&url).send().await.unwrap();
         let byte_stream = resp.bytes_stream();
-        let mut sse = OpenAiSseStream::new(byte_stream);
+        let mut sse = openai_sse_stream(byte_stream);
 
         let item = sse.next().await.expect("stream should yield an item");
         let err = item.unwrap_err();

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -4,7 +4,7 @@
 //! Uses OpenAI-compatible format with additional headers.
 
 use crate::openai_compat::{
-    OpenAiSseStream, parse_openai_response, send_chat_request, temperature_refused,
+    openai_sse_stream, parse_openai_response, send_chat_request, temperature_refused,
 };
 use crate::provider::{
     InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
@@ -705,7 +705,7 @@ impl Provider for OpenRouterProvider {
 
         // Reuse OpenAI SSE parser since the format is identical
         let byte_stream = response.bytes_stream();
-        let stream = OpenAiSseStream::new(byte_stream);
+        let stream = openai_sse_stream(byte_stream);
 
         Ok(Box::pin(stream))
     }

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -696,7 +696,7 @@ pub use http::{
 };
 
 // Folding a streamed answer back into one response.
-mod stream;
+pub(crate) mod stream;
 pub use stream::collect_stream;
 
 /// Trait for LLM providers.

--- a/crates/leviath-providers/src/provider/stream.rs
+++ b/crates/leviath-providers/src/provider/stream.rs
@@ -12,6 +12,104 @@
 
 use super::*;
 
+/// The raw bytes a provider's streaming endpoint sends back.
+///
+/// Boxed as a trait object rather than kept generic. In production this is
+/// always `reqwest`'s `bytes_stream()`; tests inject dozens of distinct mock
+/// stream types, and a generic `impl<S> Stream` makes `cargo llvm-cov`
+/// instrument each monomorphized `poll_next` separately, leaving some
+/// artificially "uncovered" even though the shared logic is fully exercised.
+/// Boxing collapses all of that into one concrete `poll_next`.
+pub type ByteStream =
+    Pin<Box<dyn Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send>>;
+
+/// Cut one frame off the front of the buffer, if a whole one has arrived.
+///
+/// `None` means "not yet, poll for more bytes"; `Some(None)` means the frame
+/// said the stream is over; `Some(Some(item))` is a chunk or an error the
+/// provider delivered inside the stream. A framer that consumed a frame with
+/// nothing in it (a keepalive, a `ping`) may answer `None` and be asked
+/// again.
+pub type FrameFn = Box<dyn FnMut(&mut String) -> Option<Option<Result<StreamChunk>>> + Send>;
+
+/// What to make of whatever is left in the buffer once the bytes stop.
+///
+/// Most wire formats end every frame with a delimiter, so a leftover is a
+/// torn frame and there is nothing to do. Ollama's NDJSON does not promise a
+/// trailing newline, so its last line can only be read here.
+pub type FlushFn = Box<dyn FnMut(&mut String) -> Option<StreamChunk> + Send>;
+
+/// A byte stream cut into [`StreamChunk`]s by a provider-specific framer.
+///
+/// One `poll_next` for every provider. Three of them used to carry a copy of
+/// this loop each - the same buffer, the same UTF-8 handling, the same
+/// transport-error mapping - with only the framing call differing, and the
+/// same eight-line comment about why the inner stream is boxed, three times.
+pub struct FramedStream {
+    inner: ByteStream,
+    buffer: String,
+    parse: FrameFn,
+    flush: Option<FlushFn>,
+}
+
+impl FramedStream {
+    /// Wrap `inner`, framing it with `parse` and, at the end, `flush`.
+    pub fn new<S>(inner: S, parse: FrameFn, flush: Option<FlushFn>) -> Self
+    where
+        S: Stream<Item = std::result::Result<bytes::Bytes, reqwest::Error>> + Send + 'static,
+    {
+        Self {
+            inner: Box::pin(inner),
+            buffer: String::new(),
+            parse,
+            flush,
+        }
+    }
+}
+
+impl Stream for FramedStream {
+    type Item = Result<StreamChunk>;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        loop {
+            if let Some(item) = (this.parse)(&mut this.buffer) {
+                return std::task::Poll::Ready(item);
+            }
+            match this.inner.as_mut().poll_next(cx) {
+                std::task::Poll::Ready(Some(Ok(bytes))) => {
+                    if let Ok(text) = std::str::from_utf8(&bytes) {
+                        this.buffer.push_str(text);
+                    }
+                }
+                std::task::Poll::Ready(Some(Err(e))) => {
+                    return std::task::Poll::Ready(Some(Err(ProviderError::transport(
+                        "reading the response stream",
+                        &e,
+                    ))));
+                }
+                std::task::Poll::Ready(None) => {
+                    // The bytes are over: a frame that arrived whole with the
+                    // last of them, then whatever the format does with a tail.
+                    if let Some(item) = (this.parse)(&mut this.buffer) {
+                        return std::task::Poll::Ready(item);
+                    }
+                    if let Some(flush) = this.flush.as_mut()
+                        && let Some(chunk) = flush(&mut this.buffer)
+                    {
+                        return std::task::Poll::Ready(Some(Ok(chunk)));
+                    }
+                    return std::task::Poll::Ready(None);
+                }
+                std::task::Poll::Pending => return std::task::Poll::Pending,
+            }
+        }
+    }
+}
+
 /// Fold a chunk stream back into the single response the runtime works with.
 ///
 /// The exact inverse of [`Provider::infer_stream`]'s default, which takes a


### PR DESCRIPTION
## What

The three streaming response parsers (OpenAI-compatible SSE, Anthropic SSE, Ollama NDJSON) each defined a `Stream` type whose `poll_next` was a copy of the same loop: a `String` buffer, UTF-8 append of each byte chunk, the same transport-error mapping, and the same eight-line comment about boxing the inner stream. Only the framing call in the middle differed.

`provider::stream::FramedStream` is that loop once. A provider supplies a boxed `FnMut(&mut String) -> Option<Option<Result<StreamChunk>>>` framer and, optionally, a flush for whatever is left when the bytes stop.

- OpenAI, Gemini, OpenRouter: `openai_sse_stream`, a `fn` pointer to the unchanged `parse_openai_sse_event`.
- Anthropic: `anthropic_sse_stream` closes over the open-tool-block index its parser carries between events; the parser's `None` (no complete event, a `ping`, a malformed event) means "poll for more", exactly as before.
- Ollama: the inline line loop becomes `ollama_frame` + `ollama_chunk`; its trailing-record read (NDJSON has no promised final newline) is the `flush` hook, and only Ollama passes one.

## Behaviour

None changed. The framers are the old bodies moved into functions; the stream tests for all three providers run unchanged against the new constructors. The O(N^2) remainder copy in each framer is deliberately left for the perf PR (4.6), which will replace it with a cursor.

## Verification

`cargo test -p leviath-providers` 906 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask coverage --package leviath-providers` at 100%. Net 48 lines fewer.
