### PR TITLE
docs(security): record the residual gaps instead of "none tracked"

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -108,10 +108,48 @@ about them:
   both implemented; anything else gets whatever the platform does by default,
   and `leviath-sys`'s fallback module says so rather than pretending otherwise.
 
-**Known gaps.** None currently tracked. Everything the threat model claims is
-implemented and tested on every supported platform. If you find something this
-document claims but the code does not do, that is a vulnerability and we want to
-hear about it - see the top of this file.
+**Known gaps.** The ones we know about, so nobody has to find them twice.
+Each is a place where the code is weaker than a reader of this document might
+assume; none is a case of the code doing something other than what it says.
+
+- **The Windows control pipe checks no peer.** On Unix the daemon refuses a
+  control connection from another user, having read the peer's uid from the
+  kernel. The Windows pipe has no such check and sets no security descriptor,
+  so what stands between another local user and the daemon there is the
+  control token alone (owner-only file, fresh per daemon). The code says the
+  same where it accepts the connection.
+- **`[sandbox]` isolates shell commands, not file tools.** The boundary
+  covers the `shell` tool, seed commands and a Rhai tool's `shell()`. File
+  tools stay on the host and rely on workdir confinement; a Rhai tool's
+  `http_get`/`http_post` and `read_file`/`write_file` run on the host too.
+  Pick `container` when the filesystem is what you need isolated, and know
+  that a script tool reaches the network from the host either way.
+- **A run's webhook secret is on disk in plaintext.** `callback_secret` is
+  persisted in the run's `meta.json` so the daemon can still sign a webhook
+  for a run it reloaded after a restart. It is stripped from every API
+  response, and the file is `0600` in a `0700` directory, which is the same
+  protection the provider keys in `config.toml` get. It is not encrypted at
+  rest, and it stays on disk until the run is deleted.
+- **`lev serve` does not check the `Host` header.** A DNS-rebinding page can
+  therefore make a browser send requests to a local server under an origin
+  the server would accept. The bearer token is what stops that from being
+  useful: every API route requires it and a rebinding page does not have it.
+  Do not embed the token in a page served from anywhere else, and do not use
+  `--cors "*"` on a machine that browses the web.
+- **OTLP log records carry the run's output unredacted.** With
+  `[telemetry]` on, every output and runtime log line is exported as it was
+  written. Nothing redacts a credential a tool happened to print on its way
+  out, so point the exporter only at a collector you would trust with the
+  run's transcript.
+- **`POST /api/update` runs the installer it fetches.** On a script install
+  the update step is `curl -fsSL https://leviath.dev/install.sh | sh`, over
+  TLS and unpinned; the script then verifies the release checksums, but the
+  script itself is trusted on the strength of the TLS connection. It is
+  behind `--allow-admin` for that reason. A pinned install goes through your
+  package manager instead.
+
+If you find something this document claims but the code does not do, that is a
+vulnerability and we want to hear about it - see the top of this file.
 
 ## Where secrets live
 
@@ -120,6 +158,7 @@ hear about it - see the top of this file.
 | Provider API keys | `~/.leviath/config.toml`, or the OS keychain | `0600` |
 | MCP OAuth access + refresh tokens | `~/.leviath/mcp-auth.json`, or the OS keychain | `0600` |
 | Run artifacts (prompts, conversations) | `~/.leviath/runs/<id>/` | `0600` in a `0700` dir |
+| A run's webhook signing secret (`callback_secret`) | `~/.leviath/runs/<id>/meta.json` | same as the run; never served, see known gaps |
 | Control socket | `~/.leviath/control.sock` (Unix) | `0600`, same-uid peers only, token required |
 | Control pipe | `\\.\pipe\leviath-control-…` (Windows) | token required |
 | Control token | `~/.leviath/control.token` | owner-only; fresh per daemon |

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -27,7 +27,9 @@ a test, so a client generator or an agent can consume the contract directly.
   environment variable: a `--token` value is visible to other local users in the process table
   (`ps`).
 - **CORS is closed by default.** Pass `--cors <origin>` (e.g. `https://leviath.dev`) or `--cors "*"`
-  to allow a browser to call it cross-origin.
+  to allow a browser to call it cross-origin. The server does not check the `Host` header, so the
+  bearer token is what stands between a DNS-rebinding page and your local API: never embed the
+  token in a page served from somewhere else, and avoid `--cors "*"` on a machine that browses.
 - **Binds to `127.0.0.1`** by default. `--host 0.0.0.0` exposes it on your network. Without
   `--tls-cert`, that puts the bearer token on the wire in cleartext for anyone on that network to read.
   If the address is publicly routable, that is the open internet. See

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -607,8 +607,10 @@ persist        = false
 on_unavailable = "error"       # error | warn
 ```
 
-Unset entirely, agents run tools on the host. Details in
-[Security and sandboxing](/docs/security#sandboxes).
+Unset entirely, agents run tools on the host. The boundary covers shell commands only: the
+`shell` tool, seed commands and a Rhai tool's `shell()`. File tools, and a Rhai tool's HTTP and
+file calls, run on the host whatever this says, held to the workdir by path confinement rather than
+by the sandbox. Details in [Security and sandboxing](/docs/security#sandboxes).
 
 ## `[rate_limits.<provider>]`
 

--- a/docs/content/observability.md
+++ b/docs/content/observability.md
@@ -119,6 +119,10 @@ excluded, so a fleet of routers and researchers will not drown the signal. See
 Log records carry the run's trace ID. A collector that joins all three signals can therefore jump
 from a log line straight to the span that produced it.
 
+They carry the line as it was written. Every output and runtime log line of every run is exported,
+and nothing redacts a credential a tool happened to print on its way out, so point the exporter only
+at a collector you would trust with the run's transcript.
+
 ## Trying it locally
 
 Any OTLP-over-HTTP collector works. With a local Jaeger all-in-one listening on 4318, enable the


### PR DESCRIPTION
## What

`SECURITY.md` said "Known gaps: none currently tracked" while the Windows control-pipe code says "documented in SECURITY.md rather than papered over". The section now lists six residuals, each verified against the source before writing:

| Gap | Where the code says so |
|---|---|
| Windows named pipe checks no peer and sets no security descriptor; the control token alone gates another local user | `control_socket/windows.rs` `accept` doc |
| `[sandbox]` isolates shell commands only; file tools and a Rhai tool's HTTP/file calls run on the host | `leviath_core::sandbox` module doc, `docs/security.md#sandboxes` |
| `callback_secret` persisted in `meta.json` in plaintext (0600/0700, stripped from every API response) | `RunMeta::redacted` |
| `lev serve` does not check `Host`; the bearer token is what defeats DNS rebinding | router has no host check |
| OTLP log records export every output/runtime line unredacted | `runtime/telemetry.rs` emits `buffer.output`/`buffer.logs` as-is; no redaction in `leviath-telemetry` |
| `POST /api/update` runs the fetched `install.sh` over TLS, unpinned (admin only) | update planner's script command |

Also: the secrets table gains the `callback_secret` row; the `[sandbox]` block in `configuration.md` states the boundary; `observability.md` says what log records carry; `api.md`'s CORS bullet explains the rebinding posture.

Dropped from the plan's list: a `lev ps --prune` mention (no such flag exists) and `telemetry.md` (the page is `observability.md`).

## Verification

`cargo xtask docs` (40 pages, 3 schemas, no problems); the serve tests that read `api.md` still pass in the pre-commit run.
