### PR TITLE
fix(dash): cut a line only where it does not fit, measured in columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,16 @@ same list.
 
 ### Fixed
 
+- The dashboard cut text to fixed character counts whatever the terminal
+  width: the detail view's model name stopped at 24 characters and its
+  working directory at 42 with most of a 200-column row empty, the header
+  title and the review prompt were capped the same way, and a run table cell
+  longer than its column was clipped at the edge with no sign anything was
+  missing. Those lines now shrink only where they do not fit, least important
+  part first (the model before the directory, the title before the status),
+  and cells are cut to their column with an ellipsis. The cut is measured in
+  terminal columns rather than bytes, so a title with em dashes or emoji is
+  no longer shortened to a third of its room.
 - The toast for turning unattended on carried the warning icon, which was a
   pause glyph, and the one for turning it off carried the green check, so on
   read as held back and off as armed. The warning icon is now `!`, and the

--- a/crates/leviath-cli/src/commands/dashboard/helpers.rs
+++ b/crates/leviath-cli/src/commands/dashboard/helpers.rs
@@ -1,6 +1,6 @@
 //! Pure utility functions used across the dashboard.
 
-use leviath_core::truncate_at_boundary;
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 /// Format a Unix timestamp as a relative time string ("just now", "2m ago", "1h ago").
 pub(super) fn relative_time(ts: i64) -> String {
@@ -34,15 +34,61 @@ pub(super) fn relative_time(ts: i64) -> String {
     }
 }
 
