### PR TITLE
refactor(cli/serve): daemon_ok, unexpected_response and one ApiError

### DIFF
--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -47,7 +47,7 @@ fn output_request(body: &SpawnAgentReq) -> Option<leviath_core::output::OutputSp
 pub(super) async fn spawn_agent(
     State(state): State<AppState>,
     Json(body): Json<SpawnAgentReq>,
-) -> Result<Json<SpawnAgentResp>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<SpawnAgentResp>, ApiError> {
     let blueprints = discover_blueprints(&state.current_config());
     let bp_info = blueprints
         .iter()
@@ -125,10 +125,7 @@ pub(super) async fn spawn_agent(
             StatusCode::BAD_REQUEST,
             format!("Failed to spawn agent: {message}"),
         )),
-        Ok(other) => Err(err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unexpected daemon response: {other:?}"),
-        )),
+        Ok(other) => Err(unexpected_response(other)),
         Err(e) => Err(daemon_error(e)),
     }
 }
@@ -153,7 +150,7 @@ pub(super) async fn list_agents(
 
 pub(super) async fn get_agent(
     AxumPath(id): AxumPath<String>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<serde_json::Value>, ApiError> {
     runstate::read_meta(&id)
         .map(|m| Json(run_json(&m, leviath_core::duration::now_secs())))
         .map_err(|_| {
@@ -178,7 +175,7 @@ pub(super) async fn agent_children(AxumPath(id): AxumPath<String>) -> Json<Vec<s
 
 pub(super) async fn agent_context(
     AxumPath(id): AxumPath<String>,
-) -> Result<Json<ContextSnapshot>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<ContextSnapshot>, ApiError> {
     runstate::read_context_snapshot(&id)
         .map(Json)
         .ok_or_else(|| {
@@ -217,7 +214,7 @@ pub(super) const HISTORY_MAX_LIMIT: usize = 100;
 pub(super) async fn agent_context_history(
     AxumPath(id): AxumPath<String>,
     Query(query): Query<HistoryQuery>,
-) -> Result<Json<Page<leviath_core::run_archive::RunPoint>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<Page<leviath_core::run_archive::RunPoint>>, ApiError> {
     use std::ops::ControlFlow;
 
     let ascending = match query.order.as_deref() {
@@ -356,7 +353,7 @@ pub(super) async fn agent_context_history(
 pub(super) async fn agent_logs(
     AxumPath(id): AxumPath<String>,
     Query(query): Query<LogsQuery>,
-) -> Result<String, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<String, ApiError> {
     let run_dir = runstate::run_dir(&id);
     if !run_dir.exists() {
         return Err((
@@ -403,7 +400,7 @@ pub(super) const MAX_FILE_READ_BYTES: u64 = 1024 * 1024;
 pub(super) async fn agent_file(
     AxumPath(id): AxumPath<String>,
     Query(query): Query<FileQuery>,
-) -> Result<Json<FileOrListing>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<FileOrListing>, ApiError> {
     let meta = runstate::read_meta(&id)
         .map_err(|_| err(StatusCode::NOT_FOUND, format!("Agent run '{id}' not found")))?;
 
@@ -550,7 +547,7 @@ fn list_run_files(
     source: FileSource,
     dir: Option<&std::path::Path>,
     hidden: bool,
-) -> Result<FileOrListing, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<FileOrListing, ApiError> {
     let workdir = PathBuf::from(&meta.workdir);
     let listing = match source {
         FileSource::Modified => modified_listing(meta, &workdir),
@@ -612,7 +609,7 @@ fn workdir_listing(
     workdir: &std::path::Path,
     dir: Option<&std::path::Path>,
     hidden: bool,
-) -> Result<RunFileListing, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<RunFileListing, ApiError> {
     let target = dir
         .map(PathBuf::from)
         .unwrap_or_else(|| workdir.to_path_buf());
@@ -682,7 +679,7 @@ fn workdir_listing(
 
 pub(super) async fn agent_result(
     AxumPath(id): AxumPath<String>,
-) -> Result<Json<AgentResultResp>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<AgentResultResp>, ApiError> {
     let meta = runstate::read_meta(&id).map_err(|_| {
         (
             StatusCode::NOT_FOUND,
@@ -736,7 +733,7 @@ pub(super) async fn agent_result(
 /// already been answered.
 pub(super) async fn agent_stages(
     AxumPath(id): AxumPath<String>,
-) -> Result<Json<RunStagesResp>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<RunStagesResp>, ApiError> {
     let meta = runstate::read_meta(&id).map_err(|_| {
         (
             StatusCode::NOT_FOUND,
@@ -758,23 +755,16 @@ pub(super) async fn agent_stages(
 pub(super) async fn kill_agent(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    match state
+) -> Result<StatusCode, ApiError> {
+    let reply = state
         .control
         .request(&ControlRequest::Cancel { run_id: id.clone() })
-        .await
-    {
-        Ok(ControlResponse::Ok { ok: true }) => Ok(StatusCode::NO_CONTENT),
-        Ok(ControlResponse::Ok { ok: false }) => Err(err(
-            StatusCode::NOT_FOUND,
-            format!("Agent run '{id}' not found"),
-        )),
-        Ok(other) => Err(err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unexpected daemon response: {other:?}"),
-        )),
-        Err(e) => Err(daemon_error(e)),
-    }
+        .await;
+    daemon_ok(
+        reply,
+        StatusCode::NO_CONTENT,
+        format!("Agent run '{id}' not found"),
+    )
 }
 
 /// `POST /api/agents/{id}/pause`: park a run. The daemon refuses when the run
@@ -783,46 +773,32 @@ pub(super) async fn kill_agent(
 pub(super) async fn pause_agent(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    match state
+) -> Result<StatusCode, ApiError> {
+    let reply = state
         .control
         .request(&ControlRequest::Pause { run_id: id.clone() })
-        .await
-    {
-        Ok(ControlResponse::Ok { ok: true }) => Ok(StatusCode::NO_CONTENT),
-        Ok(ControlResponse::Ok { ok: false }) => Err(err(
-            StatusCode::NOT_FOUND,
-            format!("Agent run '{id}' not found or not pausable"),
-        )),
-        Ok(other) => Err(err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unexpected daemon response: {other:?}"),
-        )),
-        Err(e) => Err(daemon_error(e)),
-    }
+        .await;
+    daemon_ok(
+        reply,
+        StatusCode::NO_CONTENT,
+        format!("Agent run '{id}' not found or not pausable"),
+    )
 }
 
 /// `POST /api/agents/{id}/resume`: un-pause a run.
 pub(super) async fn resume_agent(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    match state
+) -> Result<StatusCode, ApiError> {
+    let reply = state
         .control
         .request(&ControlRequest::Resume { run_id: id.clone() })
-        .await
-    {
-        Ok(ControlResponse::Ok { ok: true }) => Ok(StatusCode::NO_CONTENT),
-        Ok(ControlResponse::Ok { ok: false }) => Err(err(
-            StatusCode::NOT_FOUND,
-            format!("Agent run '{id}' not found or not paused"),
-        )),
-        Ok(other) => Err(err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unexpected daemon response: {other:?}"),
-        )),
-        Err(e) => Err(daemon_error(e)),
-    }
+        .await;
+    daemon_ok(
+        reply,
+        StatusCode::NO_CONTENT,
+        format!("Agent run '{id}' not found or not paused"),
+    )
 }
 
 #[cfg(test)]

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -29,7 +29,7 @@ pub(super) fn agents_dir() -> PathBuf {
 /// filesystem: `POST /api/blueprints` with `name = "../../../../tmp/x"` created
 /// a directory and wrote attacker-controlled TOML into it, and
 /// `DELETE /api/blueprints/{name}` recursively deleted whatever it landed on.
-fn blueprint_dir(name: &str) -> Result<PathBuf, (StatusCode, Json<ErrorResponse>)> {
+fn blueprint_dir(name: &str) -> Result<PathBuf, ApiError> {
     if !leviath_core::is_safe_path_component(name) {
         return Err((
             StatusCode::BAD_REQUEST,
@@ -161,7 +161,7 @@ const MAX_LIMIT: usize = 200;
 pub(super) async fn list_blueprints(
     State(state): State<AppState>,
     Query(query): Query<BlueprintsQuery>,
-) -> Result<Json<Page<BlueprintInfo>>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<Page<BlueprintInfo>>, ApiError> {
     let descending = match query.order.as_deref() {
         None | Some("asc") => false,
         Some("desc") => true,
@@ -354,7 +354,7 @@ fn fan_out_infos(bp: &leviath_core::blueprint::Blueprint) -> Vec<FanOutInfo> {
 
 pub(super) async fn create_blueprint(
     Json(body): Json<CreateBlueprintReq>,
-) -> Result<Json<BlueprintInfo>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<BlueprintInfo>, ApiError> {
     // Validate manifest first, keeping the parsed Blueprint so the response
     // can be built from it directly below instead of re-reading the file we
     // just wrote (re-reading would make the re-read's error arm a TOCTOU-only,
@@ -403,7 +403,7 @@ pub(super) async fn create_blueprint(
 pub(super) async fn update_blueprint(
     AxumPath(name): AxumPath<String>,
     Json(body): Json<UpdateBlueprintReq>,
-) -> Result<Json<BlueprintInfo>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<BlueprintInfo>, ApiError> {
     let bp = parse_manifest(&body.manifest).map_err(|e| {
         (
             StatusCode::BAD_REQUEST,
@@ -447,7 +447,7 @@ pub(super) async fn update_blueprint(
 
 pub(super) async fn delete_blueprint(
     AxumPath(name): AxumPath<String>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, ApiError> {
     let dir = blueprint_dir(&name)?;
     if !dir.exists() {
         return Err((

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -65,7 +65,7 @@ pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedCo
 pub(super) async fn put_config(
     State(state): State<AppState>,
     Json(req): Json<WriteConfigReq>,
-) -> Result<Json<RedactedConfig>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<RedactedConfig>, ApiError> {
     let path = &state.mcp.config_path;
     let mut config = Config::load_from_path_public(path).map_err(|e| {
         err(

--- a/crates/leviath-cli/src/commands/serve/fs.rs
+++ b/crates/leviath-cli/src/commands/serve/fs.rs
@@ -38,7 +38,7 @@ use super::types::*;
 pub(super) async fn list_dirs(
     State(state): State<AppState>,
     Query(query): Query<DirsQuery>,
-) -> Result<Json<DirsResp>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<DirsResp>, ApiError> {
     let root = state.limits.workdir_root.as_deref();
     let cwd = known_dir_or_fs_root(std::env::current_dir().ok());
 
@@ -155,7 +155,7 @@ pub(super) async fn list_dirs(
 pub(super) async fn create_dir(
     State(state): State<AppState>,
     Json(req): Json<MkdirReq>,
-) -> Result<(StatusCode, Json<MkdirResp>), (StatusCode, Json<ErrorResponse>)> {
+) -> Result<(StatusCode, Json<MkdirResp>), ApiError> {
     let parent = PathBuf::from(&req.path);
     if !parent.is_absolute() {
         return Err(err(

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -13,7 +13,7 @@ use super::types::*;
 pub(super) async fn get_interaction(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
-) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<serde_json::Value>, ApiError> {
     match state
         .control
         .request(&ControlRequest::ListInteractions)
@@ -33,10 +33,7 @@ pub(super) async fn get_interaction(
                 )),
             }
         }
-        Ok(other) => Err(err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unexpected daemon response: {other:?}"),
-        )),
+        Ok(other) => Err(unexpected_response(other)),
         Err(e) => Err(daemon_error(e)),
     }
 }
@@ -61,7 +58,7 @@ pub(super) async fn submit_interaction(
     State(state): State<AppState>,
     AxumPath(_id): AxumPath<String>,
     Json(body): Json<SubmitInteractionReq>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, ApiError> {
     let scope = body.scope.as_deref().map(approval_scope_from_wire);
     let response = InteractionResponse {
         request_id: body.request_id,
@@ -70,22 +67,15 @@ pub(super) async fn submit_interaction(
         approved: body.approved,
         scope,
     };
-    match state
+    let reply = state
         .control
         .request(&ControlRequest::AnswerInteraction { response })
-        .await
-    {
-        Ok(ControlResponse::Ok { ok: true }) => Ok(StatusCode::ACCEPTED),
-        Ok(ControlResponse::Ok { ok: false }) => Err(err(
-            StatusCode::NOT_FOUND,
-            "No such open interaction".to_string(),
-        )),
-        Ok(other) => Err(err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unexpected daemon response: {other:?}"),
-        )),
-        Err(e) => Err(daemon_error(e)),
-    }
+        .await;
+    daemon_ok(
+        reply,
+        StatusCode::ACCEPTED,
+        "No such open interaction".to_string(),
+    )
 }
 
 /// `POST /api/agents/{id}/message`: deliver a message to a running agent.
@@ -93,27 +83,20 @@ pub(super) async fn send_message(
     State(state): State<AppState>,
     AxumPath(id): AxumPath<String>,
     Json(body): Json<SendMessageReq>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    match state
+) -> Result<StatusCode, ApiError> {
+    let reply = state
         .control
         .request(&ControlRequest::Message {
             agent_id: id.clone(),
             content: body.message,
             target_region: body.target_region,
         })
-        .await
-    {
-        Ok(ControlResponse::Ok { ok: true }) => Ok(StatusCode::ACCEPTED),
-        Ok(ControlResponse::Ok { ok: false }) => Err(err(
-            StatusCode::NOT_FOUND,
-            format!("Agent run '{id}' is not accepting messages"),
-        )),
-        Ok(other) => Err(err(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Unexpected daemon response: {other:?}"),
-        )),
-        Err(e) => Err(daemon_error(e)),
-    }
+        .await;
+    daemon_ok(
+        reply,
+        StatusCode::ACCEPTED,
+        format!("Agent run '{id}' is not accepting messages"),
+    )
 }
 
 #[cfg(test)]

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -239,8 +239,6 @@ impl Resolved {
     }
 }
 
-type ApiError = (StatusCode, Json<ErrorResponse>);
-
 fn bad_request(message: String) -> ApiError {
     err(StatusCode::BAD_REQUEST, message)
 }
@@ -1043,7 +1041,7 @@ fn remove_family(ids: &[String]) -> Result<(), (StatusCode, String)> {
 pub(super) async fn delete_run(
     AxumPath(id): AxumPath<String>,
     Query(query): Query<DeleteRunQuery>,
-) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<StatusCode, ApiError> {
     // `run_dir` maps an unsafe id to a path that cannot exist, so a traversal
     // attempt arrives here as an ordinary miss rather than a removed directory.
     let ids = runstate::family_of(&id);
@@ -1072,7 +1070,7 @@ pub(super) async fn delete_run(
 /// than an operator asking to erase the machine's entire history.
 pub(super) async fn delete_runs(
     Query(query): Query<DeleteRunsQuery>,
-) -> Result<Json<DeleteRunsResp>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<DeleteRunsResp>, ApiError> {
     let targets: Vec<String> = match (&query.ids, query.before) {
         (Some(ids), _) => {
             let ids = comma_list(ids);

--- a/crates/leviath-cli/src/commands/serve/scripts.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts.rs
@@ -39,7 +39,8 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde::{Deserialize, Serialize};
 
-use super::tools::{ApiError, agent_dir};
+use super::tools::agent_dir;
+use super::types::ApiError;
 use super::types::err;
 
 /// Which extension point a script plugs into, and so which compiler decides

--- a/crates/leviath-cli/src/commands/serve/tools.rs
+++ b/crates/leviath-cli/src/commands/serve/tools.rs
@@ -16,11 +16,8 @@ use axum::http::StatusCode;
 use axum::response::Json;
 use serde::{Deserialize, Serialize};
 
-use super::types::{ErrorResponse, err};
+use super::types::{ApiError, err};
 use crate::tool_inventory::ToolInventory;
-
-/// The `(status, body)` pair every fallible handler in this module returns.
-pub(super) type ApiError = (StatusCode, Json<ErrorResponse>);
 
 /// Resolve `<agents_dir>/<name>`, refusing a name that is not a single safe
 /// path component.

--- a/crates/leviath-cli/src/commands/serve/tree.rs
+++ b/crates/leviath-cli/src/commands/serve/tree.rs
@@ -105,7 +105,7 @@ pub(super) async fn agents_tree() -> Json<Vec<AgentTreeNode>> {
 
 pub(super) async fn agent_tree_status(
     AxumPath(id): AxumPath<String>,
-) -> Result<Json<TreeStatusNode>, (StatusCode, Json<ErrorResponse>)> {
+) -> Result<Json<TreeStatusNode>, ApiError> {
     let runs = runstate::list_runs();
     let root = runs.iter().find(|r| r.run_id == id).ok_or((
         StatusCode::NOT_FOUND,

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -241,12 +241,46 @@ pub(super) struct ErrorResponse {
     pub(super) error: String,
 }
 
+/// The `(status, body)` pair every fallible handler returns.
+pub(super) type ApiError = (axum::http::StatusCode, axum::response::Json<ErrorResponse>);
+
 /// Build a `(status, JSON error)` response tuple.
-pub(super) fn err(
-    code: axum::http::StatusCode,
-    message: String,
-) -> (axum::http::StatusCode, axum::response::Json<ErrorResponse>) {
+pub(super) fn err(code: axum::http::StatusCode, message: String) -> ApiError {
     (code, axum::response::Json(ErrorResponse { error: message }))
+}
+
+/// A daemon reply this handler has no arm for.
+///
+/// 500 rather than 502: the reply decoded, so the two still speak the same
+/// protocol; the handler simply did not expect this answer to this request.
+pub(super) fn unexpected_response(
+    other: leviath_runtime::control_socket::ControlResponse,
+) -> ApiError {
+    err(
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        format!("Unexpected daemon response: {other:?}"),
+    )
+}
+
+/// The status for a control request the daemon answers with `Ok { ok }`.
+///
+/// `success` when it did the thing; 404 carrying `not_found` when it could
+/// not, since every such request names a run or an interaction and "could
+/// not" means the daemon had nothing by that name in the right state. Five
+/// handlers used to carry this four-arm match each.
+pub(super) fn daemon_ok(
+    reply: std::io::Result<leviath_runtime::control_socket::ControlResponse>,
+    success: axum::http::StatusCode,
+    not_found: String,
+) -> Result<axum::http::StatusCode, ApiError> {
+    match reply {
+        Ok(leviath_runtime::control_socket::ControlResponse::Ok { ok: true }) => Ok(success),
+        Ok(leviath_runtime::control_socket::ControlResponse::Ok { ok: false }) => {
+            Err(err(axum::http::StatusCode::NOT_FOUND, not_found))
+        }
+        Ok(other) => Err(unexpected_response(other)),
+        Err(e) => Err(daemon_error(e)),
+    }
 }
 
 /// The response for a control request the daemon did not answer.
@@ -261,9 +295,7 @@ pub(super) fn err(
 ///   understand it - the daemon was updated under a running `lev serve`, and
 ///   the two no longer speak the same protocol. Retrying cannot help; the
 ///   message says what does, which is restarting `lev serve`.
-pub(super) fn daemon_error(
-    e: std::io::Error,
-) -> (axum::http::StatusCode, axum::response::Json<ErrorResponse>) {
+pub(super) fn daemon_error(e: std::io::Error) -> ApiError {
     match e.kind() {
         std::io::ErrorKind::Unsupported => err(
             axum::http::StatusCode::BAD_GATEWAY,


### PR DESCRIPTION
## What

- `types::daemon_ok(reply, success, not_found)`: the four-arm match five handlers carried (kill, pause, resume, answer interaction, send message). `Ok { ok: true }` is the success status, `Ok { ok: false }` a 404 with the handler's own message, any other reply a 500 quoting it, a transport error `daemon_error`. Each handler is now the request it sends plus its two strings.
- `types::unexpected_response(other)`: the 500 arm, for the two handlers that keep their own match (spawn, get interaction).
- `types::ApiError`: one alias for `(StatusCode, Json<ErrorResponse>)`, replacing the two local aliases (`tools.rs`, `runs.rs`) and 29 longhand spellings across 8 files.

## Behaviour

None changed: every status code and message is byte-identical. The existing per-handler tests for the 404, 500 and 503 arms run unchanged and now exercise `daemon_ok` through each route.

## Verification

`cargo test -p leviath-cli` 4,023 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-cli` at 100%.
