### PR TITLE
refactor(core): one context diff, typed manifest field readers

### DIFF
--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -22,40 +22,19 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
         .get("agent")
         .ok_or_else(|| Error::Other("Missing [agent] section".to_string()))?;
 
-    let name = agent
-        .get("name")
-        .and_then(|v| v.as_str())
-        .unwrap_or("unnamed")
-        .to_string();
-    let version = agent
-        .get("version")
-        .and_then(|v| v.as_str())
-        .unwrap_or("0.1.0")
-        .to_string();
-    let description = agent
-        .get("description")
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
-        .to_string();
+    let name = str_of(agent, "name").unwrap_or("unnamed").to_string();
+    let version = str_of(agent, "version").unwrap_or("0.1.0").to_string();
+    let description = str_of(agent, "description").unwrap_or("").to_string();
 
-    let max_child_depth = agent
-        .get("max_child_depth")
-        .and_then(|v| v.as_integer())
-        .map(|v| v as usize);
+    let max_child_depth = int_of(agent, "max_child_depth").map(|v| v as usize);
 
-    let entry_stage = agent
-        .get("entry_stage")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+    let entry_stage = str_of(agent, "entry_stage").map(|s| s.to_string());
 
     // Issue #97 escape hatch: `[agent] dynamic_tools` (default false).
-    let dynamic_tools = agent
-        .get("dynamic_tools")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+    let dynamic_tools = bool_of(agent, "dynamic_tools").unwrap_or(false);
 
     let mut stages = Vec::new();
