### PR TITLE
test: one MCP stub server, a FakeProvider builder and shared fixtures

### DIFF
--- a/crates/leviath-cli/src/commands/context.rs
+++ b/crates/leviath-cli/src/commands/context.rs
@@ -102,6 +102,7 @@ fn format_time(secs: i64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::fixtures;
     use leviath_core::run_meta::{ContextSnapshot, RegionEntrySnapshot, RegionSnapshot, RunMeta};
 
     fn point(stage: &str, tokens: usize, entries: Vec<&str>) -> RunPoint {
@@ -202,15 +203,7 @@ mod tests {
                         world_id: "w".to_string(),
                         created_at: 0,
                     },
-                    meta: Box::new(RunMeta::new(
-                        run_id.to_string(),
-                        "a".to_string(),
-                        "/p".to_string(),
-                        "t".to_string(),
-                        None,
-                        "/w".to_string(),
-                        1,
-                    )),
+                    meta: Box::new(fixtures::run_meta(run_id)),
                 },
             )
             .unwrap();

--- a/crates/leviath-cli/src/commands/ctl.rs
+++ b/crates/leviath-cli/src/commands/ctl.rs
@@ -335,6 +335,7 @@ pub async fn respond(client: &ControlClient, args: &RespondArgs) -> anyhow::Resu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::fixtures;
     use leviath_runtime::control_socket::{ControlId, bind_control_listener, control_id};
     use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
     use tokio::task::JoinHandle;
