### PR TITLE
feat(dash): Start button and Enter-as-newline in the new-run task; a Final output view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,13 @@ same list.
   reaches it, Enter or Space or a click presses it) for terminals without the
   kitty keyboard protocol, where Ctrl+Enter arrives as a plain Enter. The
   dashboard asks the terminal for that protocol when it offers it.
+- `lev dash`'s detail view has a Final pane (`f`, or the `[f] final` chip),
+  shown once the run has submitted an answer. It reads the answer through the
+  same function `GET /api/agents/{id}/result` serves it from, so the two
+  cannot differ; the Output pane keeps showing what the stage wrote along the
+  way, which for a model that chatted one answer and submitted another is
+  different text.
+
 
 ## 0.5.5 - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,7 +152,16 @@ same list.
   change; the refactors carry 100% coverage on Linux, macOS and Windows
   (#653-#663, #674).
 
+### Added
+
+- In `lev dash`'s new-run screen, Enter now breaks the line in the task box
+  and Ctrl+Enter starts the run. A Start button sits under the editor (Tab
+  reaches it, Enter or Space or a click presses it) for terminals without the
+  kitty keyboard protocol, where Ctrl+Enter arrives as a plain Enter. The
+  dashboard asks the terminal for that protocol when it offers it.
+
 ## 0.5.5 - 2026-08-27
+
 
 - Fixed: a stage whose model can answer at nearly the width of its own context
   window could be rejected outright for asking. The reply budget was everything

--- a/crates/leviath-cli/src/commands/dashboard/click.rs
+++ b/crates/leviath-cli/src/commands/dashboard/click.rs
@@ -445,6 +445,40 @@ mod tests {
         );
     }
 
+    /// The `[f] final` chip switches to the Final view through the same
+    /// path as the other chips.
+    #[test]
+    fn clicking_the_final_chip_opens_the_final_view() {
+        crate::runstate::with_isolated_runs_dir(
+            "clicking_the_final_chip_opens_the_final_view",
+            |_d| {
+                let mut dash = make_test_dashboard();
+                let mut agent = make_test_agent("run-final-chip");
+                agent.stages = (0..3)
+                    .map(|i| crate::runstate::StageRecord::new(format!("stage{i}"), i))
+                    .collect();
+                crate::commands::dashboard::test_support::seed_run_with_final_output(
+                    "run-final-chip",
+                    "stage2",
+                    "the answer",
+                );
+                dash.agents.push(agent);
+                dash.update_display_indices();
+                dash.detail_view = true;
+                draw(&mut dash, 120, 24);
+
+                let chip = dash
+                    .click_targets
+                    .iter()
+                    .find(|(_, t)| *t == ClickTarget::ContentMode(StageContentMode::FinalOutput))
+                    .map(|(r, _)| *r)
+                    .expect("the final chip is in the title");
+                press_and_release(&mut dash, chip.x + 1, chip.y);
+                assert_eq!(dash.stage_content_mode, StageContentMode::FinalOutput);
+            },
+        );
+    }
+
     /// The new-run screen's Start button starts the run with a click, the
     /// way Enter on it does: the whole point of the button is a terminal
     /// where Ctrl+Enter cannot be told from Enter.

--- a/crates/leviath-cli/src/commands/dashboard/click.rs
+++ b/crates/leviath-cli/src/commands/dashboard/click.rs
@@ -157,6 +157,7 @@ impl Dashboard {
                 self.context_tree.cursor = idx;
                 self.toggle_context_row();
             }
+            ClickTarget::NewRunStart => self.submit_new_run(),
         }
         true
     }
@@ -444,8 +445,45 @@ mod tests {
         );
     }
 
+    /// The new-run screen's Start button starts the run with a click, the
+    /// way Enter on it does: the whole point of the button is a terminal
+    /// where Ctrl+Enter cannot be told from Enter.
+    #[test]
+    fn clicking_the_start_button_starts_the_run() {
+        let mut dash = make_test_dashboard();
+        dash.new_run_screen = true;
+        dash.new_run_agents = vec![crate::commands::dashboard::types::NewRunAgent {
+            name: "alpha".to_string(),
+            source: "installed".to_string(),
+            description: "first".to_string(),
+            path: "/agents/alpha".to_string(),
+        }];
+        dash.new_run_task.area_mut().insert_str("ship it");
+        draw(&mut dash, 120, 40);
+
+        let button = dash
+            .click_targets
+            .iter()
+            .find(|(_, t)| *t == ClickTarget::NewRunStart)
+            .map(|(r, _)| *r)
+            .expect("the Start button is on screen");
+        press_and_release(&mut dash, button.x + 2, button.y);
+
+        assert!(
+            !dash.new_run_screen,
+            "the run was dispatched and the form closed"
+        );
+        let cmd = dash
+            .spawn_cmd_rx_for_test()
+            .try_recv()
+            .expect("a spawn was dispatched");
+        assert_eq!(cmd.task, "ship it");
+        assert_eq!(cmd.agent_path, "/agents/alpha");
+    }
+
     /// A click resolves to the innermost target: the toggle registered over
     /// part of a row wins against the row it sits in.
