### PR TITLE
perf(providers): drop the tiktoken vocabularies no model can reach

### DIFF
--- a/crates/leviath-providers/src/tokenizer.rs
+++ b/crates/leviath-providers/src/tokenizer.rs
@@ -3,7 +3,7 @@
 //! Uses tiktoken-rs for accurate OpenAI model token counting and approximate
 //! counting for other providers.
 
-use tiktoken_rs::bpe_for_model;
+use tiktoken_rs::CoreBPE;
 
 /// Count tokens in text for a specific model.
 ///
@@ -29,14 +29,46 @@ pub fn count_tokens(text: &str, model: &str) -> usize {
 }
 
 /// Count tokens using tiktoken for OpenAI models.
-///
-/// Both halves return `&'static CoreBPE` from tiktoken-rs's cached singletons,
-/// so an unknown model falls back to `cl100k_base` without building a second
-/// encoder - and the singleton accessor cannot fail, so no `.expect()` is
-/// needed on the fallback path.
 fn count_tokens_tiktoken(text: &str, model: &str) -> usize {
-    let bpe = bpe_for_model(model).unwrap_or_else(|_| tiktoken_rs::cl100k_base_singleton());
-    bpe.encode_with_special_tokens(text).len()
+    bpe_for(model).encode_with_special_tokens(text).len()
+}
+
+/// The encoding a model this module can be asked about uses.
+///
+/// tiktoken-rs's own `bpe_for_model` knows every OpenAI model there has ever
+/// been, and referencing it links every vocabulary it might answer with:
+/// `r50k_base`, `p50k_base` and `p50k_edit` for the 2020-era completion
+/// models, each a megabyte-plus table compiled into the binary. Nothing here
+/// can reach them: [`count_tokens`] only asks for a name starting `gpt-`,
+/// `o3-` or `o4-`, and every such name tiktoken's table resolves lands on
+/// `o200k_base`, `o200k_harmony` or `cl100k_base`. This is that reachable
+/// slice of the table, in the same order and with the same first-match
+/// rules, so the three encodings are the only ones the binary carries.
+///
+/// The one name this answers differently: `gpt-2`, which tiktoken maps to
+/// its GPT-2 encoding and this maps to `cl100k_base` like any other name it
+/// does not know. Nobody runs an agent on GPT-2, and the count is a fallback
+/// estimate either way. An unknown name falls back to `cl100k_base` exactly
+/// as before.
+fn bpe_for(model: &str) -> &'static CoreBPE {
+    if model.starts_with("gpt-oss-") {
+        return tiktoken_rs::o200k_harmony_singleton();
+    }
+    let o200k = model == "gpt-5"
+        || model.starts_with("gpt-5-")
+        || model.starts_with("gpt-5.")
+        || model == "gpt-4.1"
+        || model.starts_with("gpt-4.1-")
+        || model.starts_with("gpt-4.5-")
+        || model == "gpt-4o"
+        || model.starts_with("gpt-4o-")
+        || model.starts_with("o3-")
+        || model == "o4-mini"
+        || model.starts_with("o4-mini-");
+    match o200k {
+        true => tiktoken_rs::o200k_base_singleton(),
+        false => tiktoken_rs::cl100k_base_singleton(),
+    }
 }
 
 /// Approximate token count for Anthropic models (~3.5 chars per token).
