### PR TITLE
refactor(providers): table-driven built-in capabilities

### DIFF
--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -2,10 +2,10 @@
 
 mod stream;
 
+use crate::capabilities::{Match, Row};
 use crate::provider::{
-    FinishReason, InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities,
-    ModelCapabilityOverride, ModelInfo, Provider, ProviderError, Result, StreamChunk, TokenUsage,
-    ToolCall,
+    FinishReason, InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderError, Result, StreamChunk, TokenUsage, ToolCall,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -296,6 +296,87 @@ pub struct AnthropicProvider {
     cache_ttl: CacheTtl,
 }
 
+/// What this build knows about Anthropic's models, most specific first.
+///
+/// The generic Claude 4.x row at the bottom catches older 4.5 snapshots; it
+/// must stay below `claude-opus-4-8` and friends, which it would otherwise
+/// swallow with the wrong output limit.
+pub(crate) const MODELS: &[Row] = &[
+    // Opus 5: top-tier, 1M context, 128K output, no temperature.
+    Row {
+        matches: &[Match::Contains("claude-opus-5")],
+        temperature: false,
+        tools: true,
+        context: 1_000_000,
+        output: 128_000,
+    },
+    // Sonnet 5: 1M context, 128K output, no temperature.
+    Row {
+        matches: &[Match::Contains("claude-sonnet-5")],
+        temperature: false,
+        tools: true,
+        context: 1_000_000,
+        output: 128_000,
+    },
+    // Fable 5 / Mythos 5: top-tier, 1M context, 128K output, no temperature.
+    Row {
+        matches: &[
+            Match::Contains("claude-fable-5"),
+            Match::Contains("claude-mythos-5"),
+        ],
+        temperature: false,
+        tools: true,
+        context: 1_000_000,
+        output: 128_000,
+    },
+    // Opus 4.8 / 4.7: 1M context, 128K output, no temperature.
+    Row {
+        matches: &[
+            Match::Contains("claude-opus-4-8"),
+            Match::Contains("claude-opus-4-7"),
+        ],
+        temperature: false,
+        tools: true,
+        context: 1_000_000,
+        output: 128_000,
+    },
+    // Opus 4.6 and Sonnet 4.6: 1M context, 128K output, temperature supported.
+    Row {
+        matches: &[Match::Contains("claude-opus-4-6")],
+        temperature: true,
+        tools: true,
+        context: 1_000_000,
+        output: 128_000,
+    },
+    Row {
+        matches: &[Match::Contains("claude-sonnet-4-6")],
+        temperature: true,
+        tools: true,
+        context: 1_000_000,
+        output: 128_000,
+    },
+    // Haiku 4.5: 200K context, 64K output, temperature supported.
+    Row {
+        matches: &[Match::Contains("claude-haiku-4-5")],
+        temperature: true,
+        tools: true,
+        context: 200_000,
+        output: 64_000,
+    },
+    // Generic Claude 4.x fallback (e.g. older 4.5 snapshots).
+    Row {
+        matches: &[
+            Match::Contains("claude-opus-4"),
+            Match::Contains("claude-sonnet-4"),
+            Match::Contains("claude-haiku-4"),
+        ],
+        temperature: false,
+        tools: true,
+        context: 1_000_000,
+        output: 32_768,
+    },
+];
+
 impl AnthropicProvider {
     /// Create a new Anthropic provider.
     pub fn new(client: reqwest::Client, api_key: String) -> Self {
@@ -328,106 +409,7 @@ impl AnthropicProvider {
 
     /// Return built-in capabilities for a model based on its name pattern.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        // Opus 5 - top-tier, 1M context, 128K output, no temperature
-        if model.contains("claude-opus-5") {
-            return ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_000_000,
-                max_output_tokens: 128_000,
-                limits_source: LimitsSource::Builtin,
-            };
-        }
-        // Sonnet 5 - 1M context, 128K output, no temperature
-        if model.contains("claude-sonnet-5") {
-            return ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_000_000,
-                max_output_tokens: 128_000,
-                limits_source: LimitsSource::Builtin,
-            };
-        }
-        // Fable 5 / Mythos 5 - top-tier, 1M context, 128K output, no temperature
-        if model.contains("claude-fable-5") || model.contains("claude-mythos-5") {
-            return ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_000_000,
-                max_output_tokens: 128_000,
-                limits_source: LimitsSource::Builtin,
-            };
-        }
-        // Opus 4.8 / 4.7 - 1M context, 128K output, no temperature
-        if model.contains("claude-opus-4-8") || model.contains("claude-opus-4-7") {
-            return ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_000_000,
-                max_output_tokens: 128_000,
-                limits_source: LimitsSource::Builtin,
-            };
-        }
-        // Opus 4.6 - 1M context, 128K output, temperature supported
-        if model.contains("claude-opus-4-6") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_000_000,
-                max_output_tokens: 128_000,
-                limits_source: LimitsSource::Builtin,
-            };
-        }
-        // Sonnet 4.6 - 1M context, 128K output, temperature supported
-        if model.contains("claude-sonnet-4-6") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_000_000,
-                max_output_tokens: 128_000,
-                limits_source: LimitsSource::Builtin,
-            };
-        }
-        // Haiku 4.5 - 200K context, 64K output, temperature supported
-        if model.contains("claude-haiku-4-5") {
-            return ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 200_000,
-                max_output_tokens: 64_000,
-                limits_source: LimitsSource::Builtin,
-            };
-        }
-        // Generic Claude 4.x fallback (e.g. older 4.5 snapshots)
-        if model.contains("claude-opus-4")
-            || model.contains("claude-sonnet-4")
-            || model.contains("claude-haiku-4")
-        {
-            return ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_000_000,
-                max_output_tokens: 32_768,
-                limits_source: LimitsSource::Builtin,
-            };
-        }
-        ModelCapabilities::default()
+        crate::capabilities::lookup(MODELS, model, ModelCapabilities::default())
     }
 
     /// Point this provider at a different host.
