### PR TITLE
refactor(providers)!: narrow what nothing outside the crate uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@ same list.
   count calls on Anthropic and Gemini now reuse a pooled connection and go
   through the provider's rate limiter; OpenAI's local tiktoken count moves off
   the async threads above 256 KB.
+- For embedders of `leviath-providers`: `RateLimiter::with_defaults` is
+  removed (build one with `RateLimiter::new(&RateLimitConfig { .. })`). The
+  `openai_compat`, `text_tools` and `debug_http` modules, and
+  `provider::{json_number, parse_tool_arguments, parse_openai_finish_reason,
+  check_http_response, decode_json}` are crate-private;
+  `tokenizer::approximate_count` is private (`count_tokens` still reaches it).
 
 ### Fixed
 

--- a/crates/leviath-providers/src/claude_code.rs
+++ b/crates/leviath-providers/src/claude_code.rs
@@ -6,7 +6,7 @@
 //! The CLI is driven as a *relay*, not as an agent: its own tools, settings
 //! files, MCP servers and slash commands are all switched off, Leviath's
 //! assembled system blocks become the entire system prompt, and tool calling
-//! rides the text protocol in [`crate::text_tools`]. Leviath keeps ownership of
+//! rides the text protocol in `text_tools`. Leviath keeps ownership of
 //! the context window, the tool loop, and the iteration count.
 //!
 //! **Flags that matter, and why:**

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -14,19 +14,19 @@ pub mod anthropic;
 pub mod capabilities;
 pub mod claude_code;
 #[cfg(feature = "debug-http")]
-pub mod debug_http;
+pub(crate) mod debug_http;
 pub mod failure;
 pub mod gemini;
 pub mod learned;
 pub mod ollama;
 pub mod openai;
-pub mod openai_compat;
+pub(crate) mod openai_compat;
 pub mod openrouter;
 pub mod pricing;
 pub mod provider;
 pub mod rate_limit;
 pub mod rhai_provider;