@@ -125,21 +157,78 @@ mod tests {
 
     #[test]
     fn test_recognized_gpt4_model_resolves_bpe_directly() {
-        // "gpt-4" is recognized by tiktoken-rs's own model table, so this
-        // exercises the `Ok(bpe)` branch of `bpe_for_model` directly.
         let count = count_tokens("Hello, world!", "gpt-4");
         assert!(count > 0);
     }
 
     #[test]
     fn an_unrecognized_gpt_model_falls_back_to_cl100k() {
-        // tiktoken-rs resolves plausible future names by prefix - `gpt-5.5`
-        // returns `Ok` - so the fallback needs a name its table genuinely has
-        // no entry for. Without this, the `unwrap_or_else` arm is never taken
-        // and an unknown model would panic in production before anyone noticed.
-        assert!(tiktoken_rs::bpe_for_model("gpt-zzz").is_err());
+        assert!(std::ptr::eq(
+            bpe_for("gpt-zzz"),
+            tiktoken_rs::cl100k_base_singleton()
+        ));
         let count = count_tokens("Hello, world!", "gpt-zzz");
         assert!(count > 0, "an unknown gpt-* model must still count tokens");
+    }
+
+    /// Every name this module can be asked about picks the encoding
+    /// tiktoken-rs's own table would have picked, `gpt-2` excepted. The
+    /// comparison is by pointer: the singletons are the encodings.
+    ///
+    /// The point of `bpe_for` is what it does NOT reference, so the test
+    /// binary is where tiktoken's full table gets to be consulted.
+    #[test]
+    fn bpe_for_agrees_with_tiktokens_table_for_every_reachable_name() {
+        let names = [
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5.5",
+            "gpt-5.4-nano",
+            "gpt-55",
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4.10",
+            "gpt-4.5-preview",
+            "gpt-4.5",
+            "gpt-4o",
+            "gpt-4o-2024-05-13",
+            "gpt-4ox",
+            "gpt-4",
+            "gpt-4-0314",
+            "gpt-4-32k",
+            "gpt-3.5-turbo",
+            "gpt-3.5",
+            "gpt-3.5-turbo-0301",
+            "gpt-35-turbo",
+            "gpt-35-turbo-16k",
+            "gpt-oss-120b",
+            "gpt-oss",
+            "gpt-zzz",
+            "gpt-",
+            "o3-",
+            "o3-mini",
+            "o3-pro",
+            "o4-mini",
+            "o4-mini-2026-06-02",
+            "o4-",
+            "o4-pro",
+        ];
+        let cl100k = tiktoken_rs::cl100k_base_singleton();
+        for name in names {
+            let theirs = tiktoken_rs::bpe_for_model(name).unwrap_or(cl100k);
+            assert!(std::ptr::eq(bpe_for(name), theirs), "{name}");
+        }
+        // The documented exception.
+        assert!(std::ptr::eq(bpe_for("gpt-2"), cl100k));
+        assert!(!std::ptr::eq(
+            tiktoken_rs::bpe_for_model("gpt-2").unwrap(),
+            cl100k
+        ));
+        // And the harmony encoding is its own singleton, not o200k_base.
+        assert!(!std::ptr::eq(
+            bpe_for("gpt-oss-20b"),
+            tiktoken_rs::o200k_base_singleton()
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

`count_tokens` resolved models through `tiktoken_rs::bpe_for_model`, whose table covers every OpenAI model ever shipped, so the binary carried `r50k_base`, `p50k_base` and `p50k_edit` (the 2020-era completion vocabularies) that no reachable name could select: this module is only asked about `gpt-*`, `o3-*` and `o4-*` names, all of which resolve to `o200k_base`, `o200k_harmony` or `cl100k_base`.

`tokenizer::bpe_for` is that reachable slice of tiktoken's table (same order, same first-match rules) referencing only the three singletons; the linker drops the other three vocabularies.

## Measured (macOS, release, `perf-tools/binsize.sh`)

| | before | after |
|---|---|---|
| `lev` bytes | 33,309,168 | **31,608,368** (−1,700,800, −5.1%) |
| `__const` | 8,796,832 | 7,125,664 |
| r50k/p50k 64-byte probe | present | absent |
| `nm \| grep -c r50k\|p50k` | (n/a) | 0 |

The plan's gate was ≥ 1.5 MB. Linux is expected to behave the same (dead-code elimination of an unreferenced `static`); the probe check is in `binsize.sh` for the next Linux measurement.

## Behaviour

Token counts for every reachable model are unchanged. `bpe_for_agrees_with_tiktokens_table_for_every_reachable_name` checks 32 name shapes by singleton pointer against tiktoken's own resolution. The one documented difference: `gpt-2` now counts with `cl100k_base` (as any unknown name does) instead of the GPT-2 encoding.

## Verification

`cargo test -p leviath-providers` 909 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-providers` at 100%.
