### PR TITLE
fix(core): classify every built-in tool for the taint gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,14 @@ same list.
   that fresh figure. It now shows the share of the whole prompt (fresh plus
   cached) that came from cache, so the figure cannot pass 100%. Stored counts
   and the API are unchanged.
+- With taint tracking on, `read_files`, `edit_document`, the `context_*` and
+  `todo_*` tools, `submit_output` and `fan_out` were gated as if they sent
+  data off the machine, because none had a classification of its own and
+  the fallback is the third-party default. Reading two files with anything
+  Private in context raised a leak prompt while reading one did not. Each
+  now carries its sibling's classification (`read_files` reads like
+  `read_file`, `fan_out` spawns like `spawn_agent`, the rest are internal),
+  and a test holds every built-in to an arm of its own.
 - The dashboard cut text to fixed character counts whatever the terminal
   width: the detail view's model name stopped at 24 characters and its
   working directory at 42 with most of a 200-column row empty, the header

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -468,8 +468,31 @@ pub enum GateDecisionSource {
 /// service - so an internal default would assume the safest case about the
 /// least-known code. Failing closed costs a prompt; failing open costs the data.
 pub fn builtin_tool_classification(tool_name: &str) -> ToolClassification {
-    match tool_name {
-        "read_file" => ToolClassification::new(
+    // An unknown tool is almost always an MCP or Rhai script tool:
+    // third-party code, usually talking to a third-party service. Treat it
+    // as outbound so the gate sees it. `ToolClassification::default()` -
+    // internal/internal - assumed the safest case about the least-known
+    // code, and left every MCP and script tool ungated.
+    classified_builtin(tool_name).unwrap_or_else(|| {
+        ToolClassification::new(
+            TaintLevel::Public,
+            ToolDirection::Outbound,
+            TaintLevel::Public,
+        )
+    })
+}
+
+/// The classification of a built-in tool by name, or `None` for a name that
+/// has no arm of its own and so takes the third-party default.
+///
+/// Separate from [`builtin_tool_classification`] so a test can hold every
+/// built-in the registry advertises to an arm of its own: the default is
+/// outbound and gated, and a built-in that reached it was blocked in every
+/// taint-tracking run with anything Private in context, silently.
+pub fn classified_builtin(tool_name: &str) -> Option<ToolClassification> {
+    let classification = match tool_name {
+        // `read_files` is `read_file` over several paths.
+        "read_file" | "read_files" => ToolClassification::new(
             TaintLevel::Internal,
             ToolDirection::Inbound,
             TaintLevel::Public,
@@ -479,7 +502,18 @@ pub fn builtin_tool_classification(tool_name: &str) -> ToolClassification {
             ToolDirection::Internal,
             TaintLevel::Public,
         ),
-        "edit_file" => ToolClassification::new(
+        // `edit_document` edits a draft the same way `edit_file` edits a
+        // file, with a person at the other end instead of the disk.
+        "edit_file" | "edit_document" => ToolClassification::new(
+            TaintLevel::Internal,
+            ToolDirection::Internal,
+            TaintLevel::Public,
+        ),
+        // The context, todo and submit tools write the run's own state: the
+        // agent's regions, its checklist, the answer the caller gets back.
+        // Nothing leaves the machine, so none is a channel the gate watches.
+        "context_write" | "context_append" | "context_read" | "context_delete" | "context_list"
+        | "todo_add" | "todo_done" | "todo_note" | "submit_output" => ToolClassification::new(
             TaintLevel::Internal,
             ToolDirection::Internal,
             TaintLevel::Public,
@@ -529,24 +563,16 @@ pub fn builtin_tool_classification(tool_name: &str) -> ToolClassification {
                 TaintLevel::Public,
             )
         }
-        "spawn_agent" | "check_agent" | "wait_for_agent" | "send_to_agent" | "kill_agent" => {
-            ToolClassification::new(
-                TaintLevel::Internal,
-                ToolDirection::Internal,
-                TaintLevel::Public,
-            )
-        }
-        // An unknown tool is almost always an MCP or Rhai script tool:
-        // third-party code, usually talking to a third-party service. Treat it
-        // as outbound so the gate sees it. `ToolClassification::default()` -
-        // internal/internal - assumed the safest case about the least-known
-        // code, and left every MCP and script tool ungated.
-        _ => ToolClassification::new(
-            TaintLevel::Public,
-            ToolDirection::Outbound,
+        // `fan_out` is many `spawn_agent`s at once.
+        "spawn_agent" | "check_agent" | "wait_for_agent" | "send_to_agent" | "kill_agent"
+        | "fan_out" => ToolClassification::new(
+            TaintLevel::Internal,
+            ToolDirection::Internal,
             TaintLevel::Public,
         ),
-    }
+        _ => return None,
+    };
+    Some(classification)
 }
 
 #[cfg(test)]
@@ -1072,6 +1098,60 @@ mod tests {
         assert_eq!(tc.sensitivity, TaintLevel::Internal);
         assert_eq!(tc.direction, ToolDirection::Inbound);
         assert_eq!(tc.clearance, TaintLevel::Public);
+    }
+
+    /// `read_files` is `read_file` over several paths, `fan_out` is many
+    /// `spawn_agent`s at once, `edit_document` hands a draft to the person
+    /// the way `present_for_review` does, and the context, todo and submit
+    /// tools write the run's own state. None had an arm, so each fell to the
+    /// third-party default and was gated as outbound: with taint tracking on
+    /// and anything Private in context, reading two files raised a leak
+    /// prompt while reading one did not.
+    #[test]
+    fn the_remaining_builtins_are_classified_like_their_siblings() {
+        assert_eq!(
+            classified_builtin("read_files"),
+            classified_builtin("read_file"),
+            "read_files"
+        );
+        assert_eq!(
+            classified_builtin("fan_out"),
+            classified_builtin("spawn_agent"),
+            "fan_out"
+        );
+        assert_eq!(
+            classified_builtin("edit_document"),
+            classified_builtin("edit_file"),
+            "edit_document"
+        );
+        for name in [
+            "context_write",
+            "context_append",
+            "context_read",
+            "context_delete",
+            "context_list",
+            "todo_add",
+            "todo_done",
+            "todo_note",
+            "submit_output",
+        ] {
+            let tc = classified_builtin(name);
+            assert!(tc.is_some(), "{name} has no arm");
+            let tc = tc.unwrap();
+            assert_eq!(tc.direction, ToolDirection::Internal, "{name}");
+            assert_eq!(tc.sensitivity, TaintLevel::Internal, "{name}");
+            assert_eq!(tc.clearance, TaintLevel::Public, "{name}");
+        }
+    }
+
+    /// The split exists so a caller can tell an arm from the default.
+    #[test]
+    fn a_third_party_name_has_no_arm_of_its_own() {
+        assert_eq!(classified_builtin("some_mcp_tool"), None);
+        assert_eq!(
+            classified_builtin("shell"),
+            Some(builtin_tool_classification("shell"))
+        );
     }
 
     // ─── resolve_taint_enabled / resolve_security cascade ───────────────────

--- a/crates/leviath-runtime/src/taint.rs
+++ b/crates/leviath-runtime/src/taint.rs
@@ -414,6 +414,28 @@ mod tests {
         assert!(decision.is_allowed());
     }
 
+    /// `read_files` had no arm in the classification table, so it took the
+    /// third-party default (outbound) and was blocked whenever anything
+    /// Private sat in context, while `read_file` on the same paths passed.
+    /// The same held for `edit_document`, the context and todo tools,
+    /// `submit_output` and `fan_out`.
+    #[test]
+    fn gate_allows_the_builtins_that_had_no_arm() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let window = make_window_with_taint(TaintLevel::Private);
+        for name in [
+            "read_files",
+            "edit_document",
+            "context_append",
+            "todo_add",
+            "submit_output",
+            "fan_out",
+        ] {
+            let decision = gate.check_traditional("agent-1", name, &window);
+            assert!(decision.is_allowed(), "{name}: {decision:?}");
+        }
+    }
+
     #[test]
     fn gate_allows_outbound_when_taint_within_clearance() {
         let mut gate = TaintGate::new(SecurityConfig::default());

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -443,6 +443,25 @@ mod tests {
         assert_eq!(tools.names().len(), 28);
     }
 
+    /// The taint gate's fallback arm is the third-party default: outbound,
+    /// so gated. A built-in that reaches it is blocked in every
+    /// taint-tracking run with anything Private in context, and nothing says
+    /// why. This holds every name the registry advertises, and every
+    /// sub-agent tool, to an arm of its own, so a tool added later cannot
+    /// slip through the way `read_files` and the context tools did.
+    #[test]
+    fn every_builtin_tool_has_its_own_taint_arm() {
+        let dir = std::env::temp_dir();
+        let tools = make_tools(&dir);
+        let subagent = SUBAGENT_TOOLS.iter().map(|s| s.to_string());
+        for name in tools.names().into_iter().chain(subagent) {
+            assert!(
+                leviath_core::taint::classified_builtin(&name).is_some(),
+                "{name} falls to the third-party default arm"
+            );
+        }
+    }
+
     // ── Sub-agent tool definitions ────────────────────────────────────────
 
     #[test]

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -222,8 +222,12 @@ flowchart TD
   P -->|ask| Q["Prompt: allow once /<br/>for session / deny"]
 ```
 
-Taint recovers as entries evict, and an unrecognized tool **fails closed**. Configure with a
-`[security]` block, layer on allowlists and Rhai policy rules, and dry-run any tool:
+Taint recovers as entries evict, and an unrecognized tool **fails closed**: an MCP or script tool
+with no classification of its own is treated as outbound and gated. Every built-in tool carries its
+own classification, so only the ones that can carry bytes out (`shell`, `web_search`, `web_fetch`
+and the HTTP tools) are ever gated; the file, context, todo, sub-agent and interaction tools are
+not. Configure with a `[security]` block, layer on allowlists and Rhai policy rules, and dry-run
+any tool:
 
 ```bash
 lev policy list


### PR DESCRIPTION
## Premise, measured

**Held.** `builtin_tool_classification` in `crates/leviath-core/src/taint.rs:470` had arms for `read_file`, `write_file`, `edit_file`, `list_dir`, `shell`/`bash`, the five network tools, the six environment tools, the four ask/review tools and the five sub-agent tools. Listed against `BuiltinTools::names()` (`crates/leviath-tools/src/defs.rs:689`) plus `SUBAGENT_TOOLS`, eleven built-ins had none and fell to the `_` arm (Public / Outbound / Public): `read_files`, `edit_document`, `context_write`, `context_append`, `context_read`, `context_delete`, `context_list`, `todo_add`, `todo_done`, `todo_note`, `submit_output`, and `fan_out` (twelve with it; it is advertised through `FAN_OUT_TOOL` rather than a literal).

One note on the brief: there is no single `BUILTIN_TOOL_NAMES` list. The canonical registry list is `BuiltinTools::names()` (the 27 advertised names plus the `bash` alias), and the sub-agent tools live apart in `SUBAGENT_TOOLS`. The guard test walks both.

## Change

- `read_files` joins the `read_file` arm (Internal / Inbound), `fan_out` joins the `spawn_agent` arm (Internal / Internal), `edit_document` joins `edit_file` (Internal / Internal), and the context, todo and submit tools get an internal arm of their own (Internal / Internal / Public).
- The match is split into `pub fn classified_builtin(name) -> Option<ToolClassification>`; `builtin_tool_classification` is that with the unchanged third-party default in the `None` case. The split is what lets a test tell "has an arm" from "took the default", since `shell` and the default share a value.
- No other behaviour changes: every existing arm and the default keep their values, and `lev policy` and the runtime gate call the same public function they did.

## Fail-first evidence

The refactor was applied first with the arms untouched, and the three new tests run against it:

```
leviath-core:    the_remaining_builtins_are_classified_like_their_siblings ... FAILED
leviath-tools:   every_builtin_tool_has_its_own_taint_arm ... FAILED
                 read_files falls to the third-party default arm
leviath-runtime: gate_allows_the_builtins_that_had_no_arm ... FAILED
                 read_files: Blocked { taint_level: Private, clearance: Public,
                                       source_regions: ["conv"], tool_name: "read_files" }
```

The runtime one is the user-visible regression: `SecurityConfig::default()` has taint tracking on, a Private entry sits in context, and `read_files` is blocked where `read_file` passes. After the arms: all taint tests pass in the three crates (79 / 1 / 52).

The guard test (`every_builtin_tool_has_its_own_taint_arm` in `crates/leviath-tools/src/lib.rs`) iterates `names()` and `SUBAGENT_TOOLS` and fails on any name `classified_builtin` answers `None` for, so a tool added to the registry later cannot slip through.

## Docs

- `docs/content/security.md`, taint section: says which built-ins are ever gated and that only unrecognized (MCP / script) tools take the fail-closed default.
- `CHANGELOG.md` under Unreleased / Fixed.

## Gates

`cargo fmt --all`, `cargo clippy --all-targets --all-features -p leviath-core -p leviath-tools -p leviath-runtime -- -D warnings`, targeted tests, `cargo xtask structure`, `cargo xtask docs`, `cargo xtask coverage --package` for each of the three crates (100%), pre-commit full suite.
