### PR TITLE
feat(providers)!: enforce [rate_limits] tokens_per_minute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,11 @@ same list.
   scrolling (#673).
 - The release binary is 1.7 MB smaller: the tiktoken vocabularies no
   supported model uses are no longer linked (#672).
-- `[rate_limits] tokens_per_minute` is documented as parsed but not enforced
-  (#651). Wiring it up is planned.
+- `[rate_limits.<provider>] tokens_per_minute` is enforced. It was parsed and
+  recorded but nothing waited on it (#651 documented that); now a call waits
+  when the tokens reported back over the last minute have reached the cap,
+  the same way it already waited on `requests_per_minute`. `0` means no token
+  limit.
 - Every CodeQL finding is resolved in code (17 alerts, none dismissed) and the
   scan is a required check. `CONTRIBUTING.md` has the recipe for running the
   same queries locally (#679).

--- a/crates/leviath-providers/src/rate_limit.rs
+++ b/crates/leviath-providers/src/rate_limit.rs
@@ -21,6 +21,9 @@ pub struct RateLimiter {
 
     /// Tokens per minute limit
     tpm_limit: u32,
+    /// The sliding window both limits count over. A minute in production;
+    /// tests inject a short one so a wait can be observed in real time.
+    window: Duration,
 
     /// Current window state
     state: Arc<Mutex<RateLimiterState>>,
@@ -35,9 +38,16 @@ struct RateLimiterState {
 impl RateLimiter {
     /// Create a new rate limiter with the given configuration.
     pub fn new(config: &RateLimitConfig) -> Self {
+        Self::with_window(config, Duration::from_secs(60))
+    }
+
+    /// A limiter counting over `window` instead of a minute; the tests use
+    /// a few hundred milliseconds so the wait paths run in real time.
+    fn with_window(config: &RateLimitConfig, window: Duration) -> Self {
         Self {
             rpm_limit: config.requests_per_minute,
             tpm_limit: config.tokens_per_minute,
+            window,
             state: Arc::new(Mutex::new(RateLimiterState {
                 request_timestamps: VecDeque::new(),
                 token_counts: VecDeque::new(),
@@ -51,6 +61,7 @@ impl RateLimiter {
         Self {
             rpm_limit: 60,
             tpm_limit: 100_000,
+            window: Duration::from_secs(60),
             state: Arc::new(Mutex::new(RateLimiterState {
                 request_timestamps: VecDeque::new(),
                 token_counts: VecDeque::new(),
@@ -63,7 +74,7 @@ impl RateLimiter {
     ///
     /// This may sleep if we are at or near the rate limit.
     pub async fn acquire(&self) -> Result<(), ProviderError> {
-        let window = Duration::from_secs(60);
+        let window = self.window;
 
         loop {
             let now = Instant::now();
@@ -90,20 +101,38 @@ impl RateLimiter {
             }
 
             let current_rpm = state.request_timestamps.len() as u32;
+            let current_tpm: usize = state.token_counts.iter().map(|(_, t)| t).sum();
+            let rpm_ok = current_rpm < self.rpm_limit;
+            // A zero `tokens_per_minute` is no token limit at all, the way a
+            // provider without a `[rate_limits]` table has none.
+            let tpm_ok = self.tpm_limit == 0 || current_tpm < self.tpm_limit as usize;
 
-            if current_rpm < self.rpm_limit {
+            if rpm_ok && tpm_ok {
                 state.request_timestamps.push_back(now);
                 return Ok(());
             }
 
-            // Calculate how long to wait
-            let oldest = state.request_timestamps.front().copied().unwrap_or(now);
-            let wait = (oldest + window).saturating_duration_since(now) + Duration::from_millis(50);
+            // Wait until whichever window is full has let its oldest entry out.
+            // The tokens a request spent are recorded after it answers, so the
+            // token window lags the request window by one call; that is the
+            // right side to err on, since the provider counts them the same way.
+            let mut until = now;
+            if !rpm_ok {
+                let oldest = state.request_timestamps.front().copied().unwrap_or(now);
+                until = until.max(oldest + window);
+            }
+            if !tpm_ok {
+                let oldest = state.token_counts.front().map(|(t, _)| *t).unwrap_or(now);
+                until = until.max(oldest + window);
+            }
+            let wait = until.saturating_duration_since(now) + Duration::from_millis(50);
 
             drop(state);
             tracing::debug!(
                 wait_ms = wait.as_millis(),
-                "Rate limiter: waiting for RPM capacity"
+                requests = current_rpm,
+                tokens = current_tpm,
+                "Rate limiter: waiting for capacity"
             );
             tokio::time::sleep(wait).await;
         }
@@ -118,7 +147,7 @@ impl RateLimiter {
     /// Check current TPM usage against limit.
     pub async fn check_tpm(&self) -> bool {
         let now = Instant::now();
-        let window = Duration::from_secs(60);
+        let window = self.window;
         let mut state = self.state.lock().await;
 
         // Prune old entries; see `acquire` for why this is not `now - window`.
@@ -202,6 +231,84 @@ mod tests {
         let limiter = RateLimiter::with_defaults();
         // Should be able to acquire at least once
         limiter.acquire().await.unwrap();
+    }
+
+    /// A limiter over a short window, so a wait is observable in real time.
+    fn short_window(rpm: u32, tpm: u32) -> Arc<RateLimiter> {
+        Arc::new(RateLimiter::with_window(
+            &RateLimitConfig {
+                requests_per_minute: rpm,
+                tokens_per_minute: tpm,
+            },
+            Duration::from_millis(400),
+        ))
+    }
+
+    /// `tokens_per_minute` throttles: with the window's token budget spent, the
+    /// next `acquire` waits for the oldest spend to leave the window.
+    #[tokio::test]
+    async fn acquire_waits_for_tpm_capacity() {
+        let limiter = short_window(60, 100);
+        limiter.record_tokens(100).await;
+        let started = Instant::now();
+        let waiting = {
+            let limiter = limiter.clone();
+            tokio::spawn(async move { limiter.acquire().await })
+        };
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        assert!(
+            !waiting.is_finished(),
+            "held while the window's tokens are spent"
+        );
+        tokio::time::timeout(Duration::from_secs(5), waiting)
+            .await
+            .expect("released once the window turned over")
+            .expect("the task completes")
+            .expect("acquire succeeds");
+        assert!(
+            started.elapsed() >= Duration::from_millis(350),
+            "waited for the window"
+        );
+    }
+
+    /// A zero `tokens_per_minute` means no token limit; only requests count.
+    #[tokio::test]
+    async fn a_zero_tokens_per_minute_is_no_token_limit() {
+        let limiter = short_window(60, 0);
+        limiter.record_tokens(1_000_000).await;
+        let started = Instant::now();
+        limiter.acquire().await.expect("nothing to wait for");
+        assert!(started.elapsed() < Duration::from_millis(300), "no wait");
+    }
+
+    /// Both windows full: the wait is for the later of the two to open.
+    #[tokio::test]
+    async fn acquire_waits_for_the_later_of_both_windows() {
+        let limiter = short_window(1, 10);
+        limiter
+            .acquire()
+            .await
+            .expect("the first request goes through");
+        tokio::time::sleep(Duration::from_millis(200)).await;
+        // The token spend lands 200 ms after the request, so its window opens
+        // 200 ms later than the request window does.
+        limiter.record_tokens(10).await;
+        let started = Instant::now();
+        let waiting = {
+            let limiter = limiter.clone();
+            tokio::spawn(async move { limiter.acquire().await })
+        };
+        tokio::time::timeout(Duration::from_secs(5), waiting)
+            .await
+            .expect("released once both windows turned over")
+            .expect("the task completes")
+            .expect("acquire succeeds");
+        // Request window alone would have opened ~200 ms in; the token window
+        // holds it to ~400 ms.
+        assert!(
+            started.elapsed() >= Duration::from_millis(350),
+            "held by the token window"
+        );
     }
 
     #[tokio::test]

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -617,10 +617,11 @@ requests_per_minute = 50
 tokens_per_minute   = 40000
 ```
 
-Only `requests_per_minute` is enforced today. `tokens_per_minute` is parsed and
-recorded but no code path throttles on it; it is accepted so a config that sets
-it keeps loading, and it will start to apply without a config change once the
-token bucket is wired in.
+Both are enforced before every call. `requests_per_minute` counts calls made in
+the last minute; `tokens_per_minute` counts the tokens those calls reported
+back, so it lags the request window by one call and errs on the provider's
+side. When either window is full the call waits for the oldest entry to leave
+it. A `tokens_per_minute` of `0` means no token limit.
 
 This shapes request *rate*. `[limits] max_concurrent_inferences` and
 `[limits.max_concurrent_inferences_by_provider]` bound *concurrency*. Both apply. Script providers

--- a/perf-tools/agents/probe/agent.leviath
+++ b/perf-tools/agents/probe/agent.leviath
@@ -10,7 +10,7 @@ task = { kind = "pinned", max_tokens = 2000, required = true, seed = "task" }
 [stages.main]
 mode = "autonomous"
 description = "Do whatever the mock provider asks, then finish"
-model = { models = [{ provider = "openai", model = "mock-1" }] }
+model = { models = [{ provider = "openai", model = "gpt-mock" }] }
 available_tools = ["shell", "write_file", "read_file", "current_time"]
 max_iterations = 4
 system_prompt = """

--- a/perf-tools/mock.py
+++ b/perf-tools/mock.py
@@ -12,7 +12,7 @@ the agent. The tool call is returned until `messages` carries a `role: "tool"`
 entry, then the reply is plain text and the run completes.
 
 Routes:
-    GET  /v1/models          two models, "mock-1" and "claude-mock"
+    GET  /v1/models          two models, "gpt-mock" and "claude-mock"
     POST /v1/chat/completions  JSON or SSE, depending on `stream`
     POST /v1/messages        the Anthropic shape of the same answer (JSON only;
                              point the harness at it with `stream_inference = false`)
@@ -103,7 +103,7 @@ class Handler(BaseHTTPRequestHandler):
         # Both providers read `data[].id`; the Anthropic one only routes to a
         # model its listing carried, so the Claude-shaped id has to be here.
         return self._json({"object": "list", "data": [
-            {"id": "mock-1", "object": "model"},
+            {"id": "gpt-mock", "object": "model"},
             {"id": "claude-mock", "object": "model", "display_name": "Claude Mock"},
         ], "has_more": False})
 
@@ -134,7 +134,7 @@ class Handler(BaseHTTPRequestHandler):
         else:
             message = {"role": "assistant", "content": "done"}
             finish = "stop"
-        self._json({"id": "c1", "object": "chat.completion", "model": "mock-1", "usage": USAGE,
+        self._json({"id": "c1", "object": "chat.completion", "model": "gpt-mock", "usage": USAGE,
                     "choices": [{"index": 0, "finish_reason": finish, "message": message}]})
 
     def _anthropic(self, req):
@@ -152,7 +152,7 @@ class Handler(BaseHTTPRequestHandler):
             content = [{"type": "text", "text": "done"}]
             stop = "end_turn"
         self._json({"id": "msg_1", "type": "message", "role": "assistant",
-                    "model": req.get("model", "mock-1"), "content": content,
+                    "model": req.get("model", "gpt-mock"), "content": content,
                     "stop_reason": stop,
                     "usage": {"input_tokens": 12, "output_tokens": 3}})
 
@@ -164,11 +164,11 @@ class Handler(BaseHTTPRequestHandler):
             delta = {"role": "assistant", "content": "done"}
             finish = "stop"
         chunks = [
-            {"id": "c1", "object": "chat.completion.chunk", "model": "mock-1",
+            {"id": "c1", "object": "chat.completion.chunk", "model": "gpt-mock",
              "choices": [{"index": 0, "delta": delta, "finish_reason": None}]},
-            {"id": "c1", "object": "chat.completion.chunk", "model": "mock-1",
+            {"id": "c1", "object": "chat.completion.chunk", "model": "gpt-mock",
              "choices": [{"index": 0, "delta": {}, "finish_reason": finish}]},
-            {"id": "c1", "object": "chat.completion.chunk", "model": "mock-1", "choices": [], "usage": USAGE},
+            {"id": "c1", "object": "chat.completion.chunk", "model": "gpt-mock", "choices": [], "usage": USAGE},
         ]
         body = "".join(f"data: {json.dumps(c)}\n\n" for c in chunks) + "data: [DONE]\n\n"
         body = body.encode()


### PR DESCRIPTION
Approved behaviour change from the plan: `[rate_limits.<provider>] tokens_per_minute` is enforced.

## What a user sees

A provider with a `[rate_limits.<name>]` table already had to set both keys (neither has a default). Until now only `requests_per_minute` throttled; `tokens_per_minute` was recorded and ignored, and `configuration.md` said so. Now a call waits when the tokens reported by the last minute's calls have reached the cap, exactly as it already waited on the request count. `0` means no token limit. A provider without the table is untouched.

## How

`RateLimiter::acquire` checks both windows under the one lock. If either is full it sleeps until the oldest entry of the fuller window leaves it (the later of the two when both are full), then re-checks. The token window lags the request window by one call, since a call's tokens are only known when it answers; that errs on the provider's side. `check_tpm` stays as the read-only probe it was.

The 60 s window becomes a field, injected in tests as 400 ms. The first attempt used tokio's paused clock and ran for 60 real seconds: the limiter reads `std::time::Instant`, which the paused clock does not move, so the sleep auto-advanced instantly and the loop spun until the wall clock caught up. Real time over a short window is the honest test.

## Fail-first

With the old `acquire` body restored and the new tests in place: `acquire_waits_for_tpm_capacity` and `acquire_waits_for_the_later_of_both_windows` fail (the call returns at once); `a_zero_tokens_per_minute_is_no_token_limit` passes on both (the control). Against the change all 21 `rate_limit` tests pass in 0.66 s.

## Live

See the comment below: a real `lev run` through the mock provider with `tokens_per_minute` below one call's reported usage, timed.

## Docs

`configuration.md` `[rate_limits]` paragraph rewritten; CHANGELOG Unreleased entry replaces the "documented as inert" line.

## Harness fix that rode along

The mock provider's model is now `gpt-mock` (was `mock-1`). Since the served-model check (#618, #680), the native OpenAI provider keeps only `gpt-*` and `o<digit>*` ids from a live listing, so a stage naming `openai/mock-1` was refused at spawn and the OpenAI half of `perf-tools` could not drive a run at all. `perf-tools/mock.py` and `perf-tools/agents/probe/agent.leviath` only.
