### PR TITLE
feat(runtime)!: exact token counting always on, with a cheap skip below half the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,17 @@ same list.
   `leviath-net::client_builder`, fourteen injected seams in `leviath-sys` and
   `leviath-agent-client::JsonRpcMessage::is_notification` are no longer public
   (#675).
+- `[limits] exact_token_counting` is gone, and the guard it switched
+  on is always on. Every inference lane (the stage's own call, the routing call,
+  compaction, titling) now measures its request with the provider's tokenizer
+  before sending it whenever the calibrated estimate plus the reply budget is
+  at or above half the model's window, refuses one that would overflow, and
+  feeds the count back into the estimate. A request under that line is sent
+  unmeasured, so a short turn pays nothing. A config that still sets the key
+  gets the unknown-key warning and loads with the rest of its `[limits]`. The
+  count calls on Anthropic and Gemini now reuse a pooled connection and go
+  through the provider's rate limiter; OpenAI's local tiktoken count moves off
+  the async threads above 256 KB.
 
 ### Fixed
 

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -144,12 +144,6 @@ pub fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {
     );
     push_if_changed(
         &mut out,
-        "exact token counting",
-        Some(&before.limits.exact_token_counting),
-        Some(&after.limits.exact_token_counting),
-    );
-    push_if_changed(
-        &mut out,
         "batch tool hint",
         Some(&before.batch_tool_hint),
         Some(&after.batch_tool_hint),
@@ -440,7 +434,6 @@ mod tests {
         after.limits.max_concurrent_inferences = Some(1);
         after.limits.max_concurrent_tools = 4;
         after.limits.default_max_iterations = None;
-        after.limits.exact_token_counting = true;
         after.batch_tool_hint = false;
         after.shell_hint = false;
 
@@ -451,7 +444,6 @@ mod tests {
         assert!(lines.contains(&"max concurrent inferences: 8 → 1".to_string()));
         assert!(lines.contains(&"max concurrent tools: 8 → 4".to_string()));
         assert!(lines.contains(&"default max iterations: 50 → (unset)".to_string()));
-        assert!(lines.contains(&"exact token counting: false → true".to_string()));
         assert!(lines.contains(&"batch tool hint: true → false".to_string()));
         assert!(lines.contains(&"platform shell hint: true → false".to_string()));
     }

--- a/crates/leviath-cli/src/commands/setup/state/limits.rs
+++ b/crates/leviath-cli/src/commands/setup/state/limits.rs
@@ -26,11 +26,6 @@ pub(super) fn limits_fields(config: &Config) -> Vec<Field> {
             value: FieldValue::Number(config.limits.default_max_iterations.map(|n| n as u64)),
         },
         Field {
-            label: "Exact token counting",
-            help: "Ask the provider for real token counts instead of estimating. Slower.",
-            value: FieldValue::Bool(config.limits.exact_token_counting),
-        },
-        Field {
             label: "Batch tool-call hint",
             help: "Nudge models to request several tools in one turn.",
             value: FieldValue::Bool(config.batch_tool_hint),
@@ -123,34 +118,33 @@ pub(super) fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
             (2, FieldValue::Number(n)) => {
                 config.limits.default_max_iterations = n.map(|n| n as usize)
             }
-            (3, FieldValue::Bool(b)) => config.limits.exact_token_counting = *b,
-            (4, FieldValue::Bool(b)) => config.batch_tool_hint = *b,
-            (5, FieldValue::Bool(b)) => config.shell_hint = *b,
+            (3, FieldValue::Bool(b)) => config.batch_tool_hint = *b,
+            (4, FieldValue::Bool(b)) => config.shell_hint = *b,
             // Unset means "leave the watchdog at its default", not "disable it";
             // disabling is an explicit 0.
-            (6, FieldValue::Number(n)) => {
+            (5, FieldValue::Number(n)) => {
                 config.limits.stall_timeout_secs =
                     n.unwrap_or(Config::default().limits.stall_timeout_secs)
             }
             // Same rule: unset keeps the default, 0 is an explicit "never".
-            (7, FieldValue::Number(n)) => {
+            (6, FieldValue::Number(n)) => {
                 config.limits.dead_cycles_before_relief = n
                     .map(|n| n as u32)
                     .unwrap_or(Config::default().limits.dead_cycles_before_relief)
             }
             // And again: unset keeps the default, 0 means keep nothing.
-            (8, FieldValue::Number(n)) => {
+            (7, FieldValue::Number(n)) => {
                 config.limits.finished_retention_secs =
                     n.unwrap_or(Config::default().limits.finished_retention_secs)
             }
             // Same rule once more, and here the default is itself 0 (off).
-            (9, FieldValue::Number(n)) => {
+            (8, FieldValue::Number(n)) => {
                 config.limits.wedge_timeout_secs =
                     n.unwrap_or(Config::default().limits.wedge_timeout_secs)
             }
             // Same rule again: unset keeps the default hour, 0 is an explicit
             // "wait for a person however long it takes".
-            (10, FieldValue::Number(n)) => {
+            (9, FieldValue::Number(n)) => {
                 config.limits.interaction_timeout_secs =
                     n.unwrap_or(Config::default().limits.interaction_timeout_secs)
             }
@@ -159,8 +153,8 @@ pub(super) fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
             // the only two settings whose absence is a real choice a user makes
             // - deleting the line is how you say "let it write" - so unset
             // stores `None` rather than reinstating a number they just removed.
-            (11, FieldValue::Number(n)) => config.limits.max_tool_call_write_bytes = *n,
-            (12, FieldValue::Number(n)) => config.limits.max_run_write_bytes = *n,
+            (10, FieldValue::Number(n)) => config.limits.max_tool_call_write_bytes = *n,
+            (11, FieldValue::Number(n)) => config.limits.max_run_write_bytes = *n,
             _ => {}
         }
     }

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -2536,13 +2536,12 @@ pub(super) mod tests {
         wizard.limits[0].value = FieldValue::Number(Some(2));
         wizard.limits[1].value = FieldValue::Number(Some(0));
         wizard.limits[2].value = FieldValue::Number(None);
-        wizard.limits[3].value = FieldValue::Bool(true);
+        wizard.limits[3].value = FieldValue::Bool(false);
         wizard.limits[4].value = FieldValue::Bool(false);
-        wizard.limits[5].value = FieldValue::Bool(false);
-        wizard.limits[6].value = FieldValue::Number(Some(11));
-        wizard.limits[7].value = FieldValue::Number(Some(22));
-        wizard.limits[8].value = FieldValue::Number(Some(33));
-        wizard.limits[9].value = FieldValue::Number(Some(44));
+        wizard.limits[5].value = FieldValue::Number(Some(11));
+        wizard.limits[6].value = FieldValue::Number(Some(22));
+        wizard.limits[7].value = FieldValue::Number(Some(33));
+        wizard.limits[8].value = FieldValue::Number(Some(44));
 
         let config = wizard.build_config();
 
@@ -2552,7 +2551,6 @@ pub(super) mod tests {
             Config::default().limits.max_concurrent_tools
         );
         assert!(config.limits.default_max_iterations.is_none());
-        assert!(config.limits.exact_token_counting);
         assert!(!config.batch_tool_hint);
         assert!(!config.shell_hint);
         // Every remaining field gets a distinct value, so a form that grows a
@@ -2609,10 +2607,10 @@ pub(super) mod tests {
         let dir = tempfile::tempdir().unwrap();
         let mut wizard = test_wizard(dir.path());
         wizard.enter(Step::Limits);
+        wizard.limits[5].value = FieldValue::Number(Some(0));
         wizard.limits[6].value = FieldValue::Number(Some(0));
         wizard.limits[7].value = FieldValue::Number(Some(0));
-        wizard.limits[8].value = FieldValue::Number(Some(0));
-        wizard.limits[9].value = FieldValue::Number(Some(300));
+        wizard.limits[8].value = FieldValue::Number(Some(300));
 
         let config = wizard.build_config();
 
@@ -2623,9 +2621,9 @@ pub(super) mod tests {
 
         let mut wizard = test_wizard(dir.path());
         wizard.enter(Step::Limits);
+        wizard.limits[5].value = FieldValue::Number(None);
         wizard.limits[6].value = FieldValue::Number(None);
         wizard.limits[7].value = FieldValue::Number(None);
-        wizard.limits[8].value = FieldValue::Number(None);
         wizard.limits[9].value = FieldValue::Number(None);
 
         let config = wizard.build_config();

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -736,8 +736,25 @@ fn print_global_script_report_in(
                 // the verdict here is the verdict the daemon would reach: it
                 // compiles against the hardened engine and requires the entry
                 // points a provider cannot run without.
-                if let Err(e) = leviath_providers::rhai_provider::check_source(name, &source) {
-                    println!("  ⚠ Warning: script provider '{name}' will not load: {e}");
+                match leviath_providers::rhai_provider::inspect_source(name, &source) {
+                    Err(e) => {
+                        println!("  ⚠ Warning: script provider '{name}' will not load: {e}");
+                    }
+                    // Said either way, because the difference is invisible at
+                    // run time: a script with no `count_tokens` is guarded by
+                    // the byte estimate, which can only refuse an overflow the
+                    // estimate already sees.
+                    Ok(report) if report.counts_tokens => {
+                        println!(
+                            "  script provider '{name}' counts tokens itself (fn count_tokens)"
+                        );
+                    }
+                    Ok(_) => {
+                        println!(
+                            "  script provider '{name}' has no fn count_tokens; the context-window \
+                             guard measures its requests with the byte estimate"
+                        );
+                    }
                 }
             }
         }
@@ -1951,6 +1968,14 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
         )
         .expect("writes");
         std::fs::write(providers.join("broken.rhai"), "fn initialize(c) { ((( }").expect("writes");
+        // And one that counts its own tokens, so both report lines are printed.
+        std::fs::write(
+            providers.join("counting.rhai"),
+            "fn initialize(config) { #{} }\n\
+             fn inference(state, request) { #{ content: \"ok\" } }\n\
+             fn count_tokens(state, text, model) { 7 }",
+        )
+        .expect("writes");
 
         // A global tool that will not load, so the skipped-tool arm runs too.
         std::fs::write(tools.join("bad.rhai"), "no directive\nlet").expect("writes");

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -120,16 +120,6 @@ pub struct LimitsConfig {
     #[serde(default = "default_default_max_iterations")]
     pub default_max_iterations: Option<usize>,
 
-    /// Opt-in exact pre-inference token budgeting. When `true`, each agent
-    /// inference is preceded by an exact token count of the assembled request
-    /// (via the provider's `count_tokens`, which uses a remote endpoint for
-    /// Anthropic/Gemini and a local heuristic otherwise) and is rejected before
-    /// sending if it would exceed the model's context window. Off by default:
-    /// normal budgeting uses cheap local estimates, and this adds a network
-    /// round-trip per inference for providers with a remote count endpoint.
-    #[serde(default)]
-    pub exact_token_counting: bool,
-
     /// Whether a model that can stream is asked to. Defaults to `true`.
     ///
     /// It makes no difference to what an agent sees: the chunks are folded back
@@ -523,7 +513,6 @@ impl Default for LimitsConfig {
             // No ceiling, which is what every install has today.
             max_agents_per_run: 0,
             default_max_iterations: default_default_max_iterations(),
-            exact_token_counting: false,
             stream_inference: default_stream_inference(),
             script_shell_timeout_secs: default_script_shell_timeout_secs(),
             script_http_timeout_secs: default_script_http_timeout_secs(),

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -1829,8 +1829,6 @@ some_custom_thing = \"forwarded to the script\"
         let limits = LimitsConfig::default();
         assert_eq!(limits.max_concurrent_inferences, Some(8));
         assert_eq!(limits.default_max_iterations, Some(50));
-        // Exact token counting is opt-in, off by default.
-        assert!(!limits.exact_token_counting);
         // Relief is on by default: ten 30-second cycles of a full lane going
         // nowhere before the daemon widens it.
         assert_eq!(limits.dead_cycles_before_relief, 10);
@@ -1968,18 +1966,24 @@ some_custom_thing = \"forwarded to the script\"
         assert_eq!(tuned.limits.inference_retry_base_ms, 2000);
     }
 
+    /// `[limits] exact_token_counting` was removed when the guard it switched
+    /// on became unconditional. A config that still sets it is reported the
+    /// way any stale key is - named, at its path, and ignored - and still
+    /// loads with the rest of its `[limits]` intact.
     #[test]
-    fn exact_token_counting_parses_when_set() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("config.toml");
+    fn a_config_that_still_sets_exact_token_counting_is_warned_about() {
         let body = format!(
-            "{}\n[limits]\nexact_token_counting = true\n",
+            "{}\n[limits]\nexact_token_counting = true\nmax_concurrent_tools = 3\n",
             config_toml_without_limits()
         );
+        let unknown = Config::unknown_config_keys(&body);
+        assert_eq!(unknown, vec!["limits.exact_token_counting".to_string()]);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
         std::fs::write(&path, body).unwrap();
         let config = with_tracing(|| Config::load_from_path(&path)).unwrap();
-        assert!(config.limits.exact_token_counting);
-        // The other fields still fall back to their per-field defaults.
+        assert_eq!(config.limits.max_concurrent_tools, 3);
         assert_eq!(config.limits.max_concurrent_inferences, Some(8));
     }
 
@@ -3445,7 +3449,6 @@ enabled = false
                 notify_spend_usd: Vec::new(),
                 max_agents_per_run: 0,
                 default_max_iterations: Some(99),
-                exact_token_counting: false,
                 stream_inference: true,
                 script_shell_timeout_secs: 45,
                 script_http_timeout_secs: 15,

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -287,8 +287,6 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         Some(parts.runs_dir.clone()),
         parts.runtime,
     );
-    // Opt-in accurate pre-inference budget guard (off by default).
-    world.set_exact_token_counting(parts.config.limits.exact_token_counting);
     // Streamed inference (on by default), so a long generation keeps bytes
     // moving instead of holding a socket that looks idle to everything between
     // here and the provider.

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -463,15 +463,13 @@ impl AnthropicProvider {
         }
     }
 
-    /// Apply common Anthropic headers to a request builder.
     /// The headers every Anthropic request carries.
     ///
-    /// The one source of truth for the set: [`Self::apply_headers`] folds it
-    /// onto a builder, and the shared `send_chat_request` takes it as pairs.
-    /// Keeping them separate is how the debug-http log drifted - it hardcoded
-    /// three headers and silently omitted `anthropic-beta`, so under
-    /// `--features debug-http` a 1h-cache request logged something the wire
-    /// never carried.
+    /// The one source of truth for the set: every call, the count included,
+    /// hands it to the shared `send_chat_request` as pairs. Keeping copies is
+    /// how the debug-http log drifted - it hardcoded three headers and silently
+    /// omitted `anthropic-beta`, so under `--features debug-http` a 1h-cache
+    /// request logged something the wire never carried.
     fn header_pairs(&self) -> Vec<(&'static str, String)> {
         let mut headers = vec![
             ("x-api-key", self.api_key.clone()),
@@ -487,32 +485,35 @@ impl AnthropicProvider {
         headers
     }
 
-    fn apply_headers(&self, builder: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
-        self.header_pairs()
-            .into_iter()
-            .fold(builder, |b, (name, value)| b.header(name, value))
-    }
-
     /// Call Anthropic's exact `/messages/count_tokens` endpoint for `text`.
     ///
     /// Wraps the text as a single user message (the endpoint counts structured
     /// message input). Returns the reported `input_tokens`, or an error the
-    /// caller turns into a heuristic fallback. Does not consume the inference
-    /// rate limiter - counting is a cheap, best-effort side call.
+    /// caller turns into a heuristic fallback.
+    ///
+    /// Over the pooled side-call client rather than the inference client: the
+    /// window guard makes this call before every request large enough to be
+    /// worth measuring, and a fresh TLS handshake per count was most of what it
+    /// cost. Through the rate limiter like `infer`, because the endpoint is
+    /// billed against the same request quota - a run near its quota was being
+    /// pushed over it by its own guard. The 429 handling in `send_chat_request`
+    /// then backs the limiter off the same way an inference refusal does.
     async fn count_tokens_remote(&self, text: &str, model: &str) -> Result<usize> {
         let url = format!("{}/messages/count_tokens", self.base_url);
         let body = serde_json::json!({
             "model": model,
             "messages": [{ "role": "user", "content": text }],
         });
-        let response = crate::provider::apply_request_timeout(
-            self.apply_headers(self.client.post(&url)).json(&body),
+        let response = crate::openai_compat::send_chat_request(
+            crate::provider::side_call_client(),
+            "anthropic",
+            &url,
+            &self.header_pairs(),
+            &body,
+            self.rate_limiter.as_ref(),
             Some(crate::provider::SIDE_CALL_TIMEOUT_SECS),
         )
-        .send()
-        .await
-        .map_err(|e| ProviderError::transport("sending the request", &e))?;
-        let response = crate::provider::check_http_response(response, None).await?;
+        .await?;
         let value: serde_json::Value = crate::provider::decode_json(response).await?;
         value
             .get("input_tokens")
@@ -850,8 +851,19 @@ impl Provider for AnthropicProvider {
     }
 
     async fn count_tokens(&self, text: &str, model: &str) -> usize {
-        // Prefer the exact `/messages/count_tokens` endpoint; fall back to the
-        // ~3.5 chars/token heuristic on any error (network, non-2xx, parse).
+        // Through the limiter first, the way `infer` is: the count endpoint
+        // spends the same request quota. Then prefer the exact
+        // `/messages/count_tokens` endpoint, and fall back to the ~3.5
+        // chars/token heuristic on any error (network, non-2xx, parse).
+        if let Some(limiter) = &self.rate_limiter {
+            // Waits for a slot. `acquire` has no failure today, and this
+            // method has no error to carry one anyway: the heuristic below is
+            // the fallback for the count, not for the wait.
+            limiter
+                .acquire()
+                .await
+                .expect("the rate limiter only waits for capacity; it does not fail");
+        }
         match self.count_tokens_remote(text, model).await {
             Ok(n) => n,
             Err(e) => {
@@ -2154,6 +2166,43 @@ mod tests {
         };
         let tokens = provider.count_tokens("anything", "claude-sonnet-4-6").await;
         assert_eq!(tokens, 42);
+    }
+
+    /// The count call spends the provider's request budget like any other
+    /// call to it. A limiter allowing one request a minute lets the first
+    /// count through and holds the second, which is the observable difference
+    /// between a count that goes through the limiter and one that bypasses it
+    /// (as it used to: the endpoint is billed against the same quota, and a
+    /// run near its quota was being pushed over it by its own guard).
+    #[tokio::test]
+    async fn the_count_call_goes_through_the_rate_limiter() {
+        let (url, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (200, "OK", br#"{"input_tokens": 7}"#.to_vec()),
+            (200, "OK", br#"{"input_tokens": 7}"#.to_vec()),
+        ])
+        .await;
+        let provider = AnthropicProvider {
+            client: reqwest::Client::new(),
+            api_key: "test-key".to_string(),
+            base_url: url,
+            rate_limiter: Some(RateLimiter::new(&crate::provider::RateLimitConfig {
+                requests_per_minute: 1,
+                tokens_per_minute: 1_000_000,
+            })),
+            capability_overrides: HashMap::new(),
+            cache_ttl: CacheTtl::default(),
+            learned: Default::default(),
+        };
+        assert_eq!(provider.count_tokens("first", "claude-sonnet-4-6").await, 7);
+        let held = tokio::time::timeout(
+            std::time::Duration::from_millis(300),
+            provider.count_tokens("second", "claude-sonnet-4-6"),
+        )
+        .await;
+        assert!(
+            held.is_err(),
+            "the second count waits for the minute the limiter allows one request in"
+        );
     }
 
     #[tokio::test]
@@ -3459,14 +3508,12 @@ mod tests {
             provider.cache_control_value(),
             serde_json::json!({ "type": "ephemeral", "ttl": "1h" })
         );
-        let req = provider
-            .apply_headers(provider.client.post("http://localhost/"))
-            .build()
-            .unwrap();
-        assert_eq!(
-            req.headers().get("anthropic-beta").unwrap(),
-            "extended-cache-ttl-2025-04-11"
-        );
+        let beta = provider
+            .header_pairs()
+            .into_iter()
+            .find(|(name, _)| *name == "anthropic-beta")
+            .map(|(_, value)| value);
+        assert_eq!(beta.as_deref(), Some("extended-cache-ttl-2025-04-11"));
     }
 
     #[test]

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -194,6 +194,10 @@ impl GeminiProvider {
     ///
     /// Wraps the text as a single user content part. Returns the reported
     /// `totalTokens`, or an error the caller turns into a heuristic fallback.
+    ///
+    /// Over the pooled side-call client and through the rate limiter, for the
+    /// reasons given on the Anthropic twin: the guard makes this call before
+    /// every large request, and it spends the same request quota.
     async fn count_tokens_remote(&self, text: &str, model: &str) -> Result<usize> {
         let native = self.native_base().ok_or_else(|| {
             ProviderError::Other(
@@ -204,18 +208,19 @@ impl GeminiProvider {
         let body = serde_json::json!({
             "contents": [{ "role": "user", "parts": [{ "text": text }] }],
         });
-        let response = crate::provider::apply_request_timeout(
-            self.client
-                .post(&url)
-                .header("x-goog-api-key", &self.api_key)
-                .header("Content-Type", "application/json")
-                .json(&body),
+        let response = send_chat_request(
+            crate::provider::side_call_client(),
+            "gemini",
+            &url,
+            &[
+                ("x-goog-api-key", self.api_key.clone()),
+                ("Content-Type", "application/json".to_string()),
+            ],
+            &body,
+            self.rate_limiter.as_ref(),
             Some(crate::provider::SIDE_CALL_TIMEOUT_SECS),
         )
-        .send()
-        .await
-        .map_err(|e| ProviderError::transport("reaching the provider", &e))?;
-        let response = crate::provider::check_http_response(response, None).await?;
+        .await?;
         let value: serde_json::Value = crate::provider::decode_json(response).await?;
         value
             .get("totalTokens")
@@ -299,8 +304,19 @@ impl Provider for GeminiProvider {
     }
 
     async fn count_tokens(&self, text: &str, model: &str) -> usize {
-        // Prefer Gemini's exact native `:countTokens` endpoint; fall back to the
-        // local heuristic on any error (network, non-2xx, parse, non-standard base).
+        // Through the limiter first, the way `infer` is: the count endpoint
+        // spends the same request quota. Then prefer Gemini's exact native
+        // `:countTokens` endpoint, and fall back to the local heuristic on any
+        // error (network, non-2xx, parse, non-standard base).
+        if let Some(limiter) = &self.rate_limiter {
+            // Waits for a slot. `acquire` has no failure today, and this
+            // method has no error to carry one anyway: the heuristic below is
+            // the fallback for the count, not for the wait.
+            limiter
+                .acquire()
+                .await
+                .expect("the rate limiter only waits for capacity; it does not fail");
+        }
         match self.count_tokens_remote(text, model).await {
             Ok(n) => n,
             Err(e) => {
@@ -919,6 +935,39 @@ mod tests {
         };
         let tokens = provider.count_tokens("anything", "gemini-3.5-flash").await;
         assert_eq!(tokens, 99);
+    }
+
+    /// See the Anthropic twin: the native `countTokens` call spends the
+    /// provider's request budget, so a limiter allowing one request a minute
+    /// holds the second count.
+    #[tokio::test]
+    async fn the_count_call_goes_through_the_rate_limiter() {
+        let (base, _bodies) = leviath_testkit::spawn_mock_sequence(vec![
+            (200, "OK", br#"{"totalTokens": 9}"#.to_vec()),
+            (200, "OK", br#"{"totalTokens": 9}"#.to_vec()),
+        ])
+        .await;
+        let provider = GeminiProvider {
+            client: reqwest::Client::new(),
+            api_key: "key".to_string(),
+            base_url: format!("{}/openai", base),
+            rate_limiter: Some(RateLimiter::new(&crate::provider::RateLimitConfig {
+                requests_per_minute: 1,
+                tokens_per_minute: 1_000_000,
+            })),
+            learned: Default::default(),
+            capability_overrides: HashMap::new(),
+        };
+        assert_eq!(provider.count_tokens("first", "gemini-3.5-flash").await, 9);
+        let held = tokio::time::timeout(
+            std::time::Duration::from_millis(300),
+            provider.count_tokens("second", "gemini-3.5-flash"),
+        )
+        .await;
+        assert!(
+            held.is_err(),
+            "the second count waits for the minute the limiter allows one request in"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -703,8 +703,12 @@ impl Provider for OllamaProvider {
         Ok(Box::pin(stream))
     }
 
+    /// The byte heuristic. Ollama's documented HTTP API has no tokenize
+    /// endpoint (a `/api/tokenize` was proposed upstream and never shipped in
+    /// a release this targets), so there is nothing exact to ask for; the
+    /// window guard's count on this provider is the same estimate the window
+    /// already keeps, and the guard reduces to the overflow check.
     async fn count_tokens(&self, text: &str, _model: &str) -> usize {
-        // Ollama exposes no token-count endpoint; approximate locally.
         leviath_core::estimate_tokens(text)
     }
 

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -353,8 +353,18 @@ impl Provider for OpenAIProvider {
     }
 
     async fn count_tokens(&self, text: &str, model: &str) -> usize {
-        // tiktoken is exact for OpenAI models and runs locally - no network call.
-        crate::tokenizer::count_tokens(text, model)
+        // tiktoken is exact for OpenAI models and runs locally - no network
+        // call. Local is not free, though: BPE over a megabyte of prompt is
+        // tens of milliseconds of CPU, and this runs on the runtime's worker
+        // threads, where that long a stretch without a yield stalls every
+        // other lane. Above the threshold it moves to a blocking thread.
+        if text.len() <= TIKTOKEN_INLINE_BYTES {
+            return crate::tokenizer::count_tokens(text, model);
+        }
+        let (text, model) = (text.to_string(), model.to_string());
+        tokio::task::spawn_blocking(move || crate::tokenizer::count_tokens(&text, &model))
+            .await
+            .expect("tiktoken does not panic on any input")
     }
 
     fn max_context_tokens(&self, model: &str) -> usize {
@@ -471,6 +481,13 @@ impl Provider for OpenAIProvider {
             .collect())
     }
 }
+
+/// The largest text tiktoken is run on inline, on the async thread that asked.
+///
+/// Below this the encode finishes in well under a millisecond and a thread
+/// hop would cost more than it saves; above it the count is a real stretch of
+/// CPU and goes to a blocking thread.
+const TIKTOKEN_INLINE_BYTES: usize = 256 * 1024;
 
 impl OpenAIProvider {
     /// GET `/models`, as the endpoint answers it.
@@ -920,6 +937,24 @@ mod tests {
         );
         let tokens = provider.count_tokens("", "gpt-5.4-mini").await;
         assert_eq!(tokens, 0);
+    }
+
+    /// A prompt above the inline threshold is counted on a blocking thread and
+    /// comes back with the same answer the inline path gives: the hop changes
+    /// where the CPU is spent, never the count.
+    #[tokio::test]
+    async fn a_large_prompt_is_counted_off_the_async_threads() {
+        let provider = OpenAIProvider::new(
+            crate::provider::build_http_client(None).expect("a test client builds"),
+            "key".to_string(),
+        );
+        let text = "word ".repeat(TIKTOKEN_INLINE_BYTES / 5 + 1_000);
+        assert!(text.len() > TIKTOKEN_INLINE_BYTES);
+        let tokens = provider.count_tokens(&text, "gpt-5.4-mini").await;
+        assert_eq!(
+            tokens,
+            crate::tokenizer::count_tokens(&text, "gpt-5.4-mini")
+        );
     }
 
     #[test]

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -741,7 +741,7 @@ mod http;
 pub use http::{
     DEFAULT_INFERENCE_TIMEOUT_SECS, HttpClient, HttpClientFactory, HttpError,
     SIDE_CALL_TIMEOUT_SECS, apply_request_timeout, build_http_client, build_http1_client,
-    malformed_url_error,
+    malformed_url_error, side_call_client,
 };
 
 // Folding a streamed answer back into one response.

--- a/crates/leviath-providers/src/provider/http.rs
+++ b/crates/leviath-providers/src/provider/http.rs
@@ -177,6 +177,43 @@ pub fn build_http1_client(
     outbound_builder(timeout_secs).http1_only().build()
 }
 
+/// How many idle connections the side-call client keeps per host.
+///
+/// Two, not one: a count call can be in flight for one lane while another
+/// lane's finishes, and a pool of one would open a fresh connection for the
+/// second every time they overlap.
+const SIDE_CALL_POOL_IDLE_PER_HOST: usize = 2;
+
+/// How long an idle side-call connection is kept before it is closed.
+const SIDE_CALL_POOL_IDLE_SECS: u64 = 30;
+
+/// The client for a provider's small, frequent side calls - the token count
+/// the window guard makes before a large request goes out.
+///
+/// The inference client above deliberately never reuses a connection, because
+/// a *large* request over a reused connection to `api.anthropic.com` stalls
+/// (see [`build_http_client`]). A count call is the opposite shape: a few
+/// kilobytes, answered in milliseconds, and made before every request that is
+/// big enough to be worth measuring. Paying a TLS handshake for each of those
+/// was most of what the call cost, so this one keeps a couple of idle
+/// connections per host for half a minute and reuses them.
+///
+/// One per process rather than one per provider, because the pool is keyed by
+/// host anyway and a provider has no reason to hold its own copy. Built on
+/// first use; the same builder options as the inference client otherwise, so
+/// the origin-confined redirect policy that keeps the API keys at home applies
+/// here too.
+pub fn side_call_client() -> &'static reqwest::Client {
+    static CLIENT: std::sync::OnceLock<reqwest::Client> = std::sync::OnceLock::new();
+    CLIENT.get_or_init(|| {
+        outbound_builder(Some(SIDE_CALL_TIMEOUT_SECS))
+            .pool_max_idle_per_host(SIDE_CALL_POOL_IDLE_PER_HOST)
+            .pool_idle_timeout(std::time::Duration::from_secs(SIDE_CALL_POOL_IDLE_SECS))
+            .build()
+            .expect("the side-call client builds from fixed options, like the inference client")
+    })
+}
+
 /// The builder both outbound clients share.
 fn outbound_builder(timeout_secs: Option<u64>) -> reqwest::ClientBuilder {
     reqwest::Client::builder()

--- a/crates/leviath-providers/src/rhai_provider/mod.rs
+++ b/crates/leviath-providers/src/rhai_provider/mod.rs
@@ -72,12 +72,38 @@ const REQUIRED_FNS: [(&str, usize, &str); 2] = [
 /// That is not cosmetic: the shared hardening raises Rhai's expression-depth
 /// limits, which are low enough in a debug build to reject legitimate scripts.
 pub fn check_source(label: &str, src: &str) -> Result<ProviderMeta> {
+    Ok(inspect_source(label, src)?.meta)
+}
+
+/// What [`check_source`] learned about a script, with the optional entry
+/// points it found beside the annotations.
+#[derive(Debug, Clone)]
+pub struct SourceReport {
+    /// The script's `// @key value` annotations.
+    pub meta: ProviderMeta,
+    /// Whether the script defines `count_tokens(state, text, model)`.
+    ///
+    /// Reported because it decides how the context-window guard treats the
+    /// provider: with the function, a large request is measured by whatever the
+    /// script asks (a remote count, or its own tokenizer); without it, the guard
+    /// measures with the byte estimate and can only catch an overflow the
+    /// estimate already sees.
+    pub counts_tokens: bool,
+}
+
+/// [`check_source`], keeping the whole report rather than the annotations
+/// alone. `lev validate` uses it to say what a script provider can and cannot
+/// do before a run finds out.
+pub fn inspect_source(label: &str, src: &str) -> Result<SourceReport> {
     let meta = parse_provider_annotations(src);
     let ast = build_init_engine(Arc::new(Vec::new()))
         .compile(src)
         .map_err(|e| ProviderError::Other(format!("compile provider script {label}: {e}")))?;
     require_entry_points(label, &ast)?;
-    Ok(meta)
+    Ok(SourceReport {
+        meta,
+        counts_tokens: has_fn(&ast, "count_tokens", 3),
+    })
 }
 
 /// Check that a compiled script defines `initialize` and `inference`.

--- a/crates/leviath-providers/src/rhai_provider/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/tests.rs
@@ -935,6 +935,29 @@ fn check_source_accepts_a_provider_and_returns_its_annotations() {
     assert_eq!(meta.default_model.as_deref(), Some("mock-1"));
 }
 
+/// The optional `count_tokens` is reported, and reported by its full shape:
+/// a function of that name with the wrong arity is one the loader will never
+/// call, and saying "yes" about it would send an operator looking elsewhere
+/// for why their counts are estimates.
+#[test]
+fn inspect_source_reports_whether_the_script_counts_tokens() {
+    let without = inspect_source("mock.rhai", GOOD_PROVIDER).expect("a usable provider");
+    assert!(!without.counts_tokens);
+    assert_eq!(without.meta.provider.as_deref(), Some("mock"));
+
+    let counting = format!("{GOOD_PROVIDER}\nfn count_tokens(state, text, model) {{ 7 }}");
+    let with = inspect_source("mock.rhai", &counting).expect("a usable provider");
+    assert!(with.counts_tokens);
+    assert!(format!("{with:?}").contains("counts_tokens: true"));
+
+    let wrong_arity = format!("{GOOD_PROVIDER}\nfn count_tokens(text) {{ 7 }}");
+    let wrong = inspect_source("mock.rhai", &wrong_arity).expect("a usable provider");
+    assert!(
+        !wrong.counts_tokens,
+        "a one-parameter count_tokens is not the contract"
+    );
+}
+
 #[test]
 fn check_source_reports_a_syntax_error() {
     let message = refusal(check_source("mock.rhai", "fn inference( { oops").unwrap_err());

--- a/crates/leviath-runtime/src/compaction_bridge.rs
+++ b/crates/leviath-runtime/src/compaction_bridge.rs
@@ -91,7 +91,17 @@ pub async fn run_compaction_job(
     let mut usage = Vec::new();
     let mut result = Ok(());
     for (region, request) in requests {
-        match tokio::time::timeout(deadline, provider.infer(&request)).await {
+        // Guarded before it is sent, like every other lane's request, and
+        // inside the same deadline so a count that hangs cannot hold the slot
+        // past it. No calibration: that corrects the agent's own window on
+        // the agent's own model, and this request goes to the compaction
+        // model, whose framing it has never measured.
+        let call = async {
+            crate::inference_bridge::guard_context_window(provider.as_ref(), &request, None)
+                .await?;
+            provider.infer(&request).await
+        };
+        match tokio::time::timeout(deadline, call).await {
             Ok(Ok(response)) => {
                 usage.push(response.tokens_used);
                 summaries.push((region, response.content));
@@ -328,5 +338,86 @@ mod tests {
         assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
         let _ = p.capabilities("m");
+    }
+
+    /// A provider with a 1,000-token window that counts every request at 950,
+    /// and records whether `infer` was ever reached.
+    struct Narrow {
+        inferred: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for Narrow {
+        async fn infer(
+            &self,
+            _req: &InferenceRequest,
+        ) -> leviath_providers::Result<InferenceResponse> {
+            self.inferred
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(InferenceResponse {
+                content: "summary".to_string(),
+                tool_calls: vec![],
+                tokens_used: TokenUsage::new(1, 0, 0, 1),
+                finish_reason: FinishReason::Complete,
+            })
+        }
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+            950
+        }
+        fn max_context_tokens(&self, _m: &str) -> usize {
+            1_000
+        }
+        fn name(&self) -> &str {
+            "narrow"
+        }
+        fn capabilities(&self, _m: &str) -> ModelCapabilities {
+            ModelCapabilities::default()
+        }
+    }
+
+    /// The compaction lane is guarded like the stage lane: a summarize request
+    /// that would overflow the compaction model's window is refused before it
+    /// is sent, and the batch fails with the refusal rather than the provider's
+    /// own rejection after the round trip.
+    #[tokio::test]
+    async fn the_compaction_lane_refuses_an_overflowing_request() {
+        let provider = Arc::new(Narrow {
+            inferred: std::sync::atomic::AtomicBool::new(false),
+        });
+        assert_eq!(provider.name(), "narrow");
+        let _ = provider.capabilities("m");
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut job = job(provider.clone(), vec!["a"]);
+        // 2,000 bytes of region text: estimated at 500, plus the 100-token
+        // reply budget, is over half the 1,000 window, so it is measured.
+        job.requests[0].1.messages.push(leviath_providers::Message {
+            role: "user".to_string(),
+            content: "x".repeat(2_000).into(),
+            cache_breakpoint: false,
+        });
+        run_compaction_job(
+            job,
+            std::time::Duration::from_secs(60),
+            tx,
+            Arc::new(Notify::new()),
+        )
+        .await;
+
+        let outcome = rx.try_recv().unwrap();
+        let err = outcome.result.expect_err("950 + 100 does not fit in 1,000");
+        assert_eq!(err.to_string(), "Token limit exceeded: 950 > 1000");
+        assert!(
+            !provider.inferred.load(std::sync::atomic::Ordering::SeqCst),
+            "refused before the call, not after it"
+        );
+        assert!(
+            outcome.usage.is_empty(),
+            "nothing ran, so nothing was billed"
+        );
+        // The provider would have answered had the request reached it, so the
+        // refusal above is the guard's doing and not the mock's.
+        let answered = provider.infer(&request()).await.expect("the mock answers");
+        assert_eq!(answered.content, "summary");
+        assert!(provider.inferred.load(std::sync::atomic::Ordering::SeqCst));
     }
 }

--- a/crates/leviath-runtime/src/context_transform.rs
+++ b/crates/leviath-runtime/src/context_transform.rs
@@ -633,7 +633,6 @@ mod tests {
             content_summary_outcomes: cs_tx,
             wake: Arc::new(Notify::new()),
             runtime: Handle::current(),
-            exact_token_counting: false,
             stream_inference: true,
         });
         (world, cs_rx)

--- a/crates/leviath-runtime/src/custom_region.rs
+++ b/crates/leviath-runtime/src/custom_region.rs
@@ -236,7 +236,8 @@ pub(crate) fn render_custom_region(render: RegionRender<'_>, out: RenderSink<'_>
                     emitted_tokens,
                     budget = region.max_tokens,
                     "custom region render exceeds its budget; sending anyway \
-                     (enable exact_token_counting for a hard guard)"
+                     (the context-window guard refuses it only if the whole \
+                     request would overflow the model)"
                 );
             }
             system_blocks.extend(blocks);

--- a/crates/leviath-runtime/src/host/health.rs
+++ b/crates/leviath-runtime/src/host/health.rs
@@ -125,7 +125,7 @@ impl WorldHost {
     pub(super) fn observe_lanes(&self, snapshot: &LaneSnapshot, relief: usize) {
         // Every `PipelineWorld::new` installs the sink resource (a no-op one
         // unless a host replaced it), so this is a hard invariant rather than a
-        // branch - the same reasoning as `set_exact_token_counting`.
+        // branch - the same reasoning as `set_stream_inference`.
         self.world
             .world()
             .resource::<crate::telemetry::Telemetry>()

--- a/crates/leviath-runtime/src/inference_bridge.rs
+++ b/crates/leviath-runtime/src/inference_bridge.rs
@@ -168,12 +168,12 @@ pub struct InferenceJob {
     /// The per-model pool permit, held for the whole request and released when
     /// the job finishes.
     pub permit: InferencePermit,
-    /// When set, count the assembled request's tokens exactly (via the
-    /// provider's `count_tokens`, which uses a remote endpoint where available)
-    /// before calling `infer`, and fail early if it would exceed the model's
-    /// context window. Off by default - the runtime's cheap `len/4` estimates
-    /// drive normal budgeting; this is the opt-in accurate guard.
-    pub exact_token_counting: bool,
+    /// What earlier calls taught the window about its own estimate, so the
+    /// pre-flight guard ([`guard_context_window`]) decides whether to measure
+    /// this request from the corrected figure rather than the raw one. `None`
+    /// before anything was measured, or for a lane that has no window of its
+    /// own to correct.
+    pub calibration: Option<crate::pipeline::PromptCalibration>,
     /// Ask the provider to stream this answer and fold the chunks back into one
     /// response, rather than waiting for the whole thing at once.
     ///
@@ -188,6 +188,63 @@ pub struct InferenceJob {
     /// Set from `[limits] stream_inference` and off for a model whose provider
     /// does not advertise streaming.
     pub stream: bool,
+}
+
+/// The share of the model's window below which a request goes out unmeasured.
+///
+/// The guard costs a provider round trip on Anthropic and Gemini, so it is only
+/// paid where it can change the answer. A request whose corrected estimate plus
+/// its reply budget sits under half the window cannot overflow it however far
+/// the estimate is off - the estimator has never been measured drifting by
+/// anything like a factor of two - and is sent as it is. Everything above the
+/// line is counted with the provider's own tokenizer before it is sent.
+pub const COUNT_ABOVE_WINDOW_FRACTION: usize = 2;
+
+/// Measure a request against the model's context window before it is sent.
+///
+/// Returns `Ok(None)` when the request was small enough to skip the count,
+/// `Ok(Some(used))` with the provider's exact prompt count when it was measured
+/// and fits, and `Err(TokenLimitExceeded)` when it was measured and would
+/// overflow. Every inference lane - the stage's own call, the routing call,
+/// compaction and titling - goes through this one function, so a window is
+/// guarded the same way whichever lane assembled the request.
+///
+/// A provider that reports no window for the model (`max_context_tokens` of
+/// zero) cannot be guarded, and is not: refusing everything on the strength of
+/// a number nobody supplied would be worse than sending it.
+///
+/// The count is the provider's (`count_tokens`): a remote endpoint on
+/// Anthropic and Gemini, tiktoken on OpenAI, a script's own `count_tokens` on
+/// a Rhai provider, and the byte heuristic elsewhere - so on a heuristic-only
+/// provider the "exact" figure is the same estimate, and the guard reduces to
+/// the overflow check.
+pub async fn guard_context_window(
+    provider: &dyn Provider,
+    request: &InferenceRequest,
+    calibration: Option<&crate::pipeline::PromptCalibration>,
+) -> Result<Option<usize>, ProviderError> {
+    let max = provider.max_context_tokens(&request.model);
+    if max == 0 {
+        return Ok(None);
+    }
+    let text = flatten_request_text(request);
+    let estimate =
+        crate::pipeline::calibrated_tokens(leviath_core::estimate_tokens(&text), calibration);
+    if estimate.saturating_add(request.max_tokens) < max / COUNT_ABOVE_WINDOW_FRACTION {
+        return Ok(None);
+    }
+    let used = provider.count_tokens(&text, &request.model).await;
+    if used.saturating_add(request.max_tokens) > max {
+        return Err(ProviderError::TokenLimitExceeded { used, max });
+    }
+    tracing::debug!(
+        model = %request.model,
+        estimated = estimate,
+        counted = used,
+        window = max,
+        "request measured before sending"
+    );
+    Ok(Some(used))
 }
 
 /// Flatten a request into the text whose tokens we count for the budget guard:
@@ -311,30 +368,10 @@ pub async fn run_inference_job(
         provider,
         request,
         permit,
-        exact_token_counting,
+        calibration,
         stream,
     } = job;
     let started = std::time::Instant::now();
-    // Opt-in accurate pre-flight budget guard: count the assembled request
-    // exactly (remote endpoint where the provider has one, heuristic otherwise)
-    // and refuse a request that would overflow the model's context window,
-    // rather than sending it and letting the provider reject it after the fact.
-    if exact_token_counting {
-        let text = flatten_request_text(&request);
-        let used = provider.count_tokens(&text, &request.model).await;
-        let max = provider.max_context_tokens(&request.model);
-        if used.saturating_add(request.max_tokens) > max {
-            drop(permit);
-            let _ = results.send(InferenceOutcome {
-                entity,
-                result: Err(ProviderError::TokenLimitExceeded { used, max }),
-                latency: started.elapsed(),
-                pricing: provider.pricing(&request.model),
-            });
-            wake.notify_one();
-            return;
-        }
-    }
     // Retry transient failures (connection reset, timeout, 429, 5xx) with
     // exponential backoff, holding the permit across the backoff; a permanent
     // error fails immediately. `backoff_after` decides each wait: a capacity
@@ -347,6 +384,12 @@ pub async fn run_inference_job(
     // copy. It used to be cloned per attempt, which doubled the live footprint
     // of every in-flight request for the whole (possibly minutes-long) call.
     let attempts = async {
+        // The pre-flight guard, inside the cancel and the job timeout with the
+        // call it protects: a count that hangs is bounded by the same deadline
+        // the request is, and a cancelled run does not wait for one. Before the
+        // loop rather than in it, because a refusal here is a fact about the
+        // request and a retry would only restate it.
+        guard_context_window(provider.as_ref(), &request, calibration.as_ref()).await?;
         let mut attempt = 1u32;
         let mut spent = Duration::ZERO;
         loop {
@@ -499,7 +542,7 @@ mod tests {
             provider,
             request: test_request(),
             permit: pools.try_acquire("p", "m").expect("free pool"),
-            exact_token_counting: false,
+            calibration: None,
             stream: false,
         }
     }
@@ -527,7 +570,7 @@ mod tests {
             provider,
             request: test_request(),
             permit,
-            exact_token_counting: false,
+            calibration: None,
             stream: false,
         };
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -580,7 +623,7 @@ mod tests {
             provider,
             request: test_request(),
             permit,
-            exact_token_counting: false,
+            calibration: None,
             stream: false,
         };
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -667,10 +710,26 @@ mod tests {
     }
 
     /// A provider with a fixed `count_tokens` result and context window, used to
-    /// drive the opt-in pre-inference budget guard. `infer` always succeeds.
+    /// drive the pre-flight window guard. `infer` always succeeds, and every
+    /// count call is tallied so a test can say whether the guard paid for one.
     struct Counter {
         count: usize,
         max: usize,
+        counts: std::sync::atomic::AtomicUsize,
+    }
+
+    impl Counter {
+        fn new(count: usize, max: usize) -> Self {
+            Self {
+                count,
+                max,
+                counts: std::sync::atomic::AtomicUsize::new(0),
+            }
+        }
+
+        fn count_calls(&self) -> usize {
+            self.counts.load(std::sync::atomic::Ordering::SeqCst)
+        }
     }
 
     #[async_trait::async_trait]
@@ -682,6 +741,8 @@ mod tests {
             Ok(response("ok"))
         }
         async fn count_tokens(&self, _text: &str, _model: &str) -> usize {
+            self.counts
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             self.count
         }
         fn max_context_tokens(&self, _model: &str) -> usize {
@@ -695,17 +756,34 @@ mod tests {
         }
     }
 
-    fn counting_job(provider: Arc<dyn Provider>, exact: bool) -> InferenceJob {
+    /// A job whose request carries `prompt_bytes` of user text, so the guard's
+    /// own estimate (`bytes / 4`) is under the test's control.
+    fn counting_job(
+        provider: Arc<dyn Provider>,
+        prompt_bytes: usize,
+        calibration: Option<crate::pipeline::PromptCalibration>,
+    ) -> InferenceJob {
         let pools = InferencePools::new(InferencePoolConfig::new());
         InferenceJob {
             entity: Entity::from_raw_u32(7)
                 .expect("a small literal index is always a valid entity id"),
             provider,
-            request: test_request(), // max_tokens: 100
+            request: sized_request(prompt_bytes), // max_tokens: 100
             permit: pools.try_acquire("p", "m").expect("free pool"),
-            exact_token_counting: exact,
+            calibration,
             stream: false,
         }
+    }
+
+    /// [`test_request`] with one user message of `bytes` ASCII bytes.
+    fn sized_request(bytes: usize) -> InferenceRequest {
+        let mut request = test_request();
+        request.messages.push(leviath_providers::Message {
+            role: "user".to_string(),
+            content: "x".repeat(bytes).into(),
+            cache_breakpoint: false,
+        });
+        request
     }
 
     #[test]
@@ -742,16 +820,73 @@ mod tests {
         assert!(text.contains("object"));
     }
 
+    /// The guard is always on now, with one cheap escape: a request whose
+    /// estimate plus its reply budget is under half the window is sent without
+    /// asking the provider, and one at or above the line is measured first.
+    /// Both against a window of 1,000 and a reply budget of 100: 400 bytes
+    /// estimate at 100 tokens (200 all told, under the line), 1,600 bytes at
+    /// 400 (500, on it).
+    #[tokio::test]
+    async fn a_large_prompt_is_counted_and_a_small_one_is_not() {
+        let small = Arc::new(Counter::new(10, 1000));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        run_inference_job(
+            counting_job(small.clone(), 400, None),
+            tx,
+            Arc::new(Notify::new()),
+            RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        assert_eq!(outcome.result.expect("sent unmeasured").content, "ok");
+        assert_eq!(small.count_calls(), 0, "a small turn pays nothing");
+
+        let large = Arc::new(Counter::new(800, 1000));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        run_inference_job(
+            counting_job(large.clone(), 1_600, None),
+            tx,
+            Arc::new(Notify::new()),
+            RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
+        )
+        .await;
+        let outcome = rx.try_recv().expect("outcome sent");
+        // count(800) + max_tokens(100) = 900 <= 1000: measured, and it fits.
+        assert_eq!(outcome.result.expect("measured and sent").content, "ok");
+        assert_eq!(large.count_calls(), 1, "one count call, no more");
+    }
+
+    /// The guard's estimate is the calibrated one. A request the raw estimate
+    /// would wave through (200 of a 1,000 window) is measured once earlier
+    /// calls have shown the provider charging 400 more than the window
+    /// believes - which is exactly the run that is about to overflow.
+    #[tokio::test]
+    async fn the_calibration_can_push_a_request_over_the_counting_line() {
+        let mut calibration = crate::pipeline::PromptCalibration::default();
+        calibration.observe(1_000, 1_400);
+        let provider = Arc::new(Counter::new(10, 1000));
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        run_inference_job(
+            counting_job(provider.clone(), 400, Some(calibration)),
+            tx,
+            Arc::new(Notify::new()),
+            RetryPolicy::default(),
+            crate::cancel::CancelToken::new(),
+        )
+        .await;
+        assert!(rx.try_recv().expect("outcome sent").result.is_ok());
+        assert_eq!(provider.count_calls(), 1);
+    }
+
     #[tokio::test]
     async fn guard_rejects_request_over_context_window() {
         // count(950) + max_tokens(100) = 1050 > context(1000) ⇒ rejected pre-flight.
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let provider = Arc::new(Counter {
-            count: 950,
-            max: 1000,
-        });
+        let provider = Arc::new(Counter::new(950, 1000));
         run_inference_job(
-            counting_job(provider, true),
+            counting_job(provider, 1_600, None),
             tx,
             Arc::new(Notify::new()),
             RetryPolicy::default(),
@@ -765,54 +900,56 @@ mod tests {
         assert_eq!(err.to_string(), "Token limit exceeded: 950 > 1000");
     }
 
+    /// A refusal is a fact about the request, not the network: it is reported
+    /// once, and the retry schedule never sees it.
     #[tokio::test]
-    async fn guard_allows_request_within_context_window() {
-        // count(800) + 100 = 900 ≤ 1000 ⇒ proceeds to infer.
+    async fn a_refused_request_is_not_retried() {
+        let provider = Arc::new(Counter::new(950, 1000));
         let (tx, mut rx) = mpsc::unbounded_channel();
-        let provider = Arc::new(Counter {
-            count: 800,
-            max: 1000,
-        });
         run_inference_job(
-            counting_job(provider, true),
+            counting_job(provider.clone(), 1_600, None),
             tx,
             Arc::new(Notify::new()),
-            RetryPolicy::default(),
+            no_delay(5),
             crate::cancel::CancelToken::new(),
         )
         .await;
-        let outcome = rx.try_recv().expect("outcome sent");
-        assert_eq!(outcome.result.expect("should succeed").content, "ok");
+        assert!(rx.try_recv().expect("outcome sent").result.is_err());
+        assert_eq!(provider.count_calls(), 1, "measured once, refused once");
+    }
+
+    /// A provider that reports no window for the model cannot be guarded and
+    /// is not: the request goes out unmeasured rather than being refused on a
+    /// number nobody supplied.
+    #[tokio::test]
+    async fn an_unknown_window_is_never_guarded() {
+        let provider = Arc::new(Counter::new(1_000_000, 0));
+        let verdict = guard_context_window(provider.as_ref(), &sized_request(1_600), None)
+            .await
+            .expect("nothing to measure against");
+        assert_eq!(verdict, None);
+        assert_eq!(provider.count_calls(), 0);
+    }
+
+    /// What the guard hands back when it did measure: the provider's count, so
+    /// a caller can feed it into the calibration.
+    #[tokio::test]
+    async fn a_measured_request_reports_its_count() {
+        let provider = Arc::new(Counter::new(800, 1000));
+        let verdict = guard_context_window(provider.as_ref(), &sized_request(1_600), None)
+            .await
+            .expect("fits");
+        assert_eq!(verdict, Some(800));
     }
 
     #[tokio::test]
     async fn counter_provider_metadata_is_exercised() {
         // Keep the Counter mock's non-`infer` trait methods measured.
-        let p = Counter { count: 5, max: 10 };
+        let p = Counter::new(5, 10);
         assert_eq!(p.name(), "counter");
         assert_eq!(p.max_context_tokens("m"), 10);
         assert_eq!(p.count_tokens("t", "m").await, 5);
         assert!(p.capabilities("m").supports_streaming);
-    }
-
-    #[tokio::test]
-    async fn guard_off_skips_the_count_and_proceeds() {
-        // Even wildly over budget, with the flag off the guard never runs.
-        let (tx, mut rx) = mpsc::unbounded_channel();
-        let provider = Arc::new(Counter {
-            count: 1_000_000,
-            max: 1000,
-        });
-        run_inference_job(
-            counting_job(provider, false),
-            tx,
-            Arc::new(Notify::new()),
-            RetryPolicy::default(),
-            crate::cancel::CancelToken::new(),
-        )
-        .await;
-        let outcome = rx.try_recv().expect("outcome sent");
-        assert_eq!(outcome.result.expect("should succeed").content, "ok");
     }
 
     #[tokio::test]
@@ -953,7 +1090,7 @@ mod tests {
             }),
             request: test_request(),
             permit: pools.try_acquire("p", "m").expect("free pool"),
-            exact_token_counting: false,
+            calibration: None,
             stream: true,
         };
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -988,7 +1125,7 @@ mod tests {
             }),
             request: test_request(),
             permit: pools.try_acquire("p", "m").expect("free pool"),
-            exact_token_counting: false,
+            calibration: None,
             stream: false,
         };
         let (tx, mut rx) = mpsc::unbounded_channel();

--- a/crates/leviath-runtime/src/pipeline/inference.rs
+++ b/crates/leviath-runtime/src/pipeline/inference.rs
@@ -500,7 +500,7 @@ pub fn dispatch_inference(
                     provider,
                     request,
                     permit,
-                    exact_token_counting: stage.exact_token_counting,
+                    calibration: calibration.copied(),
                     stream,
                 };
                 let cancel = crate::cancel::CancelToken::new();

--- a/crates/leviath-runtime/src/pipeline/mod.rs
+++ b/crates/leviath-runtime/src/pipeline/mod.rs
@@ -190,10 +190,6 @@ pub struct InferenceStage {
     pub wake: Arc<Notify>,
     /// Runtime the worker tasks are spawned onto.
     pub runtime: Handle,
-    /// Opt-in: perform an exact pre-inference token count and reject requests
-    /// that would overflow the model's context window (see
-    /// `InferenceJob::exact_token_counting`). Off by default.
-    pub exact_token_counting: bool,
     /// Whether a model that can stream is called that way. On by default; see
     /// `InferenceJob::stream`.
     pub stream_inference: bool,

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -322,6 +322,21 @@ pub fn collect_inference(
                     .insert(ProcessResponse);
             }
             Err(err) => {
+                // A request the pre-flight guard refused was measured with the
+                // provider's own tokenizer, and that measurement is the only
+                // evidence the window will get: the call never happened, so
+                // there is no response to learn from. Folded in here so the
+                // next request - the retry after compaction, or the resume -
+                // is estimated from the figure that was just refused.
+                if let leviath_providers::ProviderError::TokenLimitExceeded { used, .. } = &err {
+                    calibrate(
+                        &mut commands,
+                        outcome.entity,
+                        calibration.as_deref_mut(),
+                        estimate,
+                        *used,
+                    );
+                }
                 // A provider that is out of credits or holding a rejected key
                 // is not this request's problem: every later request to it
                 // fails the same way. Move the stage to the next candidate and

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -560,7 +560,6 @@ fn build_world(pools: InferencePools) -> (World, mpsc::UnboundedReceiver<Inferen
         content_summary_outcomes: cstx,
         wake: Arc::new(Notify::new()),
         runtime: Handle::current(),
-        exact_token_counting: false,
         stream_inference: true,
     });
     (world, rx)
@@ -2093,6 +2092,36 @@ fn collect_folds_a_worse_call_into_an_existing_calibration() {
         shortfall, 400,
         "the agent keeps one correction rather than a fresh one per call"
     );
+}
+
+/// A request the pre-flight guard refused never produced a response, but it
+/// was measured, and the measurement is the only evidence the window gets
+/// about that request. The correction learns from it, so the retry after
+/// compaction is estimated from the figure that was just refused rather than
+/// rediscovering it.
+#[test]
+fn collect_learns_from_a_refused_request_too() {
+    let (mut world, tx) = world_with_results();
+    let e = world
+        .spawn((agent_state(), AwaitingInference, PromptEstimate(1_000)))
+        .id();
+    tx.send(InferenceOutcome {
+        latency: std::time::Duration::ZERO,
+        entity: e,
+        result: Err(leviath_providers::ProviderError::TokenLimitExceeded {
+            used: 1_300,
+            max: 1_350,
+        }),
+        pricing: None,
+    })
+    .unwrap();
+
+    run_collect(&mut world);
+
+    let shortfall = world
+        .get::<PromptCalibration>(e)
+        .map_or(0, PromptCalibration::shortfall);
+    assert_eq!(shortfall, 300, "the refused count corrects the estimate");
 }
 
 /// An agent that never dispatched through the inference lane - a test driving

--- a/crates/leviath-runtime/src/pipeline/transition_choice.rs
+++ b/crates/leviath-runtime/src/pipeline/transition_choice.rs
@@ -272,9 +272,9 @@ pub fn dispatch_transition_choice(
             provider,
             request,
             permit,
-            // Routing responses are tiny (≤256 tokens) and always fit; skip the
-            // extra count call for them.
-            exact_token_counting: false,
+            // The routing request is the stage's own request plus one question,
+            // so it is guarded the way the stage's is, from the same correction.
+            calibration: calibration.copied(),
             // And buffered for the same reason: a stage name is one short
             // answer that arrives in one piece. Streaming exists here to keep a
             // long silent generation from being mistaken for a dead socket, and

--- a/crates/leviath-runtime/src/title.rs
+++ b/crates/leviath-runtime/src/title.rs
@@ -919,7 +919,6 @@ mod tests {
             content_summary_outcomes: cstx,
             wake: Arc::new(Notify::new()),
             runtime: Handle::current(),
-            exact_token_counting: false,
             stream_inference: true,
         });
         world.insert_resource(TitleSink(title_tx));
@@ -1257,6 +1256,87 @@ mod tests {
             outcome.result.expect("the third attempt answers"),
             "Recovered Title"
         );
+    }
+
+    /// A provider whose window is too small for the title request, and which
+    /// records whether the request ever reached it.
+    struct Narrow {
+        inferred: std::sync::atomic::AtomicBool,
+    }
+
+    #[async_trait::async_trait]
+    impl Provider for Narrow {
+        async fn infer(
+            &self,
+            _req: &InferenceRequest,
+        ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
+            self.inferred
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            Ok(leviath_providers::InferenceResponse {
+                content: "A Title".to_string(),
+                tool_calls: vec![],
+                tokens_used: leviath_providers::TokenUsage::new(1, 0, 0, 1),
+                finish_reason: leviath_providers::FinishReason::Complete,
+            })
+        }
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+            600
+        }
+        fn max_context_tokens(&self, _m: &str) -> usize {
+            1_000
+        }
+        fn name(&self) -> &str {
+            "narrow"
+        }
+        fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
+            leviath_providers::ModelCapabilities::default()
+        }
+    }
+
+    /// The title lane is guarded like every other: a titling request that
+    /// would overflow the title model's window (600 counted plus the 512-token
+    /// reply budget, against 1,000) is refused before it is sent.
+    #[tokio::test]
+    async fn the_title_lane_refuses_an_overflowing_request() {
+        let provider = Arc::new(Narrow {
+            inferred: std::sync::atomic::AtomicBool::new(false),
+        });
+        assert_eq!(provider.name(), "narrow");
+        let _ = provider.capabilities("m");
+        let pools = default_pools();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        run_title_job(
+            TitleJob {
+                entity: bevy_ecs::entity::Entity::PLACEHOLDER,
+                provider: provider.clone(),
+                provider_name: "mock".to_string(),
+                model: "m".to_string(),
+                // A task long enough that the estimate alone (500 tokens) puts
+                // the request on the counting side of the line.
+                request: title_request(&"t".repeat(2_000), "mock", "m"),
+                permit: pools.try_acquire("p", "m").expect("free"),
+            },
+            instant_retry(),
+            tx,
+            Arc::new(Notify::new()),
+        )
+        .await;
+        let outcome = rx.recv().await.expect("an outcome is always reported");
+        let err = outcome.result.expect_err("600 + 512 does not fit in 1,000");
+        assert_eq!(err.to_string(), "Token limit exceeded: 600 > 1000");
+        assert!(
+            !provider.inferred.load(std::sync::atomic::Ordering::SeqCst),
+            "refused before the call, not after it"
+        );
+        assert!(outcome.usage.is_none(), "nothing was served");
+        // The provider would have answered had the request reached it, so the
+        // refusal above is the guard's doing and not the mock's.
+        let answered = provider
+            .infer(&title_request("task", "mock", "m"))
+            .await
+            .expect("the mock answers");
+        assert_eq!(answered.content, "A Title");
+        assert!(provider.inferred.load(std::sync::atomic::Ordering::SeqCst));
     }
 
     /// The other half of the schedule: a permanent refusal is not retried, so

--- a/crates/leviath-runtime/src/title_bridge.rs
+++ b/crates/leviath-runtime/src/title_bridge.rs
@@ -95,6 +95,11 @@ pub async fn run_title_job(
     // at once. `infer` borrows the request, so every attempt reuses the one
     // assembled copy.
     let attempts = async {
+        // The same pre-flight guard as the stage lane, inside the same deadline.
+        // A title request is a few hundred tokens and almost never reaches the
+        // counting line, but "almost" is not a property a lane gets to rely on:
+        // the model is whatever `[title]` names, and its window is its own.
+        crate::inference_bridge::guard_context_window(provider.as_ref(), &request, None).await?;
         let mut attempt = 1u32;
         let mut spent = std::time::Duration::ZERO;
         loop {

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -373,7 +373,6 @@ impl PipelineWorld {
             content_summary_outcomes: cs_tx,
             wake: wake.clone(),
             runtime,
-            exact_token_counting: false,
             // On unless the operator turns it off: a buffered call is a socket
             // that goes silent for as long as the model thinks, which is what
             // anything on the path that reaps idle connections kills.
@@ -621,24 +620,13 @@ impl PipelineWorld {
         &self.world
     }
 
-    /// Enable (or disable) the opt-in exact pre-inference budget guard for this
-    /// world - see `inference_bridge::InferenceJob::exact_token_counting`.
-    /// Call once at startup when the run config requests it, before serving.
-    pub fn set_exact_token_counting(&mut self, enabled: bool) {
-        // `InferenceStage` is inserted by every `PipelineWorld::new` path, so it
-        // is a hard invariant here - `resource_mut` (which panics if absent) is
-        // correct and keeps this branch-free.
-        self.world
-            .resource_mut::<crate::pipeline::InferenceStage>()
-            .exact_token_counting = enabled;
-    }
-
     /// Turn streamed inference off (or back on) for this world - see
     /// `inference_bridge::InferenceJob::stream`. Call once at startup, before
     /// serving.
     pub fn set_stream_inference(&mut self, enabled: bool) {
-        // Same invariant as `set_exact_token_counting`: `InferenceStage` is
-        // inserted by every `PipelineWorld::new` path.
+        // `InferenceStage` is inserted by every `PipelineWorld::new` path, so it
+        // is a hard invariant here - `resource_mut` (which panics if absent) is
+        // correct and keeps this branch-free.
         self.world
             .resource_mut::<crate::pipeline::InferenceStage>()
             .stream_inference = enabled;
@@ -1391,25 +1379,6 @@ mod tests {
         world.world_mut().insert_resource(circuits);
 
         assert_eq!(world.open_circuits().len(), 1);
-    }
-
-    #[tokio::test]
-    async fn set_exact_token_counting_toggles_the_stage_flag() {
-        let mut world = build_world(ProviderRegistry::new());
-        // Default is off.
-        assert!(
-            !world
-                .world()
-                .resource::<crate::pipeline::InferenceStage>()
-                .exact_token_counting
-        );
-        world.set_exact_token_counting(true);
-        assert!(
-            world
-                .world()
-                .resource::<crate::pipeline::InferenceStage>()
-                .exact_token_counting
-        );
     }
 
     /// Streaming is on unless someone turns it off, and the switch reaches the

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -140,7 +140,6 @@ It is read per run, so a change takes effect on the next `lev run` with no resta
 max_concurrent_inferences = 8    # in-flight requests per model without its own pool entry
 max_concurrent_tools      = 8    # agents whose tool batches may run at once, daemon-wide
 default_max_iterations    = 50   # fallback cap for a stage that sets none
-exact_token_counting      = false
 stream_inference          = true # ask a model that can stream to stream
 script_shell_timeout_secs = 60
 mcp_idle_disconnect_secs  = 60   # disconnect an MCP server no agent has used for this long
@@ -168,7 +167,6 @@ cerebras = 1                     # every model this provider serves, together
 | `max_concurrent_inferences` | `8` | The [inference pool](/docs/engine#inference-pools) cap, per model |
 | `max_concurrent_tools` | `8` | Size of the shared tool worker pool. Clamped to at least 1 |
 | `default_max_iterations` | `50` | A stage's own `max_iterations` always wins |
-| `exact_token_counting` | `false` | Count each request exactly before sending it. See below |
 | `stream_inference` | `true` | Ask a model that can stream to stream. See below |
 | `script_shell_timeout_secs` | `60` | Cap on a Rhai script tool's `shell()` host call |
 | `mcp_idle_disconnect_secs` | `60` | Disconnect an [MCP server](/docs/mcp) no agent has used for this long. It reconnects on next use |
@@ -188,11 +186,7 @@ cerebras = 1                     # every model this provider serves, together
 | `notify_spend_usd` | empty | Dollar figures to be told about while a run is still going. See below |
 | `max_agents_per_run` | `0` | Most agents one run may create, sub-agents included. `0` is no ceiling. See below |
 
-Twelve of those need more than a table cell.
-
-**`exact_token_counting`** measures each assembled request before sending it and refuses one that
-would overflow the window. On providers with a remote counting endpoint that costs a network round
-trip per inference, so it is off by default.
+Eleven of those need more than a table cell.
 
 **`stream_inference`** asks a model that can stream to stream. It changes nothing an agent sees:
 the chunks are folded back into one finished turn before anything reads it, because half a sentence

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -625,6 +625,24 @@ result when it applies. Without one, a large file went into its region whole and
 truncated or dropped as `[result omitted]` depending on how full the region already was. That is a
 cliff rather than a limit.
 
+## Requests are measured before they are sent
+
+The window sizes what it holds with a byte estimate, corrected by what earlier calls in the run
+were charged. That is cheap and it is usually close, but a provider whose window is a hard ceiling
+rejects a request that is over by one token, and the rejection is not transient: the retry resends
+the same request and the stage dies.
+
+So a request that could be near the window is measured before it goes out. When the corrected
+estimate plus the reply budget reaches half the model's window, the runtime asks the provider's own
+tokenizer what the request costs (`/messages/count_tokens` on Anthropic, `:countTokens` on Gemini,
+tiktoken locally on OpenAI, a script's `count_tokens` on a [Rhai provider](/docs/rhai-providers))
+and refuses to send one that would not fit, naming the count and the window in the error. A request
+under that line is sent as it is, so a short turn pays nothing. Every lane is guarded the same
+way: the stage's own call, the routing call at a stage boundary, compaction and titling.
+
+The count is also fed back into the correction, so a refused request tightens the estimate for the
+retry rather than being rediscovered by it.
+
 ## Budgets travel across models
 
 This is why budgets are written as percentages. A region sized at 20% of the window is 20% whether

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -172,7 +172,7 @@ once at startup rather than per run:
   `[security] allow_local_network` (the outbound-network policy).
 - The `[limits]` the world itself is built with: `stall_timeout_secs`, `wedge_timeout_secs`,
   `dead_cycles_before_relief`, `max_concurrent_inferences`, `max_concurrent_tools`,
-  `exact_token_counting`, `provider_failures_before_open`, `provider_circuit_cooldown_secs`,
+  `provider_failures_before_open`, `provider_circuit_cooldown_secs`,
   `interaction_timeout_secs`, and `finished_retention_secs`.
 
 `[providers] fallback_order` is not one of them. It is per-run policy, so it reloads like everything

--- a/docs/content/rhai-providers.md
+++ b/docs/content/rhai-providers.md
@@ -376,6 +376,36 @@ The three optional functions each carry their own shape. `stream(state, request,
 it). `list_models(state)` returns an array of
 `{ id, display_name, max_context_tokens, max_output_tokens }`.
 
+### Counting tokens remotely
+
+`count_tokens` is what the [context-window guard](/docs/context#requests-are-measured-before-they-are-sent)
+calls before a large request goes out: once the runtime's estimate of a request plus its reply
+budget reaches half the model's window, it asks the script for the real figure and refuses a
+request that would not fit. Small turns never reach it. The example above answers with the byte
+heuristic, which is the right answer for an API with no counting endpoint. For one that has such an
+endpoint, ask it, and fall back to the heuristic if the call fails - the count is guarding a
+request, and a failed count must not become a failed request:
+
+```rhai
+fn count_tokens(state, text, model) {
+    // The shape of Anthropic's /messages/count_tokens; other APIs differ in
+    // the path and the field name, not the idea.
+    try {
+        let resp = parse_json(http_post(
+            `${state.base_url}/messages/count_tokens`,
+            to_json(#{ model: model, messages: [#{ role: "user", content: text }] }),
+            auth_headers(state),
+        ));
+        resp.input_tokens
+    } catch {
+        count_tokens_heuristic(text, "anthropic")
+    }
+}
+```
+
+`lev validate` says whether each script provider on the machine defines `count_tokens`, so you can
+tell a provider the guard measures exactly from one it measures with the estimate.
+
 ## Testing it
 
 To adapt this to another OpenAI-compatible API, change the metadata block, the default `base_url` and

--- a/docs/content/rhai-regions.md
+++ b/docs/content/rhai-regions.md
@@ -155,7 +155,7 @@ Load-time problems fail fast. Runtime problems never break an inference:
 | `render` errors or returns an invalid shape | Warning, and the region renders as a plain `[name]:` block |
 | `on_write` errors or returns an invalid type | Warning, and the entry is accepted unchanged |
 | `on_overflow` errors or returns invalid indices | Warning, and oldest-first eviction runs |
-| Rendered output exceeds the region's budget | Warning only, and it is sent anyway. `[limits] exact_token_counting` turns this into a hard guard |
+| Rendered output exceeds the region's budget | Warning only, and it is sent anyway. The [context-window guard](/docs/context#requests-are-measured-before-they-are-sent) refuses it only if the whole request would overflow the model |
 
 > [!NOTE]
 > Region hooks run in the pure-data sandbox: no filesystem, no network, no host I/O functions. They

--- a/docs/examples/groq.rhai
+++ b/docs/examples/groq.rhai
@@ -120,6 +120,24 @@ fn stream(state, request, on_chunk) {
     );
 }
 
+// Called by the context-window guard before a request large enough to be
+// near the model's window goes out (small turns never reach it). Groq has no
+// counting endpoint, so this answers with the local estimate. An API that has
+// one is asked instead, with the estimate as the fallback, so a failed count
+// never turns into a failed request:
+//
+//     fn count_tokens(state, text, model) {
+//         try {
+//             let resp = parse_json(http_post(
+//                 `${state.base_url}/count_tokens`,
+//                 to_json(#{ model: model, messages: [#{ role: "user", content: text }] }),
+//                 auth_headers(state),
+//             ));
+//             resp.input_tokens
+//         } catch {
+//             count_tokens_heuristic(text, "openai")
+//         }
+//     }
 fn count_tokens(state, text, model) {
     count_tokens_heuristic(text, "openai")
 }

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -37,7 +37,6 @@ fallback_order = ["anthropic/claude-sonnet-5", "openai/gpt-5.4-mini"]
 max_concurrent_inferences = 8
 max_concurrent_tools = 8
 default_max_iterations = 50
-exact_token_counting = false
 stream_inference = true
 script_shell_timeout_secs = 60
 stall_timeout_secs = 60

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -122,10 +122,6 @@
           "minimum": 1,
           "default": 50
         },
-        "exact_token_counting": {
-          "type": "boolean",
-          "default": false
-        },
         "stream_inference": {
           "type": "boolean",
           "default": true,

--- a/perf-tools/mock.py
+++ b/perf-tools/mock.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""A stateless OpenAI-compatible mock provider for driving a real daemon.
+"""A stateless OpenAI- and Anthropic-compatible mock provider for driving a real daemon.
 
 Usage:
     mock.py PORT                         # every turn answers "done"
@@ -12,10 +12,19 @@ the agent. The tool call is returned until `messages` carries a `role: "tool"`
 entry, then the reply is plain text and the run completes.
 
 Routes:
-    GET  /v1/models          one model, "mock-1"
+    GET  /v1/models          two models, "mock-1" and "claude-mock"
     POST /v1/chat/completions  JSON or SSE, depending on `stream`
-    GET  /count              how many completions were served (probe counter)
-    POST /reset              zero the counter
+    POST /v1/messages        the Anthropic shape of the same answer (JSON only;
+                             point the harness at it with `stream_inference = false`)
+    POST /v1/messages/count_tokens  Anthropic's count endpoint: `input_tokens`
+                             is the request text's bytes over four
+    GET  /count              how many completions and how many token counts
+                             were served (probe counters)
+    POST /reset              zero the counters
+
+The count tally is what makes the context-window guard measurable from the
+outside: a run whose request is under half the model's window must show zero
+count calls, and one above it exactly one per inference.
 """
 import json
 import sys
@@ -43,7 +52,37 @@ def tool_calls(streaming):
         calls.append(call)
     return calls
 CALLS = [0]
+COUNTS = [0]
 USAGE = {"prompt_tokens": 12, "completion_tokens": 3, "total_tokens": 15}
+
+
+def anthropic_text(req):
+    """Every piece of text an Anthropic-shaped request carries, for the count."""
+    parts = []
+    system = req.get("system", "")
+    if isinstance(system, list):
+        parts.extend(b.get("text", "") for b in system)
+    else:
+        parts.append(system or "")
+    for m in req.get("messages", []):
+        content = m.get("content", "")
+        if isinstance(content, list):
+            parts.extend(b.get("text", "") or b.get("content", "") or "" for b in content if isinstance(b, dict))
+        else:
+            parts.append(content or "")
+    return "\n".join(str(p) for p in parts)
+
+
+def anthropic_seen_tool(req):
+    """Whether any message carries a `tool_result` block, the Anthropic way of
+    saying a tool has already answered."""
+    for m in req.get("messages", []):
+        content = m.get("content", "")
+        if isinstance(content, list) and any(
+            isinstance(b, dict) and b.get("type") == "tool_result" for b in content
+        ):
+            return True
+    return False
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -60,15 +99,26 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path.startswith("/count"):
-            return self._json({"count": CALLS[0]})
-        return self._json({"object": "list", "data": [{"id": "mock-1", "object": "model"}]})
+            return self._json({"count": CALLS[0], "token_counts": COUNTS[0]})
+        # Both providers read `data[].id`; the Anthropic one only routes to a
+        # model its listing carried, so the Claude-shaped id has to be here.
+        return self._json({"object": "list", "data": [
+            {"id": "mock-1", "object": "model"},
+            {"id": "claude-mock", "object": "model", "display_name": "Claude Mock"},
+        ], "has_more": False})
 
     def do_POST(self):
         if self.path.startswith("/reset"):
             CALLS[0] = 0
+            COUNTS[0] = 0
             return self._json({"ok": True})
         n = int(self.headers.get("content-length", "0"))
         req = json.loads(self.rfile.read(n) or b"{}")
+        if self.path.startswith("/v1/messages/count_tokens"):
+            COUNTS[0] += 1
+            return self._json({"input_tokens": len(anthropic_text(req)) // 4})
+        if self.path.startswith("/v1/messages"):
+            return self._anthropic(req)
         CALLS[0] += 1
         seen_tool = any(m.get("role") == "tool" for m in req.get("messages", []))
         want_tool = TOOL is not None and not seen_tool
@@ -86,6 +136,25 @@ class Handler(BaseHTTPRequestHandler):
             finish = "stop"
         self._json({"id": "c1", "object": "chat.completion", "model": "mock-1", "usage": USAGE,
                     "choices": [{"index": 0, "finish_reason": finish, "message": message}]})
+
+    def _anthropic(self, req):
+        """The Anthropic Messages shape of the same decision, always buffered."""
+        CALLS[0] += 1
+        want_tool = TOOL is not None and not anthropic_seen_tool(req)
+        if want_tool:
+            content = [
+                {"type": "tool_use", "id": f"toolu_{i + 1}", "name": TOOL,
+                 "input": json.loads(c["function"]["arguments"])}
+                for i, c in enumerate(tool_calls(streaming=False))
+            ]
+            stop = "tool_use"
+        else:
+            content = [{"type": "text", "text": "done"}]
+            stop = "end_turn"
+        self._json({"id": "msg_1", "type": "message", "role": "assistant",
+                    "model": req.get("model", "mock-1"), "content": content,
+                    "stop_reason": stop,
+                    "usage": {"input_tokens": 12, "output_tokens": 3}})
 
     def _sse(self, want_tool):
         if want_tool:


### PR DESCRIPTION
Phase 6 of the plan, approved as a behaviour change: exact token counting is always on, `[limits] exact_token_counting` is gone.

## What a user sees

- Every inference lane (main, transition choice, compaction, title) measures its request before sending when the calibrated estimate plus `max_tokens` is at or above half the model's window, and refuses one that would overflow with `TokenLimitExceeded` instead of letting the provider reject it. Below that line nothing is counted, so small turns cost nothing extra.
- A `config.toml` that still sets `exact_token_counting` gets the existing unknown-key warning (`limits.exact_token_counting`). Note for this machine: `~/.leviath/config.toml` here has `exact_token_counting = true`, so `lev` will warn once until the line is removed.
- `lev validate` reports, per Rhai provider, whether the script defines `count_tokens` or is guarded by the byte estimate.

## How

- `inference_bridge::guard_context_window(provider, request, calibration) -> Result<Option<usize>>`: zero window means no guard; estimate via `PromptCalibration`; skip under `max / 2`; otherwise `count_tokens` and compare. Called from the main job (inside its cancel/timeout scope, before the retry loop), the compaction bridge (inside its deadline), the title bridge and the transition-choice job. A refusal feeds its measured count back into the calibration; a measured success is already fed by the response's `prompt_tokens`.
- Providers: Anthropic and Gemini count calls go through the provider's rate limiter first (a 429 backs it off the same way as `infer`) and over a process-wide pooled side-call client (`pool_max_idle_per_host(2)`, 30 s idle, same timeout and redirect policy) instead of a fresh TLS handshake per count. OpenAI's tiktoken count moves to `spawn_blocking` above 256 KiB. Ollama keeps the heuristic: its documented API has no tokenize endpoint. The circuit breaker lives in the runtime (`ProviderCircuits`) and is checked at dispatch, so a count is never attempted on an open circuit, and a refusal does not trip it.
- Rhai script contract unchanged (`count_tokens(state, text, model)`); `rhai-providers.md` and `groq.rhai` gain a remote-count example.
- Wizard limits form loses the row; docs, schema and example TOML updated; CHANGELOG Breaking entry under Unreleased.

## Fail-first

Written and run against the old code before the change:
- `the_compaction_lane_refuses_an_overflowing_request`, `the_title_lane_refuses_an_overflowing_request`: the request was sent and answered (panicked on `expect_err`).
- `the_count_call_goes_through_the_rate_limiter` (Anthropic, and the Gemini twin): the second count returned instantly instead of being held.
- `a_config_that_still_sets_exact_token_counting_is_warned_about`: `unknown_config_keys` returned nothing while the field existed.
- The main-lane tests could not compile against the old job shape; they pass now.

## Measured

Release `lev` through `perf-tools/harness.sh`, native Anthropic provider pointed at `perf-tools/mock.py` (which gained `/v1/messages`, `/v1/messages/count_tokens` and a count tally), probe agent, streaming off, titling off:

| window | result | count calls |
|---|---|---|
| 200,000 | complete, 4 inferences | 0 |
| 4,096 | complete, 4 inferences | 0 (request + 1,024 reply budget sits just under the 2,048 line) |
| 2,048 | complete, 4 inferences | 4, one per inference |

## Gates

runtime 1634, providers 952, cli 4047 tests green; clippy and rustdoc `-D warnings`; `xtask structure`, `xtask docs`; coverage 100% on runtime, providers and cli.
