### PR TITLE
feat(prices): a data-file price table, refreshed weekly without a person or an AI

### DIFF
--- a/.github/workflows/prices.yml
+++ b/.github/workflows/prices.yml
@@ -1,0 +1,120 @@
+name: Prices (Weekly Monday)
+
+# Refresh the vendor list prices in crates/leviath-providers/pricing/rates.toml
+# by running `cargo xtask prices`, which reads OpenRouter's public catalogue
+# and LiteLLM's price table and rewrites the file only where the two agree.
+# When the file moves, this opens a PR and sets it to auto-merge, so the
+# required checks gate it exactly as they gate a person's PR.
+#
+# REQUIRED SECRET: `PRICES_PAT`, a fine-grained personal access token scoped to
+# this repository with `contents: write` (push the branch) and `pull requests:
+# write` (open the PR, enable auto-merge). It cannot be `GITHUB_TOKEN`: a PR
+# opened with that token gets no CI run on this repo, so it could never merge.
+#
+# Nothing in ci.yml runs `cargo xtask prices --check`. CI must not depend on
+# two third-party endpoints being up; this workflow is the only network path.
+
+on:
+  schedule:
+    # Every Monday at 10am PST (5pm UTC), an hour after the beta promotion.
+    - cron: '0 17 * * 1'
+  workflow_dispatch:
+
+# One refresh at a time. A manual run during the scheduled one queues behind
+# it rather than opening a second PR for the same diff.
+concurrency:
+  group: prices-refresh
+  cancel-in-progress: false
+
+# The PAT carries the write scopes; the workflow token stays read-only.
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    name: Refresh the price table
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          # The push below uses this identity, so the branch lands under the
+          # PAT and the PR it opens triggers CI.
+          token: ${{ secrets.PRICES_PAT }}
+
+      - uses: ./.github/actions/rust-setup
+        with:
+          shared-key: prices
+
+      - name: Refresh the table
+        id: refresh
+        run: |
+          set -euo pipefail
+          # Exit 2 is "could not reach a source": nothing to do this week and
+          # nothing to alarm about. Any other failure is a refusal (a row would
+          # move implausibly far, a source went empty) and the job stays red so
+          # somebody looks.
+          set +e
+          cargo xtask prices | tee prices.log
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -eq 2 ]; then
+            echo "A source was unreachable; the table is untouched."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$rc" -ne 0 ]; then
+            exit "$rc"
+          fi
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open the PR
+        if: steps.refresh.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.PRICES_PAT }}
+        run: |
+          set -euo pipefail
+          date="$(date -u +%Y-%m-%d)"
+          branch="chore/prices-${date}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add crates/leviath-providers/pricing/rates.toml
+
+          # The diff table `cargo xtask prices` printed: one line per row that
+          # moved, the disagreements it declined to write, and the summary.
+          {
+            echo "chore(prices): refresh vendor list prices ${date}"
+            echo
+            echo "Produced by \`cargo xtask prices\` from OpenRouter's catalogue"
+            echo "cross-checked against LiteLLM. Rows both sources agree on within"
+            echo "5% are written; disagreements are listed and left as they were."
+            echo
+            echo '```'
+            cat prices.log
+            echo '```'
+          } > commit-message.txt
+          git commit -F commit-message.txt
+          git push -u origin "$branch"
+
+          {
+            echo "Weekly refresh of \`crates/leviath-providers/pricing/rates.toml\`"
+            echo "by \`cargo xtask prices\`. Auto-merges once the required checks pass."
+            echo
+            echo '```'
+            cat prices.log
+            echo '```'
+          } > pr-body.txt
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(prices): refresh vendor list prices ${date}" \
+            --body-file pr-body.txt
+
+          # Rebase merge, matching how every PR lands here (linear history). The
+          # branch protection's required checks hold it until they are green.
+          gh pr merge "$branch" --auto --rebase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,12 @@ same list.
 
 ### Changed
 
+- The published list prices for OpenAI, Anthropic and Google live in
+  `crates/leviath-providers/pricing/rates.toml` rather than in Rust, and each
+  row names where it came from. `lev models list` prints `n/a` where nothing
+  prices a model instead of a blank, and `lev models show` names a table
+  row's source and the day the table was read. A model that gains a row goes
+  from unpriced to a computed (still not exact) cost.
 - MCP tool calls in one batch no longer wait on each other across servers.
   The executor held one lock around every call, so a batch naming a slow
   server and a fast one ran the fast one after the slow one finished. Each
@@ -188,6 +194,11 @@ same list.
   `header_names` and `models`, `PUT /api/config` accepts `kind`, `headers` and `models`,
   and `POST /api/models/probe` (admin) asks a server what it serves before the write.
 
+- `cargo xtask prices` refreshes the vendor price table from OpenRouter's
+  public catalogue cross-checked against LiteLLM, writing a row only where
+  the two agree within 5% and refusing a move it does not believe. A weekly
+  workflow runs it and opens an auto-merging PR when the table changed, so
+  the prices stay current without a person transcribing them.
 - In `lev dash`'s new-run screen, Enter now breaks the line in the task box
   and Ctrl+Enter starts the run. A Start button sits under the editor (Tab
   reaches it, Enter or Space or a click presses it) for terminals without the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5734,9 +5734,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "cargo-husky",
