### PR TITLE
test(runtime,providers): take the two macOS-only flakes off the network and the clock

### DIFF
--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -1447,7 +1447,27 @@ mod tests {
         );
     }
 
-    /// Against the real network stack, because this is the whole point: these
+    /// A resolver that answers every name with a lookup failure.
+    ///
+    /// The DNS half of the test below used to ask the real resolver for a name
+    /// under `.invalid`. That is a network round trip, and on a macOS runner
+    /// whose resolver was slow the two-second request deadline fired first, so
+    /// the error came back as `Timeout` and the test failed on nothing to do
+    /// with the code under test. What the test needs is the error `reqwest`
+    /// builds when a lookup fails, and the resolver hook produces exactly that
+    /// one, on the same wrapper the system resolver's failure travels in.
+    struct NeverResolves;
+
+    impl reqwest::dns::Resolve for NeverResolves {
+        fn resolve(&self, name: reqwest::dns::Name) -> reqwest::dns::Resolving {
+            Box::pin(async move {
+                let message = format!("failed to lookup address information: {}", name.as_str());
+                Err(std::io::Error::other(message).into())
+            })
+        }
+    }
+
+    /// Against the real client stack, because this is the whole point: these
     /// used to arrive as one string and `Display` on a `reqwest::Error` says the
     /// same sentence for both of them.
     ///
@@ -1459,14 +1479,18 @@ mod tests {
     /// by the `connect_failure` tests, which do not go near a socket.
     #[tokio::test]
     async fn a_name_that_does_not_resolve_is_told_from_a_port_with_nothing_behind_it() {
-        let client = build_http_client(Some(2)).expect("a client builds");
-
-        let dns = client
+        let unresolvable = http::outbound_builder(Some(2))
+            .dns_resolver(NeverResolves)
+            .build()
+            .expect("a client builds");
+        let dns = unresolvable
             .get("https://no-such-host-anywhere-12345.invalid/v1/models")
             .send()
             .await
             .expect_err("does not resolve");
         assert_eq!(FailureKind::from_reqwest(&dns), FailureKind::DnsFailure);
+
+        let client = build_http_client(Some(2)).expect("a client builds");
 
         // A port nothing is listening on: an ephemeral one is claimed and the
         // listener dropped straight away, which is a port no other process holds.

--- a/crates/leviath-providers/src/provider/http.rs
+++ b/crates/leviath-providers/src/provider/http.rs
@@ -215,7 +215,10 @@ pub fn side_call_client() -> &'static reqwest::Client {
 }
 
 /// The builder both outbound clients share.
-fn outbound_builder(timeout_secs: Option<u64>) -> reqwest::ClientBuilder {
+///
+/// Visible to the provider tests so one can swap in a resolver and still get
+/// every other setting production uses.
+pub(super) fn outbound_builder(timeout_secs: Option<u64>) -> reqwest::ClientBuilder {
     reqwest::Client::builder()
         .pool_max_idle_per_host(0)
         // Follow a redirect only while it stays on the host the key was meant

--- a/crates/leviath-runtime/src/persistence_bridge.rs
+++ b/crates/leviath-runtime/src/persistence_bridge.rs
@@ -1438,16 +1438,23 @@ mod tests {
         let (tx, rx) = mpsc::unbounded_channel();
         let worker = tokio::spawn(persistence_worker(Some(runs.clone()), rx));
 
-        // The run establishes its directory the ordinary way.
+        // The run establishes its directory the ordinary way. The lane handles
+        // messages in order and an append carries an ack, so an acked append
+        // sent after the snapshot is a barrier: when it answers, the snapshot
+        // is entirely on disk. This used to poll for `meta.json` alone, and
+        // `remove_dir_all` below then raced the lane still writing the rest
+        // of the snapshot beside it - `DirectoryNotEmpty` on a macOS runner.
         tx.send(PersistMsg::Snapshot(Box::new(job("run-1"))))
             .unwrap();
+        let (settled_tx, settled_rx) = tokio::sync::oneshot::channel();
+        tx.send(PersistMsg::Append {
+            run_id: "run-1".to_string(),
+            record: Box::new(batch_record(0, "c0")),
+            ack: Some(settled_tx),
+        })
+        .unwrap();
+        settled_rx.await.expect("the first snapshot is written");
         let run_dir = runs.join("run-1");
-        for _ in 0..500 {
-            if run_dir.join("meta.json").exists() {
-                break;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
         assert!(
             run_dir.join("meta.json").exists(),
             "the first write establishes the directory"


### PR DESCRIPTION
Two tests failed on a macOS runner in the CI run for #678 and passed on rerun. Neither failure was about the code under test; both were the test depending on something outside its control.

## `persistence_bridge::tests::a_deleted_run_is_not_written_back`

Polled for `meta.json` and then `remove_dir_all`'d the run directory while the persistence lane was still writing the rest of the snapshot beside it; macOS answered `DirectoryNotEmpty`. The lane handles messages in order and an `Append` carries an ack, so an acked append sent after the first snapshot is a proper barrier. The poll loop is gone.

## `provider::tests::a_name_that_does_not_resolve_is_told_from_a_port_with_nothing_behind_it`

Asked the real resolver for a name under `.invalid` with a two-second request deadline. A slow resolver on the runner tripped the deadline first, so the error was classified `Timeout` rather than `DnsFailure`. The DNS half now goes through `reqwest`'s `dns_resolver` hook with a resolver that fails every lookup. That produces the same `hyper-util` connect wrapper (`"dns error"`) the system resolver's failure travels in, so `from_reqwest` is exercised on the real shape, with no network and no clock. The dead-port half is unchanged and still uses the production client. `outbound_builder` is now `pub(super)` so the test keeps every other production setting; nothing outside the module can see it.

## Verification

- Each test run 25x (runtime) and 10x (providers) locally: 0 failures. The DNS test now completes in ~20 ms.
- `cargo xtask coverage`: 100% on all 13 packages. fmt, clippy, docs clean; pre-commit passed.