+
     #[test]
     fn the_last_registered_target_over_a_cell_wins() {
         let mut dash = make_test_dashboard();

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -500,6 +500,17 @@ impl Dashboard {
                 // `c` shows the live current window; leave any history browsing.
                 self.reset_context_history();
             }
+            // The run's submitted answer. Offered only while the run has one:
+            // the chip is off the title otherwise, and the key does nothing.
+            KeyCode::Char('f') => {
+                let has_answer = self
+                    .selected_agent()
+                    .is_some_and(|a| runstate::read_final_output(&a.id).is_some());
+                if has_answer {
+                    self.stage_content_mode = StageContentMode::FinalOutput;
+                    self.detail_scroll = 0;
+                }
+            }
             // Browse the run's archived context-window history in the Context
             // view: `,` = earlier point, `.` = later (past the newest → live).
             KeyCode::Char(',') => self.step_context_history(-1),
@@ -613,6 +624,12 @@ impl Dashboard {
                     )
                     .unwrap_or_default();
                     (json, "Context JSON")
+                }
+                StageContentMode::FinalOutput => {
+                    let answer = runstate::read_final_output(&agent.id)
+                        .map(|answer| answer.content)
+                        .unwrap_or_default();
+                    (answer, "Final output")
                 }
             };
             if content.is_empty() {
@@ -1304,6 +1321,53 @@ mod tests {
         assert_eq!(dash.stage_content_mode, StageContentMode::Output);
         dash.handle_key(key(KeyCode::Char('c')));
         assert_eq!(dash.stage_content_mode, StageContentMode::Context);
+    }
+
+    /// `f` opens the Final view for a run that submitted an answer, and is a
+    /// no-op for one that did not: the chip is not on the title, so the key
+    /// it names is not on offer either.
+    #[test]
+    fn f_opens_the_final_view_only_when_the_run_has_an_answer() {
+        crate::runstate::with_isolated_runs_dir(
+            "f_opens_the_final_view_only_when_the_run_has_an_answer",
+            |_d| {
+                let mut dash = make_test_dashboard();
+                dash.agents.push(make_test_agent(
+                    "run-no-answer",
+                    AgentDisplayStatus::Complete,
+                ));
+                dash.agents.push(make_test_agent(
+                    "run-answered",
+                    AgentDisplayStatus::Complete,
+                ));
+                crate::commands::dashboard::test_support::seed_run_with_final_output(
+                    "run-answered",
+                    "main",
+                    "the answer",
+                );
+                dash.update_display_indices();
+                dash.detail_view = true;
+                dash.detail_scroll = 3;
+                // The list's order is the sort mode's, not the push order.
+                let row_of = |dash: &Dashboard, id: &str| {
+                    dash.display_indices
+                        .iter()
+                        .position(|&i| dash.agents[i].id == id)
+                        .expect("both runs are listed")
+                };
+
+                dash.selected = row_of(&dash, "run-no-answer");
+                dash.handle_key(key(KeyCode::Char('f')));
+                assert_eq!(dash.stage_content_mode, StageContentMode::Output);
+                assert_eq!(dash.detail_scroll, 3, "nothing happened");
+
+                dash.selected = row_of(&dash, "run-answered");
+                dash.handle_key(key(KeyCode::Char('f')));
+
+                assert_eq!(dash.stage_content_mode, StageContentMode::FinalOutput);
+                assert_eq!(dash.detail_scroll, 0);
+            },
+        );
     }
 
     #[test]
@@ -3197,6 +3261,41 @@ mod tests {
         dash.handle_key(key(KeyCode::Char('y')));
 
         assert!(!dash.toasts.is_empty());
+    }
+
+    /// The Final view yanks the answer the API serves, and says so when the
+    /// run has none.
+    #[test]
+    fn yank_final_output_mode_copies_the_answer() {
+        crate::runstate::with_isolated_runs_dir("yank_final_output_mode_copies_the_answer", |_d| {
+            let mut dash = make_test_dashboard();
+            dash.agents.push(make_test_agent(
+                "run-yank-final",
+                AgentDisplayStatus::Complete,
+            ));
+            dash.update_display_indices();
+            dash.detail_view = true;
+            dash.stage_content_mode = StageContentMode::FinalOutput;
+
+            dash.handle_key(key(KeyCode::Char('y')));
+            let toasts: Vec<String> = dash.toasts.iter().map(|t| t.message.clone()).collect();
+            assert!(
+                toasts.iter().any(|m| m.contains("No Final output content")),
+                "{toasts:?}"
+            );
+
+            crate::commands::dashboard::test_support::seed_run_with_final_output(
+                "run-yank-final",
+                "main",
+                "the answer",
+            );
+            dash.handle_yank_with_fn(|text| text == "the answer");
+            let toasts: Vec<String> = dash.toasts.iter().map(|t| t.message.clone()).collect();
+            assert!(
+                toasts.iter().any(|m| m.contains("yanked to clipboard")),
+                "{toasts:?}"
+            );
+        });
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -2,7 +2,8 @@
 //! spawn lane.
 //!
 //! `lev dash` could only ever watch runs somebody else had started. This is the
-//! other half: pick an agent, write the task, press Enter. The screen is modal
+//! other half: pick an agent, write the task, press Ctrl+Enter (or the Start
+//! button, on a terminal that cannot tell Ctrl+Enter from Enter). The screen is modal
 //! like the MCP one, and for the same reason - it owns the keys while open, so
 //! typing a task can never also mean "kill the selected run".
 //!
@@ -346,6 +347,7 @@ impl Dashboard {
         match self.new_run_focus {
             NewRunPane::Agents => self.handle_new_run_agents_key(key.code),
             NewRunPane::Task => self.handle_new_run_task_key(key),
+            NewRunPane::Start => self.handle_new_run_start_key(key.code),
         }
     }
 
@@ -364,9 +366,8 @@ impl Dashboard {
                     self.new_run_selected = 0;
                 }
             },
-            KeyCode::Tab | KeyCode::BackTab | KeyCode::Enter => {
-                self.new_run_focus = NewRunPane::Task;
-            }
+            KeyCode::Tab | KeyCode::Enter => self.new_run_focus = NewRunPane::Task,
+            KeyCode::BackTab => self.new_run_focus = NewRunPane::Start,
             KeyCode::Up => {
                 self.new_run_selected = self.new_run_selected.saturating_sub(1);
             }
@@ -387,14 +388,23 @@ impl Dashboard {
         }
     }
 
-    /// Task editor keys. Enter starts the run and Alt+Enter breaks the line,
-    /// matching the response pane so the two editors do not disagree.
+    /// Task editor keys. Enter breaks the line, the way it does in any other
+    /// text box, and Ctrl+Enter starts the run.
+    ///
+    /// Ctrl+Enter reaches the program only under the kitty keyboard protocol;
+    /// a terminal without it sends Ctrl+Enter as a plain Enter, which is a
+    /// newline here. That is what the Start button under the editor is for.
+    /// The response pane's editor keeps Enter as send: a reply is one line
+    /// far more often than a task is.
     fn handle_new_run_task_key(&mut self, key: crossterm::event::KeyEvent) {
-        use crossterm::event::KeyCode;
+        use crossterm::event::{KeyCode, KeyModifiers};
         match key.code {
             KeyCode::Esc => self.new_run_focus = NewRunPane::Agents,
-            KeyCode::Tab | KeyCode::BackTab => self.new_run_focus = NewRunPane::Agents,
-            KeyCode::Enter if key.modifiers.is_empty() => self.submit_new_run(),
+            KeyCode::Tab => self.new_run_focus = NewRunPane::Start,
+            KeyCode::BackTab => self.new_run_focus = NewRunPane::Agents,
+            KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.submit_new_run();
+            }
             KeyCode::Char('@') => {
                 self.new_run_task.area_mut().insert_char('@');
                 self.new_run_file_ref = true;
@@ -403,6 +413,17 @@ impl Dashboard {
                 let outcome = self.new_run_task.handle_key(&key);
                 self.remember_md_mode(outcome);
             }
+        }
+    }
+
+    /// Keys while the Start button holds focus: Enter or Space presses it.
+    fn handle_new_run_start_key(&mut self, code: crossterm::event::KeyCode) {
+        use crossterm::event::KeyCode;
+        match code {
+            KeyCode::Enter | KeyCode::Char(' ') => self.submit_new_run(),
+            KeyCode::Tab | KeyCode::Esc => self.new_run_focus = NewRunPane::Agents,
+            KeyCode::BackTab => self.new_run_focus = NewRunPane::Task,
+            _ => {}
         }
     }
 
