### PR TITLE
fix(core): refuse a negative manifest count and an unknown sandbox key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,12 @@ same list.
   the `--claude-code` and `--claude-code-effort` flags, and the MCP import
   from Claude Code's own config all work as before, and a config that
   already has it on comes out of the wizard with it still on.
+- A blueprint with a negative integer, or an unknown key under `[sandbox]`,
+  no longer loads; the error names the key. `max_items = -1` used to read as
+  the largest possible cap, and a few keys (a gate's `max_attempts`, a nudge
+  `max`, `request_timeout_secs`, a `stuck_after_*` threshold) dropped the
+  value without a word. A misspelled sandbox key such as `netwrok = false`
+  was ignored, so the sandbox ran looser than the file said.
 - The published list prices for OpenAI, Anthropic and Google live in
   `crates/leviath-providers/pricing/rates.toml` rather than in Rust, and each
   row names where it came from. `lev models list` prints `n/a` where nothing

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -26,7 +26,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     let version = str_of(agent, "version").unwrap_or("0.1.0").to_string();
     let description = str_of(agent, "description").unwrap_or("").to_string();
 
-    let max_child_depth = int_of(agent, "max_child_depth").map(|v| v as usize);
+    let max_child_depth = count_of(agent, "[agent]", "max_child_depth")?;
 
     let entry_stage = str_of(agent, "entry_stage").map(|s| s.to_string());
 
@@ -86,7 +86,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     blueprint.dynamic_tools = dynamic_tools;
 
     if let Some(compaction_table) = table_of(&parsed, "compaction") {
-        blueprint.compaction_config = Some(parse_compaction_config(compaction_table));
+        blueprint.compaction_config = Some(parse_compaction_config(compaction_table)?);
     }
 
     // Parse agent-level security config: [security]
@@ -109,7 +109,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     // Parse agent-level nudge defaults: [agent.nudge]. Absent ⇒ each field
     // inherits the global config's [nudge] section; a per-stage block wins.
     if let Some(nudge_table) = table_of(agent, "nudge") {
-        blueprint.nudge = Some(parse_nudge_config(nudge_table));
+        blueprint.nudge = Some(parse_nudge_config("[agent.nudge]", nudge_table)?);
     }
 
     // Parse the agent's default output shape: [agent.output]. A per-stage
@@ -120,7 +120,7 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
 
     // Parse agent-level sandbox config: [sandbox]
     if let Some(sandbox_table) = table_of(&parsed, "sandbox") {
-        blueprint.sandbox = Some(parse_sandbox_config(sandbox_table)?);
+        blueprint.sandbox = Some(parse_sandbox_config("", sandbox_table)?);
     }
 
     // Parse agent-level read-path declarations: [read_paths]. Entries are
@@ -149,12 +149,12 @@ pub fn parse_manifest(content: &str) -> Result<Blueprint> {
     if let Some(context_table) = table_of(&parsed, "context")
         && let Some(ft_table) = table_of(context_table, "file_tracking")
     {
-        blueprint.file_tracking = Some(parse_file_tracking(ft_table));
+        blueprint.file_tracking = Some(parse_file_tracking(ft_table)?);
     }
 
     // Parse repetition-detection config: [repetition_detection]
     if let Some(rd_table) = table_of(&parsed, "repetition_detection") {
-        blueprint.repetition_detection = Some(parse_repetition_detection(rd_table));
+        blueprint.repetition_detection = Some(parse_repetition_detection(rd_table)?);
     }
 
     // Parse cross-blueprint context transforms: [[transforms]]. Each maps a

--- a/crates/leviath-core/src/manifest/model.rs
+++ b/crates/leviath-core/src/manifest/model.rs
@@ -8,7 +8,10 @@ use super::*;
 
 /// Parse `[stages.<name>.model]`, or the shipped default when the stage does
 /// not name one.
-pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
+pub(super) fn parse_stage_model(
+    stage_name: &str,
+    stage_value: &toml::Value,
+) -> Result<ModelConfig> {
     let model_table = table_of(stage_value, "model");
     if let Some(mt) = model_table {
         let mut models = Vec::new();
@@ -86,18 +89,23 @@ pub(super) fn parse_stage_model(stage_value: &toml::Value) -> ModelConfig {
             }
         }
 
-        let request_timeout_secs = int_of(mt, "request_timeout_secs");
-        let request_timeout_secs = request_timeout_secs
-            .filter(|&secs| secs >= 0)
-            .map(|secs| secs as u64);
+        let request_timeout_secs = count_of(
+            mt,
+            &format!("stage '{stage_name}': model"),
+            "request_timeout_secs",
+        )?
+        .map(|secs| secs as u64);
 
-        ModelConfig {
+        Ok(ModelConfig {
             models,
             allow_user_default,
             parameters,
             request_timeout_secs,
-        }
+        })
     } else {
-        ModelConfig::new("anthropic".to_string(), "claude-sonnet-4-6".to_string())
+        Ok(ModelConfig::new(
+            "anthropic".to_string(),
+            "claude-sonnet-4-6".to_string(),
+        ))
     }
 }

--- a/crates/leviath-core/src/manifest/read.rs
+++ b/crates/leviath-core/src/manifest/read.rs
@@ -8,6 +8,8 @@
 //! the wrong type, exactly as the inline form did; a caller that wants to
 //! tell those apart still looks at the value itself.
 
