### PR TITLE
feat: OpenAI-compatible endpoints as a provider kind, with llama.cpp and LM Studio presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,15 @@ same list.
 
 ### Added
 
+- `[model_providers.<name>] kind = "openai-compatible"` reaches any server that speaks
+  OpenAI's chat API (llama.cpp, LM Studio, vLLM, BionicGPT, a gateway) natively, with no
+  Rhai script: `base_url`, an optional `api_key`, `headers` and a `models` fallback for a
+  server that does not list its own. Models are detected from `GET /models`. `lev setup`
+  offers llama.cpp and LM Studio as presets and a custom entry, each repeatable, with the
+  detected models offered as the default. `GET /api/config` reports each gateway's `kind`,
+  `header_names` and `models`, `PUT /api/config` accepts `kind`, `headers` and `models`,
+  and `POST /api/models/probe` (admin) asks a server what it serves before the write.
+
 - In `lev dash`'s new-run screen, Enter now breaks the line in the task box
   and Ctrl+Enter starts the run. A Start button sits under the editor (Tab
   reaches it, Enter or Space or a click presses it) for terminals without the

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -107,6 +107,48 @@ pub(crate) fn provider_creds_from_config(config: &Config) -> Vec<ProviderCreds> 
         options: std::collections::HashMap::new(),
     });
 
+    // Every `[model_providers.<name>]` entry that is an endpoint rather than a
+    // script. Registered natively, under its own name, so it needs no `.rhai`
+    // on disk and answers `lev models list` like the built-ins do. The script
+    // layer below never sees these: `script_provider_config` filters them.
+    let mut endpoints: Vec<(&String, &crate::config::ModelProviderConfig)> = config
+        .model_providers
+        .iter()
+        .filter(|(_, mp)| mp.is_endpoint())
+        .collect();
+    // Name order, so the registry is built the same way from one config
+    // whatever the map's iteration order was.
+    endpoints.sort_by(|a, b| a.0.cmp(b.0));
+    for (name, mp) in endpoints {
+        // Validated at load, so an endpoint without an address is not a
+        // config this function is handed; one built by hand is skipped rather
+        // than registered pointing nowhere.
+        let Some(base_url) = mp
+            .base_url
+            .as_deref()
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+        else {
+            continue;
+        };
+        let mut cred = ProviderCreds::openai_compatible(
+            name.clone(),
+            base_url,
+            mp.api_key
+                .as_deref()
+                .map(str::trim)
+                .filter(|k| !k.is_empty())
+                .map(str::to_string),
+            mp.header_pairs(),
+            mp.models.clone(),
+            mp.serves.clone().unwrap_or_default(),
+        );
+        cred.model_capabilities = caps.clone();
+        cred.request_timeout_secs = timeout;
+        cred.rate_limit = mp.rate_limit.clone();
+        creds.push(cred);
+    }
+
     // Claude Code needs no API key, but it is opt-in rather than always-on: the
     // CLI puts the user's account email address into every call and that cannot
     // be turned off. Leaving it unregistered is also how it stays out of an
@@ -266,9 +308,14 @@ pub(crate) fn script_provider_config(
     config: &Config,
 ) -> leviath_runtime::script_provider::ScriptProviderConfig {
     leviath_runtime::script_provider::ScriptProviderConfig {
+        // An endpoint entry is a native provider (see
+        // `provider_creds_from_config`), not a script waiting for a `.rhai`;
+        // handing it to the layer would have it look for one and log that it
+        // is missing.
         overrides: config
             .model_providers
             .iter()
+            .filter(|(_, mp)| !mp.is_endpoint())
             .map(|(name, mp)| (name.clone(), script_provider_spec(mp)))
             .collect(),
         default_caps: config.model_capabilities.clone(),
@@ -575,6 +622,7 @@ mod tests {
             }),
             serves: None,
             extra,
+            ..Default::default()
         };
         let spec = script_provider_spec(&mp);
         assert_eq!(spec.script.as_deref(), Some("groq"));
