### PR TITLE
fix(setup): the wizard no longer offers the Claude Code transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,13 @@ same list.
 
 ### Changed
 
+- `lev setup` no longer offers the Claude Code transport on its provider
+  list, and with it the reasoning-effort row, the terms dialog on save, and
+  the review-screen warning are gone. The transport itself stays: the
+  `claude_code_enabled`, `claude_code_effort` and `claude_code_binary` keys,
+  the `--claude-code` and `--claude-code-effort` flags, and the MCP import
+  from Claude Code's own config all work as before, and a config that
+  already has it on comes out of the wizard with it still on.
 - The published list prices for OpenAI, Anthropic and Google live in
   `crates/leviath-providers/pricing/rates.toml` rather than in Rust, and each
   row names where it came from. `lev models list` prints `n/a` where nothing

--- a/crates/leviath-cli/src/commands/setup/catalog.rs
+++ b/crates/leviath-cli/src/commands/setup/catalog.rs
@@ -19,9 +19,6 @@ pub enum Credential {
     ApiKey,
     /// A base URL, with a working default.
     BaseUrl,
-    /// Nothing - the provider is enabled by selecting it. Claude Code
-    /// authenticates through its own CLI.
-    None,
     /// One or more `[model_providers.<name>]` endpoints of kind
     /// `openai-compatible`, each with a name, an address and an optional key.
     /// The row is a preset; the entries under it are the wizard's own.
@@ -103,20 +100,6 @@ pub(crate) fn providers() -> Vec<Provider> {
             hint: DEFAULT_OLLAMA_URL,
             env_var: Some("OLLAMA_HOST"),
             signup_url: Some("https://ollama.com/download"),
-            preset_url: None,
-        },
-        Provider {
-            id: "claude-code",
-            display: "Claude Code transport",
-            blurb: "Runs on your Claude subscription instead of an API key. \
-                    ⚠️ May conflict with Anthropic's terms for third-party \
-                    apps. The CLI adds ~130 tokens of its own context to every \
-                    call, including your account email. This cannot be \
-                    disabled.",
-            credential: Credential::None,
-            hint: "",
-            env_var: None,
-            signup_url: None,
             preset_url: None,
         },
         Provider {
@@ -216,17 +199,14 @@ pub(crate) fn set_credential(config: &mut Config, id: &str, value: Option<String
         "google" => config.providers.google_api_key = value,
         "openrouter" => config.openrouter_api_key = value,
         "ollama" => config.ollama_base_url = value,
-        // `claude-code` is a boolean, handled by the selection itself, and an
-        // unknown id has nowhere to go.
+        // An unknown id has nowhere to go.
         _ => {}
     }
 }
 
-/// Whether a provider counts as configured in this config: it has a credential,
-/// or it needs none and is switched on.
+/// Whether a provider counts as configured in this config: it has a credential.
 pub(crate) fn is_configured(config: &Config, id: &str) -> bool {
     match id {
-        "claude-code" => config.providers.claude_code_enabled,
         // An endpoint preset is "configured" when the file holds an endpoint
         // entry that sits under it.
         "llama-cpp" | "lm-studio" | "openai-compatible" => config
@@ -296,7 +276,6 @@ mod tests {
         let all = providers();
         assert!(all.iter().any(|p| p.credential == Credential::ApiKey));
         assert!(all.iter().any(|p| p.credential == Credential::BaseUrl));
-        assert!(all.iter().any(|p| p.credential == Credential::None));
         assert!(all.iter().any(|p| p.credential == Credential::Endpoint));
     }
 
@@ -365,19 +344,20 @@ mod tests {
     }
 
     #[test]
-    fn claude_code_states_its_privacy_cost_up_front() {
-        // Offered, never chosen for the user, and never without the caveat.
-        let all = providers();
-        let cc = all
-            .iter()
-            .find(|p| p.id == "claude-code")
-            .expect("the transport is offered");
-        assert!(cc.blurb.contains("email"));
-        assert!(cc.blurb.contains("cannot be disabled"));
-        // Enabling it is a terms decision as much as a privacy one.
-        assert!(cc.blurb.contains("terms"));
-        assert_eq!(cc.credential, Credential::None);
-        assert!(!Config::default().providers.claude_code_enabled);
+    fn the_claude_code_transport_is_not_offered() {
+        // It is configured from the config keys or `lev setup --claude-code`,
+        // never from the pick list, so the wizard has no row for it and does
+        // not count the flag as a configured provider of its own.
+        assert!(providers().iter().all(|p| p.id != "claude-code"));
+        assert!(
+            providers()
+                .iter()
+                .all(|p| !p.display.contains("Claude Code"))
+        );
+
+        let mut config = Config::default();
+        config.providers.claude_code_enabled = true;
+        assert!(!is_configured(&config, "claude-code"));
     }
 
     // ─── credential accessors ───────────────────────────────────────────────
@@ -387,7 +367,7 @@ mod tests {
         // Catches the top-level/`[providers]` split silently dropping a field.
         for p in providers()
             .iter()
-            .filter(|p| !matches!(p.credential, Credential::None | Credential::Endpoint))
+            .filter(|p| p.credential != Credential::Endpoint)
         {
             let mut config = Config::default();
             assert!(
@@ -422,18 +402,6 @@ mod tests {
 
         assert!(stored_credential(&config, "not-a-provider").is_none());
         assert!(!is_configured(&config, "not-a-provider"));
-    }
-
-    #[test]
-    fn claude_code_is_configured_by_its_flag_not_a_credential() {
-        let mut config = Config::default();
-        assert!(!is_configured(&config, "claude-code"));
-        // It has no credential slot, so writing one must not make it look on.
-        set_credential(&mut config, "claude-code", Some("x".to_string()));
-        assert!(!is_configured(&config, "claude-code"));
-
-        config.providers.claude_code_enabled = true;
-        assert!(is_configured(&config, "claude-code"));
     }
 
     // ─── redact ─────────────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/setup/input.rs
+++ b/crates/leviath-cli/src/commands/setup/input.rs
@@ -129,10 +129,6 @@ impl Wizard {
                     self.should_quit = true;
                     Action::Continue
                 }
-                ConfirmPurpose::SaveTos => {
-                    self.claude_code_tos_accepted = true;
-                    Action::Save
-                }
                 ConfirmPurpose::NoProviders => {
                     self.next_step();
                     Action::Continue
@@ -190,7 +186,7 @@ impl Wizard {
     fn handle_nav_key(&mut self, key: KeyEvent) -> Action {
         let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
         match key.code {
-            KeyCode::Char('s') if ctrl => return self.try_save(),
+            KeyCode::Char('s') if ctrl => return Action::Save,
             KeyCode::Char('o') => self.open_signup_page(),
             KeyCode::Char('v') => self.verify_current(),
             KeyCode::PageUp => self.scroll_by(-Wizard::PAGE),
@@ -229,21 +225,12 @@ impl Wizard {
         }
     }
 
-    /// Save, unless the Claude Code terms still need confirming first.
-    fn try_save(&mut self) -> Action {
-        if self.needs_tos_confirmation() {
-            self.open_tos_confirm();
-            return Action::Continue;
-        }
-        Action::Save
-    }
-
     /// `Enter`: act on the focused row, or - only from the visible Continue
     /// button - move on.
     fn activate(&mut self) -> Action {
         if self.on_continue() {
             return match self.step {
-                Step::Review => self.try_save(),
+                Step::Review => Action::Save,
                 Step::Providers => {
                     self.forward_guarded();
                     Action::Continue
@@ -264,14 +251,9 @@ impl Wizard {
         match self.step {
             Step::Providers | Step::Agents | Step::Mcp => self.toggle(),
             Step::ProviderDetail => match self.detail_actions().get(self.cursor.wrapping_sub(1)) {
-                // Row 0 is the credential: it opens its editor, and the Claude
-                // Code row has nothing to type, so Enter cycles its effort.
-                // `wrapping_sub` turns that row into an index no action has.
-                None => {
-                    if !self.open_credential_editor() {
-                        self.adjust(1);
-                    }
-                }
+                // Row 0 is the credential: it opens its editor. `wrapping_sub`
+                // turns that row into an index no action has.
+                None => self.open_credential_editor(),
                 Some(DetailAction::OpenSignup) => self.open_signup_page(),
                 Some(DetailAction::Verify) => self.verify_current(),
             },
@@ -341,23 +323,19 @@ impl Wizard {
         self.open_picker(label, choice.0, choice.1);
     }
 
-    /// Open the credential editor for the provider on screen. Returns false
-    /// when this provider has nothing to type (Claude Code).
-    fn open_credential_editor(&mut self) -> bool {
+    /// Open the credential editor for the provider on screen. An endpoint
+    /// preset never gets here: `activate` sends it to its own form first.
+    fn open_credential_editor(&mut self) {
         let Some((index, credential, value)) = self.detail_row().map(|index| {
             let row = &self.providers[index];
             (index, row.provider.credential, row.value.clone())
         }) else {
-            return false;
+            return;
         };
-        if matches!(credential, Credential::None | Credential::Endpoint) {
-            return false;
-        }
         self.edit = Some(Edit {
             target: EditTarget::Credential(index),
             line: LineEdit::new(value, credential == Credential::ApiKey),
         });
-        true
     }
 
     /// Open the text editor for the selected field. Returns false for fields
@@ -393,12 +371,6 @@ impl Wizard {
                 } else if let Some(row) = self.providers.get_mut(self.cursor) {
                     row.selected = !row.selected;
                     self.dirty = true;
-                    // Deselecting the Claude Code transport withdraws the
-                    // terms acceptance so it must be re-confirmed if
-                    // re-enabled.
-                    if row.provider.id == "claude-code" && !row.selected {
-                        self.claude_code_tos_accepted = false;
-                    }
                 }
                 // The credential screen walks selected providers, so its
                 // position is only meaningful relative to the current
@@ -451,23 +423,10 @@ impl Wizard {
                 // everything else there is typed.
                 if let Some(index) = self.detail_row()
                     && self.is_endpoint_preset(index)
-                {
-                    if let Some(EndpointCursor::Field(entry, EndpointField::DefaultModel)) =
+                    && let Some(EndpointCursor::Field(entry, EndpointField::DefaultModel)) =
                         self.endpoint_cursor(index)
-                    {
-                        self.cycle_endpoint_model(entry, delta);
-                    }
-                    return;
-                }
-                // The effort selector is the only cyclable value here.
-                if let Some(index) = self.detail_row()
-                    && let Some(row) = self.providers.get_mut(index)
-                    && row.provider.credential == Credential::None
                 {
-                    let count = super::state::effort_options().len();
-                    let next = row.effort as isize + delta;
-                    row.effort = next.rem_euclid(count as isize) as usize;
-                    self.dirty = true;
+                    self.cycle_endpoint_model(entry, delta);
                 }
             }
             Step::Defaults | Step::Limits => {

--- a/crates/leviath-cli/src/commands/setup/input/tests.rs
+++ b/crates/leviath-cli/src/commands/setup/input/tests.rs
@@ -131,7 +131,8 @@ fn confirm_and_editor_guards_hold_when_driven_directly() {
 
     // The credential editor refuses an empty credential screen.
     w.enter(Step::ProviderDetail);
-    assert!(!w.open_credential_editor());
+    w.open_credential_editor();
+    assert!(w.edit.is_none());
 }
 
 #[test]
@@ -231,29 +232,6 @@ fn the_cursor_moves_within_an_edit() {
     w.handle_key(press(KeyCode::Char('c')));
 
     assert_eq!(w.edit.as_ref().expect("still editing").line.value(), "acd");
-}
-
-#[test]
-fn the_claude_code_transport_has_nothing_to_type_so_enter_cycles_effort() {
-    let (_dir, mut w) = wizard();
-    let index = w
-        .providers
-        .iter()
-        .position(|r| r.provider.id == "claude-code")
-        .expect("the transport is offered");
-    w.providers[index].selected = true;
-    w.enter(Step::ProviderDetail);
-    let before = w.providers[index].effort;
-
-    w.handle_key(press(KeyCode::Enter));
-
-    assert!(w.edit.is_none());
-    assert_eq!(
-        w.step,
-        Step::ProviderDetail,
-        "acting on a row never advances"
-    );
-    assert_ne!(w.providers[index].effort, before, "Enter acts on the row");
 }
 
 #[test]
@@ -613,40 +591,18 @@ fn choosing_ollama_as_the_default_lowers_the_concurrency_limit() {
 }
 
 #[test]
-fn left_and_right_cycle_the_claude_code_effort() {
-    let (_dir, mut w) = wizard();
-    let index = w
-        .providers
-        .iter()
-        .position(|r| r.provider.id == "claude-code")
-        .expect("the transport is offered");
-    w.providers[index].selected = true;
-    w.enter(Step::ProviderDetail);
-    let before = w.providers[index].effort;
-
-    w.handle_key(press(KeyCode::Right));
-    assert_ne!(w.providers[index].effort, before);
-    w.handle_key(press(KeyCode::Left));
-    assert_eq!(w.providers[index].effort, before);
-    // Wrapping backwards from the first level lands on the last.
-    w.providers[index].effort = 0;
-    w.handle_key(press(KeyCode::Left));
-    assert_eq!(
-        w.providers[index].effort,
-        crate::commands::setup::state::effort_options().len() - 1
-    );
-}
-
-#[test]
 fn arrows_on_a_keyed_provider_do_not_change_anything() {
     let (_dir, mut w) = wizard();
     w.providers[0].selected = true;
     w.enter(Step::ProviderDetail);
-    let before = w.providers[0].effort;
+    let before = w.providers[0].value.clone();
 
     w.handle_key(press(KeyCode::Right));
+    w.handle_key(press(KeyCode::Left));
 
-    assert_eq!(w.providers[0].effort, before);
+    assert_eq!(w.providers[0].value, before);
+    assert!(w.edit.is_none());
+    assert!(!w.dirty);
 }
 
 #[test]
@@ -903,10 +859,10 @@ fn o_where_there_is_nothing_to_open_says_so() {
     let index = w
         .providers
         .iter()
-        .position(|r| r.provider.id == "claude-code")
-        .expect("the transport is offered");
-    w.providers[index].selected = true;
-    w.enter(Step::ProviderDetail);
+        .position(|r| r.provider.signup_url.is_none())
+        .expect("a provider with nowhere to go");
+    w.enter(Step::Providers);
+    w.cursor = index;
 
     w.handle_key(press(KeyCode::Char('o')));
     assert_eq!(w.message.as_deref(), Some("Nothing to open here."));
@@ -941,134 +897,18 @@ fn an_unbound_key_does_nothing() {
     assert!(!w.should_quit);
 }
 
-// ─── Claude Code ToS confirmation gate ──────────────────────────────────
-
-fn wizard_with_claude_code() -> (tempfile::TempDir, Wizard) {
-    let (dir, mut w) = wizard();
-    let index = w
-        .providers
-        .iter()
-        .position(|r| r.provider.id == "claude-code")
-        .expect("the transport is offered");
-    w.providers[index].selected = true;
-    (dir, w)
-}
-
-#[test]
-fn enter_on_review_with_claude_code_shows_tos_confirmation() {
-    let (_dir, mut w) = wizard_with_claude_code();
-    w.enter(Step::Review);
-
-    let action = w.handle_key(press(KeyCode::Enter));
-
-    assert_eq!(
-        action,
-        Action::Continue,
-        "must not save without ToS acceptance"
-    );
-    assert_eq!(
-        w.confirm.as_ref().expect("dialog open").purpose,
-        ConfirmPurpose::SaveTos
-    );
-}
-
-#[test]
-fn ctrl_s_with_claude_code_shows_tos_confirmation() {
-    let (_dir, mut w) = wizard_with_claude_code();
-    w.enter(Step::Providers);
-
-    let action = w.handle_key(KeyEvent::new(KeyCode::Char('s'), KeyModifiers::CONTROL));
-
-    assert_eq!(action, Action::Continue);
-    assert_eq!(
-        w.confirm.as_ref().expect("dialog open").purpose,
-        ConfirmPurpose::SaveTos
-    );
-}
-
-#[test]
-fn pressing_y_on_tos_confirmation_accepts_and_saves() {
-    let (_dir, mut w) = wizard_with_claude_code();
-    w.enter(Step::Review);
-    w.handle_key(press(KeyCode::Enter));
-    assert!(w.confirm.is_some());
-
-    let action = w.handle_key(press(KeyCode::Char('y')));
-
-    assert!(w.claude_code_tos_accepted);
-    assert!(w.confirm.is_none());
-    assert_eq!(
-        action,
-        Action::Save,
-        "confirming is the last word on the save the user already asked for"
-    );
-}
-
-#[test]
-fn moving_focus_and_pressing_enter_also_accepts() {
-    let (_dir, mut w) = wizard_with_claude_code();
-    w.enter(Step::Review);
-    w.handle_key(press(KeyCode::Enter));
-
-    w.handle_key(press(KeyCode::Right)); // focus Accept
-    let action = w.handle_key(press(KeyCode::Enter));
-
-    assert!(w.claude_code_tos_accepted);
-    assert_eq!(action, Action::Save);
-}
-
-#[test]
-fn dismissing_the_tos_confirmation_stays_put_without_accepting() {
-    let (_dir, mut w) = wizard_with_claude_code();
-    w.enter(Step::Review);
-    w.handle_key(press(KeyCode::Enter));
-
-    let action = w.handle_key(press(KeyCode::Char('n')));
-
-    assert!(!w.claude_code_tos_accepted);
-    assert!(w.confirm.is_none());
-    assert_eq!(action, Action::Continue, "the save stays blocked");
-    assert_eq!(w.step, Step::Review, "declining must not navigate away");
-}
-
-#[test]
-fn second_enter_on_review_after_accepting_saves() {
-    let (_dir, mut w) = wizard_with_claude_code();
-    w.enter(Step::Review);
-    w.handle_key(press(KeyCode::Enter)); // shows the dialog
-    w.handle_key(press(KeyCode::Char('y'))); // accept
-
-    w.enter(Step::Review);
-    let action = w.handle_key(press(KeyCode::Enter));
-
-    assert_eq!(action, Action::Save, "should save after ToS accepted");
-}
-
-#[test]
-fn deselecting_claude_code_resets_tos_acceptance() {
-    let (_dir, mut w) = wizard_with_claude_code();
-    w.claude_code_tos_accepted = true;
-
-    let index = w
-        .providers
-        .iter()
-        .position(|r| r.provider.id == "claude-code")
-        .unwrap();
-    w.enter(Step::Providers);
-    w.cursor = index;
-    w.handle_key(press(KeyCode::Char(' '))); // deselect
-
-    assert!(!w.claude_code_tos_accepted);
-}
+// ─── dialogs and saving ─────────────────────────────────────────────────
 
 #[test]
 fn a_dialog_holds_focus_against_stray_keys() {
-    let (_dir, mut w) = wizard_with_claude_code();
+    let (_dir, mut w) = wizard();
+    w.dirty = true;
     w.enter(Step::Review);
-    w.handle_key(press(KeyCode::Enter));
+    w.handle_key(press(KeyCode::Char('q')));
     assert!(w.confirm.is_some());
 
-    // q neither quits nor dismisses: a stray key never answers a dialog.
+    // A second q neither quits nor dismisses: a stray key never answers a
+    // dialog.
     w.handle_key(press(KeyCode::Char('q')));
     assert!(!w.should_quit, "q must not quit while a dialog is open");
     assert!(w.confirm.is_some(), "and must not dismiss it either");
@@ -1076,16 +916,18 @@ fn a_dialog_holds_focus_against_stray_keys() {
     // Esc explicitly declines.
     w.handle_key(press(KeyCode::Esc));
     assert!(w.confirm.is_none());
-    assert!(!w.claude_code_tos_accepted);
+    assert!(!w.should_quit);
 }
 
 #[test]
-fn without_claude_code_review_saves_immediately() {
+fn enter_on_review_saves_immediately() {
+    // No provider gates the save behind a dialog any more.
     let (_dir, mut w) = wizard();
     w.enter(Step::Review);
 
     let action = w.handle_key(press(KeyCode::Enter));
-    assert_eq!(action, Action::Save, "no claude-code means no gate");
+    assert_eq!(action, Action::Save);
+    assert!(w.confirm.is_none());
 }
 
 // ─── the mouse ──────────────────────────────────────────────────────────
@@ -1178,16 +1020,13 @@ fn the_credential_screen_offers_its_actions_as_clickable_rows() {
 }
 
 /// A provider with nowhere to sign up offers only the check, and the rows stay
-/// contiguous rather than leaving a gap where a button would have been.
+/// contiguous rather than leaving a gap where a button would have been. Every
+/// keyed row in the catalog has a key page today, so the test strips one.
 #[test]
 fn a_provider_without_a_key_page_offers_only_the_check() {
     let (_dir, mut w) = wizard();
-    let index = w
-        .providers
-        .iter()
-        .position(|r| r.provider.signup_url.is_none())
-        .expect("the catalog has one");
-    w.providers[index].selected = true;
+    w.providers[0].provider.signup_url = None;
+    w.providers[0].selected = true;
     w.enter(Step::ProviderDetail);
 
     assert_eq!(w.detail_actions(), vec![DetailAction::Verify]);

--- a/crates/leviath-cli/src/commands/setup/plan.rs
+++ b/crates/leviath-cli/src/commands/setup/plan.rs
@@ -130,16 +130,6 @@ pub(crate) fn changes(before: &Config, plan: &SetupPlan) -> Vec<String> {
         }
     }
 
-    if before.providers.claude_code_enabled != after.providers.claude_code_enabled {
-        out.push(format!(
-            "Claude Code transport: {}",
-            if after.providers.claude_code_enabled {
-                "enabled"
-            } else {
-                "disabled"
-            }
-        ));
-    }
     push_if_changed(
         &mut out,
         "default provider",
@@ -501,21 +491,6 @@ mod tests {
         before.providers.anthropic_api_key = Some("sk-ant-same".to_string());
 
         assert!(changes(&before, &plan_of(before.clone())).is_empty());
-    }
-
-    #[test]
-    fn the_claude_code_toggle_is_reported_both_ways() {
-        let before = Config::default();
-        let mut on = before.clone();
-        on.providers.claude_code_enabled = true;
-
-        assert!(
-            changes(&before, &plan_of(on.clone()))
-                .contains(&"Claude Code transport: enabled".to_string())
-        );
-        assert!(
-            changes(&on, &plan_of(before)).contains(&"Claude Code transport: disabled".to_string())
-        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/setup/render.rs
+++ b/crates/leviath-cli/src/commands/setup/render.rs
@@ -606,8 +606,8 @@ fn build_provider_detail(wizard: &Wizard) -> Screen {
         Line::from(""),
     ];
 
-    // The credential (or effort) row is the screen's one cursor row; the
-    // marker shows whether it or the Continue button holds focus.
+    // The credential row is the screen's one cursor row; the marker shows
+    // whether it or the Continue button holds focus.
     let row_marker = if wizard.on_continue() { "  " } else { "› " };
     let credential_row = lines.len();
     match row.provider.credential {
@@ -644,33 +644,6 @@ fn build_provider_detail(wizard: &Wizard) -> Screen {
         }
         // A preset's screen is a form per entry, not this card.
         Credential::Endpoint => return endpoints::build_endpoint_detail(wizard, index),
-        Credential::None => {
-            lines.push(Line::from(vec![
-                Span::styled(row_marker, Style::default().fg(C_ACCENT)),
-                Span::styled("Reasoning effort: ", Style::default().fg(C_MUTED)),
-                Span::styled(
-                    super::state::effort_options()[row.effort],
-                    Style::default().fg(C_ACCENT),
-                ),
-            ]));
-            lines.push(Line::from(Span::styled(
-                "← / → to change.  Sign in with `claude` if you have not already.",
-                Style::default().fg(C_DIM),
-            )));
-            // The transport is opt-in, so the terms risk has to be on the
-            // screen where it is opted into - not only in the README.
-            for warning in [
-                "⚠️  Anthropic's terms prohibit third-party use of subscription auth",
-                "    without prior approval. By enabling this transport you accept",
-                "    responsibility for compliance with their terms.",
-                "    For unambiguous compliance, use a direct Anthropic API key.",
-            ] {
-                lines.push(Line::from(Span::styled(
-                    warning,
-                    Style::default().fg(C_WARN),
-                )));
-            }
-        }
     }
 
     lines.push(Line::from(""));
@@ -936,24 +909,6 @@ fn build_review(wizard: &Wizard) -> Screen {
         }
     }
 
-    if wizard
-        .providers
-        .iter()
-        .any(|r| r.selected && r.provider.id == "claude-code")
-    {
-        lines.push(Line::from(""));
-        for warning in [
-            "Claude Code transport: Anthropic's terms may prohibit third-party use of",
-            "subscription auth without prior approval. By enabling it you accept",
-            "responsibility for compliance with their terms.",
-        ] {
-            lines.push(Line::from(Span::styled(
-                warning,
-                Style::default().fg(C_WARN),
-            )));
-        }
-    }
-
     Screen {
         lines,
         rows: Vec::new(),
@@ -1080,7 +1035,7 @@ mod tests {
     }
 
     /// A provider blurb on a narrow window must wrap, not clip: the tail of
-    /// the sentence (here the transport's "cannot be disabled" caveat) has to
+    /// the longest sentence (the custom endpoint blurb ends in "them.") has to
     /// reach the screen.
     #[test]
     fn narrow_window_wraps_provider_blurbs_instead_of_clipping() {
@@ -1090,7 +1045,7 @@ mod tests {
         terminal.draw(|frame| draw(frame, &w)).unwrap();
         let screen = terminal.backend().text();
         assert!(
-            screen.contains("disabled"),
+            screen.contains("    them."),
             "the blurb tail must survive a 48-column window:\n{screen}"
         );
     }
@@ -1556,74 +1511,23 @@ mod tests {
     }
 
     #[test]
-    fn the_claude_code_card_shows_its_effort_and_its_caveat() {
+    fn a_confirmation_dialog_draws_over_the_review_screen() {
         let (_dir, mut w) = wizard();
-        let index = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-        w.providers[index].selected = true;
-        w.enter(Step::ProviderDetail);
-
-        let screen = rendered(&w);
-        assert!(screen.contains("Reasoning effort"));
-        assert!(
-            screen.contains("email"),
-            "the privacy cost must be on screen"
-        );
-        assert!(
-            screen.contains("terms"),
-            "the terms-of-service risk must be on screen:\n{screen}"
-        );
-    }
-
-    #[test]
-    fn the_review_screen_warns_about_the_claude_code_terms() {
-        let (_dir, mut w) = wizard();
-        let index = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
         w.enter(Step::Review);
-        assert!(
-            !rendered(&w).contains("Claude Code transport: Anthropic"),
-            "the warning is only for a setup that enables it"
-        );
-
-        w.providers[index].selected = true;
-        let screen = rendered(&w);
-        assert!(
-            screen.contains("Claude Code transport: Anthropic"),
-            "{screen}"
-        );
-        assert!(screen.contains("responsibility for compliance"), "{screen}");
-    }
-
-    #[test]
-    fn the_tos_confirmation_dialog_draws_over_the_review_screen() {
-        let (_dir, mut w) = wizard();
-        let index = w
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-        w.providers[index].selected = true;
-        w.enter(Step::Review);
-        w.open_tos_confirm();
+        w.dirty = true;
+        w.open_quit_confirm();
 
         let screen = rendered(&w);
         assert!(
-            screen.contains("terms of service"),
+            screen.contains("Quit setup?"),
             "dialog title missing:\n{screen}"
         );
         assert!(
-            screen.contains("[ Accept and save ]"),
+            screen.contains("[ Quit ]"),
             "the affirmative button is missing:\n{screen}"
         );
         assert!(
-            screen.contains("[ Cancel ]"),
+            screen.contains("[ Stay ]"),
             "the safe button is missing:\n{screen}"
         );
     }

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -63,10 +63,6 @@ pub struct Wizard {
     /// The user has changed something since the wizard opened, so quitting
     /// silently would discard real choices.
     pub dirty: bool,
-    /// The user has acknowledged the Claude Code transport's terms risk. A
-    /// hard gate on saving: the transport cannot be written to the config
-    /// without it, and deselecting the transport withdraws it.
-    pub claude_code_tos_accepted: bool,
     /// The user asked to leave and the loop should stop.
     pub should_quit: bool,
     /// Set once the plan has been applied, so the loop knows to stop.
@@ -156,7 +152,6 @@ impl Wizard {
                     selected: catalog::is_configured(&base, provider.id) || from_env.is_some(),
                     value: stored.unwrap_or_default(),
                     from_env,
-                    effort: effort_index(base.providers.claude_code_effort.as_deref()),
                     outcome: Outcome::Skipped,
                     checking: false,
                     provider,
@@ -227,7 +222,6 @@ impl Wizard {
             show_help: false,
             confirm: None,
             dirty: false,
-            claude_code_tos_accepted: false,
             should_quit: false,
             finished: false,
             message: None,
@@ -275,21 +269,6 @@ impl Wizard {
     /// The provider row the credential screen is currently showing.
     pub(crate) fn detail_row(&self) -> Option<usize> {
         self.selected_providers().get(self.detail).copied()
-    }
-
-    /// Whether the Claude Code transport is one of the picked providers.
-    pub(crate) fn claude_code_selected(&self) -> bool {
-        self.providers
-            .iter()
-            .any(|r| r.selected && r.provider.id == "claude-code")
-    }
-
-    /// Whether saving must first ask the user to acknowledge Anthropic's
-    /// terms. Enabling the transport routes inference through a subscription
-    /// session, so the risk is confirmed once, explicitly, rather than being
-    /// buried in a paragraph nobody reads.
-    pub(crate) fn needs_tos_confirmation(&self) -> bool {
-        self.claude_code_selected() && !self.claude_code_tos_accepted
     }
 
     /// The fields the current step edits, if it edits fields.
@@ -935,31 +914,6 @@ impl Wizard {
         });
     }
 
-    /// Saving with the Claude Code transport selected: the terms risk is
-    /// confirmed once, explicitly, on a dialog with real buttons.
-    pub(crate) fn open_tos_confirm(&mut self) {
-        use ratatui::text::Line;
-        self.confirm = Some(PendingConfirm {
-            purpose: ConfirmPurpose::SaveTos,
-            dialog: crate::tui::widgets::confirm::Confirm::new(
-                "Claude Code terms of service",
-                vec![
-                    Line::from("Anthropic's terms prohibit third-party developers from offering"),
-                    Line::from("claude.ai subscription auth for their products without prior"),
-                    Line::from("approval. The Claude Code transport routes inference through"),
-                    Line::from("your subscription via the CLI's OAuth session."),
-                    Line::from(""),
-                    Line::from("For unambiguous compliance, use a direct Anthropic API key."),
-                    Line::from(""),
-                    Line::from("Accepting means you take responsibility for compliance."),
-                ],
-                "Accept and save",
-                "Cancel",
-            )
-            .danger(),
-        });
-    }
-
     /// Leaving the Providers screen with nothing selected: Leviath cannot run
     /// an agent without a provider, so this is almost always a slip.
     pub(crate) fn open_no_providers_confirm(&mut self) {
@@ -1030,7 +984,7 @@ impl Wizard {
         for row in &self.providers {
             match row.provider.credential {
                 // Written below, from the entries rather than the row.
-                Credential::None | Credential::Endpoint => {}
+                Credential::Endpoint => {}
                 _ if !row.selected => catalog::set_credential(&mut config, row.provider.id, None),
                 // An environment-supplied credential is left out of the file:
                 // the user put it in their environment on purpose, and
@@ -1047,18 +1001,11 @@ impl Wizard {
             }
         }
 
-        // The transport is always in the table, so this reads its row when
-        // selected rather than guarding a lookup that cannot miss.
-        let transport = self
-            .providers
-            .iter()
-            .find(|r| r.provider.id == "claude-code")
-            .filter(|r| r.selected);
-        config.providers.claude_code_enabled = transport.is_some();
-        if let Some(row) = transport {
-            config.providers.claude_code_effort =
-                Some(effort_options()[row.effort.min(effort_options().len() - 1)].to_string());
-        }
+        // The Claude Code transport has no row here. Its keys
+        // (`claude_code_enabled`, `claude_code_effort`, `claude_code_binary`)
+        // are set by hand or by `lev setup --claude-code`, and the clone of
+        // `base` above carries whatever the file already says through
+        // untouched.
 
         self.write_endpoints(&mut config);
 
@@ -2498,59 +2445,21 @@ pub(super) mod tests {
     }
 
     #[test]
-    fn the_claude_code_transport_carries_its_effort_only_when_enabled() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut wizard = test_wizard(dir.path());
-        let index = wizard
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-
-        assert!(!wizard.build_config().providers.claude_code_enabled);
-
-        wizard.providers[index].selected = true;
-        wizard.providers[index].effort = effort_options().len() - 1;
-        let config = wizard.build_config();
-        assert!(config.providers.claude_code_enabled);
-        assert_eq!(
-            config.providers.claude_code_effort.as_deref(),
-            Some(*effort_options().last().expect("levels exist"))
-        );
-    }
-
-    #[test]
-    fn an_out_of_range_effort_index_clamps_rather_than_panicking() {
-        let dir = tempfile::tempdir().unwrap();
-        let mut wizard = test_wizard(dir.path());
-        let index = wizard
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-        wizard.providers[index].selected = true;
-        wizard.providers[index].effort = 99;
-
-        let config = wizard.build_config();
-
-        assert_eq!(
-            config.providers.claude_code_effort.as_deref(),
-            Some(*effort_options().last().expect("levels exist"))
-        );
-    }
-
-    #[test]
-    fn the_stored_effort_selects_the_matching_option() {
+    fn an_enabled_claude_code_transport_survives_the_wizard_untouched() {
+        // The transport has no row, so the wizard must neither switch it off
+        // nor rewrite its effort: the config keys pass straight through.
         let dir = tempfile::tempdir().unwrap();
         let base = Config {
             providers: crate::config::ProviderConfig {
+                claude_code_enabled: true,
                 claude_code_effort: Some("max".to_string()),
+                claude_code_binary: Some("/opt/claude".into()),
                 ..Config::default().providers
             },
             ..Config::default()
         };
-        let wizard = Wizard::new(
-            base,
+        let mut wizard = Wizard::new(
+            base.clone(),
             &|_| None,
             Vec::new(),
             Vec::new(),
@@ -2558,21 +2467,26 @@ pub(super) mod tests {
             std::sync::Arc::new(|_| true),
             Default::default(),
         );
+        assert!(
+            wizard
+                .providers
+                .iter()
+                .all(|r| r.provider.id != "claude-code")
+        );
 
-        let index = wizard
-            .providers
-            .iter()
-            .position(|r| r.provider.id == "claude-code")
-            .expect("the transport is offered");
-        assert_eq!(effort_options()[wizard.providers[index].effort], "max");
-    }
+        // Touching other providers does not disturb it either.
+        wizard.providers[0].selected = true;
+        wizard.providers[0].value = "sk-ant-x".to_string();
+        let config = wizard.build_config();
 
-    #[test]
-    fn an_unrecognised_stored_effort_falls_back_to_the_first_level() {
-        assert_eq!(effort_index(Some("not-a-level")), 0);
+        assert!(config.providers.claude_code_enabled);
         assert_eq!(
-            effort_options()[effort_index(None)],
-            leviath_providers::claude_code::DEFAULT_EFFORT
+            config.providers.claude_code_effort,
+            base.providers.claude_code_effort
+        );
+        assert_eq!(
+            config.providers.claude_code_binary,
+            base.providers.claude_code_binary
         );
     }
 

--- a/crates/leviath-cli/src/commands/setup/state/types.rs
+++ b/crates/leviath-cli/src/commands/setup/state/types.rs
@@ -76,8 +76,6 @@ pub struct ProviderRow {
     /// The credential is already in the environment, under this variable, and
     /// is not being written to the config.
     pub from_env: Option<&'static str>,
-    /// Reasoning effort, for the Claude Code transport only.
-    pub effort: usize,
     /// What the last verification attempt concluded.
     pub outcome: Outcome,
     /// A verification is in flight.
@@ -89,11 +87,10 @@ impl ProviderRow {
     pub(crate) fn has_credential(&self) -> bool {
         match self.provider.credential {
             Credential::ApiKey => !self.value.is_empty() || self.from_env.is_some(),
-            // Ollama and the Claude Code transport need no key; selecting them
-            // is the whole configuration, so they are always checkable. An
-            // endpoint preset checks each of its entries, which decide for
-            // themselves.
-            Credential::BaseUrl | Credential::None | Credential::Endpoint => true,
+            // Ollama needs no key; selecting it is the whole configuration,
+            // so it is always checkable. An endpoint preset checks each of
+            // its entries, which decide for themselves.
+            Credential::BaseUrl | Credential::Endpoint => true,
         }
     }
 }
@@ -270,8 +267,6 @@ pub struct Edit {
 pub enum ConfirmPurpose {
     /// `q`/Ctrl-C with unsaved choices: quit and discard?
     QuitDiscard,
-    /// Saving with the Claude Code transport selected: accept the terms risk?
-    SaveTos,
     /// Leaving the Providers screen with nothing selected: continue anyway?
     NoProviders,
 }
@@ -282,22 +277,4 @@ pub struct PendingConfirm {
     /// What answering Yes would mean.
     pub purpose: ConfirmPurpose,
     pub(crate) dialog: crate::tui::widgets::confirm::Confirm,
-}
-
-// Reasoning effort is a property of a provider row, so it belongs beside the
-// row rather than with `[limits]` - which it shared a neighbourhood with only
-// because of where it happened to sit in the original file.
-/// Reasoning-effort levels for the Claude Code transport, from the provider
-/// rather than re-typed here.
-pub(crate) fn effort_options() -> &'static [&'static str] {
-    &leviath_providers::claude_code::EFFORT_LEVELS
-}
-
-/// Index of `effort` in [`effort_options`], defaulting to the provider default.
-pub(super) fn effort_index(effort: Option<&str>) -> usize {
-    let wanted = effort.unwrap_or(leviath_providers::claude_code::DEFAULT_EFFORT);
-    effort_options()
-        .iter()
-        .position(|e| *e == wanted)
-        .unwrap_or_default()
 }

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -21,7 +21,7 @@ writes it into `~/.leviath/config.toml` for you, interactively or with
 | Google (Gemini) | `GOOGLE_API_KEY` | [aistudio.google.com](https://aistudio.google.com/app/apikey) |
 | OpenRouter | `OPENROUTER_API_KEY` | [openrouter.ai/keys](https://openrouter.ai/keys) |
 | Ollama | `OLLAMA_HOST` (optional, local) | [ollama.com/download](https://ollama.com/download) |
-| Claude Code | none (subscription; terms caveat below) | see below |
+| Claude Code | none (subscription; terms caveat below; not in the wizard) | see below |
 
 The setup flag `--ollama-url` sets the same base URL that `OLLAMA_HOST` supplies.
 
@@ -412,7 +412,9 @@ Four measured caveats. The CLI adds about 130 tokens of its own context to **eve
 account email address and the current date included, and there is no flag to turn that off. There is
 no prompt caching. Each call is a separate subprocess. And it serves Anthropic models only.
 
-Enable it through `lev setup`, or directly:
+The setup wizard does not offer it. Turn it on with `lev setup --claude-code true`
+(and `--claude-code-effort <level>` if you want something other than the default), or write the
+keys yourself:
 
 ```toml
 [providers]
@@ -421,7 +423,6 @@ claude_code_binary  = "/usr/local/bin/claude"   # unset resolves `claude` on PAT
 claude_code_effort  = "medium"                  # low | medium | high | xhigh | max
 ```
 
-It is off unless you turn it on: the wizard never selects it for you, and saving with it selected
-first asks you to accept the terms risk on an explicit dialog. `claude_code_effort` is always sent
-explicitly: left to itself the CLI picks `high` with adaptive thinking, spending output tokens and
-latency Leviath never asked for.
+It is off unless you turn it on, and running the wizard later leaves these keys as they are.
+`claude_code_effort` is always sent explicitly: left to itself the CLI picks `high` with adaptive
+thinking, spending output tokens and latency Leviath never asked for.


### PR DESCRIPTION
## What changed

`lev setup` no longer offers the Claude Code transport on its provider list. The row was subpar as a pick: it needed no credential, gated every save behind a terms dialog, and carried a reasoning-effort row and a review-screen warning that nothing else used.

Everything that only the row reached is removed rather than left dead (clippy runs with `-D warnings`, coverage is 100% per crate):

- `catalog.rs`: the `claude-code` `Provider` entry, the `Credential::None` kind, the `is_configured` arm.
- `state/types.rs`: the `effort` field on `ProviderRow`, `effort_options` / `effort_index`, `ConfirmPurpose::SaveTos`.
- `state/mod.rs`: `claude_code_tos_accepted`, `claude_code_selected`, `needs_tos_confirmation`, `open_tos_confirm`, and the block in `build_config` that derived `claude_code_enabled` from the row.
- `input.rs`: `try_save` (Enter on Review and Ctrl-S now save directly), Enter cycling effort, Left/Right effort cycling, the deselect reset. `open_credential_editor` no longer returns a bool.
- `render.rs`: the card's effort line and terms text, the review-screen warning.
- `plan.rs`: the "Claude Code transport: enabled/disabled" change line. `changes` is only called from the wizard, and the wizard can no longer alter that flag, so the line was unreachable.

## What stays

- `claude_code_enabled`, `claude_code_effort`, `claude_code_binary` in `[providers]`.
- `lev setup --claude-code <bool>` and `--claude-code-effort <level>` (non-interactive path in `setup/mod.rs`, untouched, still counts the transport as a configured provider).
- The provider in `leviath-providers`.
- The MCP import from Claude Code's `~/.claude.json` (`setup/import/`).

A config that already has `claude_code_enabled = true` survives the wizard: `build_config` clones the loaded config and never touches those keys now.

## Tests

- Added `catalog::the_claude_code_transport_is_not_offered` (no `claude-code` id, no "Claude Code" display, the flag is not a wizard-configured provider).
- Added `state::an_enabled_claude_code_transport_survives_the_wizard_untouched` (enabled + effort + binary round trip through `Wizard::new` and `build_config`, with another provider edited).
- Deleted the effort, ToS dialog, review-warning and plan-line tests. Two generic dialog tests that used the ToS dialog as a fixture now use the quit dialog (`a_dialog_holds_focus_against_stray_keys`, `a_confirmation_dialog_draws_over_the_review_screen`); `a_provider_without_a_key_page_offers_only_the_check` strips a `signup_url` since no keyed catalog row lacks one now; the narrow-window wrap test asserts on the custom endpoint blurb's tail.

## Docs

- `docs/content/providers.md`: the transport section says the wizard does not offer it and points at `lev setup --claude-code true` or the keys; the table row notes it is not in the wizard.
- CHANGELOG under Unreleased / Changed.

## Gates (from the worktree)

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`: clean
- `cargo test -p leviath-cli setup`: 347 passed
- `cargo xtask structure`: ok
- `cargo xtask docs`: 40 pages, no problems
- `cargo xtask coverage --package leviath-cli`: passes (exit 0)

## Live check

A pty driver ran the freshly built `lev setup` with a short isolated `LEVIATH_HOME`, `HOME` pointed at it, and `LEVIATH_SKIP_DOTENV=1`, pressed Enter on Welcome, and captured the Providers screen:

```
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│Leviath setup  Welcome › Providers › Credentials › Defaults › Limits › Agents › MCP servers › Review                  │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌ Providers ───────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│○ Anthropic                                                                                                           │
│    Claude models. The default for every shipped blueprint.                                                           │
│○ OpenAI                                                                                                              │
│    GPT models.                                                                                                       │
│○ Google (Gemini)                                                                                                     │
│    Gemini models.                                                                                                    │
│○ OpenRouter                                                                                                          │
│    One key, many vendors' models.                                                                                    │
│○ Ollama (local)                                                                                                      │
│    Models running on this machine. No key needed.                                                                    │
│○ llama.cpp                                                                                                           │
│    A llama.cpp server on this machine, over its OpenAI-compatible API. No key needed.                                │
│○ LM Studio                                                                                                           │
│    LM Studio's local server, over its OpenAI-compatible API. No key needed.                                          │
│○ Custom OpenAI-compatible endpoint20;2H    vLLM, BionicGPT, a gateway, or any server that speaks the OpenAI chat API:
│    headers if it wants them.                                                                                         │
│  [ Continue (no providers selected) ]                                                                                │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│↑↓ move · space/enter select · o signup · v check · tab next · ^R reveal · ? help · ^S save · q quit                  │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
RESULT: PASS
```

No Claude Code row; the eight remaining rows are present. Driver: a pty fork with SGR mouse and keyboard queries answered, whole-stream replay into a grid (the `20;2H` fragment is a CSI split across a read chunk in the replay, not in the wizard).