-    if let Some(stages_table) = parsed.get("stages").and_then(|v| v.as_table()) {
+    if let Some(stages_table) = table_of(&parsed, "stages") {
         for (stage_name, stage_value) in stages_table {
             stages.push(parse_stage(stage_name, stage_value)?);
         }
@@ -106,48 +85,48 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     blueprint.entry_stage = entry_stage;
     blueprint.dynamic_tools = dynamic_tools;
 
-    if let Some(compaction_table) = parsed.get("compaction").and_then(|v| v.as_table()) {
+    if let Some(compaction_table) = table_of(&parsed, "compaction") {
         blueprint.compaction_config = Some(parse_compaction_config(compaction_table));
     }
 
     // Parse agent-level security config: [security]
-    if let Some(security_table) = parsed.get("security").and_then(|v| v.as_table()) {
+    if let Some(security_table) = table_of(&parsed, "security") {
         blueprint.security = Some(parse_security_config(security_table));
     }
 
     // Parse agent-level batch_tool_hint override: `[agent] batch_tool_hint`.
     // Absent ⇒ inherit the global config toggle; a per-stage value overrides it.
-    if let Some(bth) = agent.get("batch_tool_hint").and_then(|v| v.as_bool()) {
+    if let Some(bth) = bool_of(agent, "batch_tool_hint") {
         blueprint.batch_tool_hint = Some(bth);
     }
 
     // Parse agent-level shell_hint override: `[agent] shell_hint`. Absent ⇒
     // inherit the global config toggle; a per-stage value overrides it.
-    if let Some(sh) = agent.get("shell_hint").and_then(|v| v.as_bool()) {
+    if let Some(sh) = bool_of(agent, "shell_hint") {
         blueprint.shell_hint = Some(sh);
     }
 
     // Parse agent-level nudge defaults: [agent.nudge]. Absent ⇒ each field
     // inherits the global config's [nudge] section; a per-stage block wins.
-    if let Some(nudge_table) = agent.get("nudge").and_then(|v| v.as_table()) {
+    if let Some(nudge_table) = table_of(agent, "nudge") {
         blueprint.nudge = Some(parse_nudge_config(nudge_table));
     }
 
     // Parse the agent's default output shape: [agent.output]. A per-stage
     // block narrows it, and whoever starts the run overrides both.
-    if let Some(output_table) = agent.get("output").and_then(|v| v.as_table()) {
+    if let Some(output_table) = table_of(agent, "output") {
         blueprint.output = Some(parse_output_spec(output_table));
     }
 
     // Parse agent-level sandbox config: [sandbox]
-    if let Some(sandbox_table) = parsed.get("sandbox").and_then(|v| v.as_table()) {
+    if let Some(sandbox_table) = table_of(&parsed, "sandbox") {
         blueprint.sandbox = Some(parse_sandbox_config(sandbox_table)?);
     }
 
     // Parse agent-level read-path declarations: [read_paths]. Entries are
     // syntax-checked here so a broken one fails `lev validate`/`lev add`/spawn
     // loudly, instead of degrading the agent at its first out-of-workdir read.
-    if let Some(rp_table) = parsed.get("read_paths").and_then(|v| v.as_table()) {
+    if let Some(rp_table) = table_of(&parsed, "read_paths") {
         blueprint.read_paths = Some(parse_read_paths(rp_table)?);
     }
 
@@ -155,38 +134,33 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     // until the user opts in, so parsing is permissive - a non-string entry is
     // still a hard error, because a list that silently loses members reads as a
     // grant that was made.
-    if let Some(sc_table) = parsed.get("safe_commands").and_then(|v| v.as_table()) {
+    if let Some(sc_table) = table_of(&parsed, "safe_commands") {
         blueprint.safe_commands = Some(parse_safe_commands(sc_table)?);
     }
 
     // Parse agent-level tool permissions: [tool_permissions]
-    if let Some(tp_table) = parsed.get("tool_permissions").and_then(|v| v.as_table()) {
+    if let Some(tp_table) = table_of(&parsed, "tool_permissions") {
         blueprint
             .metadata
             .extend(tool_permission_metadata(tp_table)?);
     }
 
     // Parse file tracking config: [context.file_tracking]
-    if let Some(context_table) = parsed.get("context").and_then(|v| v.as_table())
-        && let Some(ft_table) = context_table
-            .get("file_tracking")
-            .and_then(|v| v.as_table())
+    if let Some(context_table) = table_of(&parsed, "context")
+        && let Some(ft_table) = table_of(context_table, "file_tracking")
     {
         blueprint.file_tracking = Some(parse_file_tracking(ft_table));
     }
 
     // Parse repetition-detection config: [repetition_detection]
-    if let Some(rd_table) = parsed
-        .get("repetition_detection")
-        .and_then(|v| v.as_table())
-    {
+    if let Some(rd_table) = table_of(&parsed, "repetition_detection") {
         blueprint.repetition_detection = Some(parse_repetition_detection(rd_table));
     }
 
     // Parse cross-blueprint context transforms: [[transforms]]. Each maps a
     // parent (`from_blueprint`) region onto a child (`to_blueprint`) region when
     // a sub-agent is spawned, optionally transforming the content en route.
-    if let Some(transforms_arr) = parsed.get("transforms").and_then(|v| v.as_array()) {
+    if let Some(transforms_arr) = array_of(&parsed, "transforms") {
         blueprint
             .transforms
             .extend(transforms_arr.iter().map(parse_context_transform));
@@ -196,6 +170,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
 }
 
 mod model;
+mod read;
 mod regions;
 mod sections;
 mod stage;
@@ -203,6 +178,7 @@ mod stage;
 // Glob re-exports, so this split is invisible to every caller and to the
 // test module, exactly as `pipeline/mod.rs` does it.
 use model::*;
+use read::*;
 use regions::*;
 use sections::*;
 use stage::*;

--- a/crates/leviath-core/src/manifest/model.rs
+++ b/crates/leviath-core/src/manifest/model.rs
@@ -9,7 +9,7 @@ use super::*;
 /// Parse `[stages.<name>.model]`, or the shipped default when the stage does
 /// not name one.
 pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
-    let model_table = stage_value.get("model").and_then(|v| v.as_table());
+    let model_table = table_of(stage_value, "model");
     if let Some(mt) = model_table {
         let mut models = Vec::new();
 
@@ -17,7 +17,7 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
         // when the route matters (a local or self-hosted model). An absent
         // provider is EMPTY, not "anthropic": an author cannot know what a
         // machine has configured, and defaulting made omission a silent choice.
-        if let Some(models_arr) = mt.get("models").and_then(|v| v.as_array()) {
+        if let Some(models_arr) = array_of(mt, "models") {
             for entry in models_arr {
                 if let Some(name) = entry.as_str() {
                     models.push(ModelEntry::new(String::new(), name.to_string()));
@@ -25,9 +25,9 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
                 }
                 // A table naming no model names nothing, so it is dropped.
                 if let Some(t) = entry.as_table()
-                    && let Some(model) = t.get("model").and_then(|v| v.as_str())
+                    && let Some(model) = str_of(t, "model")
                 {
-                    let route = t.get("provider").and_then(|v| v.as_str());
+                    let route = str_of(t, "provider");
                     let route = route.unwrap_or_default().to_string();
                     models.push(ModelEntry::new(route, model.to_string()));
                 }
@@ -37,11 +37,8 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
         // Backward compat: old single-model format (provider + model at
         // top level) or old fallbacks list - treat both as models entries.
         if models.is_empty() {
-            if let Some(provider) = mt.get("provider").and_then(|v| v.as_str()) {
-                let model_name = mt
-                    .get("model")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("claude-sonnet-4-6");
+            if let Some(provider) = str_of(mt, "provider") {
+                let model_name = str_of(mt, "model").unwrap_or("claude-sonnet-4-6");
                 models.push(ModelEntry::new(
                     provider.to_string(),
                     model_name.to_string(),
@@ -49,18 +46,14 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
             }
 
             // Old fallbacks become additional models entries
-            if let Some(fallbacks_arr) = mt.get("fallbacks").and_then(|v| v.as_array()) {
+            if let Some(fallbacks_arr) = array_of(mt, "fallbacks") {
                 for fb in fallbacks_arr {
                     if let Some(fb_table) = fb.as_table() {
                         models.push(ModelEntry::new(
-                            fb_table
-                                .get("provider")
-                                .and_then(|v| v.as_str())
+                            str_of(fb_table, "provider")
                                 .unwrap_or("anthropic")
                                 .to_string(),
-                            fb_table
-                                .get("model")
-                                .and_then(|v| v.as_str())
+                            str_of(fb_table, "model")
                                 .unwrap_or("claude-sonnet-4-6")
                                 .to_string(),
                         ));
@@ -77,14 +70,11 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
             ));
         }
 
-        let allow_user_default = mt
-            .get("allow_user_default")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
+        let allow_user_default = bool_of(mt, "allow_user_default").unwrap_or(true);
 
         // Parse parameters
         let mut parameters = std::collections::HashMap::new();
-        if let Some(params) = mt.get("parameters").and_then(|v| v.as_table()) {
+        if let Some(params) = table_of(mt, "parameters") {
             for (k, v) in params {
                 // Converting a parsed `toml::Value` to JSON is infallible:
                 // serde_json maps non-finite floats to null rather than
@@ -96,7 +86,7 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
             }
         }
 
-        let request_timeout_secs = mt.get("request_timeout_secs").and_then(|v| v.as_integer());
+        let request_timeout_secs = int_of(mt, "request_timeout_secs");
         let request_timeout_secs = request_timeout_secs
             .filter(|&secs| secs >= 0)
             .map(|secs| secs as u64);

--- a/crates/leviath-core/src/manifest/read.rs
+++ b/crates/leviath-core/src/manifest/read.rs
@@ -1,0 +1,108 @@
+//! Reading one typed field off a TOML value.
+//!
+//! The manifest parser asks "the string under this key, if there is one"
+//! well over a hundred times, and every ask used to be the same
+//! `v.get(key).and_then(|v| v.as_str())` spelled out in place. These are
+//! that ask, once per type, so a site reads as what it wants rather than how
+//! it gets it. Each returns `None` both for an absent key and for a value of
+//! the wrong type, exactly as the inline form did; a caller that wants to
+//! tell those apart still looks at the value itself.
+
+/// Something with named fields: a TOML value (which may be a table) or a
+/// table itself. The parser holds both, depending on how far into the
+/// document it has descended, and asks the same questions of either.
+pub(super) trait Fields {
+    /// The value under `key`, if any.
+    fn field(&self, key: &str) -> Option<&toml::Value>;
+}
+
+impl Fields for toml::Value {
+    fn field(&self, key: &str) -> Option<&toml::Value> {
+        self.get(key)
+    }
+}
+
+impl Fields for toml::Table {
+    fn field(&self, key: &str) -> Option<&toml::Value> {
+        self.get(key)
+    }
+}
+
+/// The string under `key`, if present and a string.
+pub(super) fn str_of<'a>(v: &'a impl Fields, key: &str) -> Option<&'a str> {
+    v.field(key).and_then(|x| x.as_str())
+}
+
+/// A required-shaped string field, defaulting to empty when absent (the value's
+/// meaning is validated later by `Blueprint::validate`).
+pub(super) fn str_field(v: &impl Fields, key: &str) -> String {
+    str_of(v, key).unwrap_or_default().to_string()
+}
+
+/// The boolean under `key`, if present and a boolean.
+pub(super) fn bool_of(v: &impl Fields, key: &str) -> Option<bool> {
+    v.field(key).and_then(|x| x.as_bool())
+}
+
+/// The integer under `key`, if present and an integer. Exactly `as_integer`:
+/// no range check, since each caller decides what a negative means.
+pub(super) fn int_of(v: &impl Fields, key: &str) -> Option<i64> {
+    v.field(key).and_then(|x| x.as_integer())
+}
+
+/// The array under `key`, if present and an array.
+pub(super) fn array_of<'a>(v: &'a impl Fields, key: &str) -> Option<&'a Vec<toml::Value>> {
+    v.field(key).and_then(|x| x.as_array())
+}
+
+/// The table under `key`, if present and a table.
+pub(super) fn table_of<'a>(v: &'a impl Fields, key: &str) -> Option<&'a toml::Table> {
+    v.field(key).and_then(|x| x.as_table())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn value() -> toml::Value {
+        toml::from_str(
+            r#"
+            s = "text"
+            b = true
+            i = -3
+            a = [1, 2]
+            [t]
+            inner = 1
+            "#,
+        )
+        .unwrap()
+    }
+
+    fn check(v: &impl Fields) {
+        assert_eq!(str_of(v, "s"), Some("text"));
+        assert_eq!(bool_of(v, "b"), Some(true));
+        assert_eq!(int_of(v, "i"), Some(-3));
+        assert_eq!(array_of(v, "a").map(Vec::len), Some(2));
+        assert!(table_of(v, "t").is_some_and(|t| t.contains_key("inner")));
+        // Wrong type reads as absent, as the inline form did.
+        assert_eq!(str_of(v, "b"), None);
+        assert_eq!(bool_of(v, "s"), None);
+        assert_eq!(int_of(v, "s"), None);
+        assert!(array_of(v, "t").is_none());
+        assert!(table_of(v, "a").is_none());
+        assert_eq!(str_field(v, "s"), "text");
+        assert_eq!(str_field(v, "missing"), "");
+        assert_eq!(str_field(v, "i"), "");
+    }
+
+    #[test]
+    fn each_helper_reads_its_own_type_off_a_value() {
+        check(&value());
+    }
+
+    #[test]
+    fn each_helper_reads_its_own_type_off_a_table() {
+        let table = value().as_table().cloned().expect("a document is a table");
+        check(&table);
+    }
+}

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -29,18 +29,12 @@ pub(super) fn parse_region_layout(
         // `budget = "N%"` opts a region into percentage mode; `max_tokens` then
         // becomes the absolute cap and `min_tokens` the absolute floor. Without a
         // `budget`, `max_tokens` is the literal ceiling (legacy behavior).
-        let percent = match region_value.get("budget").and_then(|v| v.as_str()) {
+        let percent = match str_of(region_value, "budget") {
             Some(s) => Some(crate::BudgetSpec::parse_budget(s).map_err(Error::Other)?),
             None => None,
         };
-        let max_tokens_opt = region_value
-            .get("max_tokens")
-            .and_then(|v| v.as_integer())
-            .map(|v| v as usize);
-        let min_tokens = region_value
-            .get("min_tokens")
-            .and_then(|v| v.as_integer())
-            .map(|v| v as usize);
+        let max_tokens_opt = int_of(region_value, "max_tokens").map(|v| v as usize);
+        let min_tokens = int_of(region_value, "min_tokens").map(|v| v as usize);
 
         let budget = match percent {
             Some(percent) => crate::BudgetSpec::Percent {
@@ -62,41 +56,26 @@ pub(super) fn parse_region_layout(
         // guard, and reconcile them into (RegionDefinition.compact_at, the value
         // stored on RegionKind::Compacting) per the resolution contract in
         // `ContextLayout::resolve_compacting_threshold`.
-        let compact_at = match region_value.get("compact_at").and_then(|v| v.as_str()) {
+        let compact_at = match str_of(region_value, "compact_at") {
             Some(s) => Some(crate::BudgetSpec::parse_budget(s).map_err(Error::Other)?),
             None => None,
         };
-        let explicit_threshold = region_value
-            .get("threshold_tokens")
-            .and_then(|v| v.as_integer())
-            .map(|v| v as usize);
+        let explicit_threshold = int_of(region_value, "threshold_tokens").map(|v| v as usize);
 
-        let kind_str = region_value
-            .get("kind")
-            .and_then(|v| v.as_str())
-            .unwrap_or("temporary");
+        let kind_str = str_of(region_value, "kind").unwrap_or("temporary");
 
         let kind = match kind_str {
             "pinned" => RegionKind::Pinned,
             "sliding_window" => {
-                let max_items = region_value
-                    .get("max_items")
-                    .and_then(|v| v.as_integer())
-                    .unwrap_or(10) as usize;
-                let eviction_strategy = match region_value.get("strategy").and_then(|v| v.as_str())
-                {
+                let max_items = int_of(region_value, "max_items").unwrap_or(10) as usize;
+                let eviction_strategy = match str_of(region_value, "strategy") {
                     Some("bulk") => {
-                        let overflow = region_value
-                            .get("overflow")
-                            .and_then(|v| v.as_integer())
-                            .unwrap_or(10) as usize;
+                        let overflow = int_of(region_value, "overflow").unwrap_or(10) as usize;
                         EvictionStrategy::Bulk { overflow }
                     }
                     Some("compact") => {
-                        let compact_count = region_value
-                            .get("compact_count")
-                            .and_then(|v| v.as_integer())
-                            .unwrap_or(10) as usize;
+                        let compact_count =
+                            int_of(region_value, "compact_count").unwrap_or(10) as usize;
                         EvictionStrategy::Compact { compact_count }
                     }
                     Some("per_item") | None => EvictionStrategy::PerItem,
@@ -136,9 +115,7 @@ pub(super) fn parse_region_layout(
             }
             "clearable" => RegionKind::Clearable,
             "compact_history" => {
-                let source = region_value
-                    .get("source_region")
-                    .and_then(|v| v.as_str())
+                let source = str_of(region_value, "source_region")
                     .unwrap_or("")
                     .to_string();
                 RegionKind::CompactHistory {
@@ -147,16 +124,11 @@ pub(super) fn parse_region_layout(
             }
             "checklist" => RegionKind::Checklist,
             "hashmap" | "hash_map" => {
-                let max_entries = region_value
-                    .get("max_entries")
-                    .and_then(|v| v.as_integer())
-                    .map(|v| v as usize);
+                let max_entries = int_of(region_value, "max_entries").map(|v| v as usize);
                 RegionKind::HashMap { max_entries }
             }
             "custom" => {
-                let script = region_value
-                    .get("script")
-                    .and_then(|v| v.as_str())
+                let script = str_of(region_value, "script")
                     .map(str::trim)
                     .filter(|s| !s.is_empty())
                     .ok_or_else(|| {
@@ -166,10 +138,7 @@ pub(super) fn parse_region_layout(
                         ))
                     })?
                     .to_string();
-                let persistent = region_value
-                    .get("persistent")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
+                let persistent = bool_of(region_value, "persistent").unwrap_or(false);
                 RegionKind::Custom { script, persistent }
             }
             unknown => {
@@ -194,26 +163,17 @@ pub(super) fn parse_region_layout(
             _ => None,
         };
 
-        let required = region_value
-            .get("required")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        let required_message = region_value
-            .get("required_message")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+        let required = bool_of(region_value, "required").unwrap_or(false);
+        let required_message = str_of(region_value, "required_message").map(|s| s.to_string());
 
         // Default on: a region is summarizable unless its author says the
         // content does not survive a paraphrase.
-        let summarizable = region_value
-            .get("summarizable")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true);
+        let summarizable = bool_of(region_value, "summarizable").unwrap_or(true);
 
         // Default `evict`: making room is what every region did before this
         // setting existed, and it is right for the transcript regions that are
         // the majority of them.
-        let admission = match region_value.get("admission").and_then(|v| v.as_str()) {
+        let admission = match str_of(region_value, "admission") {
             Some("reject") => crate::region::Admission::Reject,
             Some("evict") | None => crate::region::Admission::Evict,
             Some(other) => {
@@ -232,7 +192,7 @@ pub(super) fn parse_region_layout(
         // A misspelling is an error rather than a silent fall back to the
         // default: the default is the *worst* placement, so a typo would quietly
         // cost the author exactly the caching they were asking for.
-        let volatility = match region_value.get("volatility").and_then(|v| v.as_str()) {
+        let volatility = match str_of(region_value, "volatility") {
             Some("stable") => crate::region::Volatility::Stable,
             Some("grows") => crate::region::Volatility::Grows,
             Some("rewritten") | None => crate::region::Volatility::Rewritten,
@@ -247,18 +207,13 @@ pub(super) fn parse_region_layout(
         // One line on what the region is for, shown to the model above its
         // contents. Optional: most regions are named well enough that a
         // sentence would only cost tokens.
-        let description = region_value
-            .get("description")
-            .and_then(|v| v.as_str())
+        let description = str_of(region_value, "description")
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty());
 
         // Spending the description on the model is opt-in: a person reading a
         // blueprint wants a sentence per region, a model re-reads it every turn.
-        let describe_in_prompt = region_value
-            .get("describe_in_prompt")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
+        let describe_in_prompt = bool_of(region_value, "describe_in_prompt").unwrap_or(false);
 
         let seed = parse_region_seed(region_name, region_value.get("seed"));
 
@@ -291,13 +246,11 @@ pub(super) fn parse_region_layout(
 /// Parse one `[[transforms.mappings]]` entry. An omitted or unrecognized
 /// `transform` yields `None` (a plain region copy at apply time).
 pub(super) fn parse_region_mapping(v: &toml::Value) -> RegionMapping {
-    let transform = match v.get("transform").and_then(|x| x.as_str()) {
+    let transform = match str_of(v, "transform") {
         Some("direct") => Some(ContentTransform::Direct),
         Some("summarize") => Some(ContentTransform::Summarize),
         Some("extract") => Some(ContentTransform::Extract {
-            fields: v
-                .get("fields")
-                .and_then(|x| x.as_array())
+            fields: array_of(v, "fields")
                 .map(|a| {
                     a.iter()
                         .filter_map(|x| x.as_str().map(String::from))
@@ -348,35 +301,35 @@ pub(super) fn parse_region_seed(
             },
         }),
         toml::Value::Table(t) => {
-            if let Some(pattern) = t.get("glob").and_then(|v| v.as_str()) {
+            if let Some(pattern) = str_of(t, "glob") {
                 Some(RegionSeed::Glob {
                     pattern: pattern.to_string(),
                 })
-            } else if let Some(files) = t.get("files").and_then(|v| v.as_array()) {
+            } else if let Some(files) = array_of(t, "files") {
                 Some(RegionSeed::Files {
                     paths: files
                         .iter()
                         .filter_map(|v| v.as_str().map(String::from))
                         .collect(),
                 })
-            } else if let Some(text) = t.get("literal").and_then(|v| v.as_str()) {
+            } else if let Some(text) = str_of(t, "literal") {
                 Some(RegionSeed::Literal {
                     text: text.to_string(),
                 })
-            } else if let Some(script) = t.get("rhai").and_then(|v| v.as_str()) {
+            } else if let Some(script) = str_of(t, "rhai") {
                 Some(RegionSeed::Rhai {
                     script: script.to_string(),
                 })
-            } else if let Some(command) = t.get("command").and_then(|v| v.as_str()) {
+            } else if let Some(command) = str_of(t, "command") {
                 Some(RegionSeed::Command {
                     command: command.to_string(),
                 })
-            } else if let Some(name) = t.get("tool").and_then(|v| v.as_str()) {
+            } else if let Some(name) = str_of(t, "tool") {
                 Some(RegionSeed::Tools {
                     calls: vec![SeedToolCall::new(name)],
                     refresh: parse_seed_refresh(t),
                 })
-            } else if let Some(list) = t.get("tools").and_then(|v| v.as_array()) {
+            } else if let Some(list) = array_of(t, "tools") {
                 let calls: Vec<SeedToolCall> =
                     list.iter().filter_map(parse_seed_tool_call).collect();
                 // An empty or wholly unreadable list is not a tool seed. Falling
@@ -388,11 +341,9 @@ pub(super) fn parse_region_seed(
                     refresh: parse_seed_refresh(t),
                 })
             } else {
-                t.get("caller")
-                    .and_then(|v| v.as_str())
-                    .map(|name| RegionSeed::CallerInput {
-                        name: name.to_string(),
-                    })
+                str_of(t, "caller").map(|name| RegionSeed::CallerInput {
+                    name: name.to_string(),
+                })
             }
         }
         _ => None,
@@ -405,9 +356,7 @@ pub(super) fn parse_region_seed(
 /// manifest, matching how the rest of this parser treats a key it cannot make
 /// sense of; `lev validate` is where a typo is reported.
 fn parse_seed_refresh(table: &toml::value::Table) -> crate::layout::SeedRefresh {
-    table
-        .get("refresh")
-        .and_then(|v| v.as_str())
+    str_of(table, "refresh")
         .and_then(crate::layout::SeedRefresh::from_str_loose)
         .unwrap_or_default()
 }
@@ -423,7 +372,7 @@ fn parse_seed_tool_call(value: &toml::Value) -> Option<SeedToolCall> {
     match value {
         toml::Value::String(name) => Some(SeedToolCall::new(name.as_str())),
         toml::Value::Table(t) => {
-            let name = t.get("name").and_then(|v| v.as_str())?;
+            let name = str_of(t, "name")?;
             match t.get("args") {
                 // Every TOML value has a JSON counterpart - the conversion has
                 // no failing case for a value that was itself parsed from TOML.

--- a/crates/leviath-core/src/manifest/sections.rs
+++ b/crates/leviath-core/src/manifest/sections.rs
@@ -8,16 +8,16 @@ use super::*;
 pub(super) fn parse_compaction_config(table: &toml::value::Table) -> CompactionConfig {
     let mut cc = CompactionConfig::default();
 
-    if let Some(provider) = table.get("provider").and_then(|v| v.as_str()) {
+    if let Some(provider) = str_of(table, "provider") {
         cc.provider = provider.to_string();
     }
-    if let Some(model) = table.get("model").and_then(|v| v.as_str()) {
+    if let Some(model) = str_of(table, "model") {
         cc.model = model.to_string();
     }
-    if let Some(sp) = table.get("system_prompt").and_then(|v| v.as_str()) {
+    if let Some(sp) = str_of(table, "system_prompt") {
         cc.system_prompt = Some(sp.to_string());
     }
-    if let Some(mst) = table.get("max_summary_tokens").and_then(|v| v.as_integer()) {
+    if let Some(mst) = int_of(table, "max_summary_tokens") {
         cc.max_summary_tokens = mst as usize;
     }
     if let Some(temp) = table.get("temperature").and_then(|v| v.as_float()) {
@@ -34,7 +34,7 @@ pub(super) fn parse_read_paths(
     table: &toml::value::Table,
 ) -> Result<crate::blueprint::ReadPathsConfig> {
     let mut allow = Vec::new();
-    if let Some(entries) = table.get("allow").and_then(|v| v.as_array()) {
+    if let Some(entries) = array_of(table, "allow") {
         for entry in entries {
             let Some(raw) = entry.as_str() else {
                 return Err(Error::Other(format!(
@@ -108,23 +108,10 @@ pub(super) fn tool_permission_metadata(
 /// region is the default because that is what the shipped layouts assume.
 pub(super) fn parse_file_tracking(table: &toml::value::Table) -> crate::FileTrackingConfig {
     crate::FileTrackingConfig {
-        region: table
-            .get("region")
-            .and_then(|v| v.as_str())
-            .unwrap_or("files")
-            .to_string(),
-        track_reads: table
-            .get("track_reads")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true),
-        track_writes: table
-            .get("track_writes")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(true),
-        max_file_tokens: table
-            .get("max_file_tokens")
-            .and_then(|v| v.as_integer())
-            .map(|v| v as usize),
+        region: str_of(table, "region").unwrap_or("files").to_string(),
+        track_reads: bool_of(table, "track_reads").unwrap_or(true),
+        track_writes: bool_of(table, "track_writes").unwrap_or(true),
+        max_file_tokens: int_of(table, "max_file_tokens").map(|v| v as usize),
     }
 }
 
@@ -134,15 +121,9 @@ pub(super) fn parse_repetition_detection(
     table: &toml::value::Table,
 ) -> crate::RepetitionDetectionConfig {
     crate::RepetitionDetectionConfig {
-        max_repeat_calls: table
-            .get("max_repeat_calls")
-            .and_then(|v| v.as_integer())
-            .map(|v| v as usize),
-        max_readonly_streak: table
-            .get("max_readonly_streak")
-            .and_then(|v| v.as_integer())
-            .map(|v| v as usize),
-        enabled: table.get("enabled").and_then(|v| v.as_bool()),
+        max_repeat_calls: int_of(table, "max_repeat_calls").map(|v| v as usize),
+        max_readonly_streak: int_of(table, "max_readonly_streak").map(|v| v as usize),
+        enabled: bool_of(table, "enabled"),
     }
 }
 
@@ -179,10 +160,7 @@ pub(super) fn parse_output_spec(table: &toml::value::Table) -> crate::output::Ou
 
 pub(super) fn parse_security_config(security_table: &toml::value::Table) -> crate::SecurityConfig {
     let mut sc = crate::SecurityConfig::default();
-    if let Some(tt) = security_table
-        .get("taint_tracking")
-        .and_then(|v| v.as_bool())
-    {
+    if let Some(tt) = bool_of(security_table, "taint_tracking") {
         sc.taint_tracking = tt;
     }
     sc
@@ -200,7 +178,7 @@ pub(super) fn parse_sandbox_config(
 
     let mut sc = ToolSandboxConfig::default();
 
-    if let Some(kind) = table.get("kind").and_then(|v| v.as_str()) {
+    if let Some(kind) = str_of(table, "kind") {
         sc.kind = match kind {
             "none" => SandboxKind::None,
             "namespace" => SandboxKind::Namespace,
@@ -213,25 +191,25 @@ pub(super) fn parse_sandbox_config(
             }
         };
     }
-    if let Some(image) = table.get("image").and_then(|v| v.as_str()) {
+    if let Some(image) = str_of(table, "image") {
         sc.image = Some(image.to_string());
     }
-    if let Some(engine) = table.get("engine").and_then(|v| v.as_str()) {
+    if let Some(engine) = str_of(table, "engine") {
         sc.engine = Some(engine.to_string());
     }
-    if let Some(network) = table.get("network").and_then(|v| v.as_bool()) {
+    if let Some(network) = bool_of(table, "network") {
         sc.network = network;
     }
-    if let Some(persist) = table.get("persist").and_then(|v| v.as_bool()) {
+    if let Some(persist) = bool_of(table, "persist") {
         sc.persist = persist;
     }
-    if let Some(mounts) = table.get("mount").and_then(|v| v.as_array()) {
+    if let Some(mounts) = array_of(table, "mount") {
         sc.mounts = mounts
             .iter()
             .filter_map(|m| m.as_str().map(str::to_string))
             .collect();
     }
-    if let Some(ou) = table.get("on_unavailable").and_then(|v| v.as_str()) {
+    if let Some(ou) = str_of(table, "on_unavailable") {
         sc.on_unavailable = match ou {
             "error" => OnUnavailable::Error,
             "warn" => OnUnavailable::Warn,

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -243,17 +243,11 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
 
     stage = apply_stage_mode(stage, stage_name, stage_value)?;
 
-    if let Some(max_iter) = stage_value
-        .get("max_iterations")
-        .and_then(|v| v.as_integer())
-    {
+    if let Some(max_iter) = int_of(stage_value, "max_iterations") {
         stage.max_iterations = Some(max_iter as usize);
     }
 
-    if let Some(tools_arr) = stage_value
-        .get("available_tools")
-        .and_then(|v| v.as_array())
-    {
+    if let Some(tools_arr) = array_of(stage_value, "available_tools") {
         stage.available_tools = tools_arr
             .iter()
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
@@ -262,10 +256,7 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
 
     // Whole MCP servers this stage may use, resolved at spawn against what
     // each actually advertises.
-    if let Some(arr) = stage_value
-        .get("available_connectors")
-        .and_then(|v| v.as_array())
-    {
+    if let Some(arr) = array_of(stage_value, "available_connectors") {
         stage.available_connectors = arr
             .iter()
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
@@ -274,7 +265,7 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
 
     // Human tools this stage keeps even when the run is unattended.
     // Validated against `available_tools` by `Stage::validate`.
-    if let Some(tools_arr) = stage_value.get("required_tools").and_then(|v| v.as_array()) {
+    if let Some(tools_arr) = array_of(stage_value, "required_tools") {
         stage.required_tools = tools_arr
             .iter()
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
@@ -285,11 +276,11 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // had a field and a builder, but the parser never looked at the key, so the
     // line was accepted and dropped. Found while enumerating the keys above,
     // and the same bug in miniature.
-    if let Some(desc) = stage_value.get("description").and_then(|v| v.as_str()) {
+    if let Some(desc) = str_of(stage_value, "description") {
         stage.description = Some(desc.trim().to_string());
     }
 
-    if let Some(sp) = stage_value.get("system_prompt").and_then(|v| v.as_str()) {
+    if let Some(sp) = str_of(stage_value, "system_prompt") {
         stage.config.insert(
             "system_prompt".to_string(),
             serde_json::Value::String(sp.trim().to_string()),
@@ -300,9 +291,7 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // *after* the `[stages.X.model]` sub-table lands under
     // `stages.X.model` (TOML nesting rules) and is silently ignored, so
     // the stage runs with no instructions. Point the author at the fix.
-    let model_has_system_prompt = stage_value
-        .get("model")
-        .and_then(|v| v.as_table())
+    let model_has_system_prompt = table_of(stage_value, "model")
         .map(|t| t.contains_key("system_prompt"))
         .unwrap_or(false);
     if model_has_system_prompt {
@@ -315,7 +304,7 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     }
 
     // Parse tool_routing configuration
-    if let Some(routing_table) = stage_value.get("tool_routing").and_then(|v| v.as_table()) {
+    if let Some(routing_table) = table_of(stage_value, "tool_routing") {
         reject_unknown_keys(
             &format!("stage '{stage_name}': tool_routing"),
             routing_table,
@@ -323,29 +312,23 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
         )?;
         let mut routing = crate::blueprint::ToolResultRouting::default();
 
-        if let Some(dr) = routing_table.get("default_region").and_then(|v| v.as_str()) {
+        if let Some(dr) = str_of(routing_table, "default_region") {
             routing.default_region = dr.to_string();
         }
-        if let Some(p) = routing_table.get("persist").and_then(|v| v.as_bool()) {
+        if let Some(p) = bool_of(routing_table, "persist") {
             routing.persist = p;
         }
-        if let Some(mt) = routing_table
-            .get("max_result_tokens")
-            .and_then(|v| v.as_integer())
-        {
+        if let Some(mt) = int_of(routing_table, "max_result_tokens") {
             routing.max_result_tokens = Some(mt as usize);
         }
-        if let Some(overrides_table) = routing_table.get("overrides").and_then(|v| v.as_table()) {
+        if let Some(overrides_table) = table_of(routing_table, "overrides") {
             for (tool_name, region_val) in overrides_table {
                 parse_tool_override(stage_name, tool_name, region_val, &mut routing)?;
             }
         }
         // Per-tool ceilings, spelled like the region overrides above so the two
         // tables read as the same idea applied to two different limits.
-        if let Some(limits) = routing_table
-            .get("max_result_tokens_per_tool")
-            .and_then(|v| v.as_table())
-        {
+        if let Some(limits) = table_of(routing_table, "max_result_tokens_per_tool") {
             for (tool_name, max_val) in limits {
                 let max = max_val.as_integer().ok_or_else(|| {
                     Error::Other(format!(
@@ -371,30 +354,27 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     }
 
     // Parse requires_children flag
-    if let Some(rc) = stage_value
-        .get("requires_children")
-        .and_then(|v| v.as_bool())
-    {
+    if let Some(rc) = bool_of(stage_value, "requires_children") {
         stage.requires_children = rc;
     }
 
     // Parse allow_complete flag: lets the LLM end the run at this
     // stage (e.g. an approving review) instead of being forced down
     // its only/first transition edge.
-    if let Some(ac) = stage_value.get("allow_complete").and_then(|v| v.as_bool()) {
+    if let Some(ac) = bool_of(stage_value, "allow_complete") {
         stage.allow_complete = ac;
     }
 
     // Parse allow_as_worker flag: opts this stage in to being used as a
     // fan-out `worker_stage` target.
-    if let Some(aw) = stage_value.get("allow_as_worker").and_then(|v| v.as_bool()) {
+    if let Some(aw) = bool_of(stage_value, "allow_as_worker") {
         stage.allow_as_worker = aw;
     }
 
     // Whether the stage must hand back a final output. `mode = "output"`
     // means it by definition; any other stage opts in by hand (a fan-out
     // worker whose merge stage depends on its summary, say).
-    if let Some(ro) = stage_value.get("require_output").and_then(|v| v.as_bool()) {
+    if let Some(ro) = bool_of(stage_value, "require_output") {
         stage.require_output = ro;
     }
 
@@ -446,50 +426,47 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // Parse allow_blocking_tools flag: says this autonomous stage means
     // to offer `ask_user_*` / `present_for_review`, so `lev validate`
     // stops warning about it.
-    if let Some(ab) = stage_value
-        .get("allow_blocking_tools")
-        .and_then(|v| v.as_bool())
-    {
+    if let Some(ab) = bool_of(stage_value, "allow_blocking_tools") {
         stage.allow_blocking_tools = ab;
     }
 
     // Parse per-stage security override: [stages.<name>.security]
-    if let Some(sec_table) = stage_value.get("security").and_then(|v| v.as_table()) {
+    if let Some(sec_table) = table_of(stage_value, "security") {
         stage.security = Some(parse_security_config(sec_table));
     }
 
     // Parse per-stage batch_tool_hint override: opt an individual stage
     // in/out of the batch-tool-calls system-prompt hint (e.g. `false` for
     // a sequential validate stage). Absent ⇒ inherit agent/global.
-    if let Some(bth) = stage_value.get("batch_tool_hint").and_then(|v| v.as_bool()) {
+    if let Some(bth) = bool_of(stage_value, "batch_tool_hint") {
         stage.batch_tool_hint = Some(bth);
     }
 
     // Parse per-stage shell_hint override: opt an individual stage
     // in/out of the platform shell hint. Absent ⇒ inherit agent/global.
-    if let Some(sh) = stage_value.get("shell_hint").and_then(|v| v.as_bool()) {
+    if let Some(sh) = bool_of(stage_value, "shell_hint") {
         stage.shell_hint = Some(sh);
     }
 
     // Parse per-stage nudge settings: [stages.<name>.nudge]. Absent ⇒
     // each field inherits agent/global.
-    if let Some(nudge_table) = stage_value.get("nudge").and_then(|v| v.as_table()) {
+    if let Some(nudge_table) = table_of(stage_value, "nudge") {
         stage.nudge = Some(parse_nudge_config(nudge_table));
     }
 
     // Parse per-stage sandbox override: [stages.<name>.sandbox]
-    if let Some(sandbox_table) = stage_value.get("sandbox").and_then(|v| v.as_table()) {
+    if let Some(sandbox_table) = table_of(stage_value, "sandbox") {
         stage.sandbox = Some(parse_sandbox_config(sandbox_table)?);
     }
 
     // Script-backed lifecycle hooks: [stages.<name>.hooks]
-    if let Some(hooks_table) = stage_value.get("hooks").and_then(|v| v.as_table()) {
+    if let Some(hooks_table) = table_of(stage_value, "hooks") {
         stage.hooks = parse_stage_hooks(stage_name, hooks_table)?;
     }
 
     // Parse the stage's declared output shape: [stages.<name>.output].
     // Narrows [agent.output]; whoever starts the run overrides both.
-    if let Some(output_table) = stage_value.get("output").and_then(|v| v.as_table()) {
+    if let Some(output_table) = table_of(stage_value, "output") {
         stage.output = Some(parse_output_spec(output_table));
     }
 
@@ -497,18 +474,12 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // injected into context between inference calls. Defaults to true
     // (via the Stage constructor); set false for stages that shouldn't
     // be interrupted (e.g. a final report generation stage).
-    if let Some(am) = stage_value
-        .get("accepts_messages")
-        .and_then(|v| v.as_bool())
-    {
+    if let Some(am) = bool_of(stage_value, "accepts_messages") {
         stage.accepts_messages = am;
     }
 
     // Parse per-stage tool permissions: [stages.<name>.tool_permissions]
-    if let Some(tp_table) = stage_value
-        .get("tool_permissions")
-        .and_then(|v| v.as_table())
-    {
+    if let Some(tp_table) = table_of(stage_value, "tool_permissions") {
         for (tool_name, policy_val) in tp_table {
             let policy_str = policy_val.as_str().ok_or_else(|| {
                 Error::Other(format!(
@@ -531,13 +502,13 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // inherits the global [context.regions] layout. NOTE (TOML nesting):
     // like [stages.<name>.model], this must be its own `[...]` section;
     // don't place `context = ...` inline keys after other sub-tables.
-    if let Some(context_table) = stage_value.get("context").and_then(|v| v.as_table()) {
+    if let Some(context_table) = table_of(stage_value, "context") {
         reject_unknown_keys(
             &format!("stage '{stage_name}': context"),
             context_table,
             CONTEXT_KEYS,
         )?;
-        if let Some(regions_table) = context_table.get("regions").and_then(|v| v.as_table()) {
+        if let Some(regions_table) = table_of(context_table, "regions") {
             let (stage_regions, stage_total) = parse_region_layout(regions_table)?;
             stage.context_layout = Some(ContextLayout::new(stage_regions, stage_total));
         }
@@ -564,20 +535,17 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     }
 
     // Parse max_revisits
-    if let Some(mr) = stage_value.get("max_revisits").and_then(|v| v.as_integer()) {
+    if let Some(mr) = int_of(stage_value, "max_revisits") {
         stage.max_revisits = Some(mr as usize);
     }
 
     // Parse transition_prompt
-    if let Some(tp) = stage_value
-        .get("transition_prompt")
-        .and_then(|v| v.as_str())
-    {
+    if let Some(tp) = str_of(stage_value, "transition_prompt") {
         stage.transition_prompt = Some(tp.trim().to_string());
     }
 
     // Parse transitions: [stages.<name>.transitions.<target>]
-    if let Some(transitions_table) = stage_value.get("transitions").and_then(|v| v.as_table()) {
+    if let Some(transitions_table) = table_of(stage_value, "transitions") {
         stage.transitions = Some(parse_transitions(transitions_table)?);
     }
 
@@ -622,36 +590,25 @@ pub(super) fn apply_stage_mode(
     stage_name: &str,
     stage_value: &toml::Value,
 ) -> Result<Stage> {
-    let Some(mode_str) = stage_value.get("mode").and_then(|v| v.as_str()) else {
+    let Some(mode_str) = str_of(stage_value, "mode") else {
         return Ok(stage);
     };
     Ok(match mode_str {
         "interactive" => stage.with_mode(StageMode::Interactive),
         "interactive_points" => {
             let mut points = Vec::new();
-            if let Some(pts_arr) = stage_value
-                .get("interaction_points")
-                .and_then(|v| v.as_array())
-            {
+            if let Some(pts_arr) = array_of(stage_value, "interaction_points") {
                 for pt in pts_arr {
-                    let pt_name = pt
-                        .get("name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let pt_prompt = pt
-                        .get("prompt")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
-                    let pt_required = pt.get("required").and_then(|v| v.as_bool()).unwrap_or(true);
+                    let pt_name = str_of(pt, "name").unwrap_or("").to_string();
+                    let pt_prompt = str_of(pt, "prompt").unwrap_or("").to_string();
+                    let pt_required = bool_of(pt, "required").unwrap_or(true);
                     // What the point does when nobody is watching.
                     // Absent means auto-approve, the behaviour every
                     // `--yolo` run has had; `"ask"` opts a genuine
                     // human checkpoint out of that. A misspelling
                     // here would silently un-gate the checkpoint, so
                     // it is an error rather than a fallback.
-                    let pt_unattended = match pt.get("unattended").and_then(|v| v.as_str()) {
+                    let pt_unattended = match str_of(pt, "unattended") {
                         None | Some("auto_approve") => {
                             crate::blueprint::UnattendedPolicy::AutoApprove
                         }
@@ -664,7 +621,7 @@ pub(super) fn apply_stage_mode(
                             )));
                         }
                     };
-                    let pt_style = match pt.get("style").and_then(|v| v.as_str()) {
+                    let pt_style = match str_of(pt, "style") {
                         Some("multiple_choice") => {
                             crate::blueprint::InteractionStyle::MultipleChoice
                         }
@@ -709,9 +666,7 @@ pub(super) fn apply_stage_mode(
                         .unwrap_or_default();
                     // Options that immediately abort the run:
                     // abort_options = ["Abort - cancel this run"]
-                    let pt_abort_options: Vec<String> = pt
-                        .get("abort_options")
-                        .and_then(|v| v.as_array())
+                    let pt_abort_options: Vec<String> = array_of(pt, "abort_options")
                         .map(|arr| {
                             arr.iter()
                                 .filter_map(|v| v.as_str().map(|s| s.to_string()))
@@ -720,9 +675,7 @@ pub(super) fn apply_stage_mode(
                         .unwrap_or_default();
                     // Options that open the last output for direct editing:
                     // edit_options = ["Add detail - expand a section"]
-                    let pt_edit_options: Vec<String> = pt
-                        .get("edit_options")
-                        .and_then(|v| v.as_array())
+                    let pt_edit_options: Vec<String> = array_of(pt, "edit_options")
                         .map(|arr| {
                             arr.iter()
                                 .filter_map(|v| v.as_str().map(|s| s.to_string()))
@@ -731,10 +684,8 @@ pub(super) fn apply_stage_mode(
                         .unwrap_or_default();
                     // Pinned region that holds the authoritative
                     // document: document_region = "plan"
-                    let pt_document_region: Option<String> = pt
-                        .get("document_region")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string());
+                    let pt_document_region: Option<String> =
+                        str_of(pt, "document_region").map(|s| s.to_string());
                     points.push(crate::blueprint::InteractionPoint {
                         name: pt_name,
                         prompt: pt_prompt,
@@ -758,10 +709,7 @@ pub(super) fn apply_stage_mode(
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
             };
-            let on_worker_failure = match stage_value
-                .get("on_worker_failure")
-                .and_then(|v| v.as_str())
-            {
+            let on_worker_failure = match str_of(stage_value, "on_worker_failure") {
                 Some("fail_all") => crate::blueprint::WorkerFailurePolicy::FailAll,
                 Some("continue") | None => crate::blueprint::WorkerFailurePolicy::Continue,
                 // Unknown used to mean continue, so a misspelled `fail_all`
@@ -868,7 +816,7 @@ pub(super) fn parse_transitions(
                 edge_table,
                 EDGE_KEYS,
             )?;
-            if let Some(gate_table) = edge_table.get("gate").and_then(|v| v.as_table()) {
+            if let Some(gate_table) = table_of(edge_table, "gate") {
                 reject_unknown_keys(
                     &format!("transition to '{target_name}': gate"),
                     gate_table,
@@ -877,12 +825,9 @@ pub(super) fn parse_transitions(
             }
         }
 
-        let hint = edge_value
-            .get("hint")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+        let hint = str_of(edge_value, "hint").map(|s| s.to_string());
 
-        let condition = match edge_value.get("condition").and_then(|v| v.as_str()) {
+        let condition = match str_of(edge_value, "condition") {
             Some("error") => TransitionCondition::Error,
             Some("max_iterations") => TransitionCondition::MaxIterations,
             Some("llm_choice") => TransitionCondition::LlmChoice,
@@ -922,7 +867,7 @@ pub(super) fn parse_transitions(
             )));
         }
 
-        let transform = match edge_value.get("transform").and_then(|v| v.as_str()) {
+        let transform = match str_of(edge_value, "transform") {
             Some("clear") => EdgeTransform::Clear,
             Some("compact") | Some("summarize") => EdgeTransform::Compact { prompt: None },
             Some("custom") => {
@@ -979,10 +924,7 @@ pub(super) fn parse_transitions(
 
         // Parse the edge gate: `gate = { require_modifications = true, ... }`
         // (or a `[stages.<name>.transitions.<target>.gate]` sub-table).
-        let gate = edge_value
-            .get("gate")
-            .and_then(|v| v.as_table())
-            .map(parse_transition_gate);
+        let gate = table_of(edge_value, "gate").map(parse_transition_gate);
 
         transitions.insert(
             target_name.clone(),
@@ -1009,28 +951,28 @@ pub(super) fn parse_transition_gate(
     table: &toml::value::Table,
 ) -> crate::blueprint::TransitionGate {
     let mut gate = crate::blueprint::TransitionGate::default();
-    if let Some(rm) = table.get("require_modifications").and_then(|v| v.as_bool()) {
+    if let Some(rm) = bool_of(table, "require_modifications") {
         gate.require_modifications = rm;
     }
-    if let Some(msg) = table.get("message").and_then(|v| v.as_str()) {
+    if let Some(msg) = str_of(table, "message") {
         gate.message = Some(msg.trim().to_string());
     }
-    if let Some(region) = table.get("region").and_then(|v| v.as_str()) {
+    if let Some(region) = str_of(table, "region") {
         gate.region = Some(region.to_string());
     }
-    if let Some(region) = table.get("require_region_updated").and_then(|v| v.as_str()) {
+    if let Some(region) = str_of(table, "require_region_updated") {
         gate.require_region_updated = Some(region.to_string());
     }
-    if let Some(regions) = table.get("require_regions").and_then(|v| v.as_array()) {
+    if let Some(regions) = array_of(table, "require_regions") {
         gate.require_regions = regions
             .iter()
             .filter_map(|v| v.as_str().map(str::to_string))
             .collect();
     }
-    if let Some(region) = table.get("require_no_open_items").and_then(|v| v.as_str()) {
+    if let Some(region) = str_of(table, "require_no_open_items") {
         gate.require_no_open_items = Some(region.to_string());
     }
-    if let Some(tools) = table.get("tools").and_then(|v| v.as_array()) {
+    if let Some(tools) = array_of(table, "tools") {
         gate.tools = tools
             .iter()
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
@@ -1038,11 +980,7 @@ pub(super) fn parse_transition_gate(
     }
     // A negative budget is a typo, not "never hold the stage" - fall back to the
     // default rather than silently disabling the gate.
-    if let Some(max) = table
-        .get("max_attempts")
-        .and_then(|v| v.as_integer())
-        .filter(|max| *max >= 0)
-    {
+    if let Some(max) = int_of(table, "max_attempts").filter(|max| *max >= 0) {
         gate.max_attempts = Some(max as usize);
     }
     gate
@@ -1076,9 +1014,7 @@ pub(super) fn parse_context_transform(t: &toml::Value) -> ContextTransform {
     ContextTransform {
         from_blueprint: str_field(t, "from_blueprint"),
         to_blueprint: str_field(t, "to_blueprint"),
-        mappings: t
-            .get("mappings")
-            .and_then(|v| v.as_array())
+        mappings: array_of(t, "mappings")
             .map(|arr| arr.iter().map(parse_region_mapping).collect())
             .unwrap_or_default(),
     }
@@ -1089,29 +1025,16 @@ pub(super) fn parse_context_transform(t: &toml::Value) -> ContextTransform {
 /// the broader level).
 pub(super) fn parse_nudge_config(table: &toml::value::Table) -> crate::blueprint::NudgeConfig {
     let mut nudge = crate::blueprint::NudgeConfig::default();
-    if let Some(enabled) = table.get("enabled").and_then(|v| v.as_bool()) {
+    if let Some(enabled) = bool_of(table, "enabled") {
         nudge.enabled = Some(enabled);
     }
     // A negative count is a typo, not "never accept the text" - fall back to
     // inheriting rather than wrapping around.
-    if let Some(max) = table
-        .get("max")
-        .and_then(|v| v.as_integer())
-        .filter(|max| *max >= 0)
-    {
+    if let Some(max) = int_of(table, "max").filter(|max| *max >= 0) {
         nudge.max = Some(max as usize);
     }
-    if let Some(text) = table.get("text").and_then(|v| v.as_str()) {
+    if let Some(text) = str_of(table, "text") {
         nudge.text = Some(text.trim().to_string());
     }
     nudge
-}
-
-/// A required-shaped string field, defaulting to empty when absent (the value's
-/// meaning is validated later by `Blueprint::validate`).
-pub(super) fn str_field(v: &toml::Value, key: &str) -> String {
-    v.get(key)
-        .and_then(|x| x.as_str())
-        .unwrap_or_default()
-        .to_string()
 }

--- a/crates/leviath-core/src/run_archive.rs
+++ b/crates/leviath-core/src/run_archive.rs
@@ -386,28 +386,64 @@ fn is_prefix(prev: &[RegionEntrySnapshot], next: &[RegionEntrySnapshot]) -> bool
     prev.len() <= next.len() && next[..prev.len()] == *prev
 }
 
-/// Compute the minimal-ish [`ContextDelta`] turning `prev` into `next`. Regions
-/// that only grew at the tail become a compact `Append`; everything else is
-/// carried as a `Set`/`Clear`/`Remove`.
-pub fn diff_context(prev: &ContextSnapshot, next: &ContextSnapshot) -> ContextDelta {
+/// What the diff needs to know about a region as it was.
+///
+/// Two questions per region: did anything change, and if so, did it change
+/// only by appending at the tail? A full previous snapshot answers them by
+/// comparing entries; a retained [`RegionDigest`] answers them from per-entry
+/// hashes. Everything else about the diff - which regions are new, which
+/// went away, which were cleared - is the same algorithm over either.
+trait PriorRegion {
+    /// The region's name, which is what pairs it with its successor.
+    fn name(&self) -> &str;
+    /// Whether `next` is this region, unchanged.
+    fn unchanged(&self, next: &RegionSnapshot) -> bool;
+    /// Whether `next` kept this region's kind and budget and only appended.
+    fn appended_to(&self, next: &RegionSnapshot) -> bool;
+    /// How many entries this region held.
+    fn entry_count(&self) -> usize;
+}
+
+impl PriorRegion for RegionSnapshot {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn unchanged(&self, next: &RegionSnapshot) -> bool {
+        self == next
+    }
+
+    fn appended_to(&self, next: &RegionSnapshot) -> bool {
+        self.kind == next.kind
+            && self.max_tokens == next.max_tokens
+            && is_prefix(&self.entries, &next.entries)
+    }
+
+    fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// The delta turning the regions `prev` describes into `next`.
+///
+/// Regions that only grew at the tail become a compact `Append`; everything
+/// else is carried as a `Set`/`Clear`/`Remove`.
+fn diff_regions<P: PriorRegion>(prev: &[P], next: &ContextSnapshot) -> ContextDelta {
     let mut regions = Vec::new();
     for nr in &next.regions {
-        match prev.regions.iter().find(|r| r.name == nr.name) {
+        match prev.iter().find(|r| r.name() == nr.name) {
             None => regions.push(RegionDelta::Set(nr.clone())),
             Some(pr) => {
-                if pr == nr {
+                if pr.unchanged(nr) {
                     // unchanged - emit nothing
-                } else if nr.entries.is_empty() && !pr.entries.is_empty() {
+                } else if nr.entries.is_empty() && pr.entry_count() > 0 {
                     regions.push(RegionDelta::Clear {
                         name: nr.name.clone(),
                     });
-                } else if pr.kind == nr.kind
-                    && pr.max_tokens == nr.max_tokens
-                    && is_prefix(&pr.entries, &nr.entries)
-                {
+                } else if pr.appended_to(nr) {
                     regions.push(RegionDelta::Append {
                         name: nr.name.clone(),
-                        entries: nr.entries[pr.entries.len()..].to_vec(),
+                        entries: nr.entries[pr.entry_count()..].to_vec(),
                         current_tokens: nr.current_tokens,
                     });
                 } else {
@@ -416,10 +452,10 @@ pub fn diff_context(prev: &ContextSnapshot, next: &ContextSnapshot) -> ContextDe
             }
         }
     }
-    for pr in &prev.regions {
-        if !next.regions.iter().any(|r| r.name == pr.name) {
+    for pr in prev {
+        if !next.regions.iter().any(|r| r.name == pr.name()) {
             regions.push(RegionDelta::Remove {
-                name: pr.name.clone(),
+                name: pr.name().to_string(),
             });
         }
     }
@@ -429,6 +465,13 @@ pub fn diff_context(prev: &ContextSnapshot, next: &ContextSnapshot) -> ContextDe
         max_tokens: next.max_tokens,
         regions,
     }
+}
+
+/// Compute the minimal-ish [`ContextDelta`] turning `prev` into `next`. Regions
+/// that only grew at the tail become a compact `Append`; everything else is
+/// carried as a `Set`/`Clear`/`Remove`.
+pub fn diff_context(prev: &ContextSnapshot, next: &ContextSnapshot) -> ContextDelta {
+    diff_regions(&prev.regions, next)
 }
 
 // ─── digest-based diffing ───────────────────────────────────────────────────
@@ -511,55 +554,36 @@ fn is_prefix_digest(prev: &[u64], next: &[RegionEntrySnapshot]) -> bool {
             .all(|(hash, entry)| *hash == entry_digest(entry))
 }
 
+impl PriorRegion for RegionDigest {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn unchanged(&self, next: &RegionSnapshot) -> bool {
+        self.kind == next.kind
+            && self.max_tokens == next.max_tokens
+            && self.current_tokens == next.current_tokens
+            && self.entries.len() == next.entries.len()
+            && is_prefix_digest(&self.entries, &next.entries)
+    }
+
+    fn appended_to(&self, next: &RegionSnapshot) -> bool {
+        self.kind == next.kind
+            && self.max_tokens == next.max_tokens
+            && is_prefix_digest(&self.entries, &next.entries)
+    }
+
+    fn entry_count(&self) -> usize {
+        self.entries.len()
+    }
+}
+
 /// [`diff_context`] against a retained [`ContextDigest`] instead of a full
-/// previous snapshot. Produces the same delta shapes for the same changes:
+/// previous snapshot. The same algorithm over a different idea of "before":
 /// unchanged regions emit nothing, tail growth becomes `Append`, everything
 /// else `Set`/`Clear`/`Remove`.
 pub fn diff_context_digest(prev: &ContextDigest, next: &ContextSnapshot) -> ContextDelta {
-    let mut regions = Vec::new();
-    for nr in &next.regions {
-        match prev.regions.iter().find(|r| r.name == nr.name) {
-            None => regions.push(RegionDelta::Set(nr.clone())),
-            Some(pr) => {
-                let unchanged = pr.kind == nr.kind
-                    && pr.max_tokens == nr.max_tokens
-                    && pr.current_tokens == nr.current_tokens
-                    && pr.entries.len() == nr.entries.len()
-                    && is_prefix_digest(&pr.entries, &nr.entries);
-                if unchanged {
-                    // emit nothing
-                } else if nr.entries.is_empty() && !pr.entries.is_empty() {
-                    regions.push(RegionDelta::Clear {
-                        name: nr.name.clone(),
-                    });
-                } else if pr.kind == nr.kind
-                    && pr.max_tokens == nr.max_tokens
-                    && is_prefix_digest(&pr.entries, &nr.entries)
-                {
-                    regions.push(RegionDelta::Append {
-                        name: nr.name.clone(),
-                        entries: nr.entries[pr.entries.len()..].to_vec(),
-                        current_tokens: nr.current_tokens,
-                    });
-                } else {
-                    regions.push(RegionDelta::Set(nr.clone()));
-                }
-            }
-        }
-    }
-    for pr in &prev.regions {
-        if !next.regions.iter().any(|r| r.name == pr.name) {
-            regions.push(RegionDelta::Remove {
-                name: pr.name.clone(),
-            });
-        }
-    }
-    ContextDelta {
-        stage_name: next.stage_name.clone(),
-        total_tokens: next.total_tokens,
-        max_tokens: next.max_tokens,
-        regions,
-    }
+    diff_regions(&prev.regions, next)
 }
 
 /// Apply a [`ContextDelta`] to `base` in place. Lenient: a delta referencing a


### PR DESCRIPTION
## What

Two merges in `leviath-core`, one commit each.

**One context diff.** `diff_context` and `diff_context_digest` were the same forty-line algorithm twice; the only difference was how "unchanged" and "grew only at the tail" were decided (entry comparison vs per-entry hashes). A private `PriorRegion` trait (`name`, `unchanged`, `appended_to`, `entry_count`) is implemented for `RegionSnapshot` and `RegionDigest`; `diff_regions` is the algorithm once; the two public functions are one-line wrappers. The equivalence tests that compare the digest path to the full path still pass, and now hold by construction.

**Typed field readers for the manifest parser.** `manifest/read.rs` has `str_of`, `bool_of`, `int_of`, `array_of`, `table_of` (and the `str_field` default-to-empty reader that lived in `stage.rs` and `regions.rs` borrowed). They accept a `toml::Value` or a `toml::Table` via a small `Fields` trait, because the parser holds both. 146 sites are routed through them (stage.rs 60, regions.rs 33, manifest.rs 21, sections.rs 20, model.rs 12); the 11 whose key is a variable or whose receiver is an expression keep the inline form. Each helper returns `None` for an absent key and a wrong-typed value, exactly as the inline form did; `int_of` is exactly `as_integer` with no range check (each caller decides what a negative means; Phase 5.7 will tighten that separately).

## Behaviour

None changed. The rewrite of the access sites was a regex over one exact shape (`X.get("k").and_then(|v| v.as_T())` with a plain identifier receiver), so nothing about defaults, error paths or ordering moved.

## Tests

`read.rs` runs every helper over both a `Value` and a `Table` (both instantiations, since coverage is measured per instantiation). The manifest tests and the diff equivalence tests run unchanged.

## Verification

`cargo test -p leviath-core` 901 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-core` at 100%.