@@ -568,15 +569,7 @@ mod tests {
     fn seed_live_run(run_id: &str) {
         crate::runstate::create_run(&crate::runstate::RunMeta {
             status: crate::runstate::RunStatus::Running,
-            ..crate::runstate::RunMeta::new(
-                run_id.into(),
-                "a".into(),
-                "/p".into(),
-                "t".into(),
-                None,
-                "/w".into(),
-                1,
-            )
+            ..fixtures::run_meta(run_id)
         })
         .unwrap();
     }
@@ -640,15 +633,7 @@ mod tests {
         crate::runstate::with_isolated_runs_dir_async("ctl-force-terminal", |_base| async {
             crate::runstate::create_run(&crate::runstate::RunMeta {
                 status: crate::runstate::RunStatus::Complete,
-                ..crate::runstate::RunMeta::new(
-                    "done-1".into(),
-                    "a".into(),
-                    "/p".into(),
-                    "t".into(),
-                    None,
-                    "/w".into(),
-                    1,
-                )
+                ..fixtures::run_meta("done-1")
             })
             .unwrap();
 

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -1085,6 +1085,7 @@ impl Dashboard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::fixtures;
     use crossterm::event::{KeyEvent, KeyModifiers};
     use tokio::sync::mpsc;
 
@@ -3468,15 +3469,7 @@ mod tests {
         dash.update_display_indices();
         dash.detail_view = true;
         let points = vec![leviath_core::run_archive::RunPoint {
-            meta: leviath_core::run_meta::RunMeta::new(
-                "run-1".to_string(),
-                "a".to_string(),
-                "/p".to_string(),
-                "t".to_string(),
-                None,
-                "/w".to_string(),
-                1,
-            ),
+            meta: fixtures::run_meta("run-1"),
             context: leviath_core::run_meta::ContextSnapshot {
                 stage_name: "s".to_string(),
                 total_tokens: 0,

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -908,6 +908,7 @@ impl Dashboard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::fixtures;
 
     use crate::commands::dashboard::test_support::make_test_dashboard;
     // Only the tests speak the control protocol now: the polling itself moved
@@ -1128,15 +1129,7 @@ mod tests {
                     world_id: "w".to_string(),
                     created_at: 0,
                 },
-                meta: Box::new(leviath_core::run_meta::RunMeta::new(
-                    run_id.to_string(),
-                    "a".to_string(),
-                    "/p".to_string(),
-                    "t".to_string(),
-                    None,
-                    "/w".to_string(),
-                    1,
-                )),
+                meta: Box::new(fixtures::run_meta(run_id)),
             },
         )
         .unwrap();
@@ -1227,15 +1220,7 @@ mod tests {
         static LOADS: AtomicUsize = AtomicUsize::new(0);
         fn counting_loader(_run_id: &str) -> Vec<leviath_core::run_archive::RunPoint> {
             LOADS.fetch_add(1, Ordering::SeqCst);
-            let mut meta = leviath_core::run_meta::RunMeta::new(
-                "run-1".to_string(),
-                "a".to_string(),
-                "/p".to_string(),
-                "t".to_string(),
-                None,
-                "/w".to_string(),
-                1,
-            );
+            let mut meta = fixtures::run_meta("run-1");
             meta.current_stage = "main".to_string();
             let point = |at: i64| leviath_core::run_archive::RunPoint {
                 meta: meta.clone(),
@@ -1282,15 +1267,7 @@ mod tests {
     #[test]
     fn a_run_switch_invalidates_the_cache_and_the_browsed_point() {
         fn one_point_loader(_run_id: &str) -> Vec<leviath_core::run_archive::RunPoint> {
-            let meta = leviath_core::run_meta::RunMeta::new(
-                "x".to_string(),
-                "a".to_string(),
-                "/p".to_string(),
-                "t".to_string(),
-                None,
-                "/w".to_string(),
-                1,
-            );
+            let meta = fixtures::run_meta("x");
             vec![leviath_core::run_archive::RunPoint {
                 meta,
                 context: leviath_core::run_meta::ContextSnapshot {

--- a/crates/leviath-cli/src/commands/test.rs
+++ b/crates/leviath-cli/src/commands/test.rs
@@ -510,7 +510,7 @@ fn truncate_str(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::{with_tracing, write_test_agent};
+    use crate::test_support::{fixtures, with_tracing, write_test_agent};
 
     // ─── validate_test_case ────────────────────────────────────────────────
 
@@ -1296,9 +1296,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
     // which covers the same assertion/response-handling logic without any
     // I/O.
 
-    use leviath_providers::{
-        FinishReason, InferenceRequest, InferenceResponse, Provider, TokenUsage, ToolCall,
-    };
+    use leviath_providers::{InferenceRequest, InferenceResponse, Provider, ToolCall};
 
     /// A mock provider that returns a fixed canned response, entirely in
     /// memory - no network calls, no subprocess spawning.
@@ -1314,17 +1312,8 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             _request: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             Ok(InferenceResponse {
-                content: self.content.clone(),
                 tool_calls: self.tool_calls.clone(),
-                tokens_used: TokenUsage {
-                    prompt_tokens: 1,
-                    completion_tokens: 1,
-                    total_tokens: 2,
-                    cached_tokens: 0,
-                    cache_write_tokens: 0,
-                    reported_cost_usd: None,
-                },
-                finish_reason: FinishReason::Complete,
+                ..fixtures::inference_response(&self.content)
             })
         }
 
@@ -1355,19 +1344,7 @@ model = { provider = "anthropic", model = "claude-sonnet-4-6" }
             &self,
             _request: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
-            Ok(InferenceResponse {
-                content: "cold hello".to_string(),
-                tool_calls: vec![],
-                tokens_used: TokenUsage {
-                    prompt_tokens: 1,
-                    completion_tokens: 1,
-                    total_tokens: 2,
-                    cached_tokens: 0,
-                    cache_write_tokens: 0,
-                    reported_cost_usd: None,
-                },
-                finish_reason: FinishReason::Complete,
-            })
+            Ok(fixtures::inference_response("cold hello"))
         }
 
         async fn count_tokens(&self, text: &str, _model: &str) -> usize {
@@ -1467,19 +1444,7 @@ max_tokens = 5000
             request: &InferenceRequest,
         ) -> leviath_providers::Result<InferenceResponse> {
             *self.seen.lock().unwrap() = Some(request.clone());
-            Ok(InferenceResponse {
-                content: "recorded".to_string(),
-                tool_calls: vec![],
-                tokens_used: TokenUsage {
-                    prompt_tokens: 1,
-                    completion_tokens: 1,
-                    total_tokens: 2,
-                    cached_tokens: 0,
-                    cache_write_tokens: 0,
-                    reported_cost_usd: None,
-                },
-                finish_reason: FinishReason::Complete,
-            })
+            Ok(fixtures::inference_response("recorded"))
         }
 
         async fn count_tokens(&self, text: &str, _model: &str) -> usize {

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -254,20 +254,16 @@ fn discover_worker(agents_dir: Option<&Path>, query: &str) -> Result<PathBuf, St
 mod tests {
     use super::*;
     use crate::config::Config;
-    use leviath_core::blueprint::WorkerFailurePolicy;
+    use crate::test_support::{FakeProvider, fixtures};
 
     fn cfg(stage: Option<&str>, agent: Option<&str>, query: Option<&str>) -> FanOutConfig {
         FanOutConfig {
             worker_agent: agent.map(String::from),
             worker_stage: stage.map(String::from),
             worker_query: query.map(String::from),
-            merge_stage: None,
             max_workers: 4,
-            on_worker_failure: WorkerFailurePolicy::Continue,
             split_prompt: "split".to_string(),
-            results_region: None,
-            max_items: None,
-            max_attempts: None,
+            ..fixtures::fanout_config()
         }
     }
 
@@ -365,27 +361,10 @@ mod tests {
     use std::collections::HashMap;
     use tokio::runtime::Handle;
 
-    struct FakeProvider;
-    #[async_trait::async_trait]
-    impl leviath_providers::Provider for FakeProvider {
-        async fn infer(
-            &self,
-            _r: &leviath_providers::InferenceRequest,
-        ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
-            Err(leviath_providers::ProviderError::Other("test".to_string()))
-        }
-        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
-            1
-        }
-        fn max_context_tokens(&self, _m: &str) -> usize {
-            100_000
-        }
-        fn name(&self) -> &str {
-            "fake"
-        }
-        fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
-            leviath_providers::ModelCapabilities::default()
-        }
+    /// Fails every inference; the window is wide enough for the budgets
+    /// the manifests here declare.
+    fn fake_provider() -> FakeProvider {
+        FakeProvider::new().context_window(100_000)
     }
 
     /// A two-stage blueprint whose second stage opts in as a fan-out worker.
@@ -485,7 +464,7 @@ mod tests {
     ) -> (PipelineWorld, DaemonFanOutSpawner, Entity) {
         let cli = Arc::new(CliToolService::new());
         let mut registry = leviath_runtime::ProviderRegistry::new();
-        registry.register("anthropic".to_string(), Arc::new(FakeProvider));
+        registry.register("anthropic".to_string(), Arc::new(fake_provider()));
         let mut world = PipelineWorld::new(
             registry,
             cli.clone(),
@@ -786,7 +765,7 @@ mod tests {
     #[tokio::test]
     async fn fake_provider_metadata_is_exercised() {
         use leviath_providers::Provider;
-        let p = FakeProvider;
+        let p = fake_provider();
         assert_eq!(p.name(), "fake");
         assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 100_000);
@@ -796,21 +775,8 @@ mod tests {
     #[tokio::test]
     async fn fake_provider_infer_errors() {
         use leviath_providers::Provider;
-        let p = FakeProvider;
-        assert!(
-            p.infer(&leviath_providers::InferenceRequest {
-                system: vec![],
-                messages: vec![],
-                model: "m".to_string(),
-                max_tokens: 1,
-                temperature: 0.0,
-                tools: vec![],
-                extra: serde_json::Value::Null,
-                request_timeout_secs: None,
-            })
-            .await
-            .is_err()
-        );
+        let p = fake_provider();
+        assert!(p.infer(&fixtures::inference_request()).await.is_err());
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -507,27 +507,20 @@ pub(crate) fn parse_blueprint_mcp_servers(manifest_toml: &str) -> Vec<MCPServerC
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::with_tracing;
+    use crate::test_support::{McpStub, with_tracing};
 
     /// A minimal stdio MCP server (python3) speaking initialize / tools/list /
     /// tools/call - mirrors the fixtures in `tools.rs`.
-    const STUB: &str = r#"
-import sys, json
-def respond(i, r):
-    sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":i,"result":r})+"\n"); sys.stdout.flush()
-for line in sys.stdin:
-    line=line.strip()
-    if not line: continue
-    req=json.loads(line); m=req.get("method",""); i=req.get("id")
-    if m=="initialize": respond(i,{"capabilities":{"tools":{"listChanged":True}},"protocolVersion":"2024-11-05"})
-    elif m=="notifications/initialized": pass
-    elif m=="tools/list": respond(i,{"tools":[{"name":"echo","description":"e","inputSchema":{"type":"object","properties":{}}}]})
-    elif m=="tools/call": respond(i,{"content":[{"type":"text","text":"ok"}],"isError":False})
-    else: respond(i,{})
-"#;
+    fn stub() -> McpStub {
+        McpStub::new()
+            .list_changed(true)
+            .tool("echo", Some("e"))
+            .input_schema(r#"{"type": "object", "properties": {}}"#)
+            .replying("ok")
+    }
 
     fn stub_config(name: &str) -> MCPServerConfig {
-        MCPServerConfig::stdio(name, "python3", vec!["-c".to_string(), STUB.to_string()])
+        MCPServerConfig::stdio(name, "python3", vec!["-c".to_string(), stub().source()])
     }
 
     fn pool() -> McpPool {
@@ -707,7 +700,7 @@ for line in sys.stdin:
     fn stub_py() -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("stub.py");
-        std::fs::write(&path, STUB).unwrap();
+        std::fs::write(&path, stub().source()).unwrap();
         (dir, path)
     }
 

--- a/crates/leviath-cli/src/daemon/recovery.rs
+++ b/crates/leviath-cli/src/daemon/recovery.rs
@@ -540,6 +540,7 @@ fn reload_one(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::{FakeProvider, fixtures};
     // Named here rather than inherited from the parent: production now spells
     // these seven as one `SpawnDeps`, so importing them above would mean seven
     // imports the module itself does not use.
@@ -563,34 +564,15 @@ mod tests {
         tokio::sync::mpsc::unbounded_channel().0
     }
 
-    struct FakeProvider;
-    #[async_trait::async_trait]
-    impl leviath_providers::Provider for FakeProvider {
-        async fn infer(
-            &self,
-            _r: &leviath_providers::InferenceRequest,
-        ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
-            Err(leviath_providers::ProviderError::Other("t".to_string()))
-        }
-        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
-            1
-        }
-        fn max_context_tokens(&self, _m: &str) -> usize {
-            1000
-        }
-        fn name(&self) -> &str {
-            "fake"
-        }
-        fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
-            leviath_providers::ModelCapabilities::default()
-        }
+    fn fake_provider() -> FakeProvider {
+        FakeProvider::new().failing("t")
     }
 
     fn test_world() -> (PipelineWorld, Arc<CliToolService>) {
         let cli = Arc::new(CliToolService::new());
         let mut registry = ProviderRegistry::new();
         for p in ["anthropic", "openai", "ollama"] {
-            registry.register(p.to_string(), Arc::new(FakeProvider));
+            registry.register(p.to_string(), Arc::new(fake_provider()));
         }
         let world = PipelineWorld::new(
             registry,
@@ -863,15 +845,7 @@ mod tests {
     #[test]
     fn a_descriptor_without_its_sidecar_restores_nothing() {
         let dir = tempfile::tempdir().unwrap();
-        let mut meta = RunMeta::new(
-            "run-1".to_string(),
-            "a".to_string(),
-            "/p".to_string(),
-            "t".to_string(),
-            None,
-            "/w".to_string(),
-            1,
-        );
+        let mut meta = fixtures::run_meta("run-1");
 
         // No descriptor at all.
         assert!(crate::runstate::read_final_output_in(dir.path(), &meta).is_none());
@@ -1781,7 +1755,7 @@ mod tests {
 
     #[tokio::test]
     async fn resumes_a_parent_parked_mid_fan_out() {
-        use leviath_core::blueprint::{FanOutConfig, WorkerFailurePolicy};
+        use leviath_core::blueprint::FanOutConfig;
         use leviath_runtime::fanout::{FanOutState, FanOutWaiting};
 
         let agent = agent_dir();
@@ -1800,16 +1774,8 @@ mod tests {
         let state = FanOutState {
             origin: leviath_runtime::fanout::FanOutOrigin::Stage,
             config: FanOutConfig {
-                worker_agent: None,
                 worker_stage: Some("w".to_string()),
-                worker_query: None,
-                merge_stage: None,
-                max_workers: 1,
-                on_worker_failure: WorkerFailurePolicy::Continue,
-                split_prompt: "s".to_string(),
-                results_region: None,
-                max_items: None,
-                max_attempts: None,
+                ..fixtures::fanout_config()
             },
             max_workers: 1,
             pending: vec![],
@@ -2386,25 +2352,12 @@ mod tests {
     #[tokio::test]
     async fn fake_provider_methods_are_exercised() {
         use leviath_providers::Provider;
-        let p = FakeProvider;
+        let p = fake_provider();
         assert_eq!(p.name(), "fake");
         assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
-        assert!(
-            p.infer(&leviath_providers::InferenceRequest {
-                system: vec![],
-                messages: vec![],
-                model: "m".to_string(),
-                max_tokens: 1,
-                temperature: 0.0,
-                tools: vec![],
-                extra: serde_json::Value::Null,
-                request_timeout_secs: None,
-            })
-            .await
-            .is_err()
-        );
+        assert!(p.infer(&fixtures::inference_request()).await.is_err());
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -774,6 +774,7 @@ fn per_agent_mcp_defs(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::McpStub;
     use leviath_runtime::components::AgentStatus;
     use leviath_runtime::host::{ControlOp, SpawnArgs};
     use tokio::sync::oneshot;
@@ -1171,24 +1172,12 @@ mod tests {
     fn stub_server_py() -> (tempfile::TempDir, std::path::PathBuf) {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("stub.py");
-        std::fs::write(
-            &path,
-            r#"
-import sys, json
-def respond(i, r):
-    sys.stdout.write(json.dumps({"jsonrpc":"2.0","id":i,"result":r})+"\n"); sys.stdout.flush()
-for line in sys.stdin:
-    line=line.strip()
-    if not line: continue
-    req=json.loads(line); m=req.get("method",""); i=req.get("id")
-    if m=="initialize": respond(i,{"capabilities":{"tools":{"listChanged":True}},"protocolVersion":"2024-11-05"})
-    elif m=="notifications/initialized": pass
-    elif m=="tools/list": respond(i,{"tools":[{"name":"stub_search","description":"s","inputSchema":{"type":"object","properties":{}}}]})
-    elif m=="tools/call": respond(i,{"content":[{"type":"text","text":"ok"}],"isError":False})
-    else: respond(i,{})
-"#,
-        )
-        .unwrap();
+        let stub = McpStub::new()
+            .list_changed(true)
+            .tool("stub_search", Some("s"))
+            .input_schema(r#"{"type": "object", "properties": {}}"#)
+            .replying("ok");
+        std::fs::write(&path, stub.source()).unwrap();
         (dir, path)
     }
 

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -775,6 +775,7 @@ fn per_agent_mcp_defs(
 mod tests {
     use super::*;
     use crate::test_support::McpStub;
+    use crate::test_support::{FakeProvider, fixtures};
     use leviath_runtime::components::AgentStatus;
     use leviath_runtime::host::{ControlOp, SpawnArgs};
     use tokio::sync::oneshot;
@@ -841,27 +842,8 @@ mod tests {
         assert!(tool_service.take(with_meta.entity()).is_none());
     }
 
-    struct FakeProvider;
-    #[async_trait::async_trait]
-    impl leviath_providers::Provider for FakeProvider {
-        async fn infer(
-            &self,
-            _r: &leviath_providers::InferenceRequest,
-        ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
-            Err(leviath_providers::ProviderError::Other("test".to_string()))
-        }
-        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
-            1
-        }
-        fn max_context_tokens(&self, _m: &str) -> usize {
-            1000
-        }
-        fn name(&self) -> &str {
-            "fake"
-        }
-        fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
-            leviath_providers::ModelCapabilities::default()
-        }
+    fn fake_provider() -> FakeProvider {
+        FakeProvider::new()
     }
 
     #[test]
@@ -1601,7 +1583,7 @@ system_prompt = "x"
         let manifest = blueprint_with_mcp(agent_dir.path(), &stub);
         // A `fake` provider so stage resolution succeeds.
         let mut providers = ProviderRegistry::new();
-        providers.register("fake".to_string(), Arc::new(FakeProvider));
+        providers.register("fake".to_string(), Arc::new(fake_provider()));
         let runs = tempfile::tempdir().unwrap();
         let mut host = build_host(HostParts {
             config: Config::default(),
@@ -1651,25 +1633,12 @@ system_prompt = "x"
     #[tokio::test]
     async fn fake_provider_methods_are_exercised() {
         use leviath_providers::Provider;
-        let p = FakeProvider;
+        let p = fake_provider();
         assert_eq!(p.name(), "fake");
         assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
-        assert!(
-            p.infer(&leviath_providers::InferenceRequest {
-                system: vec![],
-                messages: vec![],
-                model: "m".to_string(),
-                max_tokens: 1,
-                temperature: 0.0,
-                tools: vec![],
-                extra: serde_json::Value::Null,
-                request_timeout_secs: None,
-            })
-            .await
-            .is_err()
-        );
+        assert!(p.infer(&fixtures::inference_request()).await.is_err());
     }
 
     #[tokio::test]
@@ -1679,7 +1648,7 @@ system_prompt = "x"
         std::fs::write(&manifest, crate::test_support::inline_coder_manifest()).unwrap();
 
         let mut registry = ProviderRegistry::new();
-        registry.register("anthropic".to_string(), Arc::new(FakeProvider));
+        registry.register("anthropic".to_string(), Arc::new(fake_provider()));
         let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
 
         let runs = tempfile::tempdir().unwrap();
@@ -1794,7 +1763,7 @@ system_prompt = "x"
         .unwrap();
 
         let mut registry = ProviderRegistry::new();
-        registry.register("anthropic".to_string(), Arc::new(FakeProvider));
+        registry.register("anthropic".to_string(), Arc::new(fake_provider()));
         let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
         let mut host = build_host(HostParts {
             config: Config::default(),
@@ -1832,7 +1801,7 @@ system_prompt = "x"
 
         let runs = tempfile::tempdir().unwrap();
         let mut registry = ProviderRegistry::new();
-        registry.register("anthropic".to_string(), Arc::new(FakeProvider));
+        registry.register("anthropic".to_string(), Arc::new(fake_provider()));
         let mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
         let mut host = build_host(HostParts {
             config: Config::default(),

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -933,6 +933,7 @@ fn build_agent_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::{FakeProvider, fixtures};
     use leviath_core::blueprint::ModelConfig;
     use leviath_runtime::ProviderRegistry;
     use leviath_runtime::world::PipelineWorld;
@@ -1194,34 +1195,13 @@ system = { kind = "pinned", max_tokens = 1000 }
     fn registry_with(providers: &[&str]) -> ProviderRegistry {
         let mut r = ProviderRegistry::new();
         for p in providers {
-            r.register(p.to_string(), Arc::new(FakeProvider));
+            r.register(p.to_string(), Arc::new(fake_provider()));
         }
         r
     }
 
-    struct FakeProvider;
-    #[async_trait::async_trait]
-    impl leviath_providers::Provider for FakeProvider {
-        async fn infer(
-            &self,
-            _r: &leviath_providers::InferenceRequest,
-        ) -> leviath_providers::Result<leviath_providers::InferenceResponse> {
-            Err(leviath_providers::ProviderError::Other(
-                "test provider".to_string(),
-            ))
-        }
-        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
-            1
-        }
-        fn max_context_tokens(&self, _m: &str) -> usize {
-            1000
-        }
-        fn name(&self) -> &str {
-            "fake"
-        }
-        fn capabilities(&self, _m: &str) -> leviath_providers::ModelCapabilities {
-            leviath_providers::ModelCapabilities::default()
-        }
+    fn fake_provider() -> FakeProvider {
+        FakeProvider::new().failing("test provider")
     }
 
     // ── build_agent (full spawn from a manifest) ──
@@ -2879,25 +2859,12 @@ system = { kind = "pinned", max_tokens = 1000 }
 
     #[tokio::test]
     async fn fake_provider_methods_are_exercised() {
-        let p = FakeProvider;
+        let p = fake_provider();
         assert_eq!(p.name(), "fake");
         assert_eq!(p.count_tokens("t", "m").await, 1);
         assert_eq!(p.max_context_tokens("m"), 1000);
         let _ = p.capabilities("m");
-        assert!(
-            p.infer(&leviath_providers::InferenceRequest {
-                system: vec![],
-                messages: vec![],
-                model: "m".to_string(),
-                max_tokens: 1,
-                temperature: 0.0,
-                tools: vec![],
-                extra: serde_json::Value::Null,
-                request_timeout_secs: None,
-            })
-            .await
-            .is_err()
-        );
+        assert!(p.infer(&fixtures::inference_request()).await.is_err());
     }
 
     // ── [read_paths] policy resolution ────────────────────────────────────

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -784,6 +784,7 @@ impl ToolService for CliToolService {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::McpStub;
     use leviath_core::interaction::{ApprovalScope, InteractionResponse};
     use leviath_runtime::interaction_hub::InteractionHub;
     use leviath_runtime::pipeline::noop_progress;
@@ -2840,48 +2841,22 @@ mod tests {
 
     // ── MCP execution branches (real python3 JSON-RPC stub) ──
 
-    const MCP_STUB_SUCCESS: &str = r#"
-import sys, json
-def respond(id_, result):
-    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": id_, "result": result}) + "\n")
-    sys.stdout.flush()
-for line in sys.stdin:
-    line = line.strip()
-    if not line: continue
-    req = json.loads(line); method = req.get("method", ""); id_ = req.get("id")
-    if method == "initialize":
-        respond(id_, {"capabilities": {"tools": {"listChanged": False}}, "protocolVersion": "2024-11-05"})
-    elif method == "tools/list":
-        respond(id_, {"tools": [{"name": "stub_mcp_tool", "description": "s", "inputSchema": {"type": "object", "properties": {}}}]})
-    elif method == "tools/call":
-        respond(id_, {"content": [{"type": "text", "text": "ok result"}], "isError": False})
-    elif method != "notifications/initialized" and method != "notifications/cancelled":
-        respond(id_, {})
-"#;
+    /// One tool, `stub_mcp_tool`, whose reply the caller picks.
+    fn mcp_stub() -> McpStub {
+        McpStub::new()
+            .list_changed(false)
+            .tool("stub_mcp_tool", Some("s"))
+            .input_schema(r#"{"type": "object", "properties": {}}"#)
+    }
 
     /// Returns a tool *execution* error. The error flag's wire name is
     /// `isError`, and the stub must spell it exactly that way: a stub writing
     /// `is_error` against a client reading the same wrong name agrees with
     /// itself, so the bug stays invisible here while every real server's tool
     /// errors are reported to the model as successes.
-    const MCP_STUB_ERROR: &str = r#"
-import sys, json
-def respond(id_, result):
-    sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": id_, "result": result}) + "\n")
-    sys.stdout.flush()
-for line in sys.stdin:
-    line = line.strip()
-    if not line: continue
-    req = json.loads(line); method = req.get("method", ""); id_ = req.get("id")
-    if method == "initialize":
-        respond(id_, {"capabilities": {"tools": {"listChanged": False}}, "protocolVersion": "2024-11-05"})
-    elif method == "tools/list":
-        respond(id_, {"tools": [{"name": "stub_mcp_tool", "description": "s", "inputSchema": {"type": "object", "properties": {}}}]})
-    elif method == "tools/call":
-        respond(id_, {"content": [{"type": "text", "text": "boom"}], "isError": True})
-    elif method != "notifications/initialized" and method != "notifications/cancelled":
-        respond(id_, {})
-"#;
+    fn mcp_error_stub() -> McpStub {
+        mcp_stub().replying_error("boom")
+    }
 
     async fn mcp_with_stub(stub: &str) -> leviath_mcp::ToolExecutor {
         let mut client = leviath_mcp::MCPClient::spawn("python3", &["-c", stub], &HashMap::new())
@@ -2961,7 +2936,11 @@ for line in sys.stdin:
         let hub = InteractionHub::new();
         let mut allow = HashMap::new();
         allow.insert("stub__stub_mcp_tool".to_string(), ToolPolicy::Allow);
-        let state = state_with(&hub, mcp_with_stub(MCP_STUB_SUCCESS).await, allow);
+        let state = state_with(
+            &hub,
+            mcp_with_stub(&mcp_stub().replying("ok result").source()).await,
+            allow,
+        );
         let out = dispatch_tools(
             state,
             vec![call("c1", "stub__stub_mcp_tool", serde_json::json!({}))],
@@ -2976,7 +2955,7 @@ for line in sys.stdin:
         let hub = InteractionHub::new();
         let mut allow = HashMap::new();
         allow.insert("stub__stub_mcp_tool".to_string(), ToolPolicy::Allow);
-        let state = state_with(&hub, mcp_with_stub(MCP_STUB_ERROR).await, allow);
+        let state = state_with(&hub, mcp_with_stub(&mcp_error_stub().source()).await, allow);
         let out = dispatch_tools(
             state,
             vec![call("c1", "stub__stub_mcp_tool", serde_json::json!({}))],

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -2878,11 +2878,11 @@ mod tests {
     /// and the call, so the fast server's calls run while the slow one waits.
     #[tokio::test]
     async fn a_batch_across_two_mcp_servers_is_as_slow_as_its_slowest_call() {
-        let slow_stub = MCP_STUB_SUCCESS.replace(
+        let slow_stub = mcp_stub().replying("ok result").source().replace(
             "    elif method == \"tools/call\":\n",
             "    elif method == \"tools/call\":\n        import time; time.sleep(1.5)\n",
         );
-        let mut executor = mcp_with_stub(MCP_STUB_SUCCESS).await;
+        let mut executor = mcp_with_stub(&mcp_stub().replying("ok result").source()).await;
         // Two slow servers: two 1.5 s calls that can only overlap when the lock
         // is per server. One slow call beside fast ones takes ~1.5 s whether
         // the calls serialise or not, and proves nothing.

--- a/crates/leviath-cli/src/lib.rs
+++ b/crates/leviath-cli/src/lib.rs
@@ -27,6 +27,8 @@ pub(crate) mod render;
 pub mod runstate;
 pub(crate) mod shell_keys;
 #[cfg(test)]
+mod test_fixtures;
+#[cfg(test)]
 mod test_support;
 pub(crate) mod tool_inventory;
 pub(crate) mod tools;

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -1021,6 +1021,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::fixtures;
 
     /// `run_id` arrives from URL segments on `GET /api/agents/{id}/logs` and
     /// friends. `Path::join` neither normalizes `..` nor resists an absolute
@@ -1291,15 +1292,7 @@ mod tests {
 
     #[test]
     fn run_meta_touch_updates_timestamp() {
-        let mut meta = RunMeta::new(
-            "r".into(),
-            "a".into(),
-            "/p".into(),
-            "t".into(),
-            None,
-            "/w".into(),
-            1,
-        );
+        let mut meta = fixtures::run_meta("r");
         let before = meta.updated_at;
         // Touch should update (or at least not decrease) updated_at
         meta.touch();
@@ -1501,15 +1494,7 @@ mod tests {
             assert!(read_final_output("no-such-run").is_none());
 
             // A run with no answer recorded.
-            let meta = RunMeta::new(
-                "run-silent".to_string(),
-                "a".to_string(),
-                "/p".to_string(),
-                "t".to_string(),
-                None,
-                "/w".to_string(),
-                1,
-            );
+            let meta = fixtures::run_meta("run-silent");
             create_run(&meta).expect("run dir");
             assert!(read_final_output("run-silent").is_none());
 
@@ -1522,15 +1507,7 @@ mod tests {
                 "present".to_string(),
                 42,
             );
-            let mut claimed = RunMeta::new(
-                "run-claimed".to_string(),
-                "a".to_string(),
-                "/p".to_string(),
-                "t".to_string(),
-                None,
-                "/w".to_string(),
-                1,
-            );
+            let mut claimed = fixtures::run_meta("run-claimed");
             claimed.final_output = Some(answer.descriptor());
             create_run(&claimed).expect("run dir");
             assert!(read_final_output("run-claimed").is_none());
@@ -1740,15 +1717,7 @@ mod tests {
             std::fs::create_dir_all(run_dir(run_id)).unwrap();
             let mut buf = Vec::new();
             run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
-            let meta = RunMeta::new(
-                run_id.to_string(),
-                "a".to_string(),
-                "/p".to_string(),
-                "t".to_string(),
-                None,
-                "/w".to_string(),
-                1,
-            );
+            let meta = fixtures::run_meta(run_id);
             run_archive::write_record(
                 &mut buf,
                 &RunRecord::Header {
@@ -2213,15 +2182,7 @@ mod tests {
         use leviath_core::run_archive::{self, RunIdentity, RunRecord};
         let mut buf = Vec::new();
         run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
-        let meta = RunMeta::new(
-            run_id.to_string(),
-            "a".to_string(),
-            "/p".to_string(),
-            "t".to_string(),
-            None,
-            "/w".to_string(),
-            1,
-        );
+        let meta = fixtures::run_meta(run_id);
         run_archive::write_record(
             &mut buf,
             &RunRecord::Header {
@@ -2268,15 +2229,7 @@ mod tests {
             std::fs::create_dir_all(run_dir(run_id)).unwrap();
             let mut buf = Vec::new();
             run_archive::write_archive_start(&mut buf, run_archive::RUN_ARCHIVE_VERSION).unwrap();
-            let mut meta = RunMeta::new(
-                run_id.to_string(),
-                "a".to_string(),
-                "/p".to_string(),
-                "t".to_string(),
-                None,
-                "/w".to_string(),
-                1,
-            );
+            let mut meta = fixtures::run_meta(run_id);
             meta.callback_url = Some("https://example.invalid/hook".to_string());
             meta.callback_secret = Some("super-secret-signing-key".to_string());
             run_archive::write_record(
@@ -3227,15 +3180,7 @@ mod tests {
         let dir = base.join(run_id);
         let meta = RunMeta {
             status,
-            ..RunMeta::new(
-                run_id.into(),
-                "a".into(),
-                "/p".into(),
-                "t".into(),
-                None,
-                "/w".into(),
-                1,
-            )
+            ..fixtures::run_meta(run_id)
         };
         create_run_in(&dir, &meta).unwrap();
         dir

--- a/crates/leviath-cli/src/test_fixtures.rs
+++ b/crates/leviath-cli/src/test_fixtures.rs
@@ -1,0 +1,252 @@
+//! A configurable fake `Provider` and the value shapes this crate's tests
+//! build by hand, each written once.
+//!
+//! These live here rather than in `leviath-testkit` on purpose: `leviath-core`
+//! and `leviath-providers` dev-depend on testkit, so a testkit that depended
+//! on them would close a dev-dependency cycle, and that cycle makes rustc see
+//! two copies of `leviath_core` inside core's own test build (it stopped
+//! core's tests compiling when tried). Every consumer of these is in this
+//! crate, so nothing is lost by keeping them crate-local.
+
+use async_trait::async_trait;
+use leviath_providers::{
+    InferenceRequest, InferenceResponse, ModelCapabilities, Provider, ProviderError, Result,
+};
+
+/// A `Provider` that does exactly what a test tells it to and nothing else.
+///
+/// Four daemon test modules each carried a unit-struct fake whose `infer`
+/// failed with a fixed message, counted every text as one token and answered
+/// a fixed context window. They were one shape with different constants, so
+/// the constants are builder methods here.
+#[derive(Clone, Debug)]
+pub(crate) struct FakeProvider {
+    name: String,
+    reply: std::result::Result<String, String>,
+    models: Vec<String>,
+    context_window: usize,
+}
+
+impl Default for FakeProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl FakeProvider {
+    /// Named `fake`, failing every `infer` with `test`, serving no models
+    /// beyond what the default capability table says, with a 1000-token
+    /// context window.
+    pub(crate) fn new() -> Self {
+        Self {
+            name: "fake".to_string(),
+            reply: Err("test".to_string()),
+            models: Vec::new(),
+            context_window: 1000,
+        }
+    }
+
+    /// What [`Provider::name`] answers.
+    pub(crate) fn named(mut self, name: &str) -> Self {
+        self.name = name.to_string();
+        self
+    }
+
+    /// Every `infer` succeeds with this text (see
+    /// [`fixtures::inference_response`] for the rest of the response).
+    pub(crate) fn replying(mut self, text: &str) -> Self {
+        self.reply = Ok(text.to_string());
+        self
+    }
+
+    /// Every `infer` fails with [`ProviderError::Other`] carrying this
+    /// message.
+    pub(crate) fn failing(mut self, error: &str) -> Self {
+        self.reply = Err(error.to_string());
+        self
+    }
+
+    /// Publish a served catalogue: [`Provider::serves_model`] answers a key
+    /// that names one of these, and [`Provider::served_catalog`] lists them.
+    pub(crate) fn serving(mut self, models: &[&str]) -> Self {
+        self.models = models.iter().map(|m| (*m).to_string()).collect();
+        self
+    }
+
+    /// What [`Provider::max_context_tokens`] answers for every model.
+    pub(crate) fn context_window(mut self, tokens: usize) -> Self {
+        self.context_window = tokens;
+        self
+    }
+}
+
+#[async_trait]
+impl Provider for FakeProvider {
+    async fn infer(&self, _request: &InferenceRequest) -> Result<InferenceResponse> {
+        match &self.reply {
+            Ok(text) => Ok(fixtures::inference_response(text)),
+            Err(error) => Err(ProviderError::Other(error.clone())),
+        }
+    }
+
+    async fn count_tokens(&self, _text: &str, _model: &str) -> usize {
+        1
+    }
+
+    fn max_context_tokens(&self, _model: &str) -> usize {
+        self.context_window
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self, _model: &str) -> ModelCapabilities {
+        ModelCapabilities::default()
+    }
+
+    fn serves_model(&self, model_key: &str) -> Option<String> {
+        if self.models.is_empty() {
+            return self.serves_model_from_table(model_key);
+        }
+        self.models.iter().find(|m| *m == model_key).cloned()
+    }
+
+    fn served_catalog(&self) -> Option<Vec<String>> {
+        (!self.models.is_empty()).then(|| self.models.clone())
+    }
+}
+
+/// The value shapes the tests build by hand.
+///
+/// Every builder here returns exactly the literal it replaced, so a test
+/// that asserted on a field of its own hand-built value asserts on the same
+/// field of the same value now. A test that wants one field different uses
+/// struct-update syntax over the fixture.
+pub(crate) mod fixtures {
+    use leviath_core::blueprint::{FanOutConfig, WorkerFailurePolicy};
+    use leviath_core::run_meta::RunMeta;
+    use leviath_providers::{FinishReason, InferenceRequest, InferenceResponse, TokenUsage};
+
+    /// One prompt token, one completion token, nothing cached, no reported
+    /// cost.
+    pub(crate) fn token_usage() -> TokenUsage {
+        TokenUsage {
+            prompt_tokens: 1,
+            completion_tokens: 1,
+            total_tokens: 2,
+            cached_tokens: 0,
+            cache_write_tokens: 0,
+            reported_cost_usd: None,
+        }
+    }
+
+    /// An empty request for model `m` with a one-token budget: enough to
+    /// hand to a provider whose answer does not depend on what was asked.
+    pub(crate) fn inference_request() -> InferenceRequest {
+        InferenceRequest {
+            system: vec![],
+            messages: vec![],
+            model: "m".to_string(),
+            max_tokens: 1,
+            temperature: 0.0,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        }
+    }
+
+    /// A complete text reply of `content` with no tool calls, costing
+    /// [`token_usage`].
+    pub(crate) fn inference_response(content: &str) -> InferenceResponse {
+        InferenceResponse {
+            content: content.to_string(),
+            tool_calls: vec![],
+            tokens_used: token_usage(),
+            finish_reason: FinishReason::Complete,
+        }
+    }
+
+    /// A freshly started one-stage run of agent `a` (at `/p`) on task `t`
+    /// in workdir `/w`, with no model recorded.
+    pub(crate) fn run_meta(run_id: &str) -> RunMeta {
+        RunMeta::new(
+            run_id.to_string(),
+            "a".to_string(),
+            "/p".to_string(),
+            "t".to_string(),
+            None,
+            "/w".to_string(),
+            1,
+        )
+    }
+
+    /// A single-worker fan-out with no worker source, whose split prompt is
+    /// `s` and whose failed workers are skipped.
+    pub(crate) fn fanout_config() -> FanOutConfig {
+        FanOutConfig {
+            worker_agent: None,
+            worker_stage: None,
+            worker_query: None,
+            merge_stage: None,
+            max_workers: 1,
+            on_worker_failure: WorkerFailurePolicy::Continue,
+            split_prompt: "s".to_string(),
+            results_region: None,
+            max_items: None,
+            max_attempts: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn the_builder_reaches_every_answer() {
+        let p = FakeProvider::default();
+        assert_eq!(p.name(), "fake");
+        assert_eq!(p.max_context_tokens("m"), 1000);
+        assert_eq!(p.count_tokens("anything", "m").await, 1);
+        assert!(p.served_catalog().is_none());
+        // With no catalogue the default table decides, and it knows nothing
+        // about this model.
+        assert!(p.serves_model("nope").is_none());
+        let err = p.infer(&fixtures::inference_request()).await.unwrap_err();
+        assert!(err.to_string().contains("test"), "{err}");
+
+        let p = FakeProvider::new()
+            .named("mine")
+            .replying("hi")
+            .serving(&["m1", "m2"])
+            .context_window(7);
+        assert_eq!(p.name(), "mine");
+        assert_eq!(p.max_context_tokens("m"), 7);
+        assert_eq!(p.served_catalog(), Some(vec!["m1".into(), "m2".into()]));
+        assert_eq!(p.serves_model("m2").as_deref(), Some("m2"));
+        assert!(p.serves_model("nope").is_none());
+        let reply = p.infer(&fixtures::inference_request()).await.unwrap();
+        assert_eq!(reply.content, "hi");
+
+        let err = FakeProvider::new()
+            .failing("down")
+            .infer(&fixtures::inference_request())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("down"), "{err}");
+    }
+
+    #[test]
+    fn the_fixtures_are_the_literals_they_replaced() {
+        assert_eq!(fixtures::token_usage().total_tokens, 2);
+        assert_eq!(fixtures::inference_request().model, "m");
+        assert_eq!(fixtures::inference_response("x").content, "x");
+        let meta = fixtures::run_meta("r1");
+        assert_eq!(
+            (meta.run_id.as_str(), meta.agent_name.as_str()),
+            ("r1", "a")
+        );
+        assert_eq!(fixtures::fanout_config().max_workers, 1);
+    }
+}

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -3,6 +3,7 @@
 //! The tracing subscriber comes from `leviath-testkit` (one workspace-wide
 //! copy); the helpers below are CLI-specific fixtures.
 
+pub(crate) use crate::test_fixtures::{FakeProvider, fixtures};
 pub(crate) use leviath_testkit::mcp_stub::McpStub;
 pub(crate) use leviath_testkit::with_tracing;
 

--- a/crates/leviath-cli/src/test_support.rs
+++ b/crates/leviath-cli/src/test_support.rs
@@ -3,6 +3,7 @@
 //! The tracing subscriber comes from `leviath-testkit` (one workspace-wide
 //! copy); the helpers below are CLI-specific fixtures.
 
+pub(crate) use leviath_testkit::mcp_stub::McpStub;
 pub(crate) use leviath_testkit::with_tracing;
 
 /// A value whose `Serialize` impl always returns `Err`, so tests can drive the

--- a/crates/leviath-mcp/src/client.rs
+++ b/crates/leviath-mcp/src/client.rs
@@ -469,7 +469,7 @@ fn negotiated_version(echoed: Option<&Value>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::always_on_tracing_guard;
+    use crate::test_support::{always_on_tracing_guard, echo_tool_stub};
 
     // ── Additional coverage tests ──────────────────────────────────────────
 
@@ -906,36 +906,6 @@ mod tests {
         let _ = client.shutdown().await;
     }
 
-    // Python script that answers initialize then tools/list then tools/call
-    const STUB_INIT_LIST_CALL: &str = r#"
-import sys, json
-
-def respond(id, result):
-    msg = json.dumps({"jsonrpc": "2.0", "id": id, "result": result})
-    sys.stdout.write(msg + "\n")
-    sys.stdout.flush()
-
-for line in sys.stdin:
-    line = line.strip()
-    if not line:
-        continue
-    req = json.loads(line)
-    method = req.get("method", "")
-    id_ = req.get("id")
-    if method == "initialize":
-        respond(id_, {"capabilities": {"tools": {"listChanged": True}}, "protocolVersion": "2024-11-05"})
-    elif method == "notifications/initialized":
-        pass  # notification -- no response
-    elif method == "tools/list":
-        respond(id_, {"tools": [{"name": "echo", "description": "echo tool", "inputSchema": {}}]})
-    elif method == "tools/call":
-        respond(id_, {"content": [{"type": "text", "text": "hello from tool"}], "isError": False})
-    elif method == "notifications/cancelled":
-        pass
-    else:
-        respond(id_, {"error": {"code": -32601, "message": "method not found"}})
-"#;
-
     // Script that always returns a JSON-RPC error for every request
     const STUB_ERROR_SERVER: &str = r#"
 import sys, json
@@ -995,14 +965,14 @@ for line in sys.stdin:
     #[tokio::test]
     async fn test_mcp_client_spawn_succeeds() {
         let _guard = always_on_tracing_guard();
-        let _client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let _client = spawn_stub_client(&echo_tool_stub().source()).await;
         // If we got here, spawn worked
     }
 
     #[tokio::test]
     async fn test_mcp_client_connect_parses_capabilities() {
         let _guard = always_on_tracing_guard();
-        let mut client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let mut client = spawn_stub_client(&echo_tool_stub().source()).await;
         client.connect().await.expect("connect should succeed");
 
         let caps = client.capabilities().expect("should have capabilities");
@@ -1012,7 +982,7 @@ for line in sys.stdin:
 
     #[tokio::test]
     async fn test_mcp_client_capabilities_before_connect_is_none() {
-        let client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let client = spawn_stub_client(&echo_tool_stub().source()).await;
         // Before connect, capabilities should be None
         assert!(client.capabilities().is_none());
     }
@@ -1030,14 +1000,14 @@ for line in sys.stdin:
 
     #[tokio::test]
     async fn test_mcp_client_cached_tools_before_list_is_empty() {
-        let client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let client = spawn_stub_client(&echo_tool_stub().source()).await;
         assert!(client.cached_tools().is_empty());
     }
 
     #[tokio::test]
     async fn test_mcp_client_list_tools_returns_tools() {
         let _guard = always_on_tracing_guard();
-        let mut client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let mut client = spawn_stub_client(&echo_tool_stub().source()).await;
         client.connect().await.unwrap();
 
         let tools = client
@@ -1055,7 +1025,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn test_mcp_client_call_tool_returns_result() {
         let _guard = always_on_tracing_guard();
-        let mut client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let mut client = spawn_stub_client(&echo_tool_stub().source()).await;
         client.connect().await.unwrap();
         // Consume the tools/list response first
         client.list_tools().await.unwrap();
@@ -1077,7 +1047,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn test_mcp_client_shutdown_succeeds() {
         let _guard = always_on_tracing_guard();
-        let mut client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let mut client = spawn_stub_client(&echo_tool_stub().source()).await;
         client.connect().await.unwrap();
         // Shutdown should not fail even if the process is still running
         client.shutdown().await.expect("shutdown should succeed");
@@ -1588,7 +1558,7 @@ for line in sys.stdin:
 
     #[tokio::test]
     async fn protocol_version_is_none_before_connect() {
-        let client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let client = spawn_stub_client(&echo_tool_stub().source()).await;
         assert!(client.protocol_version().is_none());
     }
 
@@ -1613,7 +1583,7 @@ for line in sys.stdin:
     async fn set_refresher_on_stdio_is_a_noop() {
         // stdio has no bearer, so the transport's default no-op handles it; this
         // drives MCPClient::set_refresher and the default trait method.
-        let mut client = spawn_stub_client(STUB_INIT_LIST_CALL).await;
+        let mut client = spawn_stub_client(&echo_tool_stub().source()).await;
         client.set_refresher(std::sync::Arc::new(NoopRefresher));
     }
 
@@ -1635,11 +1605,8 @@ for line in sys.stdin:
     #[tokio::test]
     async fn from_config_builds_the_stdio_transport() {
         let _guard = always_on_tracing_guard();
-        let config = MCPServerConfig::stdio(
-            "s",
-            "python3",
-            vec!["-c".into(), STUB_INIT_LIST_CALL.into()],
-        );
+        let config =
+            MCPServerConfig::stdio("s", "python3", vec!["-c".into(), echo_tool_stub().source()]);
         let mut client = MCPClient::from_config(&config)
             .await
             .expect("stdio config should connect");

--- a/crates/leviath-mcp/src/discovery.rs
+++ b/crates/leviath-mcp/src/discovery.rs
@@ -270,7 +270,7 @@ impl Default for ToolDiscovery {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_support::always_on_tracing_guard;
+    use crate::test_support::{McpStub, always_on_tracing_guard, echo_tool_stub};
 
     // --- configured credentials ---
 
@@ -392,37 +392,16 @@ mod tests {
     // Same Python-backed JSON-RPC stub approach used in client.rs's tests
     // (a minimal in-process server reading one request per line from stdin).
 
-    const STUB_INIT_AND_LIST: &str = r#"
-import sys, json
-
-def respond(id, result):
-    msg = json.dumps({"jsonrpc": "2.0", "id": id, "result": result})
-    sys.stdout.write(msg + "\n")
-    sys.stdout.flush()
-
-for line in sys.stdin:
-    line = line.strip()
-    if not line:
-        continue
-    req = json.loads(line)
-    method = req.get("method", "")
-    id_ = req.get("id")
-    if method == "initialize":
-        respond(id_, {"capabilities": {"tools": {"listChanged": True}}, "protocolVersion": "2024-11-05"})
-    elif method == "notifications/initialized":
-        pass
-    elif method == "tools/list":
-        respond(id_, {"tools": [{"name": "echo", "description": "echo tool", "inputSchema": {}}]})
-    else:
-        respond(id_, {"error": {"code": -32601, "message": "method not found"}})
-"#;
-
     #[tokio::test]
     async fn discover_from_client_returns_tools_and_indexes_by_server_name() {
         let _guard = always_on_tracing_guard();
-        let mut client = MCPClient::spawn("python3", &["-c", STUB_INIT_AND_LIST], &HashMap::new())
-            .await
-            .expect("failed to spawn stub server");
+        let mut client = MCPClient::spawn(
+            "python3",
+            &["-c", &echo_tool_stub().source()],
+            &HashMap::new(),
+        )
+        .await
+        .expect("failed to spawn stub server");
         client.connect().await.expect("connect should succeed");
 
         let mut discovery = ToolDiscovery::new();
@@ -441,7 +420,7 @@ for line in sys.stdin:
         let config = MCPServerConfig {
             name: "configured-server".to_string(),
             command: Some("python3".to_string()),
-            args: vec!["-c".to_string(), STUB_INIT_AND_LIST.to_string()],
+            args: vec!["-c".to_string(), echo_tool_stub().source()],
             env: HashMap::new(),
             ..Default::default()
         };
@@ -477,69 +456,18 @@ for line in sys.stdin:
         assert_eq!(discovery.server_count(), 0);
     }
 
-    /// Responds with a JSON-RPC error to "initialize", so `connect()` fails.
-    const STUB_INIT_ERRORS: &str = r#"
-import sys, json
-
-def respond(id, result=None, error=None):
-    msg = {"jsonrpc": "2.0", "id": id}
-    if error is not None:
-        msg["error"] = error
-    else:
-        msg["result"] = result
-    sys.stdout.write(json.dumps(msg) + "\n")
-    sys.stdout.flush()
-
-for line in sys.stdin:
-    line = line.strip()
-    if not line:
-        continue
-    req = json.loads(line)
-    method = req.get("method", "")
-    id_ = req.get("id")
-    if method == "initialize":
-        respond(id_, error={"code": -32000, "message": "initialize failed"})
-    else:
-        respond(id_, error={"code": -32601, "message": "method not found"})
-"#;
-
     /// Initializes successfully but responds with a JSON-RPC error to
     /// "tools/list", so `list_tools()` (and therefore `discover_from_client`)
     /// fails.
-    const STUB_INIT_OK_LIST_ERRORS: &str = r#"
-import sys, json
-
-def respond(id, result=None, error=None):
-    msg = {"jsonrpc": "2.0", "id": id}
-    if error is not None:
-        msg["error"] = error
-    else:
-        msg["result"] = result
-    sys.stdout.write(json.dumps(msg) + "\n")
-    sys.stdout.flush()
-
-for line in sys.stdin:
-    line = line.strip()
-    if not line:
-        continue
-    req = json.loads(line)
-    method = req.get("method", "")
-    id_ = req.get("id")
-    if method == "initialize":
-        respond(id_, {"capabilities": {}, "protocolVersion": "2024-11-05"})
-    elif method == "notifications/initialized":
-        pass
-    elif method == "tools/list":
-        respond(id_, error={"code": -32000, "message": "listing failed"})
-    else:
-        respond(id_, error={"code": -32601, "message": "method not found"})
-"#;
+    fn list_errors_stub() -> McpStub {
+        McpStub::new().list_fails("listing failed")
+    }
 
     #[tokio::test]
     async fn discover_from_client_list_tools_error_propagates() {
         let mut client = MCPClient::spawn(
             "python3",
-            &["-c", STUB_INIT_OK_LIST_ERRORS],
+            &["-c", &list_errors_stub().source()],
             &HashMap::new(),
         )
         .await
@@ -557,7 +485,10 @@ for line in sys.stdin:
         let config = MCPServerConfig {
             name: "server1".to_string(),
             command: Some("python3".to_string()),
-            args: vec!["-c".to_string(), STUB_INIT_ERRORS.to_string()],
+            args: vec![
+                "-c".to_string(),
+                McpStub::new().init_fails("initialize failed").source(),
+            ],
             env: HashMap::new(),
             ..Default::default()
         };
@@ -573,7 +504,7 @@ for line in sys.stdin:
         let config = MCPServerConfig {
             name: "server1".to_string(),
             command: Some("python3".to_string()),
-            args: vec!["-c".to_string(), STUB_INIT_OK_LIST_ERRORS.to_string()],
+            args: vec!["-c".to_string(), list_errors_stub().source()],
             env: HashMap::new(),
             ..Default::default()
         };

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -346,7 +346,9 @@ impl Default for ToolExecutor {
 mod tests {
     use super::*;
     use crate::client::EmbeddedResource;
-    use crate::test_support::always_on_tracing_guard;
+    use crate::test_support::{
+        McpStub, always_on_tracing_guard, echo_tool_stub, spawn_ready_client,
+    };
     use std::sync::Arc;
 
     #[test]
@@ -537,24 +539,12 @@ mod tests {
     /// A stub whose `tools/call` sleeps `secs` before answering, so a call's
     /// duration is observable.
     fn slow_stub(secs: f64) -> String {
-        STUB_INIT_LIST_AND_CALL.replace(
+        echo_tool_stub().source().replace(
             "    elif method == \"tools/call\":\n",
             &format!(
                 "    elif method == \"tools/call\":\n        import time; time.sleep({secs})\n"
             ),
         )
-    }
-
-    async fn spawn_stub(source: &str) -> MCPClient {
-        let mut client = MCPClient::spawn("python3", &["-c", source], &HashMap::new())
-            .await
-            .expect("failed to spawn stub server");
-        client.connect().await.expect("connect should succeed");
-        client
-            .list_tools()
-            .await
-            .expect("list_tools should succeed");
-        client
     }
 
     /// Two servers, one slow: a batch that names both takes as long as the
@@ -565,12 +555,12 @@ mod tests {
         let mut executor = ToolExecutor::new();
         let _ = executor.add_client_advertised(
             "slow".to_string(),
-            spawn_stub(&slow_stub(2.0)).await,
+            spawn_ready_client(&slow_stub(2.0)).await,
             &HashSet::new(),
         );
         let _ = executor.add_client_advertised(
             "fast".to_string(),
-            spawn_stub(STUB_INIT_LIST_AND_CALL).await,
+            spawn_ready_client(&echo_tool_stub().source()).await,
             &HashSet::new(),
         );
         let executor = Arc::new(executor);
@@ -604,7 +594,7 @@ mod tests {
         let mut executor = ToolExecutor::new();
         let _ = executor.add_client_advertised(
             "slow".to_string(),
-            spawn_stub(&slow_stub(0.5)).await,
+            spawn_ready_client(&slow_stub(0.5)).await,
             &HashSet::new(),
         );
         let executor = Arc::new(executor);
@@ -632,7 +622,7 @@ mod tests {
         let mut executor = ToolExecutor::new();
         let _ = executor.add_client_advertised(
             "slow".to_string(),
-            spawn_stub(&slow_stub(1.0)).await,
+            spawn_ready_client(&slow_stub(1.0)).await,
             &HashSet::new(),
         );
         let (client, original) = executor.route("slow__echo").expect("routes");
@@ -662,52 +652,14 @@ mod tests {
     // uncovered here; there's no way to make client.shutdown() fail without
     // changing that documented "always succeeds" behavior.
 
-    const STUB_INIT_LIST_AND_CALL: &str = r#"
-import sys, json
-
-def respond(id, result):
-    msg = json.dumps({"jsonrpc": "2.0", "id": id, "result": result})
-    sys.stdout.write(msg + "\n")
-    sys.stdout.flush()
-
-for line in sys.stdin:
-    line = line.strip()
-    if not line:
-        continue
-    req = json.loads(line)
-    method = req.get("method", "")
-    id_ = req.get("id")
-    if method == "initialize":
-        respond(id_, {"capabilities": {"tools": {"listChanged": True}}, "protocolVersion": "2024-11-05"})
-    elif method == "notifications/initialized":
-        pass
-    elif method == "tools/list":
-        respond(id_, {"tools": [{"name": "echo", "description": "echo tool", "inputSchema": {}}]})
-    elif method == "tools/call":
-        respond(id_, {"content": [{"type": "text", "text": "hello from tool"}], "isError": False})
-    elif method == "notifications/cancelled":
-        pass
-    else:
-        respond(id_, {"error": {"code": -32601, "message": "method not found"}})
-"#;
-
-    async fn spawn_ready_client() -> MCPClient {
-        let mut client =
-            MCPClient::spawn("python3", &["-c", STUB_INIT_LIST_AND_CALL], &HashMap::new())
-                .await
-                .expect("failed to spawn stub server");
-        client.connect().await.expect("connect should succeed");
-        client
-            .list_tools()
-            .await
-            .expect("list_tools should succeed");
-        client
+    async fn spawn_echo_client() -> MCPClient {
+        spawn_ready_client(&echo_tool_stub().source()).await
     }
 
     #[tokio::test]
     async fn add_client_and_server_count_reflects_it() {
         let mut executor = ToolExecutor::new();
-        let client = spawn_ready_client().await;
+        let client = spawn_echo_client().await;
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
         assert_eq!(executor.server_count(), 1);
     }
@@ -718,7 +670,7 @@ for line in sys.stdin:
     #[tokio::test]
     async fn remove_client_takes_the_server_and_its_aliases() {
         let mut executor = ToolExecutor::new();
-        let client = spawn_ready_client().await;
+        let client = spawn_echo_client().await;
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
         assert_eq!(executor.server_count(), 1);
 
@@ -737,7 +689,7 @@ for line in sys.stdin:
     async fn execute_finds_owning_server_and_calls_tool() {
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
-        let client = spawn_ready_client().await;
+        let client = spawn_echo_client().await;
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor
@@ -752,7 +704,7 @@ for line in sys.stdin:
     async fn execute_on_specific_server_calls_tool() {
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
-        let client = spawn_ready_client().await;
+        let client = spawn_echo_client().await;
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor
@@ -771,7 +723,7 @@ for line in sys.stdin:
     async fn execute_routes_to_a_live_server_and_succeeds() {
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
-        let client = spawn_ready_client().await;
+        let client = spawn_echo_client().await;
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor
@@ -785,7 +737,7 @@ for line in sys.stdin:
     async fn shutdown_all_with_live_client_succeeds_and_clears() {
         let _guard = always_on_tracing_guard();
         let mut executor = ToolExecutor::new();
-        let client = spawn_ready_client().await;
+        let client = spawn_echo_client().await;
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
 
         let result = executor.shutdown_all().await;
@@ -824,46 +776,17 @@ for line in sys.stdin:
     // Server returns a JSON-RPC error for tools/call, which causes
     // execute_on's `client.call_tool(...).await?` to propagate the error.
 
-    const STUB_CALL_ERROR: &str = r#"
-import sys, json
-
-def respond(id, result):
-    msg = json.dumps({"jsonrpc": "2.0", "id": id, "result": result})
-    sys.stdout.write(msg + "\n")
-    sys.stdout.flush()
-
-def error(id, message):
-    msg = json.dumps({"jsonrpc": "2.0", "id": id, "error": {"code": -32603, "message": message}})
-    sys.stdout.write(msg + "\n")
-    sys.stdout.flush()
-
-for line in sys.stdin:
-    line = line.strip()
-    if not line:
-        continue
-    req = json.loads(line)
-    method = req.get("method", "")
-    id_ = req.get("id")
-    if method == "initialize":
-        respond(id_, {"capabilities": {"tools": {}}, "protocolVersion": "2024-11-05"})
-    elif method == "notifications/initialized":
-        pass
-    elif method == "tools/list":
-        respond(id_, {"tools": [{"name": "echo", "description": "echo", "inputSchema": {}}]})
-    elif method == "tools/call":
-        error(id_, "tool execution failed")
-    elif method == "notifications/cancelled":
-        pass
-"#;
-
     #[tokio::test]
     async fn execute_on_propagates_call_tool_error() {
         let _guard = always_on_tracing_guard();
-        let mut client = MCPClient::spawn("python3", &["-c", STUB_CALL_ERROR], &HashMap::new())
-            .await
-            .expect("spawn");
-        client.connect().await.expect("connect");
-        client.list_tools().await.expect("list_tools");
+        let client = spawn_ready_client(
+            &McpStub::new()
+                .capabilities_json(r#"{"tools": {}}"#)
+                .tool("echo", Some("echo"))
+                .call_fails("tool execution failed")
+                .source(),
+        )
+        .await;
 
         let mut executor = ToolExecutor::new();
         let _ = executor.add_client_advertised("server1".to_string(), client, &HashSet::new());
@@ -1088,38 +1011,16 @@ for line in sys.stdin:
 
     // ─── advertised routing with live clients ─────────────────────────────
 
-    /// A stub whose single tool is named `tool_name`, echoing a fixed reply.
-    fn stub_named(tool_name: &str) -> String {
-        format!(
-            r#"
-import sys, json
-def respond(id, result):
-    sys.stdout.write(json.dumps({{"jsonrpc": "2.0", "id": id, "result": result}}) + "\n")
-    sys.stdout.flush()
-for line in sys.stdin:
-    line = line.strip()
-    if not line:
-        continue
-    req = json.loads(line)
-    method, id_ = req.get("method", ""), req.get("id")
-    if method == "initialize":
-        respond(id_, {{"capabilities": {{}}, "protocolVersion": "2024-11-05"}})
-    elif method == "tools/list":
-        respond(id_, {{"tools": [{{"name": "{tool_name}", "inputSchema": {{}}}}]}})
-    elif method == "tools/call":
-        respond(id_, {{"content": [{{"type": "text", "text": "called " + req["params"]["name"]}}], "isError": False}})
-"#
-        )
-    }
-
+    /// A client to a stub whose single tool is named `tool_name` and
+    /// replies with the name it was called under.
     async fn spawn_named(tool_name: &str) -> MCPClient {
-        let mut client =
-            MCPClient::spawn("python3", &["-c", &stub_named(tool_name)], &HashMap::new())
-                .await
-                .expect("spawn");
-        client.connect().await.expect("connect");
-        client.list_tools().await.expect("list");
-        client
+        spawn_ready_client(
+            &McpStub::new()
+                .tool(tool_name, None)
+                .echoing_tool_name()
+                .source(),
+        )
+        .await
     }
 
     #[tokio::test]

--- a/crates/leviath-mcp/src/test_support.rs
+++ b/crates/leviath-mcp/src/test_support.rs
@@ -1,3 +1,33 @@
-//! Crate-local names for the shared helpers in `leviath-testkit`.
+//! Crate-local names for the shared helpers in `leviath-testkit`, plus the
+//! one Python stub server the client, discovery and execution tests all talk
+//! to.
 
+use std::collections::HashMap;
+
+pub(crate) use leviath_testkit::mcp_stub::McpStub;
 pub(crate) use leviath_testkit::tracing_guard as always_on_tracing_guard;
+
+use crate::client::MCPClient;
+
+/// The stub most tests want: a `tools` capability with `listChanged`, one
+/// tool named `echo` described as `echo tool`, and a `tools/call` that
+/// answers `hello from tool`.
+pub(crate) fn echo_tool_stub() -> McpStub {
+    McpStub::new()
+        .list_changed(true)
+        .tool("echo", Some("echo tool"))
+}
+
+/// Spawn `source` under `python3`, complete the handshake and list its
+/// tools, so the returned client is ready to have tools called on it.
+pub(crate) async fn spawn_ready_client(source: &str) -> MCPClient {
+    let mut client = MCPClient::spawn("python3", &["-c", source], &HashMap::new())
+        .await
+        .expect("failed to spawn stub server");
+    client.connect().await.expect("connect should succeed");
+    client
+        .list_tools()
+        .await
+        .expect("list_tools should succeed");
+    client
+}

--- a/crates/leviath-testkit/src/lib.rs
+++ b/crates/leviath-testkit/src/lib.rs
@@ -9,6 +9,8 @@
 //! per-package `test_support.rs` versions drift silently (`AlwaysOnSubscriber`
 //! reached five copies in two divergent designs, the raw-TCP mock server nine).
 
+pub mod mcp_stub;
+
 use std::sync::{Mutex, OnceLock};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/crates/leviath-testkit/src/mcp_stub.rs
+++ b/crates/leviath-testkit/src/mcp_stub.rs
@@ -1,0 +1,279 @@
+//! One parameterised Python stdio MCP server, in place of the near-identical
+//! JSON-RPC stub scripts that were pasted into each test module that needed a
+//! server to talk to.
+//!
+//! The server reads one JSON-RPC request per line from stdin and answers
+//! `initialize`, `tools/list` and `tools/call`; notifications (requests with
+//! no `id`) are ignored and any other method gets a `-32601` error. Every
+//! knob a copy differed on is a builder method here, so a test that needs a
+//! server which fails `tools/list`, or one whose tool echoes the name it was
+//! called with, says so in Rust rather than in a second Python template.
+
+/// What the stub answers to `tools/call`.
+#[derive(Clone, Debug)]
+enum CallReply {
+    /// A single text block, flagged with `isError` as given.
+    Text { text: String, is_error: bool },
+    /// A single text block reading `called <tool name>`, so a test can see
+    /// which name reached the server.
+    EchoName,
+    /// A JSON-RPC error (`-32603`) with this message.
+    Error(String),
+}
+
+/// A builder for the stub's Python source. `McpStub::new()` is a server with
+/// no tools that answers every call with `hello from tool`; chain the
+/// setters below and finish with [`McpStub::source`].
+#[derive(Clone, Debug)]
+pub struct McpStub {
+    tools: Vec<(String, Option<String>)>,
+    input_schema: String,
+    capabilities: String,
+    call: CallReply,
+    list_error: Option<String>,
+    init_error: Option<String>,
+}
+
+impl Default for McpStub {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl McpStub {
+    /// A server with no tools and empty capabilities whose `tools/call`
+    /// replies `hello from tool`.
+    pub fn new() -> Self {
+        Self {
+            tools: Vec::new(),
+            input_schema: "{}".to_string(),
+            capabilities: "{}".to_string(),
+            call: CallReply::Text {
+                text: "hello from tool".to_string(),
+                is_error: false,
+            },
+            list_error: None,
+            init_error: None,
+        }
+    }
+
+    /// Advertise a tool; `description` is omitted from the wire when `None`.
+    pub fn tool(mut self, name: &str, description: Option<&str>) -> Self {
+        self.tools
+            .push((name.to_string(), description.map(str::to_string)));
+        self
+    }
+
+    /// The `inputSchema` every advertised tool carries, as JSON text
+    /// (default `{}`).
+    pub fn input_schema(mut self, json: &str) -> Self {
+        self.input_schema = json.to_string();
+        self
+    }
+
+    /// Declare a `tools` capability with the given `listChanged` flag.
+    pub fn list_changed(self, list_changed: bool) -> Self {
+        self.capabilities_json(&format!(
+            r#"{{"tools": {{"listChanged": {list_changed}}}}}"#
+        ))
+    }
+
+    /// The whole `capabilities` object of the `initialize` result, as JSON
+    /// text (default `{}`).
+    pub fn capabilities_json(mut self, json: &str) -> Self {
+        self.capabilities = json.to_string();
+        self
+    }
+
+    /// `tools/call` succeeds with this text.
+    pub fn replying(mut self, text: &str) -> Self {
+        self.call = CallReply::Text {
+            text: text.to_string(),
+            is_error: false,
+        };
+        self
+    }
+
+    /// `tools/call` returns this text flagged `isError: true` (a tool
+    /// execution error, as distinct from a JSON-RPC error).
+    pub fn replying_error(mut self, text: &str) -> Self {
+        self.call = CallReply::Text {
+            text: text.to_string(),
+            is_error: true,
+        };
+        self
+    }
+
+    /// `tools/call` replies `called <name>` for whatever tool name it was
+    /// sent.
+    pub fn echoing_tool_name(mut self) -> Self {
+        self.call = CallReply::EchoName;
+        self
+    }
+
+    /// `tools/call` answers with a JSON-RPC error carrying this message.
+    pub fn call_fails(mut self, message: &str) -> Self {
+        self.call = CallReply::Error(message.to_string());
+        self
+    }
+
+    /// `tools/list` answers with a JSON-RPC error carrying this message.
+    pub fn list_fails(mut self, message: &str) -> Self {
+        self.list_error = Some(message.to_string());
+        self
+    }
+
+    /// `initialize` answers with a JSON-RPC error carrying this message, so
+    /// the handshake fails.
+    pub fn init_fails(mut self, message: &str) -> Self {
+        self.init_error = Some(message.to_string());
+        self
+    }
+
+    /// The Python source, ready for `python3 -c`.
+    pub fn source(&self) -> String {
+        let tools = self
+            .tools
+            .iter()
+            .map(|(name, description)| {
+                let description = description
+                    .as_deref()
+                    .map(|d| format!(", \"description\": {}", py_str(d)))
+                    .unwrap_or_default();
+                format!(
+                    "{{\"name\": {}{description}, \"inputSchema\": json.loads({})}}",
+                    py_str(name),
+                    py_str(&self.input_schema)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        let (call_text, call_echo, call_is_error, call_error) = match &self.call {
+            CallReply::Text { text, is_error } => (
+                py_str(text),
+                "False",
+                py_bool(*is_error),
+                "None".to_string(),
+            ),
+            CallReply::EchoName => ("None".to_string(), "True", "False", "None".to_string()),
+            CallReply::Error(message) => ("None".to_string(), "False", "False", py_str(message)),
+        };
+        let list_error = py_opt(self.list_error.as_deref());
+        let init_error = py_opt(self.init_error.as_deref());
+        let capabilities = py_str(&self.capabilities);
+        format!(
+            r#"
+import sys, json
+
+TOOLS = [{tools}]
+CAPABILITIES = json.loads({capabilities})
+CALL_TEXT = {call_text}
+CALL_ECHO = {call_echo}
+CALL_IS_ERROR = {call_is_error}
+CALL_ERROR = {call_error}
+LIST_ERROR = {list_error}
+INIT_ERROR = {init_error}
+
+def respond(id_, result):
+    sys.stdout.write(json.dumps({{"jsonrpc": "2.0", "id": id_, "result": result}}) + "\n")
+    sys.stdout.flush()
+
+def error(id_, code, message):
+    sys.stdout.write(json.dumps({{"jsonrpc": "2.0", "id": id_, "error": {{"code": code, "message": message}}}}) + "\n")
+    sys.stdout.flush()
+
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    req = json.loads(line)
+    method = req.get("method", "")
+    id_ = req.get("id")
+    if id_ is None:
+        continue  # a notification: nothing to answer
+    if method == "initialize":
+        if INIT_ERROR is not None:
+            error(id_, -32000, INIT_ERROR)
+        else:
+            respond(id_, {{"capabilities": CAPABILITIES, "protocolVersion": "2024-11-05"}})
+    elif method == "tools/list":
+        if LIST_ERROR is not None:
+            error(id_, -32000, LIST_ERROR)
+        else:
+            respond(id_, {{"tools": TOOLS}})
+    elif method == "tools/call":
+        if CALL_ERROR is not None:
+            error(id_, -32603, CALL_ERROR)
+        else:
+            text = "called " + req["params"]["name"] if CALL_ECHO else CALL_TEXT
+            respond(id_, {{"content": [{{"type": "text", "text": text}}], "isError": CALL_IS_ERROR}})
+    else:
+        error(id_, -32601, "method not found")
+"#
+        )
+    }
+}
+
+/// `s` as a double-quoted Python string literal.
+fn py_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+fn py_bool(b: bool) -> &'static str {
+    if b { "True" } else { "False" }
+}
+
+fn py_opt(s: Option<&str>) -> String {
+    s.map(py_str).unwrap_or_else(|| "None".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_knob_reaches_the_source() {
+        let src = McpStub::new()
+            .tool("echo", Some("say \"hi\""))
+            .tool("bare", None)
+            .input_schema(r#"{"type": "object"}"#)
+            .list_changed(true)
+            .replying_error("boom")
+            .list_fails("no list")
+            .init_fails("no init")
+            .source();
+        assert!(
+            src.contains(r#""name": "echo", "description": "say \"hi\""#),
+            "{src}"
+        );
+        assert!(src.contains(r#"{"name": "bare", "inputSchema""#), "{src}");
+        assert!(
+            src.contains(r#"CAPABILITIES = json.loads("{\"tools\": {\"listChanged\": true}}")"#)
+        );
+        assert!(src.contains("CALL_IS_ERROR = True"));
+        assert!(src.contains(r#"LIST_ERROR = "no list""#));
+        assert!(src.contains(r#"INIT_ERROR = "no init""#));
+
+        let echo = McpStub::default().echoing_tool_name().source();
+        assert!(echo.contains("CALL_ECHO = True"));
+        let failing = McpStub::new()
+            .capabilities_json(r#"{"tools": {}}"#)
+            .call_fails("nope")
+            .source();
+        assert!(failing.contains(r#"CALL_ERROR = "nope""#));
+        assert!(failing.contains(r#"json.loads("{\"tools\": {}}")"#));
+        let plain = McpStub::new().replying("ok\nthen").source();
+        assert!(plain.contains(r#"CALL_TEXT = "ok\nthen""#));
+    }
+}


### PR DESCRIPTION
Phase 9 of the plan, two commits, tests only. No production code changes.

## `test(mcp): one Python stub server instead of six copies`

`leviath_testkit::mcp_stub::McpStub` renders the Python JSON-RPC stub from parameters the copies actually varied on: tools (name, description, `inputSchema`), initialize capabilities, the `tools/call` reply (text with `isError`, an echo of the name, or a JSON-RPC error), and errors for `tools/list` / `initialize`. `leviath-mcp/src/test_support.rs` adds `spawn_ready_client(source)` and `echo_tool_stub()`. Replaced: seven copies in `leviath-mcp` and four in `leviath-cli` (`tool_service.rs`, `mcp_pool.rs`, `setup.rs`). The client only sends `initialize`/`tools/list`/`tools/call`, so the copies' divergent unknown-method branches were dead; one `-32601` branch preserves behaviour.

Left alone on purpose: the client's malformed-response scripts (each tests one broken wire shape), `paginated_stub`, the silent/closing/EPIPE scripts, the transport-level `stdio.rs` stub, and the stubs in `tools.rs`, `commands/mcp.rs`, `dashboard/mcp.rs`, `serve/mcp.rs`.

## `test(testkit): FakeProvider builder and shared fixtures`

Measured first: all four daemon fakes (`fanout_spawner`, `recovery`, `setup`, `spawn/mod`) are one shape. They become `FakeProvider::new()` with `.failing()`, `.context_window()`, `.named()`, `.replying()`, `.serving()`. Fixtures routed where used verbatim: `token_usage` (3 sites), `inference_request` (4), `inference_response` (3), `run_meta` (15 sites building the same `RunMeta::new(id, "a", "/p", "t", None, "/w", 1)`), `fanout_config` (2). Sites with distinct values were left as they are.

**Deviation from the plan, worth knowing:** the plan put these in `leviath-testkit` with normal deps on `leviath-core` and `leviath-providers`. Both of those crates dev-depend on testkit, so that closes a dev-dependency cycle. Cargo accepts it, but `cargo check --workspace --all-targets` then fails inside `leviath-core`'s own tests (`interaction.rs:471`: `String + &String` stops inferring because rustc sees two `leviath_core` crates). So `FakeProvider` and `fixtures` live in `crates/leviath-cli/src/test_fixtures.rs` (`#[cfg(test)]`, re-exported through `crate::test_support`), where every consumer is, and testkit's manifest is unchanged.

Cycle checks on the final tree: `cargo check --workspace --all-targets` ok; `cargo metadata --locked` ok; `cargo publish --dry-run -p leviath-providers --allow-dirty` packages with no testkit in the graph.

## Gates

`cargo xtask coverage` 100% on `leviath-mcp` and `leviath-cli` (per commit); clippy and rustdoc `-D warnings`; `xtask structure`, `xtask docs`, fmt. cli 4049 tests, mcp 395.

## Side note (not this PR)

Two `commands::doctor` tests read the machine's real `~/.leviath/config.toml`; on a machine whose config still sets `exact_token_counting = true` they fail after #687 (the unknown-key warning shows in the panic). They pass with `LEVIATH_HOME` at an empty dir, which is how the gates were run. Isolating those two tests is a small follow-up.