@@ -993,6 +975,7 @@ mod tests {
         assert_eq!(provider.pricing("no-such-model-9"), None);
     }
     use super::*;
+    use crate::provider::LimitsSource;
 
     // ─── A breakpoint on a tool turn is not thrown away ─────────────────────
 

--- a/crates/leviath-providers/src/capabilities.rs
+++ b/crates/leviath-providers/src/capabilities.rs
@@ -6,6 +6,92 @@
 
 use serde::{Deserialize, Serialize};
 
+/// How one row of a built-in capability table recognises a model name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Match {
+    /// The name starts with this.
+    Prefix(&'static str),
+    /// The name contains this anywhere.
+    Contains(&'static str),
+    /// The name starts with the first and contains the second.
+    PrefixAnd(&'static str, &'static str),
+}
+
+impl Match {
+    /// Whether `model` is what this pattern describes.
+    fn hits(self, model: &str) -> bool {
+        match self {
+            Self::Prefix(p) => model.starts_with(p),
+            Self::Contains(c) => model.contains(c),
+            Self::PrefixAnd(p, c) => model.starts_with(p) && model.contains(c),
+        }
+    }
+
+    /// A model name this pattern recognises, for the table tests.
+    #[cfg(test)]
+    fn example(self) -> String {
+        match self {
+            Self::Prefix(p) | Self::Contains(p) => p.to_string(),
+            Self::PrefixAnd(p, c) => format!("{p}{c}"),
+        }
+    }
+}
+
+/// One row of a provider's built-in capability table.
+///
+/// Every model any table knows streams and takes a system prompt, so a row
+/// records only what varies: whether it takes a temperature, whether it
+/// calls tools, and its two token limits. A row matches when any of its
+/// patterns does.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Row {
+    /// Any of these recognises the model.
+    pub(crate) matches: &'static [Match],
+    /// See [`ModelCapabilities::supports_temperature`].
+    pub(crate) temperature: bool,
+    /// See [`ModelCapabilities::supports_tools`].
+    pub(crate) tools: bool,
+    /// See [`ModelCapabilities::max_context_tokens`].
+    pub(crate) context: usize,
+    /// See [`ModelCapabilities::max_output_tokens`].
+    pub(crate) output: usize,
+}
+
+impl Row {
+    /// Whether any of this row's patterns recognises `model`.
+    fn hits(&self, model: &str) -> bool {
+        self.matches.iter().any(|m| m.hits(model))
+    }
+
+    /// The capabilities this row describes.
+    const fn capabilities(&self) -> ModelCapabilities {
+        ModelCapabilities {
+            supports_temperature: self.temperature,
+            supports_streaming: true,
+            supports_tools: self.tools,
+            supports_system_prompt: true,
+            max_context_tokens: self.context,
+            max_output_tokens: self.output,
+            limits_source: LimitsSource::Builtin,
+        }
+    }
+}
+
+/// The first row of `table` that recognises `model`, or `fallback`.
+///
+/// First hit wins, which is what lets a table put `gpt-5.5` above `gpt-5`
+/// and `claude-opus-4-8` above `claude-opus-4`: the specific row comes
+/// first and the family row catches the rest. The four providers that used
+/// to spell this as a ladder of `if model.starts_with(..) { return .. }`
+/// blocks each carried a note about that ordering; now the table is the
+/// note.
+pub(crate) fn lookup(table: &[Row], model: &str, fallback: ModelCapabilities) -> ModelCapabilities {
+    table
+        .iter()
+        .find(|row| row.hits(model))
+        .map_or(fallback, Row::capabilities)
+}
+
 /// Capabilities supported by a model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelCapabilities {
