### PR TITLE
fix(dash): unattended toasts say ON or OFF, and a warning is not a pause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ same list.
 
 ### Fixed
 
+- The toast for turning unattended on carried the warning icon, which was a
+  pause glyph, and the one for turning it off carried the green check, so on
+  read as held back and off as armed. The warning icon is now `!`, and the
+  three unattended toasts say ON or OFF in so many words.
 - An approval prompt nobody answered before `[limits] interaction_timeout_secs`
   was reported to the model as `User declined tool call`, as if a person had
   refused it. A six-hour deep-researcher run lost all three of its report

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -143,7 +143,7 @@ impl Dashboard {
                 // six-hour run through three approval prompts nobody saw.
                 if matches!(action, ConfirmAction::EnableYolo) {
                     self.toast(
-                        "Unattended stays off: runs will ask you (Ctrl-Y to try again)",
+                        "Unattended stays OFF: runs will ask you (Ctrl-Y to try again)",
                         ToastLevel::Info,
                     );
                 }

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -293,12 +293,18 @@ impl Dashboard {
     pub(super) fn toggle_new_run_yolo(&mut self) {
         if self.new_run_yolo {
             self.new_run_yolo = false;
-            self.toast("Unattended off: you will be asked", ToastLevel::Info);
+            self.toast(
+                "Unattended OFF: runs will ask you before each tool call",
+                ToastLevel::Info,
+            );
             return;
         }
         if self.yolo_warning_silenced {
             self.new_run_yolo = true;
-            self.toast("Unattended on", ToastLevel::Warning);
+            self.toast(
+                "Unattended ON: runs approve their own tool calls",
+                ToastLevel::Warning,
+            );
             return;
         }
         self.pending_confirm = Some((ConfirmAction::EnableYolo, yolo_warning()));
@@ -308,7 +314,10 @@ impl Dashboard {
     pub(super) fn accept_yolo_warning(&mut self, silence: bool) {
         self.new_run_yolo = true;
         self.yolo_warning_silenced = silence;
-        self.toast("Unattended on", ToastLevel::Warning);
+        self.toast(
+            "Unattended ON: runs approve their own tool calls",
+            ToastLevel::Warning,
+        );
     }
 
     // ── Keys ─────────────────────────────────────────────────────────────────
@@ -1568,7 +1577,7 @@ mod tests {
             .map(|t| t.message.clone())
             .unwrap_or_default();
         assert!(
-            toast.contains("stays off") && toast.contains("Ctrl-Y"),
+            toast.contains("stays OFF") && toast.contains("Ctrl-Y"),
             "the decline is said out loud: {toast:?}"
         );
         let help = dash.new_run_help_bar_text();

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -38,7 +38,7 @@ impl Dashboard {
             };
             let icon = match toast.level {
                 super::super::types::ToastLevel::Info => "✓",
-                super::super::types::ToastLevel::Warning => "⏸",
+                super::super::types::ToastLevel::Warning => "!",
                 super::super::types::ToastLevel::Error => "✗",
             };
             let msg = truncate(&toast.message, (toast_w - 4) as usize);


### PR DESCRIPTION
Follow-up to #696 from the user's own account of the run: the second toggle showed **no** dialog ("Don't ask again" had been ticked), so the toggle worked; what misled was the toast. Turning unattended **on** posts a warning-level toast, and the warning icon was `⏸`; turning it **off** posts an info-level toast with the green `✓`. On read as paused, off read as confirmed.

- `render/overlays.rs`: the warning icon is `!` (a warning is not a pause; this applies to every warning toast).
- `new_run.rs` / `input.rs`: `Unattended ON: runs approve their own tool calls`, `Unattended OFF: runs will ask you before each tool call`, `Unattended stays OFF: runs will ask you (Ctrl-Y to try again)`.
- CHANGELOG Fixed entry.

Tests: the #696 sequence test asserts the new wording; the dashboard suites pass. `cargo xtask docs` clean. Gates below.