@@ -928,13 +949,41 @@ mod tests {
     }
 
     #[test]
-    fn tab_enter_and_backtab_all_reach_the_task_editor() {
+    fn tab_and_enter_reach_the_task_editor() {
         let dir = tempfile::tempdir().unwrap();
         let mut dash = dash_at(dir.path());
-        for code in [KeyCode::Tab, KeyCode::Enter, KeyCode::BackTab] {
+        for code in [KeyCode::Tab, KeyCode::Enter] {
             dash.open_new_run_screen();
             dash.handle_new_run_key(key(code));
             assert_eq!(dash.new_run_focus, NewRunPane::Task, "{code:?}");
+        }
+    }
+
+    /// Tab walks agents, task, Start and round again; Shift+Tab walks the
+    /// same ring the other way.
+    #[test]
+    fn tab_cycles_agents_task_start_and_backtab_reverses() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        assert_eq!(dash.new_run_focus, NewRunPane::Agents);
+        for expected in [
+            NewRunPane::Task,
+            NewRunPane::Start,
+            NewRunPane::Agents,
+            NewRunPane::Task,
+        ] {
+            dash.handle_new_run_key(key(KeyCode::Tab));
+            assert_eq!(dash.new_run_focus, expected);
+        }
+        for expected in [
+            NewRunPane::Agents,
+            NewRunPane::Start,
+            NewRunPane::Task,
+            NewRunPane::Agents,
+        ] {
+            dash.handle_new_run_key(key(KeyCode::BackTab));
+            assert_eq!(dash.new_run_focus, expected);
         }
     }
 
@@ -950,33 +999,98 @@ mod tests {
 
     // ─── keys: task editor ────────────────────────────────────────────────
 
+    /// Enter and Alt+Enter both break the line: with an agent picked and text
+    /// in the box, a plain Enter still leaves the screen open with nothing
+    /// dispatched.
     #[test]
-    fn the_task_editor_takes_text_and_alt_enter_breaks_the_line() {
+    fn the_task_editor_takes_text_and_enter_breaks_the_line() {
         let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
         let mut dash = dash_at(dir.path());
         dash.open_new_run_screen();
+        dash.new_run_filter = "alpha".to_string();
         dash.new_run_focus = NewRunPane::Task;
 
         dash.handle_new_run_key(key(KeyCode::Char('h')));
         dash.handle_new_run_key(key(KeyCode::Char('i')));
-        dash.handle_new_run_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
+        dash.handle_new_run_key(key(KeyCode::Enter));
         dash.handle_new_run_key(key(KeyCode::Char('!')));
+        dash.handle_new_run_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::ALT));
+        dash.handle_new_run_key(key(KeyCode::Char('?')));
         assert_eq!(
             dash.new_run_task.lines(),
-            vec!["hi".to_string(), "!".to_string()]
+            vec!["hi".to_string(), "!".to_string(), "?".to_string()]
         );
+        assert!(dash.new_run_screen, "Enter did not start the run");
+        assert!(dash.spawn_cmd_rx_for_test().try_recv().is_err());
     }
 
     #[test]
-    fn escape_and_tab_hand_focus_back_to_the_picker() {
+    fn escape_and_backtab_hand_focus_back_to_the_picker_and_tab_reaches_start() {
         let dir = tempfile::tempdir().unwrap();
         let mut dash = dash_at(dir.path());
-        for code in [KeyCode::Esc, KeyCode::Tab, KeyCode::BackTab] {
+        for code in [KeyCode::Esc, KeyCode::BackTab] {
             dash.open_new_run_screen();
             dash.new_run_focus = NewRunPane::Task;
             dash.handle_new_run_key(key(code));
             assert_eq!(dash.new_run_focus, NewRunPane::Agents, "{code:?}");
         }
+        dash.new_run_focus = NewRunPane::Task;
+        dash.handle_new_run_key(key(KeyCode::Tab));
+        assert_eq!(dash.new_run_focus, NewRunPane::Start);
+    }
+
+    // ─── keys: Start button ───────────────────────────────────────────────
+
+    /// A screen with an agent picked and a task written, focus on the button.
+    fn dash_on_the_start_button(dir: &Path) -> Dashboard {
+        write_agent(&dir.join("agents/alpha"), "alpha", "first");
+        let mut dash = dash_at(dir);
+        dash.open_new_run_screen();
+        dash.new_run_filter = "alpha".to_string();
+        dash.new_run_task.area_mut().insert_str("ship it");
+        dash.new_run_focus = NewRunPane::Start;
+        dash
+    }
+
+    #[test]
+    fn enter_and_space_on_the_start_button_start_the_run() {
+        for code in [KeyCode::Enter, KeyCode::Char(' ')] {
+            let dir = tempfile::tempdir().unwrap();
+            let mut dash = dash_on_the_start_button(dir.path());
+            dash.handle_new_run_key(key(code));
+            assert!(!dash.new_run_screen, "{code:?} pressed the button");
+            let cmd = dash
+                .spawn_cmd_rx_for_test()
+                .try_recv()
+                .expect("a spawn was dispatched");
+            assert_eq!(cmd.task, "ship it");
+        }
+    }
+
+    #[test]
+    fn other_keys_on_the_start_button_move_focus_or_do_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut dash = dash_on_the_start_button(dir.path());
+        for (code, expected) in [
+            (KeyCode::Esc, NewRunPane::Agents),
+            (KeyCode::Tab, NewRunPane::Agents),
+            (KeyCode::BackTab, NewRunPane::Task),
+        ] {
+            dash.new_run_focus = NewRunPane::Start;
+            dash.handle_new_run_key(key(code));
+            assert_eq!(dash.new_run_focus, expected, "{code:?}");
+        }
+        dash.new_run_focus = NewRunPane::Start;
+        dash.handle_new_run_key(key(KeyCode::Char('x')));
+        assert_eq!(dash.new_run_focus, NewRunPane::Start, "a letter is ignored");
+        assert_eq!(
+            dash.new_run_task.text(),
+            "ship it",
+            "and not typed anywhere"
+        );
+        assert!(dash.new_run_screen);
+        assert!(dash.spawn_cmd_rx_for_test().try_recv().is_err());
     }
 
     // ─── keys: `@` completion ─────────────────────────────────────────────
@@ -1178,7 +1292,7 @@ mod tests {
         dash.new_run_focus = NewRunPane::Task;
         dash.new_run_task.area_mut().insert_str("  ship it  ");
 
-        dash.handle_new_run_key(key(KeyCode::Enter));
+        dash.handle_new_run_key(ctrl(KeyCode::Enter));
 
         assert!(!dash.new_run_screen, "the screen closes on dispatch");
         let cmd = dash
@@ -1199,8 +1313,9 @@ mod tests {
         dash.new_run_focus = NewRunPane::Task;
         dash.new_run_task.area_mut().insert_str("   ");
 
-        dash.handle_new_run_key(key(KeyCode::Enter));
+        dash.handle_new_run_key(ctrl(KeyCode::Enter));
         assert!(dash.new_run_screen, "the screen stays open to fix it");
+
         assert!(dash.spawn_cmd_rx_for_test().try_recv().is_err());
         let toasts = dash.toast_messages_for_test();
         assert!(toasts.iter().any(|m| m.contains("task")), "got: {toasts:?}");

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -191,22 +191,41 @@ impl Dashboard {
             return;
         }
 
+        // The run's submitted answer, read through the same function the
+        // HTTP API serves it from, so the Final view and
+        // `GET /api/agents/{id}/result` cannot show different text. Read once
+        // per frame: it decides whether the `[f] final` chip is offered and
+        // what that view shows.
+        let final_output = runstate::read_final_output(&agent.id);
+        // The Final view of a run without an answer (the selection moved to
+        // another run) falls back to Output rather than sitting on an empty
+        // pane whose chip is no longer on offer.
+        if self.stage_content_mode == StageContentMode::FinalOutput && final_output.is_none() {
+            self.stage_content_mode = StageContentMode::Output;
+        }
+
         let inner_h = content_area.height.saturating_sub(2) as usize;
         let render_width = content_area.width.saturating_sub(2);
-        let is_context = self.stage_content_mode == StageContentMode::Context;
         let is_output = self.stage_content_mode == StageContentMode::Output;
 
         // Build content lines. `showing_final_output` records whether the
-        // Output pane fell back to the run's final answer, so the file-path
-        // hint below can point at the file actually being shown.
+        // pane is showing the run's final answer (the Final view, or the
+        // Output pane's fallback to it), so the file-path hint below can point
+        // at the file actually being shown.
         let (all_lines, context_row_lines, showing_final_output): (Vec<Line>, Vec<usize>, bool) =
-            if is_context {
-                let (lines, rows) = self.build_context_lines(agent, render_width);
-                (lines, rows, false)
-            } else {
-                let (lines, showing_final) =
-                    self.build_output_lines(agent, is_output, render_width);
-                (lines, Vec::new(), showing_final)
+            match (self.stage_content_mode, &final_output) {
+                (StageContentMode::Context, _) => {
+                    let (lines, rows) = self.build_context_lines(agent, render_width);
+                    (lines, rows, false)
+                }
+                (StageContentMode::FinalOutput, Some(answer)) => {
+                    (final_output_lines(answer, render_width), Vec::new(), true)
+                }
+                _ => {
+                    let (lines, showing_final) =
+                        self.build_output_lines(agent, is_output, render_width);
+                    (lines, Vec::new(), showing_final)
+                }
             };
         let context_cursor_line = context_row_lines.get(self.context_tree.cursor).copied();
 
@@ -400,17 +419,23 @@ impl Dashboard {
             String::new()
         };
 
+        // The Final chip is offered only while the run has an answer to show.
+        let final_chip = match (self.stage_content_mode, &final_output) {
+            (StageContentMode::FinalOutput, _) | (_, None) => "",
+            _ => "  [f] final",
+        };
         let mode_label = match self.stage_content_mode {
-            StageContentMode::Output => format!(
-                " Output  [l] logs  [c] ctx{}{} ",
-                tool_count, search_indicator
-            ),
-            StageContentMode::Logs => format!(
-                " Logs  [o] output  [c] ctx{}{} ",
-                tool_count, search_indicator
-            ),
+            StageContentMode::Output => {
+                format!(" Output  [l] logs  [c] ctx{final_chip}{tool_count}{search_indicator} ")
+            }
+            StageContentMode::Logs => {
+                format!(" Logs  [o] output  [c] ctx{final_chip}{tool_count}{search_indicator} ")
+            }
             StageContentMode::Context => {
-                format!(" Context Window  [o] output  [l] logs{} ", search_indicator)
+                format!(" Context Window  [o] output  [l] logs{final_chip}{search_indicator} ")
+            }
+            StageContentMode::FinalOutput => {
+                format!(" Final output  [o] output  [l] logs  [c] ctx{search_indicator} ")
             }
         };
         let scroll_info = if total_rows > inner_h {
@@ -425,23 +450,25 @@ impl Dashboard {
 
         // Bottom-left file path hint
         let file_path_hint = {
-            let raw = if showing_final_output {
-                // The pane fell back to the run's final answer, which lives in
-                // the `final_output` sidecar beside `meta.json` rather than in
-                // the stage's `output.log`; name the file actually shown.
-                runstate::final_output_path(&runstate::run_dir(&agent.id))
-                    .to_string_lossy()
-                    .to_string()
-            } else {
-                let file_name = match self.stage_content_mode {
-                    StageContentMode::Output => "output.log",
-                    StageContentMode::Logs => "logs.log",
-                    StageContentMode::Context => leviath_core::files::CONTEXT_FILE,
-                };
-                runstate::stage_dir(&agent.id, self.selected_stage)
+            // The stage file each view reads; the Final view reads none, and
+            // the Output view's fallback to the run's answer reads a run file
+            // instead of its stage's.
+            let stage_file = match self.stage_content_mode {
+                StageContentMode::Output => Some("output.log"),
+                StageContentMode::Logs => Some("logs.log"),
+                StageContentMode::Context => Some(leviath_core::files::CONTEXT_FILE),
+                StageContentMode::FinalOutput => None,
+            };
+            let raw = match stage_file.filter(|_| !showing_final_output) {
+                Some(file_name) => runstate::stage_dir(&agent.id, self.selected_stage)
                     .join(file_name)
                     .to_string_lossy()
-                    .to_string()
+                    .to_string(),
+                // The run's final answer lives in the `final_output` sidecar
+                // beside `meta.json`, not in any stage's directory.
+                None => runstate::final_output_path(&runstate::run_dir(&agent.id))
+                    .to_string_lossy()
+                    .to_string(),
             };
             // Display-only `~` abbreviation of the OS home directory;
             // deliberately NOT the LEVIATH_HOME-aware resolver (see the
@@ -515,7 +542,8 @@ impl Dashboard {
     }
 
     /// Make the content pane's title chips (`[l] logs`, `[o] output`,
-    /// `[c] ctx`) clickable, over the exact columns they were drawn on.
+    /// `[c] ctx`, `[f] final`) clickable, over the exact columns they were
+    /// drawn on.
     ///
     /// The title renders inside the top border, starting one cell in, so the
     /// character offsets in the label are the screen columns. Only the chips
@@ -530,6 +558,7 @@ impl Dashboard {
             ("[l] logs", StageContentMode::Logs),
             ("[o] output", StageContentMode::Output),
             ("[c] ctx", StageContentMode::Context),
+            ("[f] final", StageContentMode::FinalOutput),
         ] {
             let Some(byte) = mode_label.find(chip) else {
                 continue;
@@ -826,6 +855,29 @@ impl Dashboard {
         };
         (lines, showing_final_output)
     }
+}
+
+/// The Final view's lines: one header naming the stage that submitted the
+/// answer and the format it was produced under, then the answer rendered as
+/// markdown, the way the Output view renders a stage's output.
+fn final_output_lines(answer: &leviath_core::FinalOutput, width: u16) -> Vec<Line<'static>> {
+    let format = answer.format.as_deref().unwrap_or("no format");
+    let truncated = match answer.truncated {
+        true => " · truncated",
+        false => "",
+    };
+    let mut lines = vec![
+        Line::from(Span::styled(
+            format!(
+                " submitted by stage {} · format: {format}{truncated}",
+                answer.stage
+            ),
+            Style::default().fg(C_DIM),
+        )),
+        Line::from(""),
+    ];
+    lines.extend(crate::render::markdown_to_text(&answer.content, width).lines);
+    lines
 }
 
 /// The number of display rows `lines` occupy at `width` once `Paragraph`
@@ -1302,29 +1354,169 @@ mod tests {
         stage: &str,
         content: &str,
     ) -> DashboardAgent {
-        // Same defensive cleanup as `setup_run_state_agent_with_logs`: a stale
-        // directory from an earlier panicked test must not leak in.
-        let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
-        let answer = leviath_core::output::FinalOutput::new(
-            content,
-            Some("markdown".to_string()),
-            stage.to_string(),
-            42,
+        crate::commands::dashboard::test_support::seed_run_with_final_output(
+            run_id, stage, content,
         );
-        let mut meta = runstate::RunMeta::new(
-            run_id.to_string(),
-            "agent".to_string(),
-            "/p".to_string(),
-            "task".to_string(),
-            None,
-            "/tmp".to_string(),
-            1,
-        );
-        meta.final_output = Some(answer.descriptor());
-        runstate::create_run(&meta).unwrap();
-        runstate::write_final_output(&runstate::run_dir(run_id), &answer.content).unwrap();
-
         make_test_agent(run_id, AgentDisplayStatus::Complete)
+    }
+
+    // ─── the Final view ──────────────────────────────────────────────────
+
+    /// The `[f] final` chip is on the title only while the run has an answer,
+    /// and its click target with it.
+    #[test]
+    fn the_final_chip_is_offered_only_when_the_run_has_an_answer() {
+        runstate::with_isolated_runs_dir(
+            "the_final_chip_is_offered_only_when_the_run_has_an_answer",
+            |_d| {
+                let mut dash = make_test_dashboard();
+                dash.stage_content_mode = StageContentMode::Output;
+
+                let without = setup_run_state_agent_with_logs("final-chip-no", &[], Some("out"));
+                let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+                terminal
+                    .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &without, 100))
+                    .unwrap();
+                let buf = rendered_buffer(&terminal);
+                assert!(!buf.contains("[f] final"), "{buf}");
+                assert!(
+                    !dash
+                        .click_targets
+                        .iter()
+                        .any(|(_, t)| *t == ClickTarget::ContentMode(StageContentMode::FinalOutput)),
+                    "no chip, no button"
+                );
+
+                dash.click_targets.clear();
+                let with = setup_run_state_agent_with_final_output(
+                    "final-chip-yes",
+                    "present",
+                    "the answer",
+                );
+                let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+                terminal
+                    .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &with, 100))
+                    .unwrap();
+                let buf = rendered_buffer(&terminal);
+                assert!(buf.contains("[f] final"), "{buf}");
+                assert!(
+                    dash.click_targets
+                        .iter()
+                        .any(|(_, t)| *t == ClickTarget::ContentMode(StageContentMode::FinalOutput)),
+                    "the chip is a button"
+                );
+                // Every other view offers it too, and none of them offers its
+                // own chip.
+                for mode in [StageContentMode::Logs, StageContentMode::Context] {
+                    dash.stage_content_mode = mode;
+                    let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+                    terminal
+                        .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &with, 100))
+                        .unwrap();
+                    let buf = rendered_buffer(&terminal);
+                    assert!(buf.contains("[f] final"), "{mode:?}: {buf}");
+                }
+            },
+        );
+    }
+
+    /// The view shows the bytes `runstate::read_final_output` returns, which
+    /// is what the HTTP API serves, under a header naming the submitting
+    /// stage and the format, with the sidecar named in the file-path hint.
+    #[test]
+    fn the_final_view_shows_exactly_what_the_api_serves() {
+        runstate::with_isolated_runs_dir(
+            "the_final_view_shows_exactly_what_the_api_serves",
+            |_d| {
+                let run_id = "final-view-content";
+                let agent = setup_run_state_agent_with_final_output(
+                    run_id,
+                    "present",
+                    "The **submitted** answer, not the chat.",
+                );
+                // The same stage also chatted something else into its output.log,
+                // which is what the Output view shows and this view must not.
+                runstate::append_stage_output(run_id, 0, "a chatty draft nobody submitted");
+                let served = runstate::read_final_output(run_id).expect("the sidecar was written");
+                assert!(
+                    served.content.contains("**submitted**"),
+                    "the probe's input is real"
+                );
+
+                let mut dash = make_test_dashboard();
+                dash.stage_content_mode = StageContentMode::FinalOutput;
+                let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+                terminal
+                    .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &agent, 100))
+                    .unwrap();
+                let buf = rendered_buffer(&terminal);
+                assert_eq!(dash.stage_content_mode, StageContentMode::FinalOutput);
+                assert!(
+                    buf.contains(" Final output  [o] output  [l] logs  [c] ctx "),
+                    "{buf}"
+                );
+                // Rendered as markdown: the emphasis markers become styling.
+                assert!(buf.contains("The submitted answer, not the chat."), "{buf}");
+                assert!(!buf.contains("chatty draft"), "{buf}");
+                assert!(buf.contains("submitted by stage present"), "{buf}");
+                assert!(buf.contains("format: markdown"), "{buf}");
+                assert!(buf.contains(leviath_core::FINAL_OUTPUT_FILE), "{buf}");
+                assert!(!buf.contains("output.log"), "{buf}");
+                let chips: Vec<ClickTarget> = dash.click_targets.iter().map(|(_, t)| *t).collect();
+                for mode in [
+                    StageContentMode::Output,
+                    StageContentMode::Logs,
+                    StageContentMode::Context,
+                ] {
+                    assert!(chips.contains(&ClickTarget::ContentMode(mode)), "{mode:?}");
+                }
+                assert!(
+                    !chips.contains(&ClickTarget::ContentMode(StageContentMode::FinalOutput)),
+                    "the view showing has no chip of its own"
+                );
+            },
+        );
+    }
+
+    /// Selecting a run without an answer while in the Final view lands on
+    /// Output, the view the chip would otherwise leave unreachable.
+    #[test]
+    fn the_final_view_falls_back_to_output_for_a_run_without_an_answer() {
+        runstate::with_isolated_runs_dir(
+            "the_final_view_falls_back_to_output_for_a_run_without_an_answer",
+            |_d| {
+                let agent = setup_run_state_agent_with_logs("final-fallback", &[], Some("plain"));
+                let mut dash = make_test_dashboard();
+                dash.stage_content_mode = StageContentMode::FinalOutput;
+                let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+                terminal
+                    .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &agent, 100))
+                    .unwrap();
+                assert_eq!(dash.stage_content_mode, StageContentMode::Output);
+                let buf = rendered_buffer(&terminal);
+                assert!(buf.contains(" Output  [l] logs  [c] ctx "), "{buf}");
+                assert!(buf.contains("plain"), "{buf}");
+                assert!(buf.contains("output.log"), "{buf}");
+            },
+        );
+    }
+
+    #[test]
+    fn final_output_lines_name_a_missing_format_and_truncation() {
+        let mut answer = leviath_core::FinalOutput::new("body", None, "last".to_string(), 1);
+        answer.truncated = true;
+        let lines = final_output_lines(&answer, 80);
+        let header: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert_eq!(
+            header,
+            " submitted by stage last · format: no format · truncated"
+        );
+        let body: String = lines
+            .iter()
+            .skip(2)
+            .flat_map(|l| l.spans.iter().map(|s| s.content.to_string()))
+            .collect();
+        assert!(body.contains("body"), "{body}");
     }
 
     /// A minimal stage record carrying just the name the final-output fallback