@@ -176,5 +262,99 @@ impl From<ModelCapabilities> for ModelCapabilityOverride {
             cache_write_per_mtok: None,
             output_per_mtok: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod table_tests {
+    use super::*;
+
+    /// Every provider table, with the fallback its provider uses.
+    fn tables() -> Vec<(&'static str, &'static [Row], ModelCapabilities)> {
+        vec![
+            (
+                "openai",
+                crate::openai::MODELS,
+                ModelCapabilities::default(),
+            ),
+            (
+                "anthropic",
+                crate::anthropic::MODELS,
+                ModelCapabilities::default(),
+            ),
+            (
+                "ollama",
+                crate::ollama::MODELS,
+                crate::ollama::FALLBACK_CAPABILITIES,
+            ),
+            (
+                "openrouter",
+                crate::openrouter::MODELS,
+                crate::openrouter::FALLBACK_CAPABILITIES,
+            ),
+        ]
+    }
+
+    #[test]
+    fn every_pattern_in_every_table_resolves_to_the_first_row_that_matches_it() {
+        for (name, table, fallback) in tables() {
+            for (i, row) in table.iter().enumerate() {
+                for m in row.matches {
+                    let model = m.example();
+                    // A pattern always matches its own example, so the
+                    // position is never absent.
+                    let first = table
+                        .iter()
+                        .position(|r| r.hits(&model))
+                        .expect("a pattern matches its own example");
+                    assert!(
+                        first <= i,
+                        "{name}: row {i} ({model}) is shadowed by row {first}"
+                    );
+                    assert_eq!(
+                        lookup(table, &model, fallback.clone()),
+                        table[first].capabilities(),
+                        "{name}: {model}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_name_no_row_recognises_gets_the_fallback() {
+        for (name, table, fallback) in tables() {
+            assert_eq!(
+                lookup(table, "nothing-anyone-has-heard-of", fallback.clone()),
+                fallback,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_three_pattern_kinds_match_what_they_say() {
+        assert!(Match::Prefix("gpt-5").hits("gpt-5-mini"));
+        assert!(!Match::Prefix("gpt-5").hits("openai/gpt-5"));
+        assert!(Match::Contains("gpt-5").hits("openai/gpt-5"));
+        assert!(Match::PrefixAnd("anthropic/", "fable").hits("anthropic/claude-fable-5"));
+        assert!(!Match::PrefixAnd("anthropic/", "fable").hits("openai/claude-fable-5"));
+        assert!(!Match::PrefixAnd("anthropic/", "fable").hits("anthropic/claude-opus-5"));
+    }
+
+    #[test]
+    fn a_row_streams_and_takes_a_system_prompt_whatever_else_it_says() {
+        let row = Row {
+            matches: &[Match::Contains("x")],
+            temperature: false,
+            tools: false,
+            context: 1,
+            output: 2,
+        };
+        let caps = row.capabilities();
+        assert!(caps.supports_streaming && caps.supports_system_prompt);
+        assert!(!caps.supports_temperature && !caps.supports_tools);
+        assert_eq!((caps.max_context_tokens, caps.max_output_tokens), (1, 2));
+        assert_eq!(caps.limits_source, LimitsSource::Builtin);
     }
 }

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -2,6 +2,7 @@
 //!
 //! Ollama provides local LLM execution via NDJSON streaming.
 
+use crate::capabilities::{Match, Row};
 use crate::provider::{
     FinishReason, InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities,
     ModelCapabilityOverride, ModelInfo, Provider, ProviderError, Result, StreamChunk, TokenUsage,
@@ -148,6 +149,89 @@ fn effective_window(show: &serde_json::Value) -> Option<usize> {
             .flatten()
     })
 }
+
+/// What this build knows about the models Ollama commonly serves.
+///
+/// `deepseek-r1` sits above the general DeepSeek row because it is the one
+/// that cannot call tools.
+pub(crate) const MODELS: &[Row] = &[
+    // Llama 3.x and Qwen 2.x/3: tool-capable, 128K context.
+    Row {
+        matches: &[
+            Match::Contains("llama3"),
+            Match::Contains("llama-3"),
+            Match::Contains("qwen2.5"),
+            Match::Contains("qwen3"),
+            Match::Contains("qwen2"),
+        ],
+        temperature: true,
+        tools: true,
+        context: 131_072,
+        output: 8192,
+    },
+    // Mistral / Mixtral: tool-capable.
+    Row {
+        matches: &[Match::Contains("mistral"), Match::Contains("mixtral")],
+        temperature: true,
+        tools: true,
+        context: 32_768,
+        output: 4096,
+    },
+    // Phi-4: tool-capable, 128K context.
+    Row {
+        matches: &[Match::Contains("phi-4"), Match::Contains("phi4")],
+        temperature: true,
+        tools: true,
+        context: 131_072,
+        output: 8192,
+    },
+    // DeepSeek R1: reasoning, no tool calls.
+    Row {
+        matches: &[Match::Contains("deepseek-r1")],
+        temperature: true,
+        tools: false,
+        context: 131_072,
+        output: 8192,
+    },
+    // DeepSeek general: tool-capable.
+    Row {
+        matches: &[Match::Contains("deepseek")],
+        temperature: true,
+        tools: true,
+        context: 131_072,
+        output: 8192,
+    },
+    // Gemma: no tool support.
+    Row {
+        matches: &[Match::Contains("gemma")],
+        temperature: true,
+        tools: false,
+        context: 131_072,
+        output: 8192,
+    },
+    // CodeLlama: no tool support.
+    Row {
+        matches: &[Match::Contains("codellama")],
+        temperature: true,
+        tools: false,
+        context: 16_384,
+        output: 4096,
+    },
+];
+
+/// What a local model this build has never heard of is assumed to be.
+///
+/// Conservative on purpose: a small window and no tools, since most models
+/// people pull into Ollama are small and tool calling is the exception.
+pub(crate) const FALLBACK_CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    supports_temperature: true,
+    supports_streaming: true,
+    supports_tools: false,
+    supports_system_prompt: true,
+    max_context_tokens: 8192,
+    max_output_tokens: 4096,
+    limits_source: LimitsSource::Builtin,
+};
 
 impl OllamaProvider {
     /// Create a new Ollama provider.
@@ -426,100 +510,7 @@ impl OllamaProvider {
 
     /// Return built-in capability defaults for a model based on its name pattern.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        // Llama 3.x and Qwen 2.x/3 - tool-capable, 128K context
-        if model.contains("llama3")
-            || model.contains("llama-3")
-            || model.contains("qwen2.5")
-            || model.contains("qwen3")
-            || model.contains("qwen2")
-        {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 131_072,
-                max_output_tokens: 8192,
-                limits_source: LimitsSource::Builtin,
-            }
-        // Mistral / Mixtral - tool-capable
-        } else if model.contains("mistral") || model.contains("mixtral") {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 32_768,
-                max_output_tokens: 4096,
-                limits_source: LimitsSource::Builtin,
-            }
-        // Phi-4 - tool-capable, 128K context
-        } else if model.contains("phi-4") || model.contains("phi4") {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 131_072,
-                max_output_tokens: 8192,
-                limits_source: LimitsSource::Builtin,
-            }
-        // DeepSeek R1 - reasoning, no tool calls
-        } else if model.contains("deepseek-r1") {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: false,
-                supports_system_prompt: true,
-                max_context_tokens: 131_072,
-                max_output_tokens: 8192,
-                limits_source: LimitsSource::Builtin,
-            }
-        // DeepSeek general - tool-capable
-        } else if model.contains("deepseek") {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 131_072,
-                max_output_tokens: 8192,
-                limits_source: LimitsSource::Builtin,
-            }
-        // Gemma - no tool support
-        } else if model.contains("gemma") {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: false,
-                supports_system_prompt: true,
-                max_context_tokens: 131_072,
-                max_output_tokens: 8192,
-                limits_source: LimitsSource::Builtin,
-            }
-        // CodeLlama - no tool support
-        } else if model.contains("codellama") {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: false,
-                supports_system_prompt: true,
-                max_context_tokens: 16_384,
-                max_output_tokens: 4096,
-                limits_source: LimitsSource::Builtin,
-            }
-        } else {
-            // Conservative fallback for unknown local models
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: false,
-                supports_system_prompt: true,
-                max_context_tokens: 8192,
-                max_output_tokens: 4096,
-                limits_source: LimitsSource::Builtin,
-            }
-        }
+        crate::capabilities::lookup(MODELS, model, FALLBACK_CAPABILITIES)
     }
 
     /// Build request body for the Ollama API.

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -1,12 +1,13 @@
 //! OpenAI provider implementation.
 
