### PR TITLE
refactor(mcp,package,telemetry,agent-client): small merges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2446,6 +2446,7 @@ name = "leviath-agent-client"
 version = "0.5.5"
 dependencies = [
  "leviath-core",
+ "leviath-tools",
  "serde",
  "serde_json",
 ]

--- a/crates/leviath-agent-client/Cargo.toml
+++ b/crates/leviath-agent-client/Cargo.toml
@@ -19,3 +19,8 @@ serde_json = { workspace = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+# The tool-name classification test checks its table against what the tool
+# crate actually ships.
+leviath-tools = { workspace = true }

--- a/crates/leviath-agent-client/src/mapping.rs
+++ b/crates/leviath-agent-client/src/mapping.rs
@@ -216,24 +216,40 @@ fn permission_title(request: &InteractionRequest) -> String {
 /// Unrecognised names - including every MCP tool, whose names are arbitrary -
 /// fall back to [`ToolKind::Other`].
 fn tool_kind_for(tool_name: Option<&str>) -> ToolKind {
-    match tool_name {
-        Some("read_file" | "read_files" | "list_files" | "grep") => ToolKind::Read,
-        // The environment tools read the host and the run rather than a file,
-        // but `Read` is the closest kind the protocol has and is what a host
-        // should show: a lookup that returns information and changes nothing.
-        Some(
-            "current_time" | "system_info" | "locale_info" | "environment_info" | "which_command"
-            | "runtime_info",
-        ) => ToolKind::Read,
-        Some("write_file" | "edit_file" | "apply_patch") => ToolKind::Edit,
-        Some("delete_file") => ToolKind::Delete,
-        Some("move_file") => ToolKind::Move,
-        Some("search" | "web_search") => ToolKind::Search,
-        Some("bash" | "run_command" | "shell") => ToolKind::Execute,
-        Some("fetch" | "web_fetch" | "http_get") => ToolKind::Fetch,
-        _ => ToolKind::Other,
-    }
+    tool_name
+        .and_then(|name| TOOL_KINDS.iter().find(|(known, _)| *known == name))
+        .map_or(ToolKind::Other, |(_, kind)| *kind)
 }
+
+/// Every built-in and bundled tool a host can be asked to approve, with the
+/// kind it should show. Nothing else belongs here: a name that no tool
+/// answers to would only ever match a third-party MCP tool by accident,
+/// and the test below holds the list to what `leviath-tools` actually ships
+/// plus the two bundled script tools.
+const TOOL_KINDS: &[(&str, ToolKind)] = &[
+    ("read_file", ToolKind::Read),
+    ("read_files", ToolKind::Read),
+    ("list_dir", ToolKind::Read),
+    // The environment tools read the host and the run rather than a file,
+    // but `Read` is the closest kind the protocol has and is what a host
+    // should show: a lookup that returns information and changes nothing.
+    ("current_time", ToolKind::Read),
+    ("system_info", ToolKind::Read),
+    ("locale_info", ToolKind::Read),
+    ("environment_info", ToolKind::Read),
+    ("which_command", ToolKind::Read),
+    ("runtime_info", ToolKind::Read),
+    ("write_file", ToolKind::Edit),
+    ("edit_file", ToolKind::Edit),
+    ("web_search", ToolKind::Search),
+    ("shell", ToolKind::Execute),
+    ("bash", ToolKind::Execute),
+    ("web_fetch", ToolKind::Fetch),
+];
+
+/// The bundled Rhai script tools, which `leviath-tools` does not list.
+#[cfg(test)]
+const SCRIPT_TOOLS: &[&str] = &["web_search", "web_fetch"];
 
 /// Whether an interaction can be answered over the protocol at all.
 ///
@@ -489,8 +505,7 @@ this trailing text is ignored";
         for (name, expected) in [
             ("read_file", ToolKind::Read),
             ("read_files", ToolKind::Read),
-            ("list_files", ToolKind::Read),
-            ("grep", ToolKind::Read),
+            ("list_dir", ToolKind::Read),
             // The environment tools read the host and the run rather than a
             // file, but a lookup that returns information and changes nothing
             // is what `Read` means to a host picking an icon.
@@ -502,22 +517,35 @@ this trailing text is ignored";
             ("runtime_info", ToolKind::Read),
             ("write_file", ToolKind::Edit),
             ("edit_file", ToolKind::Edit),
-            ("apply_patch", ToolKind::Edit),
-            ("delete_file", ToolKind::Delete),
-            ("move_file", ToolKind::Move),
-            ("search", ToolKind::Search),
             ("web_search", ToolKind::Search),
             ("bash", ToolKind::Execute),
-            ("run_command", ToolKind::Execute),
             ("shell", ToolKind::Execute),
-            ("fetch", ToolKind::Fetch),
             ("web_fetch", ToolKind::Fetch),
-            ("http_get", ToolKind::Fetch),
             ("mcp__whatever__thing", ToolKind::Other),
+            // Names that no tool answers to are not guessed at.
+            ("grep", ToolKind::Other),
+            ("delete_file", ToolKind::Other),
         ] {
             assert_eq!(tool_kind_for(Some(name)), expected, "tool {name}");
         }
         assert_eq!(tool_kind_for(None), ToolKind::Other);
+    }
+
+    /// The table names only tools that exist: everything `leviath-tools`
+    /// ships (aliases included) plus the bundled script tools. A name that
+    /// drifts from the tool crate fails here rather than silently showing
+    /// the wrong icon, or none.
+    #[test]
+    fn every_classified_tool_name_is_a_real_tool() {
+        let dir = std::env::temp_dir();
+        let shipped =
+            leviath_tools::BuiltinTools::new(leviath_tools::ToolContext::new(dir)).names();
+        for (name, _) in TOOL_KINDS {
+            assert!(
+                shipped.iter().any(|s| s == name) || SCRIPT_TOOLS.contains(name),
+                "{name} is classified but no tool answers to it"
+            );
+        }
     }
 
     // ─── is_permission_request ───────────────────────────────────────────────

--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -385,32 +385,22 @@ impl HttpTransport {
         let mut stream = response.bytes_stream();
 
         loop {
-            while let Some(event) = super::sse::parse_sse_frame(&mut buffer) {
-                if event.data.is_empty() {
-                    continue;
-                }
-                let frame: Value = serde_json::from_str(&event.data)
-                    .map_err(|e| anyhow::anyhow!("Failed to parse JSON-RPC response: {}", e))?;
-                if let Some(response) = self.handle_frame(frame, id).await? {
-                    return Ok(response);
-                }
-            }
-
-            match stream.next().await {
-                Some(Ok(chunk)) => match std::str::from_utf8(&chunk) {
-                    Ok(text) => buffer.push_str(text),
-                    Err(e) => {
-                        return Err(anyhow::anyhow!("MCP event stream is not UTF-8: {}", e));
-                    }
-                },
-                Some(Err(e)) => {
-                    return Err(anyhow::anyhow!("MCP event stream failed: {}", e));
-                }
-                None => {
-                    return Err(anyhow::anyhow!(
-                        "MCP event stream ended before answering the request"
-                    ));
-                }
+            let event =
+                next_sse_event(&mut stream, &mut buffer)
+                    .await
+                    .map_err(|end| match end {
+                        SseEnd::NotUtf8(e) => {
+                            anyhow::anyhow!("MCP event stream is not UTF-8: {}", e)
+                        }
+                        SseEnd::Failed(e) => anyhow::anyhow!("MCP event stream failed: {}", e),
+                        SseEnd::Closed => {
+                            anyhow::anyhow!("MCP event stream ended before answering the request")
+                        }
+                    })?;
+            let frame: Value = serde_json::from_str(&event.data)
+                .map_err(|e| anyhow::anyhow!("Failed to parse JSON-RPC response: {}", e))?;
+            if let Some(response) = self.handle_frame(frame, id).await? {
+                return Ok(response);
             }
         }
     }
@@ -642,40 +632,75 @@ async fn read_event_stream(response: reqwest::Response, tx: mpsc::UnboundedSende
     let mut stream = response.bytes_stream();
 
     loop {
-        while let Some(event) = super::sse::parse_sse_frame(&mut buffer) {
-            if event.data.is_empty() {
-                continue;
-            }
-            let decoded = if event.event.as_deref() == Some("endpoint") {
-                LegacyEvent::Endpoint(event.data.clone())
-            } else {
-                match serde_json::from_str(&event.data) {
-                    Ok(frame) => LegacyEvent::Frame(frame),
-                    Err(e) => {
-                        tracing::warn!(error = %e, "Discarding unparseable MCP event");
-                        continue;
-                    }
-                }
-            };
-            if tx.send(decoded).is_err() {
-                // Receiver dropped: the transport is closing.
+        let event = match next_sse_event(&mut stream, &mut buffer).await {
+            Ok(event) => event,
+            Err(SseEnd::NotUtf8(e)) => {
+                tracing::warn!(error = %e, "MCP event stream is not UTF-8");
                 return;
             }
-        }
-
-        match stream.next().await {
-            Some(Ok(chunk)) => match std::str::from_utf8(&chunk) {
-                Ok(text) => buffer.push_str(text),
-                Err(e) => {
-                    tracing::warn!(error = %e, "MCP event stream is not UTF-8");
-                    return;
-                }
-            },
-            Some(Err(e)) => {
+            Err(SseEnd::Failed(e)) => {
                 tracing::warn!(error = %e, "MCP event stream failed");
                 return;
             }
-            None => return,
+            Err(SseEnd::Closed) => return,
+        };
+        let decoded = if event.event.as_deref() == Some("endpoint") {
+            LegacyEvent::Endpoint(event.data.clone())
+        } else {
+            match serde_json::from_str(&event.data) {
+                Ok(frame) => LegacyEvent::Frame(frame),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Discarding unparseable MCP event");
+                    continue;
+                }
+            }
+        };
+        if tx.send(decoded).is_err() {
+            // Receiver dropped: the transport is closing.
+            return;
+        }
+    }
+}
+
+/// Why [`next_sse_event`] stopped delivering events.
+enum SseEnd {
+    /// A chunk was not UTF-8; SSE is text, so nothing after it can be framed.
+    NotUtf8(std::str::Utf8Error),
+    /// The HTTP body stream itself failed.
+    Failed(reqwest::Error),
+    /// The server closed the body.
+    Closed,
+}
+
+/// The next SSE event with a body, pulling bytes from `stream` into `buffer`
+/// until one is framed.
+///
+/// Keepalive frames (an event with empty data) are skipped here, so a caller
+/// only ever sees an event worth decoding. The two readers of an MCP event
+/// stream - the reply reader, which fails the request when the stream ends,
+/// and the legacy pump, which logs and stops - used to carry this loop each;
+/// what they do about an ending is theirs, how bytes become events is not.
+async fn next_sse_event<S, B>(
+    stream: &mut S,
+    buffer: &mut String,
+) -> Result<super::sse::SseEvent, SseEnd>
+where
+    S: StreamExt<Item = Result<B, reqwest::Error>> + Unpin,
+    B: AsRef<[u8]>,
+{
+    loop {
+        while let Some(event) = super::sse::parse_sse_frame(buffer) {
+            if !event.data.is_empty() {
+                return Ok(event);
+            }
+        }
+        match stream.next().await {
+            Some(Ok(chunk)) => match std::str::from_utf8(chunk.as_ref()) {
+                Ok(text) => buffer.push_str(text),
+                Err(e) => return Err(SseEnd::NotUtf8(e)),
+            },
+            Some(Err(e)) => return Err(SseEnd::Failed(e)),
+            None => return Err(SseEnd::Closed),
         }
     }
 }

--- a/crates/leviath-package/src/installer.rs
+++ b/crates/leviath-package/src/installer.rs
@@ -93,6 +93,25 @@ pub struct AgentInstaller {
     install_dir: PathBuf,
 }
 
+/// The version and description an `agent.leviath` declares, with the
+/// defaults the catalogue shows when the file is missing, unreadable or not
+/// TOML: `0.0.0` and an empty description. Three listings used to read and
+/// parse the file each with these same two lookups inline.
+fn manifest_meta(manifest_path: &Path) -> (String, String) {
+    let content = fs::read_to_string(manifest_path).unwrap_or_default();
+    let parsed: toml::Value =
+        toml::from_str(&content).unwrap_or(toml::Value::Table(toml::map::Map::new()));
+    let field = |key: &str, default: &str| -> String {
+        parsed
+            .get("agent")
+            .and_then(|a| a.get(key))
+            .and_then(|v| v.as_str())
+            .unwrap_or(default)
+            .to_string()
+    };
+    (field("version", "0.0.0"), field("description", ""))
+}
+
 impl AgentInstaller {
     /// Create a new installer using the default installation directory.
     ///
@@ -278,28 +297,7 @@ impl AgentInstaller {
             return Err(e);
         }
 
-        // Read agent.leviath to get metadata
-        let manifest_path = agent_dir.join("agent.leviath");
-        let (version, description) = if manifest_path.exists() {
-            let content = fs::read_to_string(&manifest_path).unwrap_or_default();
-            let parsed: toml::Value =
-                toml::from_str(&content).unwrap_or(toml::Value::Table(toml::map::Map::new()));
-            let version = parsed
-                .get("agent")
-                .and_then(|a| a.get("version"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("0.0.0")
-                .to_string();
-            let description = parsed
-                .get("agent")
-                .and_then(|a| a.get("description"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string();
-            (version, description)
-        } else {
-            ("0.0.0".to_string(), String::new())
-        };
+        let (version, description) = manifest_meta(&agent_dir.join("agent.leviath"));
 
         tracing::info!(
             name = %name,
@@ -354,22 +352,7 @@ impl AgentInstaller {
                         .unwrap_or("unknown")
                         .to_string();
 
-                    let content = fs::read_to_string(&manifest_path).unwrap_or_default();
-                    let parsed: toml::Value = toml::from_str(&content)
-                        .unwrap_or(toml::Value::Table(toml::map::Map::new()));
-
-                    let version = parsed
-                        .get("agent")
-                        .and_then(|a| a.get("version"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("0.0.0")
-                        .to_string();
-                    let description = parsed
-                        .get("agent")
-                        .and_then(|a| a.get("description"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string();
+                    let (version, description) = manifest_meta(&manifest_path);
 
                     agents.push(InstalledAgent {
                         name,
@@ -410,22 +393,7 @@ impl AgentInstaller {
             return None;
         }
 
-        let content = fs::read_to_string(&manifest_path).unwrap_or_default();
-        let parsed: toml::Value =
-            toml::from_str(&content).unwrap_or(toml::Value::Table(toml::map::Map::new()));
-
-        let version = parsed
-            .get("agent")
-            .and_then(|a| a.get("version"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("0.0.0")
-            .to_string();
-        let description = parsed
-            .get("agent")
-            .and_then(|a| a.get("description"))
-            .and_then(|v| v.as_str())
-            .unwrap_or("")
-            .to_string();
+        let (version, description) = manifest_meta(&manifest_path);
 
         Some(InstalledAgent {
             name: name.to_string(),

--- a/crates/leviath-telemetry/src/otel.rs
+++ b/crates/leviath-telemetry/src/otel.rs
@@ -461,7 +461,163 @@ impl OtelSink {
     }
 }
 
+impl OtelSink {
+    /// [`TelemetryEvent::RunStarted`].
+    fn run_started(
+        &self,
+        run_id: String,
+        agent_name: String,
+        model: Option<String>,
+        parent_run_id: Option<String>,
+        recovered: bool,
+        at_ms: i64,
+    ) {
+        let mut attrs = vec![
+            KeyValue::new("leviath.run.id", run_id.clone()),
+            KeyValue::new("leviath.agent.name", agent_name),
+            KeyValue::new("leviath.recovered", recovered),
+        ];
+        if let Some(model) = model {
+            attrs.push(KeyValue::new("leviath.model", model));
+        }
+        if let Some(parent) = parent_run_id {
+            attrs.push(KeyValue::new("leviath.parent_run.id", parent));
+        }
+        let span = self.start_span("agent.run", at_ms, attrs, None);
+        self.instruments.active.add(1, &[]);
+        leviath_core::sync::lock(&self.open).insert(run_id, OpenRun { span, stage: None });
+    }
+
+    /// [`TelemetryEvent::StageEntered`].
+    fn stage_entered(&self, run_id: String, stage_index: usize, stage_name: String, at_ms: i64) {
+        let mut open = leviath_core::sync::lock(&self.open);
+        let Some(run) = open.get_mut(&run_id) else {
+            return;
+        };
+        let parent = run.span.span_context().clone();
+        let span = self.start_span(
+            "agent.stage",
+            at_ms,
+            vec![
+                KeyValue::new("leviath.stage.name", stage_name),
+                KeyValue::new("leviath.stage.index", stage_index as i64),
+            ],
+            Some(&parent),
+        );
+        run.stage = Some(OpenStage {
+            index: stage_index,
+            entered_ms: at_ms,
+            span,
+        });
+    }
+
+    /// [`TelemetryEvent::StageExited`].
+    fn stage_exited(
+        &self,
+        run_id: String,
+        stage_index: usize,
+        stage_name: String,
+        prompt_tokens: usize,
+        completion_tokens: usize,
+        at_ms: i64,
+    ) {
+        let mut open = leviath_core::sync::lock(&self.open);
+        let Some(run) = open.get_mut(&run_id) else {
+            return;
+        };
+        let Some(stage) = run.stage.as_mut() else {
+            return;
+        };
+        if stage.index != stage_index {
+            return; // stale exit for a stage this sink isn't holding
+        }
+        stage
+            .span
+            .set_attribute(KeyValue::new("leviath.tokens.prompt", prompt_tokens as i64));
+        stage.span.set_attribute(KeyValue::new(
+            "leviath.tokens.completion",
+            completion_tokens as i64,
+        ));
+        let duration_s = (at_ms - stage.entered_ms).max(0) as f64 / 1000.0;
+        Self::close_stage(run, at_ms);
+        self.instruments.stage_duration.record(
+            duration_s,
+            &[KeyValue::new("leviath.stage.name", stage_name)],
+        );
+    }
+
+    /// [`TelemetryEvent::ToolCallCompleted`].
+    fn tool_call_completed(
+        &self,
+        run_id: String,
+        tool_name: String,
+        batch_latency_ms: u64,
+        success: bool,
+    ) {
+        self.instruments.tool_calls.add(
+            1,
+            &[
+                KeyValue::new("leviath.tool.name", tool_name.clone()),
+                KeyValue::new("leviath.outcome", if success { "ok" } else { "error" }),
+            ],
+        );
+        self.emit_leaf(
+            &run_id,
+            "agent.tool_call",
+            batch_latency_ms,
+            vec![
+                KeyValue::new("leviath.tool.name", tool_name),
+                KeyValue::new("leviath.success", success),
+                KeyValue::new("leviath.batch_latency_ms", batch_latency_ms as i64),
+            ],
+        );
+    }
+
+    /// [`TelemetryEvent::CompactionCompleted`].
+    fn compaction_completed(&self, run_id: String, success: bool) {
+        self.emit_leaf(
+            &run_id,
+            "agent.compaction",
+            0,
+            vec![KeyValue::new("leviath.success", success)],
+        );
+    }
+
+    /// [`TelemetryEvent::Log`].
+    fn log(&self, run_id: String, stage_index: usize, kind: LogKind, line: String) {
+        let open = leviath_core::sync::lock(&self.open);
+        let Some(run) = open.get(&run_id) else {
+            return;
+        };
+        let span_context = match run.stage.as_ref() {
+            Some(stage) => stage.span.span_context().clone(),
+            None => run.span.span_context().clone(),
+        };
+        let mut record = self.logger.create_log_record();
+        record.set_timestamp(SystemTime::now());
+        record.set_severity_number(Severity::Info);
+        record.set_body(AnyValue::from(line));
+        record.set_trace_context(
+            span_context.trace_id(),
+            span_context.span_id(),
+            Some(span_context.trace_flags()),
+        );
+        record.add_attribute("leviath.run.id", run_id);
+        record.add_attribute("leviath.stage.index", stage_index as i64);
+        record.add_attribute(
+            "leviath.log.kind",
+            match kind {
+                LogKind::Output => "output",
+                LogKind::Runtime => "runtime",
+            },
+        );
+        self.logger.emit(record);
+    }
+}
+
 impl TelemetrySink for OtelSink {
+    /// The two arms left inline carry more fields than clippy lets a
+    /// method take one by one; the rest each have a method.
     fn emit(&self, event: TelemetryEvent) {
         match event {
             TelemetryEvent::RunStarted {
@@ -471,48 +627,13 @@ impl TelemetrySink for OtelSink {
                 parent_run_id,
                 recovered,
                 at_ms,
-            } => {
-                let mut attrs = vec![
-                    KeyValue::new("leviath.run.id", run_id.clone()),
-                    KeyValue::new("leviath.agent.name", agent_name),
-                    KeyValue::new("leviath.recovered", recovered),
-                ];
-                if let Some(model) = model {
-                    attrs.push(KeyValue::new("leviath.model", model));
-                }
-                if let Some(parent) = parent_run_id {
-                    attrs.push(KeyValue::new("leviath.parent_run.id", parent));
-                }
-                let span = self.start_span("agent.run", at_ms, attrs, None);
-                self.instruments.active.add(1, &[]);
-                leviath_core::sync::lock(&self.open).insert(run_id, OpenRun { span, stage: None });
-            }
+            } => self.run_started(run_id, agent_name, model, parent_run_id, recovered, at_ms),
             TelemetryEvent::StageEntered {
                 run_id,
                 stage_index,
                 stage_name,
                 at_ms,
-            } => {
-                let mut open = leviath_core::sync::lock(&self.open);
-                let Some(run) = open.get_mut(&run_id) else {
-                    return;
-                };
-                let parent = run.span.span_context().clone();
-                let span = self.start_span(
-                    "agent.stage",
-                    at_ms,
-                    vec![
-                        KeyValue::new("leviath.stage.name", stage_name),
-                        KeyValue::new("leviath.stage.index", stage_index as i64),
-                    ],
-                    Some(&parent),
-                );
-                run.stage = Some(OpenStage {
-                    index: stage_index,
-                    entered_ms: at_ms,
-                    span,
-                });
-            }
+            } => self.stage_entered(run_id, stage_index, stage_name, at_ms),
             TelemetryEvent::StageExited {
                 run_id,
                 stage_index,
@@ -520,31 +641,14 @@ impl TelemetrySink for OtelSink {
                 prompt_tokens,
                 completion_tokens,
                 at_ms,
-            } => {
-                let mut open = leviath_core::sync::lock(&self.open);
-                let Some(run) = open.get_mut(&run_id) else {
-                    return;
-                };
-                let Some(stage) = run.stage.as_mut() else {
-                    return;
-                };
-                if stage.index != stage_index {
-                    return; // stale exit for a stage this sink isn't holding
-                }
-                stage
-                    .span
-                    .set_attribute(KeyValue::new("leviath.tokens.prompt", prompt_tokens as i64));
-                stage.span.set_attribute(KeyValue::new(
-                    "leviath.tokens.completion",
-                    completion_tokens as i64,
-                ));
-                let duration_s = (at_ms - stage.entered_ms).max(0) as f64 / 1000.0;
-                Self::close_stage(run, at_ms);
-                self.instruments.stage_duration.record(
-                    duration_s,
-                    &[KeyValue::new("leviath.stage.name", stage_name)],
-                );
-            }
+            } => self.stage_exited(
+                run_id,
+                stage_index,
+                stage_name,
+                prompt_tokens,
+                completion_tokens,
+                at_ms,
+            ),
             TelemetryEvent::InferenceCompleted {
                 run_id,
                 stage_name: _,
@@ -601,37 +705,12 @@ impl TelemetrySink for OtelSink {
                 tool_name,
                 batch_latency_ms,
                 success,
-            } => {
-                self.instruments.tool_calls.add(
-                    1,
-                    &[
-                        KeyValue::new("leviath.tool.name", tool_name.clone()),
-                        KeyValue::new("leviath.outcome", if success { "ok" } else { "error" }),
-                    ],
-                );
-                self.emit_leaf(
-                    &run_id,
-                    "agent.tool_call",
-                    batch_latency_ms,
-                    vec![
-                        KeyValue::new("leviath.tool.name", tool_name),
-                        KeyValue::new("leviath.success", success),
-                        KeyValue::new("leviath.batch_latency_ms", batch_latency_ms as i64),
-                    ],
-                );
-            }
+            } => self.tool_call_completed(run_id, tool_name, batch_latency_ms, success),
             TelemetryEvent::CompactionCompleted {
                 run_id,
                 stage_name: _,
                 success,
-            } => {
-                self.emit_leaf(
-                    &run_id,
-                    "agent.compaction",
-                    0,
-                    vec![KeyValue::new("leviath.success", success)],
-                );
-            }
+            } => self.compaction_completed(run_id, success),
             TelemetryEvent::RunCompleted {
                 run_id,
                 status,
@@ -680,35 +759,7 @@ impl TelemetrySink for OtelSink {
                 stage_index,
                 kind,
                 line,
-            } => {
-                let open = leviath_core::sync::lock(&self.open);
-                let Some(run) = open.get(&run_id) else {
-                    return;
-                };
-                let span_context = match run.stage.as_ref() {
-                    Some(stage) => stage.span.span_context().clone(),
-                    None => run.span.span_context().clone(),
-                };
-                let mut record = self.logger.create_log_record();
-                record.set_timestamp(SystemTime::now());
-                record.set_severity_number(Severity::Info);
-                record.set_body(AnyValue::from(line));
-                record.set_trace_context(
-                    span_context.trace_id(),
-                    span_context.span_id(),
-                    Some(span_context.trace_flags()),
-                );
-                record.add_attribute("leviath.run.id", run_id);
-                record.add_attribute("leviath.stage.index", stage_index as i64);
-                record.add_attribute(
-                    "leviath.log.kind",
-                    match kind {
-                        LogKind::Output => "output",
-                        LogKind::Runtime => "runtime",
-                    },
-                );
-                self.logger.emit(record);
-            }
+            } => self.log(run_id, stage_index, kind, line),
         }
     }
 


### PR DESCRIPTION
## What

One merge per crate:

| Crate | Was | Now |
|---|---|---|
| `leviath-mcp` | Two copies of the SSE byte-to-event loop (`read_sse_reply`, `read_event_stream`) | `next_sse_event(stream, buffer) -> Result<SseEvent, SseEnd>`; each caller keeps its own policy for `NotUtf8` / `Failed` / `Closed` |
| `leviath-package` | Three listings each parsing `agent.leviath` and reading `version`/`description` inline | `manifest_meta(path) -> (version, description)` with the same defaults |
| `leviath-telemetry` | A 230-line `emit` match | Six per-event methods; `InferenceCompleted` and `RunCompleted` stay inline (10 and 8 fields, clippy's limit is 7) |
| `leviath-agent-client` | A `match` of tool names, nine of which no tool answers to, and missing `list_dir` | `TOOL_KINDS` table + guard test against `BuiltinTools::names()` and the bundled script tools |

## Behaviour

**Changed (agent-client only, flagged):** an ACP host now sees `list_dir` approvals classified as `Read` (it was `Other`, so no icon), and the phantom names `list_files`, `grep`, `apply_patch`, `delete_file`, `move_file`, `search`, `run_command`, `fetch`, `http_get` fall to `Other` like every other unknown tool. They could only ever have matched a third-party MCP tool by coincidence of name. The new test `every_classified_tool_name_is_a_real_tool` fails on the old list (dev-dep on `leviath-tools`).

Everything else is unchanged: same error strings, same defaults, same spans and metrics.

## Verification

`cargo test`: package 63, mcp 394, telemetry 31, agent-client 41; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package` at 100% for all four.
