### PR TITLE
fix(dash): Enter is a newline in the response box, and unattended asks every time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,12 @@ same list.
   the box, reached with `Tab` or a click, sends on a terminal that cannot
   tell `Ctrl+Enter` from `Enter`. It is the same button the new-run screen
   starts a run with. Single-line boxes keep `Enter` as submit.
+- The unattended warning on the dashboard's new-run screen offered a "don't
+  ask again" box, so after ticking it a second `Ctrl-Y` on, off, and on
+  again armed the setting with no dialog, which read as the toggle
+  misbehaving rather than remembering. Every switch to on now shows the
+  warning; the box is gone. Nothing about it was ever written to disk, so
+  there is no saved value to drop.
 - The dashboard cut text to fixed character counts whatever the terminal
   width: the detail view's model name stopped at 24 characters and its
   working directory at 42 with most of a 200-column row empty, the header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,14 @@ same list.
   now carries its sibling's classification (`read_files` reads like
   `read_file`, `fan_out` spawns like `spawn_agent`, the rest are internal),
   and a test holds every built-in to an arm of its own.
+- The dashboard's response box sent on `Enter` while the new-run task box
+  broke the line on it, so the same key did opposite things in the two
+  long-form boxes on the screen, and a newline in a reply needed `Alt+Enter`.
+  `Enter` now inserts a newline in the response box and the in-place
+  document editor too, `Ctrl+Enter` sends, and a Send (or Save) button under
+  the box, reached with `Tab` or a click, sends on a terminal that cannot
+  tell `Ctrl+Enter` from `Enter`. It is the same button the new-run screen
+  starts a run with. Single-line boxes keep `Enter` as submit.
 - The dashboard cut text to fixed character counts whatever the terminal
   width: the detail view's model name stopped at 24 characters and its
   working directory at 42 with most of a 200-column row empty, the header

--- a/crates/leviath-cli/src/commands/dashboard/click.rs
+++ b/crates/leviath-cli/src/commands/dashboard/click.rs
@@ -158,6 +158,7 @@ impl Dashboard {
                 self.toggle_context_row();
             }
             ClickTarget::NewRunStart => self.submit_new_run(),
+            ClickTarget::ResponseSend => self.submit_input(),
         }
         true
     }
@@ -166,6 +167,7 @@ impl Dashboard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::commands::dashboard::render::{SAVE_BUTTON, SEND_BUTTON};
     use crate::commands::dashboard::state::Dashboard;
     use crate::commands::dashboard::test_support::make_test_dashboard;
     use crate::commands::dashboard::types::{AgentDisplayStatus, DashboardAgent};
