### PR TITLE
refactor(providers): small merges across the provider crate

### DIFF
--- a/crates/leviath-core/src/region/mod.rs
+++ b/crates/leviath-core/src/region/mod.rs
@@ -936,7 +936,7 @@ impl Region {
         } = &self.kind
         {
             let max = *max_items;
-            match eviction_strategy.clone() {
+            match *eviction_strategy {
                 EvictionStrategy::PerItem => {
                     // `remove_oldest` only returns None when empty, which the
                     // `len > max >= 0` guard already precludes; folding it into

--- a/crates/leviath-core/src/region/policy.rs
+++ b/crates/leviath-core/src/region/policy.rs
@@ -15,7 +15,7 @@ use super::RegionKind;
 /// The choice of strategy affects prompt caching effectiveness: PerItem eviction
 /// shifts the message prefix every iteration (breaking cache), while Bulk and
 /// Compact keep the prefix stable between eviction events.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "strategy", rename_all = "snake_case")]
 pub enum EvictionStrategy {
     /// Evict one turn group at a time (current behavior). Default.

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -35,7 +35,10 @@
 //! - Anthropic models only, and the CLI ignores the request's `max_tokens` and
 //!   `temperature` in favour of its own.
 
-use crate::provider::*;
+use crate::provider::{
+    FinishReason, InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities,
+    ModelCapabilityOverride, ModelInfo, Provider, ProviderError, Result, TokenUsage, ToolCall,
+};
 use crate::text_tools;
 use async_trait::async_trait;
 use std::collections::HashMap;
@@ -513,6 +516,7 @@ impl Default for ClaudeCodeProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::provider::{Message, SystemBlock, Tool};
 
     // ─── construction / configuration ───────────────────────────────────────
 

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -408,12 +408,19 @@ impl Provider for GeminiProvider {
 }
 
 impl GeminiProvider {
-    /// Native `/v1beta/models` listing with authoritative per-model token limits.
-    async fn list_models_native(&self, native_base: &str) -> Result<Vec<ModelInfo>> {
+    /// GET a models listing and return the array under `field`.
+    ///
+    /// The native and OpenAI-compatible listings differ in the auth header
+    /// they take and the key the array sits under, and in nothing else about
+    /// the request, so this is the one place the request is made.
+    async fn fetch_model_listing(
+        &self,
+        url: String,
+        auth: (&str, String),
+        field: &str,
+    ) -> Result<Vec<serde_json::Value>> {
         let response = crate::provider::apply_request_timeout(
-            self.client
-                .get(format!("{}/models", native_base))
-                .header("x-goog-api-key", &self.api_key),
+            self.client.get(url).header(auth.0, auth.1),
             Some(crate::provider::SIDE_CALL_TIMEOUT_SECS),
         )
         .send()
@@ -421,13 +428,23 @@ impl GeminiProvider {
         .map_err(|e| ProviderError::transport("listing models", &e))?;
         let response = crate::provider::check_http_response(response, None).await?;
         let body: serde_json::Value = crate::provider::decode_json(response).await?;
-
-        let models = body
-            .get("models")
+        body.get(field)
             .and_then(|d| d.as_array())
+            .cloned()
             .ok_or_else(|| {
-                ProviderError::InvalidResponse("No models field in models response".to_string())
-            })?
+                ProviderError::InvalidResponse(format!("No {field} field in models response"))
+            })
+    }
+
+    /// Native `/v1beta/models` listing with authoritative per-model token limits.
+    async fn list_models_native(&self, native_base: &str) -> Result<Vec<ModelInfo>> {
+        let models = self
+            .fetch_model_listing(
+                format!("{}/models", native_base),
+                ("x-goog-api-key", self.api_key.clone()),
+                "models",
+            )
+            .await?
             .iter()
             .filter_map(|item| {
                 // `name` is like "models/gemini-3.5-flash"; the id drops the prefix.
@@ -468,24 +485,13 @@ impl GeminiProvider {
     /// OpenAI-compat `/models` listing (no per-model token limits) used only when
     /// the configured base URL isn't the standard native-derivable form.
     async fn list_models_compat(&self) -> Result<Vec<ModelInfo>> {
-        let response = crate::provider::apply_request_timeout(
-            self.client
-                .get(format!("{}/models", self.base_url))
-                .header("Authorization", format!("Bearer {}", self.api_key)),
-            Some(crate::provider::SIDE_CALL_TIMEOUT_SECS),
-        )
-        .send()
-        .await
-        .map_err(|e| ProviderError::transport("listing models", &e))?;
-        let response = crate::provider::check_http_response(response, None).await?;
-        let body: serde_json::Value = crate::provider::decode_json(response).await?;
-
-        let models = body
-            .get("data")
-            .and_then(|d| d.as_array())
-            .ok_or_else(|| {
-                ProviderError::InvalidResponse("No data field in models response".to_string())
-            })?
+        let models = self
+            .fetch_model_listing(
+                format!("{}/models", self.base_url),
+                ("Authorization", format!("Bearer {}", self.api_key)),
+                "data",
+            )
+            .await?
             .iter()
             .filter_map(|item| {
                 let id = item.get("id")?.as_str()?.to_string();

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -29,7 +29,7 @@ pub struct OllamaProvider {
     api_windows: std::sync::Arc<std::sync::Mutex<HashMap<String, usize>>>,
     /// Models already warned about, so a guessed window is announced once per
     /// model rather than once per inference.
-    warned_guessed: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    warned_guessed: crate::provider::ModelMemo,
 }
 
 /// A tool-call id unique for the life of a conversation.
@@ -310,8 +310,7 @@ impl OllamaProvider {
         if leviath_core::sync::lock(&self.api_windows).contains_key(model) {
             return;
         }
-        let mut warned = leviath_core::sync::lock(&self.warned_guessed);
-        if !warned.insert(model.to_string()) {
+        if !self.warned_guessed.insert(model) {
             return;
         }
         tracing::warn!(
@@ -545,21 +544,7 @@ impl OllamaProvider {
 
         // Add tools if present (Ollama supports tool calling for some models)
         if !request.tools.is_empty() {
-            let tools: Vec<serde_json::Value> = request
-                .tools
-                .iter()
-                .map(|t| {
-                    serde_json::json!({
-                        "type": "function",
-                        "function": {
-                            "name": t.name,
-                            "description": t.description,
-                            "parameters": t.parameters,
-                        }
-                    })
-                })
-                .collect();
-            body["tools"] = serde_json::Value::Array(tools);
+            body["tools"] = crate::openai_compat::tools_array(&request.tools);
         }
 
         // `think` is Ollama's own switch for a reasoning model, and it sits at
@@ -3128,7 +3113,7 @@ mod tests {
         let _ = provider.capabilities("qwen3.8-32k:latest");
         let _ = provider.capabilities("qwen3.8-32k:latest");
         assert_eq!(
-            leviath_core::sync::lock(&provider.warned_guessed).len(),
+            provider.warned_guessed.len(),
             1,
             "warned once per model, not once per call"
         );
@@ -3137,7 +3122,7 @@ mod tests {
 
         // Primed, a second model is still a guess and gets its own warning.
         let _ = provider.capabilities("mystery:latest");
-        let warned = leviath_core::sync::lock(&provider.warned_guessed);
+        let warned = &provider.warned_guessed;
         assert!(warned.contains("mystery:latest"));
         assert_eq!(warned.len(), 2);
     }
@@ -3158,7 +3143,7 @@ mod tests {
         provider.prime_capabilities().await.expect("primes");
 
         let _ = provider.capabilities("qwen3.8-32k:latest");
-        assert!(leviath_core::sync::lock(&provider.warned_guessed).is_empty());
+        assert!(provider.warned_guessed.is_empty());
     }
 
     /// An explicit override is an answer, so it silences the warning too.
@@ -3178,7 +3163,7 @@ mod tests {
             overrides,
         );
         let _ = provider.capabilities("mystery:latest");
-        assert!(leviath_core::sync::lock(&provider.warned_guessed).is_empty());
+        assert!(provider.warned_guessed.is_empty());
     }
 
     // ─── effective window ───────────────────────────────────────────────────

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -39,10 +39,10 @@ pub struct OpenAIProvider {
     /// not one per inference: a run makes many calls and they would each pay it.
     /// A `HashSet` behind a lock rather than a field on the request, because the
     /// provider is shared across every agent talking to it.
-    reasoning_effort_none: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    reasoning_effort_none: crate::provider::ModelMemo,
     /// Models the API has refused a temperature for, so the next request to one
     /// omits it instead of spending a round trip learning the same thing again.
-    temperature_unsupported: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    temperature_unsupported: crate::provider::ModelMemo,
 }
 
 /// What this build knows about OpenAI's models, most specific first.
@@ -240,22 +240,22 @@ impl OpenAIProvider {
 
     /// Whether this model has already refused a temperature.
     fn temperature_is_unsupported(&self, model: &str) -> bool {
-        leviath_core::sync::lock(&self.temperature_unsupported).contains(model)
+        self.temperature_unsupported.contains(model)
     }
 
     /// Record that it did, for the rest of this process.
     fn remember_temperature_unsupported(&self, model: &str) {
-        leviath_core::sync::lock(&self.temperature_unsupported).insert(model.to_string());
+        self.temperature_unsupported.insert(model);
     }
 
     /// Whether this model has already refused tools over a reasoning effort.
     fn needs_reasoning_effort_none(&self, model: &str) -> bool {
-        leviath_core::sync::lock(&self.reasoning_effort_none).contains(model)
+        self.reasoning_effort_none.contains(model)
     }
 
     /// Record that it did, for the rest of this process.
     fn remember_reasoning_effort_none(&self, model: &str) {
-        leviath_core::sync::lock(&self.reasoning_effort_none).insert(model.to_string());
+        self.reasoning_effort_none.insert(model);
     }
 }
 

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -582,21 +582,7 @@ pub fn build_openai_request_body_with(
     body[token_limit.key()] = serde_json::json!(request.max_tokens);
 
     if !request.tools.is_empty() {
-        let tools: Vec<serde_json::Value> = request
-            .tools
-            .iter()
-            .map(|t| {
-                serde_json::json!({
-                    "type": "function",
-                    "function": {
-                        "name": t.name,
-                        "description": t.description,
-                        "parameters": t.parameters,
-                    }
-                })
-            })
-            .collect();
-        body["tools"] = serde_json::Value::Array(tools);
+        body["tools"] = tools_array(&request.tools);
     }
 
     merge_extra_params(
@@ -647,6 +633,28 @@ pub(crate) fn tools_refused_over_reasoning_effort(detail: &str) -> bool {
 pub(crate) fn temperature_refused(detail: &str) -> bool {
     let detail = detail.to_ascii_lowercase();
     detail.contains("temperature") && detail.contains("does not support")
+}
+
+/// The request's tools in the OpenAI `tools` wire shape.
+///
+/// One function for the three OpenAI-shaped providers (OpenAI-compatible
+/// gateways, OpenRouter and Ollama) so the shape cannot drift between them.
+pub(crate) fn tools_array(tools: &[crate::provider::Tool]) -> serde_json::Value {
+    serde_json::Value::Array(
+        tools
+            .iter()
+            .map(|t| {
+                serde_json::json!({
+                    "type": "function",
+                    "function": {
+                        "name": t.name,
+                        "description": t.description,
+                        "parameters": t.parameters,
+                    }
+                })
+            })
+            .collect(),
+    )
 }
 
 /// Merge a request's pass-through `extra` params (the manifest's

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -36,14 +36,14 @@ pub struct OpenRouterProvider {
 
     /// Models already reported as falling back, so the warning is once per
     /// model per process rather than once per inference.
-    warned_unknown: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    warned_unknown: crate::provider::ModelMemo,
 
     /// Models the gateway has refused a temperature for.
     ///
     /// Per instance rather than a table: OpenRouter fronts every vendor, so no
     /// static list can stay right about which of their models take one, and
     /// this build's table already names only a few dozen of hundreds.
-    temperature_unsupported: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+    temperature_unsupported: crate::provider::ModelMemo,
 
     /// What OpenRouter's own `/models` endpoint says each model's window is,
     /// filled once by [`Provider::prime_capabilities`].
@@ -282,21 +282,7 @@ impl OpenRouterProvider {
         body["usage"] = serde_json::json!({ "include": true });
 
         if !request.tools.is_empty() {
-            let tools: Vec<serde_json::Value> = request
-                .tools
-                .iter()
-                .map(|t| {
-                    serde_json::json!({
-                        "type": "function",
-                        "function": {
-                            "name": t.name,
-                            "description": t.description,
-                            "parameters": t.parameters,
-                        }
-                    })
-                })
-                .collect();
-            body["tools"] = serde_json::Value::Array(tools);
+            body["tools"] = crate::openai_compat::tools_array(&request.tools);
         }
 
         // Pass through extra model parameters (top_p, stop, seed, …).
@@ -462,14 +448,28 @@ pub(crate) const FALLBACK_CAPABILITIES: ModelCapabilities = ModelCapabilities {
 };
 
 impl OpenRouterProvider {
+    /// The headers every chat request carries.
+    ///
+    /// OpenRouter attributes a request to an app by the referer and title
+    /// pair, and sending only the referer left every Leviath call unnamed on
+    /// the account's activity page.
+    fn chat_headers(&self) -> [(&'static str, String); 4] {
+        [
+            ("Authorization", format!("Bearer {}", self.api_key)),
+            ("HTTP-Referer", "https://leviath.dev".to_string()),
+            ("X-Title", "Leviath".to_string()),
+            ("Content-Type", "application/json".to_string()),
+        ]
+    }
+
     /// Whether this model has already refused a temperature.
     fn temperature_is_unsupported(&self, model: &str) -> bool {
-        leviath_core::sync::lock(&self.temperature_unsupported).contains(model)
+        self.temperature_unsupported.contains(model)
     }
 
     /// Record that it did, for the rest of this process.
     fn remember_temperature_unsupported(&self, model: &str) {
-        leviath_core::sync::lock(&self.temperature_unsupported).insert(model.to_string());
+        self.temperature_unsupported.insert(model);
     }
 
     /// Say so when a model fell through to [`FALLBACK_CAPABILITIES`].
@@ -544,8 +544,7 @@ impl OpenRouterProvider {
         if leviath_core::sync::lock(&self.api_windows).contains_key(model) {
             return;
         }
-        let mut warned = leviath_core::sync::lock(&self.warned_unknown);
-        if !warned.insert(model.to_string()) {
+        if !self.warned_unknown.insert(model) {
             return;
         }
         tracing::warn!(
@@ -577,15 +576,7 @@ impl Provider for OpenRouterProvider {
         {
             fields.remove("temperature");
         }
-        let headers = [
-            ("Authorization", format!("Bearer {}", self.api_key)),
-            // OpenRouter attributes a request to an app by this pair, and
-            // sending only the referer left every Leviath call unnamed on
-            // the account's activity page.
-            ("HTTP-Referer", "https://leviath.dev".to_string()),
-            ("X-Title", "Leviath".to_string()),
-            ("Content-Type", "application/json".to_string()),
-        ];
+        let headers = self.chat_headers();
 
         let mut sent = send_chat_request(
             &self.client,
@@ -653,15 +644,7 @@ impl Provider for OpenRouterProvider {
             &self.client,
             "openrouter",
             &url,
-            &[
-                ("Authorization", format!("Bearer {}", self.api_key)),
-                // OpenRouter attributes a request to an app by this pair, and
-                // sending only the referer left every Leviath call unnamed on
-                // the account's activity page.
-                ("HTTP-Referer", "https://leviath.dev".to_string()),
-                ("X-Title", "Leviath".to_string()),
-                ("Content-Type", "application/json".to_string()),
-            ],
+            &self.chat_headers(),
             &body,
             self.rate_limiter.as_ref(),
             request.request_timeout_secs,
@@ -1162,7 +1145,7 @@ mod tests {
             provider.capabilities("moonshotai/kimi-k3");
             provider.capabilities("meta/muse-spark-1.2");
         }
-        let warned = leviath_core::sync::lock(&provider.warned_unknown);
+        let warned = &provider.warned_unknown;
         assert_eq!(warned.len(), 2, "one entry per model: {warned:?}");
     }
 
@@ -1186,7 +1169,7 @@ mod tests {
         let caps = provider.capabilities("moonshotai/kimi-k3");
         assert_eq!(caps.max_context_tokens, 1_048_576);
         assert!(
-            leviath_core::sync::lock(&provider.warned_unknown).is_empty(),
+            provider.warned_unknown.is_empty(),
             "nothing to warn about once the window is known"
         );
     }
@@ -2043,13 +2026,13 @@ mod tests {
             128_000
         );
         assert!(
-            !leviath_core::sync::lock(&provider.warned_unknown).contains("some/128k-model"),
+            !provider.warned_unknown.contains("some/128k-model"),
             "the API answered for this model, so nothing was assumed"
         );
         // The control: a model it said nothing about is still reported.
         let _ = provider.capabilities("nobody/knows");
         assert!(
-            leviath_core::sync::lock(&provider.warned_unknown).contains("nobody/knows"),
+            provider.warned_unknown.contains("nobody/knows"),
             "a model with no answer anywhere is still called out"
         );
     }

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -918,6 +918,40 @@ pub fn parse_tool_arguments(raw: &str) -> serde_json::Value {
     serde_json::from_str(raw).unwrap_or_else(|_| serde_json::Value::String(raw.to_string()))
 }
 
+/// Model names remembered for the life of the process.
+///
+/// What a provider learns about a model by being refused (no temperature,
+/// no tools over a reasoning effort) or by warning about it once is worth
+/// keeping across requests, and clones of the provider share the same set.
+/// Five fields across three providers used to spell this out as
+/// `Arc<Mutex<HashSet<String>>>` with a pair of lock-and-look helpers each.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ModelMemo(std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>);
+
+impl ModelMemo {
+    /// Whether `model` has been recorded.
+    pub(crate) fn contains(&self, model: &str) -> bool {
+        leviath_core::sync::lock(&self.0).contains(model)
+    }
+
+    /// Record `model`; `true` the first time, `false` if it was already there.
+    pub(crate) fn insert(&self, model: &str) -> bool {
+        leviath_core::sync::lock(&self.0).insert(model.to_string())
+    }
+
+    /// How many models are recorded.
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        leviath_core::sync::lock(&self.0).len()
+    }
+
+    /// Whether nothing has been recorded.
+    #[cfg(test)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
 /// How long a response's `Retry-After` header asks the caller to wait.
 ///
 /// Only the delta-seconds form is read. The header's other form is an HTTP
@@ -925,7 +959,7 @@ pub fn parse_tool_arguments(raw: &str) -> serde_json::Value {
 /// reading it would mean trusting the server's clock against ours; an
 /// unparseable value is treated as no hint at all, which falls back to the
 /// caller's own backoff.
-fn retry_after_secs(headers: &reqwest::header::HeaderMap) -> Option<u64> {
+pub(crate) fn retry_after_secs(headers: &reqwest::header::HeaderMap) -> Option<u64> {
     headers
         .get("retry-after")
         .and_then(|v| v.to_str().ok())

--- a/crates/leviath-providers/src/rate_limit.rs
+++ b/crates/leviath-providers/src/rate_limit.rs
@@ -14,6 +14,7 @@ use tokio::sync::Mutex;
 /// Tracks requests per minute (RPM) and tokens per minute (TPM),
 /// sleeping when limits are approached and applying exponential
 /// backoff on 429 responses.
+#[derive(Clone)]
 pub struct RateLimiter {
     /// Requests per minute limit
     rpm_limit: u32,
@@ -162,16 +163,6 @@ impl RateLimiter {
     pub async fn reset_backoff(&self) {
         let mut state = self.state.lock().await;
         state.consecutive_429s = 0;
-    }
-}
-
-impl Clone for RateLimiter {
-    fn clone(&self) -> Self {
-        Self {
-            rpm_limit: self.rpm_limit,
-            tpm_limit: self.tpm_limit,
-            state: Arc::clone(&self.state),
-        }
     }
 }
 

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -220,11 +220,7 @@ impl ReqwestExecutor {
 async fn classify(resp: reqwest::Response) -> Result<reqwest::Response, HostHttpError> {
     let status = resp.status();
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-        let retry_after = resp
-            .headers()
-            .get("retry-after")
-            .and_then(|v| v.to_str().ok())
-            .and_then(|v| v.parse::<u64>().ok());
+        let retry_after = crate::provider::retry_after_secs(resp.headers());
         return Err(HostHttpError::RateLimited { retry_after });
     }
     if !status.is_success() {


### PR DESCRIPTION
## What

Eight small merges across `leviath-providers` (plus one `Copy` derive in core), each a place where two or three providers had written the same thing:

| Was | Now |
|---|---|
| Five `Arc<Mutex<HashSet<String>>>` fields with lock-and-look helpers (OpenAI x2, OpenRouter x2, Ollama x1) | `provider::ModelMemo` with `contains`/`insert` |
| The OpenAI `tools` array literal in `openai_compat`, `openrouter`, `ollama` | `openai_compat::tools_array` |
| OpenRouter's four request headers as two separate literals | `OpenRouterProvider::chat_headers` |
| Gemini `list_models_native` / `list_models_compat` each sending the request | `fetch_model_listing(url, auth, field)`; callers map their own entries |
| Rhai host's own `Retry-After` parse | `provider::retry_after_secs` |
| Hand-written `impl Clone for RateLimiter` | `#[derive(Clone)]` |
| `match eviction_strategy.clone()` | `EvictionStrategy: Copy` |
| `use crate::provider::*` in `claude_code.rs` | the fourteen names it uses |

## Behaviour

None changed: every request body, header and error string is byte-identical. One nuance worth stating: the Rhai host's `Retry-After` parse now goes through the shared function, which trims whitespace before parsing (the host's copy did not). A well-formed header parses identically; a padded one is now honoured rather than ignored.

## Verification

`cargo test -p leviath-providers` 905 passed, `-p leviath-core` 899; clippy and rustdoc `-D warnings` on both; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-providers` at 100%.
