### PR TITLE
feat(cli,serve): one model catalogue, and lev models asks the providers by default

### DIFF
--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -1854,6 +1854,32 @@ mod tests {
         }
     }
 
+    /// A script that will not compile is a candidate name the registry cannot
+    /// hand back. `show` skips it the way `list` does, and still answers from
+    /// whatever else it has: here, nothing, so the model is reported unknown
+    /// rather than the command failing on a script it never named.
+    #[tokio::test]
+    async fn show_skips_a_script_provider_that_does_not_load() {
+        let dir = tempfile::tempdir().expect("a temp providers dir");
+        std::fs::write(dir.path().join("broken.rhai"), "fn initialize(config) { #{")
+            .expect("the temp dir is writable");
+        let dir = dir.path().to_path_buf();
+        crate::config::with_isolated_config_path_async(
+            "models-show_skips_a_broken_script_provider",
+            |_fake_dir| async move {
+                let args = ShowArgs {
+                    model: "nothing-has-this".to_string(),
+                    provider: None,
+                    remote: false,
+                    offline: false,
+                };
+                let result = show_with_registry(args, &script_registry(dir)).await;
+                assert!(result.is_ok(), "{result:?}");
+            },
+        )
+        .await;
+    }
+
     /// The command `rhai-providers.md` prescribes as a provider script's smoke
     /// test: it has to reach the script layer, since the built-in table has no
     /// row for a provider that names its own models at run time (issue #523).

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -1,8 +1,8 @@
 //! `lev models` - Inspect available models and their capabilities.
 
 use clap::{Args, Subcommand};
-use leviath_providers::LimitsSource;
-use leviath_providers::{ModelCapabilities, ModelInfo};
+use leviath_providers::capabilities::builtin_catalog;
+use leviath_providers::{ModelCapabilities, ModelInfo, ModelPricing};
 
 use super::run::build_provider_registry_from_config;
 use crate::config::Config;