--- a/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
@@ -11,7 +11,7 @@ use ratatui::widgets::{
 
 use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
-use crate::commands::dashboard::types::NewRunPane;
+use crate::commands::dashboard::types::{ClickTarget, NewRunPane};
 use crate::tui::widgets::markdown_edit::{MODE_CHORD, MdAction, MdEditView, chord_label};
 
 impl Dashboard {
@@ -135,6 +135,12 @@ impl Dashboard {
     }
 
     fn draw_new_run_task(&mut self, frame: &mut Frame, area: Rect) {
+        // The editor keeps every row but the last, which is the Start button's.
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(area);
+        let (area, button_row) = (rows[0], rows[1]);
         let focused = self.new_run_focus == NewRunPane::Task;
         let agent = self
             .new_run_selected_agent()
@@ -164,6 +170,30 @@ impl Dashboard {
             focused,
         );
         self.new_run_task.render(frame, area, &view);
+        self.draw_new_run_start_button(frame, button_row);
+    }
+
+    /// The Start button, right-aligned under the editor. Lit like a focused
+    /// pane's border when Tab has reached it; a click on it starts the run
+    /// whether or not it has focus.
+    fn draw_new_run_start_button(&mut self, frame: &mut Frame, row: Rect) {
+        let focused = self.new_run_focus == NewRunPane::Start;
+        let style = match focused {
+            true => Style::default()
+                .fg(Color::Black)
+                .bg(C_BORDER_FOCUS)
+                .add_modifier(Modifier::BOLD),
+            false => Style::default().fg(C_BORDER).add_modifier(Modifier::BOLD),
+        };
+        let width = (START_BUTTON.chars().count() as u16).min(row.width);
+        let rect = Rect {
+            x: row.x + row.width - width,
+            y: row.y,
+            width,
+            height: row.height.min(1),
+        };
+        frame.render_widget(Paragraph::new(Span::styled(START_BUTTON, style)), rect);
+        self.register_click(rect, ClickTarget::NewRunStart);
     }
 
     /// The `@` completion, drawn as a floating menu inside the task pane.
@@ -224,9 +254,13 @@ impl Dashboard {
             // and only there: on the picker it would be a key that does
             // nothing.
             (false, NewRunPane::Task) => format!(
-                " Enter start · Alt+↵ newline · @ file · {} bold · {MODE_CHORD} preview · ^Y unattended · F1 help · Esc back ",
+                " ^Enter start · Enter newline · Tab Start button · @ file · {} bold · {MODE_CHORD} preview · ^Y unattended · F1 help · Esc back ",
                 chord_label(MdAction::Bold)
             ),
+            (false, NewRunPane::Start) => {
+                " Enter/Space start the run · Shift+Tab task · Tab agents · ^Y unattended · F1 help · Esc back "
+                    .to_string()
+            }
         };
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(hint, Style::default().fg(C_DIM)))),
@@ -234,6 +268,9 @@ impl Dashboard {
         );
     }
 }
