### PR TITLE
fix(dash): the cache share is a share of the prompt, never over 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,13 @@ same list.
 
 ### Fixed
 
+- The dashboard's run detail strip could show a cache figure over 100%, such
+  as `cache 152%`, on a run that was mostly served from the provider's cache.
+  The prompt count every provider is normalised to is the fresh input only,
+  with cache reads counted separately, and the strip divided the reads by
+  that fresh figure. It now shows the share of the whole prompt (fresh plus
+  cached) that came from cache, so the figure cannot pass 100%. Stored counts
+  and the API are unchanged.
 - The dashboard cut text to fixed character counts whatever the terminal
   width: the detail view's model name stopped at 24 characters and its
   working directory at 42 with most of a 200-column row empty, the header

--- a/crates/leviath-cli/src/commands/dashboard/render/header.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/header.rs
@@ -132,8 +132,16 @@ impl Dashboard {
             .unwrap_or_default();
 
         let total_tok_part = if agent.tokens_in > 0 || agent.tokens_out > 0 {
-            let cache_part = if agent.cached_tokens > 0 && agent.tokens_in > 0 {
-                let pct = (agent.cached_tokens as f64 / agent.tokens_in as f64) * 100.0;
+            // `tokens_in` is the fresh input only: every provider is
+            // normalised to Anthropic's convention, where cache reads are a
+            // separate count and not part of it (see
+            // `TokenUsage::prompt_tokens`). The share of the prompt served
+            // from cache is therefore reads over fresh plus reads, which
+            // cannot pass 100%; over fresh alone it read 164% on a run that
+            // was mostly cache hits.
+            let cache_part = if agent.cached_tokens > 0 {
+                let prompt = agent.tokens_in.saturating_add(agent.cached_tokens);
+                let pct = (agent.cached_tokens as f64 / prompt as f64) * 100.0;
                 format!("  cache {:.0}%", pct)
             } else {
                 String::new()
@@ -602,6 +610,28 @@ mod tests {
         rendered_buffer(&terminal)
     }
 
+    /// The defect: a run that is mostly served from cache showed a cache
+    /// figure over 100%. Every provider is normalised so that `tokens_in` is
+    /// the FRESH input only (see `TokenUsage::prompt_tokens`), so dividing
+    /// the cache reads by it is not a share of anything. The numbers are a
+    /// real researcher run's `meta.json`: 555,075 fresh, 909,343 cached,
+    /// which the strip showed as `cache 164%`.
+    #[test]
+    fn render_info_strip_cache_share_is_a_share_of_the_whole_prompt() {
+        let mut agent = wide_agent();
+        agent.tokens_in = 555_075;
+        agent.tokens_out = 58_267;
+        agent.cached_tokens = 909_343;
+        let buf = info_strip_at(200, &agent);
+        assert!(buf.contains("total 555k↑ 58k↓  cache 62%"), "{buf}");
+        assert!(!buf.contains("164%"), "{buf}");
+        // Everything cached is the ceiling, not a division by zero.
+        agent.tokens_in = 0;
+        agent.cached_tokens = 4_000;
+        let buf = info_strip_at(200, &agent);
+        assert!(buf.contains("total 0↑ 58k↓  cache 100%"), "{buf}");
+    }
+
     /// The defect: the model was cut to 24 characters on a 200-column
     /// terminal with most of the row empty.
     #[test]
@@ -609,7 +639,7 @@ mod tests {
         let buf = info_strip_at(200, &wide_agent());
         assert!(buf.contains(LONG_MODEL), "{buf}");
         assert!(buf.contains(LONG_WORKDIR), "{buf}");
-        assert!(buf.contains("total 1M↑ 25k↓  cache 41%"), "{buf}");
+        assert!(buf.contains("total 1M↑ 25k↓  cache 29%"), "{buf}");
         assert!(!buf.contains('…'), "{buf}");
     }
 
@@ -618,7 +648,7 @@ mod tests {
     #[test]
     fn render_info_strip_narrow_shrinks_model_before_workdir_and_keeps_tokens() {
         let buf = info_strip_at(70, &wide_agent());
-        assert!(buf.contains("total 1M↑ 25k↓  cache 41%"), "{buf}");
+        assert!(buf.contains("total 1M↑ 25k↓  cache 29%"), "{buf}");
         assert!(!buf.contains(LONG_MODEL), "{buf}");
         assert!(!buf.contains(LONG_WORKDIR), "{buf}");
         // The model sits at the floor (seven characters and the ellipsis).
@@ -636,14 +666,14 @@ mod tests {
         // the workdir 19 columns.
         let buf = info_strip_at(60, &wide_agent());
         assert!(
-            buf.contains("dir   /srv/projects/ai/p…  ·  total 1M↑ 25k↓  cache 41%"),
+            buf.contains("dir   /srv/projects/ai/p…  ·  total 1M↑ 25k↓  cache 29%"),
             "{buf}"
         );
         assert!(!buf.contains("openro"), "{buf}");
         // The mid case, where the model at its floor would have fitted the
         // arithmetic of the parts but not the row: 50 wide drops it too.
         let buf = info_strip_at(50, &wide_agent());
-        assert!(buf.contains("total 1M↑ 25k↓  cache 41%"), "{buf}");
+        assert!(buf.contains("total 1M↑ 25k↓  cache 29%"), "{buf}");
         assert!(!buf.contains("openro"), "{buf}");
     }
 


### PR DESCRIPTION
## Summary

The `lev dash` run detail info strip showed a cache figure over 100% (the user saw `total 5M↑ 205k↓ cache 152%`). The strip divided cache reads by `tokens_in`, and `tokens_in` is the fresh input only, so the quotient was reads over fresh rather than a share of the prompt. It now divides by fresh plus reads, which cannot pass 100%. No stored count and no wire field changes.

## Cause

`crates/leviath-cli/src/commands/dashboard/render/header.rs:135-136` (before this change):

```rust
let cache_part = if agent.cached_tokens > 0 && agent.tokens_in > 0 {
    let pct = (agent.cached_tokens as f64 / agent.tokens_in as f64) * 100.0;
```

`agent.tokens_in` is `run.prompt_tokens` straight from the run's `meta.json` (`crates/leviath-cli/src/commands/dashboard/state/sync.rs:265-267`), and that figure is fresh input only, see the table.

## What each field carries at the point the dash reads it

Normalisation to one convention was already done (the cost accounting work, #572); the stored numbers are consistent across providers. Only the dash's derived percentage was wrong.

| Field | Convention | Where it is set |
|---|---|---|
| `TokenUsage::prompt_tokens` | fresh input only, cache reads and cache writes excluded (Anthropic's `input_tokens` convention) | `crates/leviath-providers/src/pricing.rs:19-33` (doc), `TokenUsage::new` at `:77-88` |
| Anthropic native | `input_tokens` is already exclusive; `cache_read_input_tokens` and `cache_creation_input_tokens` are read into `cached_tokens` and `cache_write_tokens` unchanged | `crates/leviath-providers/src/anthropic/stream.rs:171-188` |
| OpenAI shape (OpenAI, OpenRouter, compat) | `prompt_tokens` INCLUDES `prompt_tokens_details.cached_tokens`; the parser subtracts the cached and cache-write counts out so `prompt_tokens` becomes fresh only | `crates/leviath-providers/src/openai_compat.rs:849-863` (non-streaming), `:951-958` (streaming) |
| `TokenTotals` (run totals, becomes `meta.json` `prompt_tokens` / `cached_tokens` / `cache_write_tokens`) | plain sums of the normalised per-call counts, so `prompt_tokens` stays fresh only | `crates/leviath-runtime/src/persistence.rs:199-209` (`add_usage_priced`), called from `record_call` at `crates/leviath-runtime/src/inference_usage.rs:78-80` |
| Stage ledger and `InferenceUsage` journal records | same per-call fields copied through | `crates/leviath-runtime/src/inference_usage.rs:81-92` and `:97-106` |
| `DashboardAgent::tokens_in` / `cached_tokens` | `run.prompt_tokens` (fresh) and `run.cached_tokens` | `crates/leviath-cli/src/commands/dashboard/state/sync.rs:265-267` |

So the share of the prompt served from cache is `cached / (prompt_tokens + cached)` everywhere in this codebase. The rule from the issue's "when input includes cache, divide by input" case does not apply to any stored figure here.

Other renderers checked: `lev timeline` (`crates/leviath-cli/src/commands/timeline.rs:357-369`) and `lev stages` (`crates/leviath-cli/src/commands/stages.rs:128-145`) print raw PROMPT / CACHED counts with no percentage; `lev ps`, `lev models` and the serve JSON expose no cache percentage. The header strip was the only site.

## Reproduction

The exact 152% run is no longer under `~/.leviath/runs/` (113 runs there have `cached_tokens > prompt_tokens`; none matches 5M fresh at 1.52). The reproduction is `researcher-1787957531-3abc8e215d2d` (`openrouter/anthropic/claude-sonnet-5`), whose `meta.json` reads:

```
prompt_tokens      555075
completion_tokens   58267
cached_tokens      909343
cache_write_tokens 575844
```

909343 / 555075 = 164%. The share of the whole prompt is 909343 / (555075 + 909343) = 62%.

## Before / after

Driven with `perf-tools/dash_pty.py` (200x50, Enter to open the run) against a copy of that run under an isolated `LEVIATH_HOME`:

```
before (installed ~/.cargo/bin/lev 0.5.5)  -> total 555k↑ 58k↓  cache 164%
after  (this branch)                       -> total 555k↑ 58k↓  cache 62%
```

## Regression test

`render_info_strip_cache_share_is_a_share_of_the_whole_prompt` in `header.rs` uses that run's numbers and expects `cache 62%`, plus the all-cached edge (`tokens_in = 0`) expecting `cache 100%`. Run against the unfixed code first:

```
panicked at crates/leviath-cli/src/commands/dashboard/render/header.rs:618:9:
... total 555k↑ 58k↓  cache 164% ...
test result: FAILED. 0 passed; 1 failed
```

After the change: `26 passed` in the header module. The existing wide-agent fixture (1M fresh, 410k cached) moves from `cache 41%` to `cache 29%`, which is the corrected figure for the same numbers.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`: clean
- `cargo test -p leviath-cli --lib render::header`: 26 passed
- `cargo xtask structure`: 422 files, none over the limit
- `cargo xtask docs`: 40 pages, 3 schemas, no problems
- `cargo xtask coverage --package leviath-cli`: passed
- pre-commit: full suite passed

CHANGELOG: entry under Unreleased / Fixed.