+use crate::error::{Error, Result};
+
 /// Something with named fields: a TOML value (which may be a table) or a
 /// table itself. The parser holds both, depending on how far into the
 /// document it has descended, and asks the same questions of either.
@@ -48,6 +50,24 @@ pub(super) fn bool_of(v: &impl Fields, key: &str) -> Option<bool> {
 /// no range check, since each caller decides what a negative means.
 pub(super) fn int_of(v: &impl Fields, key: &str) -> Option<i64> {
     v.field(key).and_then(|x| x.as_integer())
+}
+
+/// The count under `key`: a non-negative integer, if the key is present and
+/// holds an integer at all. `where_` names the table for the error.
+///
+/// Every count a manifest carries used to go through `as usize`, so
+/// `max_items = -1` became the largest possible cap and read at a glance as
+/// "no limit", the opposite of what was written; a few keys dropped the value
+/// instead. Either way nothing said so. A negative is refused here, naming
+/// the key and the value, so the file fails to load rather than loading
+/// looser than it reads.
+pub(super) fn count_of(v: &impl Fields, where_: &str, key: &str) -> Result<Option<usize>> {
+    match int_of(v, key) {
+        None => Ok(None),
+        Some(n) => usize::try_from(n)
+            .map(Some)
+            .map_err(|_| Error::Other(format!("{where_}: {key} must not be negative (got {n})"))),
+    }
 }
 
 /// The array under `key`, if present and an array.
@@ -93,6 +113,12 @@ mod tests {
         assert_eq!(str_field(v, "s"), "text");
         assert_eq!(str_field(v, "missing"), "");
         assert_eq!(str_field(v, "i"), "");
+        assert_eq!(count_of(v, "[t]", "missing").unwrap(), None);
+        assert_eq!(count_of(v, "[t]", "s").unwrap(), None);
+        assert_eq!(
+            count_of(v, "[t]", "i").unwrap_err().to_string(),
+            "[t]: i must not be negative (got -3)"
+        );
     }
 
     #[test]

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -26,6 +26,8 @@ pub(super) fn parse_region_layout(
     let mut total_tokens = 0usize;
 
     for (region_name, region_value) in regions_table {
+        let where_ = format!("region '{region_name}'");
+        let count = |key: &str| count_of(region_value, &where_, key);
         // `budget = "N%"` opts a region into percentage mode; `max_tokens` then
         // becomes the absolute cap and `min_tokens` the absolute floor. Without a
         // `budget`, `max_tokens` is the literal ceiling (legacy behavior).
@@ -33,8 +35,8 @@ pub(super) fn parse_region_layout(
             Some(s) => Some(crate::BudgetSpec::parse_budget(s).map_err(Error::Other)?),
             None => None,
         };
-        let max_tokens_opt = int_of(region_value, "max_tokens").map(|v| v as usize);
-        let min_tokens = int_of(region_value, "min_tokens").map(|v| v as usize);
+        let max_tokens_opt = count("max_tokens")?;
+        let min_tokens = count("min_tokens")?;
 
         let budget = match percent {
             Some(percent) => crate::BudgetSpec::Percent {
@@ -60,22 +62,21 @@ pub(super) fn parse_region_layout(
             Some(s) => Some(crate::BudgetSpec::parse_budget(s).map_err(Error::Other)?),
             None => None,
         };
-        let explicit_threshold = int_of(region_value, "threshold_tokens").map(|v| v as usize);
+        let explicit_threshold = count("threshold_tokens")?;
 
         let kind_str = str_of(region_value, "kind").unwrap_or("temporary");
 
         let kind = match kind_str {
             "pinned" => RegionKind::Pinned,
             "sliding_window" => {
-                let max_items = int_of(region_value, "max_items").unwrap_or(10) as usize;
+                let max_items = count("max_items")?.unwrap_or(10);
                 let eviction_strategy = match str_of(region_value, "strategy") {
                     Some("bulk") => {
-                        let overflow = int_of(region_value, "overflow").unwrap_or(10) as usize;
+                        let overflow = count("overflow")?.unwrap_or(10);
                         EvictionStrategy::Bulk { overflow }
                     }
                     Some("compact") => {
-                        let compact_count =
-                            int_of(region_value, "compact_count").unwrap_or(10) as usize;
+                        let compact_count = count("compact_count")?.unwrap_or(10);
                         EvictionStrategy::Compact { compact_count }
                     }
                     Some("per_item") | None => EvictionStrategy::PerItem,
@@ -124,7 +125,7 @@ pub(super) fn parse_region_layout(
             }
             "checklist" => RegionKind::Checklist,
             "hashmap" | "hash_map" => {
-                let max_entries = int_of(region_value, "max_entries").map(|v| v as usize);
+                let max_entries = count("max_entries")?;
                 RegionKind::HashMap { max_entries }
             }
             "custom" => {

--- a/crates/leviath-core/src/manifest/sections.rs
+++ b/crates/leviath-core/src/manifest/sections.rs
@@ -5,7 +5,7 @@ use super::*;
 
 /// Parse `[compaction]` over the defaults, leaving any field the manifest does
 /// not mention at its default rather than at zero.
-pub(super) fn parse_compaction_config(table: &toml::value::Table) -> CompactionConfig {
+pub(super) fn parse_compaction_config(table: &toml::value::Table) -> Result<CompactionConfig> {
     let mut cc = CompactionConfig::default();
 
     if let Some(provider) = str_of(table, "provider") {
@@ -17,14 +17,14 @@ pub(super) fn parse_compaction_config(table: &toml::value::Table) -> CompactionC
     if let Some(sp) = str_of(table, "system_prompt") {
         cc.system_prompt = Some(sp.to_string());
     }
-    if let Some(mst) = int_of(table, "max_summary_tokens") {
-        cc.max_summary_tokens = mst as usize;
+    if let Some(mst) = count_of(table, "[compaction]", "max_summary_tokens")? {
+        cc.max_summary_tokens = mst;
     }
     if let Some(temp) = table.get("temperature").and_then(|v| v.as_float()) {
         cc.temperature = temp as f32;
     }
 
-    cc
+    Ok(cc)
 }
 
 /// Parse `[read_paths]`. Entries are syntax-checked here so a broken one fails
@@ -106,25 +106,26 @@ pub(super) fn tool_permission_metadata(
 
 /// Parse `[context.file_tracking]`. Tracking both directions into a `files`
 /// region is the default because that is what the shipped layouts assume.
-pub(super) fn parse_file_tracking(table: &toml::value::Table) -> crate::FileTrackingConfig {
-    crate::FileTrackingConfig {
+pub(super) fn parse_file_tracking(table: &toml::value::Table) -> Result<crate::FileTrackingConfig> {
+    Ok(crate::FileTrackingConfig {
         region: str_of(table, "region").unwrap_or("files").to_string(),
         track_reads: bool_of(table, "track_reads").unwrap_or(true),
         track_writes: bool_of(table, "track_writes").unwrap_or(true),
-        max_file_tokens: int_of(table, "max_file_tokens").map(|v| v as usize),
-    }
+        max_file_tokens: count_of(table, "[context.file_tracking]", "max_file_tokens")?,
+    })
 }
 
 /// Parse `[repetition_detection]`. Every field stays `None` when absent so the
 /// global config's value survives; there are no local defaults to apply here.
 pub(super) fn parse_repetition_detection(
     table: &toml::value::Table,
-) -> crate::RepetitionDetectionConfig {
-    crate::RepetitionDetectionConfig {
-        max_repeat_calls: int_of(table, "max_repeat_calls").map(|v| v as usize),
-        max_readonly_streak: int_of(table, "max_readonly_streak").map(|v| v as usize),
+) -> Result<crate::RepetitionDetectionConfig> {
+    let where_ = "[repetition_detection]";
+    Ok(crate::RepetitionDetectionConfig {
+        max_repeat_calls: count_of(table, where_, "max_repeat_calls")?,
+        max_readonly_streak: count_of(table, where_, "max_readonly_streak")?,
         enabled: bool_of(table, "enabled"),
-    }
+    })
 }
 
 /// Parse an `[agent.output]` or `[stages.<name>.output]` block.
@@ -166,10 +167,10 @@ pub(super) fn parse_security_config(security_table: &toml::value::Table) -> crat
     sc
 }
 
-/// Every key read off a `[sandbox]` table. Test-only: the parser above reads
-/// them one by one, and the schema guard in `tests.rs` holds the published
-/// schema to this list.
-#[cfg(test)]
+/// Every key read off a `[sandbox]` table. Anything else is refused: a
+/// misspelled `netwrok = false` used to be ignored, leaving the sandbox
+/// looser than the file said. The schema guard in `tests.rs` holds the
+/// published schema to this list.
 pub(super) const SANDBOX_KEYS: &[&str] = &[
     "engine",
     "image",
@@ -185,12 +186,16 @@ pub(super) const SANDBOX_KEYS: &[&str] = &[
 /// A present block with no `kind` means host passthrough; omit the block to
 /// inherit the broader (agent/global) sandbox. An unknown `kind` or
 /// `on_unavailable` value is a hard error rather than a silently-ignored
-/// misconfiguration (mirrors transition-condition/transform validation).
+/// misconfiguration (mirrors transition-condition/transform validation), and
+/// so is a key the table does not have. `where_` is the prefix an error
+/// carries: empty for the agent's own block, the stage for a stage's.
 pub(super) fn parse_sandbox_config(
+    where_: &str,
     table: &toml::value::Table,
 ) -> Result<crate::sandbox::ToolSandboxConfig> {
     use crate::sandbox::{OnUnavailable, SandboxKind, ToolSandboxConfig};
 
+    reject_unknown_keys(&format!("{where_}sandbox"), table, SANDBOX_KEYS)?;
     let mut sc = ToolSandboxConfig::default();
 
     if let Some(kind) = str_of(table, "kind") {

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -123,7 +123,11 @@ pub(super) fn validate_tool_policy(where_: &str, tool: &str, policy: &str) -> Re
 /// had not been written - which is what it was doing (#362). Region kinds and
 /// transition conditions have always been strict; this extends that to the
 /// tables holding them, with the same "valid: …" phrasing.
-fn reject_unknown_keys(where_: &str, table: &toml::value::Table, allowed: &[&str]) -> Result<()> {
+pub(super) fn reject_unknown_keys(
+    where_: &str,
+    table: &toml::value::Table,
+    allowed: &[&str],
+) -> Result<()> {
     for key in table.keys() {
         if !allowed.contains(&key.as_str()) {
             return Err(Error::Other(format!(
@@ -230,7 +234,7 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
         reject_unknown_keys(&format!("stage '{stage_name}'"), table, STAGE_KEYS)?;
     }
 
-    let model_config = parse_stage_model(stage_value);
+    let model_config = parse_stage_model(stage_name, stage_value)?;
     // A cap that does not parse fails the load. Left as a pass-through it
     // would reach the provider as a nonsense parameter or, worse, as no cap
     // at all, and a typo in a limit is the kind of mistake that only shows
@@ -243,8 +247,9 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
 
     stage = apply_stage_mode(stage, stage_name, stage_value)?;
 
-    if let Some(max_iter) = int_of(stage_value, "max_iterations") {
-        stage.max_iterations = Some(max_iter as usize);
+    let where_ = format!("stage '{stage_name}'");
+    if let Some(max_iter) = count_of(stage_value, &where_, "max_iterations")? {
+        stage.max_iterations = Some(max_iter);
     }
 
     if let Some(tools_arr) = array_of(stage_value, "available_tools") {
@@ -318,8 +323,12 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
         if let Some(p) = bool_of(routing_table, "persist") {
             routing.persist = p;
         }
-        if let Some(mt) = int_of(routing_table, "max_result_tokens") {
-            routing.max_result_tokens = Some(mt as usize);
+        if let Some(mt) = count_of(
+            routing_table,
+            &format!("{where_}: tool_routing"),
+            "max_result_tokens",
+        )? {
+            routing.max_result_tokens = Some(mt);
         }
         if let Some(overrides_table) = table_of(routing_table, "overrides") {
             for (tool_name, region_val) in overrides_table {
@@ -451,12 +460,15 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     // Parse per-stage nudge settings: [stages.<name>.nudge]. Absent ⇒
     // each field inherits agent/global.
     if let Some(nudge_table) = table_of(stage_value, "nudge") {
-        stage.nudge = Some(parse_nudge_config(nudge_table));
+        stage.nudge = Some(parse_nudge_config(
+            &format!("{where_}: nudge"),
+            nudge_table,
+        )?);
     }
 
     // Parse per-stage sandbox override: [stages.<name>.sandbox]
     if let Some(sandbox_table) = table_of(stage_value, "sandbox") {
-        stage.sandbox = Some(parse_sandbox_config(sandbox_table)?);
+        stage.sandbox = Some(parse_sandbox_config(&format!("{where_}: "), sandbox_table)?);
     }
 
     // Script-backed lifecycle hooks: [stages.<name>.hooks]
@@ -535,8 +547,8 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
     }
 
     // Parse max_revisits
-    if let Some(mr) = int_of(stage_value, "max_revisits") {
-        stage.max_revisits = Some(mr as usize);
+    if let Some(mr) = count_of(stage_value, &where_, "max_revisits")? {
+        stage.max_revisits = Some(mr);
     }
 
     // Parse transition_prompt
@@ -546,7 +558,7 @@ pub(super) fn parse_stage(stage_name: &str, stage_value: &toml::Value) -> Result
 
     // Parse transitions: [stages.<name>.transitions.<target>]
     if let Some(transitions_table) = table_of(stage_value, "transitions") {
-        stage.transitions = Some(parse_transitions(transitions_table)?);
+        stage.transitions = Some(parse_transitions(&where_, transitions_table)?);
     }
 
     Ok(stage)
@@ -806,10 +818,12 @@ pub(super) fn parse_stage_hooks(
 /// because both failure modes build an edge the runtime never takes and a
 /// dead edge is invisible until the run wedges.
 pub(super) fn parse_transitions(
+    stage: &str,
     transitions_table: &toml::value::Table,
 ) -> Result<std::collections::HashMap<String, TransitionEdge>> {
     let mut transitions = std::collections::HashMap::new();
     for (target_name, edge_value) in transitions_table {
+        let where_ = format!("{stage}: transition to '{target_name}'");
         if let Some(edge_table) = edge_value.as_table() {
             reject_unknown_keys(
                 &format!("transition to '{target_name}'"),
@@ -850,7 +864,7 @@ pub(super) fn parse_transitions(
         // Both halves are required together: a bare `condition =
         // "stuck"` edge could never fire, and thresholds under any
         // other condition would be silently ignored.
-        let stuck = parse_stuck_config(edge_value);
+        let stuck = parse_stuck_config(&where_, edge_value)?;
         let is_stuck = condition == TransitionCondition::Stuck;
         if is_stuck && stuck.is_none() {
             return Err(Error::Other(format!(
@@ -924,7 +938,10 @@ pub(super) fn parse_transitions(
 
         // Parse the edge gate: `gate = { require_modifications = true, ... }`
         // (or a `[stages.<name>.transitions.<target>.gate]` sub-table).
-        let gate = table_of(edge_value, "gate").map(parse_transition_gate);
+        let gate = match table_of(edge_value, "gate") {
+            Some(table) => Some(parse_transition_gate(&format!("{where_}: gate"), table)?),
+            None => None,
+        };
 
         transitions.insert(
             target_name.clone(),
@@ -948,8 +965,9 @@ pub(super) fn parse_transitions(
 /// Parse a transition edge's `gate = { ... }` table. Every key is optional; an
 /// empty table yields a gate that blocks nothing (`require_modifications` off).
 pub(super) fn parse_transition_gate(
+    where_: &str,
     table: &toml::value::Table,
-) -> crate::blueprint::TransitionGate {
+) -> Result<crate::blueprint::TransitionGate> {
     let mut gate = crate::blueprint::TransitionGate::default();
     if let Some(rm) = bool_of(table, "require_modifications") {
         gate.require_modifications = rm;
@@ -978,34 +996,30 @@ pub(super) fn parse_transition_gate(
             .filter_map(|v| v.as_str().map(|s| s.to_string()))
             .collect();
     }
-    // A negative budget is a typo, not "never hold the stage" - fall back to the
-    // default rather than silently disabling the gate.
-    if let Some(max) = int_of(table, "max_attempts").filter(|max| *max >= 0) {
-        gate.max_attempts = Some(max as usize);
+    // A negative budget is a typo, not "never hold the stage", and used to
+    // fall back to the default without a word. It is refused now.
+    if let Some(max) = count_of(table, where_, "max_attempts")? {
+        gate.max_attempts = Some(max);
     }
-    gate
+    Ok(gate)
 }
 
 /// Parse a transition edge's `stuck_after_*` thresholds into a [`StuckConfig`],
 /// or `None` when the edge arms none of them.
 ///
-/// Non-positive values read as unset - mirroring `enforce_max_iterations`, where
-/// `max == 0` means "unlimited" - so `stuck_after_iterations = 0` leaves the edge
-/// unarmed and the caller rejects it, rather than the edge firing on turn zero.
-pub(super) fn parse_stuck_config(edge: &toml::Value) -> Option<StuckConfig> {
-    let threshold = |key: &str| {
-        edge.get(key)
-            .and_then(|v| v.as_integer())
-            .filter(|v| *v > 0)
-            .map(|v| v as usize)
-    };
+/// Zero reads as unset - mirroring `enforce_max_iterations`, where `max == 0`
+/// means "unlimited" - so `stuck_after_iterations = 0` leaves the edge unarmed
+/// and the caller rejects it, rather than the edge firing on turn zero. A
+/// negative used to read as unset too, silently; it is refused now.
+pub(super) fn parse_stuck_config(where_: &str, edge: &toml::Value) -> Result<Option<StuckConfig>> {
+    let threshold = |key: &str| count_of(edge, where_, key).map(|n| n.filter(|n| *n > 0));
     let cfg = StuckConfig {
-        after_iterations: threshold("stuck_after_iterations"),
-        after_minutes: threshold("stuck_after_minutes"),
-        after_same_file_edits: threshold("stuck_after_same_file_edits"),
-        after_tool_calls: threshold("stuck_after_tool_calls"),
+        after_iterations: threshold("stuck_after_iterations")?,
+        after_minutes: threshold("stuck_after_minutes")?,
+        after_same_file_edits: threshold("stuck_after_same_file_edits")?,
+        after_tool_calls: threshold("stuck_after_tool_calls")?,
     };
-    cfg.is_armed().then_some(cfg)
+    Ok(cfg.is_armed().then_some(cfg))
 }
 
 /// Parse one `[[transforms]]` entry: a parent region mapped onto a child region
@@ -1023,18 +1037,21 @@ pub(super) fn parse_context_transform(t: &toml::Value) -> ContextTransform {
 /// Parse an `[agent.nudge]` / `[stages.X.nudge]` table into a `NudgeConfig`.
 /// Every key is optional; an empty table is inert (each field still inherits
 /// the broader level).
-pub(super) fn parse_nudge_config(table: &toml::value::Table) -> crate::blueprint::NudgeConfig {
+pub(super) fn parse_nudge_config(
+    where_: &str,
+    table: &toml::value::Table,
+) -> Result<crate::blueprint::NudgeConfig> {
     let mut nudge = crate::blueprint::NudgeConfig::default();
     if let Some(enabled) = bool_of(table, "enabled") {
         nudge.enabled = Some(enabled);
     }
-    // A negative count is a typo, not "never accept the text" - fall back to
-    // inheriting rather than wrapping around.
-    if let Some(max) = int_of(table, "max").filter(|max| *max >= 0) {
-        nudge.max = Some(max as usize);
+    // A negative count is a typo, not "never accept the text", and used to
+    // fall back to inheriting without a word. It is refused now.
+    if let Some(max) = count_of(table, where_, "max")? {
+        nudge.max = Some(max);
     }
     if let Some(text) = str_of(table, "text") {
         nudge.text = Some(text.trim().to_string());
     }
-    nudge
+    Ok(nudge)
 }

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -398,12 +398,14 @@ fn parse_manifest_rejects_a_stuck_condition_with_no_threshold() {
 
 /// A zero threshold reads as unset (mirroring `max_iterations = 0` meaning
 /// "unlimited"), so it leaves the edge dead rather than firing on turn zero.
+/// A negative one is refused outright; see
+/// `every_negative_manifest_integer_fails_to_load_naming_the_key`.
 #[test]
-fn parse_manifest_treats_non_positive_stuck_thresholds_as_unset() {
+fn parse_manifest_treats_zero_stuck_thresholds_as_unset() {
     let toml = stuck_edge_manifest(
         r#"condition = "stuck"
 stuck_after_iterations = 0
-stuck_after_minutes = -5"#,
+stuck_after_minutes = 0"#,
     );
     let err = parse_manifest(&toml).unwrap_err().to_string();
     assert!(
@@ -2168,9 +2170,10 @@ mode = "autonomous"
 }
 
 #[test]
-fn parse_manifest_nudge_ignores_bad_types_and_negative_max() {
-    // An empty block is inert; wrong-typed values and a negative `max`
-    // fall back to inheriting rather than misconfiguring the stage.
+fn parse_manifest_nudge_ignores_bad_types() {
+    // An empty block is inert; wrong-typed values fall back to inheriting
+    // rather than misconfiguring the stage. (A negative `max` is refused;
+    // see `every_negative_manifest_integer_fails_to_load_naming_the_key`.)
     let toml = r#"
 [agent]
 name = "nudge-bad"
@@ -2182,7 +2185,7 @@ mode = "autonomous"
 
 [stages.main.nudge]
 enabled = "yes"
-max = -1
+max = "many"
 text = 7
 "#;
     let bp = parse_manifest(toml).unwrap();
@@ -2544,7 +2547,7 @@ mode = "autonomous"
 hint = "no gate here"
 
 [stages.a.transitions.c]
-gate = { require_modifications = "yes", message = 3, region = [], tools = "write_file", max_attempts = -4 }
+gate = { require_modifications = "yes", message = 3, region = [], tools = "write_file", max_attempts = "four" }
 
 [stages.b]
 mode = "autonomous"
@@ -2556,13 +2559,14 @@ mode = "autonomous"
     let transitions = bp.find_stage("a").unwrap().transitions.as_ref().unwrap();
     // An edge with no `gate` table has no gate at all.
     assert!(transitions["b"].gate.is_none());
-    // A gate whose every key is the wrong type - including a negative
-    // attempt budget - falls back to the defaults, i.e. a gate that blocks
-    // nothing rather than one that silently never holds.
+    // A gate whose every key is the wrong type falls back to the defaults,
+    // i.e. a gate that blocks nothing rather than one that silently never
+    // holds. (A negative attempt budget is refused instead; see
+    // `every_negative_manifest_integer_fails_to_load_naming_the_key`.)
     let gate = transitions["c"].gate.as_ref().unwrap();
     assert_eq!(gate, &crate::blueprint::TransitionGate::default());
     // Zero, on the other hand, is a deliberate "record it but never hold".
-    let toml = toml.replace("max_attempts = -4", "max_attempts = 0");
+    let toml = toml.replace("max_attempts = \"four\"", "max_attempts = 0");
     let bp = parse_manifest(&toml).unwrap();
     assert_eq!(
         bp.find_stage("a").unwrap().transitions.as_ref().unwrap()["c"]
@@ -3632,7 +3636,7 @@ model = "claude-sonnet-5"
 }
 
 #[test]
-fn parse_manifest_negative_request_timeout_is_ignored() {
+fn parse_manifest_negative_request_timeout_is_refused() {
     let toml = r#"
 [agent]
 name = "neg-timeout-test"
@@ -3642,12 +3646,12 @@ provider = "anthropic"
 model = "claude-sonnet-5"
 request_timeout_secs = -5
 "#;
-    let bp = parse_manifest(toml).unwrap();
-    // A nonsensical negative value is dropped rather than wrapping into a
-    // huge u64.
-    assert_eq!(
-        bp.find_stage("main").unwrap().model.request_timeout_secs,
-        None
+    // A negative timeout used to be dropped without a word, so the stage ran
+    // on the default while the file said otherwise. It fails the load now.
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(
+        err.contains("stage 'main': model: request_timeout_secs must not be negative (got -5)"),
+        "{err}"
     );
 }
 
@@ -5571,4 +5575,167 @@ fn the_published_schema_and_the_parser_agree_on_every_key() {
             "keys of the {table} table"
         );
     }
+}
+
+// ─── negative integers and unknown sandbox keys are load errors ─────────
+
+/// Every integer a manifest carries, with a negative value, and the error
+/// each must produce. Before this list existed, `max_items = -1` went through
+/// `as usize` and became the largest possible cap, `max_child_depth = -1`
+/// became unlimited nesting, and a handful of keys quietly dropped the value
+/// instead; none of them said anything.
+fn negative_integer_cases() -> Vec<(&'static str, &'static str)> {
+    vec![
+        (
+            "[agent]\nname = \"a\"\nmax_child_depth = -1\n",
+            "[agent]: max_child_depth must not be negative (got -1)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[compaction]\nmax_summary_tokens = -2\n",
+            "[compaction]: max_summary_tokens must not be negative (got -2)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[context.file_tracking]\nmax_file_tokens = -3\n",
+            "[context.file_tracking]: max_file_tokens must not be negative (got -3)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[repetition_detection]\nmax_repeat_calls = -4\n",
+            "[repetition_detection]: max_repeat_calls must not be negative (got -4)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[repetition_detection]\nmax_readonly_streak = -5\n",
+            "[repetition_detection]: max_readonly_streak must not be negative (got -5)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[context.regions]\nr = { kind = \"pinned\", max_tokens = -6 }\n",
+            "region 'r': max_tokens must not be negative (got -6)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[context.regions]\nr = { kind = \"pinned\", budget = \"10%\", min_tokens = -7 }\n",
+            "region 'r': min_tokens must not be negative (got -7)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[context.regions]\nr = { kind = \"compacting\", threshold_tokens = -8 }\n",
+            "region 'r': threshold_tokens must not be negative (got -8)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[context.regions]\nr = { kind = \"sliding_window\", max_items = -9 }\n",
+            "region 'r': max_items must not be negative (got -9)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[context.regions]\nr = { kind = \"sliding_window\", strategy = \"bulk\", overflow = -10 }\n",
+            "region 'r': overflow must not be negative (got -10)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[context.regions]\nr = { kind = \"sliding_window\", strategy = \"compact\", compact_count = -11 }\n",
+            "region 'r': compact_count must not be negative (got -11)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[context.regions]\nr = { kind = \"hashmap\", max_entries = -12 }\n",
+            "region 'r': max_entries must not be negative (got -12)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s]\nmax_iterations = -13\n",
+            "stage 's': max_iterations must not be negative (got -13)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s]\nmax_revisits = -14\n",
+            "stage 's': max_revisits must not be negative (got -14)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s.tool_routing]\nmax_result_tokens = -15\n",
+            "stage 's': tool_routing: max_result_tokens must not be negative (got -15)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s.model]\nprovider = \"p\"\nmodel = \"m\"\nrequest_timeout_secs = -16\n",
+            "stage 's': model: request_timeout_secs must not be negative (got -16)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s.transitions.t]\ngate = { max_attempts = -17 }\n[stages.t]\n",
+            "stage 's': transition to 't': gate: max_attempts must not be negative (got -17)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s.transitions.t]\ncondition = \"stuck\"\nstuck_after_minutes = -18\n[stages.t]\n",
+            "stage 's': transition to 't': stuck_after_minutes must not be negative (got -18)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s.transitions.t]\ncondition = \"stuck\"\nstuck_after_iterations = -21\n[stages.t]\n",
+            "stage 's': transition to 't': stuck_after_iterations must not be negative (got -21)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s.transitions.t]\ncondition = \"stuck\"\nstuck_after_same_file_edits = -22\n[stages.t]\n",
+            "stage 's': transition to 't': stuck_after_same_file_edits must not be negative (got -22)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s.transitions.t]\ncondition = \"stuck\"\nstuck_after_tool_calls = -23\n[stages.t]\n",
+            "stage 's': transition to 't': stuck_after_tool_calls must not be negative (got -23)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[agent.nudge]\nmax = -19\n",
+            "[agent.nudge]: max must not be negative (got -19)",
+        ),
+        (
+            "[agent]\nname = \"a\"\n[stages.s.nudge]\nmax = -20\n",
+            "stage 's': nudge: max must not be negative (got -20)",
+        ),
+    ]
+}
+
+#[test]
+fn every_negative_manifest_integer_fails_to_load_naming_the_key() {
+    for (toml, expected) in negative_integer_cases() {
+        let err = match parse_manifest(toml) {
+            Ok(_) => panic!("loaded despite a negative value:\n{toml}"),
+            Err(e) => e.to_string(),
+        };
+        assert!(err.contains(expected), "want {expected:?} in {err:?}");
+    }
+}
+
+/// The same keys at zero still load: zero is a value each key gives a
+/// meaning to (unlimited, never hold, unset), not a typo.
+#[test]
+fn every_manifest_integer_still_loads_at_zero() {
+    for (toml, _) in negative_integer_cases() {
+        let zeroed = with_negative_literal_zeroed(toml);
+        let bp = parse_manifest(&zeroed);
+        // A `stuck` edge at zero has no threshold, which is its own error.
+        if zeroed.contains("condition = \"stuck\"") {
+            let err = bp.unwrap_err().to_string();
+            assert!(err.contains("no threshold"), "{err}");
+            continue;
+        }
+        assert!(bp.is_ok(), "{zeroed}\n{:?}", bp.err());
+    }
+}
+
+/// Replace the one negative literal in a fixture with `0`.
+fn with_negative_literal_zeroed(toml: &str) -> String {
+    let (head, tail) = toml
+        .split_once("= -")
+        .expect("fixture has a negative literal");
+    let tail = tail.trim_start_matches(|c: char| c.is_ascii_digit());
+    format!("{head}= 0{tail}")
+}
+
+#[test]
+fn sandbox_refuses_an_unknown_key_naming_it() {
+    let err = parse_manifest(&sandbox_manifest("netwrok = false"))
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("sandbox has unknown key 'netwrok'"), "{err}");
+    assert!(
+        err.contains("network"),
+        "the error lists the valid keys: {err}"
+    );
+}
+
+#[test]
+fn a_stage_sandbox_refuses_an_unknown_key_naming_it() {
+    let toml = "[agent]\nname = \"a\"\n[stages.s.sandbox]\nnetwrok = false\n";
+    let err = parse_manifest(toml).unwrap_err().to_string();
+    assert!(
+        err.contains("stage 's': sandbox has unknown key 'netwrok'"),
+        "{err}"
+    );
 }

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -408,6 +408,20 @@ transform   = "summarize"
 `extract` additionally takes `fields` to pull named pieces out. See
 [Sub-agents](/docs/sub-agents).
 
+## Counts are never negative
+
+Every count a blueprint carries (`max_iterations`, `max_items`, `max_tokens`, `max_child_depth`,
+`request_timeout_secs`, a gate's `max_attempts`, a `stuck_after_*` threshold, and the rest) must
+be zero or more. A negative value fails the load, and the error names the key and the value:
+
+```text
+region 'notes': max_items must not be negative (got -1)
+```
+
+Earlier versions read `-1` as the largest possible number, so a cap written as a typo loaded as
+no cap at all. Zero keeps whatever meaning the key gives it (`max_iterations = 0` is unlimited,
+a gate's `max_attempts = 0` never holds, a `stuck_after_*` of zero is unset).
+
 ## Validate before you run
 
 ```bash

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -201,6 +201,10 @@ Check a blueprint before running it. `PATH` defaults to `.`.
 Beyond parsing and structural validation, it reports what the blueprint leaves unsaid. Findings come
 in three levels: an **error** exits non-zero, a **warning** does not, and a **note** never does.
 
+Parsing itself refuses a few things outright, before any finding is reported: a negative count
+anywhere in the file (`max_items = -1`), an unknown key under `[sandbox]`, and an unknown key in a
+stage table. Each of those errors names the key.
+
 | Level | Code | What it means |
 |---|---|---|
 | error | `unknown-tool` | A name in `available_tools` matches nothing. See below |

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -79,6 +79,11 @@ kind = "none"             # run discovery on the host…
 The sandbox bind-mounts the run's workdir, so sandboxed commands and host-side file tools see the
 same files.
 
+A `[sandbox]` table, at the agent or the stage level, accepts only the keys shown here (`kind`,
+`image`, `engine`, `network`, `mount` or `mounts`, `persist`, `on_unavailable`). Anything else
+fails the load and the error names it, so a misspelled `netwrok = false` cannot leave the sandbox
+looser than the file reads.
+
 **Containers**, using Docker or Podman, give you the real thing. The daemon keeps a warm container
 per sandbox configuration, so stages with identical settings share one, and tears them down when
 the agent finishes. Inside it, every Linux capability is dropped and the process cannot regain


### PR DESCRIPTION
## Premises, measured

**(a) Negative integers wrap to a huge number and load.** Held, with a wrinkle. The manifest is hand-parsed (no serde), and every count went through `int_of(...) as usize` on an `i64`, so `-1` became `usize::MAX`:

- `crates/leviath-core/src/manifest.rs:29` (`max_child_depth`)
- `manifest/regions.rs:36,37,63,70,73,78,127` (`max_tokens`, `min_tokens`, `threshold_tokens`, `max_items`, `overflow`, `compact_count`, `max_entries`)
- `manifest/stage.rs:247,322,539` (`max_iterations`, `tool_routing.max_result_tokens`, `max_revisits`)
- `manifest/sections.rs:21,114,124,125` (`max_summary_tokens`, `max_file_tokens`, `max_repeat_calls`, `max_readonly_streak`)

The wrinkle: four keys did not wrap but silently dropped the value instead, and had tests asserting that: a gate's `max_attempts` (`stage.rs:983`), a nudge `max` (`stage.rs:1033`), `request_timeout_secs` (`model.rs:89`), and the `stuck_after_*` thresholds (`stage.rs:998`). Per the brief ("every integer field"), these are errors now too; the three tests that pinned the silent fallback were rewritten to pin the error (or use a wrong-typed value, which still falls back as before). The fan-out counts and the per-tool ceilings were already checked (`stage.rs:203,340,577`); their messages set the style used here.

**(b) Unknown `[sandbox]` keys are silently ignored.** Held. `parse_sandbox_config` (`sections.rs:189`) read each key with `str_of`/`bool_of` and never looked at the rest, at both the agent and the stage level. `deny_unknown_fields` does not apply (the table is not deserialized through serde); the existing `reject_unknown_keys` helper the stage tables already use is applied to the sandbox table only. `SANDBOX_KEYS` was already the list the published schema is held to, so it drops its `#[cfg(test)]`.

## Change

- `count_of(v, where_, key)` in `manifest/read.rs`: `Ok(None)` when absent or not an integer (unchanged), `Err` naming the table, key and value when negative. Every count site uses it. Message shape follows the existing style, for example `region 'notes': max_items must not be negative (got -1)`, `stage 's': transition to 't': gate: max_attempts must not be negative (got -17)`.
- `[sandbox]` / `[stages.X.sandbox]`: `sandbox has unknown key 'netwrok' (valid: engine, image, kind, mount, mounts, network, on_unavailable, persist)`, prefixed with the stage for a stage block.
- Zero keeps its meaning everywhere (unlimited / never hold / unset); a test walks every case at `0` and asserts it still loads.
- No other table gains strictness. No bundled blueprint uses `[sandbox]` or a negative count; `cargo test -p leviath-cli bundled` passes.

## Fail-first evidence

Added the three tests first and ran them against the unfixed parser:

```
test manifest::tests::every_negative_manifest_integer_fails_to_load_naming_the_key ... FAILED
  loaded despite a negative value: [agent] max_child_depth = -1
test manifest::tests::sandbox_refuses_an_unknown_key_naming_it ... FAILED  (unwrap_err on Ok)
test manifest::tests::a_stage_sandbox_refuses_an_unknown_key_naming_it ... FAILED  (unwrap_err on Ok)
test result: FAILED. 207 passed; 3 failed
```

After the fix: `220 passed` in `manifest::tests`, `916 passed` for the crate. The negative table covers all 23 keys.

## Docs

- `docs/content/agents.md`: new "Counts are never negative" section.
- `docs/content/security.md`: the sandbox table's key list and the unknown-key error.
- `docs/content/cli.md`: `lev validate` now says what parsing refuses outright.
- `CHANGELOG.md` under Unreleased / Changed.

## Gates

`cargo fmt --all`, `cargo clippy --all-targets --all-features -p leviath-core -- -D warnings`, `cargo test -p leviath-core` (916), `cargo test -p leviath-cli bundled`, `cargo xtask structure`, `cargo xtask docs`, `cargo xtask coverage --package leviath-core` (100%), pre-commit full suite.
