### PR TITLE
deps: reqwest 0.13.4 and rhai 1.26.0, with the chunk sink renamed for rhai

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,9 +3865,9 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3910,9 +3910,9 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.25.1"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
+checksum = "5e6e1be9d697d537ce450766df42ad6adf1a93f25f21d73217354ad7e3d3dae1"
 dependencies = [
  "ahash",
  "bitflags 2.13.1",
@@ -4347,7 +4347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
 dependencies = [
  "autocfg",
- "serde",
  "static_assertions",
  "version_check",
 ]
@@ -4629,9 +4628,6 @@ name = "thin-vec"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79def32ffcd477db1ff26f76dab9e3a91f0bd42a85ca96577089b24623056f9d"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "thiserror"
@@ -5288,9 +5284,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/crates/leviath-providers/src/rhai_provider/engine.rs
+++ b/crates/leviath-providers/src/rhai_provider/engine.rs
@@ -45,14 +45,14 @@ pub struct ExecConfig {
     pub jobs: mpsc::UnboundedSender<BrokerJob>,
     /// Effective per-request timeout (the stage's `request_timeout_secs`).
     pub timeout_secs: Option<u64>,
-    /// When streaming, the sink `__emit_chunk` feeds parsed chunks into.
+    /// When streaming, the sink `leviath_emit_chunk` feeds parsed chunks into.
     pub chunk_tx: Option<mpsc::UnboundedSender<crate::Result<StreamChunk>>>,
     /// `[security] allow_env_vars` - see [`build_init_engine`].
     pub env_allowlist: Arc<Vec<String>>,
 }
 
 /// Build the per-call execution engine: the hardened base plus `http_get`,
-/// `http_post`, `stream_request`, and (when streaming) `__emit_chunk`.
+/// `http_post`, `stream_request`, and (when streaming) `leviath_emit_chunk`.
 pub fn build_exec_engine(cfg: ExecConfig) -> Engine {
     let mut engine = build_init_engine(cfg.env_allowlist.clone());
     register_http_fns(&mut engine, cfg.jobs.clone(), cfg.timeout_secs);
@@ -301,7 +301,7 @@ fn register_emit_chunk(
     engine: &mut Engine,
     chunk_tx: mpsc::UnboundedSender<crate::Result<StreamChunk>>,
 ) {
-    engine.register_fn("__emit_chunk", move |result: Dynamic| {
+    engine.register_fn("leviath_emit_chunk", move |result: Dynamic| {
         let _ = chunk_tx.send(chunk_from_dynamic(result));
     });
 }

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -466,8 +466,10 @@ impl Provider for RhaiProvider {
                 chunk_tx: Some(chunk_tx),
                 env_allowlist,
             });
-            // "__emit_chunk" is a fixed valid identifier registered above.
-            let on_chunk = FnPtr::new("__emit_chunk").expect("__emit_chunk is a valid identifier");
+            // A fixed identifier registered above. It starts with a letter on
+            // purpose: rhai 1.26 stopped accepting a leading underscore here.
+            let on_chunk =
+                FnPtr::new("leviath_emit_chunk").expect("leviath_emit_chunk is a valid identifier");
             let mut scope = Scope::new();
             engine
                 .call_fn::<Dynamic>(


### PR DESCRIPTION
Replaces #665 (dependabot), which failed CI on every OS.

## What moves

- reqwest 0.13.1 -> 0.13.4 (pulls wasm-streams 0.4.2 -> 0.5.0)
- rhai 1.25.1 -> 1.26.0

## Why dependabot's version failed

rhai 1.26 rewrote `is_valid_identifier`: a function name must now start with a letter, where 1.25 accepted a leading underscore. The streaming provider builds the script's chunk sink with `FnPtr::new("__emit_chunk")`, which 1.26 rejects with `ErrorFunctionNotFound("__emit_chunk")`. That panicked the blocking task behind `stream()` and failed `native_stream_emits_chunks`, `native_stream_mid_stream_error` and `native_stream_script_throw_becomes_error_item` on Linux, macOS and Windows.

## The fix

The sink is registered and referenced as `leviath_emit_chunk`. Scripts never see the name (they receive the pointer as `on_chunk` and call `on_chunk.call(...)`), so the provider script contract is unchanged; `docs/content/rhai-providers.md` and the bundled example need no edit.

## Checked locally on the bumped lockfile

- `cargo test --workspace --all-features`: all green (providers 912, cli 4024, runtime 908, and the rest)
- `cargo clippy --workspace --all-targets --all-features -D warnings`: clean
- `cargo deny check`: passes (same pre-existing duplicate-version warnings as main)
- `cargo fmt --check`: clean
