### PR TITLE
fix(dash,daemon): say when a prompt expired, and when unattended stayed off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,17 @@ same list.
 
 ### Fixed
 
+- An approval prompt nobody answered before `[limits] interaction_timeout_secs`
+  was reported to the model as `User declined tool call`, as if a person had
+  refused it. A six-hour deep-researcher run lost all three of its report
+  writes that way with nobody at the dashboard. The result now says that no
+  one answered the prompt within the timeout, names the timeout, and says
+  how to change it; `lev timeline` labels that parked time as waiting on
+  children or prompts rather than children alone.
+- In the new-run screen, turning unattended back on re-asks the warning, and
+  its focus starts on "Keep asking me", so an Enter meant as "yes" declined
+  it with nothing but a log line to say so. The decline is now a toast, and
+  the help bar shows `unattended: on` or `off` rather than only the key.
 - Sums that a hostile number could overflow (pricing, stream byte counts, the
   rate limiter's window, region and layout sizes) saturate instead of aborting
   the daemon (#649).

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -136,7 +136,18 @@ impl Dashboard {
         };
         match dialog.handle(key) {
             ConfirmOutcome::Pending => self.pending_confirm = Some((action, dialog)),
-            ConfirmOutcome::No => self.add_log("Cancelled".to_string()),
+            ConfirmOutcome::No => {
+                self.add_log("Cancelled".to_string());
+                // The dialog's safe default is "Keep asking me", so an Enter
+                // meant as "yes" lands here. Left to a log line, that put a
+                // six-hour run through three approval prompts nobody saw.
+                if matches!(action, ConfirmAction::EnableYolo) {
+                    self.toast(
+                        "Unattended stays off: runs will ask you (Ctrl-Y to try again)",
+                        ToastLevel::Info,
+                    );
+                }
+            }
             ConfirmOutcome::Yes => match action {
                 ConfirmAction::Kill { run_ids } => {
                     for run_id in &run_ids {

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -1533,6 +1533,53 @@ mod tests {
         assert!(!dash.new_run_yolo);
     }
 
+    /// The sequence that lost a six-hour run its file writes: unattended on
+    /// (confirmed), off again, on again, and Enter on the re-asked warning.
+    /// The dialog's focus starts on "Keep asking me", so Enter declines, and
+    /// before this the only trace was a "Cancelled" log line nobody reads.
+    /// The setting stays off (that is the dialog's safe default), but the
+    /// screen now says so where the person is looking.
+    #[test]
+    fn declining_the_re_asked_warning_with_enter_says_unattended_stayed_off() {
+        let mut dash = make_test_dashboard();
+        dash.new_run_screen = true;
+
+        dash.handle_key(ctrl(KeyCode::Char('y')));
+        dash.handle_key(key(KeyCode::Char('y')));
+        assert!(dash.new_run_yolo, "on, confirmed");
+        dash.handle_key(ctrl(KeyCode::Char('y')));
+        assert!(!dash.new_run_yolo, "off again");
+
+        dash.toasts.clear();
+        dash.handle_key(ctrl(KeyCode::Char('y')));
+        assert!(
+            dash.pending_confirm.is_some(),
+            "not silenced, so it asks again"
+        );
+        dash.handle_key(key(KeyCode::Enter));
+        assert!(dash.pending_confirm.is_none());
+        assert!(
+            !dash.new_run_yolo,
+            "Enter on the focused Keep-asking button declines"
+        );
+        let toast = dash
+            .toasts
+            .last()
+            .map(|t| t.message.clone())
+            .unwrap_or_default();
+        assert!(
+            toast.contains("stays off") && toast.contains("Ctrl-Y"),
+            "the decline is said out loud: {toast:?}"
+        );
+        let help = dash.new_run_help_bar_text();
+        assert!(help.contains("unattended: off"), "{help}");
+
+        dash.handle_key(ctrl(KeyCode::Char('y')));
+        dash.handle_key(key(KeyCode::Char('y')));
+        assert!(dash.new_run_yolo);
+        assert!(dash.new_run_help_bar_text().contains("unattended: on"));
+    }
+
     /// The box silences the warning for the rest of the sitting, and only for the
     /// warning: the setting itself still has to be turned on each time.
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
@@ -243,25 +243,36 @@ impl Dashboard {
         );
     }
 
-    fn draw_new_run_help_bar(&self, frame: &mut Frame, area: Rect) {
-        let hint = match (self.new_run_file_ref, self.new_run_focus) {
+    /// The help bar's text for the current focus. Names the unattended
+    /// setting's state, not only its key: the title chip appears only when
+    /// it is on, so with it off nothing on the screen said so, and a warning
+    /// dialog declined by an Enter meant as "yes" left a person believing
+    /// the opposite of what the next run would do.
+    pub(in crate::commands::dashboard) fn new_run_help_bar_text(&self) -> String {
+        let unattended = match self.new_run_yolo {
+            true => "unattended: on",
+            false => "unattended: off",
+        };
+        match (self.new_run_file_ref, self.new_run_focus) {
             (true, _) => " ↑↓ choose · Enter/Tab insert · Esc dismiss ".to_string(),
-            (false, NewRunPane::Agents) => {
-                " ↑↓ select · type to filter · Tab write task · ^Y unattended · F1 help · Esc back "
-                    .to_string()
-            }
+            (false, NewRunPane::Agents) => format!(
+                " ↑↓ select · type to filter · Tab write task · ^Y {unattended} · F1 help · Esc back "
+            ),
             // The formatting chord is named on the pane that has the toolbar,
             // and only there: on the picker it would be a key that does
             // nothing.
             (false, NewRunPane::Task) => format!(
-                " ^Enter start · Enter newline · Tab Start button · @ file · {} bold · {MODE_CHORD} preview · ^Y unattended · F1 help · Esc back ",
+                " ^Enter start · Enter newline · Tab Start button · @ file · {} bold · {MODE_CHORD} preview · ^Y {unattended} · F1 help · Esc back ",
                 chord_label(MdAction::Bold)
             ),
-            (false, NewRunPane::Start) => {
-                " Enter/Space start the run · Shift+Tab task · Tab agents · ^Y unattended · F1 help · Esc back "
-                    .to_string()
-            }
-        };
+            (false, NewRunPane::Start) => format!(
+                " Enter/Space start the run · Shift+Tab task · Tab agents · ^Y {unattended} · F1 help · Esc back "
+            ),
+        }
+    }
+
+    fn draw_new_run_help_bar(&self, frame: &mut Frame, area: Rect) {
+        let hint = self.new_run_help_bar_text();
         frame.render_widget(
             Paragraph::new(Line::from(Span::styled(hint, Style::default().fg(C_DIM)))),
             area,

--- a/crates/leviath-cli/src/commands/timeline.rs
+++ b/crates/leviath-cli/src/commands/timeline.rs
@@ -101,7 +101,8 @@ pub(crate) struct Totals {
     pub inference: i64,
     /// Seconds running tool batches.
     pub tools: i64,
-    /// Seconds parked waiting for children.
+    /// Seconds parked: waiting on children, or on a person to answer a
+    /// prompt (an approval, an `ask_user_*` tool, an interaction point).
     pub waiting: i64,
     /// Whatever is left: scheduling, persistence, gaps between records.
     pub other: i64,
@@ -321,7 +322,7 @@ fn same_large_reply(a: &CallSpan, b: &CallSpan) -> bool {
 fn print_run(run: &RunTimeline, with_calls: bool) {
     let t = &run.totals;
     println!(
-        "{} ({}, {}) wall {} = model calls {} + tools {} + waiting on children {} + other {}",
+        "{} ({}, {}) wall {} = model calls {} + tools {} + waiting on children or prompts {} + other {}",
         run.run_id,
         run.agent_name,
         run.status,

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -529,19 +529,43 @@ pub(crate) async fn dispatch_tools(
                     &approval_keys,
                 );
                 let response = state.interaction.ask(req).await;
-                if response.approved.unwrap_or(false) {
-                    // Record a grant for each command the user just saw run. An
-                    // empty key list means this call is not reusable, so a
-                    // scoped approval degrades to "this once" - which is what
-                    // the option label they chose already told them.
-                    state.remember(response.scope, &approval_keys).await;
-                    charge_declared(&state, &tc);
-                    slots.push((tc.id.clone(), None));
-                    queued.push((slot, is_builtin, tc));
-                } else {
-                    let result = format!("[denied] User declined tool call '{}'.", tc.name);
-                    progress(&tc.id, &result);
-                    slots.push((tc.id.clone(), Some(result)));
+                match response.approved {
+                    Some(true) => {
+                        // Record a grant for each command the user just saw run.
+                        // An empty key list means this call is not reusable, so
+                        // a scoped approval degrades to "this once" - which is
+                        // what the option label they chose already told them.
+                        state.remember(response.scope, &approval_keys).await;
+                        charge_declared(&state, &tc);
+                        slots.push((tc.id.clone(), None));
+                        queued.push((slot, is_builtin, tc));
+                    }
+                    Some(false) => {
+                        let result = format!("[denied] User declined tool call '{}'.", tc.name);
+                        progress(&tc.id, &result);
+                        slots.push((tc.id.clone(), Some(result)));
+                    }
+                    // The hub's neutral answer: the prompt was cancelled or
+                    // nobody answered it before the interaction timeout. Saying
+                    // "declined" here blamed a person who never saw the prompt.
+                    None => {
+                        let secs = state.interaction.timeout_secs();
+                        tracing::warn!(
+                            tool = %tc.name,
+                            stage = %stage_name,
+                            timeout_secs = secs,
+                            "approval prompt expired unanswered; the call did not run"
+                        );
+                        let result = format!(
+                            "[denied] no one answered the approval prompt for '{}' before the \
+                             interaction timeout ({secs} s, `[limits] interaction_timeout_secs`); \
+                             the call did not run. Answer prompts in `lev dash`, raise the \
+                             timeout, or set this tool to \"allow\" for the stage.",
+                            tc.name
+                        );
+                        progress(&tc.id, &result);
+                        slots.push((tc.id.clone(), Some(result)));
+                    }
                 }
             }
             ToolPolicy::Allow => {
@@ -1391,6 +1415,38 @@ mod tests {
         )
         .await;
         assert!(out[0].1.contains("[denied]"));
+    }
+
+    /// A prompt nobody answered before `[limits] interaction_timeout_secs`
+    /// comes back as the hub's neutral response (`approved: None`). That is
+    /// not a decline, and the tool result must not say the user declined:
+    /// a six-hour deep-researcher run reported three "User declined" writes
+    /// that no one had seen, let alone refused.
+    #[tokio::test]
+    async fn an_unanswered_approval_says_so_instead_of_blaming_the_user() {
+        let hub = InteractionHub::new();
+        hub.set_timeout_secs(3600);
+        let mut ask = HashMap::new();
+        ask.insert("echo".to_string(), ToolPolicy::Ask);
+        let names: HashSet<String> = ["echo".to_string()].into_iter().collect();
+        let (state, _dir) =
+            script_state(&hub, &[("echo", "\"x\"")], names, no_script_fields().2, ask);
+        let out = dispatch_answering(
+            state,
+            vec![call("c1", "echo", serde_json::json!({}))],
+            |req| InteractionResponse::text(&req.id, ""),
+            hub,
+        )
+        .await;
+        let result = &out[0].1;
+        assert!(result.starts_with("[denied]"), "{result}");
+        assert!(!result.contains("declined"), "not a decline: {result}");
+        assert!(
+            result.contains("no one answered the approval prompt")
+                && result.contains("3600")
+                && result.contains("interaction_timeout_secs"),
+            "{result}"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -85,6 +85,11 @@ impl InteractionHub {
         self.timeout_secs.store(secs, Ordering::Relaxed);
     }
 
+    /// The configured deadline in seconds; `0` means the hub waits indefinitely.
+    pub fn timeout_secs(&self) -> u64 {
+        self.timeout_secs.load(Ordering::Relaxed)
+    }
+
     /// The current deadline, or `None` when the hub waits indefinitely.
     fn timeout(&self) -> Option<Duration> {
         match self.timeout_secs.load(Ordering::Relaxed) {
@@ -249,6 +254,14 @@ impl InteractionHub {
 pub struct HubInteractionBackend {
     hub: InteractionHub,
     agent_id: String,
+}
+
+impl HubInteractionBackend {
+    /// The hub's prompt deadline in seconds (`0`: it waits indefinitely), so a
+    /// caller can say in its own words how long an unanswered prompt waited.
+    pub fn timeout_secs(&self) -> u64 {
+        self.hub.timeout_secs()
+    }
 }
 
 #[async_trait::async_trait]

--- a/crates/leviath-runtime/src/interaction_hub_tests.rs
+++ b/crates/leviath-runtime/src/interaction_hub_tests.rs
@@ -318,3 +318,14 @@ async fn an_answer_that_lands_as_the_deadline_passes_still_wins() {
     let response = hub.expire("agent-a", "q1", &mut rx);
     assert_eq!(response.value.as_deref(), Some("approved by hand"));
 }
+
+/// The deadline reads back through the hub and through a per-agent backend,
+/// which is how a tool result can name it when a prompt expires.
+#[test]
+fn the_timeout_reads_back_through_the_hub_and_its_backends() {
+    let hub = InteractionHub::new();
+    assert_eq!(hub.timeout_secs(), 0, "a fresh hub waits indefinitely");
+    hub.set_timeout_secs(7);
+    assert_eq!(hub.timeout_secs(), 7);
+    assert_eq!(hub.backend_for("agent-a").timeout_secs(), 7);
+}


### PR DESCRIPTION
Root cause of the write failures in `deep-researcher-1787980740-c2909aa7c397`, and the two silences that hid it.

## What happened

- The run's `meta.json` has `yolo = false`: it was **not** unattended, so every `write_file` (the blueprint says `write_file = "ask"`) parked on an approval prompt.
- Nobody answered within `[limits] interaction_timeout_secs = 3600`. The hub resolves that as the neutral answer (`approved: None`), and `tool_service.rs` reported it as `[denied] User declined tool call 'write_file'`. Three writes (synthesize, twice in polish) went that way; the timeline's "waiting on children 5:15:07" for a run with no children is those prompts.
- Why it was not unattended: the new-run screen's unattended toggle had been turned on, off, and on again. The second "on" re-asks the warning dialog (unless "don't ask again" was ticked), and that dialog's focus starts on **Keep asking me**, so an Enter meant as "yes" declines it. The only trace was a "Cancelled" line in the log pane. The toggle's state machine itself is correct (the sequence is now a test, and it behaves as designed); what was missing was the feedback.

## Changes

- `daemon/tool_service.rs`: the Ask arm matches `Some(true)` / `Some(false)` / `None`. `None` now produces `[denied] no one answered the approval prompt for 'write_file' before the interaction timeout (3600 s, [limits] interaction_timeout_secs); the call did not run. Answer prompts in lev dash, raise the timeout, or set this tool to "allow" for the stage.` plus a daemon `warn!`. A real decline keeps its message. `HubInteractionBackend::timeout_secs()` exposes the deadline for that text.
- `commands/timeline.rs`: the summary line reads `waiting on children or prompts`, and the field's doc says what it counts.
- `dashboard/input.rs`: declining the unattended warning toasts `Unattended stays off: runs will ask you (Ctrl-Y to try again)`.
- `dashboard/render/new_run.rs`: the help bar shows `^Y unattended: on` / `off` on every pane, through one `new_run_help_bar_text()` the tests read.
- CHANGELOG: two Fixed entries.

## Fail-first

- `an_unanswered_approval_says_so_instead_of_blaming_the_user`: on the old code the result was `[denied] User declined tool call 'echo'.`; now it names the timeout and does not say "declined". The existing declined-approval tests still pass unchanged.
- `declining_the_re_asked_warning_with_enter_says_unattended_stayed_off` replays the exact sequence (on, confirmed; off; on; Enter): on the old code the toast list was empty; now it carries the decline and the help bar reads `unattended: off`, then `on` after a confirmed retry.

## Not changed, on purpose

The dialog still focuses "Keep asking me" first. That is the safe default for a setting that lets an agent write files without asking, and the tests document why. Left alone: the 3600 s default timeout and the blueprint's `write_file = "ask"`.

## Gates

runtime and cli tests green; clippy and rustdoc `-D warnings`; `xtask structure`, `xtask docs`; coverage 100% on `leviath-runtime` and `leviath-cli`.
