### PR TITLE
fix(daemon)!: tool seeds and Rhai tools answer to the same fences

### DIFF
--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -210,6 +210,10 @@ pub struct DaemonScriptHost {
     /// `shell()` hands to the child. The same policy the built-in shell tool
     /// applies, so `shell()` is not a way around the `env_var` gate.
     shell_env: leviath_tools::ShellEnvPolicy,
+    /// The run's write budget, when this host serves a run. A script's
+    /// `write_file` and a redirect in its `shell` are writes the run pays
+    /// for like any other; without this they were the two that did not.
+    writes: Option<Arc<crate::daemon::tool_service::WriteBudget>>,
 }
 
 impl DaemonScriptHost {
@@ -226,7 +230,18 @@ impl DaemonScriptHost {
             allow_local_network: false,
             allow_env_vars: Vec::new(),
             shell_env: leviath_tools::ShellEnvPolicy::default(),
+            writes: None,
         }
+    }
+
+    /// Charge this run's write budget for what scripts write. Consuming
+    /// builder used at spawn.
+    pub fn with_write_budget(
+        mut self,
+        writes: Arc<crate::daemon::tool_service::WriteBudget>,
+    ) -> Self {
+        self.writes = Some(writes);
+        self
     }
 
     /// Permit fetches to loopback / private / link-local addresses, from
@@ -351,7 +366,16 @@ impl ScriptHost for DaemonScriptHost {
         // Same withholding the built-in shell tool applies. A script that has
         // `shell` would otherwise be the way around the `env_var` gate above.
         self.shell_env.apply(&mut cmd);
-        self.io.run_shell(cmd, self.shell_timeout)
+        let out = self.io.run_shell(cmd, self.shell_timeout);
+        if let Some(writes) = &self.writes {
+            // A redirect is only measurable after the fact, as in the tool lane.
+            writes.record(crate::tools::measured_write_bytes(
+                "shell",
+                &serde_json::json!({ "command": command }),
+                &self.workdir,
+            ));
+        }
+        out
     }
 
     fn read_file(&self, path: &str) -> Result<String, String> {
@@ -375,7 +399,19 @@ impl ScriptHost for DaemonScriptHost {
             ));
         }
         let resolved = self.resolve_in_workdir(path)?;