-pub mod text_tools;
+pub(crate) mod text_tools;
 pub mod tokenizer;
 
 #[cfg(test)]

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -3312,7 +3312,10 @@ mod tests {
         // branch, including the `if let Some(limiter)` reset_backoff call.
         let url = spawn_ok_server().await;
         let client = reqwest::Client::new();
-        let limiter = crate::rate_limit::RateLimiter::with_defaults();
+        let limiter = crate::rate_limit::RateLimiter::new(&crate::provider::RateLimitConfig {
+            requests_per_minute: 60,
+            tokens_per_minute: 100_000,
+        });
         let body = serde_json::json!({ "model": "x" });
         let resp = send_chat_request(
             &client,

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -540,7 +540,7 @@ pub struct SystemBlock {
 /// the same `f32`, so `0.7f32` prints "0.7". Parsing that as `f64` gets the
 /// number the blueprint author actually wrote, without imposing a fixed
 /// precision on someone who wanted `0.125`.
-pub fn json_number(value: f32) -> serde_json::Value {
+pub(crate) fn json_number(value: f32) -> serde_json::Value {
     // `f32::Display` always produces a decimal that parses back, including for
     // the non-finite values, so the fallback is the same number rather than a
     // branch nothing reaches.
@@ -934,7 +934,7 @@ pub trait Provider: Send + Sync {
 ///
 /// Used by both the OpenAI and OpenRouter providers which share the same
 /// Chat Completions API response schema.
-pub fn parse_openai_finish_reason(reason: &str) -> FinishReason {
+pub(crate) fn parse_openai_finish_reason(reason: &str) -> FinishReason {
     match reason {
         "stop" => FinishReason::Complete,
         "tool_calls" => FinishReason::ToolCall,
@@ -959,7 +959,7 @@ pub fn parse_openai_finish_reason(reason: &str) -> FinishReason {
 /// off the same way, five times in a row, before the stage gave up. A string
 /// where an object should be fails schema validation, and the runtime reads
 /// the string shape as "this call was cut off" and says so back to the model.
-pub fn parse_tool_arguments(raw: &str) -> serde_json::Value {
+pub(crate) fn parse_tool_arguments(raw: &str) -> serde_json::Value {
     let raw = raw.trim();
     if raw.is_empty() {
         return serde_json::Value::Object(serde_json::Map::new());
@@ -1023,7 +1023,7 @@ pub(crate) fn retry_after_secs(headers: &reqwest::header::HeaderMap) -> Option<u
 /// - On 2xx: returns `Ok(response)` so the caller can read the body.
 ///
 /// Pass the full `reqwest::Response`; it is returned back on success.
-pub async fn check_http_response(
+pub(crate) async fn check_http_response(
     response: reqwest::Response,
     limiter: Option<&crate::rate_limit::RateLimiter>,
 ) -> Result<reqwest::Response> {
@@ -1086,7 +1086,9 @@ pub async fn check_http_response(
 /// because a dead socket was being reported as malformed JSON. The streaming
 /// path already drew this line correctly (see `openai_compat::stream_chat`);
 /// this is the buffered path drawing the same one.
-pub async fn decode_json<T: serde::de::DeserializeOwned>(response: reqwest::Response) -> Result<T> {
+pub(crate) async fn decode_json<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+) -> Result<T> {
     let bytes = response
         .bytes()
         .await

--- a/crates/leviath-providers/src/rate_limit.rs
+++ b/crates/leviath-providers/src/rate_limit.rs
@@ -56,20 +56,6 @@ impl RateLimiter {
         }
     }
 
-    /// Create a rate limiter with default limits.
-    pub fn with_defaults() -> Self {
-        Self {
-            rpm_limit: 60,
-            tpm_limit: 100_000,
-            window: Duration::from_secs(60),
-            state: Arc::new(Mutex::new(RateLimiterState {
-                request_timestamps: VecDeque::new(),
-                token_counts: VecDeque::new(),
-                consecutive_429s: 0,
-            })),
-        }
-    }
-
     /// Wait until we are allowed to make a request, then record it.
     ///
     /// This may sleep if we are at or near the rate limit.
@@ -227,8 +213,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn with_defaults_has_sensible_values() {
-        let limiter = RateLimiter::with_defaults();
+    async fn a_fresh_limiter_admits_the_first_request() {
+        let limiter = RateLimiter::new(&RateLimitConfig {
+            requests_per_minute: 60,
+            tokens_per_minute: 100_000,
+        });
         // Should be able to acquire at least once
         limiter.acquire().await.unwrap();
     }
@@ -446,8 +435,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn with_defaults_rpm_and_tpm() {
-        let limiter = RateLimiter::with_defaults();
+    async fn new_copies_rpm_and_tpm_from_the_config() {
+        let limiter = RateLimiter::new(&RateLimitConfig {
+            requests_per_minute: 60,
+            tokens_per_minute: 100_000,
+        });
         assert_eq!(limiter.rpm_limit, 60);
         assert_eq!(limiter.tpm_limit, 100_000);
     }

--- a/crates/leviath-providers/src/text_tools.rs
+++ b/crates/leviath-providers/src/text_tools.rs
@@ -21,7 +21,8 @@
 use crate::provider::{ContentBlock, Message, MessageContent, Tool};
 
 /// Info string of the fenced block carrying tool calls.
-pub const FENCE_TAG: &str = "leviath-tool-calls";
+#[cfg(test)]
+pub(crate) const FENCE_TAG: &str = "leviath-tool-calls";
 
 /// The opening fence, as it appears in text.
 const FENCE_OPEN: &str = "```leviath-tool-calls";

--- a/crates/leviath-providers/src/tokenizer.rs
+++ b/crates/leviath-providers/src/tokenizer.rs
@@ -85,7 +85,7 @@ fn approximate_count_gemini(text: &str) -> usize {
 ///
 /// Uses the common heuristic of ~4 characters per token, which is reasonably
 /// accurate for English text with GPT-style tokenizers.
-pub fn approximate_count(text: &str) -> usize {
+fn approximate_count(text: &str) -> usize {
     leviath_core::estimate_tokens(text)
 }
 


### PR DESCRIPTION
Phase 7.1 of the plan: `leviath-providers` keeps public only what something outside the crate uses. No behaviour change.

## Narrowed to `pub(crate)`

`openai_compat`, `text_tools`, `debug_http` modules; `provider::{json_number, parse_tool_arguments, parse_openai_finish_reason, check_http_response, decode_json}`; `tokenizer::approximate_count` (module-private; `count_tokens` still uses it as the fallback); `text_tools::FENCE_TAG` is test-only. Each was grepped across every workspace crate first.

## Removed

`RateLimiter::with_defaults` (tests only; the three tests that used it now build a `RateLimiter::new(&RateLimitConfig { .. })`).

## Kept, and why the audit was wrong

- No `ProviderError` arms deleted: there is no `error.rs` in this crate (the enum is in `provider.rs`), and every one of its eight variants is constructed in production or matched on by `leviath-runtime` / `leviath-cli` (`ClientBuild` in `commands/models.rs`, `TokenLimitExceeded` in `inference_bridge.rs`, `Other` at 39 sites). `pub enum` variants never trigger `dead_code`, so the grep was the real test.
- `ValidationError::Blueprint` lives in `leviath-core`, not here; untouched.

One rustdoc link to the now-private `text_tools` became a code span. CHANGELOG Unreleased carries the Breaking entry in the same style as the `leviath-scripting` one.

## Gates

lib-only `cargo check` clean (with and without `debug-http`); `cargo check --workspace --all-targets`; clippy and rustdoc `-D warnings`; `xtask structure`, `xtask docs`; coverage 100% on `leviath-providers` (949 tests).