@@ -32,9 +32,14 @@ pub struct ListArgs {
     /// Filter by provider name (anthropic, openai, ollama, openrouter)
     #[arg(short, long)]
     pub provider: Option<String>,
-    /// Fetch live model list from provider APIs (slower but complete)
-    #[arg(short = 'r', long)]
+    /// Accepted for scripts written before the listing went live by default;
+    /// it changes nothing now.
+    #[arg(short = 'r', long, hide = true)]
     pub remote: bool,
+    /// Print only the table compiled into this build, without asking any
+    /// provider what it serves
+    #[arg(long)]
+    pub offline: bool,
     /// Include models from providers this install has no credential for
     #[arg(short = 'a', long)]
     pub all: bool,
@@ -45,7 +50,7 @@ pub struct ListArgs {
 
 /// One model in `lev models list --json`.
 ///
-/// Carries the full capability set rather than the six columns the table has
+/// Carries the full capability set rather than the columns the table has
 /// room for, and turns the table's `*` marker into a field, since a caller
 /// choosing a model needs to know a capability came from config rather than
 /// from the provider.
@@ -58,6 +63,17 @@ struct ModelRow {
     /// True when `[model_capabilities]` in config.toml replaced what Leviath
     /// knows about this model.
     capabilities_overridden: bool,
+    /// True when the provider's own listing described this model; false for a
+    /// row from the table compiled into this build.
+    learned: bool,
+    /// When the provider released it, as Unix seconds, if its listing says.
+    released: Option<i64>,
+    /// The same, as `YYYY-MM-DD`.
+    released_on: Option<String>,
+    /// When the provider will withdraw it, as published, if its listing says.
+    retires: Option<String>,
+    /// USD per million tokens, when the provider's listing quotes a rate.
+    pricing: Option<ModelPricing>,
 }
 
 /// Arguments for `lev models show`.
@@ -65,13 +81,25 @@ struct ModelRow {
 pub struct ShowArgs {
     /// Model ID to look up
     pub model: String,
-    /// Provider to query (required for remote lookup)
+    /// Only ask this provider (default: every configured one)
     #[arg(short, long)]
     pub provider: Option<String>,
-    /// Fetch live model list from provider APIs (slower but complete)
-    #[arg(short = 'r', long)]
+    /// Accepted for scripts written before the lookup went live by default;
+    /// it changes nothing now.
+    #[arg(short = 'r', long, hide = true)]
     pub remote: bool,
+    /// Answer from the table compiled into this build, without asking any
+    /// provider
+    #[arg(long)]
+    pub offline: bool,
 }
+
+/// How long `lev models` waits for a provider to describe its own models.
+///
+/// The same bound `GET /api/models` uses: this is a person waiting at a
+/// prompt, and a row that admits it came from the table is worth more than
+/// a slow answer.
+const MODELS_PRIME_TIMEOUT_SECS: u64 = 5;
 
 // ─── Entrypoint ───────────────────────────────────────────────────────────────
 
@@ -83,424 +111,66 @@ pub async fn execute(args: ModelsArgs) -> anyhow::Result<()> {
     }
 }
 
-// ─── Built-in model table ─────────────────────────────────────────────────────
+// ─── Built-in catalogue ───────────────────────────────────────────────────────
 
-/// A single row in the built-in model table.
-struct BuiltinEntry {
-    provider: &'static str,
-    model_id: &'static str,
-    display_name: &'static str,
-    caps: ModelCapabilities,
-}
-
-/// Providers whose entry in [`builtin_table`] is complete enough to say "this
-/// model does not exist" about.
+/// Providers whose compiled catalogue is complete enough to say "this model
+/// does not exist" about, when no listing has been read.
 ///
-/// Anthropic, OpenAI and Google publish a short list and this table tracks it.
-/// The rest do not: Ollama serves whatever has been pulled locally, OpenRouter
-/// proxies hundreds of models of which the table lists a sample, and a script
-/// provider defines its own catalog at run time. Naming a model those hosts
-/// have and this build has not heard of is normal, so they are never checked.
+/// Anthropic, OpenAI and Google publish a short list and the catalogue tracks
+/// it. The rest do not: Ollama serves whatever has been pulled locally,
+/// OpenRouter proxies hundreds of models of which the catalogue names a
+/// sample, and a script provider defines its own catalog at run time. Naming
+/// a model those hosts have and this build has not heard of is normal, so
+/// they are never checked offline.
 const CLOSED_CATALOG_PROVIDERS: &[&str] = &["anthropic", "openai", "google"];
 
 /// The `(provider, model)` rows [`crate::lint`] checks a blueprint's model
 /// references against, limited to the providers with a closed catalog.
 pub fn closed_catalog_models() -> Vec<(String, String)> {
-    builtin_table()
+    builtin_catalog()
         .into_iter()
         .filter(|e| CLOSED_CATALOG_PROVIDERS.contains(&e.provider))
-        .map(|e| (e.provider.to_string(), e.model_id.to_string()))
+        .map(|e| (e.provider.to_string(), e.id.to_string()))
         .collect()
 }
 
-/// Context-window size per `(provider, model)`, from the same table.
+/// Context-window size per `(provider, model)`, from the same catalogue.
 ///
 /// Every provider, not only the closed catalogs: the question here is "how big
 /// is this window", and an OpenRouter row that names a size is as useful as an
-/// Anthropic one. A model absent from the table simply is not consulted.
+/// Anthropic one. A model absent from the catalogue simply is not consulted.
 pub fn builtin_model_windows() -> std::collections::HashMap<(String, String), usize> {
-    builtin_table()
+    builtin_catalog()
         .into_iter()
         .map(|e| {
             (
-                (e.provider.to_string(), e.model_id.to_string()),
-                e.caps.max_context_tokens,
+                (e.provider.to_string(), e.id.to_string()),
+                e.capabilities.max_context_tokens,
             )
         })
         .collect()
 }
 
-/// Hard-coded capability table for well-known models.
+/// The compiled catalogue as listing rows: what is shown for a provider whose
+/// own listing could not be read.
 ///
-/// This is used when the provider API is not reachable or `--remote` is not
-/// specified.  Remote results override these values for identical model IDs.
-fn builtin_table() -> Vec<BuiltinEntry> {
-    macro_rules! entry {
-        // Short form - tools defaults to true
-        ($provider:expr_2021, $id:expr_2021, $name:expr_2021,
-         temp=$t:expr_2021, ctx=$ctx:expr_2021, out=$out:expr_2021) => {
-            entry!(
-                $provider,
-                $id,
-                $name,
-                temp = $t,
-                tools = true,
-                ctx = $ctx,
-                out = $out
-            )
-        };
-        // Full form - explicit tools flag
-        ($provider:expr_2021, $id:expr_2021, $name:expr_2021,
-         temp=$t:expr_2021, tools=$to:expr_2021, ctx=$ctx:expr_2021, out=$out:expr_2021) => {
-            BuiltinEntry {
-                provider: $provider,
-                model_id: $id,
-                display_name: $name,
-                caps: ModelCapabilities {
-                    supports_temperature: $t,
-                    supports_streaming: true,
-                    supports_tools: $to,
-                    supports_system_prompt: true,
-                    max_context_tokens: $ctx,
-                    max_output_tokens: $out,
-                    limits_source: LimitsSource::Builtin,
-                },
-            }
-        };
-    }
-
-    vec![
-        // ── Anthropic ──────────────────────────────────────────────────────────
-        entry!(
-            "anthropic",
-            "claude-opus-5",
-            "Claude Opus 5",
-            temp = false,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        entry!(
-            "anthropic",
-            "claude-sonnet-5",
-            "Claude Sonnet 5",
-            temp = false,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        entry!(
-            "anthropic",
-            "claude-fable-5",
-            "Claude Fable 5",
-            temp = false,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        entry!(
-            "anthropic",
-            "claude-opus-4-8",
-            "Claude Opus 4.8",
-            temp = false,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        entry!(
-            "anthropic",
-            "claude-opus-4-7",
-            "Claude Opus 4.7",
-            temp = false,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        entry!(
-            "anthropic",
-            "claude-opus-4-6",
-            "Claude Opus 4.6",
-            temp = true,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        entry!(
-            "anthropic",
-            "claude-sonnet-4-6",
-            "Claude Sonnet 4.6",
-            temp = true,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        entry!(
-            "anthropic",
-            "claude-haiku-4-5-20251001",
-            "Claude Haiku 4.5",
-            temp = true,
-            ctx = 200_000,
-            out = 65_536
-        ),
-        // ── OpenAI ─────────────────────────────────────────────────────────────
-        // GPT-5.5 - flagship (Apr 2026), 1M+ context
-        entry!(
-            "openai",
-            "gpt-5.5",
-            "GPT-5.5",
-            temp = true,
-            ctx = 1_050_000,
-            out = 128_000
-        ),
-        entry!(
-            "openai",
-            "gpt-5.4",
-            "GPT-5.4",
-            temp = true,
-            ctx = 1_050_000,
-            out = 128_000
-        ),
-        entry!(
-            "openai",
-            "gpt-5.4-mini",
-            "GPT-5.4 Mini",
-            temp = true,
-            ctx = 400_000,
-            out = 128_000
-        ),
-        entry!(
-            "openai",
-            "gpt-5.4-nano",
-            "GPT-5.4 Nano",
-            temp = true,
-            ctx = 400_000,
-            out = 128_000
-        ),
-        // ── Google (Gemini) ────────────────────────────────────────────────────
-        // Native Google provider entries. Without these, a user whose only key
-        // is a Gemini key saw no model they could run: every Gemini row in this
-        // table routed through OpenRouter, which needs a different key.
-        entry!(
-            "google",
-            "gemini-3.5-flash",
-            "Gemini 3.5 Flash",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_535
-        ),
-        entry!(
-            "google",
-            "gemini-3.1-pro-preview",
-            "Gemini 3.1 Pro (preview)",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_535
-        ),
-        entry!(
-            "google",
-            "gemini-3-flash",
-            "Gemini 3 Flash",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_535
-        ),
-        entry!(
-            "google",
-            "gemini-3.1-flash-lite",
-            "Gemini 3.1 Flash Lite",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_535
-        ),
-        // ── OpenRouter: xAI and Meta ──────────────────────────────────────────
-        // Listed for the reason #568 exists: an unlisted model falls back to
-        // 8192 max output, and a stage asked to rewrite a whole report then
-        // truncates at 8192 every attempt and never finishes. OpenRouter
-        // reports no `max_completion_tokens` for either, so the table is where
-        // the real ceiling has to live until that issue lands.
-        entry!(
-            "openrouter",
-            "x-ai/grok-4.6",
-            "Grok 4.6",
-            temp = true,
-            ctx = 500_000,
-            out = 64_000
-        ),
-        entry!(
-            "openrouter",
-            "meta/muse-spark-1.2",
-            "Muse Spark 1.2",
-            temp = true,
-            ctx = 1_048_576,
-            out = 64_000
-        ),
-        // ── OpenRouter: Anthropic ─────────────────────────────────────────────
-        // The same models as the `anthropic` entries above, reached through the
-        // gateway instead of directly. Listed because a gateway is a route, not
-        // a model family: someone who prefers OpenRouter should be able to run
-        // the model a blueprint actually asks for, rather than whichever model
-        // that blueprint happened to put in its OpenRouter slot. Capabilities
-        // mirror the direct entries - `temp = false` in particular, since the
-        // default for an unlisted model is `true` and these do not take one.
-        entry!(
-            "openrouter",
-            "anthropic/claude-opus-5",
-            "Claude Opus 5 (via OpenRouter)",
-            temp = false,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        entry!(
-            "openrouter",
-            "anthropic/claude-sonnet-5",
-            "Claude Sonnet 5 (via OpenRouter)",
-            temp = false,
-            ctx = 1_000_000,
-            out = 128_000
-        ),
-        // ── OpenRouter: Google Gemini ──────────────────────────────────────────
-        entry!(
-            "openrouter",
-            "google/gemini-3.5-flash",
-            "Gemini 3.5 Flash",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_536
-        ),
-        entry!(
-            "openrouter",
-            "google/gemini-2.5-pro",
-            "Gemini 2.5 Pro",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_536
-        ),
-        entry!(
-            "openrouter",
-            "google/gemini-2.5-flash",
-            "Gemini 2.5 Flash",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_536
-        ),
-        entry!(
-            "openrouter",
-            "google/gemini-2.5-flash-lite",
-            "Gemini 2.5 Flash Lite",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_536
-        ),
-        // ── OpenRouter: Meta Llama 4 ───────────────────────────────────────────
-        entry!(
-            "openrouter",
-            "meta-llama/llama-4-maverick",
-            "Llama 4 Maverick",
-            temp = true,
-            ctx = 1_048_576,
-            out = 32_768
-        ),
-        entry!(
-            "openrouter",
-            "meta-llama/llama-4-scout",
-            "Llama 4 Scout",
-            temp = true,
-            ctx = 10_000_000,
-            out = 32_768
-        ),
-        // ── OpenRouter: DeepSeek ───────────────────────────────────────────────
-        entry!(
-            "openrouter",
-            "deepseek/deepseek-v4-pro",
-            "DeepSeek V4 Pro",
-            temp = true,
-            ctx = 1_048_576,
-            out = 393_216
-        ),
-        entry!(
-            "openrouter",
-            "deepseek/deepseek-v4-flash",
-            "DeepSeek V4 Flash",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_536
-        ),
-        entry!(
-            "openrouter",
-            "deepseek/deepseek-v3.2",
-            "DeepSeek V3.2",
-            temp = true,
-            ctx = 131_072,
-            out = 65_536
-        ),
-        entry!(
-            "openrouter",
-            "deepseek/deepseek-r1-0528",
-            "DeepSeek R1 (0528)",
-            temp = false,
-            tools = false,
-            ctx = 163_840,
-            out = 32_768
-        ),
-        entry!(
-            "openrouter",
-            "deepseek/deepseek-r1",
-            "DeepSeek R1",
-            temp = false,
-            tools = false,
-            ctx = 163_840,
-            out = 16_384
-        ),
-        // ── OpenRouter: Mistral ────────────────────────────────────────────────
-        entry!(
-            "openrouter",
-            "mistralai/mistral-large-2512",
-            "Mistral Large 3",
-            temp = true,
-            ctx = 262_144,
-            out = 32_768
-        ),
-        entry!(
-            "openrouter",
-            "mistralai/mistral-medium-3-5",
-            "Mistral Medium 3.5",
-            temp = true,
-            ctx = 256_000,
-            out = 32_768
-        ),
-        entry!(
-            "openrouter",
-            "mistralai/mistral-small-2603",
-            "Mistral Small 4",
-            temp = true,
-            ctx = 128_000,
-            out = 32_768
-        ),
-        // ── OpenRouter: Qwen (Alibaba) ─────────────────────────────────────────
-        entry!(
-            "openrouter",
-            "qwen/qwen3.6-plus",
-            "Qwen 3.6 Plus",
-            temp = true,
-            ctx = 1_048_576,
-            out = 65_536
-        ),
-        entry!(
-            "openrouter",
-            "qwen/qwen3-max",
-            "Qwen3 Max",
-            temp = true,
-            ctx = 131_072,
-            out = 32_768
-        ),
-        entry!(
-            "openrouter",
-            "qwen/qwen3-coder",
-            "Qwen3 Coder 480B",
-            temp = true,
-            ctx = 1_048_576,
-            out = 262_144
-        ),
-    ]
+/// One source of truth. This used to be a second table kept by hand in this
+/// file, and its numbers had drifted from the providers' own (`gpt-5.5` was
+/// still marked as taking a temperature here after the provider table learned
+/// it refuses one).
+fn catalogue_rows() -> Vec<ModelInfo> {
+    builtin_catalog()
+        .into_iter()
+        .map(|e| {
+            ModelInfo::new(e.id, e.provider, e.capabilities).named(Some(e.display_name.to_string()))
+        })
+        .collect()
 }
 
 // ─── list ─────────────────────────────────────────────────────────────────────
 
 /// Core of [`list`], with provider-registry construction injected so tests
-/// can drive the `--remote` merge/override/error paths with a
+/// can drive the live merge/fallback/error paths with a
 /// [`Provider`](leviath_providers::Provider) mock instead of hitting a real
 /// network endpoint (ollama) or spawning a real subprocess (claude-code) --
 /// both of which [`build_provider_registry`] always registers.
@@ -526,19 +196,35 @@ async fn list_with_registry(
         leviath_providers::ProviderError,
     >,
 ) -> anyhow::Result<()> {
+    list_with_registry_within(
+        args,
+        build_registry,
+        std::time::Duration::from_secs(MODELS_PRIME_TIMEOUT_SECS),
+    )
+    .await
+}
+
+/// [`list_with_registry`] with the priming bound injected, so a test can
+/// drive the "did not answer in time" fallback without waiting five seconds.
+async fn list_with_registry_within(
+    args: ListArgs,
+    build_registry: &dyn Fn(
+        &Config,
+    ) -> Result<
+        leviath_runtime::ProviderRegistry,
+        leviath_providers::ProviderError,
+    >,
+    prime_within: std::time::Duration,
+) -> anyhow::Result<()> {
     let config = Config::load()?;
     for warning in config.validate_keys() {
         eprintln!("Warning: {}", warning);
     }
 
-    // Start with the built-in table, indexed by model_id for easy overriding.
-    let mut entries: Vec<ModelInfo> = builtin_table()
-        .into_iter()
-        .map(|e| {
-            ModelInfo::new(e.model_id.to_string(), e.provider.to_string(), e.caps)
-                .named(Some(e.display_name.to_string()))
-        })
-        .collect();
+    // Start with the compiled catalogue. Whatever a provider's own listing
+    // says replaces its rows wholesale below; these survive only for a
+    // provider that could not be asked.
+    let mut entries: Vec<ModelInfo> = catalogue_rows();
 
     // Only what this install can actually run. Listing every model the binary
     // knows about made a user with one key scroll past dozens of models they
@@ -558,11 +244,17 @@ async fn list_with_registry(
     // also query it: it reports a failure differently (fatal there, a warning
     // here) and querying it twice would be a wasted round trip.
     let script_target = args.provider.as_deref().filter(|name| {
-        !available.contains(*name) && !builtin_table().iter().any(|e| e.provider == *name)
+        !available.contains(*name) && !catalogue_rows().iter().any(|e| e.provider == *name)
     });
 
-    // --remote: fetch live model lists and merge (remote wins on same ID).
-    if args.remote {
+    // Live by default: each provider's own listing replaces the catalogue's
+    // rows for it. The catalogue is out of date the day it ships (#568), and
+    // a person picking a model from it picked a generation behind what the
+    // gateway served. A provider that cannot be asked keeps its catalogue
+    // rows, and the trailing line says which is which.
+    let mut live_providers: Vec<String> = Vec::new();
+    if !args.offline {
+        registry.prime_capabilities(prime_within, &[]).await;
         // `resolvable_names`, not `provider_names`: a script provider is
         // reachable only through `get`, so a sweep built on the registered
         // names alone silently omitted every one of them - the same shape as
@@ -586,21 +278,26 @@ async fn list_with_registry(
             let Some(provider) = registry.get(&provider_name) else {
                 continue;
             };
-            match provider.list_models().await {
-                Ok(remote_models) => {
-                    for rm in remote_models {
-                        // Override builtin entry with the same ID, or append.
-                        if let Some(existing) = entries.iter_mut().find(|e| e.id == rm.id) {
-                            *existing = rm;
-                        } else {
-                            entries.push(rm);
-                        }
-                    }
+            match tokio::time::timeout(prime_within, provider.list_models()).await {
+                Ok(Ok(live)) => {
+                    // The listing is the whole answer for this provider: a
+                    // catalogue row it does not carry is a model it does not
+                    // serve, and keeping it would list a model nothing can run.
+                    entries.retain(|e| e.provider != provider_name);
+                    entries.extend(live);
+                    live_providers.push(provider_name);
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     eprintln!(
-                        "Warning: could not fetch models from '{}': {}",
+                        "Warning: could not fetch models from '{}': {}; showing this build's table",
                         provider_name, e
+                    );
+                }
+                Err(_) => {
+                    eprintln!(
+                        "Warning: '{}' did not list its models within {}s; showing this build's table",
+                        provider_name,
+                        prime_within.as_secs()
                     );
                 }
             }
@@ -608,19 +305,20 @@ async fn list_with_registry(
     }
 
     // A `--provider` naming something neither registered natively nor present
-    // in the built-in table is a script provider (or a typo). Ask the script
+    // in the catalogue is a script provider (or a typo). Ask the script
     // layer: it is the only thing that can answer for one, and a name it cannot
     // answer for is an error rather than an empty table, since nothing else
-    // could have answered either. A name the built-in table knows is left alone
+    // could have answered either. A name the catalogue knows is left alone
     // - `--provider openai` with no OpenAI key is an empty table, exactly as it
     // has always been.
     let mut script_provider_answered = false;
     if let Some(name) = script_target {
         merge_script_provider(&registry, name, &mut entries).await?;
         script_provider_answered = true;
+        live_providers.push(name.to_string());
     }
 
-    // Apply provider filter (after remote merge so we respect the filter).
+    // Apply provider filter (after the live merge so we respect the filter).
     if let Some(ref filter) = args.provider {
         entries.retain(|e| &e.provider == filter);
     }
@@ -635,6 +333,15 @@ async fn list_with_registry(
         }
     }
 
+    // Provider, then newest first, then id: a live listing runs to hundreds
+    // of rows and the one somebody is looking for is usually the recent one.
+    entries.sort_by(|a, b| {
+        a.provider
+            .cmp(&b.provider)
+            .then_with(|| b.released.cmp(&a.released))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
     // JSON before the emptiness guard: an empty catalog is an empty array, not
     // an error, and a caller polling this should not have to parse a nudge.
     if args.json {
@@ -642,10 +349,15 @@ async fn list_with_registry(
             .into_iter()
             .map(|e| ModelRow {
                 capabilities_overridden: overridden.contains(&e.id),
+                released_on: e.released.map(leviath_providers::learned::civil_date),
                 id: e.id,
                 provider: e.provider,
                 display_name: e.display_name,
                 capabilities: e.capabilities,
+                learned: e.learned,
+                released: e.released,
+                retires: e.retires,
+                pricing: e.pricing,
             })
             .collect();
         // Owned scalars with no map keys to reject, so this cannot fail.
@@ -677,14 +389,24 @@ async fn list_with_registry(
         return Ok(());
     }
 
-    // Print table header.
-    println!(
-        "{:<12} {:<40} {:<6} {:<7} {:<8} {:<8}",
-        "PROVIDER", "MODEL ID", "TEMP", "TOOLS", "CTX", "OUTPUT"
-    );
-    println!("{}", "-".repeat(85));
+    print_listing(&entries, &overridden, &live_providers);
+    Ok(())
+}
 
-    for entry in &entries {
+/// The listing as a table, with a trailing line saying which rows are the
+/// provider's own answer and which are this build's.
+fn print_listing(
+    entries: &[ModelInfo],
+    overridden: &std::collections::HashSet<String>,
+    live_providers: &[String],
+) {
+    println!(
+        "{:<12} {:<44} {:<5} {:<6} {:<7} {:<7} {:<11} {:>8} {:>8}",
+        "PROVIDER", "MODEL ID", "TEMP", "TOOLS", "CTX", "OUTPUT", "RELEASED", "IN $/M", "OUT $/M"
+    );
+    println!("{}", "-".repeat(118));
+
+    for entry in entries {
         let provider_col = if overridden.contains(&entry.id) {
             format!("*{}", entry.provider)
         } else {
@@ -695,38 +417,65 @@ async fn list_with_registry(
         let tools = bool_icon(entry.capabilities.supports_tools);
         let ctx = fmt_tokens(entry.capabilities.max_context_tokens);
         let out = fmt_tokens(entry.capabilities.max_output_tokens);
+        let released = entry
+            .released
+            .map(leviath_providers::learned::civil_date)
+            .unwrap_or_default();
+        let rates = entry
+            .pricing
+            .or_else(|| leviath_providers::pricing::published_rates(&entry.provider, &entry.id));
+        let (input, output) = match rates {
+            Some(p) => (fmt_rate(p.input_per_mtok), fmt_rate(p.output_per_mtok)),
+            None => (String::new(), String::new()),
+        };
 
         println!(
-            "{:<12} {:<40} {:<6} {:<7} {:<8} {:<8}",
-            provider_col, entry.id, temp, tools, ctx, out
+            "{:<12} {:<44} {:<5} {:<6} {:<7} {:<7} {:<11} {:>8} {:>8}",
+            provider_col, entry.id, temp, tools, ctx, out, released, input, output
         );
+    }
+
+    let live = entries.iter().filter(|e| e.learned).count();
+    let table = entries.len() - live;
+    let mut sources = live_providers.to_vec();
+    sources.sort();
+    println!();
+    match (live, table) {
+        (0, _) => println!("{table} rows from this build's table; no provider listing was read"),
+        (_, 0) => println!(
+            "{live} rows from the providers' own listings ({})",
+            sources.join(", ")
+        ),
+        _ => println!(
+            "{live} rows from the providers' own listings ({}), {table} from this build's table",
+            sources.join(", ")
+        ),
     }
 
     if overridden
         .iter()
         .any(|id| entries.iter().any(|e| &e.id == id))
     {
-        println!("\n* = capabilities overridden via [model_capabilities] in config");
+        println!("* = capabilities overridden via [model_capabilities] in config");
     }
-
-    Ok(())
 }
 
 /// Load the script provider called `name` and merge whatever `list_models`
 /// answers into `entries`.
 ///
-/// A script provider defines its catalog at run time, so the built-in table
-/// has no rows for one and `lev models list --provider <name>` used to print
-/// "No models available." for a perfectly good provider. Loading it here is
-/// what makes that command the smoke test `rhai-providers.md` prescribes: it
-/// compiles the script, runs `initialize`, and calls `list_models`.
+/// A script provider defines its catalog at run time, so the compiled
+/// catalogue has no rows for one and `lev models list --provider <name>` used
+/// to print "No models available." for a perfectly good provider. Loading it
+/// here is what makes that command the smoke test `rhai-providers.md`
+/// prescribes: it compiles the script, runs `initialize`, and calls
+/// `list_models`.
 ///
 /// **Errors rather than warning.** This is the command the Rhai docs send you
 /// to *because* a broken provider script is otherwise skipped silently at model
 /// selection, and an empty table under an exit code of 0 is that same silence
-/// one step earlier. A name reaching this function has nothing in the built-in
-/// table either, so there is no answer to fall back to and nothing an exit code
-/// of 0 could honestly mean.
+/// one step earlier. A name reaching this function has nothing in the
+/// catalogue either, so there is no answer to fall back to and nothing an exit
+/// code of 0 could honestly mean.
 async fn merge_script_provider(
     registry: &leviath_runtime::ProviderRegistry,
     name: &str,
@@ -770,100 +519,164 @@ async fn show_with_registry(
         leviath_providers::ProviderError,
     >,
 ) -> anyhow::Result<()> {
+    show_with_registry_within(
+        args,
+        build_registry,
+        std::time::Duration::from_secs(MODELS_PRIME_TIMEOUT_SECS),
+    )
+    .await
+}
+
+/// [`show_with_registry`] with the priming bound injected.
+async fn show_with_registry_within(
+    args: ShowArgs,
+    build_registry: &dyn Fn(
+        &Config,
+    ) -> Result<
+        leviath_runtime::ProviderRegistry,
+        leviath_providers::ProviderError,
+    >,
+    prime_within: std::time::Duration,
+) -> anyhow::Result<()> {
     let config = Config::load()?;
     for warning in config.validate_keys() {
         eprintln!("Warning: {}", warning);
     }
 
     let model_id = &args.model;
-
-    // 1. The built-in row, which a `[model_capabilities]` entry corrects rather
-    //    than replaces - so it has to be found before the override is applied.
-    //    Printing the override alone would report `Default` for every field the
-    //    operator did not mention, which is not what the run will use.
-    let builtin = builtin_table();
-    let builtin_entry = builtin.iter().find(|e| e.model_id == model_id);
     let user_caps = config.model_capabilities.get(model_id);
 
-    if let Some(user_caps) = user_caps {
-        let base = builtin_entry.map(|e| e.caps.clone()).unwrap_or_default();
-        print_model_detail(
-            model_id,
-            builtin_entry.map(|e| e.display_name),
-            "config (user override)",
-            &user_caps.apply_to(base),
-            true,
-        );
-        return Ok(());
-    }
-
-    // 2. The built-in table on its own.
-    if let Some(entry) = builtin_entry {
-        print_model_detail(
-            model_id,
-            Some(entry.display_name),
-            entry.provider,
-            &entry.caps,
-            false,
-        );
-        return Ok(());
-    }
-
-    // 3. Optionally fetch from provider API if --remote and --provider are both given.
-    if args.remote
-        && let Some(ref provider_name) = args.provider
-    {
+    // 1. What a provider's own listing says, unless told not to ask. Every
+    //    configured provider is asked when none is named: the id is what the
+    //    person has, and which provider serves it is the question.
+    let mut found: Option<ModelInfo> = None;
+    if !args.offline {
         let registry = build_registry(&config)?;
-        if let Some(provider) = registry.get(provider_name) {
-            match provider.list_models().await {
-                Ok(models) => {
-                    if let Some(info) = models.iter().find(|m| &m.id == model_id) {
-                        print_model_detail(
-                            model_id,
-                            info.display_name.as_deref(),
-                            &info.provider,
-                            &info.capabilities,
-                            false,
-                        );
-                        return Ok(());
+        if let Some(name) = &args.provider
+            && registry.get(name).is_none()
+        {
+            eprintln!(
+                "Warning: provider '{}' is not configured (missing API key?)",
+                name
+            );
+        }
+        registry.prime_capabilities(prime_within, &[]).await;
+        for provider_name in registry.resolvable_names() {
+            if let Some(ref filter) = args.provider
+                && filter != &provider_name
+            {
+                continue;
+            }
+            let Some(provider) = registry.get(&provider_name) else {
+                continue;
+            };
+            match tokio::time::timeout(prime_within, provider.list_models()).await {
+                Ok(Ok(models)) => {
+                    if let Some(info) = models.into_iter().find(|m| &m.id == model_id) {
+                        found = Some(info);
+                        break;
                     }
                 }
-                Err(e) => {
+                Ok(Err(e)) => {
                     eprintln!(
                         "Warning: could not fetch models from '{}': {}",
                         provider_name, e
                     );
                 }
+                Err(_) => {
+                    eprintln!(
+                        "Warning: '{}' did not list its models within {}s",
+                        provider_name,
+                        prime_within.as_secs()
+                    );
+                }
             }
-        } else {
-            eprintln!(
-                "Warning: provider '{}' is not configured (missing API key?)",
-                provider_name
-            );
         }
     }
 
-    // 4. Not found anywhere - print a helpful message with a TOML snippet.
-    println!("Model '{}' not found.", model_id);
-    println!(
-        "Add it to {} under [model_capabilities.'{}']",
-        Config::config_path().display(),
-        model_id
-    );
-    println!();
-    println!("Example:");
-    println!("[model_capabilities.'{}']", model_id);
-    println!("supports_temperature  = true");
-    println!("supports_streaming    = true");
-    println!("supports_tools        = true");
-    println!("supports_system_prompt = true");
-    println!("max_context_tokens    = 8192");
-    println!("max_output_tokens     = 4096");
+    // 2. The compiled catalogue, for a model no listing described.
+    if found.is_none() {
+        found = catalogue_rows()
+            .into_iter()
+            .find(|e| &e.id == model_id && args.provider.as_ref().is_none_or(|p| p == &e.provider));
+    }
+
+    // 3. A `[model_capabilities]` entry corrects rather than replaces whatever
+    //    was found, so it is merged last. Printing the override alone would
+    //    report `Default` for every field the operator did not mention, which
+    //    is not what the run will use.
+    match (found, user_caps) {
+        (Some(info), Some(user_caps)) => {
+            let caps = user_caps.apply_to(info.capabilities);
+            print_model_detail(
+                model_id,
+                info.display_name.as_deref(),
+                &info.provider,
+                &caps,
+                Source::Override,
+                info.pricing,
+            );
+        }
+        (Some(info), None) => {
+            let source = if info.learned {
+                Source::Listing
+            } else {
+                Source::Table
+            };
+            print_model_detail(
+                model_id,
+                info.display_name.as_deref(),
+                &info.provider,
+                &info.capabilities,
+                source,
+                info.pricing,
+            );
+        }
+        (None, Some(user_caps)) => {
+            print_model_detail(
+                model_id,
+                None,
+                "config (user override)",
+                &user_caps.apply_to(ModelCapabilities::default()),
+                Source::Override,
+                None,
+            );
+        }
+        (None, None) => {
+            // 4. Not found anywhere - print a helpful message with a TOML snippet.
+            println!("Model '{}' not found.", model_id);
+            println!(
+                "Add it to {} under [model_capabilities.'{}']",
+                Config::config_path().display(),
+                model_id
+            );
+            println!();
+            println!("Example:");
+            println!("[model_capabilities.'{}']", model_id);
+            println!("supports_temperature  = true");
+            println!("supports_streaming    = true");
+            println!("supports_tools        = true");
+            println!("supports_system_prompt = true");
+            println!("max_context_tokens    = 8192");
+            println!("max_output_tokens     = 4096");
+        }
+    }
 
     Ok(())
 }
 
 // ─── Display helpers ──────────────────────────────────────────────────────────
+
+/// Where the capabilities a detail sheet prints came from.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Source {
+    /// The provider's own listing, read just now.
+    Listing,
+    /// The table compiled into this build.
+    Table,
+    /// A `[model_capabilities]` entry, merged onto one of the above.
+    Override,
+}
 
 fn bool_icon(b: bool) -> &'static str {
     if b { "✓" } else { "✗" }
@@ -880,28 +693,47 @@ fn fmt_tokens(n: usize) -> String {
     }
 }
 
+/// A USD-per-million rate for a table column: two decimals for anything a
+/// person would read as dollars, more for the fractions of a cent the cheap
+/// models are quoted at, so `0.02` and `0.0416` do not both print as `0.02`.
+fn fmt_rate(per_mtok: f64) -> String {
+    if per_mtok >= 0.1 || per_mtok == 0.0 {
+        format!("{per_mtok:.2}")
+    } else {
+        format!("{per_mtok:.4}")
+    }
+}
+
 /// Print what a model charges, and where the figure came from.
 ///
-/// Two sources, and the difference matters to a reader: an operator's config
-/// entry is their own contracted rate and is current by definition, while a
+/// Three sources, and the difference matters to a reader. A rate the
+/// provider's listing quoted is current as of the request. An operator's
+/// config entry is their own contracted rate and is current by definition. A
 /// shipped rate is a transcription of a vendor's public page on a particular
-/// day and cannot notice a repricing. Only one of those deserves a date, and
-/// printing it is the only way somebody can judge whether to trust the number.
+/// day and cannot notice a repricing, so it is the one that carries a date
+/// and a warning; printing it is the only way somebody can judge whether to
+/// trust the number.
 ///
-/// A model with neither prints nothing rather than a zero: a run that touches
-/// it reports its cost as unavailable, and a "$0.00" line here would contradict
-/// that.
-fn print_model_pricing(provider: &str, model: &str) {
-    let Some(p) = leviath_providers::pricing::published_rates(provider, model) else {
+/// A model with none prints nothing rather than a zero: a run that touches
+/// it reports its cost as unavailable, and a "$0.00" line here would
+/// contradict that.
+fn print_model_pricing(provider: &str, model: &str, listed: Option<ModelPricing>) {
+    let published = listed.is_none();
+    let Some(p) = listed.or_else(|| leviath_providers::pricing::published_rates(provider, model))
+    else {
         return;
     };
     println!();
     println!("Pricing (USD per million tokens)");
     println!("--------------------------------");
-    println!("  Input:          ${:.2}", p.input_per_mtok);
-    println!("  Cached input:   ${:.2}", p.cached_input_per_mtok);
-    println!("  Cache write:    ${:.2}", p.cache_write_per_mtok);
-    println!("  Output:         ${:.2}", p.output_per_mtok);
+    println!("  Input:          ${:.4}", p.input_per_mtok);
+    println!("  Cached input:   ${:.4}", p.cached_input_per_mtok);
+    println!("  Cache write:    ${:.4}", p.cache_write_per_mtok);
+    println!("  Output:         ${:.4}", p.output_per_mtok);
+    if !published {
+        println!("  Source:         the provider's own listing, read just now");
+        return;
+    }
     // Always labelled as the published price, never as the operator's: a
     // capability override says nothing about whether they also declared a rate,
     // and claiming "your config" for a figure that came from this table would
@@ -922,15 +754,18 @@ fn print_model_detail(
     display_name: Option<&str>,
     provider: &str,
     caps: &ModelCapabilities,
-    is_user_override: bool,
+    source: Source,
+    listed_pricing: Option<ModelPricing>,
 ) {
     println!("Model:    {}", id);
     if let Some(name) = display_name {
         println!("Name:     {}", name);
     }
     println!("Provider: {}", provider);
-    if is_user_override {
-        println!("Source:   user override (config)");
+    match source {
+        Source::Listing => println!("Source:   the provider's own listing"),
+        Source::Table => println!("Source:   the table compiled into this build"),
+        Source::Override => println!("Source:   user override (config)"),
     }
     println!();
     println!("Capabilities");
@@ -953,12 +788,13 @@ fn print_model_detail(
         fmt_tokens(caps.max_output_tokens)
     );
 
-    print_model_pricing(provider, id);
+    print_model_pricing(provider, id, listed_pricing);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use leviath_providers::LimitsSource;
 
     // ─── fmt_tokens ─────────────────────────────────────────────────────────
 
@@ -989,63 +825,39 @@ mod tests {
         assert_eq!(bool_icon(false), "✗");
     }
 
-    // ─── builtin_table ──────────────────────────────────────────────────────
+    // ─── the compiled catalogue ─────────────────────────────────────────
 
+    /// The lint checks a blueprint against the three closed catalogues and
+    /// nothing else; an open provider in this list would flag every model
+    /// it happens not to name.
     #[test]
-    fn builtin_table_is_not_empty() {
-        let table = builtin_table();
-        assert!(!table.is_empty());
+    fn the_closed_catalogue_names_the_three_providers_that_publish_one() {
+        let rows = closed_catalog_models();
+        assert!(!rows.is_empty());
+        let providers: std::collections::BTreeSet<&str> =
+            rows.iter().map(|(p, _)| p.as_str()).collect();
+        assert_eq!(
+            providers.into_iter().collect::<Vec<_>>(),
+            ["anthropic", "google", "openai"]
+        );
     }
 
     #[test]
-    fn builtin_table_has_anthropic_models() {
-        let table = builtin_table();
-        let anthropic: Vec<_> = table.iter().filter(|e| e.provider == "anthropic").collect();
-        assert!(!anthropic.is_empty());
+    fn windows_come_from_every_provider_the_catalogue_names() {
+        let windows = builtin_model_windows();
+        assert!(windows.keys().any(|(p, _)| p == "openrouter"));
+        assert!(windows.keys().any(|(p, _)| p == "anthropic"));
+        assert!(windows.values().all(|w| *w > 0));
     }
 
     #[test]
-    fn builtin_table_has_openai_models() {
-        let table = builtin_table();
-        let openai: Vec<_> = table.iter().filter(|e| e.provider == "openai").collect();
-        assert!(!openai.is_empty());
-    }
-
-    #[test]
-    fn builtin_table_has_openrouter_models() {
-        let table = builtin_table();
-        let openrouter: Vec<_> = table
-            .iter()
-            .filter(|e| e.provider == "openrouter")
-            .collect();
-        assert!(!openrouter.is_empty());
-    }
-
-    #[test]
-    fn builtin_entries_have_valid_capabilities() {
-        for entry in builtin_table() {
-            assert!(entry.caps.max_context_tokens > 0);
-            assert!(entry.caps.max_output_tokens > 0);
-            assert!(entry.caps.supports_streaming);
-            assert!(entry.caps.supports_system_prompt);
-        }
-    }
-
-    #[test]
-    fn builtin_entries_have_unique_model_ids() {
-        let table = builtin_table();
-        let ids: Vec<&str> = table.iter().map(|e| e.model_id).collect();
-        let unique: std::collections::HashSet<&str> = ids.iter().copied().collect();
-        assert_eq!(ids.len(), unique.len());
-    }
-
-    #[test]
-    fn deepseek_r1_models_no_tools() {
-        let table = builtin_table();
-        for entry in &table {
-            if entry.model_id.contains("deepseek-r1") {
-                assert!(!entry.caps.supports_tools);
-            }
+    fn catalogue_rows_are_named_table_rows() {
+        let rows = catalogue_rows();
+        assert!(!rows.is_empty());
+        for row in &rows {
+            assert!(row.display_name.is_some(), "{}", row.id);
+            assert!(!row.learned, "{}", row.id);
+            assert_eq!(row.released, None);
         }
     }
 
@@ -1058,12 +870,18 @@ mod tests {
     fn pricing_output_warns_and_does_not_claim_a_config_source() {
         // Exercised for panics and for the branch; the text itself is asserted
         // through the table, which is what a reader is actually shown.
-        print_model_pricing("anthropic", "claude-opus-5");
-        print_model_pricing("openai", "gpt-5.5");
+        print_model_pricing("anthropic", "claude-opus-5", None);
+        print_model_pricing("openai", "gpt-5.5", None);
         // A model with no listed rate prints nothing rather than a zero, which
         // would contradict the run reporting its cost as unavailable.
-        print_model_pricing("openrouter", "x-ai/grok-4.6");
-        print_model_pricing("anthropic", "claude-opus-9");
+        print_model_pricing("openrouter", "x-ai/grok-4.6", None);
+        print_model_pricing("anthropic", "claude-opus-9", None);
+        // A rate the listing quoted is labelled as such and carries no date.
+        print_model_pricing(
+            "openrouter",
+            "qwen/qwen3.6-plus",
+            Some(ModelPricing::flat(1.0, 4.0)),
+        );
     }
 
     #[test]
@@ -1078,8 +896,23 @@ mod tests {
             limits_source: LimitsSource::Builtin,
         };
         // Should not panic
-        print_model_detail("test-model", Some("Test Model"), "test", &caps, false);
-        print_model_detail("test-model", None, "test", &caps, true);
+        print_model_detail(
+            "test-model",
+            Some("Test Model"),
+            "test",
+            &caps,
+            Source::Table,
+            None,
+        );
+        print_model_detail("test-model", None, "test", &caps, Source::Override, None);
+        print_model_detail(
+            "test-model",
+            None,
+            "test",
+            &caps,
+            Source::Listing,
+            Some(ModelPricing::flat(0.5, 1.5)),
+        );
     }
 
     // ─── fmt_tokens edge cases ──────────────────────────────────────────────
@@ -1095,44 +928,6 @@ mod tests {
         assert_eq!(fmt_tokens(10_000_000), "10M");
     }
 
-    // ─── builtin_table provider coverage ────────────────────────────────────
-
-    #[test]
-    fn builtin_table_claude_opus_no_temperature() {
-        let table = builtin_table();
-        for entry in &table {
-            if entry.model_id == "claude-opus-4-8" || entry.model_id == "claude-opus-4-7" {
-                assert!(!entry.caps.supports_temperature);
-            }
-        }
-    }
-
-    #[test]
-    fn builtin_table_claude_sonnet_supports_temperature() {
-        let table = builtin_table();
-        let sonnet = table
-            .iter()
-            .find(|e| e.model_id == "claude-sonnet-4-6")
-            .expect("claude-sonnet-4-6 should be in table");
-        assert!(sonnet.caps.supports_temperature);
-    }
-
-    #[test]
-    fn builtin_table_has_display_names() {
-        let table = builtin_table();
-        for entry in &table {
-            assert!(!entry.display_name.is_empty());
-        }
-    }
-
-    #[test]
-    fn builtin_table_context_larger_than_output() {
-        let table = builtin_table();
-        for entry in &table {
-            assert!(entry.caps.max_context_tokens >= entry.caps.max_output_tokens);
-        }
-    }
-
     // ─── bool_icon edge ─────────────────────────────────────────────────────
 
     #[test]
@@ -1140,99 +935,6 @@ mod tests {
         assert!(!bool_icon(true).is_empty());
         assert!(!bool_icon(false).is_empty());
         assert_ne!(bool_icon(true), bool_icon(false));
-    }
-
-    // ─── builtin_table model coverage ───────────────────────────────────
-
-    #[test]
-    fn builtin_table_openai_models_support_temperature() {
-        let table = builtin_table();
-        for entry in &table {
-            if entry.provider == "openai" {
-                assert!(entry.caps.supports_temperature);
-            }
-        }
-    }
-
-    /// A user whose only key is a Gemini key must find models they can run.
-    /// Every Gemini row in this table used to route through OpenRouter, which
-    /// needs a different key, so `lev models list` showed that user nothing
-    /// their key could reach.
-    #[test]
-    fn builtin_table_offers_native_google_models() {
-        let table = builtin_table();
-        let native: Vec<&str> = table
-            .iter()
-            .filter(|e| e.provider == "google")
-            .map(|e| e.model_id)
-            .collect();
-        assert!(
-            !native.is_empty(),
-            "the native google provider must offer models of its own"
-        );
-        // Native ids are bare (`gemini-3.5-flash`), never OpenRouter-prefixed.
-        for id in &native {
-            assert!(
-                !id.contains('/'),
-                "native google model id must not be vendor-prefixed: {id}"
-            );
-        }
-    }
-
-    #[test]
-    fn builtin_table_gemini_flash_models_exist() {
-        let table = builtin_table();
-        let flash: Vec<_> = table
-            .iter()
-            .filter(|e| e.model_id.contains("gemini") && e.model_id.contains("flash"))
-            .collect();
-        assert!(!flash.is_empty());
-    }
-
-    #[test]
-    fn builtin_table_deepseek_r1_no_temperature() {
-        let table = builtin_table();
-        for entry in &table {
-            if entry.model_id.contains("deepseek-r1") {
-                assert!(!entry.caps.supports_temperature);
-            }
-        }
-    }
-
-    #[test]
-    fn builtin_table_qwen_models_exist() {
-        let table = builtin_table();
-        let qwen: Vec<_> = table
-            .iter()
-            .filter(|e| e.model_id.contains("qwen"))
-            .collect();
-        assert!(!qwen.is_empty());
-    }
-
-    #[test]
-    fn builtin_table_mistral_models_exist() {
-        let table = builtin_table();
-        let mistral: Vec<_> = table
-            .iter()
-            .filter(|e| e.model_id.contains("mistral"))
-            .collect();
-        assert!(!mistral.is_empty());
-    }
-
-    #[test]
-    fn builtin_table_all_entries_have_provider() {
-        let table = builtin_table();
-        for entry in &table {
-            assert!(!entry.provider.is_empty());
-        }
-    }
-
-    #[test]
-    fn builtin_table_all_entries_have_model_id() {
-        let table = builtin_table();
-        for entry in &table {
-            assert!(!entry.model_id.is_empty());
-        }
     }
 
     // ─── execute() / list() / show() async entry points ──────────────────
@@ -1246,6 +948,7 @@ mod tests {
                     command: ModelsCommand::List(ListArgs {
                         provider: None,
                         remote: false,
+                        offline: false,
                         all: false,
                         json: false,
                     }),
@@ -1267,6 +970,7 @@ mod tests {
                     command: ModelsCommand::List(ListArgs {
                         provider: Some("anthropic".to_string()),
                         remote: false,
+                        offline: false,
                         all: false,
                         json: false,
                     }),
@@ -1287,6 +991,7 @@ mod tests {
                     command: ModelsCommand::List(ListArgs {
                         provider: Some("nonexistent_provider".to_string()),
                         remote: false,
+                        offline: false,
                         all: false,
                         json: false,
                     }),
@@ -1314,6 +1019,7 @@ mod tests {
                         model: "claude-sonnet-4-6".to_string(),
                         provider: None,
                         remote: false,
+                        offline: false,
                     }),
                 };
                 // Should find model in builtin table and print details
@@ -1334,6 +1040,7 @@ mod tests {
                         model: "totally-unknown-model-xyz".to_string(),
                         provider: None,
                         remote: false,
+                        offline: false,
                     }),
                 };
                 // Should print "Model not found" message without error
@@ -1354,6 +1061,7 @@ mod tests {
                         model: "totally-unknown-model-xyz".to_string(),
                         provider: None,
                         remote: true, // remote but no provider = skips remote lookup
+                        offline: false,
                     }),
                 };
                 let result = execute(args).await;
@@ -1374,6 +1082,7 @@ mod tests {
                         provider: Some("anthropic".to_string()),
                         remote: true,
                         // Provider won't be configured in test env (no API key)
+                        offline: false,
                     }),
                 };
                 // Should warn about unconfigured provider and then show not-found message
@@ -1402,6 +1111,7 @@ mod tests {
                     command: ModelsCommand::List(ListArgs {
                         provider: Some("openrouter".to_string()),
                         remote: false,
+                        offline: false,
                         all: false,
                         json: false,
                     }),
@@ -1424,6 +1134,7 @@ mod tests {
                     command: ModelsCommand::List(ListArgs {
                         provider: Some("openai".to_string()),
                         remote: false,
+                        offline: false,
                         all: false,
                         json: false,
                     }),
@@ -1447,6 +1158,7 @@ mod tests {
                         model: "claude-opus-4-6".to_string(),
                         provider: None,
                         remote: false,
+                        offline: false,
                     }),
                 };
                 let result = execute(args).await;
@@ -1468,6 +1180,7 @@ mod tests {
                         model: "gpt-5.5".to_string(),
                         provider: None,
                         remote: false,
+                        offline: false,
                     }),
                 };
                 let result = execute(args).await;
@@ -1489,6 +1202,7 @@ mod tests {
                         model: "deepseek/deepseek-r1".to_string(),
                         provider: None,
                         remote: false,
+                        offline: false,
                     }),
                 };
                 let result = execute(args).await;
@@ -1496,27 +1210,6 @@ mod tests {
             },
         )
         .await;
-    }
-
-    // ─── builtin_table as ModelInfo conversion ──────────────────────────
-
-    #[test]
-    fn builtin_table_to_model_info_preserves_data() {
-        let table = builtin_table();
-        let infos: Vec<ModelInfo> = table
-            .into_iter()
-            .map(|e| {
-                ModelInfo::new(e.model_id.to_string(), e.provider.to_string(), e.caps)
-                    .named(Some(e.display_name.to_string()))
-            })
-            .collect();
-
-        assert!(!infos.is_empty());
-        for info in &infos {
-            assert!(!info.id.is_empty());
-            assert!(info.display_name.is_some());
-            assert!(!info.provider.is_empty());
-        }
     }
 
     // ─── print_model_detail coverage ────────────────────────────────────
@@ -1533,14 +1226,28 @@ mod tests {
             limits_source: LimitsSource::Builtin,
         };
         // Should not panic with all features disabled
-        print_model_detail("test-model", Some("Test"), "test", &caps, false);
+        print_model_detail(
+            "test-model",
+            Some("Test"),
+            "test",
+            &caps,
+            Source::Table,
+            None,
+        );
     }
 
     #[test]
     fn print_model_detail_user_override_source() {
         let caps = ModelCapabilities::default();
         // Should not panic with user override flag set
-        print_model_detail("override-model", None, "custom", &caps, true);
+        print_model_detail(
+            "override-model",
+            None,
+            "custom",
+            &caps,
+            Source::Override,
+            None,
+        );
     }
 
     // ─── fmt_tokens additional ──────────────────────────────────────────
@@ -1587,6 +1294,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: false,
@@ -1613,6 +1321,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: Some("openai".to_string()),
                     all: false,
                     json: true,
@@ -1631,6 +1340,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: None,
                     all: true,
                     json: true,
@@ -1653,12 +1363,20 @@ mod tests {
             display_name: Some("M".to_string()),
             capabilities: ModelCapabilities::default(),
             capabilities_overridden: true,
+            learned: true,
+            released: Some(86_400),
+            released_on: Some("1970-01-02".to_string()),
+            retires: None,
+            pricing: Some(ModelPricing::flat(1.0, 2.0)),
         };
         let value: serde_json::Value =
             serde_json::from_str(&serde_json::to_string(&row).unwrap()).unwrap();
         assert_eq!(value["id"], serde_json::json!("m"));
         assert_eq!(value["capabilities_overridden"], serde_json::json!(true));
         assert!(value["capabilities"]["supports_tools"].is_boolean());
+        assert_eq!(value["learned"], serde_json::json!(true));
+        assert_eq!(value["released_on"], serde_json::json!("1970-01-02"));
+        assert_eq!(value["pricing"]["output_per_mtok"], serde_json::json!(2.0));
     }
 
     #[tokio::test]
@@ -1668,6 +1386,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: Some("anthropic".to_string()),
                     all: false,
                     json: false,
@@ -1686,6 +1405,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: Some("no-such-provider".to_string()),
                     all: false,
                     json: false,
@@ -1710,10 +1430,11 @@ mod tests {
             "models-show_builtin_model_succeeds",
             |_fake_dir| async move {
                 // Use a model ID guaranteed to be in the builtin table.
-                let known_id = builtin_table()[0].model_id.to_string();
+                let known_id = catalogue_rows()[0].id.clone();
                 let args = ShowArgs {
                     model: known_id,
                     remote: false,
+                    offline: false,
                     provider: None,
                 };
                 let result = show_with_registry(args, &build_provider_registry_from_config).await;
@@ -1731,6 +1452,7 @@ mod tests {
                 let args = ShowArgs {
                     model: "totally-unknown-model-xyz".to_string(),
                     remote: false,
+                    offline: false,
                     provider: None,
                 };
                 // Falls through all lookup tiers; must not error even when not found.
@@ -1751,6 +1473,7 @@ mod tests {
                 let args = ShowArgs {
                     model: "totally-unknown-model-xyz".to_string(),
                     remote: true,
+                    offline: false,
                     provider: None,
                 };
                 let result = show_with_registry(args, &build_provider_registry_from_config).await;
@@ -1771,9 +1494,9 @@ mod tests {
     // just that provider via `--provider`, so no real ollama/claude-code
     // provider is ever touched.
 
-    struct MockProvider {
-        models: Vec<ModelInfo>,
-        fail: bool,
+    pub(super) struct MockProvider {
+        pub(super) models: Vec<ModelInfo>,
+        pub(super) fail: bool,
     }
 
     #[async_trait::async_trait]
@@ -1847,6 +1570,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: true,
+                    offline: false,
                     provider: Some("mock".to_string()),
                     all: false,
                     json: false,
@@ -1876,6 +1600,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: true,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: false,
@@ -1899,9 +1624,10 @@ mod tests {
         crate::config::with_isolated_config_path_async(
             "models-list_remote_overrides_builtin_entry_with_same_id",
             |_fake_dir| async move {
-                let known_id = builtin_table()[0].model_id.to_string();
+                let known_id = catalogue_rows()[0].id.clone();
                 let args = ListArgs {
                     remote: true,
+                    offline: false,
                     provider: Some("mock".to_string()),
                     all: false,
                     json: false,
@@ -1929,6 +1655,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: false,
@@ -1961,6 +1688,7 @@ mod tests {
                 ];
                 let args = ListArgs {
                     remote: true,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: false,
@@ -1982,6 +1710,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: None,
                     all: true,
                     json: false,
@@ -2010,12 +1739,50 @@ mod tests {
                     .expect("the isolated config path is writable");
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: false,
                 };
+                // The provider's own listing carries the model, so the row is
+                // live and the override is merged onto it and marked.
+                let listed =
+                    ModelInfo::new("claude-sonnet-5", "anthropic", ModelCapabilities::default());
                 let result =
-                    list_with_registry(args, &mock_registry("anthropic", vec![], false)).await;
+                    list_with_registry(args, &mock_registry("anthropic", vec![listed], false))
+                        .await;
+                assert!(result.is_ok());
+            },
+        )
+        .await;
+    }
+
+    /// An entry for a model nothing lists and the table does not name still
+    /// prints, from the defaults it corrects.
+    #[tokio::test]
+    async fn show_prints_an_override_for_a_model_nobody_else_knows() {
+        crate::config::with_isolated_config_path_async(
+            "models-show_override_only",
+            |_fake_dir| async move {
+                let mut config = Config::default();
+                config.model_capabilities.insert(
+                    "my-local-llama".to_string(),
+                    leviath_providers::ModelCapabilityOverride {
+                        max_context_tokens: Some(32_768),
+                        ..Default::default()
+                    },
+                );
+                config
+                    .save_to_path(&Config::config_path())
+                    .expect("the isolated config path is writable");
+                let args = ShowArgs {
+                    model: "my-local-llama".to_string(),
+                    provider: None,
+                    remote: false,
+                    offline: true,
+                };
+                let result =
+                    show_with_registry(args, &mock_registry("anthropic", vec![], false)).await;
                 assert!(result.is_ok());
             },
         )
@@ -2029,6 +1796,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: true,
+                    offline: false,
                     provider: Some("mock".to_string()),
                     all: false,
                     json: false,
@@ -2053,6 +1821,7 @@ mod tests {
                 // an error, which would end the command before this branch.
                 let args = ListArgs {
                     remote: true,
+                    offline: false,
                     provider: Some("openai".to_string()),
                     all: false,
                     json: false,
@@ -2105,6 +1874,7 @@ mod tests {
                 // JSON so the merged row is the whole output, not a table cell.
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: Some("scripted".to_string()),
                     all: false,
                     json: true,
@@ -2142,6 +1912,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: true,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: true,
@@ -2171,6 +1942,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: true,
+                    offline: false,
                     provider: Some("once".to_string()),
                     all: false,
                     json: true,
@@ -2199,6 +1971,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: Some("quiet".to_string()),
                     all: false,
                     json: false,
@@ -2229,6 +2002,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: Some("angry".to_string()),
                     all: false,
                     json: false,
@@ -2254,7 +2028,7 @@ mod tests {
     #[tokio::test]
     async fn a_script_provider_overrides_a_builtin_row_with_the_same_id() {
         let dir = tempfile::tempdir().expect("a temp providers dir");
-        let builtin_id = builtin_table()[0].model_id.to_string();
+        let builtin_id = catalogue_rows()[0].id.clone();
         std::fs::write(
             dir.path().join("mirror.rhai"),
             format!(
@@ -2271,6 +2045,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: Some("mirror".to_string()),
                     all: true,
                     json: true,
@@ -2297,6 +2072,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: Some("openai".to_string()),
                     all: true,
                     json: false,
@@ -2316,6 +2092,7 @@ mod tests {
                 let args = ShowArgs {
                     model: "mock-remote-model".to_string(),
                     remote: true,
+                    offline: false,
                     provider: Some("mock".to_string()),
                 };
                 let remote_model = ModelInfo::new(
@@ -2341,6 +2118,7 @@ mod tests {
                 let args = ShowArgs {
                     model: "totally-unknown-model-xyz".to_string(),
                     remote: true,
+                    offline: false,
                     provider: Some("mock".to_string()),
                 };
                 let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
@@ -2358,6 +2136,7 @@ mod tests {
                 let args = ShowArgs {
                     model: "totally-unknown-model-xyz".to_string(),
                     remote: true,
+                    offline: false,
                     provider: Some("mock".to_string()),
                 };
                 let result = show_with_registry(args, &mock_registry("mock", vec![], true)).await;
@@ -2377,6 +2156,7 @@ mod tests {
                 let args = ShowArgs {
                     model: "totally-unknown-model-xyz".to_string(),
                     remote: true,
+                    offline: false,
                     provider: Some("nonexistent-provider".to_string()),
                 };
                 let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
@@ -2399,7 +2179,7 @@ mod tests {
         crate::config::with_isolated_config_path_async(
             "models-list-override",
             |_fake_dir| async move {
-                let known_id = builtin_table()[0].model_id.to_string();
+                let known_id = catalogue_rows()[0].id.clone();
                 let mut fake_config = Config::default();
                 fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
                 fake_config.model_capabilities.insert(
@@ -2423,6 +2203,7 @@ mod tests {
 
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: false,
@@ -2439,7 +2220,7 @@ mod tests {
         crate::config::with_isolated_config_path_async(
             "models-show-override",
             |_fake_dir| async move {
-                let known_id = builtin_table()[0].model_id.to_string();
+                let known_id = catalogue_rows()[0].id.clone();
                 let mut fake_config = Config::default();
                 fake_config.providers.anthropic_api_key = Some("not-a-real-key".to_string());
                 fake_config.model_capabilities.insert(
@@ -2464,6 +2245,7 @@ mod tests {
                 let args = ShowArgs {
                     model: known_id,
                     remote: false,
+                    offline: false,
                     provider: None,
                 };
                 let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
@@ -2515,6 +2297,7 @@ mod tests {
                 std::fs::write(fake_dir.join("config.toml"), "not valid toml [[[").unwrap();
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: false,
@@ -2566,6 +2349,7 @@ mod tests {
             model: "x".to_string(),
             provider: None,
             remote: false,
+            offline: false,
         }));
     }
 
@@ -2583,6 +2367,7 @@ mod tests {
         expect_show(ModelsCommand::List(ListArgs {
             provider: None,
             remote: false,
+            offline: false,
             all: false,
             json: false,
         }));
@@ -2661,6 +2446,7 @@ mod tests {
                 let args = ShowArgs {
                     model: "any-model".to_string(),
                     remote: false,
+                    offline: false,
                     provider: None,
                 };
                 let result = show_with_registry(args, &mock_registry("mock", vec![], false)).await;
@@ -2687,6 +2473,7 @@ mod tests {
             |_fake_dir| async move {
                 let args = ListArgs {
                     remote: false,
+                    offline: false,
                     provider: None,
                     all: false,
                     json: false,
@@ -2713,6 +2500,7 @@ mod tests {
                     model: "not-a-built-in-model".to_string(),
                     provider: Some("anthropic".to_string()),
                     remote: true,
+                    offline: false,
                 };
                 let err = show_with_registry(args, &cannot_build)
                     .await
@@ -2721,5 +2509,267 @@ mod tests {
             },
         )
         .await;
+    }
+}
+
+/// The listing is live by default now: what each provider says replaces the
+/// compiled catalogue's rows for it, and only a provider that could not be
+/// asked keeps them.
+#[cfg(test)]
+mod live_listing_tests {
+    use super::*;
+    use leviath_providers::ModelCapabilities;
+
+    /// A provider whose listing never arrives, for the timeout arm.
+    struct HangingProvider;
+
+    #[async_trait::async_trait]
+    impl leviath_providers::Provider for HangingProvider {
+        async fn infer(
+            &self,
+            _request: &leviath_providers::InferenceRequest,
+        ) -> Result<leviath_providers::InferenceResponse, leviath_providers::ProviderError>
+        {
+            Err(leviath_providers::ProviderError::Other("no".to_string()))
+        }
+
+        async fn count_tokens(&self, text: &str, _model: &str) -> usize {
+            leviath_core::estimate_tokens(text)
+        }
+
+        fn max_context_tokens(&self, _model: &str) -> usize {
+            1
+        }
+
+        fn name(&self) -> &str {
+            "slow"
+        }
+
+        fn capabilities(&self, _model: &str) -> ModelCapabilities {
+            ModelCapabilities::default()
+        }
+
+        async fn prime_capabilities(&self) -> Result<(), leviath_providers::ProviderError> {
+            std::future::pending().await
+        }
+
+        async fn list_models(&self) -> Result<Vec<ModelInfo>, leviath_providers::ProviderError> {
+            std::future::pending().await
+        }
+    }
+
+    /// A registry with one live mock provider and, when `slow` is set, one
+    /// that never answers.
+    fn registry_with(
+        models: Vec<ModelInfo>,
+        slow: bool,
+    ) -> impl Fn(&Config) -> Result<leviath_runtime::ProviderRegistry, leviath_providers::ProviderError>
+    {
+        move |_config: &Config| {
+            let mut registry = leviath_runtime::ProviderRegistry::new();
+            registry.register(
+                "mock".to_string(),
+                std::sync::Arc::new(super::tests::MockProvider {
+                    models: models.clone(),
+                    fail: false,
+                }),
+            );
+            if slow {
+                registry.register("slow".to_string(), std::sync::Arc::new(HangingProvider));
+            }
+            Ok(registry)
+        }
+    }
+
+    fn learned_model(id: &str, released: Option<i64>, rate: Option<f64>) -> ModelInfo {
+        let mut info = ModelInfo::new(id, "mock", ModelCapabilities::default())
+            .named(Some(format!("Mock {id}")));
+        info.learned = true;
+        info.released = released;
+        info.pricing = rate.map(|r| ModelPricing::flat(r, r * 4.0));
+        info
+    }
+
+    fn list_args(offline: bool, json: bool) -> ListArgs {
+        ListArgs {
+            provider: None,
+            remote: false,
+            offline,
+            all: false,
+            json,
+        }
+    }
+
+    #[tokio::test]
+    async fn the_listing_is_live_by_default_and_prints_dates_and_rates() {
+        crate::config::with_isolated_config_path_async("models-live-default", |_| async move {
+            let models = vec![
+                learned_model("mock-old", Some(86_400), Some(0.0416)),
+                learned_model("mock-new", Some(1_787_875_200), Some(2.5)),
+                learned_model("mock-free", None, Some(0.0)),
+                learned_model("mock-unpriced", None, None),
+            ];
+            let result =
+                list_with_registry(list_args(false, false), &registry_with(models, false)).await;
+            assert!(result.is_ok(), "{result:?}");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn offline_prints_only_this_builds_table() {
+        crate::config::with_isolated_config_path_async("models-offline", |_| async move {
+            // `--all` keeps the catalogue rows for providers this registry does
+            // not hold; offline, the mock is never asked, so nothing is live.
+            let args = ListArgs {
+                all: true,
+                ..list_args(true, false)
+            };
+            let models = vec![learned_model("mock-live", Some(1), Some(1.0))];
+            let result = list_with_registry(args, &registry_with(models, false)).await;
+            assert!(result.is_ok(), "{result:?}");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn a_provider_that_does_not_answer_in_time_keeps_the_table() {
+        crate::config::with_isolated_config_path_async("models-slow", |_| async move {
+            let models = vec![learned_model("mock-live", Some(1), Some(1.0))];
+            let result = list_with_registry_within(
+                list_args(false, false),
+                &registry_with(models, true),
+                std::time::Duration::from_millis(20),
+            )
+            .await;
+            assert!(result.is_ok(), "{result:?}");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn json_carries_the_learned_fields() {
+        crate::config::with_isolated_config_path_async("models-live-json", |_| async move {
+            let models = vec![learned_model("mock-new", Some(1_787_875_200), Some(2.5))];
+            let result =
+                list_with_registry(list_args(false, true), &registry_with(models, false)).await;
+            assert!(result.is_ok(), "{result:?}");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn show_prefers_the_providers_own_row_and_says_so() {
+        crate::config::with_isolated_config_path_async("models-show-live", |_| async move {
+            let models = vec![learned_model("mock-new", Some(1_787_875_200), Some(2.5))];
+            let args = ShowArgs {
+                model: "mock-new".to_string(),
+                provider: None,
+                remote: false,
+                offline: false,
+            };
+            let result = show_with_registry(args, &registry_with(models, false)).await;
+            assert!(result.is_ok(), "{result:?}");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn show_offline_answers_from_the_table_alone() {
+        crate::config::with_isolated_config_path_async("models-show-offline", |_| async move {
+            let known = catalogue_rows()[0].id.clone();
+            let args = ShowArgs {
+                model: known,
+                provider: None,
+                remote: false,
+                offline: true,
+            };
+            let result = show_with_registry(args, &registry_with(Vec::new(), false)).await;
+            assert!(result.is_ok(), "{result:?}");
+        })
+        .await;
+    }
+
+    #[tokio::test]
+    async fn show_reports_a_provider_that_does_not_answer_in_time() {
+        crate::config::with_isolated_config_path_async("models-show-slow", |_| async move {
+            let args = ShowArgs {
+                model: "nothing-has-this".to_string(),
+                provider: Some("slow".to_string()),
+                remote: false,
+                offline: false,
+            };
+            let result = show_with_registry_within(
+                args,
+                &registry_with(Vec::new(), true),
+                std::time::Duration::from_millis(20),
+            )
+            .await;
+            assert!(result.is_ok(), "{result:?}");
+        })
+        .await;
+    }
+
+    /// A `--provider` the catalogue knows still answers from the table when
+    /// the id is one of that provider's rows, and not from another provider's
+    /// row with the same id.
+    #[tokio::test]
+    async fn show_with_a_provider_filter_reads_only_that_providers_rows() {
+        crate::config::with_isolated_config_path_async("models-show-filter", |_| async move {
+            let args = ShowArgs {
+                model: "claude-opus-5".to_string(),
+                provider: Some("claude-code".to_string()),
+                remote: false,
+                offline: true,
+            };
+            let result = show_with_registry(args, &registry_with(Vec::new(), false)).await;
+            assert!(result.is_ok(), "{result:?}");
+        })
+        .await;
+    }
+
+    /// The stub's other trait methods are never reached by the listing; they
+    /// exist to satisfy the trait and answer the least surprising thing.
+    #[tokio::test]
+    async fn the_hanging_stub_answers_its_other_methods() {
+        use leviath_providers::Provider as _;
+        let stub = HangingProvider;
+        assert_eq!(stub.name(), "slow");
+        assert_eq!(stub.max_context_tokens("m"), 1);
+        assert_eq!(stub.capabilities("m"), ModelCapabilities::default());
+        assert_eq!(stub.count_tokens("four words go here", "m").await, 5);
+        let request = leviath_providers::InferenceRequest {
+            system: vec![],
+            messages: vec![],
+            model: "m".to_string(),
+            max_tokens: 1,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        };
+        assert!(stub.infer(&request).await.is_err());
+    }
+
+    #[test]
+    fn rates_print_at_the_precision_their_size_needs() {
+        assert_eq!(fmt_rate(0.0), "0.00");
+        assert_eq!(fmt_rate(2.5), "2.50");
+        assert_eq!(fmt_rate(0.1), "0.10");
+        assert_eq!(fmt_rate(0.0416), "0.0416");
+    }
+
+    #[test]
+    fn the_trailing_line_says_where_the_rows_came_from() {
+        let overridden = std::collections::HashSet::new();
+        let table = ModelInfo::new("t", "anthropic", ModelCapabilities::default());
+        let live = learned_model("l", None, None);
+        print_listing(std::slice::from_ref(&table), &overridden, &[]);
+        print_listing(
+            std::slice::from_ref(&live),
+            &overridden,
+            &["mock".to_string()],
+        );
+        print_listing(&[table, live], &overridden, &["mock".to_string()]);
     }
 }

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -294,6 +294,11 @@ pub(super) async fn list_models_from_config(
                     max_output_tokens: m.capabilities.max_output_tokens,
                     limits_source: limits_source_label(m.capabilities.limits_source),
                     supports_tools: m.capabilities.supports_tools,
+                    supports_temperature: m.capabilities.supports_temperature,
+                    learned: m.learned,
+                    released: m.released,
+                    retires: m.retires,
+                    pricing: m.pricing,
                 });
             }
         }
@@ -638,6 +643,17 @@ mod tests {
         assert!(!models.is_empty());
         assert!(models.iter().any(|m| m["provider"] == "claude-code"));
         assert!(models.iter().all(|m| m["id"].is_string()));
+        // The fields The Lair reads to describe a model beyond its size: the
+        // shape flags, whether the row is the provider's own answer, and the
+        // dates and rates a listing carries when it has them.
+        for m in &models {
+            assert!(m["supports_temperature"].is_boolean(), "{m}");
+            assert!(m["supports_tools"].is_boolean(), "{m}");
+            assert!(m["learned"].is_boolean(), "{m}");
+            assert!(m.get("released").is_some(), "{m}");
+            assert!(m.get("retires").is_some(), "{m}");
+            assert!(m.get("pricing").is_some(), "{m}");
+        }
     }
 
     /// A script provider's models must reach `GET /api/models`, or The Lair

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1114,6 +1114,16 @@ pub(super) struct ModelEntry {
     /// limits at all, and is a guess that can be wrong by a factor of two.
     pub(super) limits_source: String,
     pub(super) supports_tools: bool,
+    pub(super) supports_temperature: bool,
+    /// Whether the provider's own listing described this model, as opposed
+    /// to a row from the table compiled into this build.
+    pub(super) learned: bool,
+    /// When the provider released it, as Unix seconds, if its listing says.
+    pub(super) released: Option<i64>,
+    /// When the provider will withdraw it, as published, if its listing says.
+    pub(super) retires: Option<String>,
+    /// USD per million tokens, when the provider's listing quotes a rate.
+    pub(super) pricing: Option<leviath_providers::ModelPricing>,
 }
 
 #[cfg(test)]

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -608,6 +608,7 @@ mod tests {
                 command: commands::models::ModelsCommand::List(commands::models::ListArgs {
                     provider: None,
                     remote: false,
+                    offline: false,
                     all: false,
                     json: false,
                 }),

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -304,6 +304,24 @@ pub struct AnthropicProvider {
     learned: LearnedModels,
 }
 
+/// What [`MODELS`] says about `model`, for a caller with no provider in hand.
+pub(crate) fn table_capabilities(model: &str) -> ModelCapabilities {
+    crate::capabilities::lookup(MODELS, model, ModelCapabilities::default())
+}
+
+/// The models this build names when the listing cannot be read: the current
+/// line-up, as `(id, display name)`.
+pub(crate) const CATALOG: &[(&str, &str)] = &[
+    ("claude-opus-5", "Claude Opus 5"),
+    ("claude-sonnet-5", "Claude Sonnet 5"),
+    ("claude-fable-5", "Claude Fable 5"),
+    ("claude-opus-4-8", "Claude Opus 4.8"),
+    ("claude-opus-4-7", "Claude Opus 4.7"),
+    ("claude-opus-4-6", "Claude Opus 4.6"),
+    ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+    ("claude-haiku-4-5-20251001", "Claude Haiku 4.5"),
+];
+
 /// What this build knows about Anthropic's models, most specific first.
 ///
 /// The generic Claude 4.x row at the bottom catches older 4.5 snapshots; it
@@ -419,7 +437,7 @@ impl AnthropicProvider {
 
     /// Return built-in capabilities for a model based on its name pattern.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        crate::capabilities::lookup(MODELS, model, ModelCapabilities::default())
+        table_capabilities(model)
     }
 
     /// Point this provider at a different host.

--- a/crates/leviath-providers/src/capabilities.rs
+++ b/crates/leviath-providers/src/capabilities.rs
@@ -92,6 +92,72 @@ pub(crate) fn lookup(table: &[Row], model: &str, fallback: ModelCapabilities) ->
         .map_or(fallback, Row::capabilities)
 }
 
+/// One model this build names outright, for a listing that cannot ask.
+///
+/// The tables above recognise a model by a pattern in its name and so cannot
+/// enumerate anything; a listing wants rows. Each provider names the handful
+/// of models worth showing when its listing cannot be reached, and resolves
+/// their capabilities through its own table, so a row here and an inference
+/// against the same id cannot disagree. This replaced a second, hand-kept
+/// table in the CLI whose numbers had drifted from these (#568).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CatalogEntry {
+    /// The provider that serves it.
+    pub provider: &'static str,
+    /// The id a request names.
+    pub id: &'static str,
+    /// What the provider calls it.
+    pub display_name: &'static str,
+    /// What the provider's table says about it.
+    pub capabilities: ModelCapabilities,
+}
+
+/// Every model this build names outright, across the providers that name any.
+///
+/// Ollama names none: it serves whatever has been pulled, and nothing compiled
+/// in could say what that is. OpenRouter names a sample of the hundreds it
+/// fronts. The three closed catalogues (Anthropic, OpenAI, Google) name their
+/// current line-up, which is what the `unknown-model` lint checks a blueprint
+/// against when no listing has been read.
+pub fn builtin_catalog() -> Vec<CatalogEntry> {
+    let rows = |provider: &'static str,
+                catalog: &'static [(&'static str, &'static str)],
+                capabilities: fn(&str) -> ModelCapabilities| {
+        catalog.iter().map(move |(id, display_name)| CatalogEntry {
+            provider,
+            id,
+            display_name,
+            capabilities: capabilities(id),
+        })
+    };
+    rows(
+        "anthropic",
+        crate::anthropic::CATALOG,
+        crate::anthropic::table_capabilities,
+    )
+    .chain(rows(
+        "openai",
+        crate::openai::CATALOG,
+        crate::openai::table_capabilities,
+    ))
+    .chain(rows(
+        "google",
+        crate::gemini::CATALOG,
+        crate::gemini::table_capabilities,
+    ))
+    .chain(rows(
+        "openrouter",
+        crate::openrouter::CATALOG,
+        crate::openrouter::table_capabilities,
+    ))
+    .chain(rows(
+        "claude-code",
+        crate::claude_code::CATALOG,
+        crate::claude_code::table_capabilities,
+    ))
+    .collect()
+}
+
 /// Capabilities supported by a model.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelCapabilities {
@@ -264,6 +330,60 @@ impl From<ModelCapabilities> for ModelCapabilityOverride {
             cache_write_per_mtok: None,
             output_per_mtok: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod catalog_tests {
+    use super::*;
+
+    /// A catalogue id that fell through to its provider's fallback would be a
+    /// row whose numbers are a guess dressed as a fact, which is the drift
+    /// this catalogue replaced.
+    #[test]
+    fn every_catalogue_id_hits_a_real_row_of_its_providers_table() {
+        let catalog = builtin_catalog();
+        assert!(catalog.len() > 30);
+        let fallbacks = [
+            ("anthropic", ModelCapabilities::default()),
+            ("openai", ModelCapabilities::default()),
+            ("openrouter", crate::openrouter::FALLBACK_CAPABILITIES),
+        ];
+        let strays: Vec<&str> = catalog
+            .iter()
+            .filter(|e| {
+                fallbacks
+                    .iter()
+                    .any(|(p, f)| *p == e.provider && e.capabilities == *f)
+            })
+            .map(|e| e.id)
+            .collect();
+        assert!(strays.is_empty(), "on the fallback: {strays:?}");
+    }
+
+    #[test]
+    fn catalogue_ids_are_unique_per_provider_and_named() {
+        let catalog = builtin_catalog();
+        let mut seen = std::collections::HashSet::new();
+        for entry in &catalog {
+            assert!(seen.insert((entry.provider, entry.id)), "{:?}", entry.id);
+            assert!(!entry.display_name.is_empty(), "{}", entry.id);
+            assert!(
+                entry.capabilities.max_context_tokens > entry.capabilities.max_output_tokens,
+                "{}",
+                entry.id
+            );
+        }
+        for provider in ["anthropic", "openai", "google", "openrouter", "claude-code"] {
+            assert!(
+                catalog.iter().any(|e| e.provider == provider),
+                "{provider} names nothing"
+            );
+        }
+        assert!(
+            !catalog.iter().any(|e| e.provider == "ollama"),
+            "nothing compiled in can say what has been pulled"
+        );
     }
 }
 

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -111,29 +111,47 @@ impl ClaudeCodeProvider {
 
     /// Built-in capabilities for known Claude models.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        let max_output = if model.contains("opus") {
-            32_000
-        } else if model.contains("haiku") {
-            8_192
-        } else {
-            16_000
-        };
-
-        ModelCapabilities {
-            // The CLI exposes no temperature control.
-            supports_temperature: false,
-            // Streaming is not implemented: the runtime never calls
-            // `infer_stream`, and the trait's default wraps `infer`.
-            supports_streaming: false,
-            // Synthesized by the text protocol rather than native.
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens: 200_000 - INJECTION_RESERVE_TOKENS,
-            max_output_tokens: max_output,
-            limits_source: LimitsSource::Builtin,
-        }
+        table_capabilities(model)
     }
+}
 
+/// Built-in capabilities for known Claude models, for a caller with no
+/// provider in hand.
+pub(crate) fn table_capabilities(model: &str) -> ModelCapabilities {
+    let max_output = if model.contains("opus") {
+        32_000
+    } else if model.contains("haiku") {
+        8_192
+    } else {
+        16_000
+    };
+
+    ModelCapabilities {
+        // The CLI exposes no temperature control.
+        supports_temperature: false,
+        // Streaming is not implemented: the runtime never calls
+        // `infer_stream`, and the trait's default wraps `infer`.
+        supports_streaming: false,
+        // Synthesized by the text protocol rather than native.
+        supports_tools: true,
+        supports_system_prompt: true,
+        max_context_tokens: 200_000 - INJECTION_RESERVE_TOKENS,
+        max_output_tokens: max_output,
+        limits_source: LimitsSource::Builtin,
+    }
+}
+
+/// The models the CLI can be pointed at, as `(id, display name)`. There is
+/// no listing to ask.
+pub(crate) const CATALOG: &[(&str, &str)] = &[
+    ("claude-opus-5", "Claude Opus 5"),
+    ("claude-sonnet-5", "Claude Sonnet 5"),
+    ("claude-opus-4-8", "Claude Opus 4.8"),
+    ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+    ("claude-haiku-4-5", "Claude Haiku 4.5"),
+];
+
+impl ClaudeCodeProvider {
     /// The full system prompt: Leviath's assembled system blocks, plus the tool
     /// catalog and protocol when the stage has tools.
     ///
@@ -488,16 +506,9 @@ impl Provider for ClaudeCodeProvider {
     }
 
     async fn list_models(&self) -> Result<Vec<ModelInfo>> {
-        let models = [
-            ("claude-opus-5", "Claude Opus 5"),
-            ("claude-sonnet-5", "Claude Sonnet 5"),
-            ("claude-opus-4-8", "Claude Opus 4.8"),
-            ("claude-sonnet-4-6", "Claude Sonnet 4.6"),
-            ("claude-haiku-4-5", "Claude Haiku 4.5"),
-        ];
-        Ok(models
-            .into_iter()
-            .map(|(id, display)| {
+        Ok(CATALOG
+            .iter()
+            .map(|&(id, display)| {
                 ModelInfo::new(id, "claude-code", self.builtin_capabilities(id))
                     .named(Some(display.to_string()))
             })

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -73,6 +73,30 @@ impl GeminiFamily {
 /// the page token is followed regardless.
 const NATIVE_PAGE_SIZE: usize = 200;
 
+/// What the family table says about `model`, for a caller with no provider
+/// in hand.
+pub(crate) fn table_capabilities(model: &str) -> ModelCapabilities {
+    let (max_context_tokens, max_output_tokens) = GeminiFamily::classify(model).limits();
+    ModelCapabilities {
+        supports_temperature: true,
+        supports_streaming: true,
+        supports_tools: true,
+        supports_system_prompt: true,
+        max_context_tokens,
+        max_output_tokens,
+        limits_source: LimitsSource::Builtin,
+    }
+}
+
+/// The models this build names when the listing cannot be read, as
+/// `(id, display name)`.
+pub(crate) const CATALOG: &[(&str, &str)] = &[
+    ("gemini-3.5-flash", "Gemini 3.5 Flash"),
+    ("gemini-3.1-pro-preview", "Gemini 3.1 Pro (preview)"),
+    ("gemini-3-flash", "Gemini 3 Flash"),
+    ("gemini-3.1-flash-lite", "Gemini 3.1 Flash Lite"),
+];
+
 /// Google Gemini provider using the OpenAI-compatible endpoint.
 pub struct GeminiProvider {
     /// HTTP client
@@ -169,16 +193,7 @@ impl GeminiProvider {
     /// - gemini-3-flash (complex multimodal/agentic)
     /// - gemini-3.1-flash-lite (cost-efficient, high-volume)
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        let (max_context_tokens, max_output_tokens) = GeminiFamily::classify(model).limits();
-        ModelCapabilities {
-            supports_temperature: true,
-            supports_streaming: true,
-            supports_tools: true,
-            supports_system_prompt: true,
-            max_context_tokens,
-            max_output_tokens,
-            limits_source: LimitsSource::Builtin,
-        }
+        table_capabilities(model)
     }
 
     /// Derive the native Gemini API base (`.../v1beta`) from the OpenAI-compatible

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -68,6 +68,20 @@ fn is_chat_model_id(model_key: &str) -> bool {
     model_key.starts_with("gpt") || reasoning
 }
 
+/// What [`MODELS`] says about `model`, for a caller with no provider in hand.
+pub(crate) fn table_capabilities(model: &str) -> ModelCapabilities {
+    crate::capabilities::lookup(MODELS, model, ModelCapabilities::default())
+}
+
+/// The models this build names when the listing cannot be read, as
+/// `(id, display name)`.
+pub(crate) const CATALOG: &[(&str, &str)] = &[
+    ("gpt-5.5", "GPT-5.5"),
+    ("gpt-5.4", "GPT-5.4"),
+    ("gpt-5.4-mini", "GPT-5.4 Mini"),
+    ("gpt-5.4-nano", "GPT-5.4 Nano"),
+];
+
 /// What this build knows about OpenAI's models, most specific first.
 ///
 /// `gpt-5.5` sits above the `gpt-5` family row because it is the one member
@@ -166,7 +180,7 @@ impl OpenAIProvider {
 
     /// Return built-in capability defaults for a model.
     fn builtin_capabilities(&self, model: &str) -> ModelCapabilities {
-        crate::capabilities::lookup(MODELS, model, ModelCapabilities::default())
+        table_capabilities(model)
     }
 
     /// POST a chat-completions body, teaching the retry described on

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -53,19 +53,34 @@ pub struct OpenAIProvider {
 }
 
 /// Whether `model_key` is shaped like one of OpenAI's chat or reasoning
-/// models: `gpt-*`, or `o<digit>*`.
+/// models: `gpt-*`, or `o<digit>*`, and not one of the `gpt-*` names that
+/// speak a different API.
 ///
 /// One rule for two questions. [`Provider::serves_model`] uses it to route a
 /// bare model name, and [`Provider::served_catalog`] uses it to keep the
 /// embeddings, transcription and image models the listing also carries from
 /// being published as chat models. Sharing it is what guarantees the catalogue
 /// can never refuse a name routing would have accepted.
+///
+/// The exclusions are the `gpt-` families measured in the live listing that
+/// do not answer `/chat/completions`: realtime and transcription models speak
+/// their own endpoints, and image and speech models produce no text. The
+/// listing itself says nothing about which endpoint a model speaks, so the
+/// name is the only signal.
 fn is_chat_model_id(model_key: &str) -> bool {
+    const NOT_CHAT: &[&str] = &[
+        "realtime",
+        "transcribe",
+        "audio",
+        "tts",
+        "image",
+        "search-api",
+    ];
     let reasoning = model_key.starts_with('o')
         && model_key
             .get(1..2)
             .is_some_and(|c| c.chars().all(|c| c.is_ascii_digit()));
-    model_key.starts_with("gpt") || reasoning
+    (model_key.starts_with("gpt") || reasoning) && !NOT_CHAT.iter().any(|s| model_key.contains(s))
 }
 
 /// What [`MODELS`] says about `model`, for a caller with no provider in hand.
@@ -1555,6 +1570,9 @@ mod learned_tests {
             {"id":"gpt-5.5","object":"model","created":1776824847,"owned_by":"system","shutdown_date":null},
             {"id":"text-embedding-3-large","object":"model","created":1,"owned_by":"system"},
             {"id":"whisper-1","object":"model","created":2,"owned_by":"openai-internal"},
+            {"id":"gpt-realtime-2.1","object":"model","created":4,"owned_by":"system"},
+            {"id":"gpt-transcribe","object":"model","created":5,"owned_by":"system"},
+            {"id":"gpt-4o-mini-tts","object":"model","created":6,"owned_by":"system"},
             {"id":"o3","object":"model","created":3,"owned_by":"system","shutdown_date":"2027-01-01"}
         ]}"#;
         // One response only: `list_models` after priming must not fetch again.
@@ -1567,7 +1585,11 @@ mod learned_tests {
 
         let mut catalog = provider.served_catalog().expect("primed");
         catalog.sort();
-        assert_eq!(catalog, ["gpt-5.5", "o3"], "chat and reasoning ids only");
+        assert_eq!(
+            catalog,
+            ["gpt-5.5", "o3"],
+            "chat and reasoning ids only: no embeddings, speech, realtime or transcription"
+        );
         assert_eq!(provider.capabilities("gpt-5.5"), before);
 
         let listed = provider.list_models().await.expect("from the store");

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -270,12 +270,63 @@ fn builtin_capabilities(model: &str) -> ModelCapabilities {
     crate::capabilities::lookup(MODELS, model, FALLBACK_CAPABILITIES)
 }
 
+/// [`builtin_capabilities`], for the crate-level catalogue.
+pub(crate) fn table_capabilities(model: &str) -> ModelCapabilities {
+    builtin_capabilities(model)
+}
+
+/// A sample of the models the gateway fronts, named when its listing cannot
+/// be read, as `(id, display name)`. The listing is the real answer: it
+/// carried 398 models when measured, and this names two dozen.
+pub(crate) const CATALOG: &[(&str, &str)] = &[
+    ("x-ai/grok-4.6", "Grok 4.6"),
+    ("meta/muse-spark-1.2", "Muse Spark 1.2"),
+    ("anthropic/claude-opus-5", "Claude Opus 5 (via OpenRouter)"),
+    (
+        "anthropic/claude-sonnet-5",
+        "Claude Sonnet 5 (via OpenRouter)",
+    ),
+    ("google/gemini-3.5-flash", "Gemini 3.5 Flash"),
+    ("google/gemini-2.5-pro", "Gemini 2.5 Pro"),
+    ("google/gemini-2.5-flash", "Gemini 2.5 Flash"),
+    ("google/gemini-2.5-flash-lite", "Gemini 2.5 Flash Lite"),
+    ("meta-llama/llama-4-maverick", "Llama 4 Maverick"),
+    ("meta-llama/llama-4-scout", "Llama 4 Scout"),
+    ("deepseek/deepseek-v4-pro", "DeepSeek V4 Pro"),
+    ("deepseek/deepseek-v4-flash", "DeepSeek V4 Flash"),
+    ("deepseek/deepseek-v3.2", "DeepSeek V3.2"),
+    ("deepseek/deepseek-r1-0528", "DeepSeek R1 (0528)"),
+    ("deepseek/deepseek-r1", "DeepSeek R1"),
+    ("mistralai/mistral-large-2512", "Mistral Large 3"),
+    ("mistralai/mistral-medium-3-5", "Mistral Medium 3.5"),
+    ("mistralai/mistral-small-2603", "Mistral Small 4"),
+    ("qwen/qwen3.6-plus", "Qwen 3.6 Plus"),
+    ("qwen/qwen3-max", "Qwen3 Max"),
+    ("qwen/qwen3-coder", "Qwen3 Coder 480B"),
+];
+
 /// What this build knows about the models OpenRouter routes to, most
 /// specific first.
 ///
 /// Rows for a single model (`llama-4-scout`, `deepseek-v4-pro`, the
 /// Anthropic models that refuse a temperature) sit above their family rows.
 pub(crate) const MODELS: &[Row] = &[
+    // xAI Grok.
+    Row {
+        matches: &[Match::Prefix("x-ai/grok-4")],
+        temperature: true,
+        tools: true,
+        context: 500_000,
+        output: 64_000,
+    },
+    // Meta Muse.
+    Row {
+        matches: &[Match::Prefix("meta/muse")],
+        temperature: true,
+        tools: true,
+        context: 1_048_576,
+        output: 64_000,
+    },
     // Google Gemini.
     Row {
         matches: &[Match::Prefix("google/gemini")],
@@ -1009,7 +1060,7 @@ mod tests {
     fn an_unlisted_model_lands_on_the_fallback() {
         // The reported models. OpenRouter fronts hundreds and this table names
         // a few dozen, so this is the ordinary case rather than the odd one.
-        for model in ["moonshotai/kimi-k3", "meta/muse-spark-1.2"] {
+        for model in ["moonshotai/kimi-k3", "sakana/fugu-ultra"] {
             assert_eq!(
                 builtin_capabilities(model).max_context_tokens,
                 FALLBACK_CAPABILITIES.max_context_tokens,
@@ -1030,7 +1081,7 @@ mod tests {
         );
         for _ in 0..3 {
             provider.capabilities("moonshotai/kimi-k3");
-            provider.capabilities("meta/muse-spark-1.2");
+            provider.capabilities("sakana/fugu-ultra");
         }
         let warned = &provider.warned_unknown;
         assert_eq!(warned.len(), 2, "one entry per model: {warned:?}");

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -103,8 +103,28 @@ impl ProviderRegistry {
                 targets.push((name.to_string(), provider));
             }
         }
+        // Side by side rather than one after another: each provider's answer
+        // is its own network call, and a listing command or a daemon start
+        // that waited for five of them in turn paid five timeouts in the
+        // worst case where one would do.
+        let mut in_flight = tokio::task::JoinSet::new();
         for (name, provider) in targets {
-            match tokio::time::timeout(timeout, provider.prime_capabilities()).await {
+            in_flight.spawn(async move {
+                let outcome = tokio::time::timeout(timeout, provider.prime_capabilities()).await;
+                (name, outcome)
+            });
+        }
+        while let Some(joined) = in_flight.join_next().await {
+            // A panic inside a provider's priming is that provider's fault
+            // and nobody else's; it is reported the way a failed read is.
+            let (name, outcome) = match joined {
+                Ok(pair) => pair,
+                Err(e) => {
+                    tracing::warn!(error = %e, "a provider's priming task did not finish");
+                    continue;
+                }
+            };
+            match outcome {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => tracing::warn!(
                     provider = %name,
@@ -289,6 +309,7 @@ mod tests {
         Ok,
         Fails,
         Hangs,
+        Panics,
     }
 
     struct StubProvider {
@@ -336,6 +357,7 @@ mod tests {
                     tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
                     Ok(())
                 }
+                PrimeOutcome::Panics => panic!("a provider bug"),
             }
         }
 
@@ -351,6 +373,7 @@ mod tests {
                     tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
                     Ok(())
                 }
+                PrimeOutcome::Panics => panic!("a provider bug"),
             }
         }
         async fn infer(
@@ -564,6 +587,36 @@ mod tests {
         reg.prime_capabilities(std::time::Duration::from_secs(5), &[])
             .await;
         assert_eq!(primed.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    /// Priming runs side by side now, so one provider's bug is caught at its
+    /// task boundary and reported; the others still prime and the daemon
+    /// still starts.
+    #[tokio::test]
+    async fn a_panicking_prime_is_reported_and_the_rest_still_prime() {
+        let mut reg = ProviderRegistry::new();
+        let (bug, _) = priming(PrimeOutcome::Panics);
+        let (good, good_calls) = priming(PrimeOutcome::Ok);
+        reg.register("bug".to_string(), bug);
+        reg.register("good".to_string(), good);
+        reg.prime_capabilities(std::time::Duration::from_secs(5), &[])
+            .await;
+        assert_eq!(good_calls.load(std::sync::atomic::Ordering::Relaxed), 1);
+    }
+
+    /// Side by side, not one after another: two providers that each take the
+    /// whole timeout finish in one timeout, not two.
+    #[tokio::test]
+    async fn providers_prime_concurrently() {
+        let mut reg = ProviderRegistry::new();
+        let (a, _) = priming(PrimeOutcome::Hangs);
+        let (b, _) = priming(PrimeOutcome::Hangs);
+        reg.register("a".to_string(), a);
+        reg.register("b".to_string(), b);
+        let started = std::time::Instant::now();
+        reg.prime_capabilities(std::time::Duration::from_millis(200), &[])
+            .await;
+        assert!(started.elapsed() < std::time::Duration::from_millis(390));
     }
 
     /// A provider that cannot answer is a warning, not a failure: the daemon

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -829,8 +829,12 @@ Each entry from `GET /api/models` also carries `limits_source`: `api` when the p
 token limits itself, `builtin` when this build matched them off the model's name, and `override`
 when a `[model_capabilities]` entry set them. Read it before treating a window as a fact - a
 `builtin` figure for a model the table does not know is a guess, and region budgets resolve against
-it. Which providers can report, and from where, is in
-[where a window comes from](/docs/configuration#where-a-window-comes-from).
+it. Beside it: `supports_temperature` and `supports_tools`; `learned`, true when the provider's own
+listing described the model and false for a row from this build's table; and, when the listing
+carries them, `released` (Unix seconds), `retires` (the date the provider published) and `pricing`
+(USD per million tokens: `input_per_mtok`, `cached_input_per_mtok`, `cache_write_per_mtok`,
+`output_per_mtok`), each `null` otherwise. Which providers can report what, and from where, is in
+[where a model's capabilities come from](/docs/configuration#where-a-models-capabilities-come-from).
 That is what lets a console show the catalog without fetching and re-parsing every script. No other
 kind carries the key at all.
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -366,12 +366,19 @@ it returns `false`.
 
 | Command | Flags |
 |---|---|
-| `lev models list` | `-p/--provider <NAME>`, `-r/--remote` (live from the provider APIs, slower), `-a/--all` (include providers with no credential here) |
-| `lev models show <MODEL>` | `-p/--provider <NAME>` (required for a remote lookup), `-r/--remote` |
+| `lev models list` | `-p/--provider <NAME>`, `--offline` (this build's table only, no network), `-a/--all` (include providers with no credential here), `--json` |
+| `lev models show <MODEL>` | `-p/--provider <NAME>` (ask only this provider), `--offline` |
+
+Both ask every configured provider for its own listing by default, waiting up to five seconds each,
+and print what the provider said: the columns include the release date and the input and output
+price per million tokens where the listing carries them, and a trailing line says how many rows
+came from a provider and how many from the table compiled into this build. A provider that could
+not be reached keeps its table rows, with a warning naming it. `--offline` skips the network and
+prints the table alone. `-r/--remote` is still accepted for older scripts and changes nothing.
 
 `--provider` naming a [Rhai script provider](/docs/rhai-providers) loads that script and calls its
-`list_models`, with or without `--remote`: a script names its own catalog at run time, so there is
-no built-in table to read it from. A `--provider` that names nothing at all - no configured
+`list_models`: a script names its own catalog at run time, so there is no built-in table to read it
+from. A `--provider` that names nothing at all - no configured
 provider, no row in the built-in table, no script of that name that loads - **exits non-zero**
 rather than printing an empty table, since there is nothing an empty table could be reporting.
 A provider the built-in table knows but this install has no credential for is still an empty table

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -676,25 +676,34 @@ max_output_tokens    = 4096
 ```
 
 `lev models show <model>` prints the values a run will actually use, with any correction already
-applied. `GET /api/models` carries the same numbers plus a `limits_source` of `api`, `builtin` or
+applied, and says whether they came from the provider's own listing or this build's table.
+`GET /api/models` carries the same numbers plus a `limits_source` of `api`, `builtin` or
 `override`, so a client can tell a figure the provider reported from one this build matched off the
 model's name. The two are not worth the same and they look identical once printed.
 
-### Where a window comes from
+### Where a model's capabilities come from
 
 Three sources, narrowest first:
 
 1. A `[model_capabilities]` entry, if you wrote one. Your number is the last word, which is how you
-   correct an API that is itself wrong.
-2. What the provider's own API reports, read once when the daemon starts, and again whenever
-   `GET /api/models` is asked. Which providers can answer, and from where:
+   correct an API that is itself wrong. One exception: a model that has refused a temperature is
+   never sent another, whatever an entry says, because the request was made and the answer was no.
+2. What the provider's own listing reports, read once when the daemon starts, again whenever
+   `GET /api/models` or `lev models` asks, and kept for the life of the process. No two listings
+   carry the same fields, so each provider reads what its own endpoint has and leaves the rest to
+   the table:
 
-   | provider | reads | notes |
-   |---|---|---|
-   | OpenRouter | `/models` | `context_length` and `top_provider.max_completion_tokens`. Fronts far more models than any compiled table can name |
-   | Google | `/v1beta/models` | `inputTokenLimit` and `outputTokenLimit`. Needs the native base URL; an OpenAI-compat one has no such listing |
-   | Ollama | `/api/ps`, then `/api/show` | See below |
-   | Anthropic, OpenAI | nothing | Neither `/models` reports token limits at all, so the compiled table is the only answer available |
+   | provider | reads | learns | cannot learn |
+   |---|---|---|---|
+   | OpenRouter | `/models` | both limits, whether the model takes a temperature and tools (`supported_parameters`), the price per token, whether the upstream bills a cache write (the signal for explicit cache markers), the release date | nothing it lists; a few entries carry no `supported_parameters` |
+   | Anthropic | `/v1/models`, every page | `max_input_tokens`, `max_tokens`, the display name, the release date | temperature: the listing has no such field, so the table says which models refuse one |
+   | OpenAI | `/v1/models` | the model ids, release and retirement dates | sizes, temperature and tools: the listing describes none of them |
+   | Google | `/v1beta/models`, every page | both limits, whether the model samples (`maxTemperature`); models without `generateContent` are dropped | tools, price, dates. Needs the native base URL; an OpenAI-compat one has no such listing |
+   | Ollama | `/api/ps`, then `/api/show` | the served window (see below), whether the model calls tools (`capabilities`) | temperature: every local model takes one |
+
+   Once a provider's listing has been read it is also the complete list of what that provider
+   serves, so `lev validate` refuses a model it does not carry (Ollama is the exception: `/api/tags`
+   is what has been pulled, not what Ollama can serve).
 
 3. The table compiled into this build, matched against the model's name, and for an OpenRouter model
    it does not name, a conservative 128,000 tokens.
@@ -716,7 +725,9 @@ if it fell back. Neither case raises an error. The agent evicts working material
 a worse model.
 
 A provider that cannot be reached at start-up costs nothing but the fallback: Leviath warns, keeps
-the compiled table, and starts. It warns once per model when a run does land on the fallback, naming
+the compiled table, and starts. Through OpenRouter, a model listed without `temperature` is not
+sent one once the listing has been read; the whole `gpt-5` line is listed that way, and `gpt-5.5`
+refuses one outright. It warns once per model when a run does land on the fallback, naming
 the line that fixes it.
 
 > [!NOTE]

--- a/docs/content/costs.md
+++ b/docs/content/costs.md
@@ -146,8 +146,12 @@ spent most of the run.
 > a fan-out badly: in the $236 run above, the top-level agent's own record said $15. Add up the
 > tree, following `children` in each `meta.json`.
 
-Rates for models with no published price come from `[model_capabilities]` in your config, which
-is also the only place a negotiated rate or a self-hosted model's cost can live:
+OpenRouter quotes every model's rate in its listing, so a run through it is priced from what the
+gateway said that day, and `lev models list` prints those rates beside each model. Anthropic, OpenAI
+and Google publish no rate through their APIs, so theirs are transcribed into this build and dated;
+`lev models show` says which kind it is printing. Rates for models with neither come from
+`[model_capabilities]` in your config, which is also the only place a negotiated rate or a
+self-hosted model's cost can live:
 
 ```toml
 [model_capabilities."my-model"]

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -44,17 +44,19 @@ is. Browse the full catalog at [openrouter.ai/models](https://openrouter.ai/mode
 install:
 
 ```bash
-lev models list --provider openrouter        # what Leviath knows offline
-lev models list --provider openrouter --remote   # live from the provider's API
+lev models list --provider openrouter        # live from the gateway, with dates and prices
+lev models list --provider openrouter --offline   # only what this build's table names
 lev models list --all                        # every provider, even unconfigured ones
 ```
 
 > [!NOTE]
-> Without `--remote`, `lev models list` prints a built-in table of well-known models (the exception
-> is `--provider <name>` naming a [script provider](/docs/rhai-providers), which is always asked
-> directly - it has no row in that table). It is a convenience, not the catalog. A model absent from it is not necessarily invalid: `lev validate`
-> flags an unrecognized string with an `unknown-model` warning, never an error, and the string is
-> still sent to the provider exactly as written. Locally an unrecognized model gets conservative
+> `lev models list` asks each provider for its own listing and shows that; the table compiled into
+> this build is shown only for a provider that could not be reached, or with `--offline`. The table
+> is a convenience, not the catalog. A model absent from it is not necessarily invalid: with no
+> listing read, `lev validate` flags an unrecognized string with an `unknown-model` warning, never
+> an error, and the string is still sent to the provider exactly as written. Once a provider's
+> listing has been read, a model it does not carry is an `unserved-model` error instead, because
+> the provider has said outright what it serves. Locally an unrecognized model gets conservative
 > capability assumptions: 128K context and 8192 output on OpenRouter, 8192 context and 4096 output
 > elsewhere.
 


### PR DESCRIPTION
## What

Second PR for #568, stacked on #680. The CLI's hand-kept model table is gone, `lev models` asks the providers by default, and `GET /api/models` (what The Lair reads) carries what the listing learned.

- **One catalogue.** `leviath_providers::capabilities::builtin_catalog()` is the only compiled list of named models: each provider names the handful worth showing when its listing cannot be read and resolves them through its own table, and a test holds every id to a real row rather than the fallback. The CLI table had drifted (it still said `gpt-5.5` takes a temperature); it is deleted, and the lint's closed catalogue and the dashboard's window labels read the shared one.
- **`lev models list` / `show` live by default.** Every configured provider is primed and asked, concurrently, within 5 s; its listing replaces the catalogue rows for it, and a provider that could not be asked keeps them with a warning naming it. New `RELEASED`, `IN $/M`, `OUT $/M` columns, newest first within a provider, a trailing line saying how many rows came from a listing vs this build. `--offline` prints the table alone; `-r/--remote` is kept hidden as a no-op. `show` asks every provider (no `--provider` needed), says whether the sheet came from the listing or the table, and labels a listed price as such instead of as a dated transcription. `--json` rows gain `learned`, `released`, `released_on`, `retires`, `pricing`.
- **`GET /api/models`** entries gain `supports_temperature`, `learned`, `released`, `retires`, `pricing` (additive; nothing renamed). The daemon already primes before answering, Ollama included when reachable.
- **`ProviderRegistry::prime_capabilities`** runs every provider's priming in a `JoinSet`: five providers cost one timeout, not five, for the daemon start and the listing commands alike. A panic inside one provider's priming is reported and the rest still prime.
- Docs: `cli.md`, `providers.md`, `configuration.md` (the source table now says per provider what its listing carries and cannot), `api.md`, `costs.md`.

## Behaviour changes

- `lev models list` and `show` reach the network by default (bounded at 5 s per provider, all in parallel). `--offline` restores the old table-only output.
- OpenRouter lists ~400 rows when reachable instead of 21; Anthropic/OpenAI/Google list what their APIs return, with live limits where the API reports them.
- The table is wider (three new columns) and sorted by provider then release date.

## Verification

`cargo test` on cli (4038), runtime (1716), providers (950); clippy `-D warnings`; rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage` at 100% for `leviath-providers`, `leviath-runtime` and `leviath-cli`.

Closes #568 together with #680.
