### PR TITLE
perf(dashboard): stat only what can change on the poll tick

### DIFF
--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -648,13 +648,13 @@ impl Dashboard {
 
     /// Sync agent list from on-disk run-state dir (background workers).
     pub(super) fn sync_from_run_state(&mut self) {
-        // Cached listing: metas re-parse only when their files change. Cloned
-        // out of the Arcs because the big match below reads fields by value;
-        // a meta is ~1KB, so the clone is noise next to the parses it avoids.
-        let runs: Vec<runstate::RunMeta> = runstate::list_runs_cached(&mut self.meta_cache)
-            .iter()
-            .map(|meta| (**meta).clone())
-            .collect();
+        // Cached listing: metas re-parse only when their files change, and a
+        // finished run's is not even stat'ed every tick. Kept as the cache's
+        // own `Arc`s: the loop below reads fields and clones the few strings
+        // it keeps, and cloning 750 records ten times a second was a measurable
+        // share of an idle dashboard's work.
+        let runs: Vec<std::sync::Arc<runstate::RunMeta>> =
+            runstate::list_runs_cached(&mut self.meta_cache);
         // Prune the per-run caches down to runs that still exist.
         let live_dirs: std::collections::HashSet<std::path::PathBuf> = runs
             .iter()
@@ -674,6 +674,14 @@ impl Dashboard {
             .get(self.selected)
             .and_then(|&i| self.agents.get(i))
             .map(|agent| agent.id.clone());
+        // Where each known run sits, so the loop is not a search per run: 750
+        // runs was 280,000 string compares a tick.
+        let positions: std::collections::HashMap<String, usize> = self
+            .agents
+            .iter()
+            .enumerate()
+            .map(|(i, agent)| (agent.id.clone(), i))
+            .collect();
         for run in runs {
             // A live open prompt from the daemon's hub (populated each tick by
             // `sync_interactions`) is the authoritative signal that this agent is
@@ -729,7 +737,11 @@ impl Dashboard {
             // Read stages index + context snapshot through the poll caches,
             // hoisted out of the per-agent branches below so the cache borrow
             // does not overlap the `self.agents` borrow.
-            let stages = runstate::read_stages_index_cached(&run.run_id, &mut self.stages_cache);
+            let stages = runstate::read_stages_index_settled(
+                &run.run_id,
+                &mut self.stages_cache,
+                runstate::settle_window(&run),
+            );
             // The context window, only for the run on screen. It is the largest
             // file in a run directory by a wide margin, and the only thing that
             // reads it is the detail view's context card, which draws one run.
@@ -745,7 +757,7 @@ impl Dashboard {
                 None
             };
 
-            if let Some(agent) = self.agents.iter_mut().find(|a| a.id == run.run_id) {
+            if let Some(agent) = positions.get(&run.run_id).map(|&i| &mut self.agents[i]) {
                 let prev_status_was_active = matches!(
                     agent.status,
                     AgentDisplayStatus::Active | AgentDisplayStatus::Waiting
@@ -3655,6 +3667,10 @@ mod tests {
 
                 let meta2 = make_run_meta(run_id, RunStatus::Error);
                 runstate::write_meta(&meta2).unwrap();
+                // A finished run's record is re-read once a second, not every
+                // tick; this test is about the toast path, not the window, so
+                // the cache forgets the run before the next sync.
+                dash.meta_cache = Default::default();
                 dash.sync_from_run_state(); // second sync: transitions Complete -> Error
 
                 let agent = dash.agents.iter().find(|a| a.id == run_id).unwrap();

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -105,7 +105,16 @@ pub fn read_context_snapshot(run_id: &str) -> Option<ContextSnapshot> {
 /// the length check catches most of those, and a same-length same-instant
 /// rewrite is indistinguishable anyway one tick later.
 pub struct StatCache<T> {
-    entries: std::collections::HashMap<PathBuf, (std::time::SystemTime, u64, Option<Arc<T>>)>,
+    entries: std::collections::HashMap<PathBuf, CacheEntry<T>>,
+}
+
+/// One cached file: the stat it was last read at, when that stat was taken,
+/// and what it parsed to.
+struct CacheEntry<T> {
+    mtime: std::time::SystemTime,
+    len: u64,
+    checked: std::time::Instant,
+    value: Option<Arc<T>>,
 }
 
 impl<T> Default for StatCache<T> {
@@ -126,6 +135,29 @@ impl<T> StatCache<T> {
         path: &Path,
         parse: impl FnOnce(&str) -> Option<T>,
     ) -> Option<Arc<T>> {
+        self.get_with_recheck(path, parse, std::time::Duration::ZERO)
+    }
+
+    /// [`get_with`](Self::get_with), skipping the stat when the entry was
+    /// checked less than `recheck_after` ago.
+    ///
+    /// The stat is the cost. A dashboard over 750 runs stat'ed 1,500 files
+    /// ten times a second to learn that 1,490 of them, belonging to runs that
+    /// finished days ago, had not changed; two thirds of its idle CPU was that
+    /// question. A caller that knows a file has settled (a finished run's
+    /// record) asks it once a second instead, and a file it knows is live
+    /// passes `Duration::ZERO` and is stat'ed every time, as before.
+    pub fn get_with_recheck(
+        &mut self,
+        path: &Path,
+        parse: impl FnOnce(&str) -> Option<T>,
+        recheck_after: std::time::Duration,
+    ) -> Option<Arc<T>> {
+        if let Some(entry) = self.entries.get(path)
+            && entry.checked.elapsed() < recheck_after
+        {
+            return entry.value.clone();
+        }
         let Ok(meta) = std::fs::metadata(path) else {
             self.entries.remove(path);
             return None;
@@ -133,18 +165,32 @@ impl<T> StatCache<T> {
         // A filesystem with no mtimes degrades to epoch (so length changes
         // still refresh) rather than growing an unreachable error arm.
         let stamp = (meta.modified().unwrap_or(std::time::UNIX_EPOCH), meta.len());
-        if let Some((mtime, len, value)) = self.entries.get(path)
-            && (*mtime, *len) == stamp
+        let checked = std::time::Instant::now();
+        if let Some(entry) = self.entries.get_mut(path)
+            && (entry.mtime, entry.len) == stamp
         {
-            return value.clone();
+            entry.checked = checked;
+            return entry.value.clone();
         }
         let value = std::fs::read_to_string(path)
             .ok()
             .and_then(|text| parse(&text))
             .map(Arc::new);
-        self.entries
-            .insert(path.to_path_buf(), (stamp.0, stamp.1, value.clone()));
+        self.entries.insert(
+            path.to_path_buf(),
+            CacheEntry {
+                mtime: stamp.0,
+                len: stamp.1,
+                checked,
+                value: value.clone(),
+            },
+        );
         value
+    }
+
+    /// The cached value for `path`, without asking the filesystem anything.
+    pub fn peek(&self, path: &Path) -> Option<Arc<T>> {
+        self.entries.get(path).and_then(|entry| entry.value.clone())
     }
 
     /// Drop entries for files under runs that no longer exist, so a
@@ -800,9 +846,16 @@ pub fn list_runs_cached(cache: &mut StatCache<RunMeta>) -> Vec<Arc<RunMeta>> {
         for entry in entries.filter_map(|e| e.ok()) {
             live_dirs.insert(entry.path());
             let meta_path = entry.path().join(leviath_core::files::META_FILE);
-            if let Some(meta) = cache.get_with(&meta_path, |json| {
-                serde_json::from_str::<RunMeta>(json).ok()
-            }) {
+            // A run this poller already knows to be finished is asked about
+            // once a second; a live one (or one never seen) every time.
+            let recheck = cache
+                .peek(&meta_path)
+                .map_or(std::time::Duration::ZERO, |meta| settle_window(&meta));
+            if let Some(meta) = cache.get_with_recheck(
+                &meta_path,
+                |json| serde_json::from_str::<RunMeta>(json).ok(),
+                recheck,
+            ) {
                 runs.push(meta);
             }
         }
@@ -812,14 +865,44 @@ pub fn list_runs_cached(cache: &mut StatCache<RunMeta>) -> Vec<Arc<RunMeta>> {
     runs
 }
 
+/// How long a poller may go without re-stat'ing a run's files once the run
+/// has finished: `ZERO` (every tick) while it is live, a second once it is
+/// not. A finished run's record changes only when someone renames or deletes
+/// it, and a second's lag on that is what buys a 750-run dashboard back two
+/// thirds of its idle CPU.
+pub fn settle_window(meta: &RunMeta) -> std::time::Duration {
+    match meta.status {
+        RunStatus::Complete
+        | RunStatus::CompleteInteractive
+        | RunStatus::Error
+        | RunStatus::Cancelled => SETTLED_RECHECK,
+        RunStatus::Starting | RunStatus::Running | RunStatus::WaitingInput | RunStatus::Paused => {
+            std::time::Duration::ZERO
+        }
+    }
+}
+
+/// See [`settle_window`].
+const SETTLED_RECHECK: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// [`read_stages_index`] through a [`StatCache`], for pollers.
 pub fn read_stages_index_cached(
     run_id: &str,
     cache: &mut StatCache<Vec<StageRecord>>,
 ) -> Vec<StageRecord> {
+    read_stages_index_settled(run_id, cache, std::time::Duration::ZERO)
+}
+
+/// [`read_stages_index_cached`] with the poller's [`settle_window`] for the
+/// run, so a finished run's stage ledger is not stat'ed every tick either.
+pub fn read_stages_index_settled(
+    run_id: &str,
+    cache: &mut StatCache<Vec<StageRecord>>,
+    recheck_after: std::time::Duration,
+) -> Vec<StageRecord> {
     let path = run_dir(run_id).join(leviath_core::files::STAGES_FILE);
     cache
-        .get_with(&path, |json| serde_json::from_str(json).ok())
+        .get_with_recheck(&path, |json| serde_json::from_str(json).ok(), recheck_after)
         .map(|records| records.as_ref().clone())
         .unwrap_or_default()
 }
@@ -2075,6 +2158,150 @@ mod tests {
             // read_dir-failed arm).
             std::fs::remove_dir_all(runs_dir()).unwrap();
             assert!(list_runs_cached(&mut metas).is_empty());
+        });
+    }
+
+    /// A settled entry is answered from memory inside its window and from the
+    /// filesystem outside it; `peek` never asks the filesystem at all.
+    #[test]
+    fn a_stat_cache_honours_the_recheck_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("meta.json");
+        std::fs::write(&path, "1").unwrap();
+        let mut cache: StatCache<String> = StatCache::default();
+        let parse = |s: &str| Some(s.to_string());
+        assert!(cache.peek(&path).is_none(), "nothing cached yet");
+        assert_eq!(*cache.get_with(&path, parse).unwrap(), "1");
+        assert_eq!(*cache.peek(&path).unwrap(), "1");
+
+        // The file changes. Inside the window the old value stands, because
+        // the point is not to stat; outside it the change is seen. The new
+        // content is a different LENGTH: the stamp is (mtime, len), and a
+        // same-length rewrite inside one mtime tick (Windows CI has coarse
+        // ticks) is invisible to it by design.
+        std::fs::write(&path, "22").unwrap();
+        let hour = std::time::Duration::from_secs(3600);
+        assert_eq!(*cache.get_with_recheck(&path, parse, hour).unwrap(), "1");
+        assert_eq!(*cache.get_with(&path, parse).unwrap(), "22");
+        // A stat that finds the same stamp refreshes the check time without a
+        // parse, so the next windowed read is answered from memory too.
+        assert_eq!(*cache.get_with(&path, parse).unwrap(), "22");
+        assert_eq!(*cache.get_with_recheck(&path, parse, hour).unwrap(), "22");
+
+        // A missing file is forgotten, and a window does not resurrect it.
+        std::fs::remove_file(&path).unwrap();
+        assert!(cache.get_with(&path, parse).is_none());
+        assert!(cache.peek(&path).is_none());
+        assert!(cache.get_with_recheck(&path, parse, hour).is_none());
+    }
+
+    /// A finished run settles; a live, waiting or paused one does not.
+    #[test]
+    fn only_a_finished_run_settles() {
+        let mut meta = RunMeta::new(
+            "settle".to_string(),
+            "agent".to_string(),
+            "/p".to_string(),
+            "t".to_string(),
+            None,
+            "/w".to_string(),
+            1,
+        );
+        for status in [
+            RunStatus::Starting,
+            RunStatus::Running,
+            RunStatus::WaitingInput,
+            RunStatus::Paused,
+        ] {
+            meta.status = status;
+            assert_eq!(settle_window(&meta), std::time::Duration::ZERO);
+        }
+        for status in [
+            RunStatus::Complete,
+            RunStatus::CompleteInteractive,
+            RunStatus::Error,
+            RunStatus::Cancelled,
+        ] {
+            meta.status = status;
+            assert_eq!(settle_window(&meta), SETTLED_RECHECK);
+        }
+    }
+
+    /// The listing asks a finished run once a second and a live one every
+    /// time: a rename of a finished run shows up within the window, a live
+    /// run's progress immediately.
+    #[test]
+    fn a_cached_listing_settles_finished_runs() {
+        with_isolated_runs_dir("cached-listing-settles", |_d| {
+            let mut done = RunMeta::new(
+                "done".to_string(),
+                "agent".to_string(),
+                "/p".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                1,
+            );
+            done.status = RunStatus::Complete;
+            create_run(&done).unwrap();
+            let mut live = RunMeta::new(
+                "live".to_string(),
+                "agent".to_string(),
+                "/p".to_string(),
+                "t".to_string(),
+                None,
+                "/w".to_string(),
+                1,
+            );
+            live.status = RunStatus::Running;
+            create_run(&live).unwrap();
+            let mut metas = StatCache::default();
+            let mut stages = StatCache::default();
+            assert_eq!(list_runs_cached(&mut metas).len(), 2);
+
+            // Both records change on disk.
+            done.title = Some("renamed".to_string());
+            write_meta(&done).unwrap();
+            live.iteration = 7;
+            write_meta(&live).unwrap();
+            let listed = list_runs_cached(&mut metas);
+            let by_id = |id: &str| listed.iter().find(|m| m.run_id == id).unwrap().clone();
+            assert_eq!(by_id("live").iteration, 7, "a live run is read every tick");
+            assert_eq!(
+                by_id("done").title,
+                None,
+                "a finished run waits for its window"
+            );
+            // The same for the stage ledger: the first read populates, a
+            // windowed read after a change answers from memory, an unwindowed
+            // one sees the change.
+            write_stages_index("done", &[StageRecord::new("a".to_string(), 0)]).unwrap();
+            let window = settle_window(&done);
+            assert_eq!(
+                read_stages_index_settled("done", &mut stages, window).len(),
+                1
+            );
+            write_stages_index(
+                "done",
+                &[
+                    StageRecord::new("a".to_string(), 0),
+                    StageRecord::new("b".to_string(), 1),
+                ],
+            )
+            .unwrap();
+            assert_eq!(
+                read_stages_index_settled("done", &mut stages, window).len(),
+                1
+            );
+            assert_eq!(read_stages_index_cached("done", &mut stages).len(), 2);
+            // Outside the window (forced here by asking with no window) the
+            // rename is seen.
+            let fresh = metas
+                .get_with(&run_dir("done").join("meta.json"), |json| {
+                    serde_json::from_str::<RunMeta>(json).ok()
+                })
+                .unwrap();
+            assert_eq!(fresh.title.as_deref(), Some("renamed"));
         });
     }
 


### PR DESCRIPTION
## Measure first

Release build, 750-run corpus, `sample` at 1 ms for 10 s, both views: the dashboard uses ~12% of a core with a single repaint in 25 s, so the draw path is not where the time goes. Of the non-idle main-thread samples (~870 of 7,376), `stat` accounted for ~475 (`meta.json` and `stages.json` for every run, every 100 ms tick), `readdir` ~50, the `find` pairing records with rows ~80 (memcmp), the display-index sort ~30. The plan's 4.1 premise (disk reads in `draw`) does not hold with the repaint-on-change loop; this PR is the 4.2 part the profile actually points at.

## What

1. `StatCache::get_with_recheck(path, parse, recheck_after)` + `StatCache::peek`: skip the stat while an entry was checked less than `recheck_after` ago. `runstate::settle_window(&RunMeta)` is `Duration::ZERO` for Starting/Running/WaitingInput/Paused and 1 s for Complete/CompleteInteractive/Error/Cancelled. `list_runs_cached` and the new `read_stages_index_settled` use it; live runs are stat'ed every tick as before.
2. `sync_from_run_state` keeps the cache's `Arc<RunMeta>`s instead of cloning 750 records per tick.
3. The per-run `find` over `self.agents` becomes a `HashMap<String, usize>` built once per tick.

## Measured (25 s over the same corpus, release, 2 reps)

| view | before | after |
|---|---|---|
| list | 3.390 s, 3.404 s | **2.225 s, 2.269 s** (−34%) |
| detail | 3.756 s, 3.758 s | **2.228 s, 2.114 s** (−42%) |
| max RSS | 22-24 MB | 21 MB |

Repaints unchanged (1 list / 2 detail). Frame-1 hashes are not comparable run-to-run even for the same binary in this harness (relative-time cells), so the identity argument is structural: the same fields are read from the same records.

## Behaviour: one nuance, for your decision

A **finished** run whose `meta.json`/`stages.json` changes on disk (a rename, a hand edit) shows within 1 s instead of within one 100 ms tick. Deletion of a finished run is still seen immediately (the directory listing drives that). Live runs are unaffected. I have **not** queued this PR for auto-merge; say the word and it goes in, or I drop the window to e.g. 500 ms, or remove change 1 and keep 2+3 (which alone are worth maybe a tenth of the saving).

## Tests

`a_stat_cache_honours_the_recheck_window`, `only_a_finished_run_settles`, `a_cached_listing_settles_finished_runs` (a live run's edit is seen at once, a finished run's waits for the window; same for the stage ledger). One existing dashboard test that flips a finished run Complete → Error between two ticks now forgets the cache between them, since its subject is the toast path.

## Verification

`cargo test -p leviath-cli` 4,028 passed; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-cli` at 100%.