@@ -632,6 +634,71 @@ mod tests {
         dash.input_mode = false;
         draw(&mut dash, 120, 40);
         assert!(!dash.markdown_toolbar_click(x, y));
+    }
+
+    /// The Send button under the response box sends with a click, the way
+    /// Enter on it does. It is the same widget as the new-run Start button,
+    /// so its rect is the drawn text and a press beside it is not a press.
+    #[test]
+    fn clicking_the_send_button_sends_the_response() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1");
+        agent.pending_request = Some(leviath_core::interaction::InteractionRequest::free_text(
+            "ft1", "prompt", "main", true,
+        ));
+        agent.waiting_prompt = Some("prompt".to_string());
+        agent.status = AgentDisplayStatus::Waiting;
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+        dash.input_textarea.area_mut().insert_str("answer");
+
+        draw(&mut dash, 120, 40);
+        let button = dash
+            .click_targets
+            .iter()
+            .find(|(_, t)| *t == ClickTarget::ResponseSend)
+            .map(|(r, _)| *r)
+            .expect("the Send button is on screen");
+        assert_eq!(button.width as usize, SEND_BUTTON.chars().count());
+        press_and_release(&mut dash, button.x.saturating_sub(1), button.y);
+        assert!(
+            dash.input_mode,
+            "a press beside the button is not a press on it"
+        );
+        press_and_release(&mut dash, button.x + 2, button.y);
+        assert!(!dash.input_mode, "the click sent");
+        assert!(dash.agents[0].pending_request.is_none());
+    }
+
+    /// The Save button under an in-place document edit is the same wiring in
+    /// the content pane.
+    #[test]
+    fn clicking_the_save_button_saves_the_document() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1");
+        agent.pending_request = Some(leviath_core::interaction::InteractionRequest::edit_text(
+            "et1", "Edit", "main", "old",
+        ));
+        agent.status = AgentDisplayStatus::Waiting;
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+        dash.seed_input_textarea();
+
+        draw(&mut dash, 120, 40);
+        let button = dash
+            .click_targets
+            .iter()
+            .find(|(_, t)| *t == ClickTarget::ResponseSend)
+            .map(|(r, _)| *r)
+            .expect("the Save button is on screen");
+        assert_eq!(button.width as usize, SAVE_BUTTON.chars().count());
+        press_and_release(&mut dash, button.x + 2, button.y);
+        assert!(!dash.input_mode, "the click saved");
+        assert!(dash.agents[0].pending_request.is_none());
     }
 
     /// A press on the run list, with no long-form box open anywhere, must not

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -192,7 +192,6 @@ impl Dashboard {
             pending_open_run: None,
             help_scroll: std::cell::Cell::new(0),
             new_run_yolo: false,
-            yolo_warning_silenced: false,
             new_run_ctx,
             agent_builder: None,
             layout_store_path: None,

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -122,6 +122,7 @@ impl Dashboard {
             log,
             input_textarea: MarkdownEdit::default(),
             input_mode: false,
+            response_focus_send: false,
             detail_view: false,
             cmd_tx,
             pending_interactions: HashMap::new(),

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -205,7 +205,7 @@ impl Dashboard {
     /// Seed the input textarea when entering input mode. For an `EditText`
     /// pending request the buffer is pre-filled with the request's `body` (the
     /// current document) so the user edits it in place; otherwise it starts empty.
-    fn seed_input_textarea(&mut self) {
+    pub(super) fn seed_input_textarea(&mut self) {
         use interaction::InteractionKind;
         let seed = self
             .selected_agent()
@@ -327,29 +327,10 @@ impl Dashboard {
         }
         match &kind {
             Some(InteractionKind::FreeText) | Some(InteractionKind::EditText) | None => {
-                match key_code {
-                    KeyCode::Enter if key.modifiers.is_empty() => {
-                        self.submit_input();
-                    }
-                    KeyCode::Esc => {
-                        self.input_mode = false;
-                        self.input_textarea = MarkdownEdit::default();
-                        self.choice_selected = 0;
-                    }
-                    KeyCode::PageUp if self.has_scrollable_document() => self.scroll_by(10),
-                    KeyCode::PageDown if self.has_scrollable_document() => self.scroll_by(-10),
-                    _ => {
-                        let outcome = self.input_textarea.handle_key(&key);
-                        self.remember_md_mode(outcome);
-                    }
-                }
+                self.handle_response_box_key(key);
             }
             _ => match key_code {
-                KeyCode::Esc => {
-                    self.input_mode = false;
-                    self.input_textarea = MarkdownEdit::default();
-                    self.choice_selected = 0;
-                }
+                KeyCode::Esc => self.close_input_box(),
                 KeyCode::Enter => {
                     self.submit_input();
                 }
@@ -372,6 +353,49 @@ impl Dashboard {
                 _ => {}
             },
         }
+    }
+
+    /// Keys in the long-form response box and on the Send button under it.
+    ///
+    /// Enter breaks the line, the way it does in the new-run task and every
+    /// other text box, and Ctrl+Enter sends. Ctrl+Enter reaches the program
+    /// only under the kitty keyboard protocol; elsewhere it arrives as a plain
+    /// Enter, which is a newline here, and the Send button (Tab, then Enter
+    /// or Space, or a click) is how such a terminal sends. `/quit` on its own
+    /// line still ends the conversation when sent.
+    fn handle_response_box_key(&mut self, key: crossterm::event::KeyEvent) {
+        use crossterm::event::KeyModifiers;
+        if self.response_focus_send {
+            match key.code {
+                KeyCode::Enter | KeyCode::Char(' ') => self.submit_input(),
+                KeyCode::Tab | KeyCode::BackTab => self.response_focus_send = false,
+                KeyCode::Esc => self.close_input_box(),
+                _ => {}
+            }
+            return;
+        }
+        match key.code {
+            KeyCode::Enter if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.submit_input();
+            }
+            KeyCode::Tab => self.response_focus_send = true,
+            KeyCode::Esc => self.close_input_box(),
+            KeyCode::PageUp if self.has_scrollable_document() => self.scroll_by(10),
+            KeyCode::PageDown if self.has_scrollable_document() => self.scroll_by(-10),
+            _ => {
+                let outcome = self.input_textarea.handle_key(&key);
+                self.remember_md_mode(outcome);
+            }
+        }
+    }
+
+    /// Leave input mode with nothing sent: the box, its focus, and the
+    /// highlighted choice all go back to their starting state.
+    pub(super) fn close_input_box(&mut self) {
+        self.input_mode = false;
+        self.response_focus_send = false;
+        self.input_textarea = MarkdownEdit::default();
+        self.choice_selected = 0;
     }
 
     /// Enter/Space in the Context view (or a click on the row): fold or unfold
@@ -531,6 +555,7 @@ impl Dashboard {
                 // any active agent that accepts them - same key, same input area.
                 if self.selected_stage_can_respond() || self.selected_agent_accepts_messages() {
                     self.input_mode = true;
+                    self.response_focus_send = false;
                     self.choice_selected = 0;
                     self.seed_input_textarea();
                 }
@@ -1067,9 +1092,7 @@ impl Dashboard {
             }
         };
 
-        self.input_mode = false;
-        self.input_textarea = MarkdownEdit::default();
-        self.choice_selected = 0;
+        self.close_input_box();
 
         let answered_id = resp.request_id.clone();
         // The index is still valid because nothing since the
@@ -3367,10 +3390,11 @@ mod tests {
 
     // ─── d key from main list for non-run-state agent ─────────────────────
 
-    // ─── input_mode_key: FreeText Enter submits ───────────────────────────
+    // ─── input_mode_key: the response box ─────────────────────────────────
 
-    #[test]
-    fn input_mode_free_text_enter_submits() {
+    /// A dashboard in the detail view with the response box open over a
+    /// free-text question.
+    fn dash_answering_free_text() -> Dashboard {
         let mut dash = make_test_dashboard();
         let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
         agent.pending_request = Some(leviath_core::interaction::InteractionRequest::free_text(
@@ -3380,13 +3404,119 @@ mod tests {
         dash.agents.push(agent);
         dash.update_display_indices();
         dash.detail_view = true;
-        dash.input_mode = true;
-
+        dash.handle_key(key(KeyCode::Char('i')));
+        assert!(dash.input_mode);
         dash.input_textarea.area_mut().insert_str("answer");
+        dash
+    }
 
-        // Enter with no modifiers should submit
+    /// Enter breaks the line, the way it does in the new-run task; it used to
+    /// send, which made the response box the one text box on the dashboard
+    /// where a newline needed a chord. Ctrl+Enter is what sends.
+    #[test]
+    fn response_box_enter_is_a_newline_and_ctrl_enter_sends() {
+        let mut dash = dash_answering_free_text();
+
         dash.handle_key(key(KeyCode::Enter));
+        assert!(dash.input_mode, "Enter did not send");
+        dash.input_textarea.area_mut().insert_str("second line");
+        assert_eq!(dash.input_textarea.text(), "answer\nsecond line");
+
+        dash.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::CONTROL));
+        assert!(!dash.input_mode, "Ctrl+Enter sent");
+        assert!(dash.agents[0].pending_request.is_none());
+    }
+
+    /// Tab moves the keys to the Send button, where Enter or Space sends and
+    /// Tab or Shift+Tab goes back to the box. Other keys on the button do
+    /// nothing: they must not land in the text behind it.
+    #[test]
+    fn tab_reaches_the_send_button_and_enter_there_sends() {
+        let mut dash = dash_answering_free_text();
+
+        dash.handle_key(key(KeyCode::Tab));
+        assert!(dash.response_focus_send);
+        dash.handle_key(key(KeyCode::Char('x')));
+        assert_eq!(
+            dash.input_textarea.text(),
+            "answer",
+            "a stray key is dropped"
+        );
+        dash.handle_key(key(KeyCode::BackTab));
+        assert!(!dash.response_focus_send, "Shift+Tab returns to the box");
+        dash.handle_key(key(KeyCode::Tab));
+        dash.handle_key(key(KeyCode::Tab));
+        assert!(!dash.response_focus_send, "Tab returns to the box too");
+
+        dash.handle_key(key(KeyCode::Tab));
+        dash.handle_key(key(KeyCode::Enter));
+        assert!(!dash.input_mode, "Enter on the button sent");
+        assert!(
+            !dash.response_focus_send,
+            "and the focus reset with the box"
+        );
+
+        let mut dash = dash_answering_free_text();
+        dash.handle_key(key(KeyCode::Tab));
+        dash.handle_key(key(KeyCode::Char(' ')));
+        assert!(!dash.input_mode, "Space on the button sends too");
+    }
+
+    /// Esc cancels from the button as well as from the box, and reopening the
+    /// box starts in the box, not on the button.
+    #[test]
+    fn esc_on_the_send_button_cancels_and_reopening_starts_in_the_box() {
+        let mut dash = dash_answering_free_text();
+        dash.handle_key(key(KeyCode::Tab));
+        dash.handle_key(key(KeyCode::Esc));
         assert!(!dash.input_mode);
+        assert!(!dash.response_focus_send);
+        assert!(dash.agents[0].pending_request.is_some(), "nothing was sent");
+
+        dash.handle_key(key(KeyCode::Tab));
+        assert!(
+            !dash.response_focus_send,
+            "Tab outside the box is not a button move"
+        );
+        dash.handle_key(key(KeyCode::Char('i')));
+        dash.handle_key(key(KeyCode::Tab));
+        assert!(dash.response_focus_send);
+        dash.handle_key(key(KeyCode::Char('i')));
+        assert!(dash.response_focus_send, "i on the button is a stray key");
+        dash.perform_kill("run-1");
+        assert!(
+            !dash.response_focus_send,
+            "a kill closes the box, button and all"
+        );
+    }
+
+    /// An in-place document edit is the same box in a different pane, so it
+    /// takes the same keys: Enter breaks the line, Ctrl+Enter saves, Tab
+    /// reaches the button.
+    #[test]
+    fn document_edit_enter_is_a_newline_and_ctrl_enter_saves() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-1", AgentDisplayStatus::Waiting);
+        agent.pending_request = Some(leviath_core::interaction::InteractionRequest::edit_text(
+            "et1", "Edit", "main", "old",
+        ));
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+        dash.seed_input_textarea();
+
+        dash.handle_key(key(KeyCode::End));
+        dash.handle_key(key(KeyCode::Enter));
+        dash.input_textarea.area_mut().insert_str("new");
+        assert_eq!(dash.input_textarea.text(), "old\nnew");
+        assert!(dash.input_mode);
+
+        dash.handle_key(key(KeyCode::Tab));
+        assert!(dash.response_focus_send);
+        dash.handle_key(key(KeyCode::Enter));
+        assert!(!dash.input_mode, "saved from the button");
+        assert!(dash.agents[0].pending_request.is_none());
     }
 
     // ─── input_mode_key: MultipleChoice Enter submits ─────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -165,10 +165,7 @@ impl Dashboard {
                     }
                 }
                 ConfirmAction::McpRemove { name } => self.mcp_remove_named(&name),
-                // The box is read off the dialog rather than carried in the
-                // outcome: whether to ask again is a note about future
-                // questions, not a third answer to this one.
-                ConfirmAction::EnableYolo => self.accept_yolo_warning(dialog.remembered()),
+                ConfirmAction::EnableYolo => self.accept_yolo_warning(),
                 ConfirmAction::AgentDelete { name } => self.perform_agent_delete(&name),
                 ConfirmAction::AgentReset { name } => self.perform_agent_reset(&name),
                 ConfirmAction::StageDelete { name } => self.editor_delete_stage(&name),

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -288,8 +288,11 @@ impl Dashboard {
     /// characters - one filters the agent list, the other is the task itself -
     /// so there is no letter left that could mean anything but text.
     ///
-    /// Turning it *on* asks first, once per sitting. Turning it off never asks:
-    /// nothing needs confirming about deciding to be asked more.
+    /// Turning it *on* asks first, every time. The dialog once carried a
+    /// "don't ask again" box, and a warning that appeared on one switch and
+    /// not the next read as the toggle misbehaving rather than remembering.
+    /// Turning it off never asks: nothing needs confirming about deciding to
+    /// be asked more.
     pub(super) fn toggle_new_run_yolo(&mut self) {
         if self.new_run_yolo {
             self.new_run_yolo = false;
@@ -299,21 +302,12 @@ impl Dashboard {
             );
             return;
         }
-        if self.yolo_warning_silenced {
-            self.new_run_yolo = true;
-            self.toast(
-                "Unattended ON: runs approve their own tool calls",
-                ToastLevel::Warning,
-            );
-            return;
-        }
         self.pending_confirm = Some((ConfirmAction::EnableYolo, yolo_warning()));
     }
 
-    /// Apply the answer to that warning.
-    pub(super) fn accept_yolo_warning(&mut self, silence: bool) {
+    /// Apply a yes to that warning.
+    pub(super) fn accept_yolo_warning(&mut self) {
         self.new_run_yolo = true;
-        self.yolo_warning_silenced = silence;
         self.toast(
             "Unattended ON: runs approve their own tool calls",
             ToastLevel::Warning,
@@ -471,7 +465,7 @@ impl Dashboard {
     }
 }
 
-/// The warning shown before the first unattended run of a sitting.
+/// The warning shown every time unattended is switched on.
 ///
 /// It says what `--yolo` does *and* what it does not: a run that still stops
 /// for a person reads as a hang to somebody who was told it would not stop, and
@@ -498,7 +492,6 @@ fn yolo_warning() -> Confirm {
         "Keep asking me",
     )
     .danger()
-    .with_remember("Don't ask again while this dashboard is open")
 }
 
 /// Workdir-relative paths of the files under `root`, sorted, at most `cap`.
@@ -1513,10 +1506,10 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::CONTROL)
     }
 
-    /// The first Ctrl-Y of a sitting warns rather than arming anything, and the
-    /// warning has to be accepted before the setting changes.
+    /// Ctrl-Y warns rather than arming anything, and the warning has to be
+    /// accepted before the setting changes.
     #[test]
-    fn the_first_unattended_toggle_asks_before_it_arms() {
+    fn the_unattended_toggle_asks_before_it_arms() {
         let mut dash = make_test_dashboard();
         dash.new_run_screen = true;
         assert!(!dash.new_run_yolo, "off until somebody says otherwise");
@@ -1561,10 +1554,7 @@ mod tests {
 
         dash.toasts.clear();
         dash.handle_key(ctrl(KeyCode::Char('y')));
-        assert!(
-            dash.pending_confirm.is_some(),
-            "not silenced, so it asks again"
-        );
+        assert!(dash.pending_confirm.is_some(), "it asks again");
         dash.handle_key(key(KeyCode::Enter));
         assert!(dash.pending_confirm.is_none());
         assert!(
@@ -1589,51 +1579,48 @@ mod tests {
         assert!(dash.new_run_help_bar_text().contains("unattended: on"));
     }
 
-    /// The box silences the warning for the rest of the sitting, and only for the
-    /// warning: the setting itself still has to be turned on each time.
+    /// Re-opening the screen resets the setting: this is the half that stops
+    /// somebody leaving it armed and forgetting.
     #[test]
-    fn dont_ask_again_lasts_the_session_but_does_not_arm_anything() {
+    fn reopening_the_screen_turns_unattended_off() {
         let mut dash = make_test_dashboard();
         dash.new_run_screen = true;
-
         dash.handle_key(ctrl(KeyCode::Char('y')));
-        // Space ticks the box, then Enter on the focused button would decline, so
-        // answer explicitly.
-        dash.handle_key(key(KeyCode::Char(' ')));
         dash.handle_key(key(KeyCode::Char('y')));
         assert!(dash.new_run_yolo);
-        assert!(dash.yolo_warning_silenced);
 
-        // Off, then on again: no second warning.
-        dash.handle_key(ctrl(KeyCode::Char('y')));
-        dash.handle_key(ctrl(KeyCode::Char('y')));
-        assert!(dash.pending_confirm.is_none(), "it was told not to ask");
-        assert!(dash.new_run_yolo);
-
-        // Re-opening the screen still resets the setting, silence or not: this is
-        // the half that stops somebody leaving it armed and forgetting.
         dash.open_new_run_screen();
         assert!(!dash.new_run_yolo);
-        assert!(dash.yolo_warning_silenced, "but the silence holds");
     }
 
-    /// A fresh dashboard has forgotten the silence entirely, which is what makes
-    /// it a session and not a preference.
+    /// Every switch to ON asks. Turning unattended off and on again is the
+    /// same decision as the first time, and a dialog that showed up once and
+    /// then never again read as the setting being broken rather than
+    /// remembered. Space on the dialog (which used to tick a "don't ask again"
+    /// box) changes nothing now.
     #[test]
-    fn a_new_dashboard_asks_again() {
+    fn every_switch_to_on_asks_even_after_the_box_was_ticked() {
         let mut dash = make_test_dashboard();
         dash.new_run_screen = true;
+
         dash.handle_key(ctrl(KeyCode::Char('y')));
+        assert!(dash.pending_confirm.is_some(), "first on: asks");
         dash.handle_key(key(KeyCode::Char(' ')));
         dash.handle_key(key(KeyCode::Char('y')));
-        assert!(dash.yolo_warning_silenced);
+        assert!(dash.new_run_yolo, "on");
 
-        let fresh = make_test_dashboard();
+        dash.handle_key(ctrl(KeyCode::Char('y')));
+        assert!(dash.pending_confirm.is_none(), "off never asks");
+        assert!(!dash.new_run_yolo, "off");
+
+        dash.handle_key(ctrl(KeyCode::Char('y')));
         assert!(
-            !fresh.yolo_warning_silenced,
-            "closing the dashboard is what expires it"
+            dash.pending_confirm.is_some(),
+            "second on: asks again, whatever was pressed on the first dialog"
         );
-        assert!(!fresh.new_run_yolo);
+        assert!(!dash.new_run_yolo, "and arms nothing until answered");
+        dash.handle_key(key(KeyCode::Char('y')));
+        assert!(dash.new_run_yolo);
     }
 
     /// The setting reaches the spawn rather than only the screen.

--- a/crates/leviath-cli/src/commands/dashboard/render/button.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/button.rs
@@ -1,0 +1,58 @@
+//! The one push button the dashboard draws: a fixed label, right-aligned on
+//! its row, lit when Tab has reached it, and clickable whether or not it has
+//! the keys.
+//!
+//! It exists because two screens need the same thing for the same reason: a
+//! long-form box where Enter breaks the line needs a way to submit on a
+//! terminal that cannot tell Ctrl+Enter from Enter, and a button is that way.
+//! One drawing, so the two cannot drift apart in look or in click geometry.
+
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Span;
+use ratatui::widgets::Paragraph;
+
+use crate::commands::dashboard::state::Dashboard;
+use crate::commands::dashboard::theme::*;
+use crate::commands::dashboard::types::ClickTarget;
+
+impl Dashboard {
+    /// Draw `label` at the right end of `row` and register `target` on the
+    /// cells it covers, so a click lands where the text is drawn.
+    pub(super) fn draw_action_button(
+        &mut self,
+        frame: &mut Frame,
+        row: Rect,
+        label: &str,
+        focused: bool,
+        target: ClickTarget,
+    ) {
+        let style = match focused {
+            true => Style::default()
+                .fg(Color::Black)
+                .bg(C_BORDER_FOCUS)
+                .add_modifier(Modifier::BOLD),
+            false => Style::default().fg(C_BORDER).add_modifier(Modifier::BOLD),
+        };
+        let width = (label.chars().count() as u16).min(row.width);
+        let rect = Rect {
+            x: row.x + row.width - width,
+            y: row.y,
+            width,
+            height: row.height.min(1),
+        };
+        frame.render_widget(Paragraph::new(Span::styled(label.to_string(), style)), rect);
+        self.register_click(rect, target);
+    }
+}
+
+/// Split a pane into the rows an editor keeps and the one row its button
+/// takes, so every box-with-a-button lays out the same way.
+pub(super) fn editor_and_button_rows(area: Rect) -> (Rect, Rect) {
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(area);
+    (rows[0], rows[1])
+}

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -182,12 +182,20 @@ impl Dashboard {
         // in place rather than in the bottom input bar.
         if self.editing_document() {
             let view = MdEditView::new(
-                " ✎ Editing this document - your changes replace it  ·  [Enter] save  \
-                 [Alt+↵] newline  [Esc] cancel ",
+                " ✎ Editing this document - your changes replace it  ·  [^Enter] save  \
+                 [Enter] newline  [Tab] Save button  [Esc] cancel ",
                 C_SUCCESS,
-                true,
+                !self.response_focus_send,
             );
-            self.input_textarea.render(frame, content_area, &view);
+            let (editor_area, button_row) = super::button::editor_and_button_rows(content_area);
+            self.input_textarea.render(frame, editor_area, &view);
+            self.draw_action_button(
+                frame,
+                button_row,
+                super::input::SAVE_BUTTON,
+                self.response_focus_send,
+                ClickTarget::ResponseSend,
+            );
             return;
         }
 
@@ -1134,6 +1142,12 @@ mod tests {
                 dash.render_content_pane(f, area, &agent, 100);
             })
             .unwrap();
+        assert!(
+            dash.click_targets
+                .iter()
+                .any(|(_, t)| *t == ClickTarget::ResponseSend),
+            "the Save button is drawn under the editor"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -15,6 +15,12 @@ use crate::commands::dashboard::types::*;
 use crate::tui::widgets::markdown_edit::MdEditView;
 use leviath_core::interaction;
 
+/// The Send button's face. Fixed text, so the click rect is the drawn text.
+pub(in crate::commands::dashboard) const SEND_BUTTON: &str = "[ Send ]";
+
+/// The Save button's face, under an in-place document edit.
+pub(in crate::commands::dashboard) const SAVE_BUTTON: &str = "[ Save document ]";
+
 impl Dashboard {
     pub(in crate::commands::dashboard) fn render_review_body(
         &mut self,
@@ -109,14 +115,24 @@ impl Dashboard {
             // specific question - label it accordingly for consistent UX.
             let is_message_mode = pending_req.is_none() && agent.waiting_prompt.is_none();
             let hint = if is_message_mode {
-                " Provide input while this is running  [Enter] send  [Alt+↵] newline  [Esc] cancel "
+                " Provide input while this is running  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel "
             } else {
-                " Response  [Enter] send  [Alt+↵] newline  [Esc] cancel "
+                " Response  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel "
             };
             // The response box is a long-form field: it wraps, and it carries
-            // the same formatting toolbar as the task editor.
-            let view = MdEditView::new(hint, C_SUCCESS, true);
-            self.input_textarea.render(frame, prompt_area, &view);
+            // the same formatting toolbar as the task editor. Enter breaks the
+            // line there, so the Send button under it is how a terminal that
+            // cannot send Ctrl+Enter submits.
+            let (editor_area, button_row) = super::button::editor_and_button_rows(prompt_area);
+            let view = MdEditView::new(hint, C_SUCCESS, !self.response_focus_send);
+            self.input_textarea.render(frame, editor_area, &view);
+            self.draw_action_button(
+                frame,
+                button_row,
+                SEND_BUTTON,
+                self.response_focus_send,
+                ClickTarget::ResponseSend,
+            );
         } else {
             let (title, prompt_lines): (&str, Vec<Line>) = if self.input_mode {
                 let mut lines: Vec<Line> = vec![];
@@ -393,6 +409,42 @@ mod tests {
             .unwrap();
         let buf = rendered_buffer(&terminal);
         assert!(buf.contains("Esc"), "{buf}");
+        assert!(buf.contains("[Enter] newline"), "{buf}");
+        assert!(buf.contains(SEND_BUTTON), "{buf}");
+    }
+
+    /// Tab lights the Send button the way it lights the Start button: the
+    /// box's border goes quiet and the button takes the focus colour.
+    #[test]
+    fn the_send_button_lights_when_tab_reaches_it() {
+        let agent = make_test_agent("run-ft", AgentDisplayStatus::Waiting);
+        let pending: Option<interaction::InteractionRequest> = None;
+        let kind = Some(interaction::InteractionKind::FreeText);
+        let options: Vec<String> = vec![];
+        let mut styles = vec![];
+        for focus_send in [false, true] {
+            let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+            let mut dash = make_test_dashboard();
+            dash.input_mode = true;
+            dash.response_focus_send = focus_send;
+            terminal
+                .draw(|f| {
+                    let area = Rect::new(0, 0, 80, 12);
+                    dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
+                })
+                .unwrap();
+            let button = dash
+                .click_targets
+                .iter()
+                .find(|(_, t)| *t == ClickTarget::ResponseSend)
+                .map(|(r, _)| *r)
+                .expect("the button registered its rect");
+            assert_eq!(button.y, 11, "on the pane's last row");
+            assert_eq!(button.x + button.width, 80, "right-aligned");
+            styles.push(terminal.backend().buffer()[(button.x, button.y)].style());
+        }
+        assert_ne!(styles[0], styles[1], "focus changes the button's look");
+        assert_eq!(styles[1].bg, Some(C_BORDER_FOCUS));
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! The main `draw()` method dispatches to sub-modules for each region of the UI.
 
+mod button;
 mod content;
 mod graph_view;
 mod header;
@@ -11,6 +12,10 @@ mod new_run;
 mod overlays;
 mod stages;
 mod table;
+
+// The button faces, so a click test can size its press by the drawn text.
+#[cfg(test)]
+pub(super) use input::{SAVE_BUTTON, SEND_BUTTON};
 
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout};
@@ -229,7 +234,8 @@ impl Dashboard {
             let n = options.len() as u16;
             if self.input_mode {
                 match &kind {
-                    Some(InteractionKind::FreeText) | None => 11,
+                    // The editor's rows plus one for the Send button under it.
+                    Some(InteractionKind::FreeText) | None => 12,
                     _ => (n + 4).min(14),
                 }
             } else {

--- a/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/new_run.rs
@@ -136,11 +136,7 @@ impl Dashboard {
 
     fn draw_new_run_task(&mut self, frame: &mut Frame, area: Rect) {
         // The editor keeps every row but the last, which is the Start button's.
-        let rows = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([Constraint::Min(1), Constraint::Length(1)])
-            .split(area);
-        let (area, button_row) = (rows[0], rows[1]);
+        let (area, button_row) = super::button::editor_and_button_rows(area);
         let focused = self.new_run_focus == NewRunPane::Task;
         let agent = self
             .new_run_selected_agent()
@@ -170,30 +166,16 @@ impl Dashboard {
             focused,
         );
         self.new_run_task.render(frame, area, &view);
-        self.draw_new_run_start_button(frame, button_row);
-    }
-
-    /// The Start button, right-aligned under the editor. Lit like a focused
-    /// pane's border when Tab has reached it; a click on it starts the run
-    /// whether or not it has focus.
-    fn draw_new_run_start_button(&mut self, frame: &mut Frame, row: Rect) {
-        let focused = self.new_run_focus == NewRunPane::Start;
-        let style = match focused {
-            true => Style::default()
-                .fg(Color::Black)
-                .bg(C_BORDER_FOCUS)
-                .add_modifier(Modifier::BOLD),
-            false => Style::default().fg(C_BORDER).add_modifier(Modifier::BOLD),
-        };
-        let width = (START_BUTTON.chars().count() as u16).min(row.width);
-        let rect = Rect {
-            x: row.x + row.width - width,
-            y: row.y,
-            width,
-            height: row.height.min(1),
-        };
-        frame.render_widget(Paragraph::new(Span::styled(START_BUTTON, style)), rect);
-        self.register_click(rect, ClickTarget::NewRunStart);
+        // The Start button, right-aligned under the editor. Lit like a focused
+        // pane's border when Tab has reached it; a click on it starts the run
+        // whether or not it has focus.
+        self.draw_action_button(
+            frame,
+            button_row,
+            START_BUTTON,
+            self.new_run_focus == NewRunPane::Start,
+            ClickTarget::NewRunStart,
+        );
     }
 
     /// The `@` completion, drawn as a floating menu inside the task pane.

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -397,8 +397,9 @@ fn detail_sections() -> Vec<HelpSection> {
         HelpSection {
             title: "Writing a response (i)",
             entries: vec![
-                ("enter", "send"),
-                ("alt+enter", "insert a newline"),
+                ("ctrl+enter", "send (needs the kitty keyboard protocol)"),
+                ("enter", "insert a newline; so does alt+enter"),
+                ("tab", "move to the Send button; enter or space there sends"),
                 ("pgup / pgdn", "scroll the document above the prompt"),
                 ("esc", "cancel"),
                 ("/quit or /exit", "end the conversation without answering"),

--- a/crates/leviath-cli/src/commands/dashboard/run_actions.rs
+++ b/crates/leviath-cli/src/commands/dashboard/run_actions.rs
@@ -5,7 +5,6 @@ use super::helpers::truncate;
 use super::state::Dashboard;
 use super::types::*;
 use crate::runstate;
-use crate::tui::widgets::markdown_edit::MarkdownEdit;
 
 impl Dashboard {
     /// Open the kill confirmation. Acts on every marked run that is killable
@@ -121,8 +120,7 @@ impl Dashboard {
             a.pending_request = None;
         }
         // Any half-typed response to the killed run is moot.
-        self.input_mode = false;
-        self.input_textarea = MarkdownEdit::default();
+        self.close_input_box();
         self.add_log(format!("{run_id}: kill requested"));
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -23,6 +23,9 @@ pub(crate) struct Dashboard {
     /// component the new-run task and the blueprint prompts use.
     pub(super) input_textarea: MarkdownEdit,
     pub(super) input_mode: bool,
+    /// Whether Tab has moved the keys from the response box to the Send
+    /// button under it. Enter there sends; Enter in the box breaks the line.
+    pub(super) response_focus_send: bool,
     /// True when the full-screen detail view is open for the selected agent
     pub(super) detail_view: bool,
     pub(super) cmd_tx: mpsc::UnboundedSender<DaemonCommand>,

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -228,14 +228,6 @@ pub(crate) struct Dashboard {
     /// consequences, and a toggle that survives out of sight is one a user can
     /// leave on and forget.
     pub(super) new_run_yolo: bool,
-    /// Whether the unattended warning has been silenced for this session.
-    ///
-    /// In memory only, and by design. "Do not ask again" is a statement about
-    /// the sitting you are in, not a permanent preference, so closing the
-    /// dashboard is what expires it. Persisting it to the config would turn one
-    /// tick of a box into a machine-wide change nothing on screen mentions
-    /// again.
-    pub(super) yolo_warning_silenced: bool,
     /// Paths the screen reads its agents and file candidates from.
     pub(super) new_run_ctx: NewRunContext,
     /// The Agents screen (`a`): catalog and editor. Boxed: it carries a

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -190,6 +190,9 @@ pub(super) enum ClickTarget {
     ContextRow(usize),
     /// The new-run screen's Start button.
     NewRunStart,
+    /// The Send button under the response box (or the Save button under an
+    /// in-place document edit): a click sends what was typed.
+    ResponseSend,
 }
 
 /// Cursor + expansion state of the structured Context view.

--- a/crates/leviath-cli/src/tui/widgets/confirm.rs
+++ b/crates/leviath-cli/src/tui/widgets/confirm.rs
@@ -39,13 +39,6 @@ pub(crate) struct Confirm {
     pub(crate) no_label: &'static str,
     pub(crate) focus_yes: bool,
     pub(crate) danger: bool,
-    /// An optional "and stop asking" box, with its label and whether it is
-    /// ticked. `None` means the dialog does not offer one.
-    ///
-    /// A third button was the other option and is worse: the choice being made
-    /// here is not a third answer to the question, it is a note about future
-    /// questions, and a row of three buttons hides that difference.
-    pub(crate) remember: Option<(&'static str, bool)>,
 }
 
 impl Confirm {
@@ -62,24 +55,7 @@ impl Confirm {
             no_label,
             focus_yes: false,
             danger: false,
-            remember: None,
         }
-    }
-
-    /// Offer a "stop asking" box, unticked, toggled with Space.
-    ///
-    /// The caller reads [`Self::remembered`] after a `Yes` to find out whether
-    /// it was ticked. Deliberately not part of the outcome: whether to ask
-    /// again is a separate decision from the answer, and folding it into the
-    /// answer would make every other dialog carry a field it has no use for.
-    pub(crate) fn with_remember(mut self, label: &'static str) -> Self {
-        self.remember = Some((label, false));
-        self
-    }
-
-    /// Whether the "stop asking" box is ticked.
-    pub(crate) fn remembered(&self) -> bool {
-        matches!(self.remember, Some((_, true)))
     }
 
     /// Style the dialog as destructive (red border, red Yes button).
@@ -109,14 +85,6 @@ impl Confirm {
                     ConfirmOutcome::No
                 }
             }
-            // Space ticks the box rather than answering, and does nothing
-            // at all on a dialog that offers none.
-            KeyCode::Char(' ') => {
-                if let Some((_, checked)) = &mut self.remember {
-                    *checked = !*checked;
-                }
-                ConfirmOutcome::Pending
-            }
             KeyCode::Char('y') | KeyCode::Char('Y') => ConfirmOutcome::Yes,
             KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => ConfirmOutcome::No,
             _ => ConfirmOutcome::Pending,
@@ -131,17 +99,6 @@ impl Confirm {
         let inner = popup_frame(frame, popup, &self.title, accent);
 
         let mut lines = self.body.clone();
-        if let Some((label, checked)) = self.remember {
-            lines.push(Line::from(""));
-            lines.push(Line::from(vec![
-                Span::styled(
-                    if checked { "[x] " } else { "[ ] " },
-                    Style::default().fg(accent),
-                ),
-                Span::styled(label, Style::default().fg(C_WHITE)),
-                Span::styled("  (space)", Style::default().fg(C_DIM)),
-            ]));
-        }
         lines.push(Line::from(""));
         lines.push(self.button_row(accent));
         frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
@@ -279,63 +236,5 @@ mod tests {
             .draw(|frame| confirm.draw(frame, frame.area()))
             .unwrap();
         assert!(terminal.backend().text().contains("[ Kill ]"));
-    }
-
-    /// The box is a note about future questions, not an answer to this one:
-    /// Space ticks it and leaves the dialog open, and the answer still has to
-    /// be given.
-    #[test]
-    fn the_remember_box_ticks_without_answering() {
-        let mut confirm = dialog().with_remember("Don't ask again");
-        assert!(!confirm.remembered());
-
-        assert_eq!(
-            confirm.handle(&press(KeyCode::Char(' '))),
-            ConfirmOutcome::Pending
-        );
-        assert!(confirm.remembered());
-        // And it unticks.
-        confirm.handle(&press(KeyCode::Char(' ')));
-        assert!(!confirm.remembered());
-
-        confirm.handle(&press(KeyCode::Char(' ')));
-        assert_eq!(
-            confirm.handle(&press(KeyCode::Char('y'))),
-            ConfirmOutcome::Yes
-        );
-        assert!(confirm.remembered(), "the tick survives the answer");
-    }
-
-    /// Space on a dialog that offers no box does nothing at all - it must not
-    /// become a second way to answer.
-    #[test]
-    fn space_is_inert_without_a_box() {
-        let mut confirm = dialog();
-        assert_eq!(
-            confirm.handle(&press(KeyCode::Char(' '))),
-            ConfirmOutcome::Pending
-        );
-        assert!(!confirm.remembered());
-    }
-
-    /// The box is on screen, with its state and the key that changes it.
-    #[test]
-    fn the_remember_box_is_drawn_with_its_state() {
-        let mut confirm = dialog().with_remember("Don't ask again this session");
-        let mut terminal =
-            ratatui::Terminal::new(crate::tui::TestBackendHarness::new(70, 16)).unwrap();
-        terminal
-            .draw(|frame| confirm.draw(frame, frame.area()))
-            .unwrap();
-        let text = terminal.backend().text();
-        assert!(text.contains("[ ]"), "unticked to start: {text}");
-        assert!(text.contains("space"));
-
-        confirm.handle(&press(KeyCode::Char(' ')));
-        terminal
-            .draw(|frame| confirm.draw(frame, frame.area()))
-            .unwrap();
-        let text = terminal.backend().text();
-        assert!(text.contains("[x]"), "ticked: {text}");
     }
 }

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -203,9 +203,13 @@ for a run whose blueprint could not be read, the flat tab strip stays.
 | `?` / `F1` | Help |
 | `Ctrl-C` | Quit. `q` is unbound here, so a stray keystroke cannot close the dashboard mid-run |
 
-While you are typing a response, `Enter` sends it, `Alt+Enter` inserts a newline, `PgUp` / `PgDn`
-scroll the document above the prompt, and `Esc` cancels. `/quit` or `/exit` on its own line ends
-the conversation without answering.
+While you are typing a response, `Enter` inserts a newline, the way it does in the new-run task
+box, and `Ctrl+Enter` sends. Only a terminal with the kitty keyboard protocol can tell
+`Ctrl+Enter` from `Enter`; elsewhere `Tab` moves to the Send button under the box, where `Enter`
+or `Space` sends, as does a click on it. `PgUp` / `PgDn` scroll the document above the prompt, and
+`Esc` cancels. `/quit` or `/exit` on its own line ends the conversation when sent. An in-place
+document edit takes the same keys, with a Save button in place of Send. Single-line boxes (a
+rename, a filter, a server URL) still submit on `Enter`.
 
 Destructive keys always confirm on a dialog with real buttons: `←`/`→` pick an answer, `Enter`
 activates it, and a stray keypress does nothing. The safe answer holds focus to start.

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -163,10 +163,10 @@ still on screen when the cursor is at the end. See
 [Formatting a long-form box](#formatting-a-long-form-box) for what the toolbar
 along its top does.
 
-`Ctrl-Y` warns the first time you use it in a sitting, and the warning is worth reading: an
-unattended run approves its own file edits and shell commands, but it does **not** skip a checkpoint
-the blueprint asks a person for. Those still stop, and one nobody answers ends the run when the
-interaction timeout expires. The setting is off again every time the screen opens.
+`Ctrl-Y` warns every time you turn it on (turning it off never asks), and the warning is worth
+reading: an unattended run approves its own file edits and shell commands, but it does **not** skip
+a checkpoint the blueprint asks a person for. Those still stop, and one nobody answers ends the run
+when the interaction timeout expires. The setting is off again every time the screen opens.
 
 ### Detail view
 


### PR DESCRIPTION
Two `lev dash` consistency fixes, one commit each.

## 1. The response box takes Enter as a newline

The new-run task box (#694) breaks the line on Enter and submits on Ctrl+Enter, with a Start button for terminals that cannot tell the two apart. The response box still sent on Enter, so the same key did opposite things one screen apart.

Now, in the response box and the in-place document editor (`EditText`):

- `Enter` inserts a newline (so does `Alt+Enter`, as before).
- `Ctrl+Enter` sends. It reaches the program only under the kitty keyboard protocol, which the dash already enables where supported.
- A `[ Send ]` button (or `[ Save document ]` under a document edit) sits under the box. `Tab` moves to it, `Enter` or `Space` there sends, `Tab`/`Shift+Tab` return to the box, `Esc` cancels from either, and a click on it sends whether or not it has focus.
- The button is the new-run Start button's drawing, moved into `render/button.rs` (`draw_action_button` + `editor_and_button_rows`); the Start button now calls the same code rather than keeping its own copy.
- The box's title hint reads `[^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel`, and the F1 help section for "Writing a response" says the same.
- The prompt pane grows by one row (11 to 12) so the editor keeps its height.

Per-input decisions across the dashboard:

| Input | Lines | Enter | Decision |
| --- | --- | --- | --- |
| New-run task box | multi | newline | unchanged (#694) |
| Response box (question or mid-run message) | multi | **newline** (was send) | changed, Send button added |
| In-place document edit (`EditText`, in the content pane) | multi | **newline** (was save) | changed, Save button added; it is the same `MarkdownEdit` and the same key path |
| Agent editor prompt boxes (system/transition prompt) | multi | newline | unchanged; they already save on `Ctrl-S`/`Esc` |
| Choice / approval / confirm prompts | list | send the highlighted choice | unchanged, not a text box |
| Agent rename, stage/region name, filter, MCP server URL, link/table popups | single | submit | unchanged: single-line inputs keep Enter as submit |

## 2. Every switch to unattended asks

`Ctrl-Y` showed the "Run unattended?" dialog once per sitting, and the dialog had a "Don't ask again while this dashboard is open" box. After ticking it, off and on again armed the setting with no dialog, which read as the toggle misbehaving.

- Every switch to ON shows the dialog. Switching OFF never asks, as before. The ON/OFF toasts from #699 stay.
- The box and the `yolo_warning_silenced` flag are removed, along with the `Confirm::with_remember` / `remembered` API and the Space-toggles-the-box key handling, which nothing else used.
- Premise check: the flag was **never persisted**. `ui_state` has no such key (it was session-only by design), so there is no saved value to ignore or drop, and loading needs no tolerance for an old key. The docs and CHANGELOG say so.

Fail-first evidence: `every_switch_to_on_asks_even_after_the_box_was_ticked` (Ctrl-Y, Space, `y`, Ctrl-Y, Ctrl-Y, expect a dialog) run against `origin/main` before the fix:

```
thread '...every_switch_to_on_asks_even_after_the_box_was_ticked' panicked at crates/leviath-cli/src/commands/dashboard/new_run.rs:1660:9:
second on: asks again, whatever was pressed on the first dialog
test result: FAILED. 0 passed; 1 failed
```

It passes after the change.

## Live check over a pty

A real daemon with the mock provider asking `ask_user_text`, one probe run parked on the question, `lev dash` driven over a `pty.fork()` at 140x40 with the whole escape stream replayed into a grid (`ESC[r;cH` moves), keys sent one at a time. Enter (`\r`) in the box, then Tab and Enter on the button; then `n`, Ctrl-Y (`\x19`), `y`, Ctrl-Y, Ctrl-Y.

```
run probe-1788041791-e5b36e15c18b status before dash: waiting_input

===== response box after Enter =====
  | ╭ Response  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel ───────╮
  | │first line                                                                         │
  | │second line                                                                        │
  |                                                                              [ Send ]
  run status after Enter in the box: waiting_input (still waiting means Enter did not send)

===== after Tab =====
  | ╭ Response  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel ───────╮
  |                                                                              [ Send ]

===== after Enter on Send =====
  run status after Send: complete

===== Ctrl-Y #1 =====
  | │   ┌ Run unattended? ─────────────────────────────────────────────────────────┐   │
  | │   │[ Keep asking me ]   [ Run unattended ]   ←→ choose · enter confirm · esc cancel  │
  |  ↑↓ select · type to filter · Tab write task · ^Y unattended: off · F1 help · Esc back

===== Ctrl-Y #2 =====
  | │› coder   bundled   v0.1.3 ...   ✓ Unattended OFF: runs will ask you b… │
  |  ↑↓ select · type to filter · Tab write task · ^Y unattended: off · F1 help · Esc back

===== Ctrl-Y #3 =====
  | │   ┌ Run unattended? ─────────────────────────────────────────────────────────┐   │
  | │   │[ Keep asking me ]   [ Run unattended ]   ←→ choose · enter confirm · esc cancel  │
  |  ↑↓ select · type to filter · Tab write task · ^Y unattended: off · F1 help · Esc back
```

The run's status is read over `lev serve` between steps: Enter in the box left it `waiting_input`, Enter on the Send button took it to `complete`. The dialog is on screen after the first and third Ctrl-Y and only the OFF toast after the second. (Box borders trimmed to fit here.)

## Docs

- `docs/content/dashboard.md`: the response-pane paragraph and the `Ctrl-Y` paragraph.
- CHANGELOG, Fixed, one entry per part.

## Gates

`cargo fmt --all`, `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`, `cargo test -p leviath-cli dashboard` (809 passed), `cargo xtask structure` (none over 1200), `cargo xtask docs` (no problems), `cargo xtask coverage --package leviath-cli` (100% gate, exit 0). Pre-commit ran the full suite on both commits.