-        self.io.write_file(&resolved, content)
+        let bytes = content.len() as u64;
+        if let Some(writes) = &self.writes
+            && let Some(refusal) = writes.check(&self.workdir, bytes).refusal()
+        {
+            return Err(refusal);
+        }
+        let out = self.io.write_file(&resolved, content);
+        if out.is_ok()
+            && let Some(writes) = &self.writes
+        {
+            writes.record(bytes);
+        }
+        out
     }
 
     fn env_var(&self, name: &str) -> Result<String, String> {
@@ -2290,6 +2326,46 @@ mod tests {
         temp_env::with_var_unset("LEVIATH_DEFINITELY_UNSET_XYZ", || {
             assert!(host.env_var("LEVIATH_DEFINITELY_UNSET_XYZ").is_err());
         });
+    }
+
+    /// A script's writes spend the run's budget: `write_file` is refused over
+    /// the ceiling before it lands, and a redirect in `shell` is charged after.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn a_scripts_writes_spend_the_run_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let writes = Arc::new(crate::daemon::tool_service::WriteBudget::with_probe(
+            leviath_core::write_limits::WriteLimits {
+                per_call: Some(4),
+                per_run: None,
+            },
+            |_| Some(leviath_core::write_limits::MIN_FREE_BYTES * 100),
+        ));
+        let allow = ScriptAllow {
+            http_get: false,
+            http_post: false,
+            shell: true,
+            read_file: false,
+            write_file: true,
+            env_var: false,
+        };
+        let host = DaemonScriptHost::new(allow, dir.path().to_path_buf())
+            .with_write_budget(writes.clone());
+        host.write_file("small.txt", "abc").expect("fits");
+        assert_eq!(writes.written(), 3);
+        let err = host
+            .write_file("big.txt", "too big")
+            .expect_err("over the per-call ceiling");
+        assert!(err.contains("per-call"), "{err}");
+        assert!(!dir.path().join("big.txt").exists());
+        // The redirect's bytes are counted once the shell has run.
+        // The real shell blocks on the runtime, so it runs off the async
+        // thread, the way the tool lane's `block_in_place` places it.
+        tokio::task::spawn_blocking(move || host.shell("echo hi > out.txt"))
+            .await
+            .expect("joined")
+            .expect("ran");
+        let written = writes.written();
+        assert!(written > 3, "{written}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/seed_tool.rs
+++ b/crates/leviath-cli/src/daemon/seed_tool.rs
@@ -148,6 +148,9 @@ pub struct SeedToolContext {
     pub script_host: Arc<dyn leviath_scripting::ScriptHost>,
     /// The shared MCP executor.
     pub mcp: Arc<tokio::sync::Mutex<leviath_mcp::ToolExecutor>>,
+    /// The run's write budget, shared with the tool lane so what a seed
+    /// writes at spawn counts against the same ceiling as turn one.
+    pub writes: Arc<crate::daemon::tool_service::WriteBudget>,
 }
 
 /// Decides one seeded call's policy: `(tool name, is_builtin) -> policy`.
@@ -162,8 +165,25 @@ pub type SeedPolicyResolver = Arc<dyn Fn(&str, bool) -> ToolPolicy + Send + Sync
 pub fn production_runner(ctx: SeedToolContext, resolve: SeedPolicyResolver) -> SeedToolRunner {
     Arc::new(move |name: &str, args: &serde_json::Value| {
         let is_builtin = ctx.builtin_names.contains(name);
-        if let Some(refusal) = seed_policy_refusal(name, resolve(name, is_builtin)) {
+        // The same three fences the tool lane applies to a mid-run call, in
+        // the same order: a seed used to skip all of them, and a seed is the
+        // one call that runs before anyone could have been asked.
+        let policy = resolve(name, is_builtin);
+        let policy =
+            crate::tools::clamp_by_effect(name, args, policy, &|| resolve("write_file", true));
+        if let Some(refusal) = seed_policy_refusal(name, policy) {
             return Err(refusal);
+        }
+        let workdir = ctx.builtins.workdir();
+        if let Some(refusal) = crate::tools::escaping_write_refusal(name, args, workdir) {
+            return Err(refusal);
+        }
+        if let Some(refusal) = crate::tools::write_budget_refusal(name, args, workdir, &ctx.writes)
+        {
+            return Err(refusal);
+        }
+        if let Some(declared) = crate::tools::declared_write_bytes(name, args) {
+            ctx.writes.record(declared);
         }
         // A script tool is checked first, exactly as the tool lane checks it
         // first, so a discovered `.rhai` dispatches to the engine. The Rhai
@@ -176,7 +196,13 @@ pub fn production_runner(ctx: SeedToolContext, resolve: SeedPolicyResolver) -> S
             ));
         }
         match is_builtin {
-            true => block_on_daemon(ctx.builtins.execute(name, args.clone())),
+            true => {
+                let out = block_on_daemon(ctx.builtins.execute(name, args.clone()));
+                // A redirect is only measurable after the fact, as in the lane.
+                ctx.writes
+                    .record(crate::tools::measured_write_bytes(name, args, workdir));
+                out
+            }
             false => {
                 let mcp = ctx.mcp.clone();
                 let name = name.to_string();
@@ -352,11 +378,28 @@ mod tests {
         dir: &std::path::Path,
         scripts: leviath_scripting::ScriptToolSet,
     ) -> SeedToolContext {
+        ctx_with_budget(dir, scripts, Arc::new(unlimited_writes()))
+    }
+
+    /// A budget that stops nothing, over a filesystem reporting plenty of room.
+    fn unlimited_writes() -> crate::daemon::tool_service::WriteBudget {
+        crate::daemon::tool_service::WriteBudget::with_probe(Default::default(), |_| {
+            Some(leviath_core::write_limits::MIN_FREE_BYTES * 100)
+        })
+    }
+
+    /// [`ctx_over`] with the run's write budget chosen.
+    fn ctx_with_budget(
+        dir: &std::path::Path,
+        scripts: leviath_scripting::ScriptToolSet,
+        writes: Arc<crate::daemon::tool_service::WriteBudget>,
+    ) -> SeedToolContext {
         let builtins = Arc::new(leviath_tools::BuiltinTools::new(
             leviath_tools::ToolContext::new(dir.to_path_buf()),
         ));
         let builtin_names = builtins.names().into_iter().collect();
         SeedToolContext {
+            writes,
             builtins,
             builtin_names,
             script_tools: scripts,
@@ -423,6 +466,84 @@ mod tests {
         let runner = production_runner(ctx_over(dir.path(), Default::default()), ask);
         let err = runner("current_time", &serde_json::json!({})).expect_err("refused");
         assert!(err.contains("nobody to prompt"), "{err}");
+    }
+
+    /// A seed runs before the first inference, so it used to run before every
+    /// fence the tool lane applies: a `shell` seed could redirect outside the
+    /// workdir, which the same line as a tool call is refused for.
+    #[test]
+    fn a_seed_cannot_redirect_outside_the_workdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let target = outside.path().join("pwned.txt");
+        let command = format!("echo pwn > {}", target.display());
+        let runner = production_runner(ctx_over(dir.path(), Default::default()), allow_all());
+        let err = runner("shell", &serde_json::json!({ "command": command })).expect_err("refused");
+        assert!(err.contains("outside the working directory"), "{err}");
+        assert!(!target.exists(), "the seed wrote outside the workdir");
+    }
+
+    /// And the write clamp: a `shell` seed that redirects is a write, so a
+    /// `write_file = "deny"` refuses it even though `shell` itself is allowed.
+    #[test]
+    fn a_seed_redirect_answers_to_the_write_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        let deny_writes: SeedPolicyResolver = Arc::new(|name, _| match name {
+            "write_file" => ToolPolicy::Deny,
+            _ => ToolPolicy::Allow,
+        });
+        let runner = production_runner(ctx_over(dir.path(), Default::default()), deny_writes);
+        let err = runner(
+            "shell",
+            &serde_json::json!({ "command": "echo x > inside.txt" }),
+        )
+        .expect_err("refused");
+        assert!(err.contains("denied"), "{err}");
+        assert!(
+            !dir.path().join("inside.txt").exists(),
+            "the seed wrote anyway"
+        );
+    }
+
+    /// A seed's write spends the run's budget, the same budget turn one then
+    /// checks against, and a seed over the ceiling is refused before it lands.
+    #[test]
+    fn a_seed_write_spends_the_run_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let writes = Arc::new(crate::daemon::tool_service::WriteBudget::with_probe(
+            leviath_core::write_limits::WriteLimits {
+                per_call: Some(8),
+                per_run: Some(10),
+            },
+            |_| Some(leviath_core::write_limits::MIN_FREE_BYTES * 100),
+        ));
+        let runner = production_runner(
+            ctx_with_budget(dir.path(), Default::default(), writes.clone()),
+            allow_all(),
+        );
+        runner(
+            "write_file",
+            &serde_json::json!({ "path": "seeded.txt", "content": "12345678" }),
+        )
+        .expect("fits");
+        assert_eq!(writes.written(), 8);
+        let err = runner(
+            "write_file",
+            &serde_json::json!({ "path": "more.txt", "content": "123" }),
+        )
+        .expect_err("over the run ceiling");
+        assert!(err.contains("budget"), "{err}");
+        assert!(!dir.path().join("more.txt").exists());
+        // A shell redirect is measured after the fact and charged too.
+        let runner = production_runner(
+            ctx_with_budget(dir.path(), Default::default(), Arc::new(unlimited_writes())),
+            allow_all(),
+        );
+        runner(
+            "shell",
+            &serde_json::json!({ "command": "echo hi > out.txt" }),
+        )
+        .expect("ran");
     }
 
     /// Whether a name is a built-in is what the resolver is told, and it is the

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -693,11 +693,18 @@ fn build_agent_inner(
             )
         },
     );
+    // One write budget per run, created here so the seeds and the scripts
+    // that run at spawn spend the same ceiling the tool lane checks from
+    // turn one; it used to be born with the tool state, after both.
+    let writes = Arc::new(crate::daemon::tool_service::WriteBudget::new(
+        deps.config.limits.write_limits(),
+    ));
     let script_host: Arc<dyn leviath_scripting::ScriptHost> = Arc::new(
         crate::daemon::script_host::DaemonScriptHost::new(
             script_allow,
             std::path::PathBuf::from(&args.workdir),
         )
+        .with_write_budget(writes.clone())
         // Route a script `shell()` through the agent's per-stage sandbox (so a
         // script can't escape the isolation the stage declared) and cap it at the
         // configured wall-clock timeout.
@@ -755,6 +762,7 @@ fn build_agent_inner(
                     script_tools: script_tools.clone(),
                     script_host: script_host.clone(),
                     mcp: deps.shared_mcp.clone(),
+                    writes: writes.clone(),
                 },
                 Arc::new(move |name: &str, is_builtin: bool| {
                     crate::daemon::seed_tool::SeedToolPermissions {
@@ -894,6 +902,7 @@ fn build_agent_inner(
         })
     });
     let state = build_tool_state(ToolStateParts {
+        writes,
         builtins,
         builtin_names,
         mcp: deps.shared_mcp,
@@ -3654,6 +3663,31 @@ docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["a.txt", "b.txt"]
         assert_eq!(seeds.get("lit").map(String::as_str), Some("hello"));
         let docs = seeds.get("docs").unwrap();
         assert!(docs.contains("alpha") && docs.contains("beta"));
+    }
+
+    /// A seed file is read into the prompt, so it is held to the same size a
+    /// script's I/O is: a multi-megabyte file used to arrive whole.
+    #[test]
+    fn resolve_seeds_caps_an_oversized_file() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("big.txt"), vec![b'x'; 900_001]).unwrap();
+        let bp =
+            bp(r#"docs = { kind = "pinned", max_tokens = 2000, seed = { files = ["big.txt"] } }"#);
+        let wd = dir.path().to_string_lossy().to_string();
+        let args = args_with("t", HashMap::new(), &wd);
+        let seeds = resolve_seeds(
+            &bp,
+            &args,
+            &wd,
+            &seed_policy(),
+            &no_seed_tools(),
+            &no_read_paths(),
+        )
+        .unwrap();
+        let docs = seeds.get("docs").unwrap();
+        let len = docs.len();
+        assert!(len < 900_200, "{len} bytes reached the prompt");
+        assert!(docs.contains("truncated by leviath"));
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/spawn/seeds.rs
+++ b/crates/leviath-cli/src/daemon/spawn/seeds.rs
@@ -187,6 +187,7 @@ pub(super) fn resolve_seeds(
                 let out = leviath_scripting::ScriptEngine::new()
                     .transform(&src, input)
                     .map_err(|e| format!("region '{}': rhai seed failed: {e}", region.name))?;
+                let out = crate::daemon::script_host::cap_script_io(out);
                 if !out.trim().is_empty() {
                     seeds.insert(region.name.clone(), out);
                 } else if region.required {
@@ -315,7 +316,13 @@ pub(super) fn read_and_concat(
     let mut parts: Vec<String> = Vec::new();
     for path in paths {
         match std::fs::read_to_string(&path) {
-            Ok(text) => parts.push(format!("--- {} ---\n{}", path.display(), text)),
+            // Held to the same size a script's I/O is: a seed lands in the
+            // prompt whole, and a multi-megabyte file is not a seed.
+            Ok(text) => parts.push(format!(
+                "--- {} ---\n{}",
+                path.display(),
+                crate::daemon::script_host::cap_script_io(text)
+            )),
             Err(e) => {
                 if required {
                     return Err(format!(

--- a/crates/leviath-cli/src/daemon/spawn/tool_state.rs
+++ b/crates/leviath-cli/src/daemon/spawn/tool_state.rs
@@ -19,6 +19,8 @@ use super::*;
 /// silently and produces a run whose approvals are keyed to the wrong name.
 /// Nothing else in this file was ever going to catch that.
 pub(super) struct ToolStateParts<'a> {
+    /// The run's write budget, already spent on by the seeds.
+    pub(super) writes: Arc<crate::daemon::tool_service::WriteBudget>,
     /// The built-in tools, over this agent's workdir.
     pub(super) builtins: Arc<leviath_tools::BuiltinTools>,
     /// Their names, for deciding what is a builtin at dispatch.
@@ -76,10 +78,8 @@ pub(super) fn build_tool_state(parts: ToolStateParts<'_>) -> Arc<AgentToolState>
         .unwrap_or_default();
     Arc::new(AgentToolState {
         // One budget per run, so the per-run ceiling spans every batch rather
-        // than resetting with each one.
-        writes: Arc::new(crate::daemon::tool_service::WriteBudget::new(
-            parts.config.limits.write_limits(),
-        )),
+        // than resetting with each one - and spans the seeds before them.
+        writes: parts.writes,
         builtins: parts.builtins,
         mcp: parts.mcp,
         builtin_names: parts.builtin_names,


### PR DESCRIPTION
## What

A tool seed runs at spawn through `seed_tool::production_runner`, which checked the tool's policy and nothing else. So a `shell` seed could redirect outside the workdir, write through a redirect while `write_file = "deny"`, and nothing it wrote counted against the run's write budget. The Rhai script host had the budget gap too.

- `production_runner` now applies, in the tool lane's order: `clamp_by_effect` (a redirect answers to the write policy), `escaping_write_refusal` (workdir confinement), `write_budget_refusal` + declared charge, and the measured charge after a shell.
- One `Arc<WriteBudget>` per run is created in `spawn` before the seeds and shared by the seed runner (`SeedToolContext.writes`), the script host (`with_write_budget`) and the tool state (`ToolStateParts.writes`), so a seed's write is what turn one has already spent.
- `DaemonScriptHost::write_file` refuses over the ceiling before writing and records after; `shell()` records the measured redirect after it runs.
- Seed files and Rhai seed results are capped by `cap_script_io` (900 KB), the same limit a script's I/O has.

Not changed: the plan's `script_within_blueprint` for a Rhai seed's path is what `seed_path_within` already enforces.

## Behaviour change (flagged)

A seed that would escape, that writes under a write deny, or that overruns the budget is refused (required region: the spawn fails; optional: skipped with a warning, as any failed seed). An oversized seed is truncated with the standard marker. Scripts' writes now spend the run's budget.

## Tests

Fail on the unfixed code:
- `a_seed_cannot_redirect_outside_the_workdir` (the file appeared in the outside dir)
- `a_seed_redirect_answers_to_the_write_policy` (the redirect ran)
- `resolve_seeds_caps_an_oversized_file` (900 001 bytes reached the prompt)

Plus `a_seed_write_spends_the_run_budget` (declared charge, refusal over the run ceiling, measured shell charge) and `a_scripts_writes_spend_the_run_budget` (host `write_file` per-call refusal, shell redirect charged).

## Live probe

Real daemon, `--yolo`, a blueprint with two `shell` tool seeds:

```
escape:  echo pwn > /tmp/lv-seed-pwned   -> /tmp/lv-seed-pwned: absent
control: echo seeded > seeded.txt        -> seeded.txt: written
```

## Verification

`cargo test -p leviath-cli` 4,029 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-cli` at 100%.