+
+/// The Start button's face. Fixed text, so the click rect is the drawn text.
+const START_BUTTON: &str = "[ Start run ]";
 
 /// Border colour for a pane, by whether it holds the keys.
 fn focus_style(focused: bool) -> Style {
@@ -355,8 +392,42 @@ mod tests {
         let mut dash = screen();
         dash.new_run_focus = NewRunPane::Task;
         let out = rendered(&mut dash);
-        assert!(out.contains("Enter start"), "{out}");
+        assert!(out.contains("^Enter start"), "{out}");
+        assert!(out.contains("Enter newline"), "{out}");
         assert!(out.contains("@ file"), "{out}");
+    }
+
+    /// The button is on screen whichever part of the form has the keys, and
+    /// lights up only when Tab has reached it; the help bar then names the
+    /// two keys that press it.
+    #[test]
+    fn the_start_button_sits_under_the_task_and_lights_when_focused() {
+        use crate::commands::dashboard::test_support::style_at_text;
+        let mut dash = screen();
+        let backend = TestBackend::new(120, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let quiet = style_at_text(&terminal, START_BUTTON);
+        assert_eq!(quiet.fg, Some(C_BORDER), "unfocused: {quiet:?}");
+        let out = rendered(&mut dash);
+        assert!(out.contains(START_BUTTON), "{out}");
+        assert!(!out.contains("Enter/Space start"), "{out}");
+
+        dash.new_run_focus = NewRunPane::Start;
+        let mut terminal = Terminal::new(TestBackend::new(120, 24)).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let lit = style_at_text(&terminal, START_BUTTON);
+        assert_eq!(lit.bg, Some(C_BORDER_FOCUS), "focused: {lit:?}");
+        let out = rendered(&mut dash);
+        assert!(out.contains("Enter/Space start"), "help bar: {out}");
+        let button = dash
+            .click_targets
+            .iter()
+            .find(|(_, t)| *t == ClickTarget::NewRunStart)
+            .map(|(r, _)| *r)
+            .expect("the button registered its rect");
+        assert_eq!(button.width as usize, START_BUTTON.chars().count());
+        assert_eq!(button.x + button.width, 120, "right-aligned to the pane");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -339,6 +339,7 @@ fn detail_sections() -> Vec<HelpSection> {
                 ("← →", "switch stage tab"),
                 ("1-9", "jump to a stage by number"),
                 ("l / o / c", "logs / output / context"),
+                ("f", "the submitted answer, when the run has one"),
                 ("↑ ↓ / k j", "scroll a line"),
                 ("pgup / pgdn", "scroll ten lines"),
                 ("home / end (b / e)", "top / bottom"),

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -433,10 +433,17 @@ fn new_run_sections() -> Vec<HelpSection> {
         HelpSection {
             title: "New run: task",
             entries: vec![
-                ("enter", "start the run"),
-                ("alt+enter", "insert a newline"),
+                (
+                    "ctrl+enter",
+                    "start the run (needs the kitty keyboard protocol)",
+                ),
+                ("enter", "insert a newline; so does alt+enter"),
                 ("@", "reference a file from the working directory"),
-                ("tab / esc", "back to the agent list"),
+                (
+                    "tab",
+                    "the Start button: enter or space there starts the run",
+                ),
+                ("shift-tab / esc", "back to the agent list"),
             ],
         },
         HelpSection {

--- a/crates/leviath-cli/src/commands/dashboard/test_support.rs
+++ b/crates/leviath-cli/src/commands/dashboard/test_support.rs
@@ -16,6 +16,35 @@ pub(crate) fn make_test_dashboard() -> Dashboard {
     Dashboard::new(cmd_tx)
 }
 
+/// Seed a run under the current runs dir whose answer arrived through
+/// `submit_output`: the `final_output` descriptor in `meta.json` plus the
+/// sidecar beside it, submitted by `stage` under the `markdown` format, with
+/// no `output.log` anywhere. Callers run inside
+/// `runstate::with_isolated_runs_dir`, so the home runs dir is never touched.
+pub(crate) fn seed_run_with_final_output(run_id: &str, stage: &str, content: &str) {
+    use crate::runstate;
+    // A stale directory from an earlier panicked test must not leak in.
+    let _ = std::fs::remove_dir_all(runstate::run_dir(run_id));
+    let answer = leviath_core::output::FinalOutput::new(
+        content,
+        Some("markdown".to_string()),
+        stage.to_string(),
+        42,
+    );
+    let mut meta = runstate::RunMeta::new(
+        run_id.to_string(),
+        "agent".to_string(),
+        "/p".to_string(),
+        "task".to_string(),
+        None,
+        "/tmp".to_string(),
+        1,
+    );
+    meta.final_output = Some(answer.descriptor());
+    runstate::create_run(&meta).unwrap();
+    runstate::write_final_output(&runstate::run_dir(run_id), &answer.content).unwrap();
+}
+
 /// Every cell of a rendered frame, concatenated row by row.
 ///
 /// The cheapest honest assertion a render test can make: that the thing the

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -185,6 +185,8 @@ pub(super) enum ClickTarget {
     ContentMode(StageContentMode),
     /// A row of the Context view's tree, by interactive-row index.
     ContextRow(usize),
+    /// The new-run screen's Start button.
+    NewRunStart,
 }
 
 /// Cursor + expansion state of the structured Context view.
@@ -534,11 +536,16 @@ pub(super) struct McpContext {
     pub(super) connect_timeout: std::time::Duration,
 }
 
-/// Which pane of the new-run screen holds keyboard focus (Tab toggles).
+/// Which part of the new-run screen holds keyboard focus. Tab walks
+/// Agents, Task, Start and round again; Shift+Tab walks it backwards.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum NewRunPane {
     Agents,
     Task,
+    /// The Start button under the task editor: Enter or Space on it starts
+    /// the run, which is how a terminal without the kitty keyboard protocol
+    /// (where Ctrl+Enter is indistinguishable from Enter) submits.
+    Start,
 }
 
 /// One runnable agent offered by the new-run screen.

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -15,12 +15,15 @@ use ratatui::style::Color;
 #[derive(Args)]
 pub struct DashboardArgs {}
 
-/// Whether the detail content pane shows Output or Logs.
+/// What the detail content pane shows.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum StageContentMode {
     Output,
     Logs,
     Context,
+    /// The run's submitted answer, exactly as `GET /api/agents/{id}/result`
+    /// serves it. Offered only while the selected run has one.
+    FinalOutput,
 }
 
 /// How the main run list is ordered. Whatever the mode, the order is a total

--- a/crates/leviath-cli/src/main.rs
+++ b/crates/leviath-cli/src/main.rs
@@ -13,7 +13,10 @@ use std::io;
 
 use clap::Parser;
 use crossterm::ExecutableCommand;
-use crossterm::event::{DisableMouseCapture, EnableMouseCapture};
+use crossterm::event::{
+    DisableMouseCapture, EnableMouseCapture, KeyboardEnhancementFlags, PopKeyboardEnhancementFlags,
+    PushKeyboardEnhancementFlags,
+};
 use crossterm::terminal::{
     EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
 };
@@ -852,6 +855,7 @@ struct CrosstermSetup {
 /// Restore the terminal from raw mode / alternate screen / mouse capture.
 /// Safe to call redundantly: every step is a no-op when already released.
 fn restore_terminal() {
+    io::stdout().execute(PopKeyboardEnhancementFlags).ok();
     io::stdout().execute(DisableMouseCapture).ok();
     disable_raw_mode().ok();
     io::stdout().execute(LeaveAlternateScreen).ok();
@@ -895,6 +899,20 @@ impl TerminalSetup for CrosstermSetup {
     fn enable(&mut self) -> anyhow::Result<()> {
         install_terminal_restore_panic_hook();
         enable_raw_mode().map_err(anyhow::Error::from)?;
+        // The kitty keyboard protocol is what lets Ctrl+Enter (start the run
+        // from the new-run task) arrive as anything other than Enter. Asked
+        // for only where the terminal says it can, and popped again in
+        // `restore_terminal`.
+        if matches!(
+            crossterm::terminal::supports_keyboard_enhancement(),
+            Ok(true)
+        ) {
+            io::stdout()
+                .execute(PushKeyboardEnhancementFlags(
+                    KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES,
+                ))
+                .map_err(anyhow::Error::from)?;
+        }
         io::stdout()
             .execute(EnterAlternateScreen)
             .map_err(anyhow::Error::from)?;

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -38,8 +38,9 @@ panel and answer. `lev respond` does the same from the shell.
   and context-window occupancy live in the detail view.
 - **Detail view**: the run's path as a band under the header (the flat stage tabs
   on a short terminal), a context-window visualization, and content panes for **Output**,
-  **Logs**, and **Context** (JSON). Markdown is rendered. `t` swaps the band to the whole
-  blueprint, and `g` opens the blueprint full screen.
+  **Logs**, **Context** (JSON) and, once the run has submitted an answer, **Final**: the
+  answer exactly as `GET /api/agents/{id}/result` serves it. Markdown is rendered. `t` swaps
+  the band to the whole blueprint, and `g` opens the blueprint full screen.
 - **Interactions**: answer an agent's question (free-text, edit, multiple-choice, tool-approval, or
   confirm) or send it a mid-run message.
 - **Agents**: the catalog of agents this machine can run (`a`), and an editor that builds one on
@@ -185,6 +186,8 @@ for a run whose blueprint could not be read, the flat tab strip stays.
 | `PgUp` / `PgDn` | Scroll ten lines |
 | `Home` / `End` (or `b` / `e`) | Jump to the beginning / end |
 | `l` / `o` / `c` | Switch the pane to Logs / Output / Context |
+| `f` | Switch the pane to Final: the answer the run submitted, the same bytes `lev result` and the HTTP API return. The `[f] final` chip and the key are there only while the run has one; Output shows what the stage wrote along the way, which can differ |
+
 | `g` | Open the stage graph explorer |
 | `t` | Swap the band between the run's path and the whole blueprint |
 | `R` | Re-snake the path, undoing boxes you moved by hand |

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -146,13 +146,15 @@ rather than back into the form.
 |---|---|
 | `↑` / `↓` | Choose an agent. Any letter filters the list; `Backspace` shortens the filter |
 | `Tab` / `Enter` | Move from the agent list to the task |
-| `Enter` (in the task) | Start the run |
-| `Alt+Enter` | Newline, rather than starting the run |
+| `Ctrl+Enter` (in the task) | Start the run. Only a terminal with the kitty keyboard protocol (kitty, WezTerm, Ghostty, foot, recent Alacritty) can tell Ctrl+Enter from Enter; elsewhere it inserts a newline, and the Start button is the way to submit |
+| `Enter` / `Alt+Enter` | Newline |
+| `Tab` (in the task) | Move to the Start button under the editor. `Enter` or `Space` there starts the run, as does a click on it; `Tab` again returns to the agent list, `Shift+Tab` to the task |
 | `@` | Reference a file from the working directory: `↑` / `↓` choose a path, `Enter` or `Tab` inserts it, `Backspace` over the `@` ends the reference, `Esc` dismisses the list and keeps what you typed |
 | `Ctrl-Y` | Run unattended, so the agent approves its own tool calls |
 | `F1` | Help. `?` types a question mark here |
 | `Esc` (in the agent list) | Clear the filter, then close the screen |
-| `Esc` or `Tab` (in the task) | Back to the agent list |
+| `Esc` or `Shift+Tab` (in the task) | Back to the agent list |
+
 
 The task box wraps: a task longer than the pane is wide folds onto the next
 row rather than scrolling sideways, so the beginning of what you wrote is


### PR DESCRIPTION
Two user-requested dashboard changes, one commit each.

## Enter breaks the line in the new-run task; Ctrl+Enter or a Start button submits

- The task editor: Enter (and Alt+Enter) insert a newline; Ctrl+Enter starts the run.
- A `[ Start run ]` button sits right-aligned under the editor. Focus order is Agents, Task, Start (Tab forward, BackTab back; Esc from the button returns to the agent list). Enter or Space on the button starts the run; so does a click (`ClickTarget::NewRunStart`).
- Ctrl+Enter is only distinguishable from Enter under the kitty keyboard protocol. `lev dash` now pushes `DISAMBIGUATE_ESCAPE_CODES` after entering raw mode when `supports_keyboard_enhancement()` says the terminal has it, and pops it on the way out. On a terminal without it Ctrl+Enter arrives as Enter (a newline) and the button is the way to submit; the help bar says so. This is the only `main.rs` change (the import, one guarded `execute`, and the pop in `restore_terminal`), hence the `allow-main-rs-change` label.
- The response-pane editor ("Writing a response") is untouched: Enter still sends there, Alt+Enter still breaks the line. The two editors now differ; the doc comment on the task-key handler says why. Easy to align later if wanted.

## A Final output view, showing exactly what the HTTP API serves

Why the TUI and HTTP disagreed: the Output pane shows the selected stage's `output.log` (what the model said in chat) and only fell back to the run's final answer when that log was empty, while `GET /api/agents/{id}/result` and the agent GET serve `final_output`, the answer the agent submitted through `submit_output`. A model that tells one joke in chat and submits another shows differently in each.

- New content mode `StageContentMode::FinalOutput`, chip `[f] final`, key `f`. The chip appears only when `runstate::read_final_output(&run)` is `Some`, the same function the API reads through, so the two cannot drift. The view shows a dim header (`submitted by stage X · format: Y`, plus `truncated` when the descriptor says so) and the answer rendered as markdown; the file hint names the `final_output` sidecar. If the mode is selected and the run has no answer it falls back to Output. Clicking the chip works through the existing mode-chip path; `y` yanks the answer.

## Tests

new_run.rs: Enter breaks the line and dispatches nothing; Ctrl+Enter submits; Tab/BackTab cycle through Start; Enter and Space on Start submit; other keys move focus. render/new_run.rs: the button is drawn under the task and lights when focused. click.rs: clicking the button starts the run; clicking the final chip opens the view. content.rs: the chip is offered only with an answer; the view equals `read_final_output(id).content` with header, format and file hint; fallback without an answer; missing-format and truncated headers. input.rs: `f` only switches with an answer; yank copies the answer.

## Gates

clippy and rustdoc `-D warnings`; `xtask structure`, `xtask docs`; `cargo xtask coverage --package leviath-cli` 100%. (Two pre-existing `doctor::config_check_*` tests read the real `~/.leviath/config.toml`; #693 isolates them.)

## Live

Real daemon + `lev serve` + `mock.py` told to call `submit_output` with a markdown answer and then chat "done", `lev dash` over a pty replayed into a grid:
- New-run screen: `[ Start run ]` under the editor; typing `ab`, Enter, `cd` gives two rows with the screen still open; help bar reads `^Enter start · Enter newline · Tab Start button`.
- Detail view Output: `done` from `stages/0/output.log`, chips `[l] logs [c] ctx [f] final`.
- After `f`: `submitted by stage main · format: markdown`, then the rendered submitted answer, hint `runs/<id>/final_output`. Same text as `curl /api/agents/<id>/result | jq .final_output.content`.
- Ctrl+Enter was not exercised over the bare pty (it answers no kitty query, which is exactly the case the button covers); the unit test covers the key.