+use crate::capabilities::{Match, Row};
 use crate::openai_compat::{
     TokenLimitField, build_openai_request_body_with, openai_sse_stream, parse_openai_response,
     send_chat_request, temperature_refused, tools_refused_over_reasoning_effort,
 };
 use crate::provider::{
-    InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
-    ModelInfo, Provider, ProviderError, Result, StreamChunk,
+    InferenceRequest, InferenceResponse, ModelCapabilities, ModelCapabilityOverride, ModelInfo,
+    Provider, ProviderError, Result, StreamChunk,
 };
 use crate::rate_limit::RateLimiter;
 use async_trait::async_trait;
@@ -43,6 +44,45 @@ pub struct OpenAIProvider {
     /// omits it instead of spending a round trip learning the same thing again.
     temperature_unsupported: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
 }
+
+/// What this build knows about OpenAI's models, most specific first.
+///
+/// `gpt-5.5` sits above the `gpt-5` family row because it is the one member
+/// that refuses a temperature (verified against the API: it takes only its
+/// default and rejects any other value outright), and `gpt-4.1` above the
+/// implicit `gpt-4` default because its window is eight times larger.
+pub(crate) const MODELS: &[Row] = &[
+    Row {
+        matches: &[Match::Prefix("gpt-5.5")],
+        temperature: false,
+        tools: true,
+        context: 1_050_000,
+        output: 128_000,
+    },
+    // GPT-5.x family (5.4, 5.4-mini, 5.4-nano, 5-mini).
+    Row {
+        matches: &[Match::Prefix("gpt-5")],
+        temperature: true,
+        tools: true,
+        context: 400_000,
+        output: 128_000,
+    },
+    Row {
+        matches: &[Match::Prefix("gpt-4.1")],
+        temperature: true,
+        tools: true,
+        context: 1_047_576,
+        output: 32_768,
+    },
+    // o-series reasoning models: no temperature.
+    Row {
+        matches: &[Match::Prefix("o3"), Match::Prefix("o4")],
+        temperature: false,
+        tools: true,
+        context: 200_000,
+        output: 100_000,
+    },
+];
 
 impl OpenAIProvider {
     /// Create a new OpenAI provider.
@@ -101,57 +141,7 @@ impl OpenAIProvider {
 
     /// Return built-in capability defaults for a model.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        // GPT-5.5 - flagship, 1M+ context, 128K output (check before generic gpt-5)
-        if model.starts_with("gpt-5.5") {
-            ModelCapabilities {
-                // Verified against the API: it takes only its default and
-                // rejects any other value outright. The rest of the gpt-5
-                // family accepts one, which is how the generic branch below
-                // came to cover this model wrongly.
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_050_000,
-                max_output_tokens: 128_000,
-                limits_source: LimitsSource::Builtin,
-            }
-        // GPT-5.x family (5.4, 5.4-mini, 5.4-nano, 5-mini) - 400K context, 128K output
-        } else if model.starts_with("gpt-5") {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 400_000,
-                max_output_tokens: 128_000,
-                limits_source: LimitsSource::Builtin,
-            }
-        // GPT-4.1 family - 1M context (must check before generic gpt-4)
-        } else if model.starts_with("gpt-4.1") {
-            ModelCapabilities {
-                supports_temperature: true,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 1_047_576,
-                max_output_tokens: 32_768,
-                limits_source: LimitsSource::Builtin,
-            }
-        // o-series reasoning models (o3, o4) - no temperature, 200K context
-        } else if model.starts_with("o3") || model.starts_with("o4") {
-            ModelCapabilities {
-                supports_temperature: false,
-                supports_streaming: true,
-                supports_tools: true,
-                supports_system_prompt: true,
-                max_context_tokens: 200_000,
-                max_output_tokens: 100_000,
-                limits_source: LimitsSource::Builtin,
-            }
-        } else {
-            ModelCapabilities::default()
-        }
+        crate::capabilities::lookup(MODELS, model, ModelCapabilities::default())
     }
 
     /// POST a chat-completions body, teaching the retry described on