@@ -582,6 +630,103 @@ mod tests {
         assert_eq!(spec.init_config["base_url"], "http://api");
         assert_eq!(spec.init_config["api_key"], "k");
         assert_eq!(spec.init_config["region"], "us");
+    }
+
+    /// An endpoint entry becomes a native cred under its own name, with the
+    /// entry's rate limit, and never a script override.
+    #[test]
+    fn an_endpoint_entry_becomes_a_native_cred_and_not_a_script_override() {
+        let mut config = Config::default();
+        config.model_providers.insert(
+            "zeta".to_string(),
+            crate::config::ModelProviderConfig {
+                kind: Some(crate::config::ModelProviderKind::OpenaiCompatible),
+                base_url: Some(" http://localhost:8080/v1 ".to_string()),
+                api_key: Some("  ".to_string()),
+                headers: Some(
+                    [("X-Org".to_string(), "r".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                models: Some(vec!["llama-3".to_string()]),
+                serves: Some(vec!["llama".to_string()]),
+                rate_limit: Some(leviath_providers::RateLimitConfig {
+                    requests_per_minute: 5,
+                    tokens_per_minute: 500,
+                }),
+                ..Default::default()
+            },
+        );
+        config.model_providers.insert(
+            "alpha".to_string(),
+            crate::config::ModelProviderConfig {
+                kind: Some(crate::config::ModelProviderKind::OpenaiCompatible),
+                base_url: Some("http://localhost:1234/v1".to_string()),
+                api_key: Some("lm-key".to_string()),
+                ..Default::default()
+            },
+        );
+        // Written by hand with no address: skipped, not registered pointing
+        // nowhere. (A loaded config cannot hold one; `validate` refuses it.)
+        config.model_providers.insert(
+            "broken".to_string(),
+            crate::config::ModelProviderConfig {
+                kind: Some(crate::config::ModelProviderKind::OpenaiCompatible),
+                ..Default::default()
+            },
+        );
+        config.model_providers.insert(
+            "groq".to_string(),
+            crate::config::ModelProviderConfig {
+                script: Some("groq.rhai".to_string()),
+                ..Default::default()
+            },
+        );
+
+        let creds = provider_creds_from_config(&config);
+        let names: Vec<&str> = creds
+            .iter()
+            .filter(|c| c.options.contains_key("kind"))
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(names, ["alpha", "zeta"], "name order, no broken entry");
+
+        let zeta = creds.iter().find(|c| c.name == "zeta").expect("zeta");
+        let spec =
+            leviath_runtime::provider_creds::EndpointSpec::from_creds(zeta).expect("an endpoint");
+        assert_eq!(spec.base_url, "http://localhost:8080/v1", "trimmed");
+        assert_eq!(zeta.api_key, None, "a blank key is no key");
+        assert_eq!(spec.headers, vec![("X-Org".to_string(), "r".to_string())]);
+        assert_eq!(spec.models, Some(vec!["llama-3".to_string()]));
+        assert_eq!(spec.serves, vec!["llama".to_string()]);
+        assert_eq!(
+            zeta.rate_limit.as_ref().map(|r| r.requests_per_minute),
+            Some(5)
+        );
+        let alpha = creds.iter().find(|c| c.name == "alpha").expect("alpha");
+        assert_eq!(alpha.api_key.as_deref(), Some("lm-key"));
+
+        // The script layer sees only the script entry.
+        let scripts = script_provider_config(&config);
+        assert!(scripts.overrides.contains_key("groq"));
+        assert!(!scripts.overrides.contains_key("zeta"));
+        assert!(!scripts.overrides.contains_key("alpha"));
+
+        // And the registry has the endpoints natively, with no providers dir
+        // in sight.
+        let registry = build_provider_registry_from_config_probing(
+            &config,
+            &leviath_providers::provider::build_http_client,
+            &|_| false,
+        )
+        .expect("an HTTPS client builds in tests");
+        assert!(registry.has("zeta"));
+        assert!(registry.has("alpha"));
+        assert!(!registry.has("broken"));
+        assert_eq!(
+            registry.get("zeta").expect("native").served_catalog(),
+            Some(vec!["llama-3".to_string()])
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -1135,6 +1135,7 @@ mod tests {
                 )]
                 .into_iter()
                 .collect(),
+                ..Default::default()
             },
         );
 

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -20,7 +20,11 @@ fn gateways_of(c: &Config) -> Vec<GatewayInfo> {
             name: name.clone(),
             base_url: p.base_url.clone(),
             has_api_key: p.api_key.is_some(),
+            kind: p.kind().as_str().to_string(),
             script: p.script.clone(),
+            // Names only, for the reason `extra_keys` below gives.
+            header_names: p.headers.iter().flatten().map(|(k, _)| k.clone()).collect(),
+            models: p.models.clone().unwrap_or_default(),
             // Names only. See `GatewayInfo::extra_keys`: these values are
             // forwarded into a script and routinely hold credentials.
             extra_keys: {
@@ -99,7 +103,27 @@ pub(super) async fn put_config(
     // changing, so a console can edit a base URL without knowing the key or
     // sending it back through the browser.
     for gateway in req.gateways.unwrap_or_default() {
+        // Read before the entry is created, so a bad kind leaves the config
+        // exactly as it was rather than with a half-made entry.
+        let kind = match gateway.kind.as_deref() {
+            None => None,
+            Some(text) => Some(
+                crate::config::ModelProviderKind::parse(text).ok_or_else(|| {
+                    err(
+                        StatusCode::BAD_REQUEST,
+                        format!(
+                            "gateway '{}': unknown kind '{text}'; use \"script\" or \
+                             \"openai-compatible\"",
+                            gateway.name
+                        ),
+                    )
+                })?,
+            ),
+        };
         let entry = config.model_providers.entry(gateway.name).or_default();
+        if let Some(v) = kind {
+            entry.kind = Some(v);
+        }
         if let Some(v) = gateway.base_url {
             entry.base_url = Some(v);
         }
@@ -109,11 +133,24 @@ pub(super) async fn put_config(
         if let Some(v) = gateway.script {
             entry.script = Some(v);
         }
+        if let Some(v) = gateway.headers {
+            entry.headers = Some(v);
+        }
+        if let Some(v) = gateway.models {
+            entry.models = Some(v);
+        }
     }
     // Removals run last, so one request that both edits and deletes cannot
     // depend on which half was applied first.
     for name in req.remove_gateways.unwrap_or_default() {
         config.model_providers.remove(&name);
+    }
+    // The same check the loader makes, made before the write: a file this
+    // would refuse to read back is not a file worth saving.
+    for (name, provider) in &config.model_providers {
+        provider
+            .validate(name)
+            .map_err(|e| err(StatusCode::BAD_REQUEST, e.to_string()))?;
     }
 
     config.save_to_path_public(path).map_err(|e| {
@@ -124,6 +161,60 @@ pub(super) async fn put_config(
     })?;
     Ok(Json(redact(&config)))
 }
+
+/// `POST /api/models/probe` (admin-only): what an OpenAI-compatible server
+/// at `base_url` says it serves, so a console can show the list and let a
+/// person pick a default before the gateway is written.
+///
+/// Admin-gated with the write it precedes: it makes the serving host open a
+/// connection to any address the caller names, which is the same category of
+/// act as `POST /api/mcp/servers/{name}/test`.
+pub(super) async fn probe_models(
+    Json(req): Json<ProbeModelsReq>,
+) -> Result<Json<ProbeModelsResp>, ApiError> {
+    probe_models_with(req, &leviath_providers::provider::build_http_client).await
+}
+
+/// [`probe_models`], with client construction injected so the "no usable
+/// HTTPS client" answer is reachable from a test.
+pub(super) async fn probe_models_with(
+    req: ProbeModelsReq,
+    build_client: leviath_providers::provider::HttpClientFactory<'_>,
+) -> Result<Json<ProbeModelsResp>, ApiError> {
+    let (valid, message) = validate_base_url(&req.base_url);
+    if !valid {
+        return Err(err(StatusCode::BAD_REQUEST, message.unwrap_or_default()));
+    }
+    // The same provider a written gateway would get, built the same way, so
+    // the probe cannot succeed where the gateway then fails.
+    let mut creds = leviath_runtime::provider_creds::ProviderCreds::openai_compatible(
+        "probe",
+        req.base_url.trim(),
+        req.api_key.filter(|k| !k.trim().is_empty()),
+        req.headers.into_iter().flatten().collect(),
+        None,
+        Vec::new(),
+    );
+    creds.request_timeout_secs = Some(PROBE_TIMEOUT_SECS);
+    let registry = leviath_runtime::provider_creds::build_provider_registry_with(
+        std::slice::from_ref(&creds),
+        build_client,
+    )
+    .map_err(|e| err(StatusCode::BAD_GATEWAY, e.to_string()))?;
+    // Registered unconditionally under the name above: an endpoint cred
+    // needs neither a key nor a reachable port to register.
+    let provider = registry.get("probe").expect("an endpoint cred registers");
+    let models = provider
+        .list_models()
+        .await
+        .map_err(|e| err(StatusCode::BAD_GATEWAY, e.to_string()))?;
+    let mut ids: Vec<String> = models.into_iter().map(|m| m.id).collect();
+    ids.sort();
+    Ok(Json(ProbeModelsResp { models: ids }))
+}
+
+/// How long the probe waits on the server. A person is watching a form.
+const PROBE_TIMEOUT_SECS: u64 = 10;
 
 /// Format-only validation of a provider key (no network call, no persistence).
 fn validate_key_format(provider: &str, key: &str) -> (bool, Option<String>) {
@@ -1048,6 +1139,157 @@ mod tests {
         assert!(!saved.model_providers.contains_key("other"));
     }
 
+    /// An endpoint gateway round-trips its kind, headers and models, an
+    /// unsent field is left alone, and the two refusals name the gateway.
+    #[tokio::test]
+    async fn put_config_writes_an_endpoint_gateway_and_refuses_a_broken_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+        let state = || state_with_config_path(path.clone());
+
+        let resp = put_config_request(
+            state(),
+            r#"{"gateways":[{"name":"llama","kind":"openai-compatible","base_url":"http://localhost:8080/v1","headers":{"X-Org":"r"},"models":["llama-3"]}]}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["gateways"][0]["kind"], "openai-compatible");
+        assert_eq!(
+            json["gateways"][0]["header_names"],
+            serde_json::json!(["X-Org"])
+        );
+        assert_eq!(
+            json["gateways"][0]["models"],
+            serde_json::json!(["llama-3"])
+        );
+        assert!(!String::from_utf8_lossy(&body).contains("\"r\""), "{json}");
+        let saved = Config::load_from_path_public(&path).unwrap();
+        let entry = &saved.model_providers["llama"];
+        assert!(entry.is_endpoint());
+        assert_eq!(
+            entry.header_pairs(),
+            vec![("X-Org".to_string(), "r".to_string())]
+        );
+
+        // Edit only the URL: the headers and models survive.
+        let resp = put_config_request(
+            state(),
+            r#"{"gateways":[{"name":"llama","base_url":"http://localhost:8081/v1"}]}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let saved = Config::load_from_path_public(&path).unwrap();
+        let entry = &saved.model_providers["llama"];
+        assert_eq!(entry.base_url.as_deref(), Some("http://localhost:8081/v1"));
+        assert!(entry.headers.is_some());
+        assert_eq!(entry.models.as_deref().map(|m| m.len()), Some(1));
+
+        // An unknown kind is refused before anything is touched.
+        let resp =
+            put_config_request(state(), r#"{"gateways":[{"name":"llama","kind":"vllm"}]}"#).await;
+        assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("unknown kind 'vllm'"));
+
+        // An endpoint with no address is refused and not written.
+        let resp = put_config_request(
+            state(),
+            r#"{"gateways":[{"name":"bare","kind":"openai-compatible"}]}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert!(String::from_utf8_lossy(&body).contains("[model_providers.bare]"));
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert!(!saved.model_providers.contains_key("bare"));
+
+        // A script entry keeps reporting itself as one.
+        let resp = put_config_request(
+            state(),
+            r#"{"gateways":[{"name":"groq","kind":"script","script":"groq.rhai"}]}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let saved = Config::load_from_path_public(&path).unwrap();
+        assert!(!saved.model_providers["groq"].is_endpoint());
+    }
+
+    async fn probe(body: serde_json::Value) -> (axum::http::StatusCode, serde_json::Value) {
+        let app = Router::new().route("/api/models/probe", axum::routing::post(probe_models));
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/models/probe")
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        let status = resp.status();
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&bytes).unwrap())
+    }
+
+    /// The probe lists what the server lists, sorted, sending the key and
+    /// headers it was given; a refusal comes back as a 502 with the server's
+    /// words, and a URL with no scheme never leaves the process.
+    #[tokio::test]
+    async fn the_probe_lists_a_servers_models_or_relays_its_refusal() {
+        let listing = br#"{"data":[{"id":"zeta"},{"id":"alpha"}]}"#;
+        let url = leviath_testkit::spawn_mock_server(200, "OK", listing).await;
+        let (status, json) = probe(serde_json::json!({
+            "base_url": url,
+            "api_key": "k",
+            "headers": {"X-Org": "r"},
+        }))
+        .await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(json["models"], serde_json::json!(["alpha", "zeta"]));
+
+        let url = leviath_testkit::spawn_mock_server(404, "Not Found", b"no such route").await;
+        let (status, json) = probe(serde_json::json!({ "base_url": url, "api_key": " " })).await;
+        assert_eq!(status, axum::http::StatusCode::BAD_GATEWAY);
+        assert!(
+            json["error"].as_str().unwrap().contains("no such route"),
+            "{json}"
+        );
+
+        let (status, json) = probe(serde_json::json!({ "base_url": "localhost:8080" })).await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert!(
+            json["error"].as_str().unwrap().contains("http://"),
+            "{json}"
+        );
+    }
+
+    /// A machine that cannot build an HTTPS client cannot probe, and says so
+    /// as a gateway failure rather than a panic.
+    #[tokio::test]
+    async fn the_probe_reports_a_client_that_will_not_build() {
+        let failing: leviath_providers::provider::HttpClientFactory<'_> =
+            &|_| Err(leviath_providers::provider::malformed_url_error());
+        let result = probe_models_with(
+            ProbeModelsReq {
+                base_url: "http://127.0.0.1:1/v1".to_string(),
+                api_key: None,
+                headers: None,
+            },
+            failing,
+        )
+        .await;
+        let (status, _) = result.expect_err("fails");
+        assert_eq!(status, axum::http::StatusCode::BAD_GATEWAY);
+    }
+
     /// The response a write returns reports the gateway the same redacted way
     /// a read does, so a form can render straight from it.
     #[tokio::test]
@@ -1139,18 +1381,40 @@ mod tests {
             },
         );
 
+        config.model_providers.insert(
+            "llama".to_string(),
+            crate::config::ModelProviderConfig {
+                kind: Some(crate::config::ModelProviderKind::OpenaiCompatible),
+                base_url: Some("http://localhost:8080/v1".to_string()),
+                headers: Some(
+                    [("X-Api-Key".to_string(), "header-secret-value".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                models: Some(vec!["llama-3".to_string()]),
+                ..Default::default()
+            },
+        );
+
         let redacted = redact(&config);
         let gateway = &redacted.gateways[0];
         assert_eq!(gateway.name, "groq");
+        assert_eq!(gateway.kind, "script");
         assert_eq!(gateway.base_url.as_deref(), Some("https://api.groq.com"));
         assert!(gateway.has_api_key);
         assert_eq!(gateway.extra_keys, vec!["signing_secret".to_string()]);
+        let endpoint = &redacted.gateways[1];
+        assert_eq!(endpoint.kind, "openai-compatible");
+        assert_eq!(endpoint.header_names, vec!["X-Api-Key".to_string()]);
+        assert_eq!(endpoint.models, vec!["llama-3".to_string()]);
+        assert!(!endpoint.has_api_key);
 
         // The whole serialized document, because a leak anywhere in it is a
         // leak: a field added later would otherwise carry the value silently.
         let json = serde_json::to_string(&redacted).expect("serializes");
         assert!(!json.contains("sk-secret-value"), "{json}");
         assert!(!json.contains("hunter2"), "{json}");
+        assert!(!json.contains("header-secret-value"), "{json}");
     }
 
     /// Name-sorted, because the config holds gateways in a `HashMap` and a

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -194,6 +194,17 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // offered the kind anyway would put an editor in front of a 400.
     "scripts.providers",
     "config.gateways",
+    // `kind`, `header_names` and `models` on each gateway `GET /api/config`
+    // reports, and `kind`, `headers` and `models` on what `PUT /api/config`
+    // accepts: a gateway can be an OpenAI-compatible endpoint rather than a
+    // script. Announced so a console can offer the kind field, and can tell
+    // a daemon that would ignore it from one that writes it.
+    "config.gateways.kinds",
+    // `POST /api/models/probe`: ask an OpenAI-compatible server what it
+    // serves before a gateway for it is written. Admin only, like the write
+    // it precedes; announced whether or not this daemon mounts it, the same
+    // narrower claim `scripts.write` makes.
+    "models.probe",
     // `POST /api/fs/dirs`. The browser cannot open a native OS dialog onto the
     // serving machine, so the console's folder picker has to offer its own
     // "New Folder" - and one console serves every daemon version, so it needs
@@ -286,9 +297,20 @@ pub(super) struct GatewayInfo {
     pub(super) base_url: Option<String>,
     /// Whether a key is configured for it.
     pub(super) has_api_key: bool,
+    /// What backs it: `script` or `openai-compatible`.
+    pub(super) kind: String,
     /// The Rhai provider script backing it, when the entry names one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) script: Option<String>,
+    /// The names of the extra headers an endpoint sends, without their
+    /// values, for the reason `extra_keys` gives: a header is where a
+    /// second credential goes.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(super) header_names: Vec<String>,
+    /// The model ids an endpoint falls back to when its server will not
+    /// list them.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub(super) models: Vec<String>,
     /// The names of any extra keys the entry carries, without their values.
     ///
     /// `extra` is forwarded verbatim into the script's `initialize`, so people
@@ -315,6 +337,39 @@ pub(super) struct GatewayWrite {
     /// Absent leaves the existing script name.
     #[serde(default)]
     pub(super) script: Option<String>,
+    /// `script` or `openai-compatible`. Absent leaves the existing kind, and
+    /// an entry created without one is a script, as in the file.
+    #[serde(default)]
+    pub(super) kind: Option<String>,
+    /// Extra headers for an endpoint, replacing the existing set when
+    /// present. Absent leaves them as they were.
+    #[serde(default)]
+    pub(super) headers: Option<std::collections::BTreeMap<String, String>>,
+    /// The fallback model ids for an endpoint, replacing the existing list
+    /// when present.
+    #[serde(default)]
+    pub(super) models: Option<Vec<String>>,
+}
+
+/// Body of `POST /api/models/probe` (admin-only): ask an OpenAI-compatible
+/// server what it serves, before a gateway for it is written.
+#[derive(Debug, Deserialize)]
+pub(super) struct ProbeModelsReq {
+    /// Where the server listens, including any path prefix.
+    pub(super) base_url: String,
+    /// Sent as a bearer token when present.
+    #[serde(default)]
+    pub(super) api_key: Option<String>,
+    /// Extra headers on the request.
+    #[serde(default)]
+    pub(super) headers: Option<std::collections::BTreeMap<String, String>>,
+}
+
+/// Answer of `POST /api/models/probe`.
+#[derive(Debug, Serialize, Deserialize)]
+pub(super) struct ProbeModelsResp {
+    /// The ids the server listed, sorted.
+    pub(super) models: Vec<String>,
 }
 
 /// Body of `POST /api/config/validate` — a format-only key check (no network,

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -386,6 +386,11 @@ async fn execute_with_shutdown(
             // Config-write persists provider secrets to disk, so it is gated the
             // same way as MCP admin: unmounted (404) unless --allow-admin.
             .route("/api/config", put(config::put_config))
+            // The probe makes this host open a connection to any address the
+            // caller names, the same act as testing an MCP server, and it
+            // exists to precede the write above. Gated with it; there is no
+            // read half, so without admin the path 404s.
+            .route("/api/models/probe", post(config::probe_models))
             // Carrying out the update the GET half only describes: it runs a
             // package manager, replaces the blueprints in the agents directory
             // and rewrites the config. Same category of act as the three above,
@@ -2340,6 +2345,62 @@ system_prompt = "Run"
     /// mounted case really does write a file, and it must not be a developer's
     /// own `~/.leviath/tools`. One `temp_env` call, since it serializes
     /// process-wide and holds its lock across the future.
+    /// The probe has no read half, so without admin the path is a plain 404;
+    /// with admin it answers (a 502 here, since nothing listens).
+    #[tokio::test]
+    async fn the_models_probe_is_mounted_only_with_allow_admin() {
+        let home = tempfile::tempdir().expect("a temp dir");
+        let root = home.path().to_path_buf();
+        let mut vars = crate::config::config_isolation_vars(&root);
+        vars.push(("LEVIATH_HOME", Some(root.clone().into_os_string())));
+
+        temp_env::async_with_vars(vars, async move {
+            for allow_admin in [false, true] {
+                let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+                let (stop_tx, stop_rx) = tokio::sync::oneshot::channel();
+                let args = ServeArgs {
+                    port: 0,
+                    host: "127.0.0.1".to_string(),
+                    cors: None,
+                    token: Some("t".to_string()),
+                    allow_admin,
+                    workdir_root: None,
+                    no_remote_yolo: false,
+                    tls_cert: None,
+                    tls_key: None,
+                };
+                let server = tokio::spawn(serve_for_test(
+                    args,
+                    no_daemon_control(),
+                    Box::pin(async move {
+                        let _ = stop_rx.await;
+                    }),
+                    Some(ready_tx),
+                ));
+                let addr = ready_rx.await.expect("bound");
+                let client = reqwest::Client::new();
+
+                let status = client
+                    .post(format!("http://{addr}/api/models/probe"))
+                    .bearer_auth("t")
+                    .json(&serde_json::json!({ "base_url": "http://127.0.0.1:1/v1" }))
+                    .send()
+                    .await
+                    .expect("request")
+                    .status()
+                    .as_u16();
+                match allow_admin {
+                    false => assert_eq!(status, 404, "the probe must not be mounted"),
+                    true => assert_eq!(status, 502, "mounted, and nothing listens"),
+                }
+
+                let _ = stop_tx.send(());
+                let _ = server.await;
+            }
+        })
+        .await;
+    }
+
     #[tokio::test]
     async fn the_script_write_routes_are_mounted_only_with_allow_admin() {
         let home = tempfile::tempdir().expect("a temp dir");

--- a/crates/leviath-cli/src/commands/setup/catalog.rs
+++ b/crates/leviath-cli/src/commands/setup/catalog.rs
@@ -22,6 +22,10 @@ pub enum Credential {
     /// Nothing - the provider is enabled by selecting it. Claude Code
     /// authenticates through its own CLI.
     None,
+    /// One or more `[model_providers.<name>]` endpoints of kind
+    /// `openai-compatible`, each with a name, an address and an optional key.
+    /// The row is a preset; the entries under it are the wizard's own.
+    Endpoint,
 }
 
 /// One configurable provider.
@@ -43,6 +47,9 @@ pub struct Provider {
     pub env_var: Option<&'static str>,
     /// Where to get a credential, opened on request.
     pub signup_url: Option<&'static str>,
+    /// For an endpoint preset, the address a fresh entry starts with. `None`
+    /// for the custom preset, which asks.
+    pub preset_url: Option<&'static str>,
 }
 
 /// Every provider the wizard offers, in the order it offers them.
@@ -56,6 +63,7 @@ pub(crate) fn providers() -> Vec<Provider> {
             hint: "sk-ant-...",
             env_var: Some("ANTHROPIC_API_KEY"),
             signup_url: Some("https://console.anthropic.com/settings/keys"),
+            preset_url: None,
         },
         Provider {
             id: "openai",
@@ -65,6 +73,7 @@ pub(crate) fn providers() -> Vec<Provider> {
             hint: "sk-...",
             env_var: Some("OPENAI_API_KEY"),
             signup_url: Some("https://platform.openai.com/api-keys"),
+            preset_url: None,
         },
         Provider {
             id: "google",
@@ -74,6 +83,7 @@ pub(crate) fn providers() -> Vec<Provider> {
             hint: "AIza...",
             env_var: Some("GOOGLE_API_KEY"),
             signup_url: Some("https://aistudio.google.com/app/apikey"),
+            preset_url: None,
         },
         Provider {
             id: "openrouter",
@@ -83,6 +93,7 @@ pub(crate) fn providers() -> Vec<Provider> {
             hint: "sk-or-...",
             env_var: Some("OPENROUTER_API_KEY"),
             signup_url: Some("https://openrouter.ai/keys"),
+            preset_url: None,
         },
         Provider {
             id: "ollama",
@@ -92,6 +103,7 @@ pub(crate) fn providers() -> Vec<Provider> {
             hint: DEFAULT_OLLAMA_URL,
             env_var: Some("OLLAMA_HOST"),
             signup_url: Some("https://ollama.com/download"),
+            preset_url: None,
         },
         Provider {
             id: "claude-code",
@@ -105,8 +117,68 @@ pub(crate) fn providers() -> Vec<Provider> {
             hint: "",
             env_var: None,
             signup_url: None,
+            preset_url: None,
+        },
+        Provider {
+            id: "llama-cpp",
+            display: "llama.cpp",
+            blurb: "A llama.cpp server on this machine, over its OpenAI-compatible API. \
+                    No key needed.",
+            credential: Credential::Endpoint,
+            hint: LLAMA_CPP_URL,
+            env_var: None,
+            signup_url: Some("https://github.com/ggml-org/llama.cpp"),
+            preset_url: Some(LLAMA_CPP_URL),
+        },
+        Provider {
+            id: "lm-studio",
+            display: "LM Studio",
+            blurb: "LM Studio's local server, over its OpenAI-compatible API. No key \
+                    needed.",
+            credential: Credential::Endpoint,
+            hint: LM_STUDIO_URL,
+            env_var: None,
+            signup_url: Some("https://lmstudio.ai"),
+            preset_url: Some(LM_STUDIO_URL),
+        },
+        Provider {
+            id: "openai-compatible",
+            display: "Custom OpenAI-compatible endpoint",
+            blurb: "vLLM, BionicGPT, a gateway, or any server that speaks the OpenAI \
+                    chat API: a name, a base URL, and a key or headers if it wants them.",
+            credential: Credential::Endpoint,
+            hint: "http://host:port/v1",
+            env_var: None,
+            signup_url: None,
+            preset_url: None,
         },
     ]
+}
+
+/// Where llama.cpp's server listens by default.
+pub const LLAMA_CPP_URL: &str = "http://localhost:8080/v1";
+
+/// Where LM Studio's server listens by default.
+pub const LM_STUDIO_URL: &str = "http://localhost:1234/v1";
+
+/// The catalogue id of the endpoint preset that best describes an entry
+/// read from the config: the preset whose id the name starts with, then the
+/// preset whose default address it uses, then the custom one.
+///
+/// Nothing in the file records which row created an entry, and nothing needs
+/// to: the row only decides which heading the entry is shown under.
+pub(crate) fn preset_for(name: &str, entry: &crate::config::ModelProviderConfig) -> &'static str {
+    let presets: Vec<Provider> = providers()
+        .into_iter()
+        .filter(|p| p.credential == Credential::Endpoint)
+        .collect();
+    let by_name = presets
+        .iter()
+        .find(|p| name == p.id || name.starts_with(&format!("{}-", p.id)));
+    let by_url = presets
+        .iter()
+        .find(|p| p.preset_url.is_some() && p.preset_url == entry.base_url.as_deref());
+    by_name.or(by_url).map_or("openai-compatible", |p| p.id)
 }
 
 /// Ollama's default endpoint, and the value the wizard treats as "unset" so a
@@ -155,6 +227,12 @@ pub(crate) fn set_credential(config: &mut Config, id: &str, value: Option<String
 pub(crate) fn is_configured(config: &Config, id: &str) -> bool {
     match id {
         "claude-code" => config.providers.claude_code_enabled,
+        // An endpoint preset is "configured" when the file holds an endpoint
+        // entry that sits under it.
+        "llama-cpp" | "lm-studio" | "openai-compatible" => config
+            .model_providers
+            .iter()
+            .any(|(name, entry)| entry.is_endpoint() && preset_for(name, entry) == id),
         // Ollama is always usable at its default endpoint, but "configured"
         // here means "the user chose it", which is the stored URL.
         _ => stored_credential(config, id).is_some(),
@@ -219,6 +297,59 @@ mod tests {
         assert!(all.iter().any(|p| p.credential == Credential::ApiKey));
         assert!(all.iter().any(|p| p.credential == Credential::BaseUrl));
         assert!(all.iter().any(|p| p.credential == Credential::None));
+        assert!(all.iter().any(|p| p.credential == Credential::Endpoint));
+    }
+
+    /// The two local presets start at their server's own default port and
+    /// the custom one asks; every preset is an endpoint, and nothing else
+    /// carries a preset address.
+    #[test]
+    fn the_endpoint_presets_carry_their_default_addresses() {
+        let all = providers();
+        let by_id = |id: &str| all.iter().find(|p| p.id == id).expect("in the table");
+        assert_eq!(by_id("llama-cpp").preset_url, Some(LLAMA_CPP_URL));
+        assert_eq!(by_id("lm-studio").preset_url, Some(LM_STUDIO_URL));
+        assert_eq!(by_id("openai-compatible").preset_url, None);
+        for p in &all {
+            assert_eq!(
+                p.preset_url.is_some(),
+                p.credential == Credential::Endpoint && p.id != "openai-compatible",
+                "{}",
+                p.id
+            );
+        }
+    }
+
+    /// Which heading an entry from the file is shown under: the name first,
+    /// then the address, then custom.
+    #[test]
+    fn an_entry_is_filed_under_the_preset_its_name_or_address_names() {
+        use crate::config::{ModelProviderConfig, ModelProviderKind};
+        let at = |url: &str| ModelProviderConfig {
+            kind: Some(ModelProviderKind::OpenaiCompatible),
+            base_url: Some(url.to_string()),
+            ..Default::default()
+        };
+        assert_eq!(preset_for("llama-cpp", &at("http://x")), "llama-cpp");
+        assert_eq!(preset_for("llama-cpp-2", &at("http://x")), "llama-cpp");
+        assert_eq!(
+            preset_for("llama-cppish", &at("http://x")),
+            "openai-compatible"
+        );
+        assert_eq!(preset_for("mine", &at(LM_STUDIO_URL)), "lm-studio");
+        assert_eq!(preset_for("mine", &at("http://x")), "openai-compatible");
+
+        let mut config = Config::default();
+        assert!(!is_configured(&config, "llama-cpp"));
+        config
+            .model_providers
+            .insert("box".to_string(), at(LLAMA_CPP_URL));
+        assert!(is_configured(&config, "llama-cpp"));
+        assert!(!is_configured(&config, "lm-studio"));
+        assert!(!is_configured(&config, "openai-compatible"));
+        // A script entry at that address is not an endpoint.
+        config.model_providers.get_mut("box").unwrap().kind = None;
+        assert!(!is_configured(&config, "llama-cpp"));
     }
 
     #[test]
@@ -256,7 +387,7 @@ mod tests {
         // Catches the top-level/`[providers]` split silently dropping a field.
         for p in providers()
             .iter()
-            .filter(|p| p.credential != Credential::None)
+            .filter(|p| !matches!(p.credential, Credential::None | Credential::Endpoint))
         {
             let mut config = Config::default();
             assert!(

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -18,7 +18,8 @@ use ratatui::layout::Rect;
 
 use super::catalog::Credential;
 use super::state::{
-    ConfirmPurpose, DetailAction, Edit, EditTarget, FieldValue, Picker, Step, Wizard,
+    ConfirmPurpose, DetailAction, Edit, EditTarget, EndpointCursor, EndpointField, FieldValue,
+    Picker, Step, Wizard,
 };
 use crate::tui::keymap;
 use crate::tui::widgets::confirm::ConfirmOutcome;
@@ -253,6 +254,13 @@ impl Wizard {
                 }
             };
         }
+        if self.step == Step::ProviderDetail
+            && let Some(index) = self.detail_row()
+            && self.is_endpoint_preset(index)
+        {
+            self.activate_endpoint_row(index);
+            return Action::Continue;
+        }
         match self.step {
             Step::Providers | Step::Agents | Step::Mcp => self.toggle(),
             Step::ProviderDetail => match self.detail_actions().get(self.cursor.wrapping_sub(1)) {
@@ -274,6 +282,36 @@ impl Wizard {
             Step::Welcome | Step::Review => {}
         }
         Action::Continue
+    }
+
+    /// Enter on an endpoint preset's screen (the preset at provider row
+    /// `index`): a text field opens its editor, the default model cycles, the
+    /// buttons do what they say, and the add row adds.
+    fn activate_endpoint_row(&mut self, index: usize) {
+        match self.endpoint_cursor(index) {
+            Some(EndpointCursor::Add) => {
+                self.add_endpoint(index);
+            }
+            Some(EndpointCursor::Field(entry, field)) if field.is_text() => {
+                self.open_endpoint_editor(entry, field);
+            }
+            Some(EndpointCursor::Field(entry, EndpointField::DefaultModel)) => {
+                self.cycle_endpoint_model(entry, 1);
+            }
+            Some(EndpointCursor::Field(entry, EndpointField::Verify)) => {
+                self.request_endpoint_verification(entry);
+                self.message = Some("Checking…".to_string());
+            }
+            Some(EndpointCursor::Field(entry, EndpointField::Remove)) => {
+                self.remove_endpoint(entry);
+                // The rows above the cursor are gone with the entry.
+                self.cursor = self.cursor.min(self.row_count());
+            }
+            // Every field kind is matched above, so this is the cursor past
+            // the rows: reachable only with a hand-forced cursor, and acting
+            // on nothing is correct then.
+            Some(EndpointCursor::Field(..)) | None => {}
+        }
     }
 
     /// Enter on a Defaults/Limits row always acts on that row's kind: toggle
@@ -312,7 +350,7 @@ impl Wizard {
         }) else {
             return false;
         };
-        if credential == Credential::None {
+        if matches!(credential, Credential::None | Credential::Endpoint) {
             return false;
         }
         self.edit = Some(Edit {
@@ -341,7 +379,18 @@ impl Wizard {
     fn toggle(&mut self) {
         match self.step {
             Step::Providers => {
-                if let Some(row) = self.providers.get_mut(self.cursor) {
+                // An endpoint preset is selected by having entries: picking
+                // it adds the first, unpicking it drops them all.
+                if self.is_endpoint_preset(self.cursor) {
+                    let index = self.cursor;
+                    if self.providers[index].selected {
+                        self.remove_endpoints_under(self.providers[index].provider.id);
+                        self.providers[index].selected = false;
+                        self.dirty = true;
+                    } else {
+                        self.add_endpoint(index);
+                    }
+                } else if let Some(row) = self.providers.get_mut(self.cursor) {
                     row.selected = !row.selected;
                     self.dirty = true;
                     // Deselecting the Claude Code transport withdraws the
@@ -398,6 +447,18 @@ impl Wizard {
     fn adjust(&mut self, delta: isize) {
         match self.step {
             Step::ProviderDetail => {
+                // On an endpoint preset's screen the default model cycles;
+                // everything else there is typed.
+                if let Some(index) = self.detail_row()
+                    && self.is_endpoint_preset(index)
+                {
+                    if let Some(EndpointCursor::Field(entry, EndpointField::DefaultModel)) =
+                        self.endpoint_cursor(index)
+                    {
+                        self.cycle_endpoint_model(entry, delta);
+                    }
+                    return;
+                }
                 // The effort selector is the only cyclable value here.
                 if let Some(index) = self.detail_row()
                     && let Some(row) = self.providers.get_mut(index)

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -1583,3 +1583,156 @@ fn f1_opens_the_wizard_help_too() {
     assert!(!w.show_help);
     assert_eq!(w.help_scroll.get(), 0, "closing resets it");
 }
+
+// ─── OpenAI-compatible endpoints ────────────────────────────────────────
+
+fn preset(w: &Wizard, id: &str) -> usize {
+    w.providers
+        .iter()
+        .position(|r| r.provider.id == id)
+        .expect("the preset is in the table")
+}
+
+/// Space on a preset row adds the first entry; Space again drops every
+/// entry under it.
+#[test]
+fn toggling_an_endpoint_preset_adds_and_removes_its_entries() {
+    let (_dir, mut w) = wizard();
+    w.enter(Step::Providers);
+    w.cursor = preset(&w, "lm-studio");
+
+    w.handle_key(press(KeyCode::Char(' ')));
+    assert_eq!(w.endpoints.len(), 1);
+    assert_eq!(w.endpoints[0].name, "lm-studio");
+    assert_eq!(
+        w.endpoints[0].base_url,
+        crate::commands::setup::catalog::LM_STUDIO_URL
+    );
+    assert!(w.providers[w.cursor].selected);
+
+    w.handle_key(press(KeyCode::Char(' ')));
+    assert!(w.endpoints.is_empty());
+    assert!(!w.providers[w.cursor].selected);
+    assert!(w.dirty);
+}
+
+/// Enter on each row of an entry's form does what the row says.
+#[test]
+fn enter_on_the_endpoint_form_edits_cycles_checks_removes_and_adds() {
+    let (_dir, mut w) = wizard();
+    let (mut requests, _replies) = w.take_verify_ends().expect("first take");
+    let llama = preset(&w, "llama-cpp");
+    w.add_endpoint(llama);
+    w.enter(Step::ProviderDetail);
+    assert_eq!(w.detail_row(), Some(llama));
+    assert_eq!(w.row_count(), 9);
+
+    // Name: the editor opens, typing lands, Enter commits.
+    w.cursor = 0;
+    w.handle_key(press(KeyCode::Enter));
+    assert!(w.edit.is_some());
+    for c in "-x".chars() {
+        w.handle_key(press(KeyCode::Char(c)));
+    }
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.endpoints[0].name, "llama-cpp-x");
+
+    // Default model: nothing to cycle yet, so a message and no change.
+    w.cursor = 5;
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.endpoints[0].default_model, None);
+    assert!(w.message.take().is_some());
+    w.endpoints[0].models = "a, b".to_string();
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.endpoints[0].default_model.as_deref(), Some("a"));
+    w.handle_key(press(KeyCode::Left));
+    assert_eq!(w.endpoints[0].default_model.as_deref(), Some("b"));
+    // Arrows elsewhere on the form do nothing.
+    w.cursor = 1;
+    w.handle_key(press(KeyCode::Right));
+    assert_eq!(w.endpoints[0].default_model.as_deref(), Some("b"));
+
+    // Check: a request goes out.
+    w.cursor = 6;
+    w.handle_key(press(KeyCode::Enter));
+    assert!(w.endpoints[0].checking);
+    assert_eq!(
+        requests.try_recv().expect("sent").provider_id,
+        "llama-cpp-x"
+    );
+    assert!(w.message.take().unwrap().contains("Checking"));
+
+    // Add another: a second form appears; Remove takes it away and the
+    // cursor stays inside the screen.
+    w.cursor = 8;
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.endpoints.len(), 2);
+    assert_eq!(w.row_count(), 17);
+    w.cursor = 8 + 7;
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.endpoints.len(), 1);
+    assert!(w.cursor <= w.row_count());
+
+    // The Continue button still advances.
+    w.cursor = w.row_count();
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.step, Step::Defaults);
+    assert_eq!(
+        w.defaults[Wizard::PROVIDER_FIELD].value.display(),
+        "llama-cpp-x"
+    );
+}
+
+/// `v` on the preset's screen checks every entry under it, and Tab does the
+/// same on the way out.
+#[test]
+fn v_and_tab_check_every_entry_under_the_preset() {
+    let (_dir, mut w) = wizard();
+    let (mut requests, _replies) = w.take_verify_ends().expect("first take");
+    let custom = preset(&w, "openai-compatible");
+    w.add_endpoint(custom);
+    w.add_endpoint(custom);
+    w.endpoints[0].base_url = "http://127.0.0.1:1/v1".to_string();
+    w.endpoints[1].base_url = "http://127.0.0.1:2/v1".to_string();
+    w.enter(Step::ProviderDetail);
+
+    w.handle_key(press(KeyCode::Char('v')));
+    assert!(requests.try_recv().is_ok());
+    assert!(requests.try_recv().is_ok());
+    assert!(requests.try_recv().is_err());
+
+    w.handle_key(press(KeyCode::Tab));
+    assert!(requests.try_recv().is_ok());
+    assert!(requests.try_recv().is_ok());
+    assert_eq!(w.step, Step::Defaults);
+}
+
+/// A cursor forced past the form's rows (tests can do this; keys cannot)
+/// acts on nothing.
+#[test]
+fn enter_past_the_endpoint_forms_rows_does_nothing() {
+    let (_dir, mut w) = wizard();
+    let llama = preset(&w, "llama-cpp");
+    w.add_endpoint(llama);
+    w.enter(Step::ProviderDetail);
+    w.cursor = w.row_count() + 5;
+    w.handle_key(press(KeyCode::Enter));
+    assert_eq!(w.step, Step::ProviderDetail);
+    assert_eq!(w.endpoints.len(), 1);
+    assert!(w.edit.is_none());
+}
+
+/// The Escape that cancels an endpoint edit leaves the value alone.
+#[test]
+fn cancelling_an_endpoint_edit_keeps_the_old_value() {
+    let (_dir, mut w) = wizard();
+    let llama = preset(&w, "llama-cpp");
+    w.add_endpoint(llama);
+    w.enter(Step::ProviderDetail);
+    w.cursor = 2;
+    w.handle_key(press(KeyCode::Enter));
+    w.handle_key(press(KeyCode::Char('k')));
+    w.handle_key(press(KeyCode::Esc));
+    assert!(w.endpoints[0].api_key.is_empty());
+    assert!(w.edit.is_none());
+}

--- a/crates/leviath-cli/src/commands/setup/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/mod.rs
@@ -215,19 +215,30 @@ fn apply_flags(config: &mut Config, args: &SetupArgs) {
 ///
 /// Ollama sits last on purpose. It needs no key, so a config that merely
 /// mentions it is not a statement of preference, and putting it first would
-/// make it the default on a machine that never installed it.
-fn configured_providers(config: &Config) -> Vec<&'static str> {
+/// make it the default on a machine that never installed it. An
+/// OpenAI-compatible endpoint was written deliberately, so it sits with the
+/// keyed providers, after them and in name order.
+fn configured_providers(config: &Config) -> Vec<String> {
+    let mut endpoints: Vec<&str> = config
+        .model_providers
+        .iter()
+        .filter(|(_, e)| e.is_endpoint())
+        .map(|(name, _)| name.as_str())
+        .collect();
+    endpoints.sort_unstable();
     [
         ("anthropic", config.providers.anthropic_api_key.is_some()),
         ("openai", config.providers.openai_api_key.is_some()),
         ("google", config.providers.google_api_key.is_some()),
         ("openrouter", config.openrouter_api_key.is_some()),
         ("claude-code", config.providers.claude_code_enabled),
-        ("ollama", config.ollama_base_url.is_some()),
     ]
     .into_iter()
     .filter(|(_, configured)| *configured)
     .map(|(id, _)| id)
+    .chain(endpoints)
+    .chain(config.ollama_base_url.is_some().then_some("ollama"))
+    .map(str::to_string)
     .collect()
 }
 
@@ -243,11 +254,11 @@ fn configured_providers(config: &Config) -> Vec<&'static str> {
 /// already in the file survives.
 fn retarget_default_provider(config: &mut Config) {
     let configured = configured_providers(config);
-    if configured.contains(&config.default_provider.as_str()) {
+    if configured.contains(&config.default_provider) {
         return;
     }
     if let Some(first) = configured.first() {
-        config.default_provider = (*first).to_string();
+        config.default_provider = first.clone();
     }
 }
 
@@ -517,6 +528,52 @@ mod tests {
             },
         );
         assert_eq!(config.default_provider, "google");
+    }
+
+    /// An endpoint written by hand is a deliberate provider, so it can be
+    /// the default, after any keyed provider and before Ollama.
+    #[test]
+    fn an_endpoint_entry_can_become_the_default_provider() {
+        use crate::config::{ModelProviderConfig, ModelProviderKind};
+        let mut config = Config {
+            ollama_base_url: Some("http://localhost:11434".to_string()),
+            ..Config::default()
+        };
+        for name in ["zeta", "alpha"] {
+            config.model_providers.insert(
+                name.to_string(),
+                ModelProviderConfig {
+                    kind: Some(ModelProviderKind::OpenaiCompatible),
+                    base_url: Some("http://h/v1".to_string()),
+                    ..Default::default()
+                },
+            );
+        }
+        // A script entry is not a provider this can point at.
+        config.model_providers.insert(
+            "groq".to_string(),
+            ModelProviderConfig {
+                script: Some("groq.rhai".to_string()),
+                ..Default::default()
+            },
+        );
+        assert_eq!(configured_providers(&config), ["alpha", "zeta", "ollama"]);
+        apply_flags(&mut config, &args());
+        assert_eq!(config.default_provider, "alpha");
+
+        // A key still comes first.
+        apply_flags(
+            &mut config,
+            &SetupArgs {
+                openai_key: Some("sk-test".to_string()),
+                ..args()
+            },
+        );
+        assert_eq!(configured_providers(&config)[0], "openai");
+        assert_eq!(
+            config.default_provider, "alpha",
+            "already reachable, so kept"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -102,6 +102,34 @@ pub(crate) fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {
         }
     }
 
+    // Endpoints by name: added, removed, or changed in what is sent.
+    let endpoints = |config: &Config| -> Vec<(String, crate::config::ModelProviderConfig)> {
+        let mut entries: Vec<_> = config
+            .model_providers
+            .iter()
+            .filter(|(_, e)| e.is_endpoint())
+            .map(|(name, e)| (name.clone(), e.clone()))
+            .collect();
+        entries.sort_by(|a, b| a.0.cmp(&b.0));
+        entries
+    };
+    let old_endpoints = endpoints(before);
+    let new_endpoints = endpoints(after);
+    for (name, entry) in &new_endpoints {
+        match old_endpoints.iter().find(|(old, _)| old == name) {
+            None => out.push(format!("endpoint {name}: added")),
+            Some((_, old)) if !same_endpoint(old, entry) => {
+                out.push(format!("endpoint {name}: changed"))
+            }
+            Some(_) => {}
+        }
+    }
+    for (name, _) in &old_endpoints {
+        if !new_endpoints.iter().any(|(new, _)| new == name) {
+            out.push(format!("endpoint {name}: removed"));
+        }
+    }
+
     if before.providers.claude_code_enabled != after.providers.claude_code_enabled {
         out.push(format!(
             "Claude Code transport: {}",
@@ -192,6 +220,18 @@ pub(crate) fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {
     out
 }
 
+/// Whether two endpoint entries would send the same requests: the address,
+/// the key, the headers and the fallback models.
+fn same_endpoint(
+    a: &crate::config::ModelProviderConfig,
+    b: &crate::config::ModelProviderConfig,
+) -> bool {
+    a.base_url == b.base_url
+        && a.api_key == b.api_key
+        && a.headers == b.headers
+        && a.models == b.models
+}
+
 /// Append a `field: old → new` line when the two differ.
 fn push_if_changed<T: PartialEq + std::fmt::Display>(
     out: &mut Vec<String>,
@@ -215,6 +255,59 @@ fn push_if_changed<T: PartialEq + std::fmt::Display>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Endpoints are reviewed by name: added, removed, or changed in what
+    /// they send. A change to a field the request never carries is not a
+    /// change worth a line.
+    #[test]
+    fn the_review_names_endpoints_added_removed_and_changed() {
+        use crate::config::{ModelProviderConfig, ModelProviderKind};
+        let endpoint = |url: &str| ModelProviderConfig {
+            kind: Some(ModelProviderKind::OpenaiCompatible),
+            base_url: Some(url.to_string()),
+            ..Default::default()
+        };
+        let mut before = Config::default();
+        before
+            .model_providers
+            .insert("gone".to_string(), endpoint("http://old"));
+        before
+            .model_providers
+            .insert("moved".to_string(), endpoint("http://a"));
+        before
+            .model_providers
+            .insert("same".to_string(), endpoint("http://s"));
+        let mut after = before.clone();
+        after.model_providers.remove("gone");
+        after
+            .model_providers
+            .insert("moved".to_string(), endpoint("http://b"));
+        after
+            .model_providers
+            .insert("new".to_string(), endpoint("http://n"));
+        // `serves` is not part of what is sent, so it is not a change.
+        after.model_providers.get_mut("same").unwrap().serves = Some(vec!["x".to_string()]);
+
+        let plan = SetupPlan {
+            config: after,
+            agents: Vec::new(),
+            declined: Default::default(),
+        };
+        let lines = changes(&before, &plan);
+        assert!(
+            lines.contains(&"endpoint new: added".to_string()),
+            "{lines:?}"
+        );
+        assert!(
+            lines.contains(&"endpoint moved: changed".to_string()),
+            "{lines:?}"
+        );
+        assert!(
+            lines.contains(&"endpoint gone: removed".to_string()),
+            "{lines:?}"
+        );
+        assert!(!lines.iter().any(|l| l.contains("same")), "{lines:?}");
+    }
     use crate::bundled::BUNDLED_AGENTS;
 
     fn plan_of(config: Config) -> SetupPlan {

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -23,6 +23,8 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState},
 };
 
+mod endpoints;
+
 use super::catalog::{self, Credential};
 use super::state::{FieldValue, Step, Wizard};
 use crate::tui::theme::*;
@@ -549,6 +551,7 @@ fn build_providers(wizard: &Wizard) -> Screen {
             ),
             Span::styled(row.provider.display, name_style(index == wizard.cursor)),
         ];
+        let entries = wizard.endpoints_under(row.provider.id).len();
         if let Some(var) = row.from_env {
             spans.push(Span::styled(
                 format!("  (${var})"),
@@ -556,6 +559,13 @@ fn build_providers(wizard: &Wizard) -> Screen {
             ));
         } else if !row.value.is_empty() {
             spans.push(Span::styled("  (set)", Style::default().fg(C_MUTED)));
+        } else if entries == 1 {
+            spans.push(Span::styled("  (1 endpoint)", Style::default().fg(C_MUTED)));
+        } else if entries > 1 {
+            spans.push(Span::styled(
+                format!("  ({entries} endpoints)"),
+                Style::default().fg(C_MUTED),
+            ));
         }
         screen.row();
         screen.push(Line::from(spans));
@@ -632,6 +642,8 @@ fn build_provider_detail(wizard: &Wizard) -> Screen {
                 Style::default().fg(C_DIM),
             )));
         }
+        // A preset's screen is a form per entry, not this card.
+        Credential::Endpoint => return endpoints::build_endpoint_detail(wizard, index),
         Credential::None => {
             lines.push(Line::from(vec![
                 Span::styled(row_marker, Style::default().fg(C_ACCENT)),
@@ -1061,7 +1073,7 @@ mod tests {
 
     /// Render one frame and return every non-blank line of the buffer, so a
     /// test can assert on what a user would actually read.
-    fn rendered(wizard: &Wizard) -> String {
+    pub(super) fn rendered(wizard: &Wizard) -> String {
         let mut terminal = Terminal::new(TestBackendHarness::new(140, 44)).unwrap();
         terminal.draw(|frame| draw(frame, wizard)).unwrap();
         terminal.backend().text()
@@ -1362,7 +1374,7 @@ mod tests {
         assert_eq!(row_at(Rect::new(0, 0, 10, 4), &w, 2, 2), None);
     }
 
-    fn wizard() -> (tempfile::TempDir, Wizard) {
+    pub(super) fn wizard() -> (tempfile::TempDir, Wizard) {
         let dir = tempfile::tempdir().unwrap();
         let wizard = crate::commands::setup::state::tests::test_wizard(dir.path());
         (dir, wizard)

--- a/crates/leviath-cli/src/commands/setup/render/endpoints.rs
+++ b/crates/leviath-cli/src/commands/setup/render/endpoints.rs
@@ -1,0 +1,304 @@
+//! The credential screen for an endpoint preset: one small form per entry,
+//! then a row to add another.
+//!
+//! Split from the parent because a preset with two entries is sixteen cursor
+//! rows where every other provider has one, and the layout that draws them
+//! is its own thing rather than a longer arm of the provider card.
+
+use super::*;
+use crate::commands::setup::state::{EditTarget, EndpointCursor, EndpointField, EndpointRow};
+
+/// The credential screen for the endpoint preset at provider row `index`.
+pub(super) fn build_endpoint_detail(wizard: &Wizard, index: usize) -> Screen {
+    let row = &wizard.providers[index];
+    let position = wizard.detail + 1;
+    let total = wizard.selected_providers().len();
+    let entries = wizard.endpoints_under(row.provider.id);
+
+    let mut screen = Screen::default();
+    screen.push(Line::from(vec![
+        Span::styled(
+            row.provider.display,
+            Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("   {position} of {total}"),
+            Style::default().fg(C_DIM),
+        ),
+    ]));
+    screen.push(Line::from(Span::styled(
+        row.provider.blurb,
+        Style::default().fg(C_MUTED),
+    )));
+    screen.push(Line::from(""));
+
+    for (nth, &entry) in entries.iter().enumerate() {
+        push_entry(&mut screen, wizard, index, entry, nth);
+    }
+
+    let on_add = wizard.endpoint_cursor(index) == Some(EndpointCursor::Add);
+    screen.row();
+    screen.push(button_line(
+        &format!("Add another {}", row.provider.display),
+        on_add,
+    ));
+    screen.finish(wizard)
+}
+
+/// One entry's form: a heading, its fields, its two buttons.
+fn push_entry(screen: &mut Screen, wizard: &Wizard, index: usize, entry: usize, nth: usize) {
+    let row: &EndpointRow = &wizard.endpoints[entry];
+    screen.push(Line::from(vec![
+        Span::styled(
+            format!("Endpoint {}: ", nth + 1),
+            Style::default().fg(C_MUTED),
+        ),
+        Span::styled(
+            row.name.clone(),
+            Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    for field in EndpointField::ALL {
+        let focused = wizard.endpoint_cursor(index) == Some(EndpointCursor::Field(entry, field));
+        screen.row();
+        match field {
+            EndpointField::Verify | EndpointField::Remove => {
+                screen.push(button_line(&field_display(wizard, row, field), focused));
+            }
+            _ => {
+                screen.push(field_line(wizard, entry, field, focused));
+                if focused && !field.help().is_empty() {
+                    screen.push(Line::from(Span::styled(
+                        format!("    {}", field.help()),
+                        Style::default().fg(C_DIM),
+                    )));
+                }
+            }
+        }
+        if field == EndpointField::DefaultModel {
+            screen.push(entry_status_line(wizard, entry));
+        }
+    }
+    screen.push(Line::from(""));
+}
+
+/// `› Label: value`, with the editor's buffer in place of the value while
+/// this field is being typed into.
+fn field_line(wizard: &Wizard, entry: usize, field: EndpointField, focused: bool) -> Line<'static> {
+    let row = &wizard.endpoints[entry];
+    let marker = if focused { "› " } else { "  " };
+    let mut spans = vec![
+        Span::styled(marker, Style::default().fg(C_ACCENT)),
+        Span::styled(format!("{}: ", field.label()), Style::default().fg(C_MUTED)),
+    ];
+    let editing = wizard
+        .edit
+        .as_ref()
+        .filter(|edit| edit.target == EditTarget::Endpoint { entry, field });
+    match editing {
+        Some(edit) => spans.extend(edit.line.display_spans(wizard.reveal).spans),
+        None => spans.push(Span::styled(
+            field_display(wizard, row, field),
+            Style::default().fg(if focused { C_WHITE } else { C_MUTED }),
+        )),
+    }
+    Line::from(spans)
+}
+
+/// What a field shows when it is not being edited.
+fn field_display(wizard: &Wizard, row: &EndpointRow, field: EndpointField) -> String {
+    let or_hint = |value: &str, hint: &str| {
+        if value.is_empty() {
+            format!("({hint})")
+        } else {
+            value.to_string()
+        }
+    };
+    match field {
+        EndpointField::Name => row.name.clone(),
+        EndpointField::BaseUrl => or_hint(&row.base_url, "http://localhost:8080/v1"),
+        EndpointField::ApiKey if row.api_key.is_empty() => "(none)".to_string(),
+        EndpointField::ApiKey if !wizard.reveal => catalog::redact(&row.api_key),
+        EndpointField::ApiKey => row.api_key.clone(),
+        EndpointField::Headers => or_hint(&row.headers, "none"),
+        EndpointField::Models => {
+            let detected = row.outcome.models().len();
+            match (row.models.is_empty(), detected) {
+                (true, 0) => "(none typed; the check fills this in)".to_string(),
+                (true, n) => format!("({n} detected)"),
+                (false, _) => row.models.clone(),
+            }
+        }
+        EndpointField::DefaultModel => row
+            .default_model
+            .clone()
+            .unwrap_or_else(|| "(none)".to_string()),
+        EndpointField::Verify | EndpointField::Remove => field.label().to_string(),
+    }
+}
+
+/// The check's result for one entry, drawn like the provider card's.
+fn entry_status_line(wizard: &Wizard, entry: usize) -> Line<'static> {
+    let row = &wizard.endpoints[entry];
+    if row.checking {
+        let frame = SPINNER[(wizard.ticks as usize) % SPINNER.len()];
+        return Line::from(vec![
+            Span::styled(format!("    {frame} "), Style::default().fg(C_ACCENT)),
+            Span::styled("checking…", Style::default().fg(C_MUTED)),
+        ]);
+    }
+    match &row.outcome {
+        super::super::verify::Outcome::Skipped => Line::from(Span::styled(
+            "    not checked yet",
+            Style::default().fg(C_DIM),
+        )),
+        super::super::verify::Outcome::Reachable { models } => {
+            let shown: Vec<&str> = models.iter().take(6).map(String::as_str).collect();
+            let more = models.len().saturating_sub(shown.len());
+            let mut text = format!("{}: {}", row.outcome.summary(), shown.join(", "));
+            if more > 0 {
+                text.push_str(&format!(" and {more} more"));
+            }
+            Line::from(vec![
+                Span::styled(
+                    format!("    {GLYPH_COMPLETE} "),
+                    Style::default().fg(C_SUCCESS),
+                ),
+                Span::styled(text, Style::default().fg(C_SUCCESS)),
+            ])
+        }
+        super::super::verify::Outcome::Failed { .. } => Line::from(vec![
+            Span::styled(format!("    {GLYPH_ERROR} "), Style::default().fg(C_ERROR)),
+            Span::styled(
+                format!(
+                    "{}; type the model ids by hand above",
+                    row.outcome.summary()
+                ),
+                Style::default().fg(C_ERROR),
+            ),
+        ]),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::{rendered, wizard};
+    use super::*;
+    use crate::commands::setup::verify::Outcome;
+
+    fn open_llama(w: &mut Wizard) -> usize {
+        let llama = w
+            .providers
+            .iter()
+            .position(|r| r.provider.id == "llama-cpp")
+            .expect("in the table");
+        w.add_endpoint(llama);
+        w.enter(Step::ProviderDetail);
+        llama
+    }
+
+    #[test]
+    fn the_endpoint_screen_draws_every_field_and_the_add_row() {
+        let (_dir, mut w) = wizard();
+        open_llama(&mut w);
+        let screen = rendered(&w);
+        assert!(screen.contains("llama.cpp"), "{screen}");
+        assert!(screen.contains("Endpoint 1: llama-cpp"), "{screen}");
+        for field in EndpointField::ALL {
+            assert!(
+                screen.contains(field.label()),
+                "{field:?} missing:\n{screen}"
+            );
+        }
+        assert!(screen.contains("http://localhost:8080/v1"), "{screen}");
+        assert!(
+            screen.contains("(none typed; the check fills this in)"),
+            "{screen}"
+        );
+        assert!(screen.contains("not checked yet"), "{screen}");
+        assert!(screen.contains("Add another llama.cpp"), "{screen}");
+        // The focused field explains itself; the first row is the name.
+        assert!(screen.contains("› Name"), "{screen}");
+        assert!(screen.contains(EndpointField::Name.help()), "{screen}");
+    }
+
+    #[test]
+    fn the_key_is_redacted_until_revealed_and_the_buffer_shows_while_editing() {
+        let (_dir, mut w) = wizard();
+        open_llama(&mut w);
+        w.endpoints[0].api_key = "sk-endpoint-secret".to_string();
+        let screen = rendered(&w);
+        assert!(!screen.contains("sk-endpoint-secret"), "leaked:\n{screen}");
+        assert!(screen.contains("****cret"), "{screen}");
+        w.reveal = true;
+        assert!(rendered(&w).contains("sk-endpoint-secret"));
+
+        w.cursor = 1;
+        w.open_endpoint_editor(0, EndpointField::BaseUrl);
+        w.edit.as_mut().unwrap().line =
+            crate::tui::widgets::line_edit::LineEdit::new("typing", false);
+        assert!(rendered(&w).contains("typing"));
+    }
+
+    #[test]
+    fn a_check_result_lists_the_models_and_a_failure_points_at_the_models_row() {
+        let (_dir, mut w) = wizard();
+        open_llama(&mut w);
+        w.endpoints[0].outcome = Outcome::Reachable {
+            models: (1..=8).map(|n| format!("m{n}")).collect(),
+        };
+        w.endpoints[0].default_model = Some("m3".to_string());
+        let screen = rendered(&w);
+        assert!(
+            screen.contains("8 models: m1, m2, m3, m4, m5, m6 and 2 more"),
+            "{screen}"
+        );
+        assert!(screen.contains("(8 detected)"), "{screen}");
+        assert!(screen.contains("Default model: m3"), "{screen}");
+
+        w.endpoints[0].outcome = Outcome::Failed {
+            message: "unreachable - check your network".to_string(),
+        };
+        w.endpoints[0].models = "typed-one".to_string();
+        let screen = rendered(&w);
+        assert!(screen.contains("unreachable"), "{screen}");
+        assert!(screen.contains("type the model ids by hand"), "{screen}");
+        assert!(screen.contains("Models: typed-one"), "{screen}");
+
+        w.endpoints[0].checking = true;
+        assert!(rendered(&w).contains("checking"));
+    }
+
+    /// The pick-list says how many entries a preset holds, and a short
+    /// listing is shown whole.
+    #[test]
+    fn the_pick_list_counts_entries_and_a_short_listing_is_shown_whole() {
+        let (_dir, mut w) = wizard();
+        let llama = open_llama(&mut w);
+        w.enter(Step::Providers);
+        assert!(rendered(&w).contains("llama.cpp  (1 endpoint)"));
+        w.add_endpoint(llama);
+        assert!(rendered(&w).contains("llama.cpp  (2 endpoints)"));
+
+        w.enter(Step::ProviderDetail);
+        w.endpoints[0].outcome = Outcome::Reachable {
+            models: vec!["a".to_string(), "b".to_string()],
+        };
+        let screen = rendered(&w);
+        assert!(screen.contains("2 models: a, b"), "{screen}");
+        assert!(!screen.contains("more"), "{screen}");
+    }
+
+    #[test]
+    fn the_focus_marker_reaches_the_buttons_and_the_add_row() {
+        let (_dir, mut w) = wizard();
+        open_llama(&mut w);
+        w.endpoints[0].headers = "X-Org: r".to_string();
+        w.cursor = 6;
+        let screen = rendered(&w);
+        assert!(screen.contains("› [ Check this endpoint ]"), "{screen}");
+        assert!(screen.contains("Headers: X-Org: r"), "{screen}");
+        w.cursor = 8;
+        assert!(rendered(&w).contains("› [ Add another llama.cpp ]"));
+    }
+}

--- a/crates/leviath-cli/src/commands/setup/state/endpoints.rs
+++ b/crates/leviath-cli/src/commands/setup/state/endpoints.rs
@@ -1,0 +1,965 @@
+//! OpenAI-compatible endpoints in the wizard: llama.cpp, LM Studio, and
+//! anything else that speaks the API.
+//!
+//! The rest of the provider table is one row per provider with one credential
+//! each, and a `[model_providers.<name>]` endpoint is neither: a machine can
+//! run two llama.cpp servers on two ports, and each needs a name, an address,
+//! maybe a key, maybe headers. So the pick-list rows for these are presets,
+//! and picking one adds an *entry* the credential screen then edits as a small
+//! form. Several entries can sit under one preset, and the screen offers add
+//! and remove beside the fields.
+//!
+//! Everything here is data and transitions on [`Wizard`]; drawing lives in
+//! `render`, keys in `input`.
+
+use super::*;
+use crate::config::{ModelProviderConfig, ModelProviderKind};
+
+/// One `[model_providers.<name>]` endpoint, as the wizard edits it.
+#[derive(Debug, Clone)]
+pub struct EndpointRow {
+    /// The pick-list row this entry sits under, by catalogue id.
+    pub preset: &'static str,
+    /// The table key, and the name a blueprint writes before the slash.
+    pub name: String,
+    /// Where the server listens, including any path prefix.
+    pub base_url: String,
+    /// Bearer token, or empty for a server that wants none.
+    pub api_key: String,
+    /// Extra headers as typed: `Name: value` pairs separated by semicolons.
+    pub headers: String,
+    /// Model ids typed by hand, comma-separated, for a server that will not
+    /// list its own. Written to `models` and used only when detection fails.
+    pub models: String,
+    /// The model this entry should be asked for by default, picked from what
+    /// detection found or from the hand-typed list.
+    pub default_model: Option<String>,
+    /// What the last check concluded.
+    pub outcome: Outcome,
+    /// A check is in flight.
+    pub checking: bool,
+}
+
+/// The rows one entry occupies on the credential screen, in order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointField {
+    /// The table key.
+    Name,
+    /// The server address.
+    BaseUrl,
+    /// The bearer token.
+    ApiKey,
+    /// Extra headers.
+    Headers,
+    /// Hand-typed model ids.
+    Models,
+    /// The default model, cycled rather than typed.
+    DefaultModel,
+    /// Run the check.
+    Verify,
+    /// Take the entry out.
+    Remove,
+}
+
+impl EndpointField {
+    /// Every field, in screen order.
+    pub const ALL: [EndpointField; 8] = [
+        EndpointField::Name,
+        EndpointField::BaseUrl,
+        EndpointField::ApiKey,
+        EndpointField::Headers,
+        EndpointField::Models,
+        EndpointField::DefaultModel,
+        EndpointField::Verify,
+        EndpointField::Remove,
+    ];
+
+    /// The label in front of the value.
+    pub(crate) fn label(self) -> &'static str {
+        match self {
+            Self::Name => "Name",
+            Self::BaseUrl => "Base URL",
+            Self::ApiKey => "API key",
+            Self::Headers => "Headers",
+            Self::Models => "Models",
+            Self::DefaultModel => "Default model",
+            Self::Verify => "Check this endpoint",
+            Self::Remove => "Remove this endpoint",
+        }
+    }
+
+    /// One line under the value saying what it is for.
+    pub(crate) fn help(self) -> &'static str {
+        match self {
+            Self::Name => {
+                "What blueprints call this provider, as in name/model. Letters, digits, - and _."
+            }
+            Self::BaseUrl => "Where the server listens, including the /v1 prefix.",
+            Self::ApiKey => "Sent as a bearer token. Leave empty for a server that wants none.",
+            Self::Headers => "Extra headers as Name: value, several separated by semicolons.",
+            Self::Models => {
+                "Only for a server that does not list its models: ids, comma-separated."
+            }
+            Self::DefaultModel => "Left and right to choose from what the check found.",
+            Self::Verify | Self::Remove => "",
+        }
+    }
+
+    /// Whether Enter opens a text editor on this row.
+    pub(crate) fn is_text(self) -> bool {
+        matches!(
+            self,
+            Self::Name | Self::BaseUrl | Self::ApiKey | Self::Headers | Self::Models
+        )
+    }
+}
+
+/// Where the cursor sits on an endpoint preset's credential screen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EndpointCursor {
+    /// On a field of the entry at this index into `Wizard::endpoints`.
+    Field(usize, EndpointField),
+    /// On the "add another" row after the last entry.
+    Add,
+}
+
+/// The rows a name may be made of, so a table key is also a path-safe name.
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// `Name: value; Other: value` as pairs, in order. A piece with no colon is
+/// skipped rather than refused: the screen shows what was typed, and a stray
+/// semicolon should not lose the rest.
+pub(crate) fn parse_headers(text: &str) -> Vec<(String, String)> {
+    text.split(';')
+        .filter_map(|piece| {
+            let (name, value) = piece.split_once(':')?;
+            let name = name.trim();
+            (!name.is_empty()).then(|| (name.to_string(), value.trim().to_string()))
+        })
+        .collect()
+}
+
+/// The inverse of [`parse_headers`], for an entry loaded from the config.
+fn format_headers(headers: &std::collections::BTreeMap<String, String>) -> String {
+    headers
+        .iter()
+        .map(|(name, value)| format!("{name}: {value}"))
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+/// Comma-separated ids, trimmed, empties dropped.
+pub(crate) fn parse_models(text: &str) -> Vec<String> {
+    text.split(',')
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+impl EndpointRow {
+    /// A fresh entry under `preset`, named uniquely against `taken`.
+    fn fresh(preset: &Provider, taken: &[String]) -> Self {
+        let mut name = preset.id.to_string();
+        let mut n = 1;
+        while taken.contains(&name) {
+            n += 1;
+            name = format!("{}-{n}", preset.id);
+        }
+        Self {
+            preset: preset.id,
+            name,
+            base_url: preset.preset_url.unwrap_or_default().to_string(),
+            api_key: String::new(),
+            headers: String::new(),
+            models: String::new(),
+            default_model: None,
+            outcome: Outcome::Skipped,
+            checking: false,
+        }
+    }
+
+    /// An entry read back out of a config file.
+    fn from_config(name: &str, entry: &ModelProviderConfig) -> Self {
+        Self {
+            preset: catalog::preset_for(name, entry),
+            name: name.to_string(),
+            base_url: entry.base_url.clone().unwrap_or_default(),
+            api_key: entry.api_key.clone().unwrap_or_default(),
+            headers: entry
+                .headers
+                .as_ref()
+                .map(format_headers)
+                .unwrap_or_default(),
+            models: entry.models.as_deref().unwrap_or_default().join(", "),
+            default_model: None,
+            outcome: Outcome::Skipped,
+            checking: false,
+        }
+    }
+
+    /// The ids the default model may be chosen from: what the check found,
+    /// or what was typed when it found nothing.
+    pub(crate) fn model_choices(&self) -> Vec<String> {
+        let detected = self.outcome.models();
+        if detected.is_empty() {
+            parse_models(&self.models)
+        } else {
+            detected.to_vec()
+        }
+    }
+
+    /// The config entry this row writes, on top of `existing` when the
+    /// config already had one under this name, so a `rate_limit` or `serves`
+    /// set by hand survives a pass through the wizard.
+    fn to_config(&self, existing: Option<&ModelProviderConfig>) -> ModelProviderConfig {
+        let mut entry = existing.cloned().unwrap_or_default();
+        entry.kind = Some(ModelProviderKind::OpenaiCompatible);
+        entry.script = None;
+        entry.base_url = Some(self.base_url.trim().to_string());
+        entry.api_key = Some(self.api_key.trim().to_string()).filter(|k| !k.is_empty());
+        let headers: std::collections::BTreeMap<String, String> =
+            parse_headers(&self.headers).into_iter().collect();
+        entry.headers = (!headers.is_empty()).then_some(headers);
+        let models = parse_models(&self.models);
+        entry.models = (!models.is_empty()).then_some(models);
+        entry
+    }
+}
+
+impl Wizard {
+    /// The endpoint entries read out of `base`, in name order.
+    pub(super) fn endpoints_from_config(base: &Config) -> Vec<EndpointRow> {
+        let mut rows: Vec<EndpointRow> = base
+            .model_providers
+            .iter()
+            .filter(|(_, entry)| entry.is_endpoint())
+            .map(|(name, entry)| EndpointRow::from_config(name, entry))
+            .collect();
+        rows.sort_by(|a, b| a.name.cmp(&b.name));
+        rows
+    }
+
+    /// Indices into `self.endpoints` of the entries under `preset`.
+    pub(crate) fn endpoints_under(&self, preset: &str) -> Vec<usize> {
+        self.endpoints
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.preset == preset)
+            .map(|(i, _)| i)
+            .collect()
+    }
+
+    /// Whether the provider row at `index` is an endpoint preset.
+    pub(crate) fn is_endpoint_preset(&self, index: usize) -> bool {
+        self.providers
+            .get(index)
+            .is_some_and(|row| row.provider.credential == Credential::Endpoint)
+    }
+
+    /// The names every entry currently holds.
+    fn endpoint_names(&self) -> Vec<String> {
+        self.endpoints.iter().map(|e| e.name.clone()).collect()
+    }
+
+    /// Add a fresh entry under the preset at provider row `index`, and select
+    /// that row. Returns the new entry's index.
+    pub(crate) fn add_endpoint(&mut self, index: usize) -> Option<usize> {
+        let preset = self.providers.get(index)?.provider.clone();
+        if preset.credential != Credential::Endpoint {
+            return None;
+        }
+        let taken = self.endpoint_names();
+        self.endpoints.push(EndpointRow::fresh(&preset, &taken));
+        self.providers[index].selected = true;
+        self.dirty = true;
+        Some(self.endpoints.len() - 1)
+    }
+
+    /// Take the entry at `entry` out. When it was the last one under its
+    /// preset, the preset's row is deselected too.
+    pub(crate) fn remove_endpoint(&mut self, entry: usize) {
+        if entry >= self.endpoints.len() {
+            return;
+        }
+        let preset = self.endpoints.remove(entry).preset;
+        self.dirty = true;
+        if self.endpoints_under(preset).is_empty()
+            && let Some(row) = self.providers.iter_mut().find(|r| r.provider.id == preset)
+        {
+            row.selected = false;
+        }
+    }
+
+    /// Take every entry under `preset` out, for a deselected preset row.
+    pub(crate) fn remove_endpoints_under(&mut self, preset: &str) {
+        self.endpoints.retain(|e| e.preset != preset);
+    }
+
+    /// How many cursor rows the credential screen has for the preset at
+    /// provider row `index`: every entry's fields, then the add row.
+    pub(crate) fn endpoint_row_count(&self, index: usize) -> usize {
+        let preset = self.providers[index].provider.id;
+        self.endpoints_under(preset).len() * EndpointField::ALL.len() + 1
+    }
+
+    /// What the cursor is on, for the preset at provider row `index`.
+    pub(crate) fn endpoint_cursor(&self, index: usize) -> Option<EndpointCursor> {
+        let preset = self.providers.get(index)?.provider.id;
+        let entries = self.endpoints_under(preset);
+        let per_entry = EndpointField::ALL.len();
+        let cursor = self.cursor;
+        if cursor == entries.len() * per_entry {
+            return Some(EndpointCursor::Add);
+        }
+        let entry = *entries.get(cursor / per_entry)?;
+        Some(EndpointCursor::Field(
+            entry,
+            EndpointField::ALL[cursor % per_entry],
+        ))
+    }
+
+    /// Open the text editor on `field` of the entry at `entry`.
+    pub(crate) fn open_endpoint_editor(&mut self, entry: usize, field: EndpointField) {
+        let Some(row) = self.endpoints.get(entry) else {
+            return;
+        };
+        let value = match field {
+            EndpointField::Name => row.name.clone(),
+            EndpointField::BaseUrl => row.base_url.clone(),
+            EndpointField::ApiKey => row.api_key.clone(),
+            EndpointField::Headers => row.headers.clone(),
+            EndpointField::Models => row.models.clone(),
+            EndpointField::DefaultModel | EndpointField::Verify | EndpointField::Remove => {
+                return;
+            }
+        };
+        self.edit = Some(Edit {
+            target: EditTarget::Endpoint { entry, field },
+            line: crate::tui::widgets::line_edit::LineEdit::new(
+                value,
+                field == EndpointField::ApiKey,
+            ),
+        });
+    }
+
+    /// Write a committed text edit back into the entry. A name that is empty,
+    /// taken by another entry, or taken by a built-in provider is refused
+    /// with a message and the old name kept: the name is a table key and a
+    /// registry name, and either collision would make the entry unreachable.
+    pub(super) fn commit_endpoint_edit(&mut self, entry: usize, field: EndpointField, text: &str) {
+        let text = text.trim().to_string();
+        let taken = self.endpoint_names();
+        let Some(row) = self.endpoints.get_mut(entry) else {
+            return;
+        };
+        match field {
+            EndpointField::Name => {
+                // A preset's id is a fine entry name (it is the default one);
+                // a real provider's id would shadow it in the registry.
+                let built_in = catalog::providers()
+                    .iter()
+                    .any(|p| p.id == text && p.credential != Credential::Endpoint);
+                let other = taken
+                    .iter()
+                    .enumerate()
+                    .any(|(i, name)| i != entry && *name == text);
+                if !is_valid_name(&text) {
+                    self.message = Some(
+                        "A name is letters, digits, - and _ (it becomes a table key).".to_string(),
+                    );
+                } else if built_in || other {
+                    self.message = Some(format!("The name '{text}' is already taken."));
+                } else {
+                    row.name = text;
+                }
+            }
+            EndpointField::BaseUrl => row.base_url = text,
+            EndpointField::ApiKey => row.api_key = text,
+            EndpointField::Headers => row.headers = text,
+            EndpointField::Models => {
+                row.models = text;
+                // The choices may have changed under the pick.
+                if let Some(chosen) = &row.default_model
+                    && !row.model_choices().contains(chosen)
+                {
+                    row.default_model = None;
+                }
+            }
+            EndpointField::DefaultModel | EndpointField::Verify | EndpointField::Remove => {}
+        }
+        // Anything that changes what is sent stales the last check.
+        if matches!(
+            field,
+            EndpointField::BaseUrl | EndpointField::ApiKey | EndpointField::Headers
+        ) {
+            row.outcome = Outcome::Skipped;
+        }
+    }
+
+    /// Move the entry's default model through its choices.
+    pub(crate) fn cycle_endpoint_model(&mut self, entry: usize, delta: isize) {
+        let Some(row) = self.endpoints.get_mut(entry) else {
+            return;
+        };
+        let choices = row.model_choices();
+        if choices.is_empty() {
+            self.message = Some("Check the endpoint first, or type its models.".to_string());
+            return;
+        }
+        let current = row
+            .default_model
+            .as_ref()
+            .and_then(|m| choices.iter().position(|c| c == m));
+        let next = match current {
+            Some(i) => (i as isize + delta).rem_euclid(choices.len() as isize) as usize,
+            None if delta < 0 => choices.len() - 1,
+            None => 0,
+        };
+        row.default_model = Some(choices[next].clone());
+        self.dirty = true;
+    }
+
+    /// Ask the background verifier about the entry at `entry`: a one-provider
+    /// registry that lists the endpoint's models, exactly as the built-ins are
+    /// checked. Nothing is sent for an entry with no address.
+    pub(crate) fn request_endpoint_verification(&mut self, entry: usize) {
+        let Some(row) = self.endpoints.get_mut(entry) else {
+            return;
+        };
+        if row.base_url.trim().is_empty() {
+            row.outcome = Outcome::Failed {
+                message: "no base URL".to_string(),
+            };
+            return;
+        }
+        row.checking = true;
+        let mut creds = leviath_runtime::provider_creds::ProviderCreds::openai_compatible(
+            row.name.clone(),
+            row.base_url.trim(),
+            Some(row.api_key.trim().to_string()).filter(|k| !k.is_empty()),
+            parse_headers(&row.headers),
+            None,
+            Vec::new(),
+        );
+        creds.request_timeout_secs = Some(20);
+        let _ = self.verify_tx.send(VerifyRequest {
+            provider_id: row.name.clone(),
+            creds,
+        });
+    }
+
+    /// Ask about every entry under the preset at provider row `index`.
+    pub(crate) fn verify_endpoints_under(&mut self, index: usize) {
+        let preset = self.providers[index].provider.id;
+        for entry in self.endpoints_under(preset) {
+            self.request_endpoint_verification(entry);
+        }
+    }
+
+    /// Route a verifier's reply to the entry it answers for. `true` when one
+    /// took it.
+    pub(super) fn settle_endpoint_reply(&mut self, reply: &VerifyReply) -> bool {
+        let Some(row) = self
+            .endpoints
+            .iter_mut()
+            .find(|e| e.name == reply.provider_id)
+        else {
+            return false;
+        };
+        row.checking = false;
+        row.outcome = reply.outcome.clone();
+        // A pick that the listing no longer names is dropped; the first id
+        // the listing does name is offered when nothing was picked yet.
+        let choices = row.model_choices();
+        if row
+            .default_model
+            .as_ref()
+            .is_some_and(|m| !choices.contains(m))
+        {
+            row.default_model = None;
+        }
+        if row.default_model.is_none() {
+            row.default_model = choices.first().cloned();
+        }
+        true
+    }
+
+    /// The names of the entries under selected preset rows, for the default
+    /// provider radio.
+    pub(crate) fn selected_endpoint_names(&self) -> Vec<String> {
+        self.selected_providers()
+            .into_iter()
+            .filter(|&i| self.is_endpoint_preset(i))
+            .flat_map(|i| self.endpoints_under(self.providers[i].provider.id))
+            .map(|e| self.endpoints[e].name.clone())
+            .collect()
+    }
+
+    /// The default model the entry named `name` chose, if it did.
+    pub(crate) fn endpoint_default_model(&self, name: &str) -> Option<String> {
+        self.endpoints
+            .iter()
+            .find(|e| e.name == name)
+            .and_then(|e| e.default_model.clone())
+    }
+
+    /// Fold the entries into `config`: every endpoint entry the file held is
+    /// replaced by what the wizard holds now, and a script entry is untouched.
+    pub(super) fn write_endpoints(&self, config: &mut Config) {
+        let existing: HashMap<String, ModelProviderConfig> = config
+            .model_providers
+            .iter()
+            .filter(|(_, e)| e.is_endpoint())
+            .map(|(name, e)| (name.clone(), e.clone()))
+            .collect();
+        config.model_providers.retain(|_, e| !e.is_endpoint());
+        let selected = self.selected_endpoint_names();
+        for row in self.endpoints.iter().filter(|e| selected.contains(&e.name)) {
+            config
+                .model_providers
+                .insert(row.name.clone(), row.to_config(existing.get(&row.name)));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::tests::test_wizard;
+    use super::*;
+
+    fn preset_index(wizard: &Wizard, id: &str) -> usize {
+        wizard
+            .providers
+            .iter()
+            .position(|r| r.provider.id == id)
+            .expect("the preset is in the table")
+    }
+
+    #[test]
+    fn headers_and_models_parse_forgivingly_and_headers_format_back() {
+        assert_eq!(
+            parse_headers(" X-Org: research ;junk; Accept:application/json"),
+            vec![
+                ("X-Org".to_string(), "research".to_string()),
+                ("Accept".to_string(), "application/json".to_string()),
+            ]
+        );
+        assert!(parse_headers(": no name").is_empty());
+        assert_eq!(
+            parse_models("a, ,b ,"),
+            vec!["a".to_string(), "b".to_string()]
+        );
+        let map: std::collections::BTreeMap<String, String> =
+            parse_headers("B: 2; A: 1").into_iter().collect();
+        assert_eq!(format_headers(&map), "A: 1; B: 2");
+    }
+
+    #[test]
+    fn every_field_is_labelled_and_the_text_fields_are_the_first_five() {
+        for field in EndpointField::ALL {
+            assert!(!field.label().is_empty());
+            // Every value row explains itself; the buttons say what they do
+            // in their label.
+            assert_eq!(
+                field.help().is_empty(),
+                matches!(field, EndpointField::Verify | EndpointField::Remove),
+                "{field:?}"
+            );
+        }
+        let text: Vec<bool> = EndpointField::ALL.iter().map(|f| f.is_text()).collect();
+        assert_eq!(text, [true, true, true, true, true, false, false, false]);
+        assert!(EndpointField::Verify.help().is_empty());
+        assert!(!EndpointField::Headers.help().is_empty());
+    }
+
+    #[test]
+    fn picking_a_preset_adds_a_named_entry_and_removing_the_last_deselects_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = test_wizard(dir.path());
+        let llama = preset_index(&w, "llama-cpp");
+        assert!(w.endpoints.is_empty());
+
+        let first = w.add_endpoint(llama).expect("added");
+        let second = w.add_endpoint(llama).expect("added");
+        assert_eq!(w.endpoints[first].name, "llama-cpp");
+        assert_eq!(w.endpoints[second].name, "llama-cpp-2");
+        assert_eq!(w.endpoints[first].base_url, "http://localhost:8080/v1");
+        assert!(w.providers[llama].selected);
+        assert!(w.dirty);
+        assert_eq!(w.endpoints_under("llama-cpp"), vec![0, 1]);
+        assert_eq!(w.endpoint_row_count(llama), 2 * 8 + 1);
+
+        // A row that is not a preset adds nothing.
+        assert_eq!(w.add_endpoint(0), None);
+        assert_eq!(w.add_endpoint(99), None);
+
+        w.remove_endpoint(0);
+        assert!(w.providers[llama].selected, "one entry is left");
+        w.remove_endpoint(0);
+        assert!(!w.providers[llama].selected, "the last one went");
+        w.remove_endpoint(5);
+        assert!(w.endpoints.is_empty());
+
+        // The custom preset starts with no address.
+        let custom = preset_index(&w, "openai-compatible");
+        let entry = w.add_endpoint(custom).expect("added");
+        assert!(w.endpoints[entry].base_url.is_empty());
+        w.remove_endpoints_under("openai-compatible");
+        assert!(w.endpoints.is_empty());
+    }
+
+    #[test]
+    fn the_cursor_maps_onto_fields_and_the_add_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = test_wizard(dir.path());
+        let llama = preset_index(&w, "llama-cpp");
+        w.add_endpoint(llama);
+        w.add_endpoint(llama);
+
+        w.cursor = 0;
+        assert_eq!(
+            w.endpoint_cursor(llama),
+            Some(EndpointCursor::Field(0, EndpointField::Name))
+        );
+        w.cursor = 8 + 5;
+        assert_eq!(
+            w.endpoint_cursor(llama),
+            Some(EndpointCursor::Field(1, EndpointField::DefaultModel))
+        );
+        w.cursor = 16;
+        assert_eq!(w.endpoint_cursor(llama), Some(EndpointCursor::Add));
+        w.cursor = 17;
+        assert_eq!(w.endpoint_cursor(llama), None, "the continue button");
+        assert_eq!(w.endpoint_cursor(99), None);
+        assert!(w.is_endpoint_preset(llama));
+        assert!(!w.is_endpoint_preset(0));
+    }
+
+    #[test]
+    fn edits_land_on_the_right_field_and_a_bad_name_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = test_wizard(dir.path());
+        let custom = preset_index(&w, "openai-compatible");
+        w.add_endpoint(custom);
+        w.add_endpoint(custom);
+
+        w.commit_endpoint_edit(0, EndpointField::Name, " vllm ");
+        assert_eq!(w.endpoints[0].name, "vllm");
+        w.commit_endpoint_edit(0, EndpointField::Name, "");
+        assert_eq!(w.endpoints[0].name, "vllm", "empty is refused");
+        assert!(w.message.take().unwrap().contains("letters"));
+        w.commit_endpoint_edit(0, EndpointField::Name, "has space");
+        assert_eq!(w.endpoints[0].name, "vllm");
+        w.commit_endpoint_edit(0, EndpointField::Name, "ollama");
+        assert_eq!(w.endpoints[0].name, "vllm", "a built-in name is refused");
+        assert!(w.message.take().unwrap().contains("taken"));
+        w.commit_endpoint_edit(0, EndpointField::Name, "openai-compatible-2");
+        assert_eq!(
+            w.endpoints[0].name, "vllm",
+            "another entry's name is refused"
+        );
+        w.commit_endpoint_edit(0, EndpointField::Name, "lm-studio");
+        assert_eq!(w.endpoints[0].name, "lm-studio", "a preset's id is allowed");
+        w.commit_endpoint_edit(0, EndpointField::Name, "vllm");
+
+        w.endpoints[0].outcome = Outcome::Reachable {
+            models: vec!["m".to_string()],
+        };
+        w.commit_endpoint_edit(0, EndpointField::BaseUrl, "http://h:8000/v1 ");
+        assert_eq!(w.endpoints[0].base_url, "http://h:8000/v1");
+        assert_eq!(
+            w.endpoints[0].outcome,
+            Outcome::Skipped,
+            "the check is stale"
+        );
+        w.commit_endpoint_edit(0, EndpointField::ApiKey, "k");
+        assert_eq!(w.endpoints[0].api_key, "k");
+        w.commit_endpoint_edit(0, EndpointField::Headers, "X: 1");
+        assert_eq!(w.endpoints[0].headers, "X: 1");
+
+        w.commit_endpoint_edit(0, EndpointField::Models, "a, b");
+        w.endpoints[0].default_model = Some("b".to_string());
+        w.commit_endpoint_edit(0, EndpointField::Models, "a");
+        assert_eq!(w.endpoints[0].default_model, None, "the pick is gone");
+        w.commit_endpoint_edit(0, EndpointField::Verify, "ignored");
+        w.commit_endpoint_edit(9, EndpointField::Name, "ignored");
+    }
+
+    #[test]
+    fn the_editor_opens_on_text_fields_only_and_masks_the_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = test_wizard(dir.path());
+        let llama = preset_index(&w, "llama-cpp");
+        w.add_endpoint(llama);
+
+        w.open_endpoint_editor(0, EndpointField::ApiKey);
+        let edit = w.edit.take().expect("opened");
+        assert_eq!(
+            edit.target,
+            EditTarget::Endpoint {
+                entry: 0,
+                field: EndpointField::ApiKey
+            }
+        );
+        for field in [
+            EndpointField::Name,
+            EndpointField::BaseUrl,
+            EndpointField::Headers,
+            EndpointField::Models,
+        ] {
+            w.open_endpoint_editor(0, field);
+            assert!(w.edit.take().is_some(), "{field:?}");
+        }
+        w.open_endpoint_editor(0, EndpointField::DefaultModel);
+        assert!(w.edit.is_none());
+        w.open_endpoint_editor(3, EndpointField::Name);
+        assert!(w.edit.is_none());
+    }
+
+    #[test]
+    fn the_default_model_cycles_through_what_was_found_or_typed() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = test_wizard(dir.path());
+        let llama = preset_index(&w, "llama-cpp");
+        w.add_endpoint(llama);
+        w.dirty = false;
+
+        w.cycle_endpoint_model(0, 1);
+        assert_eq!(w.endpoints[0].default_model, None);
+        assert!(w.message.take().unwrap().contains("Check"));
+        assert!(!w.dirty);
+
+        w.endpoints[0].models = "x, y".to_string();
+        w.cycle_endpoint_model(0, -1);
+        assert_eq!(w.endpoints[0].default_model.as_deref(), Some("y"));
+        w.cycle_endpoint_model(0, 1);
+        assert_eq!(w.endpoints[0].default_model.as_deref(), Some("x"));
+        w.cycle_endpoint_model(0, 1);
+        assert_eq!(w.endpoints[0].default_model.as_deref(), Some("y"));
+        assert!(w.dirty);
+
+        // A listing outranks the typed ids.
+        w.endpoints[0].outcome = Outcome::Reachable {
+            models: vec!["listed".to_string()],
+        };
+        w.endpoints[0].default_model = None;
+        w.cycle_endpoint_model(0, 1);
+        assert_eq!(w.endpoints[0].default_model.as_deref(), Some("listed"));
+        w.cycle_endpoint_model(7, 1);
+    }
+
+    #[tokio::test]
+    async fn verification_sends_the_entry_as_an_endpoint_cred_and_the_reply_lands() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = test_wizard(dir.path());
+        let (mut requests, replies) = w.take_verify_ends().expect("first take");
+        let custom = preset_index(&w, "openai-compatible");
+        w.add_endpoint(custom);
+
+        // No address: refused on the spot, nothing sent.
+        w.request_endpoint_verification(0);
+        assert!(w.endpoints[0].outcome.is_failure());
+        assert!(requests.try_recv().is_err());
+
+        w.endpoints[0].base_url = "http://127.0.0.1:1/v1".to_string();
+        w.endpoints[0].api_key = "k".to_string();
+        w.endpoints[0].headers = "X-Org: r".to_string();
+        w.verify_endpoints_under(custom);
+        assert!(w.endpoints[0].checking);
+        let request = requests.recv().await.expect("sent");
+        assert_eq!(request.provider_id, "openai-compatible");
+        let spec = leviath_runtime::provider_creds::EndpointSpec::from_creds(&request.creds)
+            .expect("an endpoint cred");
+        assert_eq!(spec.base_url, "http://127.0.0.1:1/v1");
+        assert_eq!(spec.headers, vec![("X-Org".to_string(), "r".to_string())]);
+        assert_eq!(request.creds.api_key.as_deref(), Some("k"));
+        assert_eq!(request.creds.request_timeout_secs, Some(20));
+
+        replies
+            .send(VerifyReply {
+                provider_id: "openai-compatible".to_string(),
+                outcome: Outcome::Reachable {
+                    models: vec!["gpt-mock".to_string()],
+                },
+            })
+            .unwrap();
+        w.drain_verifications();
+        assert!(!w.endpoints[0].checking);
+        assert_eq!(
+            w.endpoints[0].default_model.as_deref(),
+            Some("gpt-mock"),
+            "the first listed id is offered"
+        );
+        assert_eq!(w.discovered_models(), vec!["gpt-mock".to_string()]);
+
+        // A pick the next listing does not name is dropped for the first.
+        w.endpoints[0].default_model = Some("gone".to_string());
+        replies
+            .send(VerifyReply {
+                provider_id: "openai-compatible".to_string(),
+                outcome: Outcome::Reachable {
+                    models: vec!["other".to_string()],
+                },
+            })
+            .unwrap();
+        w.drain_verifications();
+        assert_eq!(w.endpoints[0].default_model.as_deref(), Some("other"));
+
+        // A pick the listing still names is kept.
+        replies
+            .send(VerifyReply {
+                provider_id: "openai-compatible".to_string(),
+                outcome: Outcome::Reachable {
+                    models: vec!["first".to_string(), "other".to_string()],
+                },
+            })
+            .unwrap();
+        w.drain_verifications();
+        assert_eq!(w.endpoints[0].default_model.as_deref(), Some("other"));
+
+        // A reply for nobody is dropped.
+        replies
+            .send(VerifyReply {
+                provider_id: "nobody".to_string(),
+                outcome: Outcome::Skipped,
+            })
+            .unwrap();
+        w.drain_verifications();
+        w.request_endpoint_verification(4);
+    }
+
+    /// The preset's credential screen has no action rows of its own (each
+    /// entry carries its buttons), and the chooser names an entry by its
+    /// preset and address.
+    #[test]
+    fn a_preset_has_no_detail_actions_and_the_chooser_names_its_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = test_wizard(dir.path());
+        let llama = preset_index(&w, "llama-cpp");
+        w.add_endpoint(llama);
+        w.enter(Step::ProviderDetail);
+        assert_eq!(w.detail_row(), Some(llama));
+        assert!(w.detail_actions().is_empty());
+
+        assert_eq!(
+            w.provider_detail("llama-cpp"),
+            "llama.cpp at http://localhost:8080/v1"
+        );
+        assert_eq!(w.provider_detail("anthropic"), "Anthropic");
+        assert_eq!(w.provider_detail("nobody"), "from your config");
+    }
+
+    #[test]
+    fn entries_are_read_from_the_config_and_written_back_over_the_old_ones() {
+        let mut base = Config::default();
+        base.model_providers.insert(
+            "lm-studio".to_string(),
+            ModelProviderConfig {
+                kind: Some(ModelProviderKind::OpenaiCompatible),
+                base_url: Some("http://localhost:1234/v1".to_string()),
+                api_key: Some("k".to_string()),
+                headers: Some(
+                    [("X-Org".to_string(), "r".to_string())]
+                        .into_iter()
+                        .collect(),
+                ),
+                models: Some(vec!["a".to_string(), "b".to_string()]),
+                serves: Some(vec!["kept".to_string()]),
+                ..Default::default()
+            },
+        );
+        base.model_providers.insert(
+            "stale".to_string(),
+            ModelProviderConfig {
+                kind: Some(ModelProviderKind::OpenaiCompatible),
+                base_url: Some("http://old".to_string()),
+                ..Default::default()
+            },
+        );
+        base.model_providers.insert(
+            "groq".to_string(),
+            ModelProviderConfig {
+                script: Some("groq.rhai".to_string()),
+                ..Default::default()
+            },
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = Wizard::new(
+            base,
+            &|_| None,
+            Vec::new(),
+            Vec::new(),
+            dir.path(),
+            std::sync::Arc::new(|_| true),
+            Default::default(),
+        );
+        let names: Vec<&str> = w.endpoints.iter().map(|e| e.name.as_str()).collect();
+        assert_eq!(names, ["lm-studio", "stale"]);
+        assert_eq!(w.endpoints[0].preset, "lm-studio");
+        assert_eq!(w.endpoints[0].headers, "X-Org: r");
+        assert_eq!(w.endpoints[0].models, "a, b");
+        assert_eq!(w.endpoints[1].preset, "openai-compatible");
+        let lm = preset_index(&w, "lm-studio");
+        let custom = preset_index(&w, "openai-compatible");
+        assert!(w.providers[lm].selected);
+        assert!(w.providers[custom].selected);
+        assert!(w.is_endpoint_preset(lm));
+
+        // Drop the stale one, edit the other, and write.
+        w.remove_endpoint(1);
+        assert!(!w.providers[custom].selected);
+        w.endpoints[0].api_key = String::new();
+        w.endpoints[0].headers = String::new();
+        w.endpoints[0].models = String::new();
+        let config = w.build_config();
+        assert!(!config.model_providers.contains_key("stale"));
+        assert!(
+            config.model_providers.contains_key("groq"),
+            "scripts are untouched"
+        );
+        let lm = &config.model_providers["lm-studio"];
+        assert!(lm.is_endpoint());
+        assert_eq!(lm.api_key, None);
+        assert_eq!(lm.headers, None);
+        assert_eq!(lm.models, None);
+        assert_eq!(
+            lm.serves.as_deref(),
+            Some(&["kept".to_string()][..]),
+            "a hand-set field survives"
+        );
+        assert_eq!(w.selected_endpoint_names(), vec!["lm-studio".to_string()]);
+    }
+
+    #[test]
+    fn the_default_provider_radio_offers_the_entries_and_their_model() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut w = test_wizard(dir.path());
+        let llama = preset_index(&w, "llama-cpp");
+        w.add_endpoint(llama);
+        w.endpoints[0].outcome = Outcome::Reachable {
+            models: vec!["qwen".to_string()],
+        };
+        w.endpoints[0].default_model = Some("qwen".to_string());
+        w.enter(Step::Defaults);
+
+        let providers = w.defaults[Wizard::PROVIDER_FIELD].value.options().to_vec();
+        assert_eq!(providers, vec!["llama-cpp".to_string()]);
+        assert_eq!(w.build_config().default_provider, "llama-cpp");
+        assert_eq!(
+            w.build_config().default_model.as_deref(),
+            Some("qwen"),
+            "the entry's pick becomes the default model"
+        );
+        assert_eq!(
+            w.endpoint_default_model("llama-cpp").as_deref(),
+            Some("qwen")
+        );
+        assert_eq!(w.endpoint_default_model("nobody"), None);
+    }
+}

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -20,6 +20,8 @@ use crate::config::Config;
 
 // Sections of the former single-file wizard state. Glob re-exported so every
 // existing `state::Wizard` path keeps working.
+mod endpoints;
+pub(crate) use endpoints::*;
 mod limits;
 use limits::*;
 mod types;
@@ -33,6 +35,8 @@ pub struct Wizard {
     pub cursor: usize,
     /// Every provider the wizard offers, picked or not.
     pub providers: Vec<ProviderRow>,
+    /// The OpenAI-compatible endpoints, under whichever preset row each sits.
+    pub endpoints: Vec<EndpointRow>,
     /// Which selected provider the credential screen is showing.
     pub detail: usize,
     /// The Defaults screen's settings.
@@ -206,10 +210,12 @@ impl Wizard {
         let (verify_tx, verify_rx) = mpsc::unbounded_channel();
         let (reply_tx, reply_rx) = mpsc::unbounded_channel();
 
+        let endpoints = Self::endpoints_from_config(&base);
         let mut wizard = Self {
             step: Step::Welcome,
             cursor: 0,
             providers,
+            endpoints,
             detail: 0,
             defaults: Vec::new(),
             limits: limits_fields(&base),
@@ -312,6 +318,11 @@ impl Wizard {
         let Some(index) = self.detail_row() else {
             return Vec::new();
         };
+        // An endpoint preset's screen is its entries' own rows, each with its
+        // check and remove buttons; see `endpoint_row_count`.
+        if self.is_endpoint_preset(index) {
+            return Vec::new();
+        }
         let mut actions = Vec::new();
         if self.providers[index].provider.signup_url.is_some() {
             actions.push(DetailAction::OpenSignup);
@@ -326,6 +337,7 @@ impl Wizard {
             Step::Welcome | Step::Review => 0,
             Step::Providers => self.providers.len(),
             Step::ProviderDetail => match self.detail_row() {
+                Some(index) if self.is_endpoint_preset(index) => self.endpoint_row_count(index),
                 Some(_) => 1 + self.detail_actions().len(),
                 None => 0,
             },
@@ -525,6 +537,10 @@ impl Wizard {
     /// blank API key would fail with a message about the key rather than saying
     /// the obvious, that none was given.
     pub(crate) fn request_verification(&mut self, index: usize) {
+        if self.is_endpoint_preset(index) {
+            self.verify_endpoints_under(index);
+            return;
+        }
         let Some(row) = self.providers.get_mut(index) else {
             return;
         };
@@ -577,7 +593,12 @@ impl Wizard {
     pub(crate) fn drain_verifications(&mut self) {
         let mut landed = false;
         while let Ok(reply) = self.reply_rx.try_recv() {
-            if let Some(row) = self
+            // Entries first: an entry is named after its preset by default
+            // (`llama-cpp`), and the preset's own row never asks for a check
+            // under its id, so a reply carrying that name is the entry's.
+            if self.settle_endpoint_reply(&reply) {
+                landed = true;
+            } else if let Some(row) = self
                 .providers
                 .iter_mut()
                 .find(|r| r.provider.id == reply.provider_id)
@@ -644,6 +665,13 @@ impl Wizard {
             .filter(|r| r.selected)
             .flat_map(|r| r.outcome.models().iter().cloned())
             .collect();
+        let selected = self.selected_endpoint_names();
+        models.extend(
+            self.endpoints
+                .iter()
+                .filter(|e| selected.contains(&e.name))
+                .flat_map(|e| e.model_choices()),
+        );
         models.sort();
         models.dedup();
         models
@@ -655,10 +683,19 @@ impl Wizard {
     /// list and the discovered models can change between visits.
     pub(crate) fn rebuild_defaults(&mut self) {
         let chosen = self.current_default_provider();
+        // The built-ins by id, and an endpoint preset by each entry under it:
+        // the entry's name is what `default_provider` has to hold.
         let providers: Vec<String> = self
             .selected_providers()
             .iter()
-            .map(|i| self.providers[*i].provider.id.to_string())
+            .flat_map(|&i| match self.is_endpoint_preset(i) {
+                true => self
+                    .endpoints_under(self.providers[i].provider.id)
+                    .into_iter()
+                    .map(|e| self.endpoints[e].name.clone())
+                    .collect(),
+                false => vec![self.providers[i].provider.id.to_string()],
+            })
             .collect();
         // Fall back to whatever is configured when nothing is selected, so the
         // field is never empty.
@@ -671,8 +708,13 @@ impl Wizard {
 
         let mut models = vec![Self::NO_DEFAULT_MODEL.to_string()];
         models.extend(self.discovered_models());
+        // An endpoint entry chosen as the default provider brings the model
+        // picked on its own screen, unless a model was already chosen here.
+        let chosen_provider = providers.get(index).cloned().unwrap_or_default();
         let current_model = self
             .current_default_model()
+            .filter(|m| m != Self::NO_DEFAULT_MODEL)
+            .or_else(|| self.endpoint_default_model(&chosen_provider))
             .unwrap_or_else(|| Self::NO_DEFAULT_MODEL.to_string());
         if !models.contains(&current_model) {
             models.push(current_model.clone());
@@ -770,12 +812,22 @@ impl Wizard {
 
     /// What a provider id is, for the chooser's second column.
     fn provider_detail(&self, id: &str) -> String {
-        match self.providers.iter().find(|r| r.provider.id == id) {
-            Some(row) => row.provider.display.to_string(),
-            // A provider that is configured but not in the catalog: it came
-            // from the config file, so it is still a legitimate choice.
-            None => "from your config".to_string(),
+        // Entries before rows: an entry is named after its preset by default,
+        // and the preset row is never itself a choice here.
+        if let Some(entry) = self.endpoints.iter().find(|e| e.name == id) {
+            let preset = self
+                .providers
+                .iter()
+                .find(|r| r.provider.id == entry.preset)
+                .map_or(entry.preset, |r| r.provider.display);
+            return format!("{preset} at {}", entry.base_url);
         }
+        if let Some(row) = self.providers.iter().find(|r| r.provider.id == id) {
+            return row.provider.display.to_string();
+        }
+        // A provider that is configured but not in the catalog: it came
+        // from the config file, so it is still a legitimate choice.
+        "from your config".to_string()
     }
 
     /// Which providers reported a model, so the row says where it came from.
@@ -944,6 +996,9 @@ impl Wizard {
                     row.outcome = Outcome::Skipped;
                 }
             }
+            EditTarget::Endpoint { entry, field } => {
+                self.commit_endpoint_edit(entry, field, edit.line.value());
+            }
             EditTarget::Field(index) => {
                 let Some(fields) = self.fields_mut() else {
                     return;
@@ -974,7 +1029,8 @@ impl Wizard {
 
         for row in &self.providers {
             match row.provider.credential {
-                Credential::None => {}
+                // Written below, from the entries rather than the row.
+                Credential::None | Credential::Endpoint => {}
                 _ if !row.selected => catalog::set_credential(&mut config, row.provider.id, None),
                 // An environment-supplied credential is left out of the file:
                 // the user put it in their environment on purpose, and
@@ -1003,6 +1059,8 @@ impl Wizard {
             config.providers.claude_code_effort =
                 Some(effort_options()[row.effort.min(effort_options().len() - 1)].to_string());
         }
+
+        self.write_endpoints(&mut config);
 
         config.default_provider = self.current_default_provider();
         config.default_model = self

--- a/crates/leviath-cli/src/commands/setup/state/types.rs
+++ b/crates/leviath-cli/src/commands/setup/state/types.rs
@@ -90,8 +90,10 @@ impl ProviderRow {
         match self.provider.credential {
             Credential::ApiKey => !self.value.is_empty() || self.from_env.is_some(),
             // Ollama and the Claude Code transport need no key; selecting them
-            // is the whole configuration, so they are always checkable.
-            Credential::BaseUrl | Credential::None => true,
+            // is the whole configuration, so they are always checkable. An
+            // endpoint preset checks each of its entries, which decide for
+            // themselves.
+            Credential::BaseUrl | Credential::None | Credential::Endpoint => true,
         }
     }
 }
@@ -245,6 +247,13 @@ pub enum EditTarget {
     Credential(usize),
     /// The field at this index of the current step's fields.
     Field(usize),
+    /// A text field of the endpoint entry at this index in `endpoints`.
+    Endpoint {
+        /// Index into `Wizard::endpoints`.
+        entry: usize,
+        /// Which of its fields.
+        field: EndpointField,
+    },
 }
 
 /// An in-progress text edit.

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -101,12 +101,15 @@ pub struct Config {
     #[serde(default)]
     pub model_capabilities: HashMap<String, ModelCapabilityOverride>,
 
-    /// Optional overrides for Rhai *script providers*. Key is the
-    /// provider name an agent references (e.g. `"groq"`). A script activates by
-    /// being referenced + its `.rhai` file existing in the providers dir; an
-    /// entry here only supplies overrides (an API key not read from env, a
-    /// `base_url`, a `rate_limit`, a differently-named `script`, or extra keys
-    /// forwarded to the script's `initialize`).
+    /// Custom providers, keyed by the name an agent references (e.g. `"groq"`).
+    ///
+    /// Without a `kind` an entry is overrides for a Rhai *script provider*: a
+    /// script activates by being referenced + its `.rhai` file existing in the
+    /// providers dir, and the entry only supplies overrides (an API key not
+    /// read from env, a `base_url`, a `rate_limit`, a differently-named
+    /// `script`, or extra keys forwarded to the script's `initialize`). With
+    /// `kind = "openai-compatible"` it is a native provider for the server at
+    /// `base_url`, with no script at all.
     #[serde(default)]
     pub model_providers: HashMap<String, ModelProviderConfig>,
 
@@ -624,6 +627,11 @@ impl Config {
             // fail loudly and immediately.
             for server in &c.mcp_servers {
                 server.validate()?;
+            }
+            // An endpoint with no address is the same kind of mistake, and is
+            // named against its table for the same reason.
+            for (name, provider) in &c.model_providers {
+                provider.validate(name)?;
             }
 
             let path_display = path.display();
@@ -2582,6 +2590,7 @@ google_api_key = "AIza-existing"
                 ),
                 ("region".to_string(), toml::Value::String("eu".to_string())),
             ]),
+            ..Default::default()
         };
         let rendered = format!("{gateway:?}");
         assert!(!rendered.contains("SECRET-VALUE"), "key leaked: {rendered}");
@@ -2596,6 +2605,165 @@ google_api_key = "AIza-existing"
 
         let bare = format!("{:?}", ModelProviderConfig::default());
         assert!(bare.contains("api_key: \"<unset>\""), "{bare}");
+        assert!(bare.contains("kind: Script"), "{bare}");
+    }
+
+    /// An endpoint's headers are where its second credential goes, so the
+    /// debug line names them and never prints them.
+    #[test]
+    fn an_endpoints_header_values_never_reach_the_debug_line() {
+        let endpoint = ModelProviderConfig {
+            kind: Some(ModelProviderKind::OpenaiCompatible),
+            base_url: Some("http://localhost:8080/v1".to_string()),
+            headers: Some(
+                [("X-Api-Key".to_string(), "hdr-SECRET-VALUE".to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+            models: Some(vec!["llama-3".to_string()]),
+            ..Default::default()
+        };
+        let rendered = format!("{endpoint:?}");
+        assert!(
+            !rendered.contains("SECRET-VALUE"),
+            "header leaked: {rendered}"
+        );
+        assert!(rendered.contains("kind: OpenaiCompatible"), "{rendered}");
+        assert!(
+            rendered.contains("header_names: [\"X-Api-Key\"]"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("llama-3"), "{rendered}");
+    }
+
+    /// The kind is spelled the way the file spells it, both ways.
+    #[test]
+    fn a_model_provider_kind_round_trips_through_its_spelling() {
+        for kind in [
+            ModelProviderKind::Script,
+            ModelProviderKind::OpenaiCompatible,
+        ] {
+            assert_eq!(ModelProviderKind::parse(kind.as_str()), Some(kind));
+        }
+        assert_eq!(ModelProviderKind::parse("vllm"), None);
+        assert_eq!(
+            ModelProviderConfig::default().kind(),
+            ModelProviderKind::Script
+        );
+        assert!(!ModelProviderConfig::default().is_endpoint());
+    }
+
+    /// The headers reach a provider constructor as an ordered list.
+    #[test]
+    fn header_pairs_are_listed_in_name_order_and_empty_when_unset() {
+        assert!(ModelProviderConfig::default().header_pairs().is_empty());
+        let endpoint = ModelProviderConfig {
+            headers: Some(
+                [
+                    ("X-Org".to_string(), "research".to_string()),
+                    ("Authorization".to_string(), "Bearer t".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        };
+        assert_eq!(
+            endpoint.header_pairs(),
+            vec![
+                ("Authorization".to_string(), "Bearer t".to_string()),
+                ("X-Org".to_string(), "research".to_string()),
+            ]
+        );
+    }
+
+    /// An endpoint entry parses with every field, and a script entry written
+    /// before `kind` existed still reads as a script.
+    #[test]
+    fn an_endpoint_entry_parses_and_an_old_entry_is_still_a_script() {
+        let content = "\
+[model_providers.llama-cpp]
+kind = \"openai-compatible\"
+base_url = \"http://localhost:8080/v1\"
+models = [\"llama-3\"]
+
+[model_providers.llama-cpp.headers]
+X-Org = \"research\"
+
+[model_providers.groq]
+script = \"groq.rhai\"
+";
+        let config: Config = toml::from_str(content).expect("parses");
+        let llama = &config.model_providers["llama-cpp"];
+        assert!(llama.is_endpoint());
+        assert_eq!(llama.base_url.as_deref(), Some("http://localhost:8080/v1"));
+        assert_eq!(llama.models.as_deref(), Some(&["llama-3".to_string()][..]));
+        assert_eq!(
+            llama.header_pairs(),
+            vec![("X-Org".to_string(), "research".to_string())]
+        );
+        // The endpoint's own keys are read, not swept into `extra`.
+        assert!(llama.extra.is_empty(), "{:?}", llama.extra);
+        assert!(!config.model_providers["groq"].is_endpoint());
+        assert!(
+            Config::unknown_config_keys(content).is_empty(),
+            "every key here is read"
+        );
+
+        // Written back, the script entry carries no `kind` line: a config
+        // that never mentioned it is not rewritten to.
+        let written = toml::to_string_pretty(&config).expect("serializes");
+        assert!(
+            written.contains("kind = \"openai-compatible\""),
+            "{written}"
+        );
+        assert_eq!(written.matches("kind = ").count(), 1, "{written}");
+    }
+
+    /// The two load-time refusals: an endpoint with nowhere to send a request,
+    /// and a kind nothing implements. Both name the entry.
+    #[test]
+    fn an_endpoint_without_a_base_url_or_with_an_unknown_kind_fails_the_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        std::fs::write(
+            &path,
+            "[model_providers.mock]\nkind = \"openai-compatible\"\napi_key = \"k\"\n",
+        )
+        .unwrap();
+        let err = Config::load_from_path(&path).unwrap_err().to_string();
+        assert!(err.contains("[model_providers.mock]"), "{err}");
+        assert!(err.contains("base_url"), "{err}");
+
+        // A blank address is no address.
+        std::fs::write(
+            &path,
+            "[model_providers.mock]\nkind = \"openai-compatible\"\nbase_url = \"  \"\n",
+        )
+        .unwrap();
+        assert!(Config::load_from_path(&path).is_err());
+
+        std::fs::write(
+            &path,
+            "[model_providers.mock]\nkind = \"vllm\"\nbase_url = \"http://h\"\n",
+        )
+        .unwrap();
+        let err = Config::load_from_path(&path).unwrap_err().to_string();
+        assert!(err.contains("unknown variant"), "{err}");
+        assert!(err.contains("openai-compatible"), "{err}");
+
+        // A script entry with no base URL was always fine and still is.
+        std::fs::write(&path, "[model_providers.groq]\nscript = \"groq.rhai\"\n").unwrap();
+        assert!(Config::load_from_path(&path).is_ok());
+        // So is a well-formed endpoint.
+        std::fs::write(
+            &path,
+            "[model_providers.mock]\nkind = \"openai-compatible\"\nbase_url = \"http://h/v1\"\n",
+        )
+        .unwrap();
+        let loaded = Config::load_from_path(&path).expect("loads");
+        assert!(loaded.model_providers["mock"].is_endpoint());
     }
 
     /// Unix-only: the assertion is about POSIX mode bits, which Windows does

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -128,13 +128,56 @@ fn redacted(value: &Option<String>) -> &'static str {
     }
 }
 
-/// Optional overrides for a Rhai script provider, from `[model_providers.<name>]`.
+/// What backs a `[model_providers.<name>]` entry.
 ///
-/// Every field is optional. Keys not recognized below flow into [`Self::extra`]
-/// and are forwarded to the script's `initialize(config)` alongside `base_url`
-/// and `api_key`.
+/// Absent from the file means [`Self::Script`], which is what every entry
+/// written before the field existed is. Spelled out here rather than inferred
+/// from which fields are set, so a config says what it means and a typo in
+/// the value is a load error instead of a silently different provider.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ModelProviderKind {
+    /// A Rhai provider script in `~/.leviath/providers/`.
+    #[default]
+    Script,
+    /// A server speaking OpenAI's chat API, reached natively with no script:
+    /// llama.cpp, vLLM, LM Studio, or a gateway.
+    OpenaiCompatible,
+}
+
+impl ModelProviderKind {
+    /// The spelling the config file uses.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Script => "script",
+            Self::OpenaiCompatible => "openai-compatible",
+        }
+    }
+
+    /// The kind a config file spelling names, if it is one.
+    pub fn parse(text: &str) -> Option<Self> {
+        match text {
+            "script" => Some(Self::Script),
+            "openai-compatible" => Some(Self::OpenaiCompatible),
+            _ => None,
+        }
+    }
+}
+
+/// A `[model_providers.<name>]` entry: a Rhai script provider's overrides, or
+/// an OpenAI-compatible endpoint.
+///
+/// Every field is optional. For a script, keys not recognized below flow into
+/// [`Self::extra`] and are forwarded to the script's `initialize(config)`
+/// alongside `base_url` and `api_key`. For an endpoint, `base_url` is required
+/// and `headers` and `models` are read; `extra` is ignored.
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct ModelProviderConfig {
+    /// What backs the entry. Absent means a script, so every existing config
+    /// reads as it did.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub kind: Option<ModelProviderKind>,
+
     /// Script filename stem or path. Defaults to `<name>.rhai` in the providers
     /// directory (`~/.leviath/providers/`).
     #[serde(default)]
@@ -177,28 +220,99 @@ pub struct ModelProviderConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub serves: Option<Vec<String>>,
 
+    /// Extra headers on every request to an OpenAI-compatible endpoint, as
+    /// `Name = "value"`. A gateway that wants an organisation or routing header
+    /// is the usual reason. Not read for a script.
+    ///
+    /// A `BTreeMap` so the file, the debug line and the API all list them in
+    /// one order.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub headers: Option<std::collections::BTreeMap<String, String>>,
+
+    /// The model ids an OpenAI-compatible endpoint serves, for a server that
+    /// does not answer `GET /models`. Read only when detection fails: a server
+    /// that lists its models is believed over this. Not read for a script.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub models: Option<Vec<String>>,
+
     /// Any additional keys, forwarded verbatim into the script's `initialize`.
     #[serde(flatten)]
     pub extra: HashMap<String, toml::Value>,
 }
 
+impl ModelProviderConfig {
+    /// The kind this entry is, with absent read as a script.
+    pub fn kind(&self) -> ModelProviderKind {
+        self.kind.unwrap_or_default()
+    }
+
+    /// Whether this entry is an OpenAI-compatible endpoint rather than a
+    /// script.
+    pub fn is_endpoint(&self) -> bool {
+        self.kind() == ModelProviderKind::OpenaiCompatible
+    }
+
+    /// What is wrong with this entry, if anything, named against `name`.
+    ///
+    /// Checked at config load rather than at the first inference: an endpoint
+    /// with nowhere to send a request is a config that cannot work, and the
+    /// message should name the table to fix while the file is still in front
+    /// of the person who wrote it.
+    pub fn validate(&self, name: &str) -> anyhow::Result<()> {
+        if self.is_endpoint()
+            && self
+                .base_url
+                .as_deref()
+                .is_none_or(|url| url.trim().is_empty())
+        {
+            anyhow::bail!(
+                "[model_providers.{name}] has kind = \"openai-compatible\" but no \
+                 base_url; set base_url to where the server listens, such as \
+                 \"http://localhost:8080/v1\""
+            );
+        }
+        Ok(())
+    }
+
+    /// The headers as an ordered list, for a provider constructor.
+    pub fn header_pairs(&self) -> Vec<(String, String)> {
+        self.headers
+            .iter()
+            .flatten()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+}
+
 /// Hand-written for the same reason [`ProviderConfig`]'s is, and with one extra
 /// hazard: `extra` is forwarded verbatim into the script's `initialize`, which
 /// is exactly where a second credential goes when a gateway wants one under its
-/// own name. A derived `Debug` would print both `api_key` and every value in
-/// `extra`, so this reports whether the key is set and the *names* in `extra`
-/// and nothing else - the same shape `GatewayInfo` puts on the wire.
+/// own name, and an endpoint's `headers` carry the same thing. A derived `Debug`
+/// would print `api_key` and every value in both, so this reports whether the
+/// key is set and the *names* in `extra` and `headers` and nothing else - the
+/// same shape `GatewayInfo` puts on the wire.
 impl std::fmt::Debug for ModelProviderConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Sorted: a `HashMap` iterates differently between two calls, and a
         // debug line that reorders itself is one nobody can diff.
         let mut extra_keys: Vec<&str> = self.extra.keys().map(String::as_str).collect();
         extra_keys.sort_unstable();
+        // Header values are the same hazard as `extra`: an endpoint's second
+        // credential is a header. Names only, for the same reason.
+        let header_names: Vec<&str> = self
+            .headers
+            .iter()
+            .flatten()
+            .map(|(name, _)| name.as_str())
+            .collect();
         f.debug_struct("ModelProviderConfig")
+            .field("kind", &self.kind())
             .field("script", &self.script)
             .field("api_key", &redacted(&self.api_key))
             .field("base_url", &self.base_url)
             .field("rate_limit", &self.rate_limit)
+            .field("header_names", &header_names)
+            .field("models", &self.models)
             .field("extra_keys", &extra_keys)
             .finish()
     }

--- a/crates/leviath-providers/src/endpoint.rs
+++ b/crates/leviath-providers/src/endpoint.rs
@@ -1,0 +1,794 @@
+//! A provider for any server that speaks the OpenAI chat API.
+//!
+//! llama.cpp, vLLM, LM Studio, LocalAI, and most gateways answer
+//! `POST /chat/completions` and `GET /models` in OpenAI's shape, and until now
+//! reaching one from Leviath meant writing a Rhai provider script for a wire
+//! format this crate already implements twice. This is the third use of
+//! the crate-private OpenAI compatibility module, with nothing vendor-specific on top: no compiled
+//! model table, no pricing, no cache markers, just the request, the stream and
+//! the listing.
+//!
+//! What it knows about a model it learns from the server. `GET /models` fills
+//! the catalogue at priming; a server that will not list (some gateways refuse
+//! the route, llama.cpp before a model is loaded answers an empty list) falls
+//! back to the ids the config named, and with neither it says nothing rather
+//! than guessing, so a blueprint that pins a model on it is never refused.
+
+use crate::learned::{LearnedModel, LearnedModels};
+use crate::openai_compat::{
+    build_openai_request_body, openai_sse_stream, parse_openai_response, send_chat_request,
+    temperature_refused,
+};
+use crate::provider::{
+    InferenceRequest, InferenceResponse, LimitsSource, ModelCapabilities, ModelCapabilityOverride,
+    ModelInfo, Provider, ProviderError, Result, StreamChunk,
+};
+use crate::rate_limit::RateLimiter;
+use async_trait::async_trait;
+use futures_core::Stream;
+use std::collections::HashMap;
+use std::pin::Pin;
+
+/// What an unlisted model is assumed to hold, and what it is assumed to take.
+///
+/// The same conservative window OpenRouter assumes for a model its listing
+/// does not size, for the same reason: `/models` on a compatible server says
+/// which ids exist and nothing about how large they are, and a percentage
+/// region budget has to resolve against some number. The number is reported
+/// as [`LimitsSource::Builtin`] so `lev models` and the API say it is a guess,
+/// and [`EndpointProvider::capabilities`] warns once per model naming the
+/// `[model_capabilities]` entry that replaces it.
+const FALLBACK_CAPABILITIES: ModelCapabilities = ModelCapabilities {
+    supports_temperature: true,
+    supports_streaming: true,
+    supports_tools: true,
+    supports_system_prompt: true,
+    max_context_tokens: 128_000,
+    max_output_tokens: 8_192,
+    limits_source: LimitsSource::Builtin,
+};
+
+/// A provider for one OpenAI-compatible endpoint.
+///
+/// Registered under the name the config gave it, so several can coexist: a
+/// llama.cpp on one port and a vLLM on another are two entries and two of
+/// these, each with its own catalogue.
+pub struct EndpointProvider {
+    /// HTTP client, shared with every other provider on the same timeout.
+    client: reqwest::Client,
+    /// The registry name, which is also what a blueprint writes before the
+    /// slash.
+    name: String,
+    /// Where the server is, without a trailing slash and including any path
+    /// prefix (`http://localhost:8080/v1`).
+    base_url: String,
+    /// Sent as a bearer token when the server wants one. A local server
+    /// usually does not.
+    api_key: Option<String>,
+    /// Extra headers on every request, as the config wrote them.
+    headers: Vec<(String, String)>,
+    /// Client-side rate limit, when the entry set one.
+    rate_limiter: Option<RateLimiter>,
+    /// `[model_capabilities]` entries, merged onto what the server said.
+    capability_overrides: HashMap<String, ModelCapabilityOverride>,
+    /// The ids the config named for a server that cannot list its own.
+    /// `Some` is a complete catalogue; `None` is "the config did not say".
+    configured_models: Option<Vec<String>>,
+    /// Ids a bare model name may route here on, from the entry's `serves`.
+    serves: Vec<String>,
+    /// Models this server has refused a temperature for, so the next request
+    /// omits it instead of paying the round trip again.
+    temperature_unsupported: crate::provider::ModelMemo,
+    /// Models already warned about as falling back to the assumed window.
+    warned_unknown: crate::provider::ModelMemo,
+    /// What `GET /models` said, once priming has read it.
+    learned: LearnedModels,
+}
+
+impl EndpointProvider {
+    /// A provider for the server at `base_url`, registered as `name`.
+    ///
+    /// `api_key` becomes a bearer token when present; `headers` are sent on
+    /// every request after it, so a header the config names wins over the one
+    /// the key would have set.
+    pub fn new(
+        client: reqwest::Client,
+        name: impl Into<String>,
+        base_url: impl Into<String>,
+        api_key: Option<String>,
+        headers: Vec<(String, String)>,
+    ) -> Self {
+        let base_url = base_url.into();
+        Self {
+            client,
+            name: name.into(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key,
+            headers,
+            rate_limiter: None,
+            capability_overrides: HashMap::new(),
+            configured_models: None,
+            serves: Vec::new(),
+            temperature_unsupported: Default::default(),
+            warned_unknown: Default::default(),
+            learned: Default::default(),
+        }
+    }
+
+    /// Merge `[model_capabilities]` entries onto what the server reports.
+    pub fn with_overrides(mut self, overrides: HashMap<String, ModelCapabilityOverride>) -> Self {
+        self.capability_overrides = overrides;
+        self
+    }
+
+    /// Throttle requests client-side. `None` sends them as they come.
+    pub fn with_rate_limit(
+        mut self,
+        rate_limit: Option<&crate::provider::RateLimitConfig>,
+    ) -> Self {
+        self.rate_limiter = rate_limit.map(RateLimiter::new);
+        self
+    }
+
+    /// The ids to report when the server will not list its own.
+    ///
+    /// `Some` is taken as the complete catalogue, so a blueprint naming an id
+    /// outside it is refused the way it would be against a listing. `None`
+    /// leaves the provider unable to say, which refuses nothing.
+    pub fn with_models(mut self, models: Option<Vec<String>>) -> Self {
+        self.configured_models = models;
+        self
+    }
+
+    /// Ids a bare model name (no provider prefix) may resolve here on, over
+    /// and above whatever the listing or `with_models` named.
+    pub fn with_serves(mut self, serves: Vec<String>) -> Self {
+        self.serves = serves;
+        self
+    }
+
+    /// The name this provider is registered under.
+    pub fn provider_name(&self) -> &str {
+        &self.name
+    }
+
+    /// Where requests go.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// The headers every request carries: the bearer token when there is one,
+    /// then the configured extras, then the content type.
+    fn request_headers(&self) -> Vec<(&str, String)> {
+        let mut headers: Vec<(&str, String)> = Vec::with_capacity(self.headers.len() + 2);
+        if let Some(key) = &self.api_key {
+            headers.push(("Authorization", format!("Bearer {key}")));
+        }
+        for (name, value) in &self.headers {
+            headers.push((name.as_str(), value.clone()));
+        }
+        headers.push(("Content-Type", "application/json".to_string()));
+        headers
+    }
+
+    /// The request body, with the temperature dropped for a model that has
+    /// refused one or that the operator marked as taking none.
+    fn build_body(&self, request: &InferenceRequest) -> serde_json::Value {
+        let mut body = build_openai_request_body(request);
+        if !self.capabilities(&request.model).supports_temperature {
+            drop_temperature(&mut body);
+        }
+        body
+    }
+
+    /// POST `/chat/completions`, retrying once without a temperature when the
+    /// server refuses the one it was sent.
+    async fn post_chat(
+        &self,
+        request: &InferenceRequest,
+        mut body: serde_json::Value,
+    ) -> Result<reqwest::Response> {
+        let url = format!("{}/chat/completions", self.base_url);
+        let headers = self.request_headers();
+        let sent = send_chat_request(
+            &self.client,
+            &self.name,
+            &url,
+            &headers,
+            &body,
+            self.rate_limiter.as_ref(),
+            request.request_timeout_secs,
+        )
+        .await;
+        match sent {
+            Err(ProviderError::ApiError(detail)) if temperature_refused(&detail) => {
+                tracing::debug!(
+                    provider = %self.name,
+                    model = %request.model,
+                    "the endpoint refused the temperature we sent; retrying without it"
+                );
+                self.temperature_unsupported.insert(&request.model);
+                drop_temperature(&mut body);
+                send_chat_request(
+                    &self.client,
+                    &self.name,
+                    &url,
+                    &headers,
+                    &body,
+                    self.rate_limiter.as_ref(),
+                    request.request_timeout_secs,
+                )
+                .await
+            }
+            other => other,
+        }
+    }
+
+    /// GET `/models`, as the server answers it.
+    async fn fetch_models_json(&self) -> Result<serde_json::Value> {
+        let mut builder = crate::provider::apply_request_timeout(
+            self.client.get(format!("{}/models", self.base_url)),
+            Some(crate::provider::SIDE_CALL_TIMEOUT_SECS),
+        );
+        for (name, value) in self.request_headers() {
+            builder = builder.header(name, value);
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|e| ProviderError::transport("listing models", &e))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(ProviderError::ApiError(format!(
+                "HTTP {status}: {error_body}"
+            )));
+        }
+        crate::provider::decode_json(response).await
+    }
+
+    /// Say so, once per model, when a model is running on the assumed window.
+    ///
+    /// A listed model is not warned about even though the listing did not
+    /// size it: the server knows the model, and the warning is for a name
+    /// nothing has confirmed.
+    fn warn_if_unknown(&self, model: &str, resolved: &ModelCapabilities) {
+        if resolved.limits_source != LimitsSource::Builtin
+            || self.learned.contains(model)
+            || !self.warned_unknown.insert(model)
+        {
+            return;
+        }
+        let provider = &self.name;
+        tracing::warn!(
+            provider = %provider,
+            model = %model,
+            assumed_context_tokens = FALLBACK_CAPABILITIES.max_context_tokens,
+            "the endpoint's listing does not size this model, so a conservative window \
+             is assumed; percentage region budgets resolve against it. Set the real \
+             window with [model_capabilities.\"{model}\"] max_context_tokens = <n>",
+        );
+    }
+
+    /// The configured fallback as listing rows, for a server that could not
+    /// be asked.
+    fn configured_model_infos(&self) -> Option<Vec<ModelInfo>> {
+        self.configured_models.as_ref().map(|ids| {
+            ids.iter()
+                .map(|id| ModelInfo::new(id.clone(), self.name.clone(), self.capabilities(id)))
+                .collect()
+        })
+    }
+}
+
+/// Take the `temperature` out of a request body.
+///
+/// A body that is not an object is left alone: every caller here builds one,
+/// and dropping a field is not worth a panic.
+fn drop_temperature(body: &mut serde_json::Value) {
+    if let Some(fields) = body.as_object_mut() {
+        fields.remove("temperature");
+    }
+}
+
+/// The ids a `GET /models` body names, with no filtering: a compatible server
+/// lists what it serves and nothing else, so every id is a chat model.
+///
+/// Read into [`LearnedModel`] records so the catalogue is the same shape every
+/// other provider fills. The listing on these servers says nothing reliable
+/// about size or parameters, so every field stays `None` and the table of
+/// operator overrides remains the only source for them.
+pub(crate) fn parse_listing(body: &serde_json::Value) -> Result<HashMap<String, LearnedModel>> {
+    let data = body
+        .get("data")
+        .and_then(|d| d.as_array())
+        .ok_or_else(|| ProviderError::InvalidResponse("Missing 'data' array".to_string()))?;
+    Ok(data
+        .iter()
+        .filter_map(|item| item.get("id")?.as_str().map(str::to_string))
+        .map(|id| (id, LearnedModel::default()))
+        .collect())
+}
+
+#[async_trait]
+impl Provider for EndpointProvider {
+    async fn infer(&self, request: &InferenceRequest) -> Result<InferenceResponse> {
+        tracing::debug!(provider = %self.name, model = %request.model, "calling endpoint");
+
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.acquire().await?;
+        }
+
+        let body = self.build_body(request);
+        let response = self.post_chat(request, body).await?;
+        let response_body: serde_json::Value = crate::provider::decode_json(response).await?;
+        let result = parse_openai_response(&response_body)?;
+
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.record_tokens(result.tokens_used.total_tokens).await;
+        }
+
+        Ok(result)
+    }
+
+    async fn infer_stream(
+        &self,
+        request: &InferenceRequest,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk>> + Send>>> {
+        tracing::debug!(provider = %self.name, model = %request.model, "calling endpoint (streaming)");
+
+        if let Some(limiter) = &self.rate_limiter {
+            limiter.acquire().await?;
+        }
+
+        let mut body = self.build_body(request);
+        crate::openai_compat::make_streaming(&mut body);
+        let response = self.post_chat(request, body).await?;
+
+        Ok(Box::pin(openai_sse_stream(response.bytes_stream())))
+    }
+
+    async fn count_tokens(&self, text: &str, _model: &str) -> usize {
+        // No tokenizer is known for an arbitrary server, and most of them
+        // expose no count route; the local estimate is the honest answer.
+        leviath_core::estimate_tokens(text)
+    }
+
+    fn max_context_tokens(&self, model: &str) -> usize {
+        self.capabilities(model).max_context_tokens
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn capabilities(&self, model: &str) -> ModelCapabilities {
+        let base = self.learned.corrected(model, FALLBACK_CAPABILITIES);
+        let mut caps = match self.capability_overrides.get(model) {
+            Some(o) => o.apply_to(base),
+            None => {
+                self.warn_if_unknown(model, &base);
+                base
+            }
+        };
+        if self.temperature_unsupported.contains(model) {
+            caps.supports_temperature = false;
+        }
+        caps
+    }
+
+    fn serves_model(&self, model_key: &str) -> Option<String> {
+        // The listing first, then the configured fallbacks. Nothing here can
+        // claim a model it has not been told about: an arbitrary server has no
+        // compiled table to guess from, and claiming everything would take
+        // every bare model name away from the providers that do know.
+        self.learned.find_by_key(model_key).or_else(|| {
+            let configured = self.configured_models.iter().flatten();
+            configured
+                .chain(self.serves.iter())
+                .any(|id| id == model_key)
+                .then(|| model_key.to_string())
+        })
+    }
+
+    fn served_catalog(&self) -> Option<Vec<String>> {
+        self.learned
+            .catalog()
+            .or_else(|| self.configured_models.clone())
+    }
+
+    fn pricing(&self, model: &str) -> Option<crate::ModelPricing> {
+        // Only what the operator wrote down. A local server bills nothing and
+        // a gateway's rates are its own business; a guessed zero would make a
+        // run's total look exact when it is not.
+        self.capability_overrides
+            .get(model)
+            .and_then(|o| o.pricing())
+    }
+
+    async fn prime_capabilities(&self) -> Result<()> {
+        let body = self.fetch_models_json().await?;
+        let learned = parse_listing(&body)?;
+        let count = learned.len();
+        self.learned.replace(learned);
+        tracing::debug!(provider = %self.name, models = count, "learned the endpoint's model ids");
+        Ok(())
+    }
+
+    /// The listing, primed on first call; the configured ids when the server
+    /// cannot be asked and the config named some; the error otherwise, so a
+    /// caller can say the endpoint did not answer rather than that it serves
+    /// nothing.
+    async fn list_models(&self) -> Result<Vec<ModelInfo>> {
+        if self.learned.is_empty()
+            && let Err(e) = self.prime_capabilities().await
+        {
+            return match self.configured_model_infos() {
+                Some(configured) => Ok(configured),
+                None => Err(e),
+            };
+        }
+        Ok(self
+            .learned
+            .to_model_infos(&self.name, |id| self.capabilities(id)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::always_on_tracing_guard;
+    use leviath_testkit::{spawn_mock_sequence, spawn_mock_server};
+
+    fn client() -> reqwest::Client {
+        crate::provider::build_http_client(None).expect("a test client builds")
+    }
+
+    fn provider_at(url: &str) -> EndpointProvider {
+        EndpointProvider::new(client(), "local", url, None, Vec::new())
+    }
+
+    fn request(model: &str) -> InferenceRequest {
+        InferenceRequest {
+            system: vec![],
+            messages: vec![crate::provider::Message {
+                role: "user".to_string(),
+                content: "hi".into(),
+                cache_breakpoint: false,
+            }],
+            model: model.to_string(),
+            max_tokens: 100,
+            temperature: 0.2,
+            tools: vec![],
+            extra: serde_json::Value::Null,
+            request_timeout_secs: None,
+        }
+    }
+
+    const OK_BODY: &[u8] = br#"{"choices":[{"message":{"content":"hello"},"finish_reason":"stop"}],"usage":{"prompt_tokens":3,"completion_tokens":2,"total_tokens":5}}"#;
+    const LISTING: &[u8] = br#"{"object":"list","data":[{"id":"gpt-mock","object":"model"},{"id":"local/qwen","object":"model"},{"object":"model"}]}"#;
+
+    // ─── construction ───────────────────────────────────────────────────────
+
+    #[test]
+    fn the_base_url_loses_its_trailing_slash_and_the_name_is_kept() {
+        let provider = EndpointProvider::new(
+            client(),
+            "llama-cpp",
+            "http://localhost:8080/v1/",
+            None,
+            Vec::new(),
+        );
+        assert_eq!(provider.base_url(), "http://localhost:8080/v1");
+        assert_eq!(provider.provider_name(), "llama-cpp");
+        assert_eq!(provider.name(), "llama-cpp");
+    }
+
+    #[test]
+    fn headers_carry_the_key_then_the_extras_then_the_content_type() {
+        let provider = EndpointProvider::new(
+            client(),
+            "gw",
+            "http://h/v1",
+            Some("secret".to_string()),
+            vec![("X-Org".to_string(), "research".to_string())],
+        );
+        let headers = provider.request_headers();
+        assert_eq!(
+            headers,
+            vec![
+                ("Authorization", "Bearer secret".to_string()),
+                ("X-Org", "research".to_string()),
+                ("Content-Type", "application/json".to_string()),
+            ]
+        );
+
+        // No key, no Authorization header at all: a local server that gets
+        // one it did not ask for may reject the request.
+        let plain = provider_at("http://h/v1");
+        let keyless = plain.request_headers();
+        assert_eq!(keyless.len(), 1);
+        assert_eq!(keyless[0].0, "Content-Type");
+    }
+
+    // ─── capabilities ───────────────────────────────────────────────────────
+
+    #[test]
+    fn an_unlisted_model_gets_the_assumed_window_and_warns_once() {
+        let _guard = always_on_tracing_guard();
+        let provider = provider_at("http://h/v1");
+        let caps = provider.capabilities("mystery");
+        assert_eq!(caps, FALLBACK_CAPABILITIES);
+        assert!(caps.supports_tools);
+        assert!(caps.supports_streaming);
+        assert!(caps.supports_temperature);
+        assert_eq!(provider.max_context_tokens("mystery"), 128_000);
+        // The second ask is the same answer and no second warning.
+        provider.capabilities("mystery");
+        assert_eq!(provider.warned_unknown.len(), 1);
+    }
+
+    #[test]
+    fn an_operator_entry_corrects_the_window_and_is_never_warned_about() {
+        let mut overrides = HashMap::new();
+        overrides.insert(
+            "qwen".to_string(),
+            ModelCapabilityOverride {
+                max_context_tokens: Some(32_768),
+                input_per_mtok: Some(0.5),
+                output_per_mtok: Some(1.5),
+                ..Default::default()
+            },
+        );
+        let provider = provider_at("http://h/v1").with_overrides(overrides);
+        let caps = provider.capabilities("qwen");
+        assert_eq!(caps.max_context_tokens, 32_768);
+        assert_eq!(caps.limits_source, LimitsSource::Override);
+        assert!(provider.warned_unknown.is_empty());
+        // Pricing is only what was written down.
+        assert_eq!(
+            provider.pricing("qwen").expect("configured").input_per_mtok,
+            0.5
+        );
+        assert_eq!(provider.pricing("other"), None);
+    }
+
+    #[test]
+    fn a_refused_temperature_outranks_everything() {
+        let provider = provider_at("http://h/v1");
+        provider.temperature_unsupported.insert("m");
+        assert!(!provider.capabilities("m").supports_temperature);
+        // And the body is built without one.
+        let body = provider.build_body(&request("m"));
+        assert!(body.get("temperature").is_none());
+        // A model with no refusal keeps it.
+        let body = provider.build_body(&request("n"));
+        assert_eq!(body["temperature"], 0.2);
+    }
+
+    #[test]
+    fn dropping_the_temperature_leaves_a_non_object_alone() {
+        let mut body = serde_json::json!({"temperature": 0.1, "model": "m"});
+        drop_temperature(&mut body);
+        assert_eq!(body, serde_json::json!({"model": "m"}));
+        let mut text = serde_json::json!("not an object");
+        drop_temperature(&mut text);
+        assert_eq!(text, "not an object");
+    }
+
+    #[tokio::test]
+    async fn token_counting_is_the_local_estimate() {
+        let provider = provider_at("http://h/v1");
+        assert_eq!(
+            provider.count_tokens("twelve chars", "m").await,
+            leviath_core::estimate_tokens("twelve chars")
+        );
+    }
+
+    // ─── catalogue ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn the_listing_is_read_without_filtering_and_skips_rows_with_no_id() {
+        let body: serde_json::Value = serde_json::from_slice(LISTING).unwrap();
+        let learned = parse_listing(&body).unwrap();
+        let mut ids: Vec<&String> = learned.keys().collect();
+        ids.sort();
+        assert_eq!(ids, ["gpt-mock", "local/qwen"]);
+        assert!(learned["gpt-mock"].max_context_tokens.is_none());
+
+        let missing = parse_listing(&serde_json::json!({"object": "list"})).unwrap_err();
+        assert!(missing.to_string().contains("Missing 'data'"), "{missing}");
+    }
+
+    #[tokio::test]
+    async fn priming_fills_the_catalogue_and_routing_answers_from_it() {
+        let _guard = always_on_tracing_guard();
+        let url = spawn_mock_server(200, "OK", LISTING).await;
+        let provider = EndpointProvider::new(
+            client(),
+            "local",
+            url,
+            Some("k".to_string()),
+            vec![("X-Org".to_string(), "r".to_string())],
+        );
+        assert_eq!(provider.served_catalog(), None, "not asked yet");
+        assert_eq!(provider.serves_model("gpt-mock"), None);
+
+        provider.prime_capabilities().await.expect("primed");
+        let mut catalog = provider.served_catalog().expect("listed");
+        catalog.sort();
+        assert_eq!(catalog, ["gpt-mock", "local/qwen"]);
+        assert_eq!(
+            provider.serves_model("gpt-mock").as_deref(),
+            Some("gpt-mock")
+        );
+        // A namespaced id answers for its last segment, like a gateway's.
+        assert_eq!(provider.serves_model("qwen").as_deref(), Some("local/qwen"));
+        assert_eq!(provider.serves_model("nope"), None);
+        // A listed model is not warned about: the endpoint knows it, even if
+        // it did not size it.
+        provider.capabilities("gpt-mock");
+        assert!(provider.warned_unknown.is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_models_primes_on_first_call_and_reports_the_listing() {
+        let url = spawn_mock_server(200, "OK", LISTING).await;
+        let provider = provider_at(&url);
+        let models = provider.list_models().await.expect("listed");
+        let ids: Vec<&str> = models.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, ["gpt-mock", "local/qwen"]);
+        assert!(models.iter().all(|m| m.provider == "local" && m.learned));
+        assert_eq!(models[0].capabilities.limits_source, LimitsSource::Builtin);
+        // The second call is answered from memory: the one-shot server is gone.
+        assert_eq!(provider.list_models().await.expect("cached").len(), 2);
+    }
+
+    #[tokio::test]
+    async fn a_server_that_refuses_the_listing_falls_back_to_the_configured_ids() {
+        let url = spawn_mock_server(404, "Not Found", b"no such route").await;
+        let provider = provider_at(&url).with_models(Some(vec!["llama-3".to_string()]));
+
+        let err = provider.prime_capabilities().await.unwrap_err();
+        assert!(err.to_string().contains("HTTP 404"), "{err}");
+        assert_eq!(provider.served_catalog(), Some(vec!["llama-3".to_string()]));
+        assert_eq!(provider.serves_model("llama-3").as_deref(), Some("llama-3"));
+        assert_eq!(provider.serves_model("other"), None);
+
+        // Nothing was learned, so listing asks again (the one-shot server is
+        // gone, so this is a transport failure) and answers with the config.
+        let models = provider.list_models().await.expect("the configured ids");
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0].id, "llama-3");
+        assert!(!models[0].learned);
+    }
+
+    #[tokio::test]
+    async fn with_neither_a_listing_nor_configured_ids_the_provider_cannot_say() {
+        // Nothing listens on this port.
+        let provider = provider_at("http://127.0.0.1:1");
+        assert_eq!(provider.served_catalog(), None);
+        assert!(provider.list_models().await.is_err());
+        assert_eq!(provider.serves_model("anything"), None);
+    }
+
+    #[tokio::test]
+    async fn a_listing_that_is_not_json_or_has_no_data_is_an_error() {
+        let url = spawn_mock_server(200, "OK", b"not json").await;
+        assert!(provider_at(&url).prime_capabilities().await.is_err());
+        let url = spawn_mock_server(200, "OK", br#"{"models":[]}"#).await;
+        let err = provider_at(&url).prime_capabilities().await.unwrap_err();
+        assert!(err.to_string().contains("Missing 'data'"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_error_body_still_reports_the_status() {
+        let url = leviath_testkit::spawn_mock_server_truncated_body(500, "Internal").await;
+        let err = provider_at(&url).prime_capabilities().await.unwrap_err();
+        assert!(err.to_string().contains("unknown error"), "{err}");
+    }
+
+    #[test]
+    fn serves_routes_a_bare_name_without_widening_the_catalogue() {
+        let provider = provider_at("http://h/v1").with_serves(vec!["mine".to_string()]);
+        assert_eq!(provider.serves_model("mine").as_deref(), Some("mine"));
+        assert_eq!(provider.served_catalog(), None);
+    }
+
+    // ─── inference ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn infer_posts_the_openai_shape_and_parses_the_answer() {
+        let _guard = always_on_tracing_guard();
+        let (url, bodies) = spawn_mock_sequence(vec![(200, "OK", OK_BODY.to_vec())]).await;
+        let provider = EndpointProvider::new(
+            client(),
+            "local",
+            url,
+            None,
+            vec![("X-Org".to_string(), "r".to_string())],
+        )
+        .with_rate_limit(Some(&crate::provider::RateLimitConfig {
+            requests_per_minute: 60,
+            tokens_per_minute: 100_000,
+        }));
+        let response = provider
+            .infer(&request("gpt-mock"))
+            .await
+            .expect("answered");
+        assert_eq!(response.content, "hello");
+        assert_eq!(response.tokens_used.total_tokens, 5);
+
+        let sent: serde_json::Value =
+            serde_json::from_str(&bodies.lock().unwrap()[0]).expect("a JSON body was sent");
+        assert_eq!(sent["model"], "gpt-mock");
+        assert_eq!(sent["max_tokens"], 100);
+        assert_eq!(sent["temperature"], 0.2);
+        assert_eq!(sent["messages"][0]["content"], "hi");
+    }
+
+    #[tokio::test]
+    async fn a_refused_temperature_is_retried_without_one_and_remembered() {
+        let _guard = always_on_tracing_guard();
+        let refusal = br#"{"error":{"message":"Unsupported value: 'temperature' does not support 0.2 with this model.","type":"invalid_request_error","param":"temperature","code":"unsupported_value"}}"#;
+        let (url, bodies) = spawn_mock_sequence(vec![
+            (400, "Bad Request", refusal.to_vec()),
+            (200, "OK", OK_BODY.to_vec()),
+            (200, "OK", OK_BODY.to_vec()),
+        ])
+        .await;
+        let provider = provider_at(&url);
+        provider.infer(&request("strict")).await.expect("retried");
+        // A second inference for the same model omits it up front.
+        provider.infer(&request("strict")).await.expect("answered");
+
+        let sent = bodies.lock().unwrap();
+        assert_eq!(sent.len(), 3);
+        assert!(sent[0].contains("temperature"));
+        assert!(!sent[1].contains("temperature"));
+        assert!(!sent[2].contains("temperature"));
+        assert!(!provider.capabilities("strict").supports_temperature);
+    }
+
+    #[tokio::test]
+    async fn an_ordinary_refusal_is_returned_as_it_came() {
+        let url = spawn_mock_server(500, "Internal Server Error", b"boom").await;
+        let err = provider_at(&url).infer(&request("m")).await.unwrap_err();
+        assert!(err.to_string().contains("boom"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn a_body_that_is_not_json_is_an_invalid_response() {
+        let url = spawn_mock_server(200, "OK", b"not json").await;
+        let err = provider_at(&url).infer(&request("m")).await.unwrap_err();
+        assert!(err.to_string().contains("Invalid response"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn streaming_frames_the_servers_events() {
+        let _guard = always_on_tracing_guard();
+        let sse = b"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\ndata: [DONE]\n\n";
+        let url = spawn_mock_server(200, "OK", sse).await;
+        let provider = provider_at(&url).with_rate_limit(Some(&crate::provider::RateLimitConfig {
+            requests_per_minute: 60,
+            tokens_per_minute: 100_000,
+        }));
+        let mut stream = provider
+            .infer_stream(&request("m"))
+            .await
+            .expect("streaming");
+        use tokio_stream::StreamExt;
+        let first = stream.next().await.expect("a chunk").expect("ok");
+        assert_eq!(first.delta, "hi");
+    }
+
+    #[tokio::test]
+    async fn a_streaming_refusal_is_an_error_before_any_chunk() {
+        let url = spawn_mock_server(503, "Service Unavailable", b"down").await;
+        assert!(provider_at(&url).infer_stream(&request("m")).await.is_err());
+    }
+}

--- a/crates/leviath-providers/src/lib.rs
+++ b/crates/leviath-providers/src/lib.rs
@@ -15,6 +15,7 @@ pub mod capabilities;
 pub mod claude_code;
 #[cfg(feature = "debug-http")]
 pub(crate) mod debug_http;
+pub mod endpoint;
 pub mod failure;
 pub mod gemini;
 pub mod learned;
@@ -35,6 +36,7 @@ mod test_support;
 pub use anthropic::AnthropicProvider;
 pub use capabilities::{LimitsSource, ModelCapabilities, ModelCapabilityOverride};
 pub use claude_code::ClaudeCodeProvider;
+pub use endpoint::EndpointProvider;
 pub use gemini::GeminiProvider;
 pub use learned::{LearnedModel, LearnedModels};
 pub use ollama::OllamaProvider;

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -34,11 +34,86 @@ pub struct ProviderCreds {
     pub rate_limit: Option<leviath_providers::RateLimitConfig>,
     /// Provider-specific settings that don't fit the api-key / base-URL shape.
     ///
-    /// Currently only `claude-code` reads this, for `binary` (path to the
-    /// `claude` executable) and `effort` (reasoning level). Kept as a map rather
-    /// than named fields so one provider's options don't accrete onto a struct
-    /// shared by six.
+    /// `claude-code` reads `binary` (path to the `claude` executable) and
+    /// `effort` (reasoning level). An OpenAI-compatible endpoint is marked by
+    /// `kind` and carries its headers and model list here too; see
+    /// [`Self::openai_compatible`] and [`EndpointSpec`], which are the only
+    /// two places that spell those keys. Kept as a map rather than named
+    /// fields so one provider's options don't accrete onto a struct shared by
+    /// seven.
     pub options: std::collections::HashMap<String, String>,
+}
+
+/// The `options` key that marks an entry as an OpenAI-compatible endpoint.
+const KIND_OPTION: &str = "kind";
+/// The `kind` value for one.
+const OPENAI_COMPATIBLE: &str = "openai-compatible";
+/// The `options` key prefix a request header travels under: `header:0:X-Org`.
+const HEADER_PREFIX: &str = "header:";
+/// The `options` key holding the configured model ids, as a JSON array.
+const MODELS_OPTION: &str = "models";
+/// The `options` key holding the `serves` routing hints, as a JSON array.
+const SERVES_OPTION: &str = "serves";
+
+/// What [`build_provider_registry`] needs to build an
+/// [`leviath_providers::EndpointProvider`], read back out of a
+/// [`ProviderCreds`] made by [`ProviderCreds::openai_compatible`].
+///
+/// A struct rather than five loose reads so the encoding is written once
+/// there and read once in [`Self::from_creds`], and nothing else has to know
+/// how a header is spelled in the options map.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EndpointSpec {
+    /// Where the server listens, including any path prefix.
+    pub base_url: String,
+    /// Extra headers on every request, in the order the config listed them.
+    pub headers: Vec<(String, String)>,
+    /// The ids to fall back to when the server will not list. `None` when the
+    /// config named none.
+    pub models: Option<Vec<String>>,
+    /// Ids a bare model name may route here on.
+    pub serves: Vec<String>,
+}
+
+impl EndpointSpec {
+    /// The endpoint `creds` describes, or `None` when it is not one.
+    ///
+    /// An endpoint with no base URL is not an endpoint: the config layer
+    /// refuses to load one, so this is a second guard rather than the first.
+    pub fn from_creds(creds: &ProviderCreds) -> Option<Self> {
+        if creds.options.get(KIND_OPTION).map(String::as_str) != Some(OPENAI_COMPATIBLE) {
+            return None;
+        }
+        let base_url = creds.base_url.clone()?;
+        // Sorted by the position the encoder stamped, so the config's own
+        // order is what the wire sees whatever order the map iterates in.
+        let mut headers: Vec<(usize, String, String)> = creds
+            .options
+            .iter()
+            .filter_map(|(key, value)| {
+                let rest = key.strip_prefix(HEADER_PREFIX)?;
+                let (position, name) = rest.split_once(':')?;
+                Some((position.parse().ok()?, name.to_string(), value.clone()))
+            })
+            .collect();
+        headers.sort();
+        Some(Self {
+            base_url,
+            headers: headers
+                .into_iter()
+                .map(|(_, name, value)| (name, value))
+                .collect(),
+            models: creds
+                .options
+                .get(MODELS_OPTION)
+                .and_then(|json| serde_json::from_str(json).ok()),
+            serves: creds
+                .options
+                .get(SERVES_OPTION)
+                .and_then(|json| serde_json::from_str(json).ok())
+                .unwrap_or_default(),
+        })
+    }
 }
 
 /// Hand-written so the API key can never reach a log line.
@@ -48,6 +123,18 @@ pub struct ProviderCreds {
 /// Nothing did, which is when it is cheap to make impossible.
 impl std::fmt::Debug for ProviderCreds {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // A header value is a credential as often as not (`X-Api-Key`), so
+        // the options map is printed with those values replaced. Sorted so
+        // two lines from one struct read the same.
+        let mut options: Vec<(&str, &str)> = self
+            .options
+            .iter()
+            .map(|(key, value)| match key.starts_with(HEADER_PREFIX) {
+                true => (key.as_str(), "<set>"),
+                false => (key.as_str(), value.as_str()),
+            })
+            .collect();
+        options.sort_unstable();
         f.debug_struct("ProviderCreds")
             .field("name", &self.name)
             .field(
@@ -61,7 +148,7 @@ impl std::fmt::Debug for ProviderCreds {
             .field("model_capabilities", &self.model_capabilities)
             .field("request_timeout_secs", &self.request_timeout_secs)
             .field("rate_limit", &self.rate_limit)
-            .field("options", &self.options)
+            .field("options", &options)
             .finish()
     }
 }
@@ -77,6 +164,49 @@ impl ProviderCreds {
             request_timeout_secs: None,
             rate_limit: None,
             options: std::collections::HashMap::new(),
+        }
+    }
+
+    /// A cred entry for an OpenAI-compatible endpoint registered as `name`.
+    ///
+    /// Everything an [`leviath_providers::EndpointProvider`] needs travels in
+    /// the fields every other provider already has, plus the options map:
+    /// the kind marker, one `header:<n>:<name>` entry per header (numbered so
+    /// the config's order survives a `HashMap`), and the model lists as JSON.
+    /// [`EndpointSpec::from_creds`] reads it back.
+    pub fn openai_compatible(
+        name: impl Into<String>,
+        base_url: impl Into<String>,
+        api_key: Option<String>,
+        headers: Vec<(String, String)>,
+        models: Option<Vec<String>>,
+        serves: Vec<String>,
+    ) -> Self {
+        let mut options = std::collections::HashMap::new();
+        options.insert(KIND_OPTION.to_string(), OPENAI_COMPATIBLE.to_string());
+        for (position, (header, value)) in headers.into_iter().enumerate() {
+            options.insert(format!("{HEADER_PREFIX}{position}:{header}"), value);
+        }
+        if let Some(models) = models {
+            options.insert(
+                MODELS_OPTION.to_string(),
+                serde_json::to_string(&models).expect("a list of strings is JSON"),
+            );
+        }
+        if !serves.is_empty() {
+            options.insert(
+                SERVES_OPTION.to_string(),
+                serde_json::to_string(&serves).expect("a list of strings is JSON"),
+            );
+        }
+        Self {
+            name: name.into(),
+            api_key,
+            base_url: Some(base_url.into()),
+            model_capabilities: std::collections::HashMap::new(),
+            request_timeout_secs: None,
+            rate_limit: None,
+            options,
         }
     }
 }
@@ -215,6 +345,28 @@ pub fn build_provider_registry_probing(
     for c in creds {
         let caps = c.model_capabilities.clone();
         let timeout = c.request_timeout_secs;
+        // Decided by kind before the name is looked at: an endpoint is
+        // registered under whatever name the config gave it, and that name is
+        // the user's to choose.
+        if let Some(endpoint) = EndpointSpec::from_creds(c) {
+            registry.register(
+                c.name.clone(),
+                Arc::new(
+                    leviath_providers::EndpointProvider::new(
+                        clients.get_or_build(timeout, build_client)?,
+                        c.name.clone(),
+                        endpoint.base_url,
+                        c.api_key.clone(),
+                        endpoint.headers,
+                    )
+                    .with_overrides(caps)
+                    .with_rate_limit(c.rate_limit.as_ref())
+                    .with_models(endpoint.models)
+                    .with_serves(endpoint.serves),
+                ),
+            );
+            continue;
+        }
         match c.name.as_str() {
             "anthropic" => {
                 if let Some(ref key) = c.api_key {
@@ -385,6 +537,127 @@ mod tests {
         // A provider that needs no key says so rather than claiming one.
         let keyless = format!("{:?}", ProviderCreds::simple("ollama"));
         assert!(keyless.contains("<unset>"), "{keyless}");
+    }
+
+    /// The options map is the only place an endpoint's extras travel, so the
+    /// encoder and the decoder have to agree on every key, including the
+    /// order headers come back in.
+    #[test]
+    fn an_endpoint_cred_round_trips_through_the_options_map() {
+        let creds = ProviderCreds::openai_compatible(
+            "vllm",
+            "http://localhost:8000/v1",
+            Some("k".to_string()),
+            vec![
+                ("X-Org".to_string(), "research".to_string()),
+                ("Accept".to_string(), "application/json".to_string()),
+            ],
+            Some(vec!["llama-3".to_string()]),
+            vec!["llama".to_string()],
+        );
+        let spec = EndpointSpec::from_creds(&creds).expect("an endpoint");
+        assert_eq!(
+            spec,
+            EndpointSpec {
+                base_url: "http://localhost:8000/v1".to_string(),
+                headers: vec![
+                    ("X-Org".to_string(), "research".to_string()),
+                    ("Accept".to_string(), "application/json".to_string()),
+                ],
+                models: Some(vec!["llama-3".to_string()]),
+                serves: vec!["llama".to_string()],
+            }
+        );
+
+        // Nothing configured stays nothing rather than becoming an empty list.
+        let bare = ProviderCreds::openai_compatible("x", "http://h", None, vec![], None, vec![]);
+        let spec = EndpointSpec::from_creds(&bare).expect("an endpoint");
+        assert_eq!(spec.models, None);
+        assert!(spec.serves.is_empty());
+        assert!(spec.headers.is_empty());
+    }
+
+    /// Not an endpoint: a native provider, an endpoint that lost its address,
+    /// and options written by hand that do not decode.
+    #[test]
+    fn a_cred_that_is_not_an_endpoint_yields_no_spec() {
+        assert_eq!(
+            EndpointSpec::from_creds(&ProviderCreds::simple("anthropic")),
+            None
+        );
+
+        let mut no_url =
+            ProviderCreds::openai_compatible("x", "http://h", None, vec![], None, vec![]);
+        no_url.base_url = None;
+        assert_eq!(EndpointSpec::from_creds(&no_url), None);
+
+        let mut odd = ProviderCreds::openai_compatible("x", "http://h", None, vec![], None, vec![]);
+        odd.options
+            .insert("header:X-No-Position".to_string(), "v".to_string());
+        odd.options
+            .insert("header:notanumber:X-Bad".to_string(), "v".to_string());
+        odd.options
+            .insert("models".to_string(), "not json".to_string());
+        odd.options.insert("serves".to_string(), "[".to_string());
+        let spec = EndpointSpec::from_creds(&odd).expect("still an endpoint");
+        assert!(spec.headers.is_empty());
+        assert_eq!(spec.models, None);
+        assert!(spec.serves.is_empty());
+    }
+
+    /// A header value is a credential as often as not.
+    #[test]
+    fn debug_output_never_contains_a_header_value() {
+        let creds = ProviderCreds::openai_compatible(
+            "gw",
+            "http://h/v1",
+            None,
+            vec![("X-Api-Key".to_string(), "hdr-SECRET-VALUE".to_string())],
+            None,
+            vec![],
+        );
+        let rendered = format!("{creds:?}");
+        assert!(
+            !rendered.contains("SECRET-VALUE"),
+            "header leaked: {rendered}"
+        );
+        assert!(rendered.contains("header:0:X-Api-Key"), "{rendered}");
+        assert!(rendered.contains("openai-compatible"), "{rendered}");
+    }
+
+    /// An endpoint registers under its own name, whatever that name is, and
+    /// carries its rate limit and overrides.
+    #[test]
+    fn an_endpoint_cred_registers_a_native_provider_under_its_name() {
+        let mut creds = ProviderCreds::openai_compatible(
+            "mock",
+            "http://127.0.0.1:1/v1",
+            None,
+            vec![],
+            Some(vec!["gpt-mock".to_string()]),
+            vec![],
+        );
+        creds.rate_limit = Some(leviath_providers::RateLimitConfig {
+            requests_per_minute: 10,
+            tokens_per_minute: 1000,
+        });
+        creds.model_capabilities.insert(
+            "gpt-mock".to_string(),
+            leviath_providers::ModelCapabilityOverride {
+                max_context_tokens: Some(4096),
+                ..Default::default()
+            },
+        );
+        let registry = build_provider_registry(&[creds]).expect("an HTTPS client builds in tests");
+        let provider = registry.get("mock").expect("registered");
+        assert_eq!(provider.name(), "mock");
+        assert_eq!(provider.max_context_tokens("gpt-mock"), 4096);
+        assert_eq!(
+            provider.served_catalog(),
+            Some(vec!["gpt-mock".to_string()])
+        );
+        // Nothing else was registered under a built-in name by accident.
+        assert!(!registry.has("openai"));
     }
 
     #[test]
@@ -610,9 +883,14 @@ mod tests {
         // One case per branch that needs a client. A single provider would leave
         // the other arms' error paths unproven, which is exactly the hole this
         // seam exists to close.
-        for name in ["anthropic", "openai", "google", "openrouter", "ollama"] {
+        let endpoint =
+            ProviderCreds::openai_compatible("mock", "http://h/v1", None, vec![], None, vec![]);
+        let keyed = ["anthropic", "openai", "google", "openrouter", "ollama"].map(|name| {
             let mut cred = ProviderCreds::simple(name);
             cred.api_key = Some("k".to_string());
+            cred
+        });
+        for cred in keyed.into_iter().chain([endpoint]) {
             // Ollama's arm is only reached when something answers at its
             // address, so the probe is injected rather than left to depend on
             // whether the machine running the suite has Ollama up. It does not

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -911,7 +911,9 @@ than that feature, not broken.
 | `scripts.read` | The `GET` half of the scripts routes |
 | `scripts.write` | That this build serves the write half. Whether *this* daemon mounts it is `--allow-admin`, which you find out by calling one and reading the status |
 | `scripts.providers` | `provider` as a fifth script `kind`, the machine's drop-in model providers |
-| `config.gateways` | `gateways` on `GET /api/config`, the script-backed providers this machine has |
+| `config.gateways` | `gateways` on `GET /api/config`, the custom providers this machine has |
+| `config.gateways.kinds` | `kind`, `header_names` and `models` on each gateway, and `kind`, `headers` and `models` accepted by `PUT /api/config`: a gateway can be an OpenAI-compatible endpoint rather than a script |
+| `models.probe` | `POST /api/models/probe`, which asks an OpenAI-compatible server what it serves before a gateway for it is written; admin only |
 | `fs.mkdir` | `POST /api/fs/dirs`, so a folder picker can offer "New Folder" rather than one that 404s |
 
 ## Live updates over WebSocket

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -50,6 +50,7 @@ a test, so a client generator or an agent can consume the contract directly.
   | `POST /api/mcp/servers` | 405, because `GET /api/mcp/servers` is mounted |
   | `DELETE /api/mcp/servers/{name}` | 404, because nothing else is mounted on that path |
   | `POST /api/update` | 405, because `GET /api/update` is mounted |
+  | `POST /api/models/probe` | 404, because nothing else is mounted on that path |
 - **`--workdir-root`** confines agent workdirs; **`--no-remote-yolo`** forbids `"yolo": true` and
   `"allow": [...]` on spawn, which are one lever rather than two.
 
@@ -176,7 +177,8 @@ Base path `/api`; all JSON unless noted.
 | `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question |
 | `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q`; the detail carries the manifest, the regions and the [fan-out limits](#fan-out-limits) |
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
-| `GET /api/models` | Enumerate models, with each one's token limits and where they came from |
+| `GET /api/models` | Enumerate models, with each one's token limits and where they came from. An OpenAI-compatible gateway's detected models are listed under the gateway's name |
+| `POST /api/models/probe` *(admin)* | Ask an OpenAI-compatible server what it serves before writing a gateway for it: `{"base_url", "api_key"?, "headers"?}` → `{"models": [ids]}`, or 502 carrying the server's own error text. See [below](#gateways) |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
 | `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. Writes need admin. See [below](#tools-and-scripts) |
 | `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` *(admin)* · `POST /{name}/test` *(admin)* | MCP servers. Add, remove, login and test need admin: each connects to a server, opens a browser, or spawns a command |
@@ -824,6 +826,28 @@ without an `agent`, since the answer is the same either way.
 
 Each listed provider carries a `provider` object with what its leading `// @` comments declare:
 `description`, `default_model`, `max_context_tokens`, `max_output_tokens` and `supports_streaming`.
+
+## Gateways
+
+`gateways` on `GET /api/config` lists every `[model_providers.<name>]` entry, name-sorted, and
+each one says what backs it: `kind` is `script` for a Rhai provider or `openai-compatible` for a
+server that speaks OpenAI's chat API. Beside `name`, `base_url`, `has_api_key` and `script`, an
+endpoint reports `header_names` (the names of its extra headers, never their values, because a
+header is where a second credential goes) and `models`, the ids it falls back to when its server
+will not list them. `extra_keys` names a script's forwarded keys the same way.
+
+`PUT /api/config` takes the same fields on each gateway in `gateways`: `kind`, `base_url`,
+`api_key`, `script`, `headers` (a name-to-value map) and `models`. Every field is optional and an
+absent one leaves what the entry already had, so a console can edit a URL without knowing the
+key or sending the headers back. An unknown `kind`, or an `openai-compatible` gateway with no
+`base_url`, is refused with a 400 and nothing is written.
+
+`POST /api/models/probe` is for the form before the write: it sends `GET /models` to `base_url`
+with the given `api_key` and `headers`, exactly as the gateway would, and answers
+`{"models": [ids]}` sorted. A server that refuses or does not answer is a 502 whose `error` is the
+server's own text, and a `base_url` with no scheme is a 400. It is mounted only with
+`--allow-admin`, like the write it precedes: it makes the serving host open a connection to any
+address the caller names.
 
 Each entry from `GET /api/models` also carries `limits_source`: `api` when the provider reported the
 token limits itself, `builtin` when this build matched them off the model's name, and `override`

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -734,6 +734,20 @@ nothing about what gets written.
 lev setup --non-interactive --anthropic-key sk-ant-... --install-agents
 ```
 
+The provider list ends with three entries for servers that speak OpenAI's chat API, and picking
+any of them writes a [`kind = "openai-compatible"`](/docs/configuration#openai-compatible-endpoints)
+entry rather than a key. **llama.cpp** and **LM Studio** are presets: each starts at its server's
+default address (`http://localhost:8080/v1` and `http://localhost:1234/v1`) with no key, and is
+written as `llama-cpp` or `lm-studio`. **Custom OpenAI-compatible endpoint** asks for a name, a
+base URL, an optional key and optional headers (`Name: value`, several separated by semicolons).
+All three repeat: the credential screen for a preset is a small form per endpoint with **Add
+another** at the end and **Remove this endpoint** on each, so two llama.cpp servers on two ports
+are two entries. **Check this endpoint** asks the server for its models; on success they are
+listed and the **Default model** row cycles through them, and on failure the entry is kept and the
+**Models** row takes the ids by hand, which is what the entry's `models` list is. Every endpoint
+appears in the default-provider choice by its own name. These entries have no flags; script them
+by writing `config.toml`.
+
 > [!NOTE]
 > The bundled agents are **not** installed unless `--install-agents` is passed in non-interactive
 > mode. That is deliberate, so a scripted setup does not write blueprints you did not ask for.

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -741,8 +741,11 @@ the line that fixes it.
 
 ## `[model_providers.<name>]`
 
-Optional overrides for a [Rhai script provider](/docs/rhai-providers). A script activates by being
-referenced and existing in `~/.leviath/providers/`; this table only supplies extras.
+A custom provider, keyed by the name a blueprint writes before the slash. Without a `kind` the
+entry is overrides for a [Rhai script provider](/docs/rhai-providers): a script activates by being
+referenced and existing in `~/.leviath/providers/`, and this table only supplies extras. With
+`kind = "openai-compatible"` it is a native provider for a server that speaks OpenAI's chat API,
+described in [its own section](#openai-compatible-endpoints) below.
 
 ```toml
 [model_providers.groq]
@@ -768,6 +771,68 @@ serves = ["deepseek-v4-flash"]
 Only needed by a script with no `list_models`; one that has it is asked directly and its answer
 wins. A provider that reports neither claims no models and can only be reached by a blueprint that
 pins it. See [preferring a script provider](/docs/providers#preferring-a-script-provider).
+
+## OpenAI-compatible endpoints
+
+A `[model_providers.<name>]` entry with `kind = "openai-compatible"` reaches any server that
+answers `POST /chat/completions` and `GET /models` in OpenAI's shape, with no script to write:
+llama.cpp, LM Studio, vLLM, BionicGPT, and any OpenAI-compatible gateway. llama.cpp and LM Studio
+are presets in `lev setup`; the rest go through the wizard's **Custom OpenAI-compatible endpoint**
+entry, or straight into the file.
+
+```toml
+default_provider = "llama-cpp"
+default_model    = "qwen3-8b"
+
+[providers]
+anthropic_api_key = "sk-ant-..."
+
+[model_providers.llama-cpp]
+kind     = "openai-compatible"
+base_url = "http://localhost:8080/v1"
+
+[model_providers.llama-cpp-big]
+kind     = "openai-compatible"
+base_url = "http://192.168.1.20:8080/v1"
+api_key  = "..."                   # optional; sent as a bearer token
+headers  = { "X-Org" = "research" }  # optional; extra headers on every request
+```
+
+This is three providers: two llama.cpp servers under their own names, and Anthropic. A blueprint
+reaches a model on one of them as `llama-cpp/qwen3-8b` or `llama-cpp-big/llama-3-70b`, and the
+`default_provider` above sends every stage that allows a user default to the first. `base_url` is
+required and includes the path prefix the server expects, usually `/v1`. Each entry may also carry
+`rate_limit` and `serves`, which mean what they mean for a script provider.
+
+Streaming and tool calls are on. Each request carries the temperature the stage asks for, and a
+server that refuses one is asked again without it and remembered for the rest of the process.
+
+**Detection.** At start-up Leviath asks each endpoint `GET /models` and uses the ids it lists,
+with no filtering: `lev models list --provider llama-cpp` and `GET /api/models` show them, and the
+wizard offers them as the default model. A server that refuses the route or does not answer falls
+back to the ids named in `models`:
+
+```toml
+[model_providers.gateway]
+kind     = "openai-compatible"
+base_url = "https://llm.example.com/v1"
+models   = ["mixtral-8x22b", "llama-3-70b"]
+```
+
+`models` is read only when detection fails; a server that lists its models is believed over it.
+With neither a listing nor a `models` list the provider does not say what it serves, and a
+blueprint that pins a model on it is sent through rather than refused.
+
+**Windows and cost.** A `/models` listing says nothing reliable about context windows, so an
+endpoint's models are assumed to hold 128 000 tokens until a
+[`[model_capabilities]`](#model_capabilitiesmodel_id) entry names the real figure; `lev models
+show <model>` reports which it is. Token counts are the local estimate, and cost is reported as
+unknown unless the same entry sets a price.
+
+Ollama keeps its own native provider ([`[providers] ollama_base_url`](#providers)) rather than
+going through this kind, because Leviath reads a model's context window and tool support from
+Ollama's `/api/show`, which the OpenAI-style shim does not report. Pointing an
+`openai-compatible` entry at Ollama works, but loses that.
 
 ## `[[mcp_servers]]`
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -384,8 +384,16 @@ tokens_per_minute   = 100000
 
 ## Custom OpenAI-compatible providers
 
-Point Leviath at any OpenAI-compatible endpoint with a small Rhai script.
-[Rhai providers](/docs/rhai-providers) walks through a complete Groq provider.
+Any server that speaks OpenAI's chat API is a provider with three lines of config and no script:
+a `[model_providers.<name>]` entry with `kind = "openai-compatible"` and a `base_url`, plus an
+`api_key` or `headers` if the server wants them. That covers llama.cpp, LM Studio, vLLM,
+BionicGPT and most gateways; Leviath asks the server what models it serves and falls back to a
+`models` list you write when it will not say. `lev setup` offers llama.cpp and LM Studio as
+presets and a custom entry for the rest. The details, the detection rules and a two-server
+example are in [OpenAI-compatible endpoints](/docs/configuration#openai-compatible-endpoints).
+
+A server that needs more than the OpenAI shape, or a different one altogether, is a small Rhai
+script instead. [Rhai providers](/docs/rhai-providers) walks through a complete Groq provider.
 
 ## Claude Code transport
 

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -166,6 +166,18 @@ base_url = "https://api.groq.com/openai/v1"
 requests_per_minute = 30
 tokens_per_minute = 60000
 
+# A server that speaks OpenAI's chat API needs no script: llama.cpp, LM Studio,
+# vLLM, BionicGPT or a gateway. base_url is required; api_key, headers and
+# models are optional. models is read only when GET /models fails.
+# [model_providers.llama-cpp]
+# kind = "openai-compatible"
+# base_url = "http://localhost:8080/v1"
+# api_key = "..."
+# models = ["qwen3-8b"]
+#
+# [model_providers.llama-cpp.headers]
+# X-Org = "research"
+
 [[mcp_servers]]
 name = "filesystem"
 transport = "stdio"

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -583,11 +583,18 @@
     },
     "model_providers": {
       "type": "object",
-      "description": "Overrides for Rhai script providers, keyed by the name an agent references. Any key not listed here is forwarded verbatim to the script's initialize().",
+      "description": "Custom providers, keyed by the name an agent references. Without a kind, overrides for a Rhai script provider (any key not listed here is forwarded verbatim to the script's initialize()); with kind = \"openai-compatible\", a native provider for the server at base_url.",
       "additionalProperties": {
         "type": "object",
         "additionalProperties": true,
         "properties": {
+          "kind": {
+            "enum": [
+              "script",
+              "openai-compatible"
+            ],
+            "description": "What backs the entry. Absent means script. openai-compatible requires base_url."
+          },
           "script": {
             "type": "string"
           },
@@ -596,6 +603,27 @@
           },
           "base_url": {
             "type": "string"
+          },
+          "headers": {
+            "type": "object",
+            "description": "Extra headers on every request to an openai-compatible endpoint.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "models": {
+            "type": "array",
+            "description": "Model ids an openai-compatible endpoint serves, read only when GET /models fails.",
+            "items": {
+              "type": "string"
+            }
+          },
+          "serves": {
+            "type": "array",
+            "description": "Model ids a bare model name may resolve to this provider on.",
+            "items": {
+              "type": "string"
+            }
           },
           "rate_limit": {
             "type": "object",

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1262,6 +1262,26 @@
         }
       }
     },
+    "/api/models/probe": {
+      "post": {
+        "tags": [
+          "config"
+        ],
+        "summary": "Ask an OpenAI-compatible server what models it serves",
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed. Body: `base_url` (required), `api_key`, `headers`. Answers `{\"models\": [ids]}`, or 502 carrying the server's own error text, or 400 for a base URL with no scheme.",
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "502": {
+            "$ref": "#/components/responses/BadGateway"
+          }
+        }
+      }
+    },
     "/ws": {
       "get": {
         "tags": [


### PR DESCRIPTION
Approved feature: any OpenAI-compatible server (llama.cpp, LM Studio, vLLM, BionicGPT, a gateway) as a first-class provider, with model detection, from `lev setup` and from the HTTP API. Five commits, one per layer.

## Config

```toml
[model_providers.llama-cpp]
kind     = "openai-compatible"          # absent = today's script provider, unchanged
base_url = "http://localhost:8080/v1"   # required for this kind
api_key  = "..."                        # optional
headers  = { "X-Org" = "research" }     # optional
models   = ["qwen3-8b"]                 # optional; used only when GET /models fails
```

A blueprint names it like any provider (`provider = "llama-cpp"`). An endpoint with no `base_url`, or an unknown `kind`, fails the config load naming the entry. Existing files write back byte for byte (every new field is `skip_serializing_if` none).

## Provider

`leviath_providers::EndpointProvider` over the existing `openai_compat` client: chat, streaming, tools, bearer key plus custom headers, temperature with a one-shot retry without it on refusal (remembered per model, like OpenRouter). Catalogue from `GET {base_url}/models` with no name filtering; fallbacks in order: the configured `models` list (a complete catalogue), then "cannot say" (a blueprint pinning a model is never refused). Windows default to 128k/8k as `builtin` with one warning per unlisted model naming the `[model_capabilities]` key that sets the real value; pricing only from that override. Local token estimate. The runtime builds one per entry and keeps the script layer for entries without the kind.

## Wizard

Three pick-list rows: **llama.cpp** (`llama-cpp`, `http://localhost:8080/v1`), **LM Studio** (`lm-studio`, `http://localhost:1234/v1`), **Custom OpenAI-compatible endpoint**. One form per entry (name, base URL, key, headers as `Name: value; ...`, models, default model), `[Check this endpoint]` = `GET /models`, which lists the ids and offers the first as default; on failure the entry stays and the hand-typed models are written. Add as many as wanted; they join the default-provider radio; entries in an existing config load back. Ollama keeps its native provider (its `/api/show` reports windows and tool support, which the OpenAI-style shim does not).

## HTTP API

`GET /api/config` gateways gain `kind`, `header_names` (never values), `models`; `PUT /api/config` accepts `kind`, `headers`, `models` (absent leaves the existing value) and 400s on an unknown kind or an endpoint without a URL. `POST /api/models/probe {base_url, api_key?, headers?}` returns `{"models": [...]}` or 502 with the endpoint's error; mounted only with `--allow-admin` (404 otherwise, tested). `GET /api/models` includes detected endpoint models. OpenAPI and `api.md` updated; the route-drift and capability tests pass.

## Docs

`configuration.md` "OpenAI-compatible endpoints" (its own section: the kind, the two-endpoints-plus-Anthropic example, headers, `models` fallback, detection, which servers, presets vs Custom, the Ollama note), `providers.md`, the wizard rows under `lev setup` in `cli.md`, `api.md`, `config.example.toml`, `config.schema.json`, CHANGELOG Added.

## Gates

Coverage 100% on `leviath-providers`, `leviath-runtime`, `leviath-cli`; clippy and rustdoc `-D warnings`; `xtask structure` (421 files), `xtask docs`; pre-commit on all five commits.

## Live (isolated home, `perf-tools/mock.py` as the endpoint)

- `lev models list --provider mock`: the mock's two ids, marked learned.
- A config with `kind = "openai-compatible"` and a header, `lev run probe -m mock/gpt-mock --yolo`: run complete, the mock served 5 completions.
- `lev serve`: `POST /api/models/probe` 404 without admin; 200 `{"models": ["claude-mock", "gpt-mock"]}` with it; 502 for a dead port; `GET /api/config` shows `kind`, `header_names: ["X-Org"]`.
- `lev setup` over a pty: picked "Custom OpenAI-compatible endpoint", typed the base URL, `[Check this endpoint]` reported "2 models: claude-mock, gpt-mock", default model cycled to `gpt-mock`, Ctrl-S wrote the `[model_providers.*] kind = "openai-compatible"` entry (no `models`, since detection worked) and the defaults.