+ "chrono",
+ "reqwest",
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,6 +2615,7 @@ dependencies = [
  "tiktoken-rs",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
 ]
 

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -424,9 +424,12 @@ fn print_listing(
         let rates = entry
             .pricing
             .or_else(|| leviath_providers::pricing::published_rates(&entry.provider, &entry.id));
+        // `n/a` rather than a blank: a blank reads as "free" or "forgot", and
+        // a run on this model reports its cost as unavailable, which is what
+        // the column should say too.
         let (input, output) = match rates {
             Some(p) => (fmt_rate(p.input_per_mtok), fmt_rate(p.output_per_mtok)),
-            None => (String::new(), String::new()),
+            None => (UNPRICED.to_owned(), UNPRICED.to_owned()),
         };
 
         println!(
@@ -693,6 +696,10 @@ fn fmt_tokens(n: usize) -> String {
     }
 }
 
+/// What the price columns say for a model no listing, config entry or table
+/// row prices.
+const UNPRICED: &str = "n/a";
+
 /// A USD-per-million rate for a table column: two decimals for anything a
 /// person would read as dollars, more for the fractions of a cent the cheap
 /// models are quoted at, so `0.02` and `0.0416` do not both print as `0.02`.
@@ -709,23 +716,25 @@ fn fmt_rate(per_mtok: f64) -> String {
 /// Three sources, and the difference matters to a reader. A rate the
 /// provider's listing quoted is current as of the request. An operator's
 /// config entry is their own contracted rate and is current by definition. A
-/// shipped rate is a transcription of a vendor's public page on a particular
-/// day and cannot notice a repricing, so it is the one that carries a date
-/// and a warning; printing it is the only way somebody can judge whether to
-/// trust the number.
+/// shipped rate is a row of the price table this build compiled in, refreshed
+/// from OpenRouter's catalogue and LiteLLM on a particular day, so it is the
+/// one that names its source and carries a date; printing both is the only
+/// way somebody can judge whether to trust the number.
 ///
-/// A model with none prints nothing rather than a zero: a run that touches
-/// it reports its cost as unavailable, and a "$0.00" line here would
-/// contradict that.
+/// A model with none prints `n/a` rather than a zero: a run that touches it
+/// reports its cost as unavailable, and a "$0.00" line here would contradict
+/// that.
 fn print_model_pricing(provider: &str, model: &str, listed: Option<ModelPricing>) {
-    let published = listed.is_none();
-    let Some(p) = listed.or_else(|| leviath_providers::pricing::published_rates(provider, model))
-    else {
-        return;
-    };
     println!();
     println!("Pricing (USD per million tokens)");
     println!("--------------------------------");
+    let published = listed.is_none();
+    let Some(p) = listed.or_else(|| leviath_providers::pricing::published_rates(provider, model))
+    else {
+        println!("  {UNPRICED}: no listing, config entry or published row prices this model.");
+        println!("  A rate under [model_capabilities.\"{model}\"] in your config would.");
+        return;
+    };
     println!("  Input:          ${:.4}", p.input_per_mtok);
     println!("  Cached input:   ${:.4}", p.cached_input_per_mtok);
     println!("  Cache write:    ${:.4}", p.cache_write_per_mtok);
@@ -738,14 +747,29 @@ fn print_model_pricing(provider: &str, model: &str, listed: Option<ModelPricing>
     // capability override says nothing about whether they also declared a rate,
     // and claiming "your config" for a figure that came from this table would
     // be worse than not showing a source at all.
+    let source = leviath_providers::pricing::published_rate(provider, model)
+        .map(|row| describe_source(&row.source))
+        .unwrap_or_default();
     println!(
-        "  Source:         published list price, read {}",
+        "  Source:         published list price ({source}), table read {}",
         leviath_providers::pricing::rates_read_on()
     );
-    println!("  \u{26a0}  {provider} does not serve prices through its API, so this was");
-    println!("     transcribed by hand and may be out of date. A rate set on the");
-    println!("     model's config entry overrides this, and is the only way to");
-    println!("     record a negotiated price no public page would show.");
+    println!("  \u{26a0}  {provider} does not serve prices through its API, so this is a");
+    println!("     row of the table compiled into this build, which cannot notice a");
+    println!("     repricing until the next refresh. A rate set on the model's config");
+    println!("     entry overrides it, and is the only way to record a negotiated");
+    println!("     price no public page would show.");
+}
+
+/// A row's `source` field as a reader would say it.
+fn describe_source(source: &str) -> &str {
+    match source {
+        "both" => "OpenRouter's catalogue, agreed by LiteLLM",
+        "openrouter" => "OpenRouter's catalogue only",
+        "litellm" => "LiteLLM's table only",
+        "manual" => "written by hand",
+        other => other,
+    }
 }
 
 /// Print a detailed capability sheet for a single model.
@@ -872,16 +896,28 @@ mod tests {
         // through the table, which is what a reader is actually shown.
         print_model_pricing("anthropic", "claude-opus-5", None);
         print_model_pricing("openai", "gpt-5.5", None);
-        // A model with no listed rate prints nothing rather than a zero, which
+        // A model with no listed rate prints `n/a` rather than a zero, which
         // would contradict the run reporting its cost as unavailable.
         print_model_pricing("openrouter", "x-ai/grok-4.6", None);
         print_model_pricing("anthropic", "claude-opus-9", None);
+        print_model_pricing("google", "gemini-3-flash", None);
         // A rate the listing quoted is labelled as such and carries no date.
         print_model_pricing(
             "openrouter",
             "qwen/qwen3.6-plus",
             Some(ModelPricing::flat(1.0, 4.0)),
         );
+    }
+
+    /// Every source the table can carry has a reading, and one it cannot is
+    /// shown as written rather than hidden.
+    #[test]
+    fn a_rate_source_is_said_in_words() {
+        assert!(describe_source("both").contains("agreed by LiteLLM"));
+        assert!(describe_source("openrouter").contains("only"));
+        assert!(describe_source("litellm").contains("only"));
+        assert_eq!(describe_source("manual"), "written by hand");
+        assert_eq!(describe_source("elsewhere"), "elsewhere");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/models.rs
+++ b/crates/leviath-cli/src/commands/models.rs
@@ -740,7 +740,7 @@ fn print_model_pricing(provider: &str, model: &str, listed: Option<ModelPricing>
     // be worse than not showing a source at all.
     println!(
         "  Source:         published list price, read {}",
-        leviath_providers::pricing::RATES_READ_ON
+        leviath_providers::pricing::rates_read_on()
     );
     println!("  \u{26a0}  {provider} does not serve prices through its API, so this was");
     println!("     transcribed by hand and may be out of date. A rate set on the");

--- a/crates/leviath-providers/Cargo.toml
+++ b/crates/leviath-providers/Cargo.toml
@@ -27,6 +27,8 @@ tokio = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+# The shipped price table is a TOML file compiled in with `include_str!`.
+toml = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tiktoken-rs = { workspace = true }

--- a/crates/leviath-providers/pricing/rates.toml
+++ b/crates/leviath-providers/pricing/rates.toml
@@ -7,7 +7,52 @@
 # `openrouter` or `litellm` when only one listed it, and `manual` for a row a
 # person wrote, which the refresh never overwrites.
 
-read_on = "2026-08-23"
+read_on = "2026-08-29"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-3-7-sonnet-20250219"
+input = 3.0
+cache_read = 0.3
+cache_write = 3.75
+output = 15.0
+source = "litellm"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-3-haiku"
+input = 0.25
+cache_read = 0.03
+cache_write = 0.3
+output = 1.25
+source = "openrouter"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-3-opus-20240229"
+input = 15.0
+cache_read = 1.5
+cache_write = 18.75
+output = 75.0
+source = "litellm"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-4-opus-20250514"
+input = 15.0
+cache_read = 1.5
+cache_write = 18.75
+output = 75.0
+source = "litellm"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-4-sonnet-20250514"
+input = 3.0
+cache_read = 0.3
+cache_write = 3.75
+output = 15.0
+source = "litellm"
 
 [[rate]]
 provider = "anthropic"
@@ -25,6 +70,42 @@ input = 1.0
 cache_read = 0.1
 cache_write = 1.25
 output = 5.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-mythos-5"
+input = 10.0
+cache_read = 1.0
+cache_write = 12.5
+output = 50.0
+source = "litellm"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-mythos-preview"
+input = 10.0
+cache_read = 1.0
+cache_write = 12.5
+output = 50.0
+source = "litellm"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-opus-4"
+input = 15.0
+cache_read = 1.5
+cache_write = 18.75
+output = 75.0
+source = "openrouter"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-opus-4-5"
+input = 5.0
+cache_read = 0.5
+cache_write = 6.25
+output = 25.0
 source = "both"
 
 [[rate]]
@@ -47,6 +128,15 @@ source = "both"
 
 [[rate]]
 provider = "anthropic"
+prefix = "claude-opus-4-7-fast"
+input = 30.0
+cache_read = 3.0
+cache_write = 37.5
+output = 150.0
+source = "openrouter"
+
+[[rate]]
+provider = "anthropic"
 prefix = "claude-opus-4-8"
 input = 5.0
 cache_read = 0.5
@@ -56,12 +146,39 @@ source = "both"
 
 [[rate]]
 provider = "anthropic"
+prefix = "claude-opus-4-8-fast"
+input = 10.0
+cache_read = 1.0
+cache_write = 12.5
+output = 50.0
+source = "openrouter"
+
+[[rate]]
+provider = "anthropic"
 prefix = "claude-opus-5"
 input = 5.0
 cache_read = 0.5
 cache_write = 6.25
 output = 25.0
 source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-opus-5-fast"
+input = 10.0
+cache_read = 1.0
+cache_write = 12.5
+output = 50.0
+source = "openrouter"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-sonnet-4"
+input = 3.0
+cache_read = 0.3
+cache_write = 3.75
+output = 15.0
+source = "openrouter"
 
 [[rate]]
 provider = "anthropic"
@@ -83,12 +200,138 @@ source = "both"
 
 [[rate]]
 provider = "google"
+prefix = "gemini-2.0-flash"
+input = 0.1
+cache_read = 0.025
+cache_write = 0.1
+output = 0.4
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.0-flash-lite"
+input = 0.075
+cache_read = 0.01875
+cache_write = 0.075
+output = 0.3
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.5-computer-use-preview-10-2025"
+input = 1.25
+cache_read = 1.25
+cache_write = 1.25
+output = 10.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.5-flash"
+input = 0.3
+cache_read = 0.03
+cache_write = 0.3
+output = 2.5
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.5-flash-lite"
+input = 0.1
+cache_read = 0.01
+cache_write = 0.1
+output = 0.4
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.5-flash-native-audio-latest"
+input = 0.5
+cache_read = 0.5
+cache_write = 0.5
+output = 2.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.5-flash-native-audio-preview-09-2025"
+input = 0.5
+cache_read = 0.5
+cache_write = 0.5
+output = 2.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.5-flash-native-audio-preview-12-2025"
+input = 0.5
+cache_read = 0.5
+cache_write = 0.5
+output = 2.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.5-pro"
+input = 1.25
+cache_read = 0.125
+cache_write = 1.25
+output = 10.0
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-2.5-pro-preview-tts"
+input = 1.0
+cache_read = 0.125
+cache_write = 1.0
+output = 20.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
 prefix = "gemini-3-flash"
 input = 0.5
 cache_read = 0.05
 cache_write = 0.5
 output = 3.0
 source = "manual"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3-flash-preview"
+input = 0.5
+cache_read = 0.05
+cache_write = 0.5
+output = 3.0
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3-pro-image"
+input = 2.0
+cache_read = 0.2
+cache_write = 2.0
+output = 12.0
+source = "openrouter"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3-pro-preview"
+input = 2.0
+cache_read = 0.2
+cache_write = 2.0
+output = 12.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.1-flash-image"
+input = 0.5
+cache_read = 0.5
+cache_write = 0.5
+output = 3.0
+source = "openrouter"
 
 [[rate]]
 provider = "google"
@@ -101,12 +344,30 @@ source = "both"
 
 [[rate]]
 provider = "google"
+prefix = "gemini-3.1-flash-live-preview"
+input = 0.75
+cache_read = 0.75
+cache_write = 0.75
+output = 4.5
+source = "litellm"
+
+[[rate]]
+provider = "google"
 prefix = "gemini-3.1-pro"
 input = 2.0
 cache_read = 0.2
 cache_write = 2.0
 output = 12.0
 source = "manual"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.1-pro-preview"
+input = 2.0
+cache_read = 0.2
+cache_write = 2.0
+output = 12.0
+source = "both"
 
 [[rate]]
 provider = "google"
@@ -118,6 +379,465 @@ output = 9.0
 source = "both"
 
 [[rate]]
+provider = "google"
+prefix = "gemini-3.5-flash-lite"
+input = 0.3
+cache_read = 0.03
+cache_write = 0.3
+output = 2.5
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.5-live-translate-preview"
+input = 3.5
+cache_read = 3.5
+cache_write = 3.5
+output = 21.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.6-flash"
+input = 0.75
+cache_read = 0.075
+cache_write = 0.75
+output = 3.75
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.7-flash"
+input = 0.75
+cache_read = 0.075
+cache_write = 0.75
+output = 3.75
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-exp-1206"
+input = 0.3
+cache_read = 0.03
+cache_write = 0.3
+output = 2.5
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-flash-latest"
+input = 0.3
+cache_read = 0.03
+cache_write = 0.3
+output = 2.5
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-flash-lite-latest"
+input = 0.1
+cache_read = 0.01
+cache_write = 0.1
+output = 0.4
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-gemma-2-27b-it"
+input = 0.35
+cache_read = 0.35
+cache_write = 0.35
+output = 1.05
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-gemma-2-9b-it"
+input = 0.35
+cache_read = 0.35
+cache_write = 0.35
+output = 1.05
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-omni-flash-preview"
+input = 1.5
+cache_read = 1.5
+cache_write = 1.5
+output = 9.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-pro-latest"
+input = 1.25
+cache_read = 0.125
+cache_write = 1.25
+output = 10.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-robotics-er-1.5-preview"
+input = 0.3
+cache_read = 0.3
+cache_write = 0.3
+output = 2.5
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-robotics-er-1.6-preview"
+input = 1.0
+cache_read = 1.0
+cache_write = 1.0
+output = 5.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-robotics-er-2-preview"
+input = 2.0
+cache_read = 0.2
+cache_write = 2.0
+output = 10.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-robotics-er-2-streaming-preview"
+input = 2.0
+cache_read = 2.0
+cache_write = 2.0
+output = 10.0
+source = "litellm"
+
+[[rate]]
+provider = "google"
+prefix = "gemma-2-27b-it"
+input = 0.65
+cache_read = 0.65
+cache_write = 0.65
+output = 0.65
+source = "openrouter"
+
+[[rate]]
+provider = "google"
+prefix = "gemma-3-12b-it"
+input = 0.05
+cache_read = 0.05
+cache_write = 0.05
+output = 0.15
+source = "openrouter"
+
+[[rate]]
+provider = "google"
+prefix = "gemma-3-27b-it"
+input = 0.08
+cache_read = 0.04
+cache_write = 0.08
+output = 0.45
+source = "openrouter"
+
+[[rate]]
+provider = "google"
+prefix = "gemma-3-4b-it"
+input = 0.05
+cache_read = 0.05
+cache_write = 0.05
+output = 0.1
+source = "openrouter"
+
+[[rate]]
+provider = "google"
+prefix = "gemma-4-26b-a4b-it"
+input = 0.07
+cache_read = 0.07
+cache_write = 0.07
+output = 0.34
+source = "openrouter"
+
+[[rate]]
+provider = "google"
+prefix = "gemma-4-31b-it"
+input = 0.09
+cache_read = 0.05
+cache_write = 0.09
+output = 0.34
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "chat-latest"
+input = 5.0
+cache_read = 0.5
+cache_write = 5.0
+output = 30.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "chatgpt-4o-latest"
+input = 5.0
+cache_read = 5.0
+cache_write = 5.0
+output = 15.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "daybreak-blue-latest"
+input = 4.0
+cache_read = 0.4
+cache_write = 5.0
+output = 20.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "daybreak-red-latest"
+input = 12.5
+cache_read = 1.25
+cache_write = 15.625
+output = 75.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-3.5-turbo"
+input = 0.5
+cache_read = 0.5
+cache_write = 0.5
+output = 1.5
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-3.5-turbo-0613"
+input = 1.0
+cache_read = 1.0
+cache_write = 1.0
+output = 2.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-3.5-turbo-1106"
+input = 1.0
+cache_read = 1.0
+cache_write = 1.0
+output = 2.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-3.5-turbo-16k"
+input = 3.0
+cache_read = 3.0
+cache_write = 3.0
+output = 4.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-3.5-turbo-instruct"
+input = 1.5
+cache_read = 1.5
+cache_write = 1.5
+output = 2.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4"
+input = 30.0
+cache_read = 30.0
+cache_write = 30.0
+output = 60.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4-0125-preview"
+input = 10.0
+cache_read = 10.0
+cache_write = 10.0
+output = 30.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4-1106-preview"
+input = 10.0
+cache_read = 10.0
+cache_write = 10.0
+output = 30.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4-turbo"
+input = 10.0
+cache_read = 10.0
+cache_write = 10.0
+output = 30.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4.1"
+input = 2.0
+cache_read = 0.5
+cache_write = 2.0
+output = 8.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4.1-mini"
+input = 0.4
+cache_read = 0.1
+cache_write = 0.4
+output = 1.6
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4.1-nano-2025-04-14"
+input = 0.1
+cache_read = 0.025
+cache_write = 0.1
+output = 0.4
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4o"
+input = 2.5
+cache_read = 1.25
+cache_write = 2.5
+output = 10.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4o-2024-05-13"
+input = 5.0
+cache_read = 5.0
+cache_write = 5.0
+output = 15.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-4o-mini"
+input = 0.15
+cache_read = 0.075
+cache_write = 0.15
+output = 0.6
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5"
+input = 1.25
+cache_read = 0.125
+cache_write = 1.25
+output = 10.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5-image"
+input = 10.0
+cache_read = 1.25
+cache_write = 10.0
+output = 10.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5-image-mini"
+input = 2.5
+cache_read = 0.25
+cache_write = 2.5
+output = 2.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5-mini"
+input = 0.25
+cache_read = 0.025
+cache_write = 0.25
+output = 2.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5-nano"
+input = 0.05
+cache_read = 0.005
+cache_write = 0.05
+output = 0.4
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5-pro"
+input = 15.0
+cache_read = 15.0
+cache_write = 15.0
+output = 120.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.1-codex-mini"
+input = 0.25
+cache_read = 0.03
+cache_write = 0.25
+output = 2.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.2"
+input = 1.75
+cache_read = 0.175
+cache_write = 1.75
+output = 14.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.2-pro"
+input = 21.0
+cache_read = 21.0
+cache_write = 21.0
+output = 168.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.3-chat-latest"
+input = 1.75
+cache_read = 0.175
+cache_write = 1.75
+output = 14.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.3-codex"
+input = 1.75
+cache_read = 0.175
+cache_write = 1.75
+output = 14.0
+source = "openrouter"
+
+[[rate]]
 provider = "openai"
 prefix = "gpt-5.4"
 input = 2.5
@@ -125,6 +845,15 @@ cache_read = 0.25
 cache_write = 2.5
 output = 15.0
 source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.4-image-2"
+input = 8.0
+cache_read = 2.0
+cache_write = 8.0
+output = 15.0
+source = "openrouter"
 
 [[rate]]
 provider = "openai"
@@ -146,9 +875,180 @@ source = "both"
 
 [[rate]]
 provider = "openai"
+prefix = "gpt-5.4-pro"
+input = 30.0
+cache_read = 30.0
+cache_write = 30.0
+output = 180.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
 prefix = "gpt-5.5"
 input = 5.0
 cache_read = 0.5
 cache_write = 5.0
 output = 30.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.5-pro"
+input = 30.0
+cache_read = 30.0
+cache_write = 30.0
+output = 180.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.6"
+input = 4.0
+cache_read = 0.4
+cache_write = 5.0
+output = 20.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.6-cyber"
+input = 12.5
+cache_read = 1.25
+cache_write = 15.625
+output = 75.0
+source = "litellm"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.6-luna"
+input = 0.2
+cache_read = 0.02
+cache_write = 0.25
+output = 1.2
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.6-sol-pro"
+input = 2.0
+cache_read = 0.2
+cache_write = 2.5
+output = 10.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.6-terra"
+input = 2.0
+cache_read = 0.2
+cache_write = 2.5
+output = 12.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-audio"
+input = 2.5
+cache_read = 2.5
+cache_write = 2.5
+output = 10.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-audio-mini"
+input = 0.6
+cache_read = 0.6
+cache_write = 0.6
+output = 2.4
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-chat-latest"
+input = 5.0
+cache_read = 0.5
+cache_write = 5.0
+output = 30.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-oss-120b"
+input = 0.037
+cache_read = 0.037
+cache_write = 0.037
+output = 0.17
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-oss-20b"
+input = 0.03
+cache_read = 0.03
+cache_write = 0.03
+output = 0.13
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-oss-safeguard-20b"
+input = 0.075
+cache_read = 0.0375
+cache_write = 0.075
+output = 0.3
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "o1"
+input = 15.0
+cache_read = 7.5
+cache_write = 15.0
+output = 60.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "o1-pro"
+input = 150.0
+cache_read = 150.0
+cache_write = 150.0
+output = 600.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "o3"
+input = 2.0
+cache_read = 0.5
+cache_write = 2.0
+output = 8.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "o3-mini"
+input = 1.1
+cache_read = 0.55
+cache_write = 1.1
+output = 4.4
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "o3-pro"
+input = 20.0
+cache_read = 20.0
+cache_write = 20.0
+output = 80.0
+source = "openrouter"
+
+[[rate]]
+provider = "openai"
+prefix = "o4-mini"
+input = 1.1
+cache_read = 0.275
+cache_write = 1.1
+output = 4.4
 source = "both"

--- a/crates/leviath-providers/pricing/rates.toml
+++ b/crates/leviath-providers/pricing/rates.toml
@@ -1,0 +1,154 @@
+# Published list prices, USD per million tokens, for the providers whose APIs
+# do not quote them. Read by `leviath_providers::pricing::published_rates`
+# (longest matching `prefix` wins) and rewritten by `cargo xtask prices`, which
+# takes the figures from OpenRouter's catalogue cross-checked against LiteLLM.
+#
+# `source` records where a row came from: `both` when the two sources agreed,
+# `openrouter` or `litellm` when only one listed it, and `manual` for a row a
+# person wrote, which the refresh never overwrites.
+
+read_on = "2026-08-23"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-fable-5"
+input = 10.0
+cache_read = 1.0
+cache_write = 12.5
+output = 50.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-haiku-4-5"
+input = 1.0
+cache_read = 0.1
+cache_write = 1.25
+output = 5.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-opus-4-6"
+input = 5.0
+cache_read = 0.5
+cache_write = 6.25
+output = 25.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-opus-4-7"
+input = 5.0
+cache_read = 0.5
+cache_write = 6.25
+output = 25.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-opus-4-8"
+input = 5.0
+cache_read = 0.5
+cache_write = 6.25
+output = 25.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-opus-5"
+input = 5.0
+cache_read = 0.5
+cache_write = 6.25
+output = 25.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-sonnet-4-6"
+input = 3.0
+cache_read = 0.3
+cache_write = 3.75
+output = 15.0
+source = "both"
+
+[[rate]]
+provider = "anthropic"
+prefix = "claude-sonnet-5"
+input = 2.0
+cache_read = 0.2
+cache_write = 2.5
+output = 10.0
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3-flash"
+input = 0.5
+cache_read = 0.05
+cache_write = 0.5
+output = 3.0
+source = "manual"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.1-flash-lite"
+input = 0.25
+cache_read = 0.025
+cache_write = 0.25
+output = 1.5
+source = "both"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.1-pro"
+input = 2.0
+cache_read = 0.2
+cache_write = 2.0
+output = 12.0
+source = "manual"
+
+[[rate]]
+provider = "google"
+prefix = "gemini-3.5-flash"
+input = 1.5
+cache_read = 0.15
+cache_write = 1.5
+output = 9.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.4"
+input = 2.5
+cache_read = 0.25
+cache_write = 2.5
+output = 15.0
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.4-mini"
+input = 0.75
+cache_read = 0.075
+cache_write = 0.75
+output = 4.5
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.4-nano"
+input = 0.2
+cache_read = 0.02
+cache_write = 0.2
+output = 1.25
+source = "both"
+
+[[rate]]
+provider = "openai"
+prefix = "gpt-5.5"
+input = 5.0
+cache_read = 0.5
+cache_write = 5.0
+output = 30.0
+source = "both"

--- a/crates/leviath-providers/src/pricing.rs
+++ b/crates/leviath-providers/src/pricing.rs
@@ -9,6 +9,8 @@
 //! onward, and understates by however much it silently skipped - worse than
 //! admitting the figure is not available.
 
+use std::sync::LazyLock;
+
 use serde::{Deserialize, Serialize};
 
 /// Token usage breakdown.
@@ -158,18 +160,90 @@ impl ModelPricing {
     }
 }
 
-/// The day the rates in [`published_rates`] were read from the vendors' pages.
+/// The rows of `pricing/rates.toml`, parsed once.
+///
+/// A parse failure is a panic on first use rather than an error: the file is
+/// compiled in, so a malformed one is a build of this crate that cannot price
+/// anything, and the tests below catch it before it ships.
+static RATE_TABLE: LazyLock<RateTable> = LazyLock::new(|| {
+    toml::from_str(include_str!("../pricing/rates.toml"))
+        .expect("pricing/rates.toml is well-formed; `cargo xtask prices` writes it")
+});
+
+/// The shape of `pricing/rates.toml`.
+#[derive(Debug, Deserialize)]
+struct RateTable {
+    /// The day the rows were last refreshed, `YYYY-MM-DD`.
+    read_on: String,
+    /// Every row, in file order.
+    #[serde(default)]
+    rate: Vec<PublishedRate>,
+}
+
+/// One row of the shipped price table: what a family of models charges, and
+/// where the figure came from.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct PublishedRate {
+    /// The provider the row applies to: `anthropic`, `openai` or `google`.
+    pub provider: String,
+    /// The model-id prefix the row covers. A dated variant such as
+    /// `gpt-5.5-2026-04-23` is covered by `gpt-5.5`; the longest matching
+    /// prefix wins, so `gpt-5.4-mini` is not swallowed by `gpt-5.4`.
+    pub prefix: String,
+    /// Fresh input, USD per million tokens.
+    pub input: f64,
+    /// Input served from cache, USD per million tokens.
+    pub cache_read: f64,
+    /// Input written into the cache, USD per million tokens.
+    pub cache_write: f64,
+    /// Output, USD per million tokens.
+    pub output: f64,
+    /// Where the row came from: `both` when OpenRouter's catalogue and LiteLLM
+    /// agreed, `openrouter` or `litellm` when only one listed it, `manual` for
+    /// a row a person wrote, which `cargo xtask prices` never overwrites.
+    pub source: String,
+}
+
+impl PublishedRate {
+    /// The row as the four rates cost accounting bills by.
+    pub fn pricing(&self) -> ModelPricing {
+        ModelPricing {
+            input_per_mtok: self.input,
+            cached_input_per_mtok: self.cache_read,
+            cache_write_per_mtok: self.cache_write,
+            output_per_mtok: self.output,
+        }
+    }
+}
+
+/// The day the rates in [`published_rates`] were last refreshed.
 ///
 /// Shipped with the numbers so staleness is visible rather than assumed. A
 /// build months old is quoting months-old prices, and the only honest thing to
 /// do about that is say so.
-pub const RATES_READ_ON: &str = "2026-08-23";
+pub fn rates_read_on() -> &'static str {
+    &RATE_TABLE.read_on
+}
+
+/// The table row that prices `model` at `provider`, with its source, or `None`
+/// when no row's prefix matches. The longest matching prefix wins.
+pub fn published_rate(provider: &str, model: &str) -> Option<&'static PublishedRate> {
+    RATE_TABLE
+        .rate
+        .iter()
+        .filter(|row| row.provider == provider && model.starts_with(&row.prefix))
+        .max_by_key(|row| row.prefix.len())
+}
 
 /// Published list prices for the providers whose APIs do not quote them.
 ///
 /// ⚠️ **A snapshot, not a feed.** Anthropic, OpenAI and Google publish rates on
-/// a web page with nothing programmatic behind it, so these were transcribed by
-/// hand on [`RATES_READ_ON`] and cannot notice a repricing. They are a floor
+/// a web page with nothing programmatic behind it, so the rows live in
+/// `pricing/rates.toml`, compiled into this crate and refreshed by `cargo xtask
+/// prices`, which reads the vendors' list prices as OpenRouter's catalogue
+/// carries them, cross-checks them against LiteLLM's table, and rewrites the
+/// file when the two agree. A build cannot notice a repricing between
+/// refreshes; [`rates_read_on`] says how old the figures are. They are a floor
 /// under "no cost at all", not an authority:
 ///
 /// * a per-model config entry overrides any row here, and is the right place
@@ -190,41 +264,7 @@ pub const RATES_READ_ON: &str = "2026-08-23";
 /// modelled. They would need per-request state this table does not see, and a
 /// wrong adjustment is worse than a plain list price.
 pub fn published_rates(provider: &str, model: &str) -> Option<ModelPricing> {
-    // (model prefix, input, cache read, cache write, output), longest prefix
-    // first so `gpt-5.5` is not swallowed by `gpt-5`.
-    let rows: &[(&str, f64, f64, f64, f64)] = match provider {
-        "anthropic" => &[
-            ("claude-fable-5", 10.0, 1.0, 12.5, 50.0),
-            ("claude-opus-5", 5.0, 0.5, 6.25, 25.0),
-            ("claude-opus-4-8", 5.0, 0.5, 6.25, 25.0),
-            ("claude-opus-4-7", 5.0, 0.5, 6.25, 25.0),
-            ("claude-opus-4-6", 5.0, 0.5, 6.25, 25.0),
-            ("claude-sonnet-5", 2.0, 0.2, 2.5, 10.0),
-            ("claude-sonnet-4-6", 3.0, 0.3, 3.75, 15.0),
-            ("claude-haiku-4-5", 1.0, 0.1, 1.25, 5.0),
-        ],
-        "openai" => &[
-            ("gpt-5.5", 5.0, 0.5, 5.0, 30.0),
-            ("gpt-5.4-mini", 0.75, 0.075, 0.75, 4.5),
-            ("gpt-5.4-nano", 0.2, 0.02, 0.2, 1.25),
-            ("gpt-5.4", 2.5, 0.25, 2.5, 15.0),
-        ],
-        "google" => &[
-            ("gemini-3.5-flash", 1.5, 0.15, 1.5, 9.0),
-            ("gemini-3.1-pro", 2.0, 0.2, 2.0, 12.0),
-            ("gemini-3.1-flash-lite", 0.25, 0.025, 0.25, 1.5),
-            ("gemini-3-flash", 0.5, 0.05, 0.5, 3.0),
-        ],
-        _ => return None,
-    };
-    rows.iter()
-        .find(|(prefix, ..)| model.starts_with(prefix))
-        .map(|&(_, input, read, write, output)| ModelPricing {
-            input_per_mtok: input,
-            cached_input_per_mtok: read,
-            cache_write_per_mtok: write,
-            output_per_mtok: output,
-        })
+    published_rate(provider, model).map(PublishedRate::pricing)
 }
 
 impl crate::ModelCapabilityOverride {
@@ -414,8 +454,60 @@ mod cost_tests {
     /// current price from one transcribed a year ago.
     #[test]
     fn the_table_carries_the_day_it_was_read() {
-        assert_eq!(RATES_READ_ON.len(), "YYYY-MM-DD".len());
-        assert!(RATES_READ_ON.starts_with("202"));
+        let read_on = rates_read_on();
+        assert_eq!(read_on.len(), "YYYY-MM-DD".len());
+        assert!(read_on.starts_with("202"));
+    }
+
+    /// A row names where its figures came from, and only from the four places
+    /// `cargo xtask prices` knows, so a typo in the file cannot invent a fifth.
+    #[test]
+    fn every_row_names_a_known_source_and_provider() {
+        let rows = &RATE_TABLE.rate;
+        assert!(!rows.is_empty());
+        let bad_source: Vec<&PublishedRate> = rows
+            .iter()
+            .filter(|r| !["openrouter", "litellm", "both", "manual"].contains(&r.source.as_str()))
+            .collect();
+        assert!(bad_source.is_empty(), "unknown source: {bad_source:?}");
+        let bad_provider: Vec<&PublishedRate> = rows
+            .iter()
+            .filter(|r| !["anthropic", "openai", "google"].contains(&r.provider.as_str()))
+            .collect();
+        assert!(
+            bad_provider.is_empty(),
+            "unknown provider: {bad_provider:?}"
+        );
+    }
+
+    /// The file is sorted by provider then prefix with no duplicate prefix, so
+    /// a hand edit and the refresh produce the same file for the same rows and
+    /// a diff shows only what changed.
+    #[test]
+    fn the_file_is_sorted_and_has_no_duplicate_prefixes() {
+        let keys: Vec<(&str, &str)> = RATE_TABLE
+            .rate
+            .iter()
+            .map(|r| (r.provider.as_str(), r.prefix.as_str()))
+            .collect();
+        let mut sorted = keys.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(keys, sorted);
+    }
+
+    /// `lev models show` names a rate's source, which the row carries and the
+    /// four-rate view does not.
+    #[test]
+    fn a_row_carries_its_source_and_prices_like_the_rate_view() {
+        let row = published_rate("openai", "gpt-5.5-2026-04-23").expect("listed");
+        assert_eq!(row.prefix, "gpt-5.5");
+        assert!(!row.source.is_empty());
+        assert_eq!(
+            Some(row.pricing()),
+            published_rates("openai", "gpt-5.5-2026-04-23")
+        );
+        assert_eq!(published_rate("openai", "davinci"), None);
     }
 
     /// Rates declared on a model's config entry are what the direct providers

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -371,8 +371,10 @@ it returns `false`.
 
 Both ask every configured provider for its own listing by default, waiting up to five seconds each,
 and print what the provider said: the columns include the release date and the input and output
-price per million tokens where the listing carries them, and a trailing line says how many rows
-came from a provider and how many from the table compiled into this build. A provider that could
+price per million tokens where the listing or the build's price table carries them (`n/a` where
+neither does), and a trailing line says how many rows came from a provider and how many from the
+table compiled into this build. `lev models show` names where a table row's rate came from and the
+day the table was read; see [where the prices come from](/docs/costs#where-the-prices-come-from). A provider that could
 not be reached keeps its table rows, with a warning naming it. `--offline` skips the network and
 prints the table alone. `-r/--remote` is still accepted for older scripts and changes nothing.
 

--- a/docs/content/costs.md
+++ b/docs/content/costs.md
@@ -146,12 +146,28 @@ spent most of the run.
 > a fan-out badly: in the $236 run above, the top-level agent's own record said $15. Add up the
 > tree, following `children` in each `meta.json`.
 
-OpenRouter quotes every model's rate in its listing, so a run through it is priced from what the
-gateway said that day, and `lev models list` prints those rates beside each model. Anthropic, OpenAI
-and Google publish no rate through their APIs, so theirs are transcribed into this build and dated;
-`lev models show` says which kind it is printing. Rates for models with neither come from
-`[model_capabilities]` in your config, which is also the only place a negotiated rate or a
-self-hosted model's cost can live:
+## Where the prices come from
+
+A computed cost is a reconstruction from list prices, not an invoice. The provider's bill is the
+figure that counts; this one exists so a run can be compared with the last one and a runaway
+noticed before the bill arrives. Where a figure comes from decides how far to trust it:
+
+| provider | source | live or table | coverage |
+|---|---|---|---|
+| OpenRouter | its own catalogue, plus the real cost each call reports | live | every model it serves; `cost_is_exact` is true for these |
+| OpenAI, Anthropic, Google | the vendor list prices as carried by OpenRouter's catalogue, cross-checked against LiteLLM's table | table, refreshed weekly by an automated PR | current families; a model the table has no row for is `n/a` |
+| Ollama | free by design | neither | every model; a self-hosted cost belongs in the override below |
+| Rhai script providers, OpenAI-compatible endpoints | the script's `list_models`, or a `[model_capabilities]` override | whichever the script gives | unpriced unless one of those says otherwise |
+
+`lev models list` prints each model's input and output rate, or `n/a` where nothing prices it;
+`lev models show` names the source of a table row and the day the table was read. The table is
+compiled into the build, so a build cannot notice a repricing between refreshes, and a refresh is
+the deterministic `cargo xtask prices`: it writes a row only where the two sources agree within 5%,
+keeps a disagreement as it was and prints it, and refuses a move it does not believe.
+
+A negotiated rate never appears on a public page, so it belongs in the per-model override in your
+config, which wins over every table row and is also the only place a self-hosted model's cost can
+live:
 
 ```toml
 [model_capabilities."my-model"]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -13,6 +13,11 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+# `cargo xtask prices`: fetch two public price catalogues, rewrite the TOML
+# table the providers crate compiles in, and stamp the day it was read.
+reqwest = { workspace = true }
+toml = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -10,9 +10,12 @@
 //!   `docs`                      Check `docs/content/` for dead links and bad frontmatter.
 //!   `structure`                 Hold every source file to the production-line limit.
 //!   `structure --list`          Print every file's production-line count, longest first.
+//!   `prices`                    Refresh the vendor list prices from OpenRouter and LiteLLM.
+//!   `prices --check`            Print the diff and fail if the price table would change.
 
 mod coverage;
 mod docs;
+mod prices;
 mod structure;
 mod version;
 
@@ -27,7 +30,14 @@ fn main() -> Result<()> {
 ///
 /// Extracted from `main` so it can be unit-tested without spawning processes.
 pub fn dispatch(args: &[String]) -> Result<()> {
-    dispatch_with(args, coverage::run, version::run, docs::run, structure::run)
+    dispatch_with(
+        args,
+        coverage::run,
+        version::run,
+        docs::run,
+        structure::run,
+        prices::run,
+    )
 }
 
 /// Route the CLI arguments to the provided handler closures.
@@ -40,6 +50,7 @@ pub fn dispatch_with(
     run_ver: impl FnOnce(version::VersionMode) -> Result<()>,
     run_docs: impl FnOnce(docs::DocsMode) -> Result<()>,
     run_struct: impl FnOnce(structure::StructureMode) -> Result<()>,
+    run_prices: impl FnOnce(prices::PricesMode) -> Result<()>,
 ) -> Result<()> {
     let subcommand = args.first().map(String::as_str).unwrap_or("help");
     match subcommand {
@@ -59,6 +70,10 @@ pub fn dispatch_with(
             let mode = structure::StructureMode::parse(&args[1..])?;
             run_struct(mode)
         }
+        "prices" => {
+            let mode = prices::PricesMode::parse(&args[1..])?;
+            run_prices(mode)
+        }
         "help" | "--help" | "-h" => {
             println!("Usage: cargo xtask <subcommand>");
             println!();
@@ -70,6 +85,8 @@ pub fn dispatch_with(
             println!("  structure                 Hold every file to the production-line limit");
             println!("  structure --list          Print every file's production-line count");
             println!("  docs                      Check docs/content for dead links + frontmatter");
+            println!("  prices                    Refresh the vendor list prices (network)");
+            println!("  prices --check            Fail if the price table would change (network)");
             Ok(())
         }
         other => anyhow::bail!("Unknown subcommand: '{other}'. Run `cargo xtask help` for usage."),
@@ -109,6 +126,11 @@ mod tests {
         Ok(())
     }
 
+    /// A `run_prices` stub matching `impl FnOnce(PricesMode) -> Result<()>`.
+    fn prices_ok(_mode: prices::PricesMode) -> Result<()> {
+        Ok(())
+    }
+
     /// Covers the stub body so tests that pass it without calling it still get
     /// this single coverage hit.
     #[test]
@@ -116,6 +138,8 @@ mod tests {
         assert!(cov_ok(CoverageMode::All).is_ok());
         assert!(ver_ok(VersionMode::Check).is_ok());
         assert!(docs_ok(docs::DocsMode::Check).is_ok());
+        assert!(struct_ok(structure::StructureMode::Check).is_ok());
+        assert!(prices_ok(prices::PricesMode::Check).is_ok());
     }
 
     /// Build an owned-args slice from string literals (dispatch takes `&[String]`).
@@ -178,6 +202,7 @@ mod tests {
             ver_ok,
             docs_ok,
             struct_ok,
+            prices_ok,
         )
         .unwrap();
         assert_eq!(got, Some(CoverageMode::All));
@@ -195,6 +220,7 @@ mod tests {
             ver_ok,
             docs_ok,
             struct_ok,
+            prices_ok,
         )
         .unwrap();
         assert_eq!(got, Some(CoverageMode::Package("leviath-core".to_owned())));
@@ -209,6 +235,7 @@ mod tests {
             ver_ok,
             docs_ok,
             struct_ok,
+            prices_ok,
         );
         assert!(
             result.is_err(),
@@ -224,6 +251,7 @@ mod tests {
             ver_ok,
             docs_ok,
             struct_ok,
+            prices_ok,
         );
         assert!(result.is_err());
         assert!(
@@ -248,6 +276,7 @@ mod tests {
                 Ok(())
             },
             struct_ok,
+            prices_ok,
         )
         .unwrap();
         assert_eq!(got, Some(docs::DocsMode::Check));
@@ -261,10 +290,47 @@ mod tests {
             ver_ok,
             docs_ok,
             struct_ok,
+            prices_ok,
         );
         assert!(
             result.is_err(),
             "an unknown docs flag must error: {result:?}"
+        );
+    }
+
+    // ── prices arm: mode parsing + dispatch ─────────────────────────────────
+
+    #[test]
+    fn dispatch_with_prices_parses_check() {
+        let mut got = None;
+        dispatch_with(
+            &args(&["prices", "--check"]),
+            cov_ok,
+            ver_ok,
+            docs_ok,
+            struct_ok,
+            |mode| {
+                got = Some(mode);
+                Ok(())
+            },
+        )
+        .unwrap();
+        assert_eq!(got, Some(prices::PricesMode::Check));
+    }
+
+    #[test]
+    fn dispatch_with_prices_bad_arg_returns_err_without_calling_run_prices() {
+        let result = dispatch_with(
+            &args(&["prices", "--write"]),
+            cov_ok,
+            ver_ok,
+            docs_ok,
+            struct_ok,
+            prices_ok,
+        );
+        assert!(
+            result.is_err(),
+            "an unknown prices flag must error: {result:?}"
         );
     }
 
@@ -282,6 +348,7 @@ mod tests {
             },
             docs_ok,
             struct_ok,
+            prices_ok,
         )
         .unwrap();
         assert_eq!(got, Some(VersionMode::Set("1.2.3".to_owned())));
@@ -299,6 +366,7 @@ mod tests {
             },
             docs_ok,
             struct_ok,
+            prices_ok,
         )
         .unwrap();
         assert_eq!(got, Some(VersionMode::Check));
@@ -312,6 +380,7 @@ mod tests {
             ver_ok,
             docs_ok,
             struct_ok,
+            prices_ok,
         );
         assert!(
             result.is_err(),
@@ -327,6 +396,7 @@ mod tests {
             |_mode| anyhow::bail!("simulated version failure"),
             docs_ok,
             struct_ok,
+            prices_ok,
         );
         assert!(
             result

--- a/xtask/src/prices.rs
+++ b/xtask/src/prices.rs
@@ -1,0 +1,714 @@
+//! `cargo xtask prices` - refresh the vendor list prices without a person or
+//! an AI in the loop.
+//!
+//! Anthropic, OpenAI and Google quote no price through their APIs, so
+//! `crates/leviath-providers/pricing/rates.toml` carries their list prices and
+//! a cost computed from it is only as current as the file. Keeping it current
+//! by hand means transcription, and transcription is where a wrong digit gets
+//! in. This command reads the same list prices from two places that do publish
+//! them programmatically and writes the file only where they agree:
+//!
+//! * OpenRouter's public catalogue (`/api/v1/models`, no key), which carries
+//!   each vendor's models under the vendor's own prefix with the vendor's list
+//!   price, and is what Leviath already prices OpenRouter runs from;
+//! * LiteLLM's `model_prices_and_context_window.json`, a community table of
+//!   the same prices, as the cross-check.
+//!
+//! The rules are fixed so two runs on the same inputs write the same file:
+//!
+//! * a model both sources price within 5% is written with `source = "both"`,
+//!   at OpenRouter's figure;
+//! * a model only one source prices is written with that source's name;
+//! * a model the two price more than 5% apart is not written; the existing
+//!   row, if any, is kept and the disagreement is printed;
+//! * a row whose `source` is `manual` is never overwritten;
+//! * a model id is kept as the vendor writes it, minus the `openai/`,
+//!   `anthropic/` or `google/` prefix. OpenRouter spells Anthropic's versions
+//!   with a dot (`claude-opus-4.8`) where the API id has a dash
+//!   (`claude-opus-4-8`), so those are normalised. Variants after a colon
+//!   (`:batch`, `:free`, `:thinking`) are routing options, not models, and
+//!   are dropped;
+//! * a new id that a shorter new id covers as a prefix at the same price, such
+//!   as `gpt-5.5-2026-04-23` beside `gpt-5.5`, is not written. Lookup is by
+//!   longest matching prefix, so the shorter row already prices it;
+//! * a cache-read rate is taken as published. A cache-write rate is taken only
+//!   when it is at least the input rate: a write is a premium on input, and a
+//!   figure below input (OpenRouter lists Google's per-hour storage price in
+//!   that field) is not a per-token rate. Either defaults to the input rate;
+//! * a source entry with a zero or negative input or output price is not a
+//!   price (a free tier, or a model priced by the image) and is dropped.
+//!
+//! And it refuses, leaving the file untouched, when any existing row would
+//! move by more than 3x, when the finished table has a row with no positive
+//! output price, or when either source lists nothing for one of the three
+//! providers. Any of those is a broken source or a broken parser, and a bad
+//! table is worse than a stale one.
+//!
+//! `--check` prints the diff and exits 1 if the file would change, touching
+//! nothing. A network failure exits 2, also touching nothing.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+/// Path of the price table, relative to the workspace root.
+pub const RATES_FILE: &str = "crates/leviath-providers/pricing/rates.toml";
+
+/// OpenRouter's public model catalogue, with each model's list price.
+const OPENROUTER_URL: &str = "https://openrouter.ai/api/v1/models";
+
+/// LiteLLM's price table, the cross-check.
+const LITELLM_URL: &str =
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+
+/// The providers the table prices, in the order the file sorts them.
+const PROVIDERS: [&str; 3] = ["anthropic", "google", "openai"];
+
+/// Two figures within this fraction of each other agree.
+const AGREE_TOLERANCE: f64 = 0.05;
+
+/// An existing row moving by more than this ratio, either way, is refused.
+const REFUSE_RATIO: f64 = 3.0;
+
+/// How long to wait on either source before calling it a network failure.
+const FETCH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Header written above the rows, so the file explains itself.
+const FILE_HEADER: &str = "\
+# Published list prices, USD per million tokens, for the providers whose APIs
+# do not quote them. Read by `leviath_providers::pricing::published_rates`
+# (longest matching `prefix` wins) and rewritten by `cargo xtask prices`, which
+# takes the figures from OpenRouter's catalogue cross-checked against LiteLLM.
+#
+# `source` records where a row came from: `both` when the two sources agreed,
+# `openrouter` or `litellm` when only one listed it, and `manual` for a row a
+# person wrote, which the refresh never overwrites.
+";
+
+// ── CLI argument parsing ─────────────────────────────────────────────────────
+
+/// What `cargo xtask prices` was asked to do.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PricesMode {
+    /// Fetch, merge, and rewrite the file when the rows changed.
+    Write,
+    /// Fetch, merge, print the diff, and fail if the file would change.
+    Check,
+}
+
+impl PricesMode {
+    /// Parse the arguments after `prices`.
+    pub fn parse(args: &[String]) -> Result<Self> {
+        match args.first().map(String::as_str) {
+            None => Ok(Self::Write),
+            Some("--check") => Ok(Self::Check),
+            Some(other) => anyhow::bail!("Unknown `prices` argument: '{other}'. Try `--check`."),
+        }
+    }
+}
+
+// ── Fetching ─────────────────────────────────────────────────────────────────
+
+/// A fetch of a URL to its body. A plain `fn` pointer so the merge can be
+/// tested against fixture JSON without a network.
+pub type Fetch = fn(&str) -> Result<String>;
+
+/// A source could not be read. Distinguished from every other failure because
+/// it maps to exit 2 and says nothing about the table.
+#[derive(Debug)]
+pub struct NetworkError(pub String);
+
+impl fmt::Display for NetworkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "network: {}", self.0)
+    }
+}
+
+impl std::error::Error for NetworkError {}
+
+/// Whether an error from [`run_with`] was the network rather than the data.
+pub fn is_network_error(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<NetworkError>().is_some()
+}
+
+/// The real fetch: a GET with a bounded wait, any failure a [`NetworkError`].
+fn fetch_http(url: &str) -> Result<String> {
+    let body = reqwest::blocking::Client::builder()
+        .timeout(FETCH_TIMEOUT)
+        .user_agent("leviath-xtask-prices")
+        .build()
+        .and_then(|client| client.get(url).send())
+        .and_then(reqwest::blocking::Response::error_for_status)
+        .and_then(reqwest::blocking::Response::text)
+        .map_err(|e| NetworkError(format!("{url}: {e}")))?;
+    Ok(body)
+}
+
+// ── The table ────────────────────────────────────────────────────────────────
+
+/// One row of `rates.toml`.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct Row {
+    /// `anthropic`, `google` or `openai`.
+    pub provider: String,
+    /// The model-id prefix the row covers.
+    pub prefix: String,
+    /// Fresh input, USD per million tokens.
+    pub input: f64,
+    /// Cache read, USD per million tokens.
+    pub cache_read: f64,
+    /// Cache write, USD per million tokens.
+    pub cache_write: f64,
+    /// Output, USD per million tokens.
+    pub output: f64,
+    /// `both`, `openrouter`, `litellm` or `manual`.
+    pub source: String,
+}
+
+impl Row {
+    /// The four rates as a compact `in/read/write/out` string for the diff.
+    fn rates(&self) -> String {
+        format!(
+            "{}/{}/{}/{} ({})",
+            fmt_num(self.input),
+            fmt_num(self.cache_read),
+            fmt_num(self.cache_write),
+            fmt_num(self.output),
+            self.source
+        )
+    }
+}
+
+/// The file as parsed.
+#[derive(Debug, Deserialize)]
+struct RateFile {
+    /// `YYYY-MM-DD` of the last refresh.
+    read_on: String,
+    /// The rows, in file order.
+    #[serde(default)]
+    rate: Vec<Row>,
+}
+
+/// The rows keyed by `(provider, prefix)`, which is also the file's order.
+pub type Rows = BTreeMap<(String, String), Row>;
+
+/// The table: the day it was read, and its rows.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Table {
+    /// `YYYY-MM-DD` of the last refresh.
+    pub read_on: String,
+    /// Every row.
+    pub rows: Rows,
+}
+
+/// Parse `rates.toml`.
+pub fn parse_table(text: &str) -> Result<Table> {
+    let file: RateFile = toml::from_str(text).context("rates.toml does not parse")?;
+    let rows = file
+        .rate
+        .into_iter()
+        .map(|row| ((row.provider.clone(), row.prefix.clone()), row))
+        .collect();
+    Ok(Table {
+        read_on: file.read_on,
+        rows,
+    })
+}
+
+/// Render a table as the file, sorted by provider then prefix.
+pub fn render_table(table: &Table) -> String {
+    let mut out = String::from(FILE_HEADER);
+    out.push_str(&format!("\nread_on = \"{}\"\n", table.read_on));
+    for row in table.rows.values() {
+        out.push_str(&format!(
+            "\n[[rate]]\nprovider = \"{}\"\nprefix = \"{}\"\ninput = {}\ncache_read = {}\ncache_write = {}\noutput = {}\nsource = \"{}\"\n",
+            row.provider,
+            row.prefix,
+            fmt_num(row.input),
+            fmt_num(row.cache_read),
+            fmt_num(row.cache_write),
+            fmt_num(row.output),
+            row.source
+        ));
+    }
+    out
+}
+
+/// A per-million figure as TOML: always a float (`5.0`, not `5`), and the
+/// shortest digits that round-trip.
+fn fmt_num(v: f64) -> String {
+    if v.fract() == 0.0 {
+        format!("{v:.1}")
+    } else {
+        format!("{v}")
+    }
+}
+
+/// Round to a millionth of a dollar per million tokens, so a per-token figure
+/// multiplied out does not leave float noise in the file.
+fn round6(v: f64) -> f64 {
+    (v * 1e6).round() / 1e6
+}
+
+// ── The sources ──────────────────────────────────────────────────────────────
+
+/// One model's price as a source publishes it, USD per million tokens. The
+/// cache sides are optional because most sources omit one or both.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Rate {
+    /// Fresh input.
+    pub input: f64,
+    /// Cache read, when published.
+    pub cache_read: Option<f64>,
+    /// Cache write, when published.
+    pub cache_write: Option<f64>,
+    /// Output.
+    pub output: f64,
+}
+
+impl Rate {
+    /// The four rates a row carries, with the cache sides defaulted per the
+    /// module rules: a read as published, a write only when it is a premium.
+    fn resolve(&self) -> (f64, f64, f64, f64) {
+        let input = round6(self.input);
+        let read = self
+            .cache_read
+            .filter(|r| *r > 0.0)
+            .map(round6)
+            .unwrap_or(input);
+        let write = self
+            .cache_write
+            .map(round6)
+            .filter(|w| *w >= input)
+            .unwrap_or(input);
+        (input, read, write, round6(self.output))
+    }
+
+    /// Whether two sources agree: input and output within tolerance, and each
+    /// cache side within tolerance where both publish it.
+    fn agrees(&self, other: &Rate) -> bool {
+        within(self.input, other.input)
+            && within(self.output, other.output)
+            && both_within(self.cache_read, other.cache_read)
+            && both_within(self.cache_write, other.cache_write)
+    }
+}
+
+/// Whether two figures are within [`AGREE_TOLERANCE`] of the larger.
+fn within(a: f64, b: f64) -> bool {
+    (a - b).abs() <= AGREE_TOLERANCE * a.abs().max(b.abs())
+}
+
+/// [`within`] when both sides are present; agreement when either is absent.
+fn both_within(a: Option<f64>, b: Option<f64>) -> bool {
+    match (a, b) {
+        (Some(a), Some(b)) => within(a, b),
+        _ => true,
+    }
+}
+
+/// Prices keyed by `(provider, model id)`.
+pub type Prices = BTreeMap<(String, String), Rate>;
+
+/// The vendor id as the table spells it. OpenRouter writes Anthropic's
+/// versions with a dot where the API id has a dash.
+fn vendor_id(provider: &str, id: &str) -> String {
+    if provider == "anthropic" {
+        id.replace('.', "-")
+    } else {
+        id.to_owned()
+    }
+}
+
+/// A per-token figure from a source, as per million, or `None` when absent or
+/// not a number.
+fn per_million(value: Option<&serde_json::Value>) -> Option<f64> {
+    let v = value?;
+    let per_token = match v {
+        serde_json::Value::String(s) => s.trim().parse::<f64>().ok()?,
+        serde_json::Value::Number(n) => n.as_f64()?,
+        _ => return None,
+    };
+    Some(per_token * 1_000_000.0)
+}
+
+/// Whether a rate is a price at all. A zero or negative side is a free tier
+/// or a model billed some other way, and the table must never carry one.
+fn is_priced(rate: &Rate) -> bool {
+    rate.input > 0.0 && rate.output > 0.0
+}
+
+/// Parse OpenRouter's `/api/v1/models` body into the three vendors' prices.
+pub fn parse_openrouter(body: &str) -> Result<Prices> {
+    let doc: serde_json::Value = serde_json::from_str(body).context("OpenRouter: not JSON")?;
+    let models = doc
+        .get("data")
+        .and_then(serde_json::Value::as_array)
+        .context("OpenRouter: no `data` array")?;
+    let mut out = Prices::new();
+    for model in models {
+        let Some(id) = model.get("id").and_then(serde_json::Value::as_str) else {
+            continue;
+        };
+        let Some((vendor, rest)) = id.split_once('/') else {
+            continue;
+        };
+        if !PROVIDERS.contains(&vendor) || rest.contains(':') {
+            continue;
+        }
+        let pricing = model.get("pricing");
+        let field = |name: &str| per_million(pricing.and_then(|p| p.get(name)));
+        let (Some(input), Some(output)) = (field("prompt"), field("completion")) else {
+            continue;
+        };
+        let rate = Rate {
+            input,
+            cache_read: field("input_cache_read"),
+            cache_write: field("input_cache_write"),
+            output,
+        };
+        if is_priced(&rate) {
+            out.insert((vendor.to_owned(), vendor_id(vendor, rest)), rate);
+        }
+    }
+    Ok(out)
+}
+
+/// Parse LiteLLM's price table into the three vendors' prices.
+///
+/// LiteLLM keys a model several ways (`gemini/gemini-2.5-pro` beside
+/// `gemini-2.5-pro`); they collapse to one id, and when the copies disagree
+/// beyond tolerance the id is dropped rather than picked from.
+pub fn parse_litellm(body: &str) -> Result<Prices> {
+    let doc: serde_json::Value = serde_json::from_str(body).context("LiteLLM: not JSON")?;
+    let entries = doc.as_object().context("LiteLLM: not an object")?;
+    let mut seen: BTreeMap<(String, String), Vec<(String, Rate)>> = BTreeMap::new();
+    for (key, entry) in entries {
+        let provider = match entry
+            .get("litellm_provider")
+            .and_then(serde_json::Value::as_str)
+        {
+            Some("openai") => "openai",
+            Some("anthropic") => "anthropic",
+            Some("gemini") => "google",
+            _ => continue,
+        };
+        if entry.get("mode").and_then(serde_json::Value::as_str) != Some("chat")
+            || key.contains(':')
+        {
+            continue;
+        }
+        let id = match key.split_once('/') {
+            None => key.as_str(),
+            Some((_, rest)) if !rest.contains('/') => rest,
+            Some(_) => continue,
+        };
+        let field = |name: &str| per_million(entry.get(name));
+        let (Some(input), Some(output)) = (
+            field("input_cost_per_token"),
+            field("output_cost_per_token"),
+        ) else {
+            continue;
+        };
+        let rate = Rate {
+            input,
+            cache_read: field("cache_read_input_token_cost"),
+            cache_write: field("cache_creation_input_token_cost"),
+            output,
+        };
+        if is_priced(&rate) {
+            seen.entry((provider.to_owned(), id.to_owned()))
+                .or_default()
+                .push((key.clone(), rate));
+        }
+    }
+    let mut out = Prices::new();
+    for (model, mut copies) in seen {
+        copies.sort_by(|a, b| a.0.cmp(&b.0));
+        let first = &copies[0].1;
+        if copies.iter().all(|(_, r)| r.agrees(first)) {
+            out.insert(model, first.clone());
+        }
+    }
+    Ok(out)
+}
+
+// ── The merge ────────────────────────────────────────────────────────────────
+
+/// What a merge did to one row, for the diff.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Change {
+    /// A row the file did not have.
+    Added(Row),
+    /// A row that moved, old and new.
+    Changed(Row, Row),
+}
+
+impl fmt::Display for Change {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Change::Added(row) => {
+                write!(f, "+ {}/{}: {}", row.provider, row.prefix, row.rates())
+            }
+            Change::Changed(old, new) => write!(
+                f,
+                "~ {}/{}: {} -> {}",
+                old.provider,
+                old.prefix,
+                old.rates(),
+                new.rates()
+            ),
+        }
+    }
+}
+
+/// The result of a merge: the table to write, and what to say about it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Merged {
+    /// The table after the merge. `read_on` is `today` only when a row moved.
+    pub table: Table,
+    /// Every row added or changed, in file order.
+    pub changes: Vec<Change>,
+    /// Models the two sources price more than 5% apart, and so were not
+    /// written.
+    pub disagreements: Vec<String>,
+}
+
+/// Merge the two sources into the existing table under the module's rules.
+///
+/// Errors are refusals: the caller must leave the file alone.
+pub fn merge(
+    existing: &Table,
+    openrouter: &Prices,
+    litellm: &Prices,
+    today: &str,
+) -> Result<Merged> {
+    for provider in PROVIDERS {
+        let lists = |prices: &Prices| prices.keys().any(|(p, _)| p == provider);
+        if !lists(openrouter) {
+            anyhow::bail!("refusing: OpenRouter lists no priced {provider} model");
+        }
+        if !lists(litellm) {
+            anyhow::bail!("refusing: LiteLLM lists no priced {provider} model");
+        }
+    }
+
+    // 1. Candidates: one rate per id, with the source that vouches for it.
+    let mut disagreements = Vec::new();
+    let mut candidates: BTreeMap<(String, String), (Rate, &str)> = BTreeMap::new();
+    let keys: std::collections::BTreeSet<&(String, String)> =
+        openrouter.keys().chain(litellm.keys()).collect();
+    for key in keys {
+        let candidate = match (openrouter.get(key), litellm.get(key)) {
+            (Some(a), Some(b)) if a.agrees(b) => (a.clone(), "both"),
+            (Some(a), Some(b)) => {
+                disagreements.push(format!(
+                    "{}/{}: openrouter {} vs litellm {}",
+                    key.0,
+                    key.1,
+                    rate_summary(a),
+                    rate_summary(b)
+                ));
+                continue;
+            }
+            (Some(a), None) => (a.clone(), "openrouter"),
+            (None, Some(b)) => (b.clone(), "litellm"),
+            (None, None) => continue,
+        };
+        candidates.insert(key.clone(), candidate);
+    }
+
+    // 2. Collapse new ids a shorter new id already prices. Existing rows are
+    //    exempt: they are refreshed, never collapsed away.
+    let mut kept: Vec<((String, String), Rate, &str)> = Vec::new();
+    for (key, (rate, source)) in candidates {
+        let covered = !existing.rows.contains_key(&key)
+            && kept.iter().any(|(k, r, _)| {
+                k.0 == key.0
+                    && key.1.len() > k.1.len()
+                    && key.1.starts_with(&k.1)
+                    && r.agrees(&rate)
+            });
+        if !covered {
+            kept.push((key, rate, source));
+        }
+    }
+
+    // 3. Apply to the table.
+    let mut rows = existing.rows.clone();
+    let mut changes = Vec::new();
+    for ((provider, prefix), rate, source) in kept {
+        let (input, cache_read, cache_write, output) = rate.resolve();
+        let new = Row {
+            provider: provider.clone(),
+            prefix: prefix.clone(),
+            input,
+            cache_read,
+            cache_write,
+            output,
+            source: source.to_owned(),
+        };
+        match rows.get(&(provider.clone(), prefix.clone())) {
+            Some(old) if old.source == "manual" => {}
+            Some(old) => {
+                let ratio = |a: f64, b: f64| (a / b).max(b / a);
+                let worst = ratio(old.input, new.input).max(ratio(old.output, new.output));
+                if worst > REFUSE_RATIO {
+                    anyhow::bail!(
+                        "refusing: {provider}/{prefix} would move by {worst:.1}x ({} -> {}); \
+                         a change that large is a broken source until a person says otherwise",
+                        old.rates(),
+                        new.rates()
+                    );
+                }
+                if *old != new {
+                    changes.push(Change::Changed(old.clone(), new.clone()));
+                    rows.insert((provider, prefix), new);
+                }
+            }
+            None => {
+                changes.push(Change::Added(new.clone()));
+                rows.insert((provider, prefix), new);
+            }
+        }
+    }
+
+    if let Some(row) = rows.values().find(|r| r.output <= 0.0 || r.input <= 0.0) {
+        anyhow::bail!(
+            "refusing: {}/{} has no positive price ({})",
+            row.provider,
+            row.prefix,
+            row.rates()
+        );
+    }
+
+    let read_on = if changes.is_empty() {
+        existing.read_on.clone()
+    } else {
+        today.to_owned()
+    };
+    Ok(Merged {
+        table: Table { read_on, rows },
+        changes,
+        disagreements,
+    })
+}
+
+/// A source rate as `in/read/write/out` with `-` for an absent side.
+fn rate_summary(rate: &Rate) -> String {
+    let opt = |v: Option<f64>| {
+        v.map(|v| fmt_num(round6(v)))
+            .unwrap_or_else(|| "-".to_owned())
+    };
+    format!(
+        "{}/{}/{}/{}",
+        fmt_num(round6(rate.input)),
+        opt(rate.cache_read),
+        opt(rate.cache_write),
+        fmt_num(round6(rate.output))
+    )
+}
+
+// ── Running ──────────────────────────────────────────────────────────────────
+
+/// What a run did.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Outcome {
+    /// Nothing moved; the file is untouched.
+    Unchanged,
+    /// This many rows were written (or, under `--check`, would be).
+    Changed(usize),
+}
+
+/// Fetch both sources, merge, and write or check, reporting on stdout.
+pub fn run_with(mode: PricesMode, fetch: Fetch, path: &Path, today: &str) -> Result<Outcome> {
+    let text =
+        std::fs::read_to_string(path).with_context(|| format!("reading {}", path.display()))?;
+    let existing = parse_table(&text)?;
+    let openrouter = parse_openrouter(&fetch(OPENROUTER_URL)?)?;
+    let litellm = parse_litellm(&fetch(LITELLM_URL)?)?;
+    let merged = merge(&existing, &openrouter, &litellm, today)?;
+
+    for change in &merged.changes {
+        println!("{change}");
+    }
+    for d in &merged.disagreements {
+        println!("? {d} (not written)");
+    }
+    let added = merged
+        .changes
+        .iter()
+        .filter(|c| matches!(c, Change::Added(_)))
+        .count();
+    println!(
+        "prices: {} rows, {} added, {} changed, {} disagreements; openrouter {} models, litellm {} models",
+        merged.table.rows.len(),
+        added,
+        merged.changes.len() - added,
+        merged.disagreements.len(),
+        openrouter.len(),
+        litellm.len()
+    );
+
+    if merged.changes.is_empty() {
+        println!(
+            "prices: {} is current as of {}",
+            path.display(),
+            existing.read_on
+        );
+        return Ok(Outcome::Unchanged);
+    }
+    let count = merged.changes.len();
+    match mode {
+        PricesMode::Check => anyhow::bail!(
+            "{} would change ({count} rows); run `cargo xtask prices`",
+            path.display()
+        ),
+        PricesMode::Write => {
+            std::fs::write(path, render_table(&merged.table))
+                .with_context(|| format!("writing {}", path.display()))?;
+            println!(
+                "prices: wrote {} rows to {} (read_on {today})",
+                count,
+                path.display()
+            );
+            Ok(Outcome::Changed(count))
+        }
+    }
+}
+
+/// The workspace root, from this crate's manifest directory.
+fn workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+/// Today as `YYYY-MM-DD`, UTC, so two machines on one day agree.
+fn today() -> String {
+    chrono::Utc::now().format("%Y-%m-%d").to_string()
+}
+
+/// Entry point for `cargo xtask prices [--check]`.
+///
+/// A network failure exits 2 here rather than through `main`'s exit 1, so a
+/// workflow can tell "could not check" from "the table is wrong".
+pub fn run(mode: PricesMode) -> Result<()> {
+    let path = workspace_root().join(RATES_FILE);
+    match run_with(mode, fetch_http, &path, &today()) {
+        Ok(_) => Ok(()),
+        Err(err) if is_network_error(&err) => {
+            eprintln!("prices: {err}");
+            std::process::exit(2);
+        }
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(test)]
+#[path = "prices_tests.rs"]
+mod tests;

--- a/xtask/src/prices_tests.rs
+++ b/xtask/src/prices_tests.rs
@@ -608,7 +608,11 @@ fn the_file_round_trips_sorted_with_float_literals() {
 #[test]
 fn the_shipped_file_parses_and_renders_to_itself() {
     let path = workspace_root().join(RATES_FILE);
-    let text = std::fs::read_to_string(&path).unwrap();
+    // A Windows checkout with `core.autocrlf` hands us CRLF; the refresh
+    // always writes LF, so compare the file as git stores it.
+    let text = std::fs::read_to_string(&path)
+        .unwrap()
+        .replace("\r\n", "\n");
     let t = parse_table(&text).unwrap();
     assert!(!t.rows.is_empty());
     assert_eq!(

--- a/xtask/src/prices_tests.rs
+++ b/xtask/src/prices_tests.rs
@@ -1,0 +1,826 @@
+//! Tests for `cargo xtask prices`: the parsers and the merge rules, against
+//! fixture JSON. Nothing here touches the network.
+
+use super::*;
+
+/// A per-token string as OpenRouter writes it.
+fn or_model(
+    id: &str,
+    prompt: &str,
+    completion: &str,
+    read: Option<&str>,
+    write: Option<&str>,
+) -> String {
+    let mut pricing = format!("\"prompt\": \"{prompt}\", \"completion\": \"{completion}\"");
+    if let Some(r) = read {
+        pricing.push_str(&format!(", \"input_cache_read\": \"{r}\""));
+    }
+    if let Some(w) = write {
+        pricing.push_str(&format!(", \"input_cache_write\": \"{w}\""));
+    }
+    format!("{{\"id\": \"{id}\", \"pricing\": {{{pricing}}}}}")
+}
+
+fn openrouter_body(models: &[String]) -> String {
+    format!("{{\"data\": [{}]}}", models.join(","))
+}
+
+fn ll_entry(
+    key: &str,
+    provider: &str,
+    mode: &str,
+    input: Option<f64>,
+    output: Option<f64>,
+    read: Option<f64>,
+    write: Option<f64>,
+) -> String {
+    let mut fields = format!("\"litellm_provider\": \"{provider}\", \"mode\": \"{mode}\"");
+    for (name, v) in [
+        ("input_cost_per_token", input),
+        ("output_cost_per_token", output),
+        ("cache_read_input_token_cost", read),
+        ("cache_creation_input_token_cost", write),
+    ] {
+        if let Some(v) = v {
+            fields.push_str(&format!(", \"{name}\": {v:e}"));
+        }
+    }
+    format!("\"{key}\": {{{fields}}}")
+}
+
+fn litellm_body(entries: &[String]) -> String {
+    format!("{{{}}}", entries.join(","))
+}
+
+fn rate(input: f64, read: Option<f64>, write: Option<f64>, output: f64) -> Rate {
+    Rate {
+        input,
+        cache_read: read,
+        cache_write: write,
+        output,
+    }
+}
+
+fn key(provider: &str, id: &str) -> (String, String) {
+    (provider.to_owned(), id.to_owned())
+}
+
+fn row(provider: &str, prefix: &str, rates: [f64; 4], source: &str) -> Row {
+    Row {
+        provider: provider.to_owned(),
+        prefix: prefix.to_owned(),
+        input: rates[0],
+        cache_read: rates[1],
+        cache_write: rates[2],
+        output: rates[3],
+        source: source.to_owned(),
+    }
+}
+
+fn table(read_on: &str, rows: Vec<Row>) -> Table {
+    Table {
+        read_on: read_on.to_owned(),
+        rows: rows
+            .into_iter()
+            .map(|r| ((r.provider.clone(), r.prefix.clone()), r))
+            .collect(),
+    }
+}
+
+/// One priced model per provider on both sides, so `merge`'s emptiness
+/// refusal is satisfied and a test can add the case it is about.
+fn baseline() -> (Prices, Prices) {
+    let mut or = Prices::new();
+    let mut ll = Prices::new();
+    for (p, id) in [
+        ("anthropic", "claude-base"),
+        ("google", "gemini-base"),
+        ("openai", "gpt-base"),
+    ] {
+        or.insert(key(p, id), rate(1.0, Some(0.1), None, 4.0));
+        ll.insert(key(p, id), rate(1.0, Some(0.1), None, 4.0));
+    }
+    (or, ll)
+}
+
+fn empty_table() -> Table {
+    table("2026-01-01", Vec::new())
+}
+
+// ── Argument parsing ─────────────────────────────────────────────────────────
+
+#[test]
+fn mode_parses_write_check_and_rejects_the_rest() {
+    assert_eq!(PricesMode::parse(&[]).unwrap(), PricesMode::Write);
+    assert_eq!(
+        PricesMode::parse(&["--check".to_owned()]).unwrap(),
+        PricesMode::Check
+    );
+    let err = PricesMode::parse(&["--force".to_owned()]).unwrap_err();
+    assert!(err.to_string().contains("--force"));
+}
+
+// ── OpenRouter parser ────────────────────────────────────────────────────────
+
+#[test]
+fn openrouter_keeps_the_three_vendors_per_million_and_normalises_anthropic() {
+    let body = openrouter_body(&[
+        or_model("anthropic/claude-opus-4.8", "0.000005", "0.000025", Some("0.0000005"), Some("0.00000625")),
+        or_model("openai/gpt-5.5", "0.000005", "0.00003", Some("0.0000005"), None),
+        or_model("google/gemini-3.5-flash", "0.0000015", "0.000009", None, None),
+        or_model("x-ai/grok-4.6", "0.000003", "0.000015", None, None),
+        or_model("openai/gpt-5.5:batch", "0.0000025", "0.000015", None, None),
+        or_model("google/lyria-3", "0", "0", None, None),
+        "{\"id\": \"no-slash\", \"pricing\": {\"prompt\": \"0.1\", \"completion\": \"0.2\"}}".to_owned(),
+        "{\"id\": \"openai/no-pricing\"}".to_owned(),
+        "{\"id\": \"openai/bad-number\", \"pricing\": {\"prompt\": \"abc\", \"completion\": \"0.1\"}}".to_owned(),
+        "{\"name\": \"no id\"}".to_owned(),
+    ]);
+    let prices = parse_openrouter(&body).unwrap();
+    let ids: Vec<&(String, String)> = prices.keys().collect();
+    assert_eq!(
+        ids,
+        vec![
+            &key("anthropic", "claude-opus-4-8"),
+            &key("google", "gemini-3.5-flash"),
+            &key("openai", "gpt-5.5"),
+        ]
+    );
+    let opus = &prices[&key("anthropic", "claude-opus-4-8")];
+    assert_eq!(opus.input, 5.0);
+    assert_eq!(opus.output, 25.0);
+    assert_eq!(opus.cache_read, Some(0.5));
+    assert_eq!(opus.cache_write, Some(6.25));
+    let gpt = &prices[&key("openai", "gpt-5.5")];
+    assert_eq!(gpt.cache_read, Some(0.5));
+    assert_eq!(gpt.cache_write, None);
+}
+
+#[test]
+fn openrouter_rejects_a_body_that_is_not_its_shape() {
+    assert!(parse_openrouter("not json").is_err());
+    assert!(parse_openrouter("{\"models\": []}").is_err());
+    assert!(parse_openrouter("{\"data\": []}").unwrap().is_empty());
+}
+
+#[test]
+fn per_million_reads_strings_and_numbers_and_nothing_else() {
+    assert_eq!(per_million(None), None);
+    assert_eq!(per_million(Some(&serde_json::json!(true))), None);
+    assert_eq!(per_million(Some(&serde_json::json!("0.000001"))), Some(1.0));
+    assert_eq!(per_million(Some(&serde_json::json!(0.000002))), Some(2.0));
+}
+
+// ── LiteLLM parser ───────────────────────────────────────────────────────────
+
+#[test]
+fn litellm_maps_providers_filters_chat_and_strips_the_gemini_prefix() {
+    let body = litellm_body(&[
+        ll_entry(
+            "gpt-5.5",
+            "openai",
+            "chat",
+            Some(5e-6),
+            Some(3e-5),
+            Some(5e-7),
+            None,
+        ),
+        ll_entry(
+            "claude-opus-4-8",
+            "anthropic",
+            "chat",
+            Some(5e-6),
+            Some(2.5e-5),
+            Some(5e-7),
+            Some(6.25e-6),
+        ),
+        ll_entry(
+            "gemini/gemini-3.5-flash",
+            "gemini",
+            "chat",
+            Some(1.5e-6),
+            Some(9e-6),
+            None,
+            None,
+        ),
+        ll_entry(
+            "text-embedding-3",
+            "openai",
+            "embedding",
+            Some(1e-7),
+            Some(0.0),
+            None,
+            None,
+        ),
+        ll_entry(
+            "ft:gpt-4o",
+            "openai",
+            "chat",
+            Some(3e-6),
+            Some(1.2e-5),
+            None,
+            None,
+        ),
+        ll_entry(
+            "vertex_ai/gemini/gemini-x",
+            "gemini",
+            "chat",
+            Some(1e-6),
+            Some(2e-6),
+            None,
+            None,
+        ),
+        ll_entry(
+            "mistral-large",
+            "mistral",
+            "chat",
+            Some(1e-6),
+            Some(2e-6),
+            None,
+            None,
+        ),
+        ll_entry("openai/container", "openai", "chat", None, None, None, None),
+        ll_entry(
+            "gemini/gemini-exp",
+            "gemini",
+            "chat",
+            Some(0.0),
+            Some(0.0),
+            None,
+            None,
+        ),
+        "\"sample_spec\": \"not an object\"".to_owned(),
+    ]);
+    let prices = parse_litellm(&body).unwrap();
+    let ids: Vec<&(String, String)> = prices.keys().collect();
+    assert_eq!(
+        ids,
+        vec![
+            &key("anthropic", "claude-opus-4-8"),
+            &key("google", "gemini-3.5-flash"),
+            &key("openai", "gpt-5.5"),
+        ]
+    );
+    assert_eq!(prices[&key("google", "gemini-3.5-flash")].input, 1.5);
+    assert_eq!(
+        prices[&key("anthropic", "claude-opus-4-8")].cache_write,
+        Some(6.25)
+    );
+}
+
+#[test]
+fn litellm_collapses_agreeing_copies_and_drops_disagreeing_ones() {
+    let body = litellm_body(&[
+        ll_entry(
+            "gemini/gemini-pro",
+            "gemini",
+            "chat",
+            Some(1.25e-6),
+            Some(1e-5),
+            None,
+            None,
+        ),
+        ll_entry(
+            "gemini-pro",
+            "gemini",
+            "chat",
+            Some(1.25e-6),
+            Some(1e-5),
+            None,
+            None,
+        ),
+        ll_entry(
+            "gemini/gemini-flash",
+            "gemini",
+            "chat",
+            Some(3e-7),
+            Some(2.5e-6),
+            None,
+            None,
+        ),
+        ll_entry(
+            "gemini-flash",
+            "gemini",
+            "chat",
+            Some(6e-7),
+            Some(2.5e-6),
+            None,
+            None,
+        ),
+    ]);
+    let prices = parse_litellm(&body).unwrap();
+    assert_eq!(prices.len(), 1);
+    assert!(prices.contains_key(&key("google", "gemini-pro")));
+}
+
+#[test]
+fn litellm_rejects_a_body_that_is_not_an_object() {
+    assert!(parse_litellm("[]").is_err());
+    assert!(parse_litellm("nope").is_err());
+}
+
+// ── Merge rules ──────────────────────────────────────────────────────────────
+
+#[test]
+fn agreement_within_five_percent_writes_both_at_openrouters_figure() {
+    let (mut or, mut ll) = baseline();
+    or.insert(key("openai", "gpt-9"), rate(2.0, Some(0.2), None, 12.0));
+    ll.insert(key("openai", "gpt-9"), rate(2.08, Some(0.2), None, 12.4));
+    let merged = merge(&empty_table(), &or, &ll, "2026-08-29").unwrap();
+    let row = &merged.table.rows[&key("openai", "gpt-9")];
+    assert_eq!(row.input, 2.0);
+    assert_eq!(row.output, 12.0);
+    assert_eq!(row.cache_read, 0.2);
+    assert_eq!(row.cache_write, 2.0, "no write premium published: input");
+    assert_eq!(row.source, "both");
+    assert_eq!(merged.table.read_on, "2026-08-29");
+    assert!(merged.disagreements.is_empty());
+    assert_eq!(merged.changes.len(), 4, "three baseline rows plus this one");
+}
+
+#[test]
+fn a_model_only_one_source_prices_is_written_with_that_source() {
+    let (mut or, mut ll) = baseline();
+    or.insert(
+        key("anthropic", "claude-only-or"),
+        rate(5.0, Some(0.5), Some(6.25), 25.0),
+    );
+    ll.insert(key("google", "gemini-only-ll"), rate(0.5, None, None, 3.0));
+    let merged = merge(&empty_table(), &or, &ll, "2026-08-29").unwrap();
+    let a = &merged.table.rows[&key("anthropic", "claude-only-or")];
+    assert_eq!(a.source, "openrouter");
+    assert_eq!(a.cache_write, 6.25, "a premium is taken");
+    let g = &merged.table.rows[&key("google", "gemini-only-ll")];
+    assert_eq!(g.source, "litellm");
+    assert_eq!((g.cache_read, g.cache_write), (0.5, 0.5));
+}
+
+#[test]
+fn a_disagreement_keeps_the_existing_row_and_is_reported() {
+    let (mut or, mut ll) = baseline();
+    or.insert(key("openai", "gpt-9"), rate(2.0, None, None, 12.0));
+    ll.insert(key("openai", "gpt-9"), rate(2.5, None, None, 12.0));
+    or.insert(key("openai", "gpt-new"), rate(1.0, None, None, 2.0));
+    ll.insert(key("openai", "gpt-new"), rate(1.0, None, None, 3.0));
+    let existing = table(
+        "2026-01-01",
+        vec![row("openai", "gpt-9", [1.9, 0.19, 1.9, 11.0], "both")],
+    );
+    let merged = merge(&existing, &or, &ll, "2026-08-29").unwrap();
+    assert_eq!(
+        merged.table.rows[&key("openai", "gpt-9")],
+        row("openai", "gpt-9", [1.9, 0.19, 1.9, 11.0], "both")
+    );
+    assert!(!merged.table.rows.contains_key(&key("openai", "gpt-new")));
+    assert_eq!(merged.disagreements.len(), 2);
+    assert!(
+        merged.disagreements[0]
+            .contains("openai/gpt-9: openrouter 2.0/-/-/12.0 vs litellm 2.5/-/-/12.0")
+    );
+}
+
+#[test]
+fn a_manual_row_is_never_overwritten() {
+    let (mut or, mut ll) = baseline();
+    or.insert(key("google", "gemini-pinned"), rate(9.0, None, None, 90.0));
+    ll.insert(key("google", "gemini-pinned"), rate(9.0, None, None, 90.0));
+    let pinned = row("google", "gemini-pinned", [4.0, 0.4, 4.0, 40.0], "manual");
+    let existing = table("2026-01-01", vec![pinned.clone()]);
+    let merged = merge(&existing, &or, &ll, "2026-08-29").unwrap();
+    assert_eq!(merged.table.rows[&key("google", "gemini-pinned")], pinned);
+    assert!(
+        merged
+            .changes
+            .iter()
+            .all(|c| !c.to_string().contains("pinned"))
+    );
+}
+
+#[test]
+fn a_dated_variant_at_the_same_price_collapses_into_its_family() {
+    let (mut or, mut ll) = baseline();
+    for id in [
+        "gpt-9",
+        "gpt-9-2026-04-23",
+        "gpt-9-mini",
+        "gpt-9-mini-2026-05-01",
+    ] {
+        let (i, o) = if id.contains("mini") {
+            (0.5, 3.0)
+        } else {
+            (2.0, 12.0)
+        };
+        or.insert(key("openai", id), rate(i, None, None, o));
+        ll.insert(key("openai", id), rate(i, None, None, o));
+    }
+    let merged = merge(&empty_table(), &or, &ll, "2026-08-29").unwrap();
+    let openai: Vec<&str> = merged
+        .table
+        .rows
+        .keys()
+        .filter(|(p, _)| p == "openai")
+        .map(|(_, id)| id.as_str())
+        .collect();
+    assert_eq!(openai, vec!["gpt-9", "gpt-9-mini", "gpt-base"]);
+}
+
+#[test]
+fn an_existing_row_is_refreshed_not_collapsed() {
+    let (mut or, mut ll) = baseline();
+    or.insert(
+        key("anthropic", "claude-sonnet-4"),
+        rate(3.0, None, None, 15.0),
+    );
+    ll.insert(
+        key("anthropic", "claude-sonnet-4"),
+        rate(3.0, None, None, 15.0),
+    );
+    or.insert(
+        key("anthropic", "claude-sonnet-4-6"),
+        rate(3.0, Some(0.3), Some(3.75), 15.0),
+    );
+    ll.insert(
+        key("anthropic", "claude-sonnet-4-6"),
+        rate(3.0, Some(0.3), Some(3.75), 15.0),
+    );
+    let existing = table(
+        "2026-01-01",
+        vec![row(
+            "anthropic",
+            "claude-sonnet-4-6",
+            [3.0, 0.3, 3.75, 15.0],
+            "openrouter",
+        )],
+    );
+    let merged = merge(&existing, &or, &ll, "2026-08-29").unwrap();
+    let refreshed = &merged.table.rows[&key("anthropic", "claude-sonnet-4-6")];
+    assert_eq!(refreshed.source, "both", "the row is refreshed in place");
+    assert!(
+        merged
+            .table
+            .rows
+            .contains_key(&key("anthropic", "claude-sonnet-4"))
+    );
+    let change = merged
+        .changes
+        .iter()
+        .find(|c| matches!(c, Change::Changed(..)))
+        .expect("a source change is a change");
+    assert!(
+        change
+            .to_string()
+            .contains("(openrouter) -> 3.0/0.3/3.75/15.0 (both)")
+    );
+}
+
+#[test]
+fn nothing_new_leaves_the_table_and_its_date_alone() {
+    let (or, ll) = baseline();
+    let merged = merge(&empty_table(), &or, &ll, "2026-08-29").unwrap();
+    let again = merge(&merged.table, &or, &ll, "2026-12-25").unwrap();
+    assert_eq!(again.table, merged.table);
+    assert!(again.changes.is_empty());
+    assert_eq!(again.table.read_on, "2026-08-29");
+}
+
+#[test]
+fn a_cache_write_below_input_is_storage_not_a_rate() {
+    let (mut or, mut ll) = baseline();
+    or.insert(
+        key("google", "gemini-x"),
+        rate(1.5, Some(0.15), Some(0.0416667), 9.0),
+    );
+    ll.insert(key("google", "gemini-x"), rate(1.5, Some(0.15), None, 9.0));
+    let merged = merge(&empty_table(), &or, &ll, "2026-08-29").unwrap();
+    let g = &merged.table.rows[&key("google", "gemini-x")];
+    assert_eq!(g.cache_write, 1.5);
+    assert_eq!(g.cache_read, 0.15);
+}
+
+#[test]
+fn a_zero_cache_read_defaults_to_input() {
+    let r = rate(2.0, Some(0.0), Some(2.5), 8.0);
+    assert_eq!(r.resolve(), (2.0, 2.0, 2.5, 8.0));
+}
+
+#[test]
+fn a_move_over_three_times_is_refused() {
+    let (mut or, mut ll) = baseline();
+    or.insert(key("openai", "gpt-9"), rate(2.0, None, None, 12.0));
+    ll.insert(key("openai", "gpt-9"), rate(2.0, None, None, 12.0));
+    let existing = table(
+        "2026-01-01",
+        vec![row("openai", "gpt-9", [2.0, 0.2, 2.0, 50.0], "both")],
+    );
+    let err = merge(&existing, &or, &ll, "2026-08-29").unwrap_err();
+    assert!(
+        err.to_string().contains("openai/gpt-9 would move by 4.2x"),
+        "{err}"
+    );
+
+    let existing = table(
+        "2026-01-01",
+        vec![row("openai", "gpt-9", [7.0, 0.7, 7.0, 12.0], "both")],
+    );
+    assert!(merge(&existing, &or, &ll, "2026-08-29").is_err());
+
+    let existing = table(
+        "2026-01-01",
+        vec![row("openai", "gpt-9", [1.0, 0.1, 1.0, 12.0], "both")],
+    );
+    assert!(
+        merge(&existing, &or, &ll, "2026-08-29").is_ok(),
+        "2x is a repricing"
+    );
+}
+
+#[test]
+fn a_source_with_nothing_for_a_provider_is_refused() {
+    let (or, ll) = baseline();
+    let mut no_google = or.clone();
+    no_google.retain(|(p, _), _| p != "google");
+    let err = merge(&empty_table(), &no_google, &ll, "2026-08-29").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("OpenRouter lists no priced google"),
+        "{err}"
+    );
+    let mut no_openai = ll.clone();
+    no_openai.retain(|(p, _), _| p != "openai");
+    let err = merge(&empty_table(), &or, &no_openai, "2026-08-29").unwrap_err();
+    assert!(
+        err.to_string().contains("LiteLLM lists no priced openai"),
+        "{err}"
+    );
+}
+
+#[test]
+fn a_row_without_a_positive_price_is_refused() {
+    let (or, ll) = baseline();
+    let existing = table(
+        "2026-01-01",
+        vec![row("openai", "gpt-free", [1.0, 0.1, 1.0, 0.0], "manual")],
+    );
+    let err = merge(&existing, &or, &ll, "2026-08-29").unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("openai/gpt-free has no positive price"),
+        "{err}"
+    );
+}
+
+#[test]
+fn agreement_compares_every_side_both_publish() {
+    let a = rate(1.0, Some(0.1), Some(1.25), 4.0);
+    assert!(a.agrees(&rate(1.04, Some(0.1), None, 4.0)));
+    assert!(!a.agrees(&rate(1.0, Some(0.2), Some(1.25), 4.0)));
+    assert!(!a.agrees(&rate(1.0, Some(0.1), Some(2.0), 4.0)));
+    assert!(!a.agrees(&rate(1.0, None, None, 4.3)));
+}
+
+// ── Rendering ────────────────────────────────────────────────────────────────
+
+#[test]
+fn the_file_round_trips_sorted_with_float_literals() {
+    let t = table(
+        "2026-08-29",
+        vec![
+            row("openai", "gpt-9", [5.0, 0.5, 5.0, 30.0], "both"),
+            row(
+                "anthropic",
+                "claude-9",
+                [0.075, 0.0075, 0.09375, 0.375],
+                "litellm",
+            ),
+        ],
+    );
+    let text = render_table(&t);
+    assert!(text.starts_with("# Published list prices"));
+    assert!(text.contains("read_on = \"2026-08-29\""));
+    assert!(text.contains("input = 5.0\n"));
+    assert!(text.contains("cache_read = 0.0075\n"));
+    let anthropic_at = text.find("prefix = \"claude-9\"").unwrap();
+    let openai_at = text.find("prefix = \"gpt-9\"").unwrap();
+    assert!(anthropic_at < openai_at, "sorted by provider");
+    assert_eq!(parse_table(&text).unwrap(), t);
+}
+
+#[test]
+fn the_shipped_file_parses_and_renders_to_itself() {
+    let path = workspace_root().join(RATES_FILE);
+    let text = std::fs::read_to_string(&path).unwrap();
+    let t = parse_table(&text).unwrap();
+    assert!(!t.rows.is_empty());
+    assert_eq!(
+        render_table(&t),
+        text,
+        "the file is what the refresh would write"
+    );
+}
+
+#[test]
+fn a_malformed_file_is_an_error() {
+    assert!(parse_table("read_on = 5").is_err());
+    assert!(parse_table("[[rate]]\nprovider = \"x\"").is_err());
+}
+
+#[test]
+fn numbers_print_as_the_shortest_float() {
+    assert_eq!(fmt_num(5.0), "5.0");
+    assert_eq!(fmt_num(0.3), "0.3");
+    assert_eq!(fmt_num(round6(0.1 + 0.2)), "0.3");
+    assert_eq!(fmt_num(round6(0.0000000416666 * 1e6)), "0.041667");
+}
+
+#[test]
+fn a_change_prints_old_and_new() {
+    let added = Change::Added(row("openai", "gpt-9", [5.0, 0.5, 5.0, 30.0], "both"));
+    assert_eq!(added.to_string(), "+ openai/gpt-9: 5.0/0.5/5.0/30.0 (both)");
+    let changed = Change::Changed(
+        row("openai", "gpt-9", [5.0, 0.5, 5.0, 30.0], "both"),
+        row("openai", "gpt-9", [4.0, 0.4, 4.0, 20.0], "openrouter"),
+    );
+    assert_eq!(
+        changed.to_string(),
+        "~ openai/gpt-9: 5.0/0.5/5.0/30.0 (both) -> 4.0/0.4/4.0/20.0 (openrouter)"
+    );
+}
+
+// ── run_with ─────────────────────────────────────────────────────────────────
+
+fn fixture_openrouter() -> String {
+    openrouter_body(&[
+        or_model(
+            "anthropic/claude-opus-4.8",
+            "0.000005",
+            "0.000025",
+            Some("0.0000005"),
+            Some("0.00000625"),
+        ),
+        or_model(
+            "openai/gpt-5.5",
+            "0.000005",
+            "0.00003",
+            Some("0.0000005"),
+            None,
+        ),
+        or_model(
+            "google/gemini-3.5-flash",
+            "0.0000015",
+            "0.000009",
+            Some("0.00000015"),
+            Some("0.00000004"),
+        ),
+    ])
+}
+
+fn fixture_litellm() -> String {
+    litellm_body(&[
+        ll_entry(
+            "gpt-5.5",
+            "openai",
+            "chat",
+            Some(5e-6),
+            Some(3e-5),
+            Some(5e-7),
+            None,
+        ),
+        ll_entry(
+            "claude-opus-4-8",
+            "anthropic",
+            "chat",
+            Some(5e-6),
+            Some(2.5e-5),
+            Some(5e-7),
+            Some(6.25e-6),
+        ),
+        ll_entry(
+            "gemini/gemini-3.5-flash",
+            "gemini",
+            "chat",
+            Some(1.5e-6),
+            Some(9e-6),
+            Some(1.5e-7),
+            None,
+        ),
+    ])
+}
+
+fn fixture_fetch(url: &str) -> Result<String> {
+    if url.contains("openrouter") {
+        Ok(fixture_openrouter())
+    } else {
+        Ok(fixture_litellm())
+    }
+}
+
+fn failing_fetch(url: &str) -> Result<String> {
+    Err(NetworkError(format!("{url}: connection refused")).into())
+}
+
+fn garbage_fetch(_url: &str) -> Result<String> {
+    Ok("<html>".to_owned())
+}
+
+fn scratch_file(text: &str) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("rates.toml");
+    std::fs::write(&path, text).unwrap();
+    (dir, path)
+}
+
+const EMPTY_FILE: &str = "read_on = \"2026-01-01\"\n";
+
+#[test]
+fn write_mode_rewrites_the_file_and_stamps_today() {
+    let (_dir, path) = scratch_file(EMPTY_FILE);
+    let outcome = run_with(PricesMode::Write, fixture_fetch, &path, "2026-08-29").unwrap();
+    assert_eq!(outcome, Outcome::Changed(3));
+    let written = parse_table(&std::fs::read_to_string(&path).unwrap()).unwrap();
+    assert_eq!(written.read_on, "2026-08-29");
+    assert_eq!(written.rows.len(), 3);
+    let gemini = &written.rows[&key("google", "gemini-3.5-flash")];
+    assert_eq!(gemini.cache_write, 1.5, "storage figure rejected");
+    assert_eq!(gemini.source, "both");
+
+    // A second run on the same sources changes nothing and keeps the date.
+    let again = run_with(PricesMode::Write, fixture_fetch, &path, "2026-12-25").unwrap();
+    assert_eq!(again, Outcome::Unchanged);
+    assert_eq!(
+        parse_table(&std::fs::read_to_string(&path).unwrap())
+            .unwrap()
+            .read_on,
+        "2026-08-29"
+    );
+}
+
+#[test]
+fn check_mode_fails_when_the_file_would_change_and_touches_nothing() {
+    let (_dir, path) = scratch_file(EMPTY_FILE);
+    let err = run_with(PricesMode::Check, fixture_fetch, &path, "2026-08-29").unwrap_err();
+    assert!(err.to_string().contains("would change (3 rows)"), "{err}");
+    assert!(!is_network_error(&err));
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), EMPTY_FILE);
+}
+
+#[test]
+fn check_mode_passes_a_current_file() {
+    let (_dir, path) = scratch_file(EMPTY_FILE);
+    run_with(PricesMode::Write, fixture_fetch, &path, "2026-08-29").unwrap();
+    let outcome = run_with(PricesMode::Check, fixture_fetch, &path, "2026-08-30").unwrap();
+    assert_eq!(outcome, Outcome::Unchanged);
+}
+
+#[test]
+fn a_network_failure_is_distinguished_and_touches_nothing() {
+    let (_dir, path) = scratch_file(EMPTY_FILE);
+    let err = run_with(PricesMode::Write, failing_fetch, &path, "2026-08-29").unwrap_err();
+    assert!(is_network_error(&err));
+    assert!(
+        err.to_string().contains("network: https://openrouter.ai"),
+        "{err}"
+    );
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), EMPTY_FILE);
+}
+
+#[test]
+fn a_garbage_body_is_a_data_error_not_a_network_one() {
+    let (_dir, path) = scratch_file(EMPTY_FILE);
+    let err = run_with(PricesMode::Write, garbage_fetch, &path, "2026-08-29").unwrap_err();
+    assert!(!is_network_error(&err));
+    assert!(err.to_string().contains("OpenRouter: not JSON"), "{err}");
+}
+
+#[test]
+fn a_missing_or_unparseable_file_is_an_error() {
+    let dir = tempfile::tempdir().unwrap();
+    let missing = dir.path().join("absent.toml");
+    assert!(run_with(PricesMode::Write, fixture_fetch, &missing, "2026-08-29").is_err());
+    let (_dir, bad) = scratch_file("read_on = 5\n");
+    assert!(run_with(PricesMode::Write, fixture_fetch, &bad, "2026-08-29").is_err());
+}
+
+#[test]
+fn a_refusal_leaves_the_file_untouched() {
+    let text = render_table(&table(
+        "2026-01-01",
+        vec![row("openai", "gpt-5.5", [1.0, 0.1, 1.0, 5.0], "both")],
+    ));
+    let (_dir, path) = scratch_file(&text);
+    let err = run_with(PricesMode::Write, fixture_fetch, &path, "2026-08-29").unwrap_err();
+    assert!(err.to_string().contains("would move by 6.0x"), "{err}");
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), text);
+}
+
+#[test]
+fn today_is_a_civil_date_and_the_root_holds_the_table() {
+    assert_eq!(today().len(), "YYYY-MM-DD".len());
+    assert!(workspace_root().join(RATES_FILE).is_file());
+}
+
+#[test]
+fn the_network_error_reads_as_one() {
+    let err = NetworkError("x".to_owned());
+    assert_eq!(err.to_string(), "network: x");
+    assert!(std::error::Error::source(&err).is_none());
+}


### PR DESCRIPTION
Approved: keep the vendor price table current without a person transcribing it or an AI guessing. OpenRouter stays its own live source; OpenAI, Anthropic and Google (no price endpoint of their own) get their list prices from OpenRouter's catalogue of their models, cross-checked against LiteLLM's published JSON. Six commits.

## The data file

`crates/leviath-providers/pricing/rates.toml`: `read_on` plus `[[rate]]` rows (`provider`, `prefix`, `input`, `cache_read`, `cache_write`, `output` in USD per million, `source` = `both` | `openrouter` | `litellm` | `manual`). `published_rates` keeps its longest-prefix semantics; a test asserts the shipped file round-trips byte for byte. The 14 hand rows both sources carry are `both`; `gemini-3-flash` and `gemini-3.1-pro` (listed upstream only as `-preview`) are `manual` and never overwritten.

## `cargo xtask prices`

Deterministic merge, unit-tested on fixtures with no network (31 tests):
- both sources within 5% (input, output, each cache side where both publish it): written at OpenRouter's figure as `both`; one source only: written under its name; disagreement: the existing row stays and the pair is printed.
- Ids normalised (vendor prefix stripped, `:free`/`:batch` variants dropped, `claude-opus-4.8` to `claude-opus-4-8`, LiteLLM `ft:` and non-chat entries skipped). New dated variants fold into a shorter id at the same price; existing rows refresh in place.
- Cache write is taken only when it is at least the input rate (OpenRouter puts Google's per-hour storage price there); otherwise the input rate.
- Refusals with the file untouched: an existing row moving more than 3x, a non-positive price in the finished table, a provider with no rows from either source. `--check` exits 1 on a pending change, network failure exits 2. Unchanged rows leave the file and `read_on` alone, so a quiet week opens no PR.

## The weekly PR

`.github/workflows/prices.yml`: Mondays an hour after beta, plus manual dispatch. Runs the tool; on a diff, pushes `chore/prices-<date>`, opens a PR whose body is the printed diff, and runs `gh pr merge --auto --rebase`, so the 16 required checks gate it. **Needs a repo secret `PRICES_PAT`** (fine-grained, this repo, contents: write and pull requests: write): a PR from `GITHUB_TOKEN` gets no CI here. Exit 2 (network) is "nothing this week"; anything else stays red. CI itself never touches the network.

## What the first real run did

0 of 16 existing rows changed; 100 added, for example `gpt-5 1.25/0.125/1.25/10`, `gpt-5.2 1.75/0.175/1.75/14`, `o3 2/0.5/2/8`, `claude-opus-4-5 5/0.5/6.25/25`, `gemini-2.5-pro 1.25/0.125/1.25/10` (all `both`), `claude-sonnet-4 3/0.3/3.75/15` (openrouter only), `gpt-5.6 4/0.4/5/20` (litellm only). Printed and not written: `gpt-4.1-nano` (cache read 0.03 vs 0.025) and `gpt-5.6-sol` (2/10 vs 4/20). A `--check` after the write exits 0.

Approved behaviour change: runs on models that gained a row now get a computed cost instead of none; `is_exact` stays false for every table-derived cost.

## CLI and docs

`lev models list` prints `n/a` in both price columns where nothing prices a model; `lev models show` names the rate's source and the table's date, or the `[model_capabilities."<model>"]` key to set one. `docs/content/costs.md` gains "Where the prices come from" (per provider: source, live or table, coverage, the weekly refresh, and that a computed cost is a reconstruction, not an invoice). CHANGELOG Added and Changed entries.

## Gates

`cargo xtask prices --check`, fmt, clippy `-D warnings`, rustdoc `-D warnings`, `xtask structure`, `xtask docs`, `cargo deny check` (no new dependencies: reqwest, toml, chrono were already in the workspace), coverage 100% on `leviath-providers` and `leviath-cli`, `cargo test -p xtask`.
