### PR TITLE
refactor(runtime): internal merges

### DIFF
--- a/crates/leviath-runtime/src/context_tools.rs
+++ b/crates/leviath-runtime/src/context_tools.rs
@@ -20,6 +20,23 @@ pub fn is_context_tool(name: &str) -> bool {
     name.starts_with("context_") || name.starts_with("todo_")
 }
 
+/// The string argument under `key`, if the model passed one.
+fn str_arg<'a>(args: &'a serde_json::Value, key: &str) -> Option<&'a str> {
+    args.get(key).and_then(|v| v.as_str())
+}
+
+/// The reply for a tool call that left out `key`.
+fn missing(key: &str) -> String {
+    format!("[error] missing '{key}' argument")
+}
+
+/// Whether the region is keyed; `None` when there is no such region.
+fn is_hashmap_region(window: &ContextWindow, name: &str) -> Option<bool> {
+    window
+        .get_region(name)
+        .map(|r| matches!(r.kind, RegionKind::HashMap { .. }))
+}
+
 /// Build the "section not found" error listing the writable regions.
 fn region_not_found(name: &str, window: &ContextWindow) -> String {
     let available: Vec<&str> = window
@@ -71,11 +88,11 @@ pub fn handle_context_tool(
         // unfinished items and one holding three finished ones are the same
         // string to every other region kind, which is why no gate could ask.
         "todo_add" => {
-            let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
-                return "[error] missing 'region' argument".to_string();
+            let Some(region_name) = str_arg(args, "region") else {
+                return missing("region");
             };
-            let Some(item) = args.get("item").and_then(|v| v.as_str()) else {
-                return "[error] missing 'item' argument".to_string();
+            let Some(item) = str_arg(args, "item") else {
+                return missing("item");
             };
             let tokens = leviath_core::estimate_tokens(item);
             match checklist_region(window, region_name) {
@@ -87,8 +104,8 @@ pub fn handle_context_tool(
             }
         }
         "todo_done" | "todo_note" => {
-            let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
-                return "[error] missing 'region' argument".to_string();
+            let Some(region_name) = str_arg(args, "region") else {
+                return missing("region");
             };
             let Some(id) = args.get("id").and_then(|v| v.as_u64()) else {
                 return "[error] missing 'id' argument".to_string();
@@ -118,18 +135,17 @@ pub fn handle_context_tool(
             }
         }
         "context_write" => {
-            let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
-                return "[error] missing 'region' argument".to_string();
+            let Some(region_name) = str_arg(args, "region") else {
+                return missing("region");
             };
-            let Some(content) = args.get("content").and_then(|v| v.as_str()) else {
-                return "[error] missing 'content' argument".to_string();
+            let Some(content) = str_arg(args, "content") else {
+                return missing("content");
             };
             let key = args.get("key").and_then(|v| v.as_str());
             let tokens = leviath_core::estimate_tokens(content);
 
-            let is_hashmap = match window.get_region(region_name) {
-                Some(r) => matches!(r.kind, RegionKind::HashMap { .. }),
-                None => return region_not_found(region_name, window),
+            let Some(is_hashmap) = is_hashmap_region(window, region_name) else {
+                return region_not_found(region_name, window);
             };
             let region = window.get_region_mut(region_name).expect("region present");
             if is_hashmap {
@@ -155,18 +171,17 @@ pub fn handle_context_tool(
             }
         }
         "context_append" => {
-            let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
-                return "[error] missing 'region' argument".to_string();
+            let Some(region_name) = str_arg(args, "region") else {
+                return missing("region");
             };
-            let Some(content) = args.get("content").and_then(|v| v.as_str()) else {
-                return "[error] missing 'content' argument".to_string();
+            let Some(content) = str_arg(args, "content") else {
+                return missing("content");
             };
             let key = args.get("key").and_then(|v| v.as_str());
             let tokens = leviath_core::estimate_tokens(content);
 
-            let is_hashmap = match window.get_region(region_name) {
-                Some(r) => matches!(r.kind, RegionKind::HashMap { .. }),
-                None => return region_not_found(region_name, window),
+            let Some(is_hashmap) = is_hashmap_region(window, region_name) else {
+                return region_not_found(region_name, window);
             };
             let region = window.get_region_mut(region_name).expect("region present");
             if is_hashmap {
@@ -208,8 +223,8 @@ pub fn handle_context_tool(
             }
         }
         "context_read" => {
-            let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
-                return "[error] missing 'region' argument".to_string();
+            let Some(region_name) = str_arg(args, "region") else {
+                return missing("region");
             };
             let key = args.get("key").and_then(|v| v.as_str());
             let region = match window.get_region(region_name) {
@@ -252,8 +267,8 @@ pub fn handle_context_tool(
             }
         }
         "context_delete" => {
-            let Some(region_name) = args.get("region").and_then(|v| v.as_str()) else {
-                return "[error] missing 'region' argument".to_string();
+            let Some(region_name) = str_arg(args, "region") else {
+                return missing("region");
             };
             if window.get_region(region_name).is_none() {
                 return region_not_found(region_name, window);

--- a/crates/leviath-runtime/src/embed/spawner.rs
+++ b/crates/leviath-runtime/src/embed/spawner.rs
@@ -4,7 +4,7 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex};
 
 use bevy_ecs::entity::Entity;
 
@@ -57,10 +57,7 @@ impl EmbedSpawner {
         // The blueprint: staged inline by `AgentWorld::spawn`, or a manifest
         // path to load.
         let blueprint = match args.blueprint_path.strip_prefix("inline:") {
-            Some(key) => self
-                .staged
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
+            Some(key) => leviath_core::sync::lock(&self.staged)
                 .remove(key)
                 .ok_or_else(|| format!("no staged blueprint under '{key}'"))?,
             None => {

--- a/crates/leviath-runtime/src/embed/tool_service.rs
+++ b/crates/leviath-runtime/src/embed/tool_service.rs
@@ -11,7 +11,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex};
 
 use bevy_ecs::entity::Entity;
 use leviath_tools::{BuiltinTools, ToolContext};
@@ -72,19 +72,13 @@ impl BasicToolService {
             backend: self.hub.backend_for(agent_id),
             stage_name: Mutex::new(String::new()),
         };
-        self.agents
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .insert(entity, Arc::new(state));
+        leviath_core::sync::lock(&self.agents).insert(entity, Arc::new(state));
     }
 
     /// Drop `entity`'s tool state. Called by the reaper when a terminal agent
     /// is unloaded, so the map stays bounded by the set of live agents.
     pub fn unregister(&self, entity: Entity) {
-        self.agents
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .remove(&entity);
+        leviath_core::sync::lock(&self.agents).remove(&entity);
     }
 }
 
@@ -95,12 +89,7 @@ impl ToolService for BasicToolService {
         calls: Vec<leviath_providers::ToolCall>,
         progress: ToolProgress,
     ) -> BoxedToolExec {
-        let state = self
-            .agents
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .get(&entity)
-            .cloned();
+        let state = leviath_core::sync::lock(&self.agents).get(&entity).cloned();
         Box::new(move || {
             Box::pin(async move {
                 let mut results = Vec::with_capacity(calls.len());
@@ -115,11 +104,7 @@ impl ToolService for BasicToolService {
                     }
                     return results;
                 };
-                let stage_name = state
-                    .stage_name
-                    .lock()
-                    .unwrap_or_else(PoisonError::into_inner)
-                    .clone();
+                let stage_name = leviath_core::sync::lock(&state.stage_name).clone();
                 for call in calls {
                     // Interaction tools block on the hub (the host answers);
                     // everything else runs on the built-ins.
@@ -144,16 +129,8 @@ impl ToolService for BasicToolService {
     }
 
     fn sync_stage(&self, entity: Entity, _stage_index: usize, stage_name: &str) {
-        if let Some(state) = self
-            .agents
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .get(&entity)
-        {
-            *state
-                .stage_name
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner) = stage_name.to_string();
+        if let Some(state) = leviath_core::sync::lock(&self.agents).get(&entity) {
+            *leviath_core::sync::lock(&state.stage_name) = stage_name.to_string();
         }
     }
 }

--- a/crates/leviath-runtime/src/embed/world.rs
+++ b/crates/leviath-runtime/src/embed/world.rs
@@ -3,7 +3,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex};
 
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::UnboundedSender;
@@ -378,10 +378,7 @@ impl AgentWorld {
         let blueprint_path = match resolved {
             Resolved::Path(path) => path.to_string_lossy().into_owned(),
             Resolved::Inline(blueprint) => {
-                self.staged
-                    .lock()
-                    .unwrap_or_else(PoisonError::into_inner)
-                    .insert(run_id.clone(), *blueprint);
+                leviath_core::sync::lock(&self.staged).insert(run_id.clone(), *blueprint);
                 format!("inline:{run_id}")
             }
         };
@@ -528,9 +525,7 @@ mod tests {
     #[async_trait::async_trait]
     impl Provider for Mock {
         async fn infer(&self, _r: &InferenceRequest) -> Result<InferenceResponse, ProviderError> {
-            self.responses
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
+            leviath_core::sync::lock(&self.responses)
                 .pop_front()
                 .ok_or_else(|| ProviderError::Other("script exhausted".to_string()))
         }
@@ -584,9 +579,7 @@ mod tests {
     #[async_trait::async_trait]
     impl Provider for Recorder {
         async fn infer(&self, r: &InferenceRequest) -> Result<InferenceResponse, ProviderError> {
-            self.seen
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
+            leviath_core::sync::lock(&self.seen)
                 .push(r.system.iter().map(|b| b.text.clone()).collect());
             Ok(text("done"))
         }
@@ -1186,7 +1179,7 @@ conversation = { kind = "sliding_window", max_items = 40, max_tokens = 20000 }
         .await
         .expect("completes");
         world.shutdown().await;
-        let seen = seen.lock().unwrap_or_else(PoisonError::into_inner);
+        let seen = leviath_core::sync::lock(&seen);
         seen.first().cloned().expect("one inference happened")
     }
 

--- a/crates/leviath-runtime/src/fanout/worker_sources.rs
+++ b/crates/leviath-runtime/src/fanout/worker_sources.rs
@@ -29,37 +29,32 @@ const SOURCES_REGION: &str = "sources_index";
 /// Best-effort throughout, like the stuck and error notes: a parent with no
 /// such region, a worker that recorded nothing, or a region too full to take
 /// the lines all leave the parent exactly as it was.
+/// The sources region of `entity`'s context window as one text, one entry
+/// per line, if the entity has such a region.
+fn sources_text(world: &World, entity: Entity) -> Option<String> {
+    world
+        .get::<ContextWindow>(entity)
+        .and_then(|w| w.get_region(SOURCES_REGION))
+        .map(|r| {
+            r.content
+                .iter()
+                .map(|e| e.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+}
+
 pub(super) fn merge_worker_sources(
     world: &mut World,
     parent: Entity,
     worker: Entity,
     item_id: &str,
 ) {
-    let Some(worker_text) = world
-        .get::<ContextWindow>(worker)
-        .and_then(|w| w.get_region(SOURCES_REGION))
-        .map(|r| {
-            r.content
-                .iter()
-                .map(|e| e.content.clone())
-                .collect::<Vec<_>>()
-                .join("\n")
-        })
-    else {
+    let Some(worker_text) = sources_text(world, worker) else {
         return;
     };
 
-    let Some(existing) = world
-        .get::<ContextWindow>(parent)
-        .and_then(|w| w.get_region(SOURCES_REGION))
-        .map(|r| {
-            r.content
-                .iter()
-                .map(|e| e.content.clone())
-                .collect::<Vec<_>>()
-                .join("\n")
-        })
-    else {
+    let Some(existing) = sources_text(world, parent) else {
         // The parent does not keep a bibliography, so there is nothing this
         // could usefully merge into.
         return;

--- a/crates/leviath-runtime/src/host/emit.rs
+++ b/crates/leviath-runtime/src/host/emit.rs
@@ -47,10 +47,7 @@ impl WorldHost {
             };
             let agent_id = state.agent_id.clone();
             let status = status_str(&state.status);
-            let terminal = matches!(
-                state.status,
-                AgentStatus::Complete | AgentStatus::Error { .. } | AgentStatus::Cancelled
-            );
+            let terminal = crate::pipeline::is_terminal_status(&state.status);
             let cur = {
                 let totals = self
                     .world
@@ -291,14 +288,7 @@ impl WorldHost {
         // life (the set is keyed by request id, so prune by what is still
         // pending - the same shape `cancel_tree` uses).
         if reaped_any {
-            let still_open: std::collections::HashSet<String> = self
-                .interactions
-                .pending()
-                .into_iter()
-                .map(|(_, req)| req.id)
-                .collect();
-            self.emitted_interactions
-                .retain(|id| still_open.contains(id));
+            self.prune_emitted_interactions();
         }
 
         for (agent_id, request) in self.interactions.pending() {

--- a/crates/leviath-runtime/src/host/mod.rs
+++ b/crates/leviath-runtime/src/host/mod.rs
@@ -205,6 +205,25 @@ mod listing;
 mod subagents;
 
 impl WorldHost {
+    /// Forget the emitted-interaction ids that are no longer pending.
+    ///
+    /// The hub is keyed by agent id but the emitted set is keyed by request
+    /// id, so it is pruned by what is still open. Called after a cancel and
+    /// after a reap, the two moments an interaction can stop being pending
+    /// without being answered.
+    fn prune_emitted_interactions(&mut self) {
+        let still_open: std::collections::HashSet<String> = self
+            .interactions
+            .pending()
+            .into_iter()
+            .map(|(_, req)| req.id)
+            .collect();
+        self.emitted_interactions
+            .retain(|id| still_open.contains(id));
+    }
+}
+
+impl WorldHost {
     /// Register any agent that exists in the world but is missing from the run-id
     /// map, so the host's view is the world's view.
     ///
@@ -299,10 +318,7 @@ impl WorldHost {
             None => true,
             Some(parent_ref) => match world.get::<AgentState>(parent_ref.parent_entity) {
                 None => true,
-                Some(state) => matches!(
-                    state.status,
-                    AgentStatus::Complete | AgentStatus::Error { .. } | AgentStatus::Cancelled
-                ),
+                Some(state) => crate::pipeline::is_terminal_status(&state.status),
             },
         }
     }

--- a/crates/leviath-runtime/src/host/subagents.rs
+++ b/crates/leviath-runtime/src/host/subagents.rs
@@ -267,16 +267,7 @@ impl WorldHost {
             cancelled |= self.world.cancel(self.world.own_agent(e));
             if let Some(agent_id) = agent_id {
                 self.interactions.cancel_for_agent(&agent_id);
-                // The hub is keyed by agent id but the emitted-interaction set is
-                // keyed by request id, so drop the ids that are no longer pending.
-                let still_open: HashSet<String> = self
-                    .interactions
-                    .pending()
-                    .into_iter()
-                    .map(|(_, req)| req.id)
-                    .collect();
-                self.emitted_interactions
-                    .retain(|id| still_open.contains(id));
+                self.prune_emitted_interactions();
             }
         }
         cancelled

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -25,7 +25,7 @@
 //! model* across every agent in the world.
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::{AcquireError, Notify, OwnedSemaphorePermit, Semaphore};
 
@@ -248,10 +248,7 @@ impl InferencePools {
     /// This is what makes "the pool is full and has been for hours" observable
     /// rather than inferred.
     pub fn occupancy(&self) -> Vec<PoolOccupancy> {
-        let map = self
-            .semaphores
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let map = leviath_core::sync::lock(&self.semaphores);
         let mut out: Vec<PoolOccupancy> = map
             .iter()
             .map(|(model, semaphore)| {
@@ -279,10 +276,7 @@ impl InferencePools {
     /// and "waiting on nothing" is the one shape this reporting exists to
     /// prevent.
     pub fn provider_occupancy(&self) -> Vec<ProviderPoolOccupancy> {
-        let map = self
-            .provider_semaphores
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let map = leviath_core::sync::lock(&self.provider_semaphores);
         let mut out: Vec<ProviderPoolOccupancy> = map
             .iter()
             .map(|(provider, (cap, semaphore))| ProviderPoolOccupancy {
@@ -299,10 +293,7 @@ impl InferencePools {
     /// or `None` when that provider has no configured cap.
     fn provider_semaphore_for(&self, provider: &str) -> Option<Arc<Semaphore>> {
         let permits = self.config.provider_limit_for(provider)?;
-        let mut map = self
-            .provider_semaphores
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let mut map = leviath_core::sync::lock(&self.provider_semaphores);
         if let Some((_, existing)) = map.get(provider) {
             return Some(existing.clone());
         }
@@ -313,10 +304,7 @@ impl InferencePools {
 
     /// Fetch (or lazily create) the semaphore for `model`.
     fn semaphore_for(&self, model: &str) -> Arc<Semaphore> {
-        let mut map = self
-            .semaphores
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner);
+        let mut map = leviath_core::sync::lock(&self.semaphores);
         if let Some(existing) = map.get(model) {
             return existing.clone();
         }

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -20,7 +20,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, OnceLock, PoisonError};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
 use bevy_ecs::prelude::Resource;
@@ -112,17 +112,14 @@ impl InteractionHub {
     async fn submit(&self, agent_id: &str, request: InteractionRequest) -> InteractionResponse {
         let id = request.id.clone();
         let (responder, rx) = oneshot::channel();
-        self.pending
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .insert(
-                id.clone(),
-                PendingEntry {
-                    agent_id: agent_id.to_string(),
-                    request,
-                    responder,
-                },
-            );
+        leviath_core::sync::lock(&self.pending).insert(
+            id.clone(),
+            PendingEntry {
+                agent_id: agent_id.to_string(),
+                request,
+                responder,
+            },
+        );
         // Wake the driver so it ticks and reflects this open request into the
         // agent's status (Active → Waiting) for the dashboard to surface.
         self.nudge();
@@ -161,10 +158,7 @@ impl InteractionHub {
         id: &str,
         rx: &mut oneshot::Receiver<InteractionResponse>,
     ) -> InteractionResponse {
-        self.pending
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .remove(id);
+        leviath_core::sync::lock(&self.pending).remove(id);
         if let Ok(answered) = rx.try_recv() {
             return answered;
         }
@@ -182,9 +176,7 @@ impl InteractionHub {
     /// Every open request, as `(agent_id, request)` pairs, for surfacing to
     /// clients.
     pub fn pending(&self) -> Vec<(String, InteractionRequest)> {
-        self.pending
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
+        leviath_core::sync::lock(&self.pending)
             .values()
             .map(|e| (e.agent_id.clone(), e.request.clone()))
             .collect()
@@ -193,11 +185,7 @@ impl InteractionHub {
     /// Answer an open request. Returns `false` if no request with that id is
     /// open (already answered, cancelled, or never existed).
     pub fn answer(&self, response: InteractionResponse) -> bool {
-        let entry = self
-            .pending
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .remove(&response.request_id);
+        let entry = leviath_core::sync::lock(&self.pending).remove(&response.request_id);
         match entry {
             Some(entry) => {
                 // The awaiting `submit` may have gone away (agent despawned); a
@@ -216,10 +204,7 @@ impl InteractionHub {
     /// Returns `false` if no such request is open.
     pub fn cancel(&self, request_id: &str) -> bool {
         // Dropping the entry drops its responder, waking `submit` with an error.
-        let removed = self
-            .pending
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
+        let removed = leviath_core::sync::lock(&self.pending)
             .remove(request_id)
             .is_some();
         if removed {
@@ -238,7 +223,7 @@ impl InteractionHub {
     /// that no longer exists.
     pub fn cancel_for_agent(&self, agent_id: &str) -> usize {
         // Dropping each entry drops its responder, waking `submit` with an error.
-        let mut pending = self.pending.lock().unwrap_or_else(PoisonError::into_inner);
+        let mut pending = leviath_core::sync::lock(&self.pending);
         let before = pending.len();
         pending.retain(|_, entry| entry.agent_id != agent_id);
         let removed = before - pending.len();

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -229,10 +229,7 @@ pub(crate) fn reconcile_stage_ledger(
 ) {
     use leviath_core::run_meta::StageRunStatus;
     let active = crate::persistence::stage_status_from(status);
-    let run_is_over = matches!(
-        status,
-        AgentStatus::Complete | AgentStatus::Error { .. } | AgentStatus::Cancelled
-    );
+    let run_is_over = super::is_terminal_status(status);
     for rec in ledger.0.iter_mut() {
         if rec.index == cursor_index {
             rec.entered = true;

--- a/crates/leviath-runtime/src/pipeline/wedge.rs
+++ b/crates/leviath-runtime/src/pipeline/wedge.rs
@@ -188,7 +188,7 @@ pub fn fail_wedged_runs(
         // A terminal agent is the goal, not a problem, and the host reaps it. A
         // paused one is stopped because somebody stopped it, and must come back
         // with no clock already running against it.
-        if is_terminal(&state.status) || state.status == AgentStatus::Paused {
+        if super::is_terminal_status(&state.status) || state.status == AgentStatus::Paused {
             if wedged.is_some() {
                 commands.entity(entity).remove::<Wedged>();
             }
@@ -223,15 +223,6 @@ pub fn fail_wedged_runs(
         // driven into that stage instead of ending here.
         crate::pipeline::fail_stage(&mut commands, entity, &mut state, message);
     }
-}
-
-/// Whether an agent has stopped for good. Terminal agents are left to the host,
-/// which reaps them once their state has been persisted and reported.
-fn is_terminal(status: &AgentStatus) -> bool {
-    matches!(
-        status,
-        AgentStatus::Complete | AgentStatus::Error { .. } | AgentStatus::Cancelled
-    )
 }
 
 #[cfg(test)]

--- a/crates/leviath-runtime/src/script_provider.rs
+++ b/crates/leviath-runtime/src/script_provider.rs
@@ -25,7 +25,7 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex, PoisonError};
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
 use leviath_providers::rhai_provider::host::HttpExecutor;
@@ -342,17 +342,14 @@ impl ScriptProviderLayer {
         ) {
             Ok(p) => {
                 let provider: Arc<dyn Provider> = Arc::new(p);
-                self.cache
-                    .lock()
-                    .unwrap_or_else(PoisonError::into_inner)
-                    .insert(
-                        name.to_string(),
-                        Cached {
-                            mtime,
-                            config: config.clone(),
-                            provider: provider.clone(),
-                        },
-                    );
+                leviath_core::sync::lock(&self.cache).insert(
+                    name.to_string(),
+                    Cached {
+                        mtime,
+                        config: config.clone(),
+                        provider: provider.clone(),
+                    },
+                );
                 Some(provider)
             }
             Err(e) => {
@@ -372,7 +369,7 @@ impl ScriptProviderLayer {
         mtime: SystemTime,
         config: &Arc<ScriptProviderConfig>,
     ) -> Option<Arc<dyn Provider>> {
-        let cache = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
+        let cache = leviath_core::sync::lock(&self.cache);
         let cached = cache.get(name)?;
         if cached.mtime == mtime && Arc::ptr_eq(&cached.config, config) {
             Some(cached.provider.clone())
@@ -383,10 +380,7 @@ impl ScriptProviderLayer {
 
     /// Drop any cached entry for `name`.
     fn evict(&self, name: &str) {
-        self.cache
-            .lock()
-            .unwrap_or_else(PoisonError::into_inner)
-            .remove(name);
+        leviath_core::sync::lock(&self.cache).remove(name);
     }
 }
 


### PR DESCRIPTION
## What

Five internal merges in `leviath-runtime`, no public API touched:

| Was | Now |
|---|---|
| `wedge::is_terminal` plus three inline `matches!(Complete \| Error \| Cancelled)` (persist, host orphan check, host status emit) | `pipeline::is_terminal_status` everywhere |
| 24 x `.lock().unwrap_or_else(PoisonError::into_inner)` in 7 files | `leviath_core::sync::lock(&m)` (same semantics, already used elsewhere); dead `PoisonError` imports removed |
| The retain-by-pending prune in `cancel_tree` and the reaper | `WorldHost::prune_emitted_interactions` |
| Two copies of "sources region as text" in the fan-out merge, cloning every entry | `sources_text`, borrowing |
| 9 identical missing-argument guards and 2 region-kind lookups in `context_tools` | `str_arg`, `missing`, `is_hashmap_region` |

Not done from the plan's list, with reasons: `provider_creds` (the four `with_overrides(..).with_base_url(..)` arms differ by concrete provider type, so a shared helper is either a generic measured four times or four closures; no win), and the `context_window`/`block_cache` entry joins (their callees take `&[String]`, so borrowing would ripple signatures for no measured gain; Phase 4 territory). `enter_chosen_stage` stays a separate PR as planned.

## Behaviour

None changed.

## Verification

`cargo test -p leviath-runtime` 1,712 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-runtime` at 100%.
