### PR TITLE
refactor(core): name the run and agent directory files once

### DIFF
--- a/crates/leviath-cli/src/blueprint_edit/catalog.rs
+++ b/crates/leviath-cli/src/blueprint_edit/catalog.rs
@@ -82,7 +82,10 @@ pub fn discover(agents_dir: &Path, cwd: &Path, config: &Config) -> Vec<CatalogEn
         .map(|a| {
             let path = PathBuf::from(&a.path);
             let (dir, manifest_path) = if path.is_dir() {
-                (path.clone(), path.join("agent.leviath"))
+                (
+                    path.clone(),
+                    path.join(leviath_core::files::MANIFEST_FILENAME),
+                )
             } else {
                 (
                     path.parent().map(Path::to_path_buf).unwrap_or_default(),
@@ -149,7 +152,7 @@ pub fn bundled_manifest(agent: &BundledAgent) -> &'static str {
     agent
         .files
         .iter()
-        .find(|(rel, _)| *rel == "agent.leviath")
+        .find(|(rel, _)| *rel == leviath_core::files::MANIFEST_FILENAME)
         .map(|(_, text)| *text)
         .expect("every bundled agent has a manifest")
 }
@@ -159,7 +162,7 @@ pub fn bundled_manifest(agent: &BundledAgent) -> &'static str {
 pub fn write_agent(agents_dir: &Path, name: &str, manifest: &str) -> std::io::Result<PathBuf> {
     let dir = agents_dir.join(name);
     std::fs::create_dir_all(&dir)?;
-    std::fs::write(dir.join("agent.leviath"), manifest)?;
+    std::fs::write(dir.join(leviath_core::files::MANIFEST_FILENAME), manifest)?;
     Ok(dir)
 }
 
@@ -171,7 +174,11 @@ pub fn copy_bundled_extras(
     from: &BundledAgent,
 ) -> std::io::Result<()> {
     let dir = agents_dir.join(name);
-    for (rel, contents) in from.files.iter().filter(|(rel, _)| *rel != "agent.leviath") {
+    for (rel, contents) in from
+        .files
+        .iter()
+        .filter(|(rel, _)| *rel != leviath_core::files::MANIFEST_FILENAME)
+    {
         let path = dir.join(rel);
         // A joined path always has a parent.
         std::fs::create_dir_all(path.parent().unwrap_or(&dir))?;
@@ -206,7 +213,7 @@ pub fn rename_agent_with(
     if new.exists() {
         return Err(format!("An agent named {to} already exists."));
     }
-    let manifest_path = old.join("agent.leviath");
+    let manifest_path = old.join(leviath_core::files::MANIFEST_FILENAME);
     let text = std::fs::read_to_string(&manifest_path)
         .map_err(|e| format!("Could not read {}: {e}", manifest_path.display()))?;
     let mut doc = super::ManifestDoc::parse(&text).map_err(|e| e.to_string())?;

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -68,7 +68,12 @@ impl AgentAction {
 /// instead of refusing to plan. An unreadable manifest is exactly the state a
 /// half-finished copy leaves behind.
 pub fn installed_version(agents_dir: &Path, name: &str) -> Option<String> {
-    let manifest = std::fs::read_to_string(agents_dir.join(name).join("agent.leviath")).ok()?;
+    let manifest = std::fs::read_to_string(
+        agents_dir
+            .join(name)
+            .join(leviath_core::files::MANIFEST_FILENAME),
+    )
+    .ok()?;
     leviath_core::manifest::parse_manifest(&manifest)
         .ok()
         .map(|bp| bp.version)

--- a/crates/leviath-cli/src/commands/add.rs
+++ b/crates/leviath-cli/src/commands/add.rs
@@ -268,7 +268,9 @@ fn collect_seed_commands(value: &toml::Value) -> Vec<String> {
 
 /// Print the capability inventory for a freshly installed agent, if it has one.
 fn print_capabilities(name: &str, install_dir: &Path, config: Option<&crate::config::Config>) {
-    let manifest = std::fs::read_to_string(install_dir.join("agent.leviath")).unwrap_or_default();
+    let manifest =
+        std::fs::read_to_string(install_dir.join(leviath_core::files::MANIFEST_FILENAME))
+            .unwrap_or_default();
     let scripts = script_tool_names(install_dir);
     let report = read_path_report(&manifest, config);
     let findings = describe_capabilities(&manifest, &scripts, report.as_ref());
@@ -326,7 +328,7 @@ fn install_from_dir(
     agents_dir: &Path,
     config: Option<&crate::config::Config>,
 ) -> anyhow::Result<()> {
-    let manifest_path = src.join("agent.leviath");
+    let manifest_path = src.join(leviath_core::files::MANIFEST_FILENAME);
     if !manifest_path.exists() {
         anyhow::bail!(
             "No agent.leviath found in '{}'. Is this an agent directory?",
@@ -653,7 +655,7 @@ mod capability_tests {
         crate::test_support::with_tracing(|| {
             let dir = tempfile::tempdir().unwrap();
             std::fs::write(
-                dir.path().join("agent.leviath"),
+                dir.path().join(leviath_core::files::MANIFEST_FILENAME),
                 "[agent]\nname = \"q\"\n\n[tool_permissions]\nshell = \"allow\"\n",
             )
             .unwrap();
@@ -665,7 +667,7 @@ mod capability_tests {
             // And the quiet path: a plain agent prints nothing.
             let plain = tempfile::tempdir().unwrap();
             std::fs::write(
-                plain.path().join("agent.leviath"),
+                plain.path().join(leviath_core::files::MANIFEST_FILENAME),
                 "[agent]\nname = \"p\"\n\n[stages.main]\nsystem_prompt = \"p\"\n",
             )
             .unwrap();

--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -819,7 +819,7 @@ fn read_run_status(runs_dir: &std::path::Path, run_id: &str) -> Option<RunStatus
     struct StatusOnly {
         status: RunStatus,
     }
-    let path = runs_dir.join(run_id).join("meta.json");
+    let path = runs_dir.join(run_id).join(leviath_core::files::META_FILE);
     let json = std::fs::read_to_string(path).ok()?;
     serde_json::from_str::<StatusOnly>(&json)
         .ok()

--- a/crates/leviath-cli/src/commands/create.rs
+++ b/crates/leviath-cli/src/commands/create.rs
@@ -47,7 +47,10 @@ fn execute_with(
     fs::create_dir_all(blueprint_dir)?;
 
     let manifest = create_manifest(&args.name, &args.template);
-    write_file(&blueprint_dir.join("agent.leviath"), manifest.as_bytes())?;
+    write_file(
+        &blueprint_dir.join(leviath_core::files::MANIFEST_FILENAME),
+        manifest.as_bytes(),
+    )?;
 
     let gitignore_content = ".env\n*.leviath-bundle\n.leviath/\n";
     write_file(

--- a/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
+++ b/crates/leviath-cli/src/commands/dashboard/agents/editor.rs
@@ -483,7 +483,7 @@ impl Dashboard {
         }
         let name = self.editor().name.clone();
         let written = std::fs::create_dir_all(&dir)
-            .and_then(|()| std::fs::write(dir.join("agent.leviath"), &text));
+            .and_then(|()| std::fs::write(dir.join(leviath_core::files::MANIFEST_FILENAME), &text));
         if let Err(e) = written {
             self.editor().message = Some(format!("Could not write {}: {e}", dir.display()));
             return;
@@ -495,7 +495,10 @@ impl Dashboard {
             let _ = editor.layout.save();
             editor.dirty = false;
             editor.is_new = false;
-            editor.message = Some(format!("Saved to {}", dir.join("agent.leviath").display()));
+            editor.message = Some(format!(
+                "Saved to {}",
+                dir.join(leviath_core::files::MANIFEST_FILENAME).display()
+            ));
         }
         self.refresh_catalog();
         self.toast(format!("Saved {name}"), ToastLevel::Info);
@@ -538,7 +541,7 @@ impl Dashboard {
         // An agent never saved leaves nothing behind (its scripts were
         // materialised for the lint's sake).
         if let Some(dir) = unsaved_dir
-            && !dir.join("agent.leviath").exists()
+            && !dir.join(leviath_core::files::MANIFEST_FILENAME).exists()
         {
             let _ = std::fs::remove_dir_all(&dir);
         }

--- a/crates/leviath-cli/src/commands/dashboard/graph.rs
+++ b/crates/leviath-cli/src/commands/dashboard/graph.rs
@@ -10,10 +10,13 @@ use crate::tui::flowgraph::StageGraph;
 /// `None` when the manifest cannot be read or parsed.
 pub(super) fn load_stage_graph(agent_path: &str) -> Option<Arc<StageGraph>> {
     let path = std::path::Path::new(agent_path);
-    let manifest_path = if path.file_name().is_some_and(|f| f == "agent.leviath") {
+    let manifest_path = if path
+        .file_name()
+        .is_some_and(|f| f == leviath_core::files::MANIFEST_FILENAME)
+    {
         path.to_path_buf()
     } else {
-        path.join("agent.leviath")
+        path.join(leviath_core::files::MANIFEST_FILENAME)
     };
     let content = std::fs::read_to_string(&manifest_path).ok()?;
     let blueprint = leviath_core::manifest::parse_manifest(&content).ok()?;
@@ -31,7 +34,7 @@ pub(super) fn bundled_stage_graph(name: &str) -> Option<Arc<StageGraph>> {
     let content = agent
         .files
         .iter()
-        .find(|(path, _)| *path == "agent.leviath")
+        .find(|(path, _)| *path == leviath_core::files::MANIFEST_FILENAME)
         .map(|(_, content)| *content)
         .unwrap_or_default();
     leviath_core::manifest::parse_manifest(content)

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -608,7 +608,8 @@ impl Dashboard {
                 ),
                 StageContentMode::Context => {
                     let json = std::fs::read_to_string(
-                        runstate::stage_dir(&agent.id, self.selected_stage).join("context.json"),
+                        runstate::stage_dir(&agent.id, self.selected_stage)
+                            .join(leviath_core::files::CONTEXT_FILE),
                     )
                     .unwrap_or_default();
                     (json, "Context JSON")

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -436,7 +436,7 @@ impl Dashboard {
                 let file_name = match self.stage_content_mode {
                     StageContentMode::Output => "output.log",
                     StageContentMode::Logs => "logs.log",
-                    StageContentMode::Context => "context.json",
+                    StageContentMode::Context => leviath_core::files::CONTEXT_FILE,
                 };
                 runstate::stage_dir(&agent.id, self.selected_stage)
                     .join(file_name)

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -658,7 +658,7 @@ fn stage_canary(
 ) -> std::io::Result<std::path::PathBuf> {
     let agent_dir = root.join("doctor");
     std::fs::create_dir_all(&agent_dir)?;
-    let manifest = agent_dir.join("agent.leviath");
+    let manifest = agent_dir.join(leviath_core::files::MANIFEST_FILENAME);
     std::fs::write(&manifest, canary_manifest(provider, model))?;
     Ok(manifest)
 }

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -126,7 +126,7 @@ fn scan_directory_for_agents(dir: &Path, config: &Config, cwd: &Path) -> Vec<(Pa
     }
 
     // Check if this directory itself has an agent.leviath
-    let direct_manifest = dir.join("agent.leviath");
+    let direct_manifest = dir.join(leviath_core::files::MANIFEST_FILENAME);
     if direct_manifest.exists()
         && let Some(info) = read_agent_info(&direct_manifest, config, cwd)
     {
@@ -138,7 +138,7 @@ fn scan_directory_for_agents(dir: &Path, config: &Config, cwd: &Path) -> Vec<(Pa
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
-                let manifest_path = path.join("agent.leviath");
+                let manifest_path = path.join(leviath_core::files::MANIFEST_FILENAME);
                 if manifest_path.exists()
                     && let Some(info) = read_agent_info(&manifest_path, config, cwd)
                 {
@@ -222,7 +222,11 @@ pub(crate) fn build_list_report(
         };
     }
     let installed = scan_directory_for_agents(agents_dir, config, cwd);
-    let local = read_agent_info(&cwd.join("agent.leviath"), config, cwd);
+    let local = read_agent_info(
+        &cwd.join(leviath_core::files::MANIFEST_FILENAME),
+        config,
+        cwd,
+    );
     let configured: Vec<(PathBuf, AgentInfo)> = config
         .agent_paths
         .iter()
@@ -243,7 +247,10 @@ pub(crate) fn build_list_report(
         agents.push(ListedAgent {
             info,
             source: "local",
-            path: cwd.join("agent.leviath").display().to_string(),
+            path: cwd
+                .join(leviath_core::files::MANIFEST_FILENAME)
+                .display()
+                .to_string(),
         });
     }
 
@@ -299,7 +306,7 @@ fn print_agent_listing(
     }
 
     // 2. Local (current directory)
-    let local_manifest = cwd.join("agent.leviath");
+    let local_manifest = cwd.join(leviath_core::files::MANIFEST_FILENAME);
     if filter.shows_agents()
         && local_manifest.exists()
         && let Some(info) = read_agent_info(&local_manifest, config, cwd)

--- a/crates/leviath-cli/src/commands/pack.rs
+++ b/crates/leviath-cli/src/commands/pack.rs
@@ -107,19 +107,20 @@ fn find_manifest(project_path: &Path) -> anyhow::Result<PathBuf> {
 
 fn find_manifest_with_cwd(project_path: &Path, cwd: &Path) -> anyhow::Result<PathBuf> {
     if project_path.is_file()
-        && project_path.file_name() == Some(std::ffi::OsStr::new("agent.leviath"))
+        && project_path.file_name()
+            == Some(std::ffi::OsStr::new(leviath_core::files::MANIFEST_FILENAME))
     {
         return Ok(project_path.to_path_buf());
     }
 
     if project_path.is_dir() {
-        let manifest = project_path.join("agent.leviath");
+        let manifest = project_path.join(leviath_core::files::MANIFEST_FILENAME);
         if manifest.exists() {
             return Ok(manifest);
         }
     }
 
-    let current_manifest = cwd.join("agent.leviath");
+    let current_manifest = cwd.join(leviath_core::files::MANIFEST_FILENAME);
     if current_manifest.exists() {
         return Ok(current_manifest);
     }

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -16,13 +16,15 @@ pub fn find_manifest(path: &str) -> anyhow::Result<PathBuf> {
     let p = Path::new(path);
 
     // 1. Explicit agent.leviath file
-    if p.is_file() && p.file_name() == Some(std::ffi::OsStr::new("agent.leviath")) {
+    if p.is_file()
+        && p.file_name() == Some(std::ffi::OsStr::new(leviath_core::files::MANIFEST_FILENAME))
+    {
         return Ok(p.to_path_buf());
     }
 
     // 2. Directory with agent.leviath inside
     if p.is_dir() {
-        let manifest = p.join("agent.leviath");
+        let manifest = p.join(leviath_core::files::MANIFEST_FILENAME);
         if manifest.exists() {
             return Ok(manifest);
         }
@@ -32,14 +34,14 @@ pub fn find_manifest(path: &str) -> anyhow::Result<PathBuf> {
     //    through the shared LEVIATH_HOME-aware helper, so `lev run <name>`
     //    finds the same install tree `lev add` writes when the override is set.
     if let Some(installed) = leviath_core::paths::agents_dir()
-        .map(|d| d.join(path).join("agent.leviath"))
+        .map(|d| d.join(path).join(leviath_core::files::MANIFEST_FILENAME))
         .filter(|p| p.exists())
     {
         return Ok(installed);
     }
 
     // 4. agent.leviath in current directory (for `lev run` with no path)
-    let current_manifest = PathBuf::from("agent.leviath");
+    let current_manifest = PathBuf::from(leviath_core::files::MANIFEST_FILENAME);
     if current_manifest.exists() {
         return Ok(current_manifest);
     }

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -58,7 +58,7 @@ pub(super) async fn spawn_agent(
                 format!("Blueprint '{}' not found", body.blueprint),
             )
         })?;
-    let manifest_path = PathBuf::from(&bp_info.path).join("agent.leviath");
+    let manifest_path = PathBuf::from(&bp_info.path).join(leviath_core::files::MANIFEST_FILENAME);
 
     let workdir = body.workdir.clone().unwrap_or_else(|| {
         std::env::current_dir()

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -98,7 +98,7 @@ pub(super) fn discover_blueprints(config: &crate::config::Config) -> Vec<Bluepri
             continue;
         }
         // Check dir itself
-        let manifest = dir.join("agent.leviath");
+        let manifest = dir.join(leviath_core::files::MANIFEST_FILENAME);
         if manifest.exists() {
             results.extend(read_blueprint_info(&manifest, &dir));
         }
@@ -115,7 +115,7 @@ pub(super) fn discover_blueprints(config: &crate::config::Config) -> Vec<Bluepri
             .collect();
         subdirs.sort();
         for p in subdirs {
-            let m = p.join("agent.leviath");
+            let m = p.join(leviath_core::files::MANIFEST_FILENAME);
             if m.exists() {
                 results.extend(read_blueprint_info(&m, &p));
             }
@@ -378,7 +378,7 @@ pub(super) async fn create_blueprint(
         )
     })?;
 
-    let manifest_path = dir.join("agent.leviath");
+    let manifest_path = dir.join(leviath_core::files::MANIFEST_FILENAME);
     std::fs::write(&manifest_path, &body.manifest).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -414,7 +414,7 @@ pub(super) async fn update_blueprint(
     })?;
 
     let dir = blueprint_dir(&name)?;
-    let manifest_path = dir.join("agent.leviath");
+    let manifest_path = dir.join(leviath_core::files::MANIFEST_FILENAME);
     if !manifest_path.exists() {
         return Err((
             StatusCode::NOT_FOUND,
@@ -560,7 +560,11 @@ system_prompt = "do it"
             let name = format!("{FIXTURE_PREFIX}{name}");
             let sub = dir.path().join(&name);
             std::fs::create_dir_all(&sub).unwrap();
-            std::fs::write(sub.join("agent.leviath"), manifest(&name, description)).unwrap();
+            std::fs::write(
+                sub.join(leviath_core::files::MANIFEST_FILENAME),
+                manifest(&name, description),
+            )
+            .unwrap();
         }
         dir
     }

--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -570,8 +570,14 @@ fn matches_query(meta: &RunMeta, q: &str, sources: &[Source]) -> bool {
             .modified_files
             .iter()
             .any(|path| search::find_ignore_ascii_case(path, q).is_some()),
-        Source::Context => scan_file(&runstate::run_dir(&meta.run_id).join("context.json"), q),
-        Source::Journal => scan_file(&runstate::run_dir(&meta.run_id).join("run.lvr"), q),
+        Source::Context => scan_file(
+            &runstate::run_dir(&meta.run_id).join(leviath_core::files::CONTEXT_FILE),
+            q,
+        ),
+        Source::Journal => scan_file(
+            &runstate::run_dir(&meta.run_id).join(leviath_core::files::ARCHIVE_FILE),
+            q,
+        ),
         Source::Logs => stage_indices(&meta.run_id).iter().any(|idx| {
             let output = runstate::tail_stage_output(&meta.run_id, *idx, SEARCH_LOG_TAIL_BYTES);
             let operational = runstate::tail_stage_log(&meta.run_id, *idx, SEARCH_LOG_TAIL_BYTES);

--- a/crates/leviath-cli/src/commands/serve/scripts.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts.rs
@@ -627,7 +627,7 @@ fn collect_providers(dir: &Path, out: &mut Vec<ScriptItem>) {
 /// the blueprint routes are where a broken manifest is reported, and a script
 /// listing that failed outright would take the tools down with it.
 fn collect_declared(dir: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
-    let Ok(text) = std::fs::read_to_string(dir.join("agent.leviath")) else {
+    let Ok(text) = std::fs::read_to_string(dir.join(leviath_core::files::MANIFEST_FILENAME)) else {
         return;
     };
     let Ok(bp) = leviath_core::manifest::parse_manifest(&text) else {

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -157,7 +157,7 @@ async fn execute_with_registry(
     let project_path = Path::new(&path);
 
     // Verify agent.leviath exists
-    let manifest_path = project_path.join("agent.leviath");
+    let manifest_path = project_path.join(leviath_core::files::MANIFEST_FILENAME);
     if !manifest_path.exists() {
         anyhow::bail!(
             "No agent.leviath found in '{}'. Not an agent project.",

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -239,7 +239,7 @@ fn manifest_path_for(path: &std::path::Path) -> std::path::PathBuf {
     if path.is_file() {
         path.to_path_buf()
     } else {
-        path.join("agent.leviath")
+        path.join(leviath_core::files::MANIFEST_FILENAME)
     }
 }
 

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -231,7 +231,7 @@ fn discover_worker(agents_dir: Option<&Path>, query: &str) -> Result<PathBuf, St
         std::fs::read_dir(dir).map_err(|e| format!("read agents dir '{}': {e}", dir.display()))?;
     for entry in entries.flatten() {
         let path = entry.path();
-        let manifest = path.join("agent.leviath");
+        let manifest = path.join(leviath_core::files::MANIFEST_FILENAME);
         if !manifest.is_file() {
             continue;
         }

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -411,7 +411,9 @@ impl McpPool {
         };
         let mut paths: Vec<String> = Vec::new();
         for entry in entries.flatten() {
-            let Ok(text) = std::fs::read_to_string(entry.path().join("meta.json")) else {
+            let Ok(text) =
+                std::fs::read_to_string(entry.path().join(leviath_core::files::META_FILE))
+            else {
                 continue;
             };
             let Ok(meta) = serde_json::from_str::<leviath_core::run_meta::RunMeta>(&text) else {

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -72,7 +72,7 @@ pub fn reload_persisted_agents(
         .filter_map(|dir_entry| {
             let run_dir = dir_entry.path();
             let meta = read_meta(&run_dir)?; // no meta.json, or unreadable/unparseable
-            let parked_on_fanout = run_dir.join("fanout.json").exists();
+            let parked_on_fanout = run_dir.join(leviath_core::files::FANOUT_FILE).exists();
             Some((meta, parked_on_fanout))
         })
         .collect();
@@ -134,7 +134,9 @@ fn restore_fan_outs(world: &mut PipelineWorld, reloaded: &[(RunMeta, Entity)], r
         .map(|(m, e)| (m.run_id.as_str(), *e))
         .collect();
     for (meta, entity) in reloaded {
-        let path = runs_dir.join(&meta.run_id).join("fanout.json");
+        let path = runs_dir
+            .join(&meta.run_id)
+            .join(leviath_core::files::FANOUT_FILE);
         let Some(state) = std::fs::read_to_string(&path)
             .ok()
             .and_then(|s| serde_json::from_str::<leviath_runtime::fanout::FanOutState>(&s).ok())
@@ -343,7 +345,7 @@ fn reload_one(
     // `{meta, context}`. Fall back to the separate JSON files only for runs written
     // before the archive existed, or an archive that couldn't be read at all - that
     // pair may be one tick out of sync, but it's the pre-existing behavior.
-    let folded = std::fs::read(run_dir.join("run.lvr"))
+    let folded = std::fs::read(run_dir.join(leviath_core::files::ARCHIVE_FILE))
         .ok()
         .and_then(|bytes| run_archive::read_archive_lenient(&mut bytes.as_slice()).ok())
         .and_then(|(_version, records)| run_archive::fold(&records));
@@ -359,7 +361,7 @@ fn reload_one(
             )
         }
         None => {
-            let snapshot = std::fs::read_to_string(run_dir.join("context.json"))
+            let snapshot = std::fs::read_to_string(run_dir.join(leviath_core::files::CONTEXT_FILE))
                 .ok()
                 .and_then(|s| serde_json::from_str::<ContextSnapshot>(&s).ok())
                 .unwrap_or_else(|| ContextSnapshot {
@@ -511,9 +513,10 @@ fn reload_one(
     // `Active` + `ReadyToInfer` restore - so the open prompt survives the restart
     // instead of being dropped and re-inferred (issue #38). A missing/malformed
     // sidecar, or a blueprint that no longer matches, leaves the default restore.
-    if let Some(state) = std::fs::read_to_string(run_dir.join("interactions.json"))
-        .ok()
-        .and_then(|s| serde_json::from_str::<InteractionPointState>(&s).ok())
+    if let Some(state) =
+        std::fs::read_to_string(run_dir.join(leviath_core::files::INTERACTIONS_FILE))
+            .ok()
+            .and_then(|s| serde_json::from_str::<InteractionPointState>(&s).ok())
     {
         // Built against this world's ECS a few lines above, so it is ours.
         let agent = world.own_agent(entity);

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -79,12 +79,12 @@ fn write_private_atomic(path: &std::path::Path, body: &str) -> anyhow::Result<()
 fn write_context_snapshot_to(dir: &std::path::Path, snap: &ContextSnapshot) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(snap)
         .expect("infallible: ContextSnapshot always serializes to JSON");
-    write_private_atomic(&dir.join("context.json"), &json)
+    write_private_atomic(&dir.join(leviath_core::files::CONTEXT_FILE), &json)
 }
 
 /// Read the context snapshot for a run, if present.
 pub fn read_context_snapshot(run_id: &str) -> Option<ContextSnapshot> {
-    let path = run_dir(run_id).join("context.json");
+    let path = run_dir(run_id).join(leviath_core::files::CONTEXT_FILE);
     let json = std::fs::read_to_string(&path).ok()?;
     serde_json::from_str(&json).ok()
 }
@@ -165,7 +165,7 @@ impl<T> StatCache<T> {
 /// a mature run's journal is tens of MB, and parsing it whole per request was
 /// the API's single largest transient allocation.
 pub fn read_run_archive(run_id: &str) -> Option<Vec<leviath_core::run_archive::RunRecord>> {
-    let path = run_dir(run_id).join("run.lvr");
+    let path = run_dir(run_id).join(leviath_core::files::ARCHIVE_FILE);
     let bytes = std::fs::read(&path).ok()?;
     // Lenient, not strict: this reads an archive some other build may have
     // written, so a record kind added later must be stepped over rather than
@@ -183,7 +183,7 @@ pub fn visit_run_records(
     run_id: &str,
     visit: &mut dyn FnMut(&leviath_core::run_archive::RunRecord) -> std::ops::ControlFlow<()>,
 ) -> Option<()> {
-    let path = run_dir(run_id).join("run.lvr");
+    let path = run_dir(run_id).join(leviath_core::files::ARCHIVE_FILE);
     let file = std::fs::File::open(&path).ok()?;
     let mut reader = std::io::BufReader::with_capacity(64 * 1024, file);
     leviath_core::run_archive::read_archive_start(&mut reader).ok()?;
@@ -211,7 +211,7 @@ pub fn visit_run_archive(
     run_id: &str,
     visit: &mut dyn FnMut(leviath_core::run_archive::PointRef<'_>) -> std::ops::ControlFlow<()>,
 ) -> Option<()> {
-    let path = run_dir(run_id).join("run.lvr");
+    let path = run_dir(run_id).join(leviath_core::files::ARCHIVE_FILE);
     let file = std::fs::File::open(&path).ok()?;
     let mut reader = std::io::BufReader::with_capacity(64 * 1024, file);
     leviath_core::run_archive::visit_archive_points(&mut reader, visit).ok()
@@ -444,7 +444,7 @@ pub fn write_meta(meta: &RunMeta) -> anyhow::Result<()> {
 pub(crate) fn write_meta_to(dir: &std::path::Path, meta: &RunMeta) -> anyhow::Result<()> {
     let json =
         serde_json::to_string_pretty(meta).expect("infallible: RunMeta always serializes to JSON");
-    write_private_atomic(&dir.join("meta.json"), &json)
+    write_private_atomic(&dir.join(leviath_core::files::META_FILE), &json)
 }
 
 /// Read run metadata for a given run ID.
@@ -672,7 +672,7 @@ fn force_terminal_in(
 /// Read run metadata out of an explicit run directory (the daemon works from its
 /// own configured `runs_dir` rather than the home-resolved one).
 pub(crate) fn read_meta_from(dir: &std::path::Path) -> anyhow::Result<RunMeta> {
-    let path = dir.join("meta.json");
+    let path = dir.join(leviath_core::files::META_FILE);
     let json = std::fs::read_to_string(&path)?;
     Ok(serde_json::from_str(&json)?)
 }
@@ -688,7 +688,7 @@ fn list_runs_in_dir(dir: PathBuf) -> Vec<RunMeta> {
 
     if let Ok(entries) = std::fs::read_dir(&dir) {
         for entry in entries.filter_map(|e| e.ok()) {
-            let meta_path = entry.path().join("meta.json");
+            let meta_path = entry.path().join(leviath_core::files::META_FILE);
             if let Ok(json) = std::fs::read_to_string(&meta_path)
                 && let Ok(meta) = serde_json::from_str::<RunMeta>(&json)
             {
@@ -799,7 +799,7 @@ pub fn list_runs_cached(cache: &mut StatCache<RunMeta>) -> Vec<Arc<RunMeta>> {
     if let Ok(entries) = std::fs::read_dir(&dir) {
         for entry in entries.filter_map(|e| e.ok()) {
             live_dirs.insert(entry.path());
-            let meta_path = entry.path().join("meta.json");
+            let meta_path = entry.path().join(leviath_core::files::META_FILE);
             if let Some(meta) = cache.get_with(&meta_path, |json| {
                 serde_json::from_str::<RunMeta>(json).ok()
             }) {
@@ -817,7 +817,7 @@ pub fn read_stages_index_cached(
     run_id: &str,
     cache: &mut StatCache<Vec<StageRecord>>,
 ) -> Vec<StageRecord> {
-    let path = run_dir(run_id).join("stages.json");
+    let path = run_dir(run_id).join(leviath_core::files::STAGES_FILE);
     cache
         .get_with(&path, |json| serde_json::from_str(json).ok())
         .map(|records| records.as_ref().clone())
@@ -831,7 +831,7 @@ pub fn read_context_snapshot_cached(
     run_id: &str,
     cache: &mut StatCache<ContextSnapshot>,
 ) -> Option<Arc<ContextSnapshot>> {
-    let path = run_dir(run_id).join("context.json");
+    let path = run_dir(run_id).join(leviath_core::files::CONTEXT_FILE);
     cache.get_with(&path, |json| serde_json::from_str(json).ok())
 }
 
@@ -891,7 +891,7 @@ pub fn write_stages_index(run_id: &str, stages: &[StageRecord]) -> anyhow::Resul
 fn write_stages_index_to(dir: &std::path::Path, stages: &[StageRecord]) -> anyhow::Result<()> {
     let json = serde_json::to_string_pretty(&stages)
         .expect("infallible: StageRecord slice always serializes to JSON");
-    write_private_atomic(&dir.join("stages.json"), &json)
+    write_private_atomic(&dir.join(leviath_core::files::STAGES_FILE), &json)
 }
 
 /// Read the stages index for a run, or return an empty vec on any error.
@@ -904,7 +904,7 @@ pub fn read_stages_index(run_id: &str) -> Vec<StageRecord> {
 /// Restart recovery works from its configured runs directory rather than the
 /// home one, so it cannot resolve the path itself.
 pub fn read_stages_index_from(dir: &std::path::Path) -> Vec<StageRecord> {
-    let json = match std::fs::read_to_string(dir.join("stages.json")) {
+    let json = match std::fs::read_to_string(dir.join(leviath_core::files::STAGES_FILE)) {
         Ok(j) => j,
         Err(_) => return Vec::new(),
     };
@@ -959,7 +959,7 @@ pub fn write_stage_context(
 
 /// Read the context snapshot for a specific stage, if present.
 pub fn read_stage_context(run_id: &str, stage_idx: usize) -> Option<ContextSnapshot> {
-    let path = stage_dir(run_id, stage_idx).join("context.json");
+    let path = stage_dir(run_id, stage_idx).join(leviath_core::files::CONTEXT_FILE);
     let json = std::fs::read_to_string(&path).ok()?;
     serde_json::from_str(&json).ok()
 }

--- a/crates/leviath-core/src/files.rs
+++ b/crates/leviath-core/src/files.rs
@@ -1,0 +1,29 @@
+//! The names of the files a run directory and an agent directory hold.
+//!
+//! One place for each name. The persistence lane writes these files, the
+//! CLI's run state reader, the recovery scan, the dashboard and the HTTP API
+//! read them back, and each of them used to spell the name out where it was
+//! used. A name that lives in one constant cannot be misspelled in one reader
+//! and quietly never match again.
+
+/// The run's metadata: status, timings, totals. Written by the persistence
+/// lane on every change and read by everything that lists runs.
+pub const META_FILE: &str = "meta.json";
+
+/// The run's latest context-window snapshot.
+pub const CONTEXT_FILE: &str = "context.json";
+
+/// The per-stage ledger: which stages ran, in what order, at what cost.
+pub const STAGES_FILE: &str = "stages.json";
+
+/// The fan-out record for a run that split into workers.
+pub const FANOUT_FILE: &str = "fanout.json";
+
+/// The interactions a paused run is waiting on.
+pub const INTERACTIONS_FILE: &str = "interactions.json";
+
+/// The run archive: the append-only journal every other file is a view of.
+pub const ARCHIVE_FILE: &str = "run.lvr";
+
+/// The blueprint manifest inside an agent directory.
+pub const MANIFEST_FILENAME: &str = "agent.leviath";

--- a/crates/leviath-core/src/lib.rs
+++ b/crates/leviath-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod config;
 pub mod credentials;
 pub mod duration;
 pub mod error;
+pub mod files;
 pub mod interaction;
 pub mod layout;
 pub mod lifecycle;

--- a/crates/leviath-package/src/bundler.rs
+++ b/crates/leviath-package/src/bundler.rs
@@ -104,7 +104,7 @@ impl AgentBundler {
         }
 
         // Verify agent.leviath exists
-        let manifest_path = project_path.join("agent.leviath");
+        let manifest_path = project_path.join(leviath_core::files::MANIFEST_FILENAME);
         if !manifest_path.exists() {
             anyhow::bail!("No agent.leviath found in '{}'", project_path.display());
         }

--- a/crates/leviath-package/src/installer.rs
+++ b/crates/leviath-package/src/installer.rs
@@ -297,7 +297,8 @@ impl AgentInstaller {
             return Err(e);
         }
 
-        let (version, description) = manifest_meta(&agent_dir.join("agent.leviath"));
+        let (version, description) =
+            manifest_meta(&agent_dir.join(leviath_core::files::MANIFEST_FILENAME));
 
         tracing::info!(
             name = %name,
@@ -344,7 +345,7 @@ impl AgentInstaller {
             let path = entry.path();
 
             if path.is_dir() {
-                let manifest_path = path.join("agent.leviath");
+                let manifest_path = path.join(leviath_core::files::MANIFEST_FILENAME);
                 if manifest_path.exists() {
                     let name = path
                         .file_name()
@@ -388,7 +389,7 @@ impl AgentInstaller {
             return None;
         }
 
-        let manifest_path = agent_dir.join("agent.leviath");
+        let manifest_path = agent_dir.join(leviath_core::files::MANIFEST_FILENAME);
         if !manifest_path.exists() {
             return None;
         }

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -348,7 +348,9 @@ async fn append_record(
     run_id: &str,
     record: &leviath_core::run_archive::RunRecord,
 ) {
-    let path = runs_dir.join(run_id).join("run.lvr");
+    let path = runs_dir
+        .join(run_id)
+        .join(leviath_core::files::ARCHIVE_FILE);
     if !tokio::fs::try_exists(&path).await.unwrap_or(false) {
         tracing::warn!(run_id = %run_id, "persistence: record append skipped, no archive yet");
         return;
@@ -447,13 +449,18 @@ async fn write_snapshot(
     let archived =
         append_run_archive(&dir, job, machine_id, world_id, prev_context, status_before).await;
     let meta_json = serde_json::to_string_pretty(&job.meta).expect("RunMeta always serializes");
-    write_bytes_atomic(&dir.join("meta.json"), meta_json.into_bytes(), &job.run_id).await;
+    write_bytes_atomic(
+        &dir.join(leviath_core::files::META_FILE),
+        meta_json.into_bytes(),
+        &job.run_id,
+    )
+    .await;
     // Compact, not pretty: the context is the largest file the lane writes and
     // every consumer parses it; pretty-printing only inflated the write (and
     // its transient allocation) by half.
     let ctx_json = serde_json::to_string(&job.context).expect("ContextSnapshot always serializes");
     write_bytes_atomic(
-        &dir.join("context.json"),
+        &dir.join(leviath_core::files::CONTEXT_FILE),
         ctx_json.into_bytes(),
         &job.run_id,
     )
@@ -493,7 +500,7 @@ async fn write_snapshot(
         let stages_json =
             serde_json::to_string_pretty(&job.stages).expect("StageRecord slice always serializes");
         write_bytes_atomic(
-            &dir.join("stages.json"),
+            &dir.join(leviath_core::files::STAGES_FILE),
             stages_json.into_bytes(),
             &job.run_id,
         )
@@ -519,7 +526,7 @@ async fn write_snapshot(
     }
     // Fan-out waiting state (whole-file), or remove any stale file once the
     // parent is no longer parked on a fan-out.
-    let fanout_path = dir.join("fanout.json");
+    let fanout_path = dir.join(leviath_core::files::FANOUT_FILE);
     match &job.fanout {
         Some(json) => {
             write_bytes_atomic(&fanout_path, json.clone().into_bytes(), &job.run_id).await
@@ -530,7 +537,7 @@ async fn write_snapshot(
     }
     // Interaction-point waiting state (whole-file), or remove any stale file once the
     // agent is no longer parked at a stage-boundary interaction point.
-    let interactions_path = dir.join("interactions.json");
+    let interactions_path = dir.join(leviath_core::files::INTERACTIONS_FILE);
     match &job.interactions {
         Some(json) => {
             write_bytes_atomic(&interactions_path, json.clone().into_bytes(), &job.run_id).await
@@ -568,7 +575,7 @@ async fn append_run_archive(
 ) -> bool {
     use leviath_core::run_archive::{RunIdentity, RunRecord};
 
-    let path = dir.join("run.lvr");
+    let path = dir.join(leviath_core::files::ARCHIVE_FILE);
     let file_exists = tokio::fs::try_exists(&path).await.unwrap_or(false);
     let at = job.meta.updated_at;
 


### PR DESCRIPTION
## What

`leviath_core::files` names the seven files a run directory and an agent directory are made of (`META_FILE`, `CONTEXT_FILE`, `STAGES_FILE`, `FANOUT_FILE`, `INTERACTIONS_FILE`, `ARCHIVE_FILE`, `MANIFEST_FILENAME`). 77 production sites across 26 files in `leviath-cli`, `leviath-runtime` and `leviath-package` use them instead of the literal.

Scope kept deliberately narrow:
- Production code only. Tests keep their literals, because a test saying `"meta.json"` is what checks the constant still means what the on-disk format needs.
- Comments untouched.
- `leviath-sys` keeps its two `run.lvr` mentions (it sits below `leviath-core`).
- The plan's `leviath_tools::{DENIED, ERROR}` prefixes are not done: the 68 `[error]` producers are inline messages and the only consumers are tests, so a constant would add churn with nothing reading it. The four-way tool-name agreement test is left for 5.10, where the `BUILTIN_TOOL_NAMES` list it needs is introduced (and where the `repetition.rs` list's `glob`/`grep`/`search` entries get looked at).

## Behaviour

None. Each constant has exactly the value the literal had.

## Verification

Workspace `cargo check --all-targets`; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; coverage at 100% for `leviath-cli` (4,023), `leviath-runtime` (1,712), `leviath-package` (63); `leviath-core` tests 899.
