### PR TITLE
fix(security): clear every CodeQL finding at its root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,20 @@ cargo llvm-cov --package <crate> --lib --html --open   # browsable per-crate rep
 
 > Branch coverage isn't collected: `cargo llvm-cov --branch` reliably SIGSEGVs inside LLVM's own coverage-mapping code ([open upstream bug](https://github.com/llvm/llvm-project/issues/119558)). See the doc comment atop `xtask/src/coverage.rs` for the full investigation.
 
+## Running CodeQL locally
+
+GitHub's default CodeQL setup scans every push with the `rust-code-scanning` suite and the `remote` threat model, and the repo keeps that count at zero with nothing dismissed. Waiting twenty minutes per push to learn whether a fix took is the slow way; the same queries run locally in a few minutes:
+
+```bash
+brew install codeql                                                    # the CLI (Linux: the GitHub release tarball)
+codeql database create target/codeql-db --language=rust --overwrite    # builds the workspace through cargo
+codeql database analyze target/codeql-db codeql/rust-queries:codeql-suites/rust-code-scanning.qls \
+  --format=sarif-latest --output=target/codeql.sarif --download
+python3 perf-tools/codeql_summary.py target/codeql.sarif                # rule, sink, and every flow's source
+```
+
+The summary's exit status is the number of findings, so a shell can gate on it. Two things worth knowing before reading a result: the Rust model treats every parameter of an axum handler as request data, `State` included (see `SECURITY.md`, "What the scanners say"), and the sensitive-data queries go by variable *name*, so a loop variable called `secret` that holds env-var names reads as a leak.
+
 ## Live-testing against a real daemon
 
 A green test suite and a 100% coverage number are not the same thing as

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -151,6 +151,17 @@ assume; none is a case of the code doing something other than what it says.
 If you find something this document claims but the code does not do, that is a
 vulnerability and we want to hear about it - see the top of this file.
 
+**What the scanners say.** CodeQL runs on every push and the count is kept at
+zero, with nothing dismissed. One class needs explaining so it is not
+re-triaged: CodeQL's Rust model treats every parameter of an axum handler as
+request data, the shared `State` included, so a file location read off the
+server state counts as a path-injection finding even when the operator set it
+at startup. `lev serve` therefore keeps the config and token-store locations
+behind a resolver installed at startup (`McpAdmin::paths()`, and
+`UpdateJobs::with_env` for the update route). A new admin route reads paths
+through that resolver, never through a field on the state. `CONTRIBUTING.md`
+has the recipe for running the same queries locally.
+
 ## Where secrets live
 
 | What | Where | Mode |

--- a/crates/leviath-cli/src/commands/auth.rs
+++ b/crates/leviath-cli/src/commands/auth.rs
@@ -256,8 +256,8 @@ fn migrate(path: &std::path::Path, to_file: bool, dry_run: bool) -> anyhow::Resu
     }
 
     println!("{}", plan.summary);
-    for account in &plan.moving {
-        println!("  - {account}");
+    for moved in &plan.moving {
+        println!("  - {moved}");
     }
     if dry_run {
         println!("\nDry run: nothing was changed.");

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -63,10 +63,10 @@ pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedCo
 /// present field, and writes it back with the file's `0600` permissions — the
 /// same file `lev setup` and MCP admin edits. Returns the new redacted config.
 pub(super) async fn put_config(
-    State(state): State<AppState>,
     Json(req): Json<WriteConfigReq>,
 ) -> Result<Json<RedactedConfig>, ApiError> {
-    let path = &state.mcp.config_path;
+    let paths = super::mcp::admin_paths();
+    let path = &paths.config;
     let mut config = Config::load_from_path_public(path).map_err(|e| {
         err(
             StatusCode::INTERNAL_SERVER_ERROR,
@@ -335,6 +335,7 @@ mod limits_source_label_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::serve::mcp::{AdminPaths, scoped};
     use axum::Router;
     use axum::body::Body;
     use axum::http::Request;
@@ -745,29 +746,33 @@ mod tests {
 
     // ─── put_config endpoint ──────────────────────────────────────────────────
 
-    fn state_with_config_path(path: std::path::PathBuf) -> AppState {
+    /// The state and the file locations a `put_config` test runs against.
+    fn state_with_config_path(path: std::path::PathBuf) -> (AppState, AdminPaths) {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
-        AppState {
+        let state = AppState {
             update_check: Default::default(),
             update_jobs: Default::default(),
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
-            mcp: crate::commands::serve::mcp::McpAdmin {
-                config_path: path,
-                ..Default::default()
-            },
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
             limits: Default::default(),
-        }
+        };
+        (state, paths_for(path))
+    }
+
+    fn paths_for(config: std::path::PathBuf) -> AdminPaths {
+        let store = config.with_file_name("mcp-auth.json");
+        AdminPaths { config, store }
     }
 
     /// [`state_with_config_path`], but its config source *watches* that file
     /// rather than holding a copy - the way `lev serve` builds one. What the
     /// handlers see is then whatever is on disk, which is the whole point of
     /// issue #532.
-    fn state_watching_config_path(path: std::path::PathBuf) -> AppState {
+    fn state_watching_config_path(path: std::path::PathBuf) -> (AppState, AdminPaths) {
         let (tx, _) = broadcast::channel::<ServerEvent>(64);
-        AppState {
+        let state = AppState {
             update_check: Default::default(),
             update_jobs: Default::default(),
             config: Arc::new(crate::daemon::config_reload::ConfigReloader::new(
@@ -776,12 +781,10 @@ mod tests {
             )),
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
-            mcp: crate::commands::serve::mcp::McpAdmin {
-                config_path: path,
-                ..Default::default()
-            },
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
             limits: Default::default(),
-        }
+        };
+        (state, paths_for(path))
     }
 
     /// Force a file's mtime strictly newer, so the reload is observable even
@@ -796,10 +799,13 @@ mod tests {
     /// The endpoint's answer as JSON rather than as `RedactedConfig`: a
     /// gateway serializes with `skip_serializing_if` fields that its own
     /// `Deserialize` requires, so the wire form is the only faithful reading.
-    async fn get_config_request(state: AppState) -> serde_json::Value {
-        let app = Router::new()
-            .route("/api/config", get(get_config))
-            .with_state(state);
+    async fn get_config_request((state, paths): (AppState, AdminPaths)) -> serde_json::Value {
+        let app = scoped(
+            Router::new()
+                .route("/api/config", get(get_config))
+                .with_state(state),
+            paths,
+        );
         let req = Request::builder()
             .uri("/api/config")
             .body(Body::empty())
@@ -868,10 +874,16 @@ mod tests {
         assert_eq!(gateways[0]["base_url"], "https://api.cerebras.ai/v1");
     }
 
-    async fn put_config_request(state: AppState, body: &str) -> axum::http::Response<Body> {
-        let app = Router::new()
-            .route("/api/config", axum::routing::put(put_config))
-            .with_state(state);
+    async fn put_config_request(
+        (state, paths): (AppState, AdminPaths),
+        body: &str,
+    ) -> axum::http::Response<Body> {
+        let app = scoped(
+            Router::new()
+                .route("/api/config", axum::routing::put(put_config))
+                .with_state(state),
+            paths,
+        );
         let req = Request::builder()
             .method("PUT")
             .uri("/api/config")

--- a/crates/leviath-cli/src/commands/serve/mcp.rs
+++ b/crates/leviath-cli/src/commands/serve/mcp.rs
@@ -13,14 +13,62 @@ use super::types::{AppState, err};
 use crate::config::Config;
 use leviath_mcp::{AuthStore, LoginOutcome, MCPClient, MCPServerConfig, OAuthClient};
 
-/// Where `lev serve` reads and writes MCP state, plus the seams the login flow
-/// needs. Cheap to clone (paths + fn pointers).
+/// Where this server reads and rewrites the operator's files.
+///
+/// Resolved from `LEVIATH_HOME` and `LEVIATH_CONFIG_PATH`, never from anything
+/// in a request. The distinction matters to a taint scanner: everything
+/// reachable from a handler's parameters, the shared state included, reads as
+/// request data, and a file location that is request data is a path-injection
+/// finding. So the handlers get these from [`admin_paths`], a plain function
+/// over the environment, and not from a field on [`AppState`]. The update
+/// route keeps its own locations in `UpdateEnv` for the same reason.
+#[derive(Clone, Debug)]
+pub struct AdminPaths {
+    /// Config file to read and rewrite.
+    pub config: std::path::PathBuf,
+    /// OAuth token store.
+    pub store: std::path::PathBuf,
+}
+
+/// The operator's file locations for this process.
+///
+/// Resolved on every call: the lookup is two environment reads, and a lazily
+/// cached copy would pin the first test's home directory on the whole test
+/// binary. In a test build a [`TEST_PATHS`] scope wins over the environment,
+/// which is how the handler tests point at a temp dir.
+pub fn admin_paths() -> AdminPaths {
+    #[cfg(test)]
+    if let Ok(paths) = TEST_PATHS.try_with(Clone::clone) {
+        return paths;
+    }
+    AdminPaths {
+        config: Config::config_path(),
+        store: AuthStore::default_path().unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+tokio::task_local! {
+    /// Test override for [`admin_paths`]; see [`scoped`].
+    pub(crate) static TEST_PATHS: AdminPaths;
+}
+
+/// Wrap a router so every request it serves sees `paths` from
+/// [`admin_paths`]. Test-only: production resolves from the environment.
+#[cfg(test)]
+pub(crate) fn scoped(router: axum::Router, paths: AdminPaths) -> axum::Router {
+    router.layer(axum::middleware::from_fn(
+        move |req: axum::extract::Request, next: axum::middleware::Next| {
+            let paths = paths.clone();
+            async move { TEST_PATHS.scope(paths, next.run(req)).await }
+        },
+    ))
+}
+
+/// The seams the login flow needs: how to open a browser, and what time it
+/// is. Cheap to clone (an `Arc` and a fn pointer).
 #[derive(Clone)]
 pub struct McpAdmin {
-    /// Config file to read and rewrite.
-    pub config_path: std::path::PathBuf,
-    /// OAuth token store.
-    pub store_path: std::path::PathBuf,
     /// How to open the browser during a login.
     pub opener: leviath_mcp::BrowserOpener,
     /// Current Unix time; a fn so a long-lived server stays current per request.
@@ -38,8 +86,6 @@ fn system_now() -> u64 {
 impl Default for McpAdmin {
     fn default() -> Self {
         Self {
-            config_path: Config::config_path(),
-            store_path: AuthStore::default_path().unwrap_or_default(),
             opener: std::sync::Arc::new(leviath_sys::open_url),
             clock: system_now,
         }
@@ -98,11 +144,12 @@ fn auth_status(server: &MCPServerConfig, store: &AuthStore, now: u64) -> String 
 /// `GET /api/mcp/servers` - list configured servers with their auth status.
 pub(super) async fn list_servers(State(state): State<AppState>) -> impl IntoResponse {
     let admin = &state.mcp;
-    let config = match Config::load_from_path_public(&admin.config_path) {
+    let paths = admin_paths();
+    let config = match Config::load_from_path_public(&paths.config) {
         Ok(config) => config,
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
-    let store = AuthStore::load(&admin.store_path).unwrap_or_default();
+    let store = AuthStore::load(&paths.store).unwrap_or_default();
     let now = (admin.clock)();
     let servers: Vec<McpServerInfo> = config
         .mcp_servers
@@ -127,11 +174,8 @@ pub(super) struct AddServerRequest {
 }
 
 /// `POST /api/mcp/servers` - add a server.
-pub(super) async fn add_server(
-    State(state): State<AppState>,
-    Json(req): Json<AddServerRequest>,
-) -> impl IntoResponse {
-    let admin = &state.mcp;
+pub(super) async fn add_server(Json(req): Json<AddServerRequest>) -> impl IntoResponse {
+    let paths = admin_paths();
     let server = MCPServerConfig {
         name: req.name,
         command: req.command,
@@ -144,7 +188,7 @@ pub(super) async fn add_server(
         return err(StatusCode::BAD_REQUEST, e.to_string()).into_response();
     }
 
-    let mut config = match Config::load_from_path_public(&admin.config_path) {
+    let mut config = match Config::load_from_path_public(&paths.config) {
         Ok(config) => config,
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
@@ -156,7 +200,7 @@ pub(super) async fn add_server(
         .into_response();
     }
     config.mcp_servers.push(server.clone());
-    if let Err(e) = config.save_to_path_public(&admin.config_path) {
+    if let Err(e) = config.save_to_path_public(&paths.config) {
         return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
     (
@@ -167,12 +211,9 @@ pub(super) async fn add_server(
 }
 
 /// `DELETE /api/mcp/servers/{name}` - remove a server and its credentials.
-pub(super) async fn remove_server(
-    State(state): State<AppState>,
-    AxumPath(name): AxumPath<String>,
-) -> impl IntoResponse {
-    let admin = &state.mcp;
-    let mut config = match Config::load_from_path_public(&admin.config_path) {
+pub(super) async fn remove_server(AxumPath(name): AxumPath<String>) -> impl IntoResponse {
+    let paths = admin_paths();
+    let mut config = match Config::load_from_path_public(&paths.config) {
         Ok(config) => config,
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
@@ -185,13 +226,13 @@ pub(super) async fn remove_server(
         )
         .into_response();
     }
-    if let Err(e) = config.save_to_path_public(&admin.config_path) {
+    if let Err(e) = config.save_to_path_public(&paths.config) {
         return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
-    if let Ok(mut store) = AuthStore::load(&admin.store_path)
+    if let Ok(mut store) = AuthStore::load(&paths.store)
         && store.remove(&name)
     {
-        let _ = store.save(&admin.store_path);
+        let _ = store.save(&paths.store);
     }
     StatusCode::NO_CONTENT.into_response()
 }
@@ -205,7 +246,8 @@ pub(super) async fn login(
     AxumPath(name): AxumPath<String>,
 ) -> impl IntoResponse {
     let admin = &state.mcp;
-    let config = match Config::load_from_path_public(&admin.config_path) {
+    let paths = admin_paths();
+    let config = match Config::load_from_path_public(&paths.config) {
         Ok(config) => config,
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
@@ -227,7 +269,7 @@ pub(super) async fn login(
         }
     };
 
-    let mut store = AuthStore::load(&admin.store_path).unwrap_or_default();
+    let mut store = AuthStore::load(&paths.store).unwrap_or_default();
     let reuse = store.get(&name).map(|a| a.client_id.clone());
     let outcome = match OAuthClient::new()
         .login(
@@ -251,7 +293,7 @@ pub(super) async fn login(
             .into_response();
     };
     store.set(&name, *auth);
-    if let Err(e) = store.save(&admin.store_path) {
+    if let Err(e) = store.save(&paths.store) {
         return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response();
     }
     Json(serde_json::json!({ "status": "authenticated", "server": name })).into_response()
@@ -263,7 +305,8 @@ pub(super) async fn status(
     AxumPath(name): AxumPath<String>,
 ) -> impl IntoResponse {
     let admin = &state.mcp;
-    let config = match Config::load_from_path_public(&admin.config_path) {
+    let paths = admin_paths();
+    let config = match Config::load_from_path_public(&paths.config) {
         Ok(config) => config,
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
@@ -274,7 +317,7 @@ pub(super) async fn status(
         )
         .into_response();
     };
-    let store = AuthStore::load(&admin.store_path).unwrap_or_default();
+    let store = AuthStore::load(&paths.store).unwrap_or_default();
     Json(McpServerInfo::describe(server, &store, (admin.clock)())).into_response()
 }
 
@@ -284,7 +327,8 @@ pub(super) async fn test_server(
     AxumPath(name): AxumPath<String>,
 ) -> impl IntoResponse {
     let admin = &state.mcp;
-    let config = match Config::load_from_path_public(&admin.config_path) {
+    let paths = admin_paths();
+    let config = match Config::load_from_path_public(&paths.config) {
         Ok(config) => config,
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     };
@@ -296,7 +340,7 @@ pub(super) async fn test_server(
         .into_response();
     };
     let auth_header = match OAuthClient::new()
-        .authorization_header(&name, &admin.store_path, (admin.clock)())
+        .authorization_header(&name, &paths.store, (admin.clock)())
         .await
     {
         Ok(header) => header,
@@ -355,11 +399,8 @@ mod tests {
         1_000
     }
 
-    /// An app state whose MCP admin points at temp paths.
-    fn state_at(
-        dir: &std::path::Path,
-        opener: impl Fn(&str) -> bool + Send + Sync + 'static,
-    ) -> AppState {
+    /// An app state with a test browser opener and a fixed clock.
+    fn state_at(opener: impl Fn(&str) -> bool + Send + Sync + 'static) -> AppState {
         let (tx, _) = broadcast::channel::<ServerEvent>(16);
         AppState {
             update_check: Default::default(),
@@ -368,8 +409,6 @@ mod tests {
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: McpAdmin {
-                config_path: dir.join("config.toml"),
-                store_path: dir.join("mcp-auth.json"),
                 opener: Arc::new(opener),
                 clock: fixed_clock,
             },
@@ -385,6 +424,22 @@ mod tests {
             .route("/api/mcp/servers/{name}/login", post(login))
             .route("/api/mcp/servers/{name}/test", post(test_server))
             .with_state(state)
+    }
+
+    /// The config and store a test keeps under `dir`.
+    fn paths_in(dir: &std::path::Path) -> AdminPaths {
+        AdminPaths {
+            config: dir.join("config.toml"),
+            store: dir.join("mcp-auth.json"),
+        }
+    }
+
+    /// A router over [`state_at`] whose handlers read the files under `dir`.
+    fn app_at(
+        dir: &std::path::Path,
+        opener: impl Fn(&str) -> bool + Send + Sync + 'static,
+    ) -> Router {
+        scoped(router(state_at(opener)), paths_in(dir))
     }
 
     async fn send(
@@ -418,7 +473,7 @@ mod tests {
     #[tokio::test]
     async fn add_list_status_and_remove_round_trip() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
 
         // Empty to start.
         let (status_code, body) = send(&app, "GET", "/api/mcp/servers", None).await;
@@ -456,7 +511,7 @@ mod tests {
     #[tokio::test]
     async fn add_rejects_a_malformed_server() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         let (status_code, _) = send(
             &app,
             "POST",
@@ -471,7 +526,7 @@ mod tests {
     #[tokio::test]
     async fn add_rejects_a_duplicate() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         let body = serde_json::json!({ "name": "x", "command": "npx" });
         send(&app, "POST", "/api/mcp/servers", Some(body.clone())).await;
         let (status_code, _) = send(&app, "POST", "/api/mcp/servers", Some(body)).await;
@@ -481,7 +536,7 @@ mod tests {
     #[tokio::test]
     async fn remove_of_an_unknown_server_is_404() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         let (status_code, _) = send(&app, "DELETE", "/api/mcp/servers/ghost", None).await;
         assert_eq!(status_code, StatusCode::NOT_FOUND);
     }
@@ -489,7 +544,7 @@ mod tests {
     #[tokio::test]
     async fn status_of_an_unknown_server_is_404() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         let (status_code, _) = send(&app, "GET", "/api/mcp/servers/ghost/status", None).await;
         assert_eq!(status_code, StatusCode::NOT_FOUND);
     }
@@ -497,7 +552,7 @@ mod tests {
     #[tokio::test]
     async fn login_of_an_unknown_server_is_404() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         let (status_code, _) = send(&app, "POST", "/api/mcp/servers/ghost/login", None).await;
         assert_eq!(status_code, StatusCode::NOT_FOUND);
     }
@@ -505,7 +560,7 @@ mod tests {
     #[tokio::test]
     async fn login_of_a_stdio_server_is_rejected() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -520,7 +575,7 @@ mod tests {
     #[tokio::test]
     async fn test_of_an_unknown_server_is_404() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         let (status_code, _) = send(&app, "POST", "/api/mcp/servers/ghost/test", None).await;
         assert_eq!(status_code, StatusCode::NOT_FOUND);
     }
@@ -604,7 +659,7 @@ mod tests {
     async fn login_completes_and_status_reports_authenticated() {
         let base = mock_oauth_server().await;
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), auto_consent));
+        let app = app_at(dir.path(), auto_consent);
 
         send(
             &app,
@@ -639,7 +694,7 @@ mod tests {
         )));
 
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -665,7 +720,7 @@ mod tests {
     #[tokio::test]
     async fn login_reports_a_bad_gateway_when_discovery_fails() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -680,7 +735,7 @@ mod tests {
     #[tokio::test]
     async fn test_endpoint_connects_and_lists_tools() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         let stub = r#"
 import sys, json
 for line in sys.stdin:
@@ -709,7 +764,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn test_endpoint_reports_a_bad_gateway_on_connect_failure() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -724,7 +779,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn test_reports_a_bad_gateway_when_the_token_cannot_refresh() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -764,8 +819,6 @@ for line in sys.stdin:
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: McpAdmin {
-                config_path: cfg,
-                store_path: store,
                 opener: Arc::new(never_opens),
                 clock: fixed_clock,
             },
@@ -776,7 +829,13 @@ for line in sys.stdin:
     #[tokio::test]
     async fn read_endpoints_surface_an_unreadable_config() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(broken_state(dir.path()));
+        let app = scoped(
+            router(broken_state(dir.path())),
+            AdminPaths {
+                config: dir.path().join("cfg-dir"),
+                store: dir.path().join("store-dir"),
+            },
+        );
         for (method, uri) in [
             ("GET", "/api/mcp/servers"),
             ("GET", "/api/mcp/servers/x/status"),
@@ -796,7 +855,13 @@ for line in sys.stdin:
     #[tokio::test]
     async fn add_surfaces_an_unreadable_config() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(broken_state(dir.path()));
+        let app = scoped(
+            router(broken_state(dir.path())),
+            AdminPaths {
+                config: dir.path().join("cfg-dir"),
+                store: dir.path().join("store-dir"),
+            },
+        );
         let (status_code, _) = send(
             &app,
             "POST",
@@ -820,14 +885,18 @@ for line in sys.stdin:
             event_tx: tx,
             control: crate::commands::serve::testutil::no_daemon_client(),
             mcp: McpAdmin {
-                config_path: file.join("config.toml"),
-                store_path: dir.path().join("s.json"),
                 opener: Arc::new(never_opens),
                 clock: fixed_clock,
             },
             limits: Default::default(),
         };
-        let app = router(state);
+        let app = scoped(
+            router(state),
+            AdminPaths {
+                config: file.join("config.toml"),
+                store: dir.path().join("s.json"),
+            },
+        );
         let (status_code, _) = send(
             &app,
             "POST",
@@ -842,7 +911,7 @@ for line in sys.stdin:
     async fn remove_surfaces_an_unwritable_config() {
         // Config reads fine, add one server, then make the config file read-only.
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -862,7 +931,7 @@ for line in sys.stdin:
     async fn login_surfaces_an_unwritable_store() {
         let base = mock_oauth_server().await;
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), auto_consent));
+        let app = app_at(dir.path(), auto_consent);
         send(
             &app,
             "POST",
@@ -885,7 +954,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn list_and_status_describe_a_stdio_server() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -904,7 +973,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn remove_clears_stored_credentials() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -927,7 +996,7 @@ for line in sys.stdin:
     async fn a_second_login_reuses_the_client_id() {
         let base = mock_oauth_server().await;
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), auto_consent));
+        let app = app_at(dir.path(), auto_consent);
         send(
             &app,
             "POST",
@@ -944,7 +1013,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn test_endpoint_reports_a_spawn_failure() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         send(
             &app,
             "POST",
@@ -959,7 +1028,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn test_endpoint_reports_a_list_tools_failure() {
         let dir = tempfile::tempdir().unwrap();
-        let app = router(state_at(dir.path(), never_opens));
+        let app = app_at(dir.path(), never_opens);
         let stub = r#"
 import sys, json
 for line in sys.stdin:
@@ -993,8 +1062,13 @@ for line in sys.stdin:
     fn default_admin_uses_real_paths() {
         // Constructing the default must not panic even with no LEVIATH_HOME; it
         // resolves the real config/store locations.
-        let admin = McpAdmin::default();
-        assert!(admin.config_path.to_string_lossy().contains("config.toml"));
+        let _admin = McpAdmin::default();
+        assert!(
+            admin_paths()
+                .config
+                .to_string_lossy()
+                .contains("config.toml")
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -859,34 +859,36 @@ mod tests {
             config: crate::commands::serve::testutil::fixed_config(Config::default()),
             event_tx: tx,
             control: no_daemon_control(),
-            mcp: crate::commands::serve::mcp::McpAdmin {
-                // A path nothing else in the binary can reach, and one that does
-                // not exist - `load_from_path` answers a missing file with the
-                // defaults, so the handler is deterministic.
-                //
-                // `McpAdmin::default()` resolves `Config::config_path()`, which
-                // follows `LEVIATH_HOME`, and other tests move that with
-                // `temp_env` while these run. So `GET /api/mcp/servers` was
-                // reading whichever config file the process happened to be
-                // pointed at - the developer's real one on an ordinary run, and
-                // a temp one mid-write on an unlucky one, where a half-written
-                // TOML parses as an error and the route answers 500. That is
-                // what failed `test_router_serves_routes_the_old_hand_copy_missed`
-                // about one run in three, on an assertion about *routing*.
-                config_path: std::env::temp_dir()
-                    .join("leviath-serve-router-tests-no-such-config.toml"),
-                store_path: std::env::temp_dir()
-                    .join("leviath-serve-router-tests-no-such-store.json"),
-                ..Default::default()
-            },
+            mcp: crate::commands::serve::mcp::McpAdmin::default(),
             limits: Default::default(),
+        }
+    }
+
+    /// The file locations [`test_app`] serves under.
+    fn test_paths() -> crate::commands::serve::mcp::AdminPaths {
+        crate::commands::serve::mcp::AdminPaths {
+            // A path nothing else in the binary can reach, and one that does
+            // not exist - `load_from_path` answers a missing file with the
+            // defaults, so the handler is deterministic.
+            //
+            // `McpAdmin::default()` resolves `Config::config_path()`, which
+            // follows `LEVIATH_HOME`, and other tests move that with
+            // `temp_env` while these run. So `GET /api/mcp/servers` was
+            // reading whichever config file the process happened to be
+            // pointed at - the developer's real one on an ordinary run, and
+            // a temp one mid-write on an unlucky one, where a half-written
+            // TOML parses as an error and the route answers 500. That is
+            // what failed `test_router_serves_routes_the_old_hand_copy_missed`
+            // about one run in three, on an assertion about *routing*.
+            config: std::env::temp_dir().join("leviath-serve-router-tests-no-such-config.toml"),
+            store: std::env::temp_dir().join("leviath-serve-router-tests-no-such-store.json"),
         }
     }
 
     /// The production route table over a test state - auth, CORS, and the
     /// admin routes are absent, exactly as `api_router` leaves them.
     fn test_app() -> Router {
-        api_router().with_state(test_state())
+        crate::commands::serve::mcp::scoped(api_router().with_state(test_state()), test_paths())
     }
 
     #[tokio::test]

--- a/crates/leviath-core/src/secrets.rs
+++ b/crates/leviath-core/src/secrets.rs
@@ -520,14 +520,17 @@ mod tests {
     #[test]
     fn filtered_withholds_credentials_and_keeps_toolchains() {
         let out = withheld(ShellEnvMode::Filtered, &[], &[]);
-        for secret in [
+        for withheld in [
             "ANTHROPIC_API_KEY",
             "GITHUB_TOKEN",
             "AWS_SECRET_ACCESS_KEY",
             "LEVIATH_API_TOKEN",
             "DATABASE_URL",
         ] {
-            assert!(out.iter().any(|n| n == secret), "{secret} must be withheld");
+            assert!(
+                out.iter().any(|n| n == withheld),
+                "{withheld} must be withheld"
+            );
         }
         for kept in [
             "SSH_AUTH_SOCK",

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -1413,7 +1413,7 @@ mod tests {
         let client = build_http_client(Some(2)).expect("a client builds");
 
         let dns = client
-            .get("http://no-such-host-anywhere-12345.invalid/v1/models")
+            .get("https://no-such-host-anywhere-12345.invalid/v1/models")
             .send()
             .await
             .expect_err("does not resolve");
@@ -2385,8 +2385,8 @@ mod tests {
         // The `None` arm must return the builder unchanged (no per-request cap);
         // build a request both ways and confirm both are constructible.
         let client = build_http_client(None).expect("an HTTPS client builds in tests");
-        let with_none = apply_request_timeout(client.post("http://example.invalid/"), None);
-        let with_some = apply_request_timeout(client.post("http://example.invalid/"), Some(5));
+        let with_none = apply_request_timeout(client.post("https://example.invalid/"), None);
+        let with_some = apply_request_timeout(client.post("https://example.invalid/"), Some(5));
         assert!(with_none.build().is_ok());
         assert!(with_some.build().is_ok());
     }

--- a/crates/leviath-providers/src/provider/http.rs
+++ b/crates/leviath-providers/src/provider/http.rs
@@ -123,7 +123,7 @@ pub fn malformed_url_error() -> HttpError {
     reqwest::Client::builder()
         .build()
         .expect("a builder with no options set always yields a client")
-        .get("http://[")
+        .get("https://[")
         .build()
         .expect_err("reqwest rejects a string that is not a URL")
 }

--- a/perf-tools/codeql_summary.py
+++ b/perf-tools/codeql_summary.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Summarise a CodeQL SARIF file: one line per finding, with its data flows.
+
+Usage: codeql_summary.py target/codeql.sarif
+
+Prints the rule, the sink, and each distinct flow (source first) so a finding
+can be traced to the line it starts from without opening the Security tab.
+Exit status is the number of findings, capped at 125, so a shell can gate on it.
+"""
+
+import json
+import sys
+
+
+def where(location):
+    physical = location["physicalLocation"]
+    name = physical["artifactLocation"]["uri"].split("/")[-1]
+    return f"{name}:{physical['region']['startLine']}"
+
+
+def flows(result):
+    seen = set()
+    for flow in result.get("codeFlows", []):
+        steps = []
+        for step in flow["threadFlows"][0]["locations"]:
+            here = where(step["location"])
+            if not steps or steps[-1] != here:
+                steps.append(here)
+        chain = " > ".join(steps)
+        if chain not in seen:
+            seen.add(chain)
+            yield chain
+
+
+def main(path):
+    with open(path, encoding="utf-8") as handle:
+        sarif = json.load(handle)
+    results = sarif["runs"][0]["results"]
+    by_rule = {}
+    for result in results:
+        by_rule.setdefault(result["ruleId"], []).append(result)
+    for rule, hits in sorted(by_rule.items()):
+        print(f"{rule}: {len(hits)}")
+        for hit in hits:
+            physical = hit["locations"][0]["physicalLocation"]
+            print(f"  SINK {physical['artifactLocation']['uri']}:{physical['region']['startLine']}")
+            for chain in flows(hit):
+                print(f"    {chain}")
+    print(f"total: {len(results)}")
+    return min(len(results), 125)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1]))


### PR DESCRIPTION
Clears all 17 CodeQL alerts (8 open, 9 dismissed) in code. Nothing is dismissed, no suppression comments, no query filters.

## Measured, not assumed

The fixes were checked against the same suite GitHub's default setup runs (`codeql/rust-queries` `rust-code-scanning.qls`, threat model `remote`) on a local database, before and after:

| | `main` (057b3d33) | this branch |
|---|---|---|
| `rust/path-injection` | 8 | 0 |
| `rust/non-https-url` | 4 | 0 |
| `rust/cleartext-logging` | 2 | 0 |

(GitHub's pack version reports one more `perms.rs` path sink than the local one; same class, same flows.) The diagnostics queries `ExtractionErrors` and `UnresolvedMacroCalls` return no rows for either database, so the zero is over fully extracted sinks and handlers.

## The three classes

**`rust/path-injection` (11 alerts, #3-#10, #15-#17).** Every one of the 20 data flows starts at a `.route(..., handler)` line: CodeQL's axum model marks each handler parameter as request data, the shared `State` included, so `state.mcp.config_path` / `store_path` counted as user-provided at every `create_dir_all`, `read_to_string` and `write_private` beneath them.

- Tried first: a resolver closure (`Arc<dyn Fn() -> AdminPaths>`) on the state, the shape `UpdateJobs::with_env` uses. Measured: still 9 findings, the taint follows `(self.paths)()` from its receiver.
- Shipped: the locations are not on the state. `mcp::admin_paths()` resolves them from `LEVIATH_HOME` / `LEVIATH_CONFIG_PATH` per call (two env reads; a cached copy would pin the first test's home on the whole test binary), every handler calls it, and `McpAdmin` keeps only `opener` and `clock`. Tests point handlers at a temp dir through a `tokio::task_local!` override scoped by a test-only tower layer, `mcp::scoped(router, paths)`, so `router`/`put_config_request`/`get_config_request`/`test_app` carry it and individual tests are untouched. `add_server`, `remove_server` and `put_config` no longer take `State` at all.

**`rust/non-https-url` (4 alerts, #11-#14).** `http://` literals in `provider.rs` tests and the test-only `malformed_url_error()` helper; none is ever sent (`.invalid` hosts, a request that is built and dropped, a string that is not a URL). `https://` is exactly as unresolvable and exactly as malformed.

**`rust/cleartext-logging` (2 alerts, #1-#2).** Name heuristics (`maybeSecret` / `maybeAccountInfo` regexes): a test loop variable called `secret` that holds env-var *names*, and `println!("  - {account}")` in `lev auth migrate`, which prints keychain account *labels*. Renamed `withheld` and `moved`.

## Also in this PR

- `perf-tools/codeql_summary.py`: rule, sink and every flow's source from a SARIF; exit status is the finding count.
- `CONTRIBUTING.md`: "Running CodeQL locally" (four commands, ~4 minutes).
- `SECURITY.md`: "What the scanners say", so the `State`-taint class is not re-triaged and a new admin route reads paths through `admin_paths()`.

## No behaviour change

- `lev serve` resolves the same two paths it did before (`Config::config_path()`, `AuthStore::default_path()`); they are read per request instead of once at start, which also means an operator who moves `LEVIATH_HOME` mid-run gets the new location, where before the server kept the old one.
- 639 serve tests pass unchanged apart from the constructor swap; workspace tests, clippy `-D warnings`, `cargo doc`, `xtask structure`, `xtask docs` and 100% coverage on cli/core/providers are in the checks below.
- Live check: see the last comment.

After merge the 9 dismissed alerts should transition to "fixed" on their own once the default-setup scan runs on `main`; if any stays open it is a real finding and gets its own fix.