+/// Fit `s` into `max` terminal columns, ending in an ellipsis when it had to
+/// be cut. The ellipsis is part of the budget, so the result never draws wider
+/// than `max`.
+///
+/// Measured in display columns, not bytes: a run title full of em dashes or
+/// emoji used to be cut at a third of the room it was given, and a wide
+/// character counts for the two cells it occupies.
 pub(super) fn truncate(s: &str, max: usize) -> String {
     let s = s.trim();
-    if s.len() <= max {
-        s.to_string()
-    } else {
-        // Cut on a char boundary so multi-byte content (em-dashes, emoji in run
-        // titles) shortens instead of panicking.
-        format!("{}…", truncate_at_boundary(s, max))
+    if s.width() <= max {
+        return s.to_string();
     }
+    if max == 0 {
+        return String::new();
+    }
+    let keep = max - 1;
+    let mut out = String::new();
+    let mut used = 0;
+    for ch in s.chars() {
+        let w = ch.width().unwrap_or(0);
+        if used + w > keep {
+            break;
+        }
+        out.push(ch);
+        used += w;
+    }
+    out.push('…');
+    out
+}
+
+/// The fewest columns a shrinkable part keeps before the next one is touched.
+pub(super) const FIT_FLOOR: usize = 8;
+
+/// Fit a line made of `parts` into `width` columns.
+///
+/// Returned unchanged when the whole line fits. Otherwise the parts named in
+/// `shrink_order` (least important first) are cut with [`truncate`], each down
+/// to [`FIT_FLOOR`] columns before the next one is touched, and the walk stops
+/// as soon as the line fits. Parts not named never change, so a caller decides
+/// exactly what gives way and in what order. When every shrinkable part sits
+/// at the floor and the line is still too long, what remains is left to the
+/// widget to clip.
+pub(super) fn fit_parts(parts: &[String], width: usize, shrink_order: &[usize]) -> Vec<String> {
+    let mut out: Vec<String> = parts.to_vec();
+    for &idx in shrink_order {
+        let total: usize = out.iter().map(|p| p.width()).sum();
+        if total <= width {
+            break;
+        }
+        let excess = total - width;
+        let current = out[idx].width();
+        let target = current.saturating_sub(excess).max(FIT_FLOOR.min(current));
+        out[idx] = truncate(&out[idx], target);
+    }
+    out
 }
 
 /// Format a token count in compact style: ≥1000 → "21k", else raw.
@@ -137,7 +183,8 @@ mod tests {
     #[test]
     fn test_truncate_long() {
         let result = truncate("hello world", 5);
-        assert_eq!(result, "hello…");
+        assert_eq!(result, "hell…");
+        assert_eq!(result.width(), 5);
     }
 
     #[test]
@@ -201,39 +248,124 @@ mod tests {
     #[test]
     fn test_truncate_unicode() {
         let result = truncate("abcdef", 3);
-        assert_eq!(result, "abc…");
+        assert_eq!(result, "ab…");
     }
 
     #[test]
-    fn test_truncate_multibyte_char_boundary() {
-        // Em-dash (–) is 3 bytes (U+2013, bytes E2 80 93).
-        // Slicing at a byte index inside the em-dash must not panic.
+    fn test_truncate_multibyte_counts_columns_not_bytes() {
+        // The en dash is 3 bytes but one column. Byte counting cut this line
+        // at "Research the histo" when asked for 22; column counting keeps
+        // 21 characters plus the ellipsis.
         let s = "Research the history – covering all topics";
-        // "Research the history " is 21 bytes, then "–" is bytes 21..24.
-        // Truncating at max=22 would land inside the em-dash without the fix.
-        let result = truncate(s, 22);
-        assert!(!result.is_empty());
-        assert!(result.ends_with('…'));
-        // Should back up to byte 21 (the space before the em-dash)
-        assert_eq!(result, "Research the history …");
-
-        // Also test truncating right at the start of the em-dash
-        let result2 = truncate(s, 21);
-        assert_eq!(result2, "Research the history …");
-
-        // And right after the em-dash
-        let result3 = truncate(s, 24);
-        assert_eq!(result3, "Research the history –…");
+        assert_eq!(truncate(s, 22), "Research the history …");
+        assert_eq!(truncate(s, 21), "Research the history…");
+        assert_eq!(truncate(s, 24), "Research the history – …");
+        assert_eq!(truncate(s, 24).width(), 24);
     }
 
     #[test]
-    fn test_truncate_emoji() {
-        // Emoji like 🔥 is 4 bytes. Truncating in the middle must not panic.
+    fn test_truncate_emoji_is_two_columns() {
+        // 🔥 is 4 bytes and 2 columns. The budget is spent in columns: with 7
+        // there is room for "Hello " (6) but not the 2-wide emoji, and with 9
+        // the emoji fits and the ellipsis follows it.
         let s = "Hello 🔥 world";
-        let result = truncate(s, 7); // lands inside the emoji (bytes 6..10)
-        assert!(!result.is_empty());
-        assert!(result.ends_with('…'));
-        assert_eq!(result, "Hello …");
+        assert_eq!(truncate(s, 7), "Hello …");
+        assert_eq!(truncate(s, 9), "Hello 🔥…");
+        assert_eq!(truncate(s, 9).width(), 9);
+        // Wholly multi-byte text: 13 columns wide, cut to 6.
+        assert_eq!(truncate(&"…".repeat(13), 6), "…".repeat(6));
+    }
+
+    #[test]
+    fn test_truncate_zero_width_is_empty() {
+        // No room for even the ellipsis: draw nothing rather than one column
+        // more than was offered.
+        assert_eq!(truncate("hello", 0), "");
+        assert_eq!(truncate("", 0), "");
+    }
+
+    #[test]
+    fn test_truncate_one_column_is_the_ellipsis() {
+        assert_eq!(truncate("hello", 1), "…");
+    }
+
+    fn parts(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn fit_parts_leaves_a_fitting_line_alone() {
+        let p = parts(&[
+            "dir ",
+            "~/projects/leviath",
+            " · ",
+            "openrouter/z-ai/glm-5.3",
+        ]);
+        assert_eq!(fit_parts(&p, 80, &[3, 1]), p);
+        // Exactly full is still fitting.
+        let total: usize = p.iter().map(|s| s.width()).sum();
+        assert_eq!(fit_parts(&p, total, &[3, 1]), p);
+    }
+
+    #[test]
+    fn fit_parts_shrinks_the_first_named_part_only_when_it_is_enough() {
+        let p = parts(&[
+            "dir ",
+            "~/projects/leviath",
+            " · ",
+            "openrouter/z-ai/glm-5.3",
+        ]);
+        // 4 + 18 + 3 + 23 = 48; ten columns over, so the model loses ten.
+        let out = fit_parts(&p, 38, &[3, 1]);
+        assert_eq!(out[0], "dir ");
+        assert_eq!(out[1], "~/projects/leviath");
+        assert_eq!(out[2], " · ");
+        assert_eq!(out[3], "openrouter/z…");
+        assert_eq!(out.iter().map(|s| s.width()).sum::<usize>(), 38);
+    }
+
+    #[test]
+    fn fit_parts_moves_to_the_second_part_after_the_first_hits_the_floor() {
+        let p = parts(&[
+            "dir ",
+            "~/projects/leviath",
+            " · ",
+            "openrouter/z-ai/glm-5.3",
+        ]);
+        // 48 wide, 28 asked: the model can only give 15 (down to 8), so the
+        // workdir gives the remaining 5.
+        let out = fit_parts(&p, 28, &[3, 1]);
+        assert_eq!(out[3], "openrou…");
+        assert_eq!(out[3].width(), FIT_FLOOR);
+        assert_eq!(out[1], "~/projects/l…");
+        assert_eq!(out.iter().map(|s| s.width()).sum::<usize>(), 28);
+    }
+
+    #[test]
+    fn fit_parts_stops_at_the_floor_and_never_touches_unnamed_parts() {
+        let p = parts(&[
+            "dir ",
+            "~/projects/leviath",
+            " · ",
+            "openrouter/z-ai/glm-5.3",
+        ]);
+        // Far too narrow: both named parts sit at the floor, the fixed parts
+        // are intact, and the line is simply still too long.
+        let out = fit_parts(&p, 10, &[3, 1]);
+        assert_eq!(out[0], "dir ");
+        assert_eq!(out[2], " · ");
+        assert_eq!(out[1].width(), FIT_FLOOR);
+        assert_eq!(out[3].width(), FIT_FLOOR);
+    }
+
+    #[test]
+    fn fit_parts_floor_does_not_grow_a_part_shorter_than_it() {
+        // A part already narrower than the floor is left as it is rather than
+        // padded, and the excess moves on to the next named part.
+        let p = parts(&["ab", "0123456789abcdef"]);
+        let out = fit_parts(&p, 12, &[0, 1]);
+        assert_eq!(out[0], "ab");
+        assert_eq!(out[1], "012345678…");
     }
 
     // OSC52 encoding and the /dev/tty write path now live in `leviath_sys::tty`

--- a/crates/leviath-cli/src/commands/dashboard/render/header.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/header.rs
@@ -5,8 +5,9 @@ use ratatui::layout::Rect;
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Padding, Paragraph};
+use unicode_width::UnicodeWidthStr;
 
-use crate::commands::dashboard::helpers::{format_tokens, truncate};
+use crate::commands::dashboard::helpers::{fit_parts, format_tokens, truncate};
 use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
 use crate::commands::dashboard::types::*;
@@ -25,66 +26,62 @@ impl Dashboard {
         // work · 19h old`, which is the whole story in two figures.
         let elapsed = duration::precise(agent.runtime_secs);
         let age = duration::compact(duration::between(agent.started_at, agent.clock_now));
-        let status_color = agent.status.color();
+        let status_style = Style::default()
+            .fg(agent.status.color())
+            .add_modifier(Modifier::BOLD);
         let spinner_frame = SPINNER[(self.tick_count as usize) % SPINNER.len()];
-        let status_span = match &agent.status {
-            AgentDisplayStatus::Active => Span::styled(
-                format!("{} {} ", spinner_frame, agent.status),
-                Style::default()
-                    .fg(status_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            // Cap the status text so a long error message (the full text lives in
-            // the Output pane) can't consume the whole line and push the run id
-            // off the right edge.
-            _ => Span::styled(
-                format!("{} ", truncate(&agent.status.to_string(), 28)),
-                Style::default()
-                    .fg(status_color)
-                    .add_modifier(Modifier::BOLD),
-            ),
+        let status_text = match &agent.status {
+            AgentDisplayStatus::Active => format!("{} {}", spinner_frame, agent.status),
+            other => other.to_string(),
         };
         let raw_title = agent.title.as_deref().unwrap_or(&agent.blueprint_name);
         let title_text = raw_title.trim_start_matches('#').trim();
-        let hdr_line = Line::from(vec![
-            Span::styled(
-                format!(" {} ", truncate(title_text, 28)),
+        let dim = Style::default().fg(C_DIM);
+        // A run whose script could not be used looks exactly like a healthy
+        // one otherwise: a broken output validator is skipped rather than
+        // fatal, so the run completes and reports success. This is the only
+        // place that says the result went unchecked.
+        let broken = match agent.broken_scripts.len() {
+            0 => String::new(),
+            n => format!(" · ⚠ {n} broken script{}", if n == 1 { "" } else { "s" }),
+        };
+        let (msg_glyph, msg_style) = if agent.accepts_messages {
+            ("💬 ", Style::default().fg(C_SUCCESS))
+        } else {
+            ("🔇 ", dim)
+        };
+        // The line as text, then fitted to the row: the title gives way first,
+        // then the status (a long error message lives in full in the Output
+        // pane), and nothing else moves, so the run id stays on screen.
+        let parts: Vec<(String, Style)> = vec![
+            (" ".to_string(), dim),
+            (
+                title_text.to_string(),
                 Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
             ),
-            Span::styled("· ", Style::default().fg(C_DIM)),
-            status_span,
-            Span::styled("· ", Style::default().fg(C_DIM)),
-            Span::styled(
-                format!("{}↑", format_tokens(agent.tokens_in)),
-                Style::default().fg(C_DIM),
+            (" · ".to_string(), dim),
+            (status_text, status_style),
+            (" · ".to_string(), dim),
+            (format!("{}↑", format_tokens(agent.tokens_in)), dim),
+            (format!(" {}↓", format_tokens(agent.tokens_out)), dim),
+            (format!(" · {} work", elapsed), dim),
+            (format!(" · {} old ", age), dim),
+            (msg_glyph.to_string(), msg_style),
+            ("· ".to_string(), dim),
+            (agent.id.clone(), dim),
+            (
+                broken,
+                Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                format!(" {}↓", format_tokens(agent.tokens_out)),
-                Style::default().fg(C_DIM),
-            ),
-            Span::styled(format!(" · {} work", elapsed), Style::default().fg(C_DIM)),
-            Span::styled(format!(" · {} old ", age), Style::default().fg(C_DIM)),
-            if agent.accepts_messages {
-                Span::styled("💬 ", Style::default().fg(C_SUCCESS))
-            } else {
-                Span::styled("🔇 ", Style::default().fg(C_DIM))
-            },
-            Span::styled("· ", Style::default().fg(C_DIM)),
-            Span::styled(agent.id.clone(), Style::default().fg(C_DIM)),
-            // A run whose script could not be used looks exactly like a healthy
-            // one otherwise: a broken output validator is skipped rather than
-            // fatal, so the run completes and reports success. This is the only
-            // place that says the result went unchecked.
-            match agent.broken_scripts.len() {
-                0 => Span::raw(""),
-                n => Span::styled(
-                    format!(" · ⚠ {n} broken script{}", if n == 1 { "" } else { "s" }),
-                    Style::default().fg(C_WARN).add_modifier(Modifier::BOLD),
-                ),
-            },
-        ]);
+        ];
+        let texts: Vec<String> = parts.iter().map(|(t, _)| t.clone()).collect();
+        let spans: Vec<Span> = fit_parts(&texts, hdr_area.width as usize, &[1, 3])
+            .into_iter()
+            .zip(parts.iter().map(|(_, style)| *style))
+            .map(|(text, style)| Span::styled(text, style))
+            .collect();
         frame.render_widget(
-            Paragraph::new(hdr_line).style(Style::default().bg(Color::Rgb(20, 20, 30))),
+            Paragraph::new(Line::from(spans)).style(Style::default().bg(Color::Rgb(20, 20, 30))),
             hdr_area,
         );
     }
@@ -96,9 +93,12 @@ impl Dashboard {
         agent: &DashboardAgent,
         _area_width: u16,
     ) {
-        // Task line: truncated original prompt
-        let max_task = (info_area.width as usize).saturating_sub(10);
-        let task_display = truncate(&agent.task, max_task);
+        // The room inside the border and its one column of padding each side.
+        let inner_width = (info_area.width as usize).saturating_sub(4);
+
+        // Task line: the original prompt, cut only where it does not fit
+        // after its seven-column label.
+        let task_display = truncate(&agent.task, inner_width.saturating_sub(7));
         let task_line = Line::from(vec![
             Span::styled(" task  ", Style::default().fg(C_DIM)),
             Span::styled(task_display, Style::default().fg(C_MUTED)),
@@ -117,7 +117,6 @@ impl Dashboard {
             Some(rest) if !home.is_empty() => format!("~{rest}"),
             _ => agent.workdir.clone(),
         };
-        let workdir_truncated = truncate(&workdir_display, 42);
 
         let stage_tok_part = agent
             .stages
@@ -149,19 +148,38 @@ impl Dashboard {
             String::new()
         };
 
-        let model_part = agent
-            .model
-            .as_deref()
-            .map(|m| format!("  ·  {}", truncate(m, 24)))
-            .unwrap_or_default();
+        let (model_sep, model_part) = match agent.model.as_deref() {
+            Some(m) => ("  ·  ".to_string(), m.to_string()),
+            None => (String::new(), String::new()),
+        };
 
-        let stats_line = Line::from(vec![
-            Span::styled(" dir   ", Style::default().fg(C_DIM)),
-            Span::styled(workdir_truncated, Style::default().fg(C_MUTED)),
-            Span::styled(stage_tok_part, Style::default().fg(C_DIM)),
-            Span::styled(total_tok_part, Style::default().fg(C_DIM)),
-            Span::styled(model_part, Style::default().fg(C_MUTED)),
-        ]);
+        // Everything shown in full when the row has the room. When it does
+        // not, the model gives way first and the workdir second; the token
+        // figures are the numbers the line exists for and never shrink.
+        let mut parts = vec![
+            " dir   ".to_string(),
+            workdir_display,
+            stage_tok_part,
+            total_tok_part,
+            model_sep,
+            model_part,
+        ];
+        let mut fitted = fit_parts(&parts, inner_width, &[5, 1]);
+        // A row too narrow for both at their floors drops the model rather
+        // than clip the token figures off the right edge, and the workdir
+        // gets the room back.
+        if fitted.iter().map(|p| p.width()).sum::<usize>() > inner_width {
+            parts[4].clear();
+            parts[5].clear();
+            fitted = fit_parts(&parts, inner_width, &[1]);
+        }
+        let colors = [C_DIM, C_MUTED, C_DIM, C_DIM, C_MUTED, C_MUTED];
+        let spans: Vec<Span> = fitted
+            .into_iter()
+            .zip(colors)
+            .map(|(text, color)| Span::styled(text, Style::default().fg(color)))
+            .collect();
+        let stats_line = Line::from(spans);
 
         frame.render_widget(
             Paragraph::new(vec![task_line, stats_line]).block(
@@ -554,5 +572,159 @@ mod tests {
             .unwrap();
         let buf = rendered_buffer(&terminal);
         assert!(buf.contains("test task"), "{buf}");
+    }
+
+    // ── Fitting to the row ─────────────────────────────────────────────────
+
+    const LONG_MODEL: &str = "openrouter/z-ai/glm-5.3-preview-long-name";
+    const LONG_WORKDIR: &str = "/srv/projects/ai/personal/leviath/worktrees/fit-to-width";
+
+    fn wide_agent() -> DashboardAgent {
+        let mut agent = make_test_agent("run-wide", AgentDisplayStatus::Active);
+        agent.model = Some(LONG_MODEL.to_string());
+        agent.workdir = LONG_WORKDIR.to_string();
+        agent.tokens_in = 1_000_000;
+        agent.tokens_out = 25_000;
+        agent.cached_tokens = 410_000;
+        agent
+    }
+
+    fn info_strip_at(width: u16, agent: &DashboardAgent) -> String {
+        let backend = TestBackend::new(width, 4);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let dash = make_test_dashboard();
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, width, 4);
+                dash.render_info_strip(f, area, agent, width);
+            })
+            .unwrap();
+        rendered_buffer(&terminal)
+    }
+
+    /// The defect: the model was cut to 24 characters on a 200-column
+    /// terminal with most of the row empty.
+    #[test]
+    fn render_info_strip_wide_shows_the_whole_model_and_workdir() {
+        let buf = info_strip_at(200, &wide_agent());
+        assert!(buf.contains(LONG_MODEL), "{buf}");
+        assert!(buf.contains(LONG_WORKDIR), "{buf}");
+        assert!(buf.contains("total 1M↑ 25k↓  cache 41%"), "{buf}");
+        assert!(!buf.contains('…'), "{buf}");
+    }
+
+    /// Narrow: the model gives way first, the workdir keeps as much as the
+    /// model's floor leaves it, and the token figures stay whole.
+    #[test]
+    fn render_info_strip_narrow_shrinks_model_before_workdir_and_keeps_tokens() {
+        let buf = info_strip_at(70, &wide_agent());
+        assert!(buf.contains("total 1M↑ 25k↓  cache 41%"), "{buf}");
+        assert!(!buf.contains(LONG_MODEL), "{buf}");
+        assert!(!buf.contains(LONG_WORKDIR), "{buf}");
+        // The model sits at the floor (seven characters and the ellipsis).
+        assert!(buf.contains("·  openrou…"), "{buf}");
+        // The workdir gave up the rest and kept its head.
+        assert!(buf.contains("dir   /srv/projects/a…  ·  total"), "{buf}");
+    }
+
+    /// Narrower than both floors allow: the model is dropped altogether
+    /// rather than clipping the token figures, and the workdir takes the
+    /// room the model's floor was holding.
+    #[test]
+    fn render_info_strip_below_the_floors_drops_the_model_and_keeps_the_tokens() {
+        // 60 wide: 56 inside, 7 for the label and 30 for the totals leaves
+        // the workdir 19 columns.
+        let buf = info_strip_at(60, &wide_agent());
+        assert!(
+            buf.contains("dir   /srv/projects/ai/p…  ·  total 1M↑ 25k↓  cache 41%"),
+            "{buf}"
+        );
+        assert!(!buf.contains("openro"), "{buf}");
+        // The mid case, where the model at its floor would have fitted the
+        // arithmetic of the parts but not the row: 50 wide drops it too.
+        let buf = info_strip_at(50, &wide_agent());
+        assert!(buf.contains("total 1M↑ 25k↓  cache 41%"), "{buf}");
+        assert!(!buf.contains("openro"), "{buf}");
+    }
+
+    /// With a little less room than the whole line, only the model is cut and
+    /// the workdir is untouched: the shrink order is model, then workdir.
+    #[test]
+    fn render_info_strip_slightly_narrow_cuts_only_the_model() {
+        let buf = info_strip_at(120, &wide_agent());
+        assert!(buf.contains(LONG_WORKDIR), "{buf}");
+        assert!(buf.contains("openrouter/z-ai/g…"), "{buf}");
+        assert!(!buf.contains(LONG_MODEL), "{buf}");
+    }
+
+    /// The task line gets the whole inner width too.
+    #[test]
+    fn render_info_strip_task_uses_the_row() {
+        let mut agent = wide_agent();
+        agent.task = "t".repeat(150);
+        let buf = info_strip_at(200, &agent);
+        assert!(buf.contains(&"t".repeat(150)), "{buf}");
+        let narrow = info_strip_at(60, &agent);
+        // 60 wide, 4 for border and padding, 7 for the label: 49 columns.
+        assert!(narrow.contains(&format!("{}…", "t".repeat(48))), "{narrow}");
+        assert!(!narrow.contains(&"t".repeat(49)), "{narrow}");
+    }
+
+    /// The header row: at 200 columns a long title and the run id are both
+    /// whole; at 80 the title gives way and the id stays.
+    #[test]
+    fn render_header_breadcrumb_fits_the_title_to_the_row() {
+        let long_title = "Add adversarial and cross-company risk analysis to the blueprint";
+        let mut agent = make_test_agent("run-abc-123456", AgentDisplayStatus::Complete);
+        agent.title = Some(long_title.to_string());
+
+        let backend = TestBackend::new(200, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let dash = make_test_dashboard();
+        terminal
+            .draw(|f| dash.render_header_breadcrumb(f, Rect::new(0, 0, 200, 1), &agent))
+            .unwrap();
+        let wide = rendered_buffer(&terminal);
+        assert!(wide.contains(long_title), "{wide}");
+        assert!(wide.contains("run-abc-123456"), "{wide}");
+        assert!(!wide.contains('…'), "{wide}");
+
+        let backend = TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| dash.render_header_breadcrumb(f, Rect::new(0, 0, 80, 1), &agent))
+            .unwrap();
+        let narrow = rendered_buffer(&terminal);
+        assert!(!narrow.contains(long_title), "{narrow}");
+        assert!(narrow.contains("Add adversarial"), "{narrow}");
+        assert!(narrow.contains('…'), "{narrow}");
+        assert!(narrow.contains("run-abc-123456"), "{narrow}");
+        assert!(narrow.contains("COMPLETE"), "{narrow}");
+    }
+
+    /// A long error status is the second thing to give way, after the title.
+    #[test]
+    fn render_header_breadcrumb_cuts_a_long_error_after_the_title() {
+        let mut agent = make_test_agent(
+            "run-err-1",
+            AgentDisplayStatus::Error(
+                "provider returned 502 after three attempts and the breaker opened".to_string(),
+            ),
+        );
+        agent.title = Some("Short".to_string());
+        let backend = TestBackend::new(70, 1);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let dash = make_test_dashboard();
+        terminal
+            .draw(|f| dash.render_header_breadcrumb(f, Rect::new(0, 0, 70, 1), &agent))
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(
+            buf.contains("Short"),
+            "title is already at the floor: {buf}"
+        );
+        assert!(buf.contains("ERROR: "), "{buf}");
+        assert!(!buf.contains("breaker opened"), "{buf}");
+        assert!(buf.contains("run-err-1"), "{buf}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -36,8 +36,11 @@ impl Dashboard {
         }
         let rv_scroll_y = max_rv_scroll - self.review_scroll;
 
+        // The prompt is the pane's title, so it gets the top border less the
+        // corners and its own padding, rather than a fixed 50 characters.
         let rv_title = if let Some(req) = &pending_req {
-            format!(" {} ", truncate(&req.prompt, 50))
+            let room = (review_area.width as usize).saturating_sub(4);
+            format!(" {} ", truncate(&req.prompt, room))
         } else {
             " Review ".to_string()
         };
@@ -569,5 +572,39 @@ mod tests {
             .unwrap();
         let buf = rendered_buffer(&terminal);
         assert!(buf.contains("Anything else?"), "{buf}");
+    }
+
+    /// The prompt in the review pane's title is cut to the pane, not to a
+    /// fixed 50 characters: whole on a wide pane, ellipsis on a narrow one.
+    #[test]
+    fn render_review_body_fits_the_prompt_to_the_pane() {
+        let prompt = "Review the draft and say whether the executive summary is ready";
+        let mut req = make_pending_req(interaction::InteractionKind::FreeText);
+        req.prompt = prompt.to_string();
+        let pending = Some(req);
+        let lines: Vec<ratatui::text::Line<'static>> =
+            vec![ratatui::text::Line::from("Review content")];
+        let mut dash = make_test_dashboard();
+
+        let backend = TestBackend::new(120, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| dash.render_review_body(f, Rect::new(0, 0, 120, 10), &lines, &pending))
+            .unwrap();
+        let wide = rendered_buffer(&terminal);
+        assert!(wide.contains(prompt), "{wide}");
+
+        let backend = TestBackend::new(40, 10);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| dash.render_review_body(f, Rect::new(0, 0, 40, 10), &lines, &pending))
+            .unwrap();
+        let narrow = rendered_buffer(&terminal);
+        assert!(!narrow.contains(prompt), "{narrow}");
+        // 40 wide, 4 off: 36 columns, 35 of prompt and the ellipsis.
+        assert!(
+            narrow.contains("Review the draft and say whether th…"),
+            "{narrow}"
+        );
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -1,17 +1,42 @@
 //! Agent table, log panel, and help bar rendering.
 
 use ratatui::Frame;
-use ratatui::layout::Rect;
+use ratatui::layout::{Constraint, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table};
 use unicode_width::UnicodeWidthStr;
 
-use crate::commands::dashboard::helpers::{format_tokens, relative_time, truncate};
+use crate::commands::dashboard::helpers::{fit_parts, format_tokens, relative_time, truncate};
 use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
 use crate::commands::dashboard::types::*;
 use leviath_core::interaction;
+
+/// The run table's columns, as shares of the width inside its border.
+const TABLE_COLUMNS: [Constraint; 6] = [
+    Constraint::Percentage(22),
+    Constraint::Percentage(12),
+    Constraint::Percentage(14),
+    Constraint::Percentage(18),
+    Constraint::Percentage(14),
+    Constraint::Percentage(20),
+];
+
+/// The column widths the table will draw with, in columns, for a table drawn
+/// over `area`: the same layout the widget runs, over the same inner width,
+/// with its default one-column spacing. A cell longer than its column is
+/// clipped at the column edge with no sign that anything is missing, so each
+/// text cell is cut to this width with an ellipsis before it is handed over.
+fn table_column_widths(area: Rect) -> Vec<usize> {
+    let inner = Rect::new(0, 0, area.width.saturating_sub(2), 1);
+    Layout::horizontal(TABLE_COLUMNS)
+        .spacing(1)
+        .split(inner)
+        .iter()
+        .map(|r| r.width as usize)
+        .collect()
+}
 
 impl Dashboard {
     pub(in crate::commands::dashboard) fn draw_agent_table(
@@ -53,6 +78,7 @@ impl Dashboard {
         // A mark column appears only while at least one run is marked, so the
         // table looks exactly as before until the feature is used.
         let any_marked = !self.marked.is_empty();
+        let col_w = table_column_widths(area);
 
         let rows: Vec<Row> = self
             .display_indices
@@ -74,8 +100,8 @@ impl Dashboard {
                 let title_str = agent
                     .title
                     .as_deref()
-                    .map(|t| truncate(t.trim_start_matches('#').trim(), 26))
-                    .unwrap_or_else(|| truncate(&agent.task, 26));
+                    .map(|t| t.trim_start_matches('#').trim().to_string())
+                    .unwrap_or_else(|| agent.task.trim().to_string());
                 let tok_str = if agent.tokens_in == 0 && agent.tokens_out == 0 {
                     "-".to_string()
                 } else {
@@ -85,15 +111,20 @@ impl Dashboard {
                         format_tokens(agent.tokens_out)
                     )
                 };
+                // The stage name gives way to its counter, and the whole cell
+                // to its column.
                 let stage_str = if agent.num_stages > 1 {
-                    format!(
-                        "{} {}/{}",
-                        truncate(&agent.stage, 10),
-                        agent.stage_index + 1,
-                        agent.num_stages
+                    fit_parts(
+                        &[
+                            agent.stage.clone(),
+                            format!(" {}/{}", agent.stage_index + 1, agent.num_stages),
+                        ],
+                        col_w[2],
+                        &[0],
                     )
+                    .concat()
                 } else {
-                    truncate(&agent.stage, 14)
+                    truncate(&agent.stage, col_w[2])
                 };
                 let status_str = match (&agent.status, &agent.wait_reason) {
                     (AgentDisplayStatus::Active, _) => format!("{} ACTIVE", spinner_frame),
@@ -114,50 +145,52 @@ impl Dashboard {
                     (status, _) => status.to_string(),
                 };
                 let short_id = agent.id.split('-').next_back().unwrap_or("").to_string();
-                let mut title_spans = Vec::new();
-                if any_marked {
-                    if self.marked.contains(&agent.id) {
-                        title_spans.push(Span::styled("✓ ", Style::default().fg(C_ACCENT)));
-                    } else {
-                        // Unmarked rows get the same width, so titles stay aligned.
-                        title_spans.push(Span::raw("  "));
-                    }
-                }
-                title_spans.push(Span::styled(
-                    tree.prefix.clone(),
-                    Style::default().fg(C_DIM),
-                ));
+                // The mark, shown only while something is marked; unmarked
+                // rows get the same width, so titles stay aligned.
+                let mark = match (any_marked, self.marked.contains(&agent.id)) {
+                    (false, _) => "",
+                    (true, true) => "✓ ",
+                    (true, false) => "  ",
+                };
                 // The fold arrow, on runs that have sub-agents. Leaves get the
                 // same two columns of blank so every title still lines up.
-                title_spans.push(Span::styled(
-                    if !tree.expandable {
-                        "  "
-                    } else if tree.collapsed {
-                        "▸ "
-                    } else {
-                        "▾ "
-                    },
-                    Style::default().fg(C_ACCENT),
-                ));
-                title_spans.push(Span::styled(title_str, Style::default().fg(C_WHITE)));
-                title_spans.push(Span::styled(
-                    format!(" #{}", short_id),
-                    Style::default().fg(C_DIM),
-                ));
+                let arrow = if !tree.expandable {
+                    "  "
+                } else if tree.collapsed {
+                    "▸ "
+                } else {
+                    "▾ "
+                };
                 // A fold has to say what it swallowed, or the run simply looks
                 // like it has no workers.
-                if tree.collapsed {
-                    title_spans.push(Span::styled(
-                        format!(" +{}", tree.hidden),
-                        Style::default().fg(C_ACCENT),
-                    ));
-                }
+                let hidden = if tree.collapsed {
+                    format!(" +{}", tree.hidden)
+                } else {
+                    String::new()
+                };
+                // Only the title gives way: the id and the fold count are
+                // what tell one row from another.
+                let title_parts = [
+                    mark.to_string(),
+                    tree.prefix.clone(),
+                    arrow.to_string(),
+                    title_str,
+                    format!(" #{}", short_id),
+                    hidden,
+                ];
+                let title_colors = [C_ACCENT, C_DIM, C_ACCENT, C_WHITE, C_DIM, C_ACCENT];
+                let title_spans: Vec<Span> = fit_parts(&title_parts, col_w[0], &[3])
+                    .into_iter()
+                    .zip(title_colors)
+                    .map(|(text, color)| Span::styled(text, Style::default().fg(color)))
+                    .collect();
                 let title_cell = Cell::from(Line::from(title_spans));
                 Row::new(vec![
                     title_cell,
-                    Cell::from(agent.blueprint_name.clone()),
+                    Cell::from(truncate(&agent.blueprint_name, col_w[1])),
                     Cell::from(stage_str),
-                    Cell::from(status_str).style(Style::default().fg(status_color)),
+                    Cell::from(truncate(&status_str, col_w[3]))
+                        .style(Style::default().fg(status_color)),
                     Cell::from(tok_str),
                     Cell::from(started_str).style(Style::default().fg(C_DIM)),
                 ])
@@ -231,24 +264,14 @@ impl Dashboard {
             return;
         }
 
-        let table = Table::new(
-            rows,
-            [
-                ratatui::layout::Constraint::Percentage(22),
-                ratatui::layout::Constraint::Percentage(12),
-                ratatui::layout::Constraint::Percentage(14),
-                ratatui::layout::Constraint::Percentage(18),
-                ratatui::layout::Constraint::Percentage(14),
-                ratatui::layout::Constraint::Percentage(20),
-            ],
-        )
-        .header(header)
-        .block(block)
-        .row_highlight_style(
-            Style::default()
-                .add_modifier(Modifier::REVERSED)
-                .fg(C_WHITE),
-        );
+        let table = Table::new(rows, TABLE_COLUMNS)
+            .header(header)
+            .block(block)
+            .row_highlight_style(
+                Style::default()
+                    .add_modifier(Modifier::REVERSED)
+                    .fg(C_WHITE),
+            );
 
         frame.render_stateful_widget(table, area, &mut self.table_state);
         self.register_run_row_clicks(area, any_marked);
@@ -872,7 +895,7 @@ mod tests {
         let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-no-title", AgentDisplayStatus::Active);
         agent.title = None;
-        agent.task = "fallback task text".to_string();
+        agent.task = "fallback task".to_string();
         dash.agents.push(agent);
         dash.update_display_indices();
         terminal
@@ -882,7 +905,7 @@ mod tests {
             })
             .unwrap();
         let buf = rendered_buffer(&terminal);
-        assert!(buf.contains("fallback task text"), "{buf}");
+        assert!(buf.contains("fallback task #title"), "{buf}");
     }
 
     #[test]
@@ -1682,5 +1705,87 @@ mod tests {
         let line = dash.build_main_list_help_bar();
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("[space] mark"), "{text}");
+    }
+
+    // ── Cells cut to their column ──────────────────────────────────────────
+
+    fn table_at(width: u16, dash: &mut Dashboard) -> String {
+        let backend = TestBackend::new(width, 20);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dash.draw_agent_table(f, area);
+            })
+            .unwrap();
+        rendered_buffer(&terminal)
+    }
+
+    /// The widths the table draws with sum to the inner width less the five
+    /// gaps, and a zero-width area does not underflow.
+    #[test]
+    fn table_column_widths_follow_the_layout() {
+        let widths = table_column_widths(Rect::new(0, 0, 120, 10));
+        assert_eq!(widths.len(), 6);
+        assert_eq!(widths.iter().sum::<usize>(), 118 - 5);
+        assert_eq!(
+            table_column_widths(Rect::new(0, 0, 0, 0))
+                .iter()
+                .sum::<usize>(),
+            0
+        );
+    }
+
+    /// A long title is whole when its column is wide enough and cut with an
+    /// ellipsis, keeping its id, when it is not. Before, it was always cut to
+    /// 26 characters, and a title longer than the column was clipped silently.
+    #[test]
+    fn draw_agent_table_cuts_the_title_to_its_column_and_keeps_the_id() {
+        let title = "Add adversarial and cross-company risk analysis";
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-abc-zz9", AgentDisplayStatus::Active);
+        agent.title = Some(title.to_string());
+        dash.agents.push(agent);
+        dash.update_display_indices();
+
+        let wide = table_at(300, &mut dash);
+        assert!(wide.contains(&format!("{title} #zz9")), "{wide}");
+
+        let narrow = table_at(100, &mut dash);
+        assert!(!narrow.contains(title), "{narrow}");
+        assert!(narrow.contains("… #zz9"), "{narrow}");
+    }
+
+    /// The blueprint, stage, and status cells are cut to their columns too,
+    /// and the stage counter outlives the stage name.
+    #[test]
+    fn draw_agent_table_cuts_the_other_text_cells_to_their_columns() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-cells", AgentDisplayStatus::Active);
+        agent.blueprint_name = "a-very-long-blueprint-name-indeed".to_string();
+        agent.stage = "gather-and-cross-check-sources".to_string();
+        agent.num_stages = 3;
+        agent.stage_index = 1;
+        agent.status = AgentDisplayStatus::Error(
+            "provider returned 502 after three attempts and the breaker opened".to_string(),
+        );
+        dash.agents.push(agent);
+        dash.update_display_indices();
+
+        let buf = table_at(100, &mut dash);
+        assert!(!buf.contains("a-very-long-blueprint-name-indeed"), "{buf}");
+        assert!(buf.contains("a-very-l"), "{buf}");
+        assert!(!buf.contains("gather-and-cross-check-sources"), "{buf}");
+        assert!(buf.contains("… 2/3"), "{buf}");
+        assert!(!buf.contains("breaker opened"), "{buf}");
+        assert!(buf.contains("ERROR: "), "{buf}");
+
+        let wide = table_at(500, &mut dash);
+        assert!(wide.contains("a-very-long-blueprint-name-indeed"), "{wide}");
+        assert!(
+            wide.contains("gather-and-cross-check-sources 2/3"),
+            "{wide}"
+        );
+        assert!(wide.contains("breaker opened"), "{wide}");
     }
 }


### PR DESCRIPTION
User-reported: the detail view's info strip showed `openrouter/z-ai/glm-5.3-…` with most of the terminal empty.

## Cause

`render/header.rs` cut the model at a fixed 24 columns and the workdir at 42 whatever the width, and `helpers::truncate` measured bytes (`s.len()`), so multi-byte text was cut early and the ellipsis was added on top of the budget. About 31 fixed-width cuts existed across the dashboard.

## Change

- `truncate(s, max)` fits into `max` display columns (`unicode_width`), ellipsis inside the budget.
- New `fit_parts(parts, width, shrink_order)`: unchanged when the line fits; otherwise the named parts shrink in priority order, each to an 8-column floor, and stop as soon as the line fits. A plain `fn`.
- Applied where the `Rect` is in hand: the info strip (model shrinks first, then workdir; token counts never; if both are at the floor and the tokens would still clip, the model is dropped), the header breadcrumb (title first, then status), the review prompt title, and the run table (title cut to its column keeping ` #id` and ` +n`; stage name shrinks under its counter; blueprint and status cells cut at their column instead of silently clipping).
- Left alone, with the reason in the report: the stage tabs row (per-stage width is not a `Rect`), the toast text (fitted by the toast renderer), and log lines (scroll).

## Tests

Column-width `truncate` (en dash, emoji, all-multibyte, 0 and 1); `fit_parts` fits / one / two / floor; info strip at 200, 120, 70, 60, 50 columns; header title at 200 and 80; table cells at 100, 300 and 500; review prompt at 120 and 40. 791 dashboard tests green.

## Gates

clippy and rustdoc `-D warnings`; `xtask structure` (418 files); `xtask docs`; coverage 100% on `leviath-cli`.

## Live

`lev dash` over a pty with a run whose model is `openrouter/z-ai/glm-5.3-preview-long-name`:
- 200x50: `dir ~/projects/ai/personal/leviath/worktrees/fit-to-width · stage 259k↑ 3k↓ · total 5M↑ 205k↓ cache 152% · openrouter/z-ai/glm-5.3-preview-long-name`, no ellipsis anywhere.
- 70x30: `dir ~/proje… · stage 259k↑ 3k↓ · total 5M↑ 205k↓ cache 152`: model dropped, workdir at its floor, the figures whole (the last `%` clips because the figures alone are one column over the border at that width, by design).

Side note, not this PR: that run reports `cache 152%`, i.e. more cached tokens than prompt tokens; the percentage's denominator looks wrong for a provider that reports cache reads separately from input. Worth its own look.