@@ -467,6 +457,7 @@ mod tests {
         assert_eq!(provider.pricing("no-such-model-9"), None);
     }
     use super::*;
+    use crate::provider::LimitsSource;
     use crate::test_support::always_on_tracing_guard;
     use leviath_testkit::{spawn_mock_server, spawn_mock_server_truncated_body};
 

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -3,6 +3,7 @@
 //! OpenRouter provides access to multiple models through a unified API.
 //! Uses OpenAI-compatible format with additional headers.
 
+use crate::capabilities::{Match, Row};
 use crate::openai_compat::{
     openai_sse_stream, parse_openai_response, send_chat_request, temperature_refused,
 };
@@ -315,169 +316,133 @@ impl OpenRouterProvider {
 /// and lifting it out is what lets `capabilities` merge an override onto it
 /// instead of replacing it wholesale.
 fn builtin_capabilities(model: &str) -> ModelCapabilities {
-    // ── Google Gemini ─────────────────────────────────────────────────────
-    if model.starts_with("google/gemini") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 1_048_576,
-            max_output_tokens: 65_536,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── Meta Llama 4 Scout - 10M context ─────────────────────────────────
-    if model.contains("llama-4-scout") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 10_000_000,
-            max_output_tokens: 32_768,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── Meta Llama 4 (Maverick + others) - 1M context ────────────────────
-    if model.starts_with("meta-llama/llama-4") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 1_048_576,
-            max_output_tokens: 32_768,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── DeepSeek R1 - reasoning-only, no tools, no temperature ───────────
-    if model.contains("deepseek-r1") {
-        return ModelCapabilities {
-            supports_temperature: false,
-            supports_streaming: true,
-            supports_tools: false,
-            supports_system_prompt: true,
-            max_context_tokens: 163_840,
-            max_output_tokens: 32_768,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── DeepSeek V4 Pro - 1M context, 384K output ────────────────────────
-    if model.contains("deepseek-v4-pro") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 1_048_576,
-            max_output_tokens: 393_216,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── DeepSeek V4 Flash / V3.x ─────────────────────────────────────────
-    if model.starts_with("deepseek/deepseek-v") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 1_048_576,
-            max_output_tokens: 65_536,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── Mistral Large ─────────────────────────────────────────────────────
-    if model.contains("mistral-large") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 262_144,
-            max_output_tokens: 32_768,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── Mistral Medium / Small ────────────────────────────────────────────
-    if model.starts_with("mistralai/") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 131_072,
-            max_output_tokens: 32_768,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── Qwen 3.6+ / Qwen3 Coder - 1M context ────────────────────────────
-    if model.contains("qwen3.6") || model.contains("qwen3-coder") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 1_048_576,
-            max_output_tokens: 65_536,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── Qwen3 general ─────────────────────────────────────────────────────
-    if model.starts_with("qwen/") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 131_072,
-            max_output_tokens: 32_768,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── Anthropic models via OpenRouter - inherit direct-provider flags ───
-    let anthropic_no_temp = model.contains("claude-opus-4-8")
-        || model.contains("claude-opus-4-7")
-        || model.contains("claude-fable-5")
-        || model.contains("claude-mythos-5");
-    if model.starts_with("anthropic/") {
-        return ModelCapabilities {
-            supports_temperature: !anthropic_no_temp,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 1_000_000,
-            max_output_tokens: 128_000,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── OpenAI o-series via OpenRouter - no temperature ───────────────────
-    if model.starts_with("openai/o") {
-        return ModelCapabilities {
-            supports_temperature: false,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 200_000,
-            max_output_tokens: 100_000,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── OpenAI GPT-5.x via OpenRouter ────────────────────────────────────
-    if model.starts_with("openai/gpt-5") {
-        return ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 1_050_000,
-            max_output_tokens: 128_000,
-            limits_source: LimitsSource::Builtin,
-        };
-    }
-    // ── Conservative fallback for unknown OpenRouter models ───────────────
-    FALLBACK_CAPABILITIES
+    crate::capabilities::lookup(MODELS, model, FALLBACK_CAPABILITIES)
 }
+
+/// What this build knows about the models OpenRouter routes to, most
+/// specific first.
+///
+/// Rows for a single model (`llama-4-scout`, `deepseek-v4-pro`, the
+/// Anthropic models that refuse a temperature) sit above their family rows.
+pub(crate) const MODELS: &[Row] = &[
+    // Google Gemini.
+    Row {
+        matches: &[Match::Prefix("google/gemini")],
+        temperature: true,
+        tools: true,
+        context: 1_048_576,
+        output: 65_536,
+    },
+    // Meta Llama 4 Scout: 10M context.
+    Row {
+        matches: &[Match::Contains("llama-4-scout")],
+        temperature: true,
+        tools: true,
+        context: 10_000_000,
+        output: 32_768,
+    },
+    // Meta Llama 4 (Maverick and others): 1M context.
+    Row {
+        matches: &[Match::Prefix("meta-llama/llama-4")],
+        temperature: true,
+        tools: true,
+        context: 1_048_576,
+        output: 32_768,
+    },
+    // DeepSeek R1: reasoning-only, no tools, no temperature.
+    Row {
+        matches: &[Match::Contains("deepseek-r1")],
+        temperature: false,
+        tools: false,
+        context: 163_840,
+        output: 32_768,
+    },
+    // DeepSeek V4 Pro: 1M context, 384K output.
+    Row {
+        matches: &[Match::Contains("deepseek-v4-pro")],
+        temperature: true,
+        tools: true,
+        context: 1_048_576,
+        output: 393_216,
+    },
+    // DeepSeek V4 Flash / V3.x.
+    Row {
+        matches: &[Match::Prefix("deepseek/deepseek-v")],
+        temperature: true,
+        tools: true,
+        context: 1_048_576,
+        output: 65_536,
+    },
+    // Mistral Large.
+    Row {
+        matches: &[Match::Contains("mistral-large")],
+        temperature: true,
+        tools: true,
+        context: 262_144,
+        output: 32_768,
+    },
+    // Mistral Medium / Small.
+    Row {
+        matches: &[Match::Prefix("mistralai/")],
+        temperature: true,
+        tools: true,
+        context: 131_072,
+        output: 32_768,
+    },
+    // Qwen 3.6+ / Qwen3 Coder: 1M context.
+    Row {
+        matches: &[Match::Contains("qwen3.6"), Match::Contains("qwen3-coder")],
+        temperature: true,
+        tools: true,
+        context: 1_048_576,
+        output: 65_536,
+    },
+    // Qwen3 general.
+    Row {
+        matches: &[Match::Prefix("qwen/")],
+        temperature: true,
+        tools: true,
+        context: 131_072,
+        output: 32_768,
+    },
+    // Anthropic models via OpenRouter inherit the direct provider's flags:
+    // these four refuse a temperature, the rest of the family takes one.
+    Row {
+        matches: &[
+            Match::PrefixAnd("anthropic/", "claude-opus-4-8"),
+            Match::PrefixAnd("anthropic/", "claude-opus-4-7"),
+            Match::PrefixAnd("anthropic/", "claude-fable-5"),
+            Match::PrefixAnd("anthropic/", "claude-mythos-5"),
+        ],
+        temperature: false,
+        tools: true,
+        context: 1_000_000,
+        output: 128_000,
+    },
+    Row {
+        matches: &[Match::Prefix("anthropic/")],
+        temperature: true,
+        tools: true,
+        context: 1_000_000,
+        output: 128_000,
+    },
+    // OpenAI o-series via OpenRouter: no temperature.
+    Row {
+        matches: &[Match::Prefix("openai/o")],
+        temperature: false,
+        tools: true,
+        context: 200_000,
+        output: 100_000,
+    },
+    // OpenAI GPT-5.x via OpenRouter.
+    Row {
+        matches: &[Match::Prefix("openai/gpt-5")],
+        temperature: true,
+        tools: true,
+        context: 1_050_000,
+        output: 128_000,
+    },
+];
 
 /// What an OpenRouter model this build has never heard of is assumed to be.
 ///
@@ -486,7 +451,7 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
 /// guessing low is that percentage budgets resolve against a window eight times
 /// smaller than a 1M-token model really has, which is why reaching this is
 /// worth saying out loud - see [`OpenRouterProvider::warn_if_unknown`].
-const FALLBACK_CAPABILITIES: ModelCapabilities = ModelCapabilities {
+pub(crate) const FALLBACK_CAPABILITIES: ModelCapabilities = ModelCapabilities {
     supports_temperature: true,
     supports_streaming: true,
     supports_tools: true,


### PR DESCRIPTION
## What

OpenAI, Anthropic, Ollama and OpenRouter each answered "what can this model do" with a ladder of `if model.starts_with(..) { return ModelCapabilities { .. } }` blocks. Every block spelled out all seven fields; two never varied (every known model streams and takes a system prompt) and one was always `LimitsSource::Builtin`. Order was load-bearing (`gpt-5.5` above `gpt-5`, `claude-opus-4-8` above the generic Claude 4 row), and each ladder had its own comment saying so.

`capabilities::{Match, Row, lookup}` is that ladder once:

- `Match::{Prefix, Contains, PrefixAnd}` is how a row recognises a name.
- `Row` records only what varies: temperature, tools, and the two token limits.
- `lookup(table, model, fallback)` returns the first matching row, so the table's order is the documentation.

Each provider now owns a `const MODELS: &[Row]` and its `builtin_capabilities` is a one-liner. OpenRouter's "Anthropic models that refuse a temperature" case (a boolean the old code computed beside the prefix check) is `Match::PrefixAnd("anthropic/", ..)`, so a `claude-fable-5` under another vendor prefix still falls through exactly as before.

Gemini's classifier is untouched: its four equal constants are a deliberate shape, per the comment beside them.

## Behaviour

None changed. Before deleting the old ladders I ran a throwaway test with both implementations side by side over 81 model names (every pattern of every table, the near misses like `gpt-4o`, `x/claude-fable-5`, `openai/oops`, and unknowns); they agreed on all 81. The ~50 per-provider capability tests run unchanged.

## Tests

`capabilities::table_tests` walks every pattern of every table and asserts it resolves to the first row that matches, so a row shadowed by an earlier one cannot be added without the test naming it; plus the fallback path and each `Match` kind.

## Verification

`cargo test -p leviath-providers` 910 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-providers` at 100%.
