### PR TITLE
fix(serve)!: admin-gate MCP login and test, and the billed half of doctor

### DIFF
--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -98,6 +98,12 @@ pub struct DoctorArgs {
     #[arg(long)]
     pub no_daemon: bool,
 
+    /// Stop after the resolve check: no provider call, no daemon, nothing
+    /// billed. Proves the config parses and names a model something answers
+    /// to, which is most of what goes wrong.
+    #[arg(long)]
+    pub offline: bool,
+
     /// Print the checks as JSON instead of a table.
     #[arg(long)]
     pub json: bool,
@@ -848,6 +854,23 @@ pub async fn run_checks(
      ),
     daemon: DaemonTarget<'_>,
 ) -> Vec<Check> {
+    run_checks_with(args, build_registry, daemon, tempfile::tempdir).await
+}
+
+/// [`run_checks`] with the scratch-directory factory injected.
+///
+/// The daemon check stages its canary blueprint in a fresh temp directory. A
+/// machine with no writable scratch space is a finding, not a panic, and the
+/// only way to prove that on every platform is to hand in a factory that
+/// refuses.
+pub async fn run_checks_with(
+    args: &DoctorArgs,
+    build_registry: &(
+         dyn Fn(&Config) -> Result<ProviderRegistry, leviath_providers::ProviderError> + Sync
+     ),
+    daemon: DaemonTarget<'_>,
+    scratch: fn() -> std::io::Result<tempfile::TempDir>,
+) -> Vec<Check> {
     let mut checks = Vec::new();
 
     // A config that will not parse is itself a finding, and the most common
@@ -897,6 +920,10 @@ pub async fn run_checks(
     let Some(resolved) = resolved else {
         return checks;
     };
+    // Everything past this point bills or spawns.
+    if args.offline {
+        return checks;
+    }
 
     let check = inference_check(resolved.provider.as_ref(), &resolved.model).await;
     let inference_failed = check.status == CheckStatus::Fail;
@@ -909,11 +936,16 @@ pub async fn run_checks(
         DaemonTarget::Skip => {}
         DaemonTarget::Unavailable(reason) => checks.push(Check::fail("daemon", reason)),
         DaemonTarget::Client(client) => {
-            // `.expect`: a temp directory that cannot be created means the
-            // machine has no writable scratch space at all, which every other
-            // part of a run would hit first. Nothing here could report it more
-            // usefully.
-            let stage = tempfile::tempdir().expect("the system temp directory is writable");
+            let stage = match scratch() {
+                Ok(stage) => stage,
+                Err(e) => {
+                    checks.push(Check::fail(
+                        "daemon",
+                        format!("no writable scratch space to stage the probe run in: {e}"),
+                    ));
+                    return checks;
+                }
+            };
             checks.push(
                 daemon_check(
                     client,

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -1132,6 +1132,60 @@ async fn run_checks_skips_the_daemon_when_asked_to() {
     assert!(checks.iter().all(|c| c.status != CheckStatus::Fail));
 }
 
+/// `--offline` proves the config and the resolution and then stops: no
+/// inference, no daemon, whatever daemon target the caller had in hand.
+#[tokio::test]
+async fn run_checks_stops_after_resolve_when_offline() {
+    let checks = with_env(|root| async move {
+        write_config(&root, "stub", Some("m"), "");
+        // A provider that would fail the inference if it were called.
+        let build = always(registry_with(
+            "stub",
+            StubProvider::failing("must not be called"),
+        ));
+        let args = DoctorArgs {
+            offline: true,
+            ..DoctorArgs::default()
+        };
+        let target = DaemonTarget::Unavailable("must not be consulted".to_string());
+        run_checks(&args, &build, target).await
+    })
+    .await;
+    assert_eq!(checks.len(), 3, "{checks:?}");
+    assert_eq!(checks[2].name, "resolve");
+    assert!(checks.iter().all(|c| c.status != CheckStatus::Fail));
+}
+
+/// A machine with no writable scratch space fails the daemon check instead
+/// of panicking the command.
+#[tokio::test]
+async fn run_checks_reports_a_scratch_dir_it_cannot_create() {
+    fn no_scratch() -> std::io::Result<tempfile::TempDir> {
+        Err(std::io::Error::other("scratch is read-only"))
+    }
+    let checks = with_env(|root| async move {
+        write_config(&root, "stub", Some("m"), "");
+        let build = always(registry_with("stub", StubProvider::replying("PONG")));
+        let (id, _server) = scripted_daemon(&root, vec![LISTING.to_string()]);
+        let client = ControlClient::new(id);
+        run_checks_with(
+            &DoctorArgs::default(),
+            &build,
+            DaemonTarget::Client(&client),
+            no_scratch,
+        )
+        .await
+    })
+    .await;
+    assert_eq!(checks.len(), 5, "{checks:?}");
+    assert_eq!(checks[4].name, "daemon");
+    assert_eq!(checks[4].status, CheckStatus::Fail);
+    assert!(
+        checks[4].detail.contains("scratch is read-only"),
+        "{checks:?}"
+    );
+}
+
 #[tokio::test]
 async fn run_checks_reports_a_daemon_that_would_not_start() {
     // The credentials are fine and the report says so; the daemon is the

--- a/crates/leviath-cli/src/commands/serve/doctor.rs
+++ b/crates/leviath-cli/src/commands/serve/doctor.rs
@@ -1,37 +1,80 @@
-//! `GET /api/doctor` - the browser's "check my setup" button.
+//! `GET /api/doctor` and `POST /api/doctor/live` - the browser's "check my
+//! setup" button, in two halves.
 //!
-//! Runs exactly the checks `lev doctor` runs
-//! ([`crate::commands::doctor::run_checks`]), semantics preserved, and returns
-//! them as data instead of a table. See that module for what each layer proves.
+//! Both run the checks `lev doctor` runs ([`crate::commands::doctor::run_checks`]),
+//! semantics preserved, and return them as data instead of a table. See that
+//! module for what each layer proves. The split is about what a request can
+//! cost: the read half stops before the first billed call, and the half that
+//! bills and spawns is mounted only behind `--allow-admin`.
 
 use axum::extract::State;
+use axum::http::StatusCode;
 use axum::response::Json;
 
 use super::types::*;
 use crate::commands::doctor::{CheckStatus, DaemonTarget, DoctorArgs, run_checks};
 use crate::commands::run::session::build_provider_registry_from_config;
 
-/// `GET /api/doctor`: prove the provider wiring works, one layer at a time.
+/// `GET /api/doctor`: the checks that cost nothing.
+///
+/// Config, search and resolve, then stop: exactly `lev doctor --offline`. It
+/// used to run the whole chain, which made an unauthenticated-looking read
+/// into two billed provider calls and a spawned run for anyone holding the
+/// bearer token, on every press of a button.
 ///
 /// A failing check is an `ok: false` entry in a 200, never an HTTP error - the
 /// endpoint answering at all is not the thing being diagnosed. The config is
 /// re-read per request (not taken from [`AppState`]) so the button reflects an
 /// edit the user just made.
+pub(super) async fn run_doctor(State(_state): State<AppState>) -> Json<DoctorResp> {
+    let args = DoctorArgs {
+        offline: true,
+        ..DoctorArgs::default()
+    };
+    let checks = run_checks(
+        &args,
+        &build_provider_registry_from_config,
+        DaemonTarget::Skip,
+    )
+    .await;
+    Json(report(checks))
+}
+
+/// One live doctor at a time. Two of them would race two throwaway runs and
+/// four billed calls against the same config, and a double-clicked button
+/// means one check.
+static LIVE: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// `POST /api/doctor/live`: the whole chain, billed calls included. Admin only.
 ///
 /// Live-call behavior is `lev doctor`'s own, bounded by its own deadlines:
 /// `inference` makes one real, billed provider call under the probe's 60s
 /// request timeout, and `daemon` spawns a throwaway one-stage run (a second
 /// billed call) through this server's control socket, waited on for at most
 /// the doctor's 90s. A daemon that is not running reports as a failing
-/// `daemon` check rather than skipping it.
-pub(super) async fn run_doctor(State(state): State<AppState>) -> Json<DoctorResp> {
+/// `daemon` check rather than skipping it. `409` while another live doctor is
+/// still going.
+pub(super) async fn run_doctor_live(
+    State(state): State<AppState>,
+) -> Result<Json<DoctorResp>, (StatusCode, Json<ErrorResponse>)> {
+    let Ok(_running) = LIVE.try_lock() else {
+        return Err(err(
+            StatusCode::CONFLICT,
+            "a live doctor run is already in progress".to_string(),
+        ));
+    };
     let checks = run_checks(
         &DoctorArgs::default(),
         &build_provider_registry_from_config,
         DaemonTarget::Client(&state.control),
     )
     .await;
-    Json(DoctorResp {
+    Ok(Json(report(checks)))
+}
+
+/// The checks as the wire shape both halves answer with.
+fn report(checks: Vec<crate::commands::doctor::Check>) -> DoctorResp {
+    DoctorResp {
         checks: checks
             .into_iter()
             .map(|c| DoctorCheck {
@@ -44,7 +87,7 @@ pub(super) async fn run_doctor(State(state): State<AppState>) -> Json<DoctorResp
                 elapsed_ms: c.elapsed_ms,
             })
             .collect(),
-    })
+    }
 }
 
 #[cfg(test)]
@@ -142,6 +185,58 @@ mod tests {
             );
             // The offline checks carry no timing.
             assert!(report.checks.iter().all(|c| c.elapsed_ms.is_none()));
+        })
+        .await;
+    }
+
+    /// The live route is not in the shared table: it is mounted behind
+    /// `--allow-admin` by `execute_with_shutdown`, so over the plain table it
+    /// is a 404 like the other admin routes.
+    #[tokio::test]
+    async fn the_live_doctor_is_not_reachable_without_admin() {
+        with_env(|_root| async move {
+            let app = super::super::api_router().with_state(test_state());
+            let req = Request::builder()
+                .method("POST")
+                .uri("/api/doctor/live")
+                .body(Body::empty())
+                .unwrap();
+            let resp = app.oneshot(req).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        })
+        .await;
+    }
+
+    /// Mounted, the live route runs the same chain and, against the same
+    /// empty config, stops at the same place with the same shape. A second
+    /// caller while one is going is told so rather than doubled up.
+    #[tokio::test]
+    async fn the_live_doctor_runs_once_at_a_time() {
+        with_env(|_root| async move {
+            let app = axum::Router::new()
+                .route("/api/doctor/live", axum::routing::post(run_doctor_live))
+                .with_state(test_state());
+            let request = || {
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/doctor/live")
+                    .body(Body::empty())
+                    .unwrap()
+            };
+
+            let held = LIVE.lock().await;
+            let resp = app.clone().oneshot(request()).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::CONFLICT);
+            drop(held);
+
+            let resp = app.oneshot(request()).await.unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+            let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let report: DoctorResp = serde_json::from_slice(&body).unwrap();
+            assert_eq!(report.checks.len(), 3);
+            assert_eq!(report.checks[2].name, "resolve");
         })
         .await;
     }

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -139,13 +139,13 @@ fn api_router() -> Router<AppState> {
             "/api/agents/{id}/interaction",
             get(interactions::get_interaction).post(interactions::submit_interaction),
         )
-        // MCP servers - read-only surface. The mutating half is mounted by
-        // `execute_with_shutdown`, behind `--allow-admin`.
+        // MCP servers - read-only surface. Everything that connects to one or
+        // opens a browser is mounted by `execute_with_shutdown`, behind
+        // `--allow-admin`.
         .route("/api/mcp/servers", get(mcp::list_servers))
         .route("/api/mcp/servers/{name}/status", get(mcp::status))
-        .route("/api/mcp/servers/{name}/login", post(mcp::login))
-        .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
-        // Doctor - the same checks `lev doctor` runs, returned as data.
+        // Doctor - the offline half of the checks `lev doctor` runs, returned
+        // as data. The billed half is behind `--allow-admin` too.
         .route("/api/doctor", get(doctor::run_doctor))
         // Update - how this copy was installed, and what upgrades it. The
         // console has no other way to know, and printed a macOS-only command
@@ -373,6 +373,15 @@ async fn execute_with_shutdown(
         true => app
             .route("/api/mcp/servers", post(mcp::add_server))
             .route("/api/mcp/servers/{name}", delete(mcp::remove_server))
+            // Login opens the operator's browser and completes an OAuth flow
+            // on this host; test connects to the server and, for a stdio one,
+            // spawns its command. Neither is a read, and both were reachable by
+            // anyone holding the bearer token.
+            .route("/api/mcp/servers/{name}/login", post(mcp::login))
+            .route("/api/mcp/servers/{name}/test", post(mcp::test_server))
+            // The live doctor makes two billed provider calls and spawns a run
+            // through the daemon. The read half above stops before either.
+            .route("/api/doctor/live", post(doctor::run_doctor_live))
             // Config-write persists provider secrets to disk, so it is gated the
             // same way as MCP admin: unmounted (404) unless --allow-admin.
             .route("/api/config", put(config::put_config))

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -387,12 +387,13 @@ async fn real_run(args: commands::run::RunArgs) -> anyhow::Result<()> {
 /// propagated: the whole point of the command is to say whether the credentials
 /// or the daemon is at fault, and aborting here would answer neither.
 /// `--no-daemon` skips both the auto-start and the check, so a caller who only
-/// wants to test credentials never causes a daemon to exist. The checks
+/// wants to test credentials never causes a daemon to exist; `--offline`
+/// stops earlier still and skips it for the same reason. The checks
 /// themselves are the tested `commands::doctor::run_checks`; the auto-start and
 /// socket connect are the un-unit-testable slivers kept here.
 async fn real_doctor(args: commands::doctor::DoctorArgs) -> anyhow::Result<()> {
     use commands::doctor::DaemonTarget;
-    if args.no_daemon {
+    if args.no_daemon || args.offline {
         return commands::doctor::execute(args, DaemonTarget::Skip).await;
     }
     let started = ensure_daemon_running()

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -177,8 +177,8 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/models` | Enumerate models, with each one's token limits and where they came from |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
 | `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. Writes need admin. See [below](#tools-and-scripts) |
-| `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` · `POST /{name}/test` | MCP servers (add/remove need admin) |
-| `GET /api/doctor` | The checks `lev doctor` runs, as data. A failing check is `ok: false` inside a 200, never an HTTP error |
+| `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` *(admin)* · `POST /{name}/test` *(admin)* | MCP servers. Add, remove, login and test need admin: each connects to a server, opens a browser, or spawns a command |
+| `GET /api/doctor` · `POST /api/doctor/live` *(admin)* | The checks `lev doctor` runs, as data. `GET` is `lev doctor --offline`: config, search and resolve, nothing billed. `POST .../live` runs the whole chain (two billed calls and a throwaway run) and answers 409 while one is already going. A failing check is `ok: false` inside a 200, never an HTTP error |
 | `GET /api/update` | Whether anything newer exists, how this copy was installed, and the command that upgrades it. See [below](#asking-how-to-upgrade) |
 | `POST /api/update` *(admin)* · `GET /api/update/jobs/{id}` | Carry that plan out, and read where it got to. See [below](#pressing-the-button) |
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -691,6 +691,7 @@ the run. Nothing is left in `lev ps` or on disk.
 |---|---|
 | `-m`, `--model <MODEL>` | Test a specific model. Takes the same forms as `lev run --model` |
 | `--no-daemon` | Stop after the third check. Contacts no daemon, starts none, and creates no run |
+| `--offline` | Stop after the second check. Proves the config parses and the model resolves, and bills nothing |
 | `--json` | Print the checks as `{"checks": [...], "passed": bool}` |
 
 `--model` takes `provider/model` to pick both, and a bare model id pairs with your
@@ -700,7 +701,7 @@ string before wiring it into a blueprint: it goes further than `lev models list 
 compiles the provider and reads its catalog but never sends an inference.
 
 `lev doctor` exits non-zero when a check fails, so it works as a CI gate. It bills two inferences
-per run, each capped at 64 output tokens; `--no-daemon` bills one.
+per run, each capped at 64 output tokens; `--no-daemon` bills one, and `--offline` none.
 
 ### `lev setup`
 

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1004,7 +1004,7 @@
             "$ref": "#/components/responses/Ok"
           }
         },
-        "description": "Returns `{\"status\": \"authenticated\"}` when the browser flow completed and credentials were stored, or `{\"status\": \"not_required\"}` when the server answered a probe carrying its configured headers, which means there is no OAuth flow to run."
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because it opens the operator's browser on the host running the server and completes an OAuth flow there. Returns `{\"status\": \"authenticated\"}` when the browser flow completed and credentials were stored, or `{\"status\": \"not_required\"}` when the server answered a probe carrying its configured headers, which means there is no OAuth flow to run."
       }
     },
     "/api/mcp/servers/{name}/test": {
@@ -1022,7 +1022,8 @@
           "200": {
             "$ref": "#/components/responses/Ok"
           }
-        }
+        },
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because it connects to the server and, for a stdio server, spawns its configured command."
       }
     },
     "/api/doctor": {
@@ -1030,11 +1031,28 @@
         "tags": [
           "diagnostics"
         ],
-        "summary": "The `lev doctor` checks, as data",
-        "description": "A failing check is reported inside a 200 with `ok: false`, not as an HTTP error: the request succeeded, the install is what did not.",
+        "summary": "The offline `lev doctor` checks, as data",
+        "description": "The same checks as `lev doctor --offline`: config, search and resolve, then stop. Nothing here contacts a provider or the daemon, so pressing the button costs nothing. A failing check is reported inside a 200 with `ok: false`, not as an HTTP error: the request succeeded, the install is what did not.",
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          }
+        }
+      }
+    },
+    "/api/doctor/live": {
+      "post": {
+        "tags": [
+          "diagnostics"
+        ],
+        "summary": "The whole `lev doctor` chain, billed calls included",
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed: past the offline checks it makes one billed provider call, then spawns a throwaway one-stage run through the daemon (a second billed call) and waits for it. One at a time; a second caller while one is going gets 409. A failing check is reported inside a 200 with `ok: false`, not as an HTTP error.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          },
+          "409": {
+            "description": "Another live doctor run is already in progress"
           }
         }
       }


### PR DESCRIPTION
## What

Three routes reachable with only the bearer token were not reads:

| Route | What it does | Now |
|---|---|---|
| `POST /api/mcp/servers/{name}/login` | Opens the operator's browser on the serving host and runs an OAuth flow | Mounted only with `--allow-admin` (404 otherwise), beside add/remove |
| `POST /api/mcp/servers/{name}/test` | Connects to the server; for a stdio server, spawns its command | Same |
| `GET /api/doctor` | Ran the whole `lev doctor` chain: two billed calls + a spawned run, unguarded, unserialised | Runs only the offline checks (config, search, resolve), bills nothing |
| `POST /api/doctor/live` *(new)* | The whole chain | Admin only; single-flight (409 while one is going) |

Plus `lev doctor --offline` (same stopping point on the CLI; skips the daemon auto-start like `--no-daemon`, one line in `main.rs`), and the daemon check's scratch-directory `.expect` becomes a failing `daemon` check via an injected factory (`run_checks_with`).

Design note: the plan proposed `GET /api/doctor?live=1` with a 403 without admin. `types.rs` documents that admin is decided by *mounting*, never by a check inside a handler someone could route around, so the live half is its own mounted route instead. The single-flight lock is a `static` in the doctor module: one live doctor per `lev serve` process is the intended scope, and it avoids threading a field through 49 `AppState` constructions.

## Behaviour change (flagged)

Without `--allow-admin`: MCP login/test are gone (404) and the doctor button no longer bills. With it: the live doctor lives at `POST /api/doctor/live`. OpenAPI and `docs/content/api.md` / `cli.md` updated; the route-drift test holds the spec to the router.

## Tests

- Serve: `the_live_doctor_is_not_reachable_without_admin` (404 over the shared table), `the_live_doctor_runs_once_at_a_time` (409 while the lock is held, 200 after), existing offline `GET` test unchanged.
- Doctor: `run_checks_stops_after_resolve_when_offline` (a provider that would fail the inference is never called), `run_checks_reports_a_scratch_dir_it_cannot_create`.

## Live probe

Real daemon + mock provider, `default_provider = "openai"`, `default_model = "mock-1"`:

```
no-admin GET /api/doctor:        checks=[config, search, resolve]   mock_count 0->0
no-admin POST /api/doctor/live:  404
no-admin POST login / test:      404 404
admin    POST /api/doctor/live:  [config ok, search ok, resolve ok, inference ok, daemon ok]   mock_count 0->3
```

## Verification

`cargo test -p leviath-cli` 4,027 passed (incl. the OpenAPI route-drift test); clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-cli` at 100%. Touches `main.rs` (one condition), so it carries `allow-main-rs-change`.
