### PR TITLE
fix(core): read mounts as well as mount, and hold the schema to the parser

### DIFF
--- a/crates/leviath-core/src/manifest/sections.rs
+++ b/crates/leviath-core/src/manifest/sections.rs
@@ -166,6 +166,21 @@ pub(super) fn parse_security_config(security_table: &toml::value::Table) -> crat
     sc
 }
 
+/// Every key read off a `[sandbox]` table. Test-only: the parser above reads
+/// them one by one, and the schema guard in `tests.rs` holds the published
+/// schema to this list.
+#[cfg(test)]
+pub(super) const SANDBOX_KEYS: &[&str] = &[
+    "engine",
+    "image",
+    "kind",
+    "mount",
+    "mounts",
+    "network",
+    "on_unavailable",
+    "persist",
+];
+
 /// Parse a `[sandbox]` / `[stages.X.sandbox]` table into a `ToolSandboxConfig`.
 /// A present block with no `kind` means host passthrough; omit the block to
 /// inherit the broader (agent/global) sandbox. An unknown `kind` or
@@ -203,7 +218,20 @@ pub(super) fn parse_sandbox_config(
     if let Some(persist) = bool_of(table, "persist") {
         sc.persist = persist;
     }
-    if let Some(mounts) = array_of(table, "mount") {
+    // Both spellings: the published schema lists both, and `config.toml`'s own
+    // `[sandbox]` table (a different parser) documents `mounts`, so a blueprint
+    // author copying from there wrote a key that was silently ignored.
+    let listed = match (array_of(table, "mount"), array_of(table, "mounts")) {
+        (Some(a), Some(b)) if a != b => {
+            return Err(Error::Other(
+                "sandbox names both `mount` and `mounts` with different lists; keep one"
+                    .to_string(),
+            ));
+        }
+        (Some(a), _) | (None, Some(a)) => Some(a),
+        (None, None) => None,
+    };
+    if let Some(mounts) = listed {
         sc.mounts = mounts
             .iter()
             .filter_map(|m| m.as_str().map(str::to_string))

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -8,7 +8,7 @@ use super::*;
 /// Kept beside the parser because it is only true of the parser: a key added
 /// below and not added here is refused, which is the failure mode worth having
 /// - the alternative was accepting it and doing nothing, forever.
-const STAGE_KEYS: &[&str] = &[
+pub(super) const STAGE_KEYS: &[&str] = &[
     "accepts_messages",
     "allow_as_worker",
     "allow_blocking_tools",
@@ -55,10 +55,10 @@ const STAGE_KEYS: &[&str] = &[
 /// regions from an otherwise inherited one. Either way what is left out is
 /// hidden rather than destroyed. An author who guesses any other key hears
 /// about it instead of quietly carrying the region they meant to drop.
-const CONTEXT_KEYS: &[&str] = &["regions", "hide"];
+pub(super) const CONTEXT_KEYS: &[&str] = &["regions", "hide"];
 
 /// Every key read off `[stages.<name>.tool_routing]`.
-const TOOL_ROUTING_KEYS: &[&str] = &[
+pub(super) const TOOL_ROUTING_KEYS: &[&str] = &[
     "default_region",
     "max_result_tokens",
     "max_result_tokens_per_tool",
@@ -67,7 +67,7 @@ const TOOL_ROUTING_KEYS: &[&str] = &[
 ];
 
 /// Every key read off a transition edge's `gate = { ... }`.
-const GATE_KEYS: &[&str] = &[
+pub(super) const GATE_KEYS: &[&str] = &[
     "max_attempts",
     "message",
     "region",
@@ -79,7 +79,7 @@ const GATE_KEYS: &[&str] = &[
 ];
 
 /// Every key read off one `[stages.<name>.transitions.<target>]` edge.
-const EDGE_KEYS: &[&str] = &[
+pub(super) const EDGE_KEYS: &[&str] = &[
     "condition",
     "gate",
     "hint",

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -5469,3 +5469,106 @@ b = { kind = "pinned", max_tokens = -1 }
 "#;
     let _ = parse_manifest(toml);
 }
+
+// ─── sandbox mount spellings ─────────────────────────────────────────────
+
+fn sandbox_manifest(table: &str) -> String {
+    format!(
+        "[agent]\nname = \"a\"\n\n[sandbox]\n{table}\n\n\
+         [stages.s]\nmodel = {{ provider = \"anthropic\", model = \"m\" }}\n"
+    )
+}
+
+#[test]
+fn sandbox_mounts_is_read_the_same_as_mount() {
+    let bp = parse_manifest(&sandbox_manifest("mounts = [\"/data\", \"/cache\"]")).unwrap();
+    assert_eq!(
+        bp.sandbox.unwrap().mounts,
+        vec!["/data".to_string(), "/cache".to_string()]
+    );
+}
+
+#[test]
+fn sandbox_accepts_both_spellings_when_they_agree() {
+    let bp = parse_manifest(&sandbox_manifest(
+        "mount = [\"/data\"]\nmounts = [\"/data\"]",
+    ))
+    .unwrap();
+    assert_eq!(bp.sandbox.unwrap().mounts, vec!["/data".to_string()]);
+}
+
+#[test]
+fn sandbox_refuses_both_spellings_when_they_differ() {
+    let err = parse_manifest(&sandbox_manifest(
+        "mount = [\"/data\"]\nmounts = [\"/other\"]",
+    ))
+    .unwrap_err()
+    .to_string();
+    assert!(err.contains("both `mount` and `mounts`"), "{err}");
+}
+
+// ─── the published schema and the parser name the same keys ─────────────
+
+/// The schema is what people validate against and the parser is what runs;
+/// a key in one and not the other is either a silently ignored setting or a
+/// validation failure for a working blueprint. Both directions, per table.
+#[test]
+fn the_published_schema_and_the_parser_agree_on_every_key() {
+    let schema: serde_json::Value = serde_json::from_str(include_str!(
+        "../../../../docs/schema/blueprint.schema.json"
+    ))
+    .expect("the schema is valid JSON");
+    let keys_at = |path: &[&str]| -> Vec<String> {
+        let mut node = &schema;
+        for step in path {
+            node = &node[step];
+        }
+        let mut keys: Vec<String> = node["properties"]
+            .as_object()
+            .unwrap_or_else(|| panic!("no properties at {path:?}"))
+            .keys()
+            .cloned()
+            .collect();
+        keys.sort();
+        keys
+    };
+    let sorted = |list: &[&str]| -> Vec<String> {
+        let mut v: Vec<String> = list.iter().map(|s| s.to_string()).collect();
+        v.sort();
+        v
+    };
+    for (table, schema_path, parser) in [
+        ("stage", &["$defs", "stage"][..], super::stage::STAGE_KEYS),
+        (
+            "stage.context",
+            &["$defs", "stage", "properties", "context"][..],
+            super::stage::CONTEXT_KEYS,
+        ),
+        (
+            "stage.tool_routing",
+            &["$defs", "stage", "properties", "tool_routing"][..],
+            super::stage::TOOL_ROUTING_KEYS,
+        ),
+        (
+            "transition",
+            &["$defs", "transition"][..],
+            super::stage::EDGE_KEYS,
+        ),
+        (
+            "transition.gate",
+            &["$defs", "transition", "properties", "gate"][..],
+            super::stage::GATE_KEYS,
+        ),
+        (
+            "sandbox",
+            &["$defs", "sandbox"][..],
+            super::sections::SANDBOX_KEYS,
+        ),
+    ] {
+        assert_eq!(
+            keys_at(schema_path),
+            sorted(parser),
+            "keys of the {table} table"
+        );
+    }
+}


### PR DESCRIPTION
The "blueprint schema hygiene" item from the plan, minus the two pieces that need a separate yes (see the end).

## `mounts` is read as well as `mount`

`parse_sandbox_config` read bind mounts off `mount` only. The published `blueprint.schema.json` lists both spellings, and `config.toml`'s `[sandbox]` table (a serde struct, not this parser) documents `mounts`, so a blueprint author copying from the config docs wrote a key that loaded fine and did nothing. Either spelling is read now; both present with different lists is a load error: `sandbox names both `mount` and `mounts` with different lists; keep one`.

Behaviour change, stated: a blueprint with `mounts = [...]` under `[sandbox]` now mounts those paths where before it mounted nothing. Nothing with `mount` changes.

Fail-first: with the old parser logic swapped back in, `sandbox_mounts_is_read_the_same_as_mount` and `sandbox_refuses_both_spellings_when_they_differ` fail; `sandbox_accepts_both_spellings_when_they_agree` passes on both (the control).

## The schema and the parser name the same keys

`the_published_schema_and_the_parser_agree_on_every_key` compares `blueprint.schema.json`'s properties with the parser's key lists in both directions for six tables: stage, stage.context, stage.tool_routing, transition, transition.gate, sandbox. They agree today (the mismatches the original audit listed were fixed by earlier PRs); the test is what keeps it that way. The five existing key lists in `stage.rs` become `pub(super)`; `sections.rs` gains a test-only `SANDBOX_KEYS`.

## Not in this PR, needs a decision

- **Unknown `[sandbox]` keys as a load error.** Today a typo such as `netwrok = false` is ignored. Listed under "needs your yes" in the plan.
- **Taint arms for eleven built-ins.** While preparing the "every built-in has an explicit taint arm" guard, it turned out that `read_files`, `edit_document`, the five `context_*` tools, the three `todo_*` tools, `submit_output` and `fan_out` have no arm in `builtin_tool_classification` and fall through to the "unknown third-party, outbound" classification. Adding arms changes what the taint gate does for those tools, so it is reported rather than folded in. Details in the PR comment.

## Verified

`cargo test -p leviath-core` (912) green; clippy and rustdoc `-D warnings`; `cargo xtask structure --check`; `cargo xtask docs`; `cargo xtask coverage --package leviath-core` at 100%.
