### PR TITLE
docs: install on Windows from PowerShell, not through a spawned one

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ lev create my-agent              # scaffold your own agent
 curl -fsSL https://leviath.dev/install.sh | sh
 ```
 
-**Windows**, pasting into either Command Prompt or PowerShell:
+**Windows**, in PowerShell (Windows Terminal opens one; not Command Prompt):
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://leviath.dev/install.ps1 | iex"
+irm https://leviath.dev/install.ps1 | iex
 ```
 
 Both install prebuilt binaries, so no Rust toolchain is needed. Stable is the default; for beta or

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -37,9 +37,18 @@ curl -fsSL https://leviath.dev/install.sh | sh
 irm https://leviath.dev/install.ps1 | iex
 ```
 
+No administrator is needed: it unpacks into `%LOCALAPPDATA%\Leviath\bin` and adds that folder to
+your own PATH.
+
 Paste it into PowerShell rather than Command Prompt. The old form that spawned PowerShell from
 cmd (`powershell -ExecutionPolicy Bypass -c "..."`) is the launch pattern endpoint protection
 refuses on managed machines - it answered "Access is denied." before anything ran.
+
+If Windows Defender or another antivirus quarantines `lev.exe`, that is a false positive on a new,
+unsigned binary, not something it found. You can check the file is exactly what this repo's CI
+built with `gh attestation verify "$env:LOCALAPPDATA\Leviath\bin\lev.exe" --repo GEMISIS/leviath`,
+then restore it from quarantine or add the folder to the exclusions; reporting it as a false
+positive to your vendor helps every later install.
 
 Check it worked:
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -31,11 +31,15 @@ One command, any platform. It installs a prebuilt binary, so no Rust toolchain i
 curl -fsSL https://leviath.dev/install.sh | sh
 ```
 
-**Windows**
+**Windows**, in PowerShell (Windows Terminal opens one):
 
 ```powershell
-powershell -ExecutionPolicy Bypass -c "irm https://leviath.dev/install.ps1 | iex"
+irm https://leviath.dev/install.ps1 | iex
 ```
+
+Paste it into PowerShell rather than Command Prompt. The old form that spawned PowerShell from
+cmd (`powershell -ExecutionPolicy Bypass -c "..."`) is the launch pattern endpoint protection
+refuses on managed machines - it answered "Access is denied." before anything ran.
 
 Check it worked:
 


### PR DESCRIPTION
## Summary
The documented Windows one-liner (`powershell -ExecutionPolicy Bypass -c "irm https://leviath.dev/install.ps1 | iex"`) is the textbook launch pattern that AppLocker / Defender ASR / EDRs refuse — a user reported cmd answering `Access is denied.` before anything ran, while `irm … | iex` inside an open PowerShell worked. README and getting-started now give the PowerShell-native command and say where to paste it. Site side: GEMISIS/leviath.dev (same change, plus the `install.ps1` stub now passes `-Channel` to the dist installer explicitly — it was setting an env var the installer never read, so every Windows install landed on alpha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEghnENp713SaXixQUpB1k