### PR TITLE
fix(serve): resolve ?agent= through the catalog, and allow every RunMeta field

### DIFF
--- a/crates/leviath-cli/src/commands/serve/runs.rs
+++ b/crates/leviath-cli/src/commands/serve/runs.rs
@@ -411,8 +411,18 @@ fn resolve(query: &RunsQuery) -> Result<Resolved, ApiError> {
 /// `skip_serializing_if = "Option::is_none"`, so a probe left at its defaults
 /// omits them and the allowlist silently refuses a field that does exist -
 /// `?fields=read_paths` and `?fields=final_output` were both rejected on runs
-/// that had them. Filling the options is what makes the sentence above true.
+/// that had them, and then `?fields=waiting_on` was, which is what the
+/// leviath.dev console asks for on every sidebar load (issue #656). Filling
+/// the options is what makes the sentence above true, and
+/// `every_skip_if_none_option_on_run_meta_is_filled_by_the_probe` in the tests
+/// reads the struct's source to catch the next one added without a line here.
 fn known_meta_fields() -> HashSet<String> {
+    serialized_keys(&probe_meta())
+}
+
+/// A `RunMeta` with every `skip_serializing_if` option set, so that
+/// serializing it names every key a real run can carry.
+fn probe_meta() -> RunMeta {
     let mut probe = RunMeta::new(
         String::new(),
         String::new(),
@@ -424,7 +434,14 @@ fn known_meta_fields() -> HashSet<String> {
     );
     probe.read_paths = Some(Default::default());
     probe.final_output = Some(Default::default());
+    probe.waiting_on = Some(leviath_core::run_meta::WaitReason::ToolApproval);
     probe.output_request = Some(Default::default());
+    probe.model_override = Some(String::new());
+    probe
+}
+
+/// The top-level keys `probe` serializes to, plus the two the route adds.
+fn serialized_keys(probe: &RunMeta) -> HashSet<String> {
     // `RunMeta` is a struct, so this is always an object; `as_object` keeps
     // that assumption in one place instead of adding a match arm nothing can
     // reach.

--- a/crates/leviath-cli/src/commands/serve/runs_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/runs_tests.rs
@@ -161,11 +161,53 @@ fn fields_always_keeps_run_id_and_rejects_what_it_cannot_serve() {
 /// allowlist honest.
 #[test]
 fn fields_accepts_the_optional_ones_that_only_some_runs_carry() {
-    for optional in ["read_paths", "final_output", "output_request"] {
+    for optional in [
+        "read_paths",
+        "final_output",
+        "waiting_on",
+        "output_request",
+        "model_override",
+    ] {
         let r = resolve_ok(&[("fields", optional)]);
         let fields = r.fields.expect("fields set");
         assert!(fields.contains(optional), "{optional} should be selectable");
     }
+}
+
+/// The probe has to name every field the struct has, and the only place that
+/// list exists is the struct itself. So read it: every `pub` field declared
+/// inside `RunMeta` in `run_meta.rs` must be a key the probe serializes. A
+/// field added with `skip_serializing_if` and no line in `probe_meta` fails
+/// here rather than as a 400 in a console (issue #656 was `waiting_on`).
+#[test]
+fn every_skip_if_none_option_on_run_meta_is_filled_by_the_probe() {
+    let source = std::fs::read_to_string(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../leviath-core/src/run_meta.rs"
+    ))
+    .expect("the RunMeta source");
+    // The struct's lines: from its declaration to the first column-zero `}`.
+    let declared: Vec<&str> = source
+        .lines()
+        .skip_while(|line| *line != "pub struct RunMeta {")
+        .skip(1)
+        .take_while(|line| *line != "}")
+        .filter_map(|line| line.trim().strip_prefix("pub "))
+        .filter_map(|rest| rest.split_once(':'))
+        .map(|(name, _)| name.trim())
+        .collect();
+    assert!(declared.len() > 30, "found only {declared:?}");
+
+    let known = known_meta_fields();
+    let missing: Vec<&str> = declared
+        .iter()
+        .copied()
+        .filter(|name| !known.contains(*name))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "RunMeta fields the probe does not serialize (fill them in probe_meta): {missing:?}"
+    );
 }
 
 /// A silently ignored parameter is the API smell that produces the worst bug

--- a/crates/leviath-cli/src/commands/serve/scripts.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts.rs
@@ -34,14 +34,13 @@
 use std::collections::{BTreeMap, HashMap};
 use std::path::{Component, Path, PathBuf};
 
-use axum::extract::{Path as AxumPath, Query};
+use axum::extract::{Path as AxumPath, Query, State};
 use axum::http::StatusCode;
 use axum::response::Json;
 use serde::{Deserialize, Serialize};
 
 use super::tools::agent_dir;
-use super::types::ApiError;
-use super::types::err;
+use super::types::{ApiError, AppState, err};
 
 /// Which extension point a script plugs into, and so which compiler decides
 /// whether it is valid.
@@ -133,7 +132,12 @@ struct Target {
 /// request can ask for a `.toml`, a manifest, or anything else in the agent's
 /// directory. A `name` that already carries the extension is accepted and means
 /// the same file, since that is how the listing spells a path back.
-fn resolve(kind: &str, name: &str, agent: Option<&str>) -> Result<Target, ApiError> {
+fn resolve(
+    config: &crate::config::Config,
+    kind: &str,
+    name: &str,
+    agent: Option<&str>,
+) -> Result<Target, ApiError> {
     let Some(kind) = ScriptKind::parse(kind) else {
         return Err(err(
             StatusCode::BAD_REQUEST,
@@ -163,7 +167,7 @@ fn resolve(kind: &str, name: &str, agent: Option<&str>) -> Result<Target, ApiErr
             ));
         }
         (Some(agent), _) => {
-            let base = agent_dir(agent)?;
+            let base = agent_dir(config, agent)?;
             // Tools are scanned out of `tools/`; a hook or validator is named by
             // a manifest path that resolves against the agent's own directory.
             let dir = match kind {
@@ -674,11 +678,12 @@ fn collect_declared(dir: &Path, agent: &str, out: &mut Vec<ScriptItem>) {
 /// them out of the agent view would only mean a console had to make a second
 /// request to draw the same page.
 pub(super) async fn list_scripts(
+    State(state): State<AppState>,
     Query(q): Query<ScriptQuery>,
 ) -> Result<Json<ScriptsResp>, ApiError> {
     let mut scripts = Vec::new();
     if let Some(name) = q.agent.as_deref() {
-        let dir = agent_dir(name)?;
+        let dir = agent_dir(&state.current_config(), name)?;
         collect_tools(&dir.join("tools"), "agent", Some(name), &mut scripts);
         collect_declared(&dir, name, &mut scripts);
     }
@@ -689,10 +694,11 @@ pub(super) async fn list_scripts(
 
 /// `GET /api/scripts/{kind}/{name}[?agent=<name>]`: the source text.
 pub(super) async fn get_script(
+    State(state): State<AppState>,
     AxumPath((kind, name)): AxumPath<(String, String)>,
     Query(q): Query<ScriptQuery>,
 ) -> Result<Json<ScriptSource>, ApiError> {
-    let target = resolve(&kind, &name, q.agent.as_deref())?;
+    let target = resolve(&state.current_config(), &kind, &name, q.agent.as_deref())?;
     guard(&target, Presence::Required)?;
     read_script(&target)
 }
@@ -745,11 +751,12 @@ fn stem_of(path: &Path) -> String {
 /// Mounted only under `--allow-admin`, because what this writes is code every
 /// agent on the machine may then execute.
 pub(super) async fn put_script(
+    State(state): State<AppState>,
     AxumPath((kind, name)): AxumPath<(String, String)>,
     Query(q): Query<ScriptQuery>,
     Json(body): Json<WriteScriptReq>,
 ) -> Result<Json<ScriptWritten>, ApiError> {
-    let target = resolve(&kind, &name, q.agent.as_deref())?;
+    let target = resolve(&state.current_config(), &kind, &name, q.agent.as_deref())?;
     if let Err(e) = std::fs::create_dir_all(&target.dir) {
         return Err(err(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -781,10 +788,11 @@ fn write_script(target: &Target, content: &str) -> Result<Json<ScriptWritten>, A
 
 /// `DELETE /api/scripts/{kind}/{name}[?agent=<name>]` (admin only): remove it.
 pub(super) async fn delete_script(
+    State(state): State<AppState>,
     AxumPath((kind, name)): AxumPath<(String, String)>,
     Query(q): Query<ScriptQuery>,
 ) -> Result<StatusCode, ApiError> {
-    let target = resolve(&kind, &name, q.agent.as_deref())?;
+    let target = resolve(&state.current_config(), &kind, &name, q.agent.as_deref())?;
     guard(&target, Presence::Required)?;
     remove_script(&target)
 }

--- a/crates/leviath-cli/src/commands/serve/scripts_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/scripts_tests.rs
@@ -1,7 +1,8 @@
 //! Tests for the script read/write routes.
 
 use super::*;
-use crate::commands::serve::testutil::with_home;
+use crate::commands::serve::testutil::{state_with_agent_paths, with_home};
+use crate::config::Config;
 use axum::Router;
 use axum::body::Body;
 use axum::http::Request;
@@ -31,7 +32,7 @@ fn providers_root(home: &Path) -> PathBuf {
 
 /// Every script route, mounted the way production mounts them under
 /// `--allow-admin`, so a test drives the real handlers.
-fn admin_router() -> Router {
+fn admin_router(agent_paths: Vec<PathBuf>) -> Router {
     Router::new()
         .route("/api/scripts", get(list_scripts))
         .route("/api/scripts/validate", post(validate_script))
@@ -39,10 +40,22 @@ fn admin_router() -> Router {
             "/api/scripts/{kind}/{name}",
             get(get_script).put(put_script).delete(delete_script),
         )
+        .with_state(state_with_agent_paths(agent_paths))
 }
 
 async fn call(req: Request<Body>) -> (StatusCode, serde_json::Value) {
-    let resp = admin_router().oneshot(req).await.expect("a response");
+    call_with_paths(Vec::new(), req).await
+}
+
+/// `call`, against a server whose config lists `agent_paths`.
+async fn call_with_paths(
+    agent_paths: Vec<PathBuf>,
+    req: Request<Body>,
+) -> (StatusCode, serde_json::Value) {
+    let resp = admin_router(agent_paths)
+        .oneshot(req)
+        .await
+        .expect("a response");
     let status = resp.status();
     let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
@@ -200,7 +213,8 @@ fn status_pairs_flatten_both_outcomes() {
 #[tokio::test]
 async fn a_tool_resolves_into_the_agents_tools_directory() {
     with_home(|home| async move {
-        let target = resolve("tool", "summarize", Some("researcher")).expect("resolves");
+        let target =
+            resolve(&Config::default(), "tool", "summarize", Some("researcher")).expect("resolves");
         assert_eq!(target.dir, agent_root(&home, "researcher").join("tools"));
         assert_eq!(target.scope, "agent");
         assert_eq!(target.agent.as_deref(), Some("researcher"));
@@ -214,7 +228,13 @@ async fn a_tool_resolves_into_the_agents_tools_directory() {
 #[tokio::test]
 async fn a_hook_resolves_beside_the_manifest_not_under_tools() {
     with_home(|home| async move {
-        let target = resolve("stage_hook", "hooks", Some("researcher")).expect("resolves");
+        let target = resolve(
+            &Config::default(),
+            "stage_hook",
+            "hooks",
+            Some("researcher"),
+        )
+        .expect("resolves");
         assert_eq!(target.dir, agent_root(&home, "researcher"));
         assert_eq!(
             target.path,
@@ -227,7 +247,7 @@ async fn a_hook_resolves_beside_the_manifest_not_under_tools() {
 #[tokio::test]
 async fn a_global_tool_resolves_into_the_shared_directory() {
     with_home(|home| async move {
-        let target = resolve("tool", "summarize", None).expect("resolves");
+        let target = resolve(&Config::default(), "tool", "summarize", None).expect("resolves");
         assert_eq!(target.dir, global_root(&home));
         assert_eq!(target.scope, "global");
         assert!(target.agent.is_none());
@@ -240,8 +260,8 @@ async fn a_global_tool_resolves_into_the_shared_directory() {
 #[tokio::test]
 async fn a_name_that_already_carries_the_extension_is_the_same_file() {
     with_home(|home| async move {
-        let bare = resolve("tool", "summarize", None).expect("resolves");
-        let dotted = resolve("tool", "summarize.rhai", None).expect("resolves");
+        let bare = resolve(&Config::default(), "tool", "summarize", None).expect("resolves");
+        let dotted = resolve(&Config::default(), "tool", "summarize.rhai", None).expect("resolves");
         assert_eq!(bare.path, dotted.path);
         assert!(bare.path.starts_with(global_root(&home)));
     })
@@ -251,7 +271,8 @@ async fn a_name_that_already_carries_the_extension_is_the_same_file() {
 #[tokio::test]
 async fn an_unknown_kind_is_refused() {
     with_home(|_home| async move {
-        let (status, _) = resolve("model_provider", "x", None).expect_err("no such kind");
+        let (status, _) =
+            resolve(&Config::default(), "model_provider", "x", None).expect_err("no such kind");
         assert_eq!(status, StatusCode::BAD_REQUEST);
     })
     .await;
@@ -260,7 +281,8 @@ async fn an_unknown_kind_is_refused() {
 #[tokio::test]
 async fn a_traversing_script_name_is_refused() {
     with_home(|_home| async move {
-        let (status, _) = resolve("tool", "../../evil", None).expect_err("a traversal");
+        let (status, _) =
+            resolve(&Config::default(), "tool", "../../evil", None).expect_err("a traversal");
         assert_eq!(status, StatusCode::BAD_REQUEST);
     })
     .await;
@@ -269,8 +291,36 @@ async fn a_traversing_script_name_is_refused() {
 #[tokio::test]
 async fn a_traversing_agent_name_is_refused() {
     with_home(|_home| async move {
-        let (status, _) = resolve("tool", "x", Some("../../etc")).expect_err("a traversal");
+        let (status, _) =
+            resolve(&Config::default(), "tool", "x", Some("../../etc")).expect_err("a traversal");
         assert_eq!(status, StatusCode::BAD_REQUEST);
+    })
+    .await;
+}
+
+/// An agent the catalog found through `config.agent_paths` resolves to its
+/// own directory, the one `GET /api/blueprints` reports as `path`. It used to
+/// resolve to `~/.leviath/agents/<name>`, which for such an agent does not
+/// exist, so a `PUT` wrote a tool nothing would ever load (issue #643).
+#[tokio::test]
+async fn an_agent_from_a_configured_path_resolves_to_its_own_directory() {
+    with_home(|home| async move {
+        let workspace = home.join("workspace");
+        let agent = workspace.join("researcher");
+        write(&agent.join("agent.leviath"), manifest_with_hooks());
+        let config = Config {
+            agent_paths: vec![workspace],
+            ..Default::default()
+        };
+
+        let tool = resolve(&config, "tool", "summarize", Some("researcher")).expect("resolves");
+        assert_eq!(tool.dir, agent.join("tools"));
+        let hook = resolve(&config, "stage_hook", "hooks", Some("researcher")).expect("resolves");
+        assert_eq!(hook.dir, agent);
+        // A name the catalog does not know still lands in the installed
+        // directory, so a new agent can be created there.
+        let fresh = resolve(&config, "tool", "summarize", Some("newcomer")).expect("resolves");
+        assert_eq!(fresh.dir, agent_root(&home, "newcomer").join("tools"));
     })
     .await;
 }
@@ -280,7 +330,8 @@ async fn a_traversing_agent_name_is_refused() {
 #[tokio::test]
 async fn a_hook_without_an_agent_is_refused() {
     with_home(|_home| async move {
-        let (status, body) = resolve("region_hook", "x", None).expect_err("no scope");
+        let (status, body) =
+            resolve(&Config::default(), "region_hook", "x", None).expect_err("no scope");
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(body.0.error.contains("?agent="), "{}", body.0.error);
     })
@@ -878,7 +929,8 @@ async fn validating_an_unknown_kind_is_a_400() {
 #[tokio::test]
 async fn a_provider_resolves_into_the_providers_directory() {
     with_home(|home| async move {
-        let target = resolve("provider", "groq", None).expect("a provider is global");
+        let target =
+            resolve(&Config::default(), "provider", "groq", None).expect("a provider is global");
         assert_eq!(target.path, providers_root(&home).join("groq.rhai"));
         assert_eq!(target.scope, "global");
         assert!(target.agent.is_none());
@@ -891,7 +943,8 @@ async fn a_provider_resolves_into_the_providers_directory() {
 #[tokio::test]
 async fn a_provider_with_an_agent_is_refused() {
     with_home(|_home| async move {
-        let (status, body) = resolve("provider", "groq", Some("researcher")).expect_err("global");
+        let (status, body) = resolve(&Config::default(), "provider", "groq", Some("researcher"))
+            .expect_err("global");
         assert_eq!(status, StatusCode::BAD_REQUEST);
         assert!(body.0.error.contains("?agent="), "{}", body.0.error);
     })
@@ -1123,6 +1176,88 @@ async fn validating_a_provider_does_not_run_initialize() {
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body["valid"], true);
+    })
+    .await;
+}
+
+// ─── agents discovered through config.agent_paths ───────────────────────────
+
+/// The whole round trip for an agent that lives in a configured path rather
+/// than the installed directory: its tools are listed, its hook opens, and a
+/// write lands beside its manifest. Every one of these went to an empty
+/// `~/.leviath/agents/<name>/` before (issue #643).
+#[tokio::test]
+async fn the_routes_see_an_agent_discovered_through_agent_paths() {
+    with_home(|home| async move {
+        let workspace = home.join("workspace");
+        let agent = workspace.join("researcher");
+        write(&agent.join("agent.leviath"), manifest_with_hooks());
+        write(&agent.join("tools").join("web_search.rhai"), GOOD_TOOL);
+        write(&agent.join("hooks.rhai"), "fn on_stage_enter(ctx) { () }");
+        let paths = vec![workspace];
+
+        let (status, body) = call_with_paths(
+            paths.clone(),
+            Request::builder()
+                .uri("/api/scripts?agent=researcher")
+                .body(Body::empty())
+                .expect("a request"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let scripts = body["scripts"].as_array().expect("a scripts array");
+        let own = scripts
+            .iter()
+            .find(|s| s["name"] == "web_search")
+            .expect("the agent's own tool");
+        assert_eq!(own["source"], "agent");
+        assert!(
+            own["path"]
+                .as_str()
+                .expect("a path")
+                .starts_with(&agent.display().to_string()),
+            "{}",
+            own["path"]
+        );
+
+        let (status, body) = call_with_paths(
+            paths.clone(),
+            Request::builder()
+                .uri("/api/scripts/stage_hook/hooks?agent=researcher")
+                .body(Body::empty())
+                .expect("a request"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["content"], "fn on_stage_enter(ctx) { () }");
+
+        let (status, body) = call_with_paths(
+            paths.clone(),
+            Request::builder()
+                .method("PUT")
+                .uri("/api/scripts/tool/summarize?agent=researcher")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&serde_json::json!({ "content": GOOD_TOOL })).expect("json"),
+                ))
+                .expect("a request"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(agent.join("tools").join("summarize.rhai").is_file());
+        assert!(!agent_root(&home, "researcher").exists());
+
+        let (status, _) = call_with_paths(
+            paths,
+            Request::builder()
+                .method("DELETE")
+                .uri("/api/scripts/tool/summarize?agent=researcher")
+                .body(Body::empty())
+                .expect("a request"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+        assert!(!agent.join("tools").join("summarize.rhai").exists());
     })
     .await;
 }

--- a/crates/leviath-cli/src/commands/serve/testutil.rs
+++ b/crates/leviath-cli/src/commands/serve/testutil.rs
@@ -39,6 +39,24 @@ where
     .await
 }
 
+/// An `AppState` whose config lists `paths` under `agent_paths` and that
+/// talks to no daemon, for routes that only need the blueprint catalog.
+pub(super) fn state_with_agent_paths(paths: Vec<std::path::PathBuf>) -> super::types::AppState {
+    let (event_tx, _) = tokio::sync::broadcast::channel(64);
+    super::types::AppState {
+        update_check: Default::default(),
+        update_jobs: Default::default(),
+        config: fixed_config(crate::config::Config {
+            agent_paths: paths,
+            ..Default::default()
+        }),
+        event_tx,
+        control: no_daemon_client(),
+        mcp: super::mcp::McpAdmin::default(),
+        limits: Default::default(),
+    }
+}
+
 /// A control client pointing at an address with no daemon - used by tests that
 /// never exercise agent actions (read/websocket/polling/config paths).
 pub(super) fn no_daemon_client() -> ControlClient {

--- a/crates/leviath-cli/src/commands/serve/tools.rs
+++ b/crates/leviath-cli/src/commands/serve/tools.rs
@@ -11,33 +11,46 @@
 
 use std::path::PathBuf;
 
-use axum::extract::Query;
+use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::Json;
 use serde::{Deserialize, Serialize};
 
-use super::types::{ApiError, err};
+use super::types::{ApiError, AppState, err};
 use crate::tool_inventory::ToolInventory;
 
-/// Resolve `<agents_dir>/<name>`, refusing a name that is not a single safe
-/// path component.
+/// The directory of the agent called `name`, refusing a name that is not a
+/// single safe path component.
+///
+/// The name is looked up in the same catalog `GET /api/blueprints` lists, so an
+/// agent found through `config.agent_paths` resolves to where it actually is.
+/// It used to be `agents_dir().join(name)` unconditionally: an agent under
+/// development in a configured path was listed and could be spawned, yet its
+/// `tools/` never showed up here, its hooks could not be opened, and a
+/// `PUT /api/scripts/...?agent=` wrote into an empty `~/.leviath/agents/<name>/`
+/// nothing would load (issue #643). A name the catalog does not know still
+/// falls back to the installed directory, so a new agent can be created there.
 ///
 /// The same gate, on the same directory, that `blueprint_dir` applies in
 /// `blueprints.rs`: `Path::join` neither normalizes `..` nor resists an
 /// absolute path, and this name arrives in a query string. Shared from here
 /// because the tools and scripts routes both take an `?agent=` and both would
 /// otherwise write their own copy of the check.
-pub(super) fn agent_dir(name: &str) -> Result<PathBuf, ApiError> {
-    match leviath_core::is_safe_path_component(name) {
-        true => Ok(super::blueprints::agents_dir().join(name)),
-        false => Err(err(
+pub(super) fn agent_dir(config: &crate::config::Config, name: &str) -> Result<PathBuf, ApiError> {
+    if !leviath_core::is_safe_path_component(name) {
+        return Err(err(
             StatusCode::BAD_REQUEST,
             format!(
                 "Invalid agent name '{name}': names may contain only letters, digits, \
                  '.', '_' and '-'"
             ),
-        )),
+        ));
     }
+    let known = super::blueprints::discover_blueprints(config)
+        .into_iter()
+        .find(|b| b.name == name)
+        .map(|b| PathBuf::from(b.path));
+    Ok(known.unwrap_or_else(|| super::blueprints::agents_dir().join(name)))
 }
 
 /// Query parameters for `GET /api/tools`.
@@ -91,9 +104,12 @@ pub(super) struct ToolsResp {
 /// MCP tools are deliberately absent. They depend on a server being reachable
 /// rather than on anything installed here, and `/api/mcp/servers/{name}`
 /// already answers for them.
-pub(super) async fn list_tools(Query(q): Query<ToolsQuery>) -> Result<Json<ToolsResp>, ApiError> {
+pub(super) async fn list_tools(
+    State(state): State<AppState>,
+    Query(q): Query<ToolsQuery>,
+) -> Result<Json<ToolsResp>, ApiError> {
     let dir = match q.agent.as_deref() {
-        Some(name) => Some(agent_dir(name)?),
+        Some(name) => Some(agent_dir(&state.current_config(), name)?),
         None => None,
     };
     let inventory = ToolInventory::discover(dir.as_deref(), q.agent.as_deref());
@@ -131,7 +147,8 @@ mod tests {
     use std::path::Path;
     use tower::ServiceExt;
 
-    use super::super::testutil::with_home;
+    use super::super::testutil::{state_with_agent_paths, with_home};
+    use crate::config::Config;
 
     fn write_tool(dir: &Path, file: &str, body: &str) {
         std::fs::create_dir_all(dir).expect("the directory");
@@ -139,7 +156,17 @@ mod tests {
     }
 
     async fn get_tools(uri: &str) -> (StatusCode, serde_json::Value) {
-        let app = Router::new().route("/api/tools", get(list_tools));
+        get_tools_with_paths(Vec::new(), uri).await
+    }
+
+    /// `get_tools`, against a server whose config lists `agent_paths`.
+    async fn get_tools_with_paths(
+        agent_paths: Vec<std::path::PathBuf>,
+        uri: &str,
+    ) -> (StatusCode, serde_json::Value) {
+        let app = Router::new()
+            .route("/api/tools", get(list_tools))
+            .with_state(state_with_agent_paths(agent_paths));
         let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
         let resp = app.oneshot(req).await.unwrap();
         let status = resp.status();
@@ -251,8 +278,54 @@ mod tests {
     #[tokio::test]
     async fn agent_dir_accepts_a_plain_name() {
         with_home(|home| async move {
-            let dir = agent_dir("researcher").expect("a plain name resolves");
+            let dir = agent_dir(&Config::default(), "researcher").expect("a plain name resolves");
             assert!(dir.starts_with(home.join(".leviath").join("agents")));
+        })
+        .await;
+    }
+
+    /// An agent listed because its directory is under `config.agent_paths`
+    /// resolves to that directory, not to an empty `~/.leviath/agents/<name>`.
+    /// The catalog and the tools route used to disagree about where such an
+    /// agent lived, so its own `tools/` never appeared (issue #643).
+    #[tokio::test]
+    async fn an_agent_from_a_configured_path_lists_its_own_tools() {
+        with_home(|home| async move {
+            let workspace = home.join("workspace");
+            let agent = workspace.join("researcher");
+            std::fs::create_dir_all(&agent).expect("the agent directory");
+            std::fs::write(
+                agent.join("agent.leviath"),
+                "[agent]\nname = \"researcher\"\nversion = \"0.1.0\"\ndescription = \"d\"\n\
+                 \n[stages.main]\nsystem_prompt = \"go\"\n",
+            )
+            .expect("the manifest");
+            write_tool(
+                &agent.join("tools"),
+                "web_search.rhai",
+                "// @tool web_search\n// @description searches\n1",
+            );
+            let config = Config {
+                agent_paths: vec![workspace.clone()],
+                ..Default::default()
+            };
+            assert_eq!(
+                agent_dir(&config, "researcher").expect("a known name resolves"),
+                agent
+            );
+
+            let (status, body) =
+                get_tools_with_paths(vec![workspace], "/api/tools?agent=researcher").await;
+            assert_eq!(status, StatusCode::OK);
+            let tools = body["tools"].as_array().expect("a tools array");
+            let own = tools
+                .iter()
+                .find(|t| t["name"] == "web_search")
+                .expect("the agent's own tool");
+            assert_eq!(own["source"], "agent");
+            assert_eq!(own["agent"], "researcher");
+            let path = own["path"].as_str().expect("a path");
+            assert!(path.starts_with(&agent.display().to_string()), "{path}");
         })
         .await;
     }


### PR DESCRIPTION
Closes #643
Closes #656

## #643: script and tool routes could not see agents from `config.agent_paths`

`agent_dir` in `serve/tools.rs` always returned `agents_dir().join(name)`, while `GET /api/blueprints` lists agents from every `config.agent_paths` entry too. An agent under development in a configured path was listed and spawnable, but `GET /api/tools?agent=`, `GET /api/scripts?agent=` and `GET/PUT/DELETE /api/scripts/{kind}/{name}?agent=` all looked in an empty `~/.leviath/agents/<name>/`.

`agent_dir` now takes the config, looks the name up in `discover_blueprints` (the same catalog `get_blueprint` and `spawn_agent` use) and returns that entry's directory. A name the catalog does not know still falls back to the installed directory so a new agent can be created there. The `is_safe_path_component` check on the name is unchanged and still runs first. The five handlers gained a `State<AppState>` extractor to reach the config.

## #656: `GET /api/runs?fields=waiting_on` returned 400

`known_meta_fields` serializes a probe `RunMeta`; `waiting_on` and `model_override` carry `skip_serializing_if = "Option::is_none"` and were left `None`, so their keys never appeared. The issue comment lists eight fields, but only five on `RunMeta` itself are skip-if-none (`read_paths`, `final_output`, `waiting_on`, `output_request`, `model_override`); `description`, `key` and `metadata` are on the region snapshot types, not `RunMeta`. The probe now fills all five.

To stop the next one, a test reads `RunMeta`'s declaration out of `run_meta.rs` and asserts every declared `pub` field is in the allowlist. It fails with the field named if a skip-if-none option is added without a matching line in `probe_meta`.

## Tests

All five new tests were run against the unfixed code first and fail there:
- `scripts::tests::an_agent_from_a_configured_path_resolves_to_its_own_directory`
- `scripts::tests::the_routes_see_an_agent_discovered_through_agent_paths` (list, get hook, put, delete round trip; asserts nothing lands in `~/.leviath/agents`)
- `tools::tests::an_agent_from_a_configured_path_lists_its_own_tools`
- `runs::tests::fields_accepts_the_optional_ones_that_only_some_runs_carry` (now includes `waiting_on` and `model_override`)
- `runs::tests::every_skip_if_none_option_on_run_meta_is_filled_by_the_probe`

`cargo xtask coverage` passes at 100% on all 13 packages; fmt, clippy, docs and structure are clean.
