### PR TITLE
fix(net): cap every read from a remote peer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,14 @@ same list.
   `max`, `request_timeout_secs`, a `stuck_after_*` threshold) dropped the
   value without a word. A misspelled sandbox key such as `netwrok = false`
   was ignored, so the sandbox ran looser than the file said.
+- Every read from a remote peer is capped. A provider's buffered JSON reply is
+  cut at 64 MiB, one streamed frame (SSE or NDJSON) at 8 MiB, and one line
+  from an MCP stdio server at 1 MiB; the same caps cover MCP HTTP replies and
+  their event streams. Past a cap the inference or tool call fails with a
+  message naming the cap and the peer instead of the daemon buffering until
+  it is killed. The rest of an oversized MCP line is drained, so the next
+  call to that server still works. The caps are constants in
+  `leviath_net::read_caps`, not configuration.
 - The published list prices for OpenAI, Anthropic and Google live in
   `crates/leviath-providers/pricing/rates.toml` rather than in Rust, and each
   row names where it came from. `lev models list` prints `n/a` where nothing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2553,6 +2553,7 @@ dependencies = [
  "form_urlencoded",
  "futures-util",
  "leviath-core",
+ "leviath-net",
  "leviath-sys",
  "leviath-testkit",
  "rand 0.10.2",
@@ -2572,6 +2573,7 @@ dependencies = [
 name = "leviath-net"
 version = "0.5.5"
 dependencies = [
+ "encoding_rs",
  "leviath-testkit",
  "reqwest",
  "tokio",
@@ -2601,6 +2603,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "leviath-core",
+ "leviath-net",
  "leviath-scripting",
  "leviath-sys",
  "leviath-testkit",

--- a/crates/leviath-mcp/Cargo.toml
+++ b/crates/leviath-mcp/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 
 [dependencies]
 leviath-core = { workspace = true }
+leviath-net = { workspace = true }
 leviath-sys = { workspace = true }
 tokio = { workspace = true, features = ["process", "io-util", "sync", "macros", "rt"] }
 serde = { workspace = true }

--- a/crates/leviath-mcp/src/auth/mod.rs
+++ b/crates/leviath-mcp/src/auth/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod metadata;
 mod pkce;
 pub mod store;
 
+use leviath_net::read_caps::{JSON_BODY_CAP, read_body_capped, read_text_capped};
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -544,17 +545,20 @@ impl OAuthClient {
             .map_err(|e| anyhow::anyhow!("client registration request failed: {}", e))?;
         if !response.status().is_success() {
             let status = response.status();
-            let text = response.text().await.unwrap_or_default();
+            let text = read_text_capped(response, JSON_BODY_CAP)
+                .await
+                .unwrap_or_default();
             return Err(anyhow::anyhow!(
                 "client registration failed with HTTP {}: {}",
                 status,
                 text.trim()
             ));
         }
-        let registration: RegistrationResponse = response
-            .json()
+        let value = read_json_body(response)
             .await
-            .map_err(|e| anyhow::anyhow!("failed to parse registration response: {}", e))?;
+            .map_err(registration_parse_error)?;
+        let registration: RegistrationResponse =
+            serde_json::from_value(value).map_err(registration_parse_error)?;
         Ok(registration.client_id)
     }
 
@@ -594,7 +598,7 @@ impl OAuthClient {
         if !response.status().is_success() {
             anyhow::bail!("HTTP {}", response.status());
         }
-        Ok(response.json().await?)
+        read_json_body(response).await
     }
 
     /// POST a form and return the JSON response as a value, surfacing an OAuth
@@ -607,7 +611,9 @@ impl OAuthClient {
     ) -> anyhow::Result<serde_json::Value> {
         let response = self.http.post(url).form(params).send().await?;
         let status = response.status();
-        let body = response.text().await.unwrap_or_default();
+        let body = read_text_capped(response, JSON_BODY_CAP)
+            .await
+            .unwrap_or_default();
         if !status.is_success() {
             anyhow::bail!("HTTP {}: {}", status, body.trim());
         }
@@ -849,6 +855,22 @@ async fn write_response(stream: &mut tokio::net::TcpStream, status: &str, messag
     );
     let _ = stream.write_all(response.as_bytes()).await;
     let _ = stream.flush().await;
+}
+
+/// A body read through the shared cap and parsed as JSON.
+///
+/// The read and the parse fail separately (a connection that dropped, a body
+/// that is not JSON), and both are reachable from a test through a raw
+/// socket; a named function rather than two closures so each caller adds no
+/// uncovered region of its own.
+async fn read_json_body(response: reqwest::Response) -> anyhow::Result<serde_json::Value> {
+    let body = read_body_capped(response, JSON_BODY_CAP).await?;
+    Ok(serde_json::from_slice(&body)?)
+}
+
+/// The context every failure to read or parse a registration reply carries.
+fn registration_parse_error(e: impl std::fmt::Display) -> anyhow::Error {
+    anyhow::anyhow!("failed to parse registration response: {}", e)
 }
 
 #[cfg(test)]
@@ -2382,6 +2404,88 @@ mod tests {
                 .post_form("http://127.0.0.1:1/token", &[("a", "b")])
                 .await
                 .is_err()
+        );
+    }
+
+    /// One connection answering with `raw`, for the failures axum cannot
+    /// produce: a body shorter than its `Content-Length`.
+    async fn serve_raw(raw: &'static [u8]) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 8192];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock.write_all(raw).await;
+            let _ = sock.shutdown().await;
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn get_json_errors_on_a_body_that_stops_early() {
+        let base = serve_raw(
+            b"HTTP/1.1 200 OK\r\nContent-Length: 500\r\nConnection: close\r\n\r\n{\"a\":",
+        )
+        .await;
+        let err = OAuthClient::new()
+            .get_json(&format!("{base}/x"))
+            .await
+            .expect_err("a truncated body must fail");
+        assert!(
+            !err.to_string().contains("expected"),
+            "a read failure, not a parse one: {err}"
+        );
+    }
+
+    fn registration_meta(endpoint: &str) -> AuthServerMetadata {
+        serde_json::from_value(serde_json::json!({
+            "issuer": "https://x",
+            "authorization_endpoint": "https://x/a",
+            "token_endpoint": "https://x/t",
+            "registration_endpoint": endpoint,
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn register_errors_on_a_body_that_stops_early() {
+        let base = serve_raw(
+            b"HTTP/1.1 201 Created\r\nContent-Length: 500\r\nConnection: close\r\n\r\n{\"c",
+        )
+        .await;
+        let err = OAuthClient::new()
+            .register(
+                &registration_meta(&format!("{base}/register")),
+                "http://127.0.0.1:5000/callback",
+            )
+            .await
+            .expect_err("a truncated registration reply must fail");
+        assert!(
+            err.to_string()
+                .contains("failed to parse registration response"),
+            "got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_errors_on_a_reply_without_a_client_id() {
+        let base = serve_raw(
+            b"HTTP/1.1 201 Created\r\nContent-Length: 11\r\nConnection: close\r\n\r\n{\"other\":1}",
+        )
+        .await;
+        let err = OAuthClient::new()
+            .register(
+                &registration_meta(&format!("{base}/register")),
+                "http://127.0.0.1:5000/callback",
+            )
+            .await
+            .expect_err("a reply with no client_id must fail");
+        assert!(
+            err.to_string()
+                .contains("failed to parse registration response"),
+            "got: {err}"
         );
     }
 

--- a/crates/leviath-mcp/src/transport/http.rs
+++ b/crates/leviath-mcp/src/transport/http.rs
@@ -13,6 +13,9 @@
 //! Streamable is tried first; a `404`/`405` on the POST means the server only
 //! implements the legacy shape, and the connection transparently falls back.
 
+use leviath_net::read_caps::{
+    JSON_BODY_CAP, STREAM_FRAME_CAP, frame_within_cap, peer_of, read_text_capped,
+};
 use std::collections::HashMap;
 use std::time::Duration;
 
@@ -356,8 +359,7 @@ impl HttpTransport {
 
     /// Read a response whose body is a single JSON document.
     async fn read_json_reply(response: reqwest::Response) -> anyhow::Result<JsonRpcResponse> {
-        let body = response
-            .text()
+        let body = read_text_capped(response, JSON_BODY_CAP)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to read MCP response body: {}", e))?;
         let frame: Value = serde_json::from_str(&body)
@@ -382,21 +384,22 @@ impl HttpTransport {
         id: Option<u64>,
     ) -> anyhow::Result<JsonRpcResponse> {
         let mut buffer = String::new();
+        let peer = peer_of(&response);
         let mut stream = response.bytes_stream();
 
         loop {
-            let event =
-                next_sse_event(&mut stream, &mut buffer)
-                    .await
-                    .map_err(|end| match end {
-                        SseEnd::NotUtf8(e) => {
-                            anyhow::anyhow!("MCP event stream is not UTF-8: {}", e)
-                        }
-                        SseEnd::Failed(e) => anyhow::anyhow!("MCP event stream failed: {}", e),
-                        SseEnd::Closed => {
-                            anyhow::anyhow!("MCP event stream ended before answering the request")
-                        }
-                    })?;
+            let event = next_sse_event(&mut stream, &mut buffer, STREAM_FRAME_CAP, &peer)
+                .await
+                .map_err(|end| match end {
+                    SseEnd::NotUtf8(e) => {
+                        anyhow::anyhow!("MCP event stream is not UTF-8: {}", e)
+                    }
+                    SseEnd::Failed(e) => anyhow::anyhow!("MCP event stream failed: {}", e),
+                    SseEnd::TooLarge(msg) => anyhow::anyhow!("MCP event {}", msg),
+                    SseEnd::Closed => {
+                        anyhow::anyhow!("MCP event stream ended before answering the request")
+                    }
+                })?;
             let frame: Value = serde_json::from_str(&event.data)
                 .map_err(|e| anyhow::anyhow!("Failed to parse JSON-RPC response: {}", e))?;
             if let Some(response) = self.handle_frame(frame, id).await? {
@@ -618,7 +621,9 @@ fn response_matches(response: &JsonRpcResponse, id: Option<u64>) -> bool {
 
 /// Build an error from a failed HTTP status, including the body if readable.
 async fn error_for_status(status: StatusCode, response: reqwest::Response) -> anyhow::Error {
-    let body = response.text().await.unwrap_or_default();
+    let body = read_text_capped(response, JSON_BODY_CAP)
+        .await
+        .unwrap_or_default();
     if body.is_empty() {
         anyhow::anyhow!("MCP server returned HTTP {}", status)
     } else {
@@ -629,10 +634,11 @@ async fn error_for_status(status: StatusCode, response: reqwest::Response) -> an
 /// Decode an SSE response, forwarding decoded events onto `tx`.
 async fn read_event_stream(response: reqwest::Response, tx: mpsc::UnboundedSender<LegacyEvent>) {
     let mut buffer = String::new();
+    let peer = peer_of(&response);
     let mut stream = response.bytes_stream();
 
     loop {
-        let event = match next_sse_event(&mut stream, &mut buffer).await {
+        let event = match next_sse_event(&mut stream, &mut buffer, STREAM_FRAME_CAP, &peer).await {
             Ok(event) => event,
             Err(SseEnd::NotUtf8(e)) => {
                 tracing::warn!(error = %e, "MCP event stream is not UTF-8");
@@ -640,6 +646,10 @@ async fn read_event_stream(response: reqwest::Response, tx: mpsc::UnboundedSende
             }
             Err(SseEnd::Failed(e)) => {
                 tracing::warn!(error = %e, "MCP event stream failed");
+                return;
+            }
+            Err(SseEnd::TooLarge(msg)) => {
+                tracing::warn!(error = %msg, "MCP event stream stopped at the frame cap");
                 return;
             }
             Err(SseEnd::Closed) => return,
@@ -668,6 +678,9 @@ enum SseEnd {
     NotUtf8(std::str::Utf8Error),
     /// The HTTP body stream itself failed.
     Failed(reqwest::Error),
+    /// A partial event grew past the frame cap; the message names the cap
+    /// and the peer.
+    TooLarge(String),
     /// The server closed the body.
     Closed,
 }
@@ -683,6 +696,8 @@ enum SseEnd {
 async fn next_sse_event<S, B>(
     stream: &mut S,
     buffer: &mut String,
+    frame_cap: usize,
+    peer: &str,
 ) -> Result<super::sse::SseEvent, SseEnd>
 where
     S: StreamExt<Item = Result<B, reqwest::Error>> + Unpin,
@@ -693,6 +708,12 @@ where
             if !event.data.is_empty() {
                 return Ok(event);
             }
+        }
+        // Measured once the whole events are off the front, so this is one
+        // partial event: a peer that never sends the blank line.
+        if let Err(msg) = frame_within_cap(buffer.len(), frame_cap, peer) {
+            buffer.clear();
+            return Err(SseEnd::TooLarge(msg));
         }
         match stream.next().await {
             Some(Ok(chunk)) => match std::str::from_utf8(chunk.as_ref()) {
@@ -1768,6 +1789,86 @@ mod tests {
             err.to_string().contains("event stream failed"),
             "got: {err}"
         );
+    }
+
+    /// A reply stream that never sends the blank line ending its event is
+    /// stopped at the frame cap, with the cap and the peer in the error.
+    #[tokio::test]
+    async fn a_reply_event_past_the_frame_cap_is_an_error() {
+        let _guard = always_on_tracing_guard();
+        let app = Router::new().route(
+            "/mcp",
+            post(|| async {
+                (
+                    [(CONTENT_TYPE, "text/event-stream")],
+                    format!("data: {}", "x".repeat(STREAM_FRAME_CAP + 1)),
+                )
+                    .into_response()
+            }),
+        );
+        let url = format!("{}/mcp", serve(app).await);
+        let mut t = transport(&url);
+        let err = t
+            .send_request(&init(), DEFAULT_REQUEST_TIMEOUT)
+            .await
+            .err()
+            .expect("an event past the cap must fail");
+        assert!(
+            err.to_string()
+                .contains("MCP event stream frame exceeded 8 MiB from 127.0.0.1"),
+            "got: {err}"
+        );
+    }
+
+    /// The same overrun on the legacy server-to-client stream stops the pump,
+    /// which the waiting request sees as a stream that ended.
+    #[tokio::test]
+    async fn a_legacy_event_past_the_frame_cap_ends_the_stream() {
+        let _guard = always_on_tracing_guard();
+        let app = legacy_router(get(|| async {
+            (
+                [(CONTENT_TYPE, "text/event-stream")],
+                format!("data: {}", "x".repeat(STREAM_FRAME_CAP + 1)),
+            )
+                .into_response()
+        }));
+        let url = format!("{}/sse", serve(app).await);
+        let mut t = transport(&url);
+        let err = t
+            .send_request(&init(), DEFAULT_REQUEST_TIMEOUT)
+            .await
+            .err()
+            .expect("a stream cut at the cap never names an endpoint");
+        assert!(
+            err.to_string().contains("before naming a POST endpoint"),
+            "got: {err}"
+        );
+    }
+
+    /// The framing helper itself, with a cap small enough to overrun in one
+    /// chunk: the buffer is measured only after whole events are cut off it,
+    /// and is released once the cap fires.
+    #[tokio::test]
+    async fn next_sse_event_measures_the_partial_event_against_the_cap() {
+        let chunks: Vec<Result<&[u8], reqwest::Error>> = vec![
+            Ok(b"data: ok\n\n"),
+            Ok(b"data: this partial event is longer than the cap"),
+        ];
+        let mut stream = futures_util::stream::iter(chunks);
+        let mut buffer = String::new();
+        let first = next_sse_event(&mut stream, &mut buffer, 16, "mcp.example")
+            .await
+            .ok()
+            .expect("a whole event under the cap");
+        assert_eq!(first.data, "ok");
+        let err = next_sse_event(&mut stream, &mut buffer, 16, "mcp.example")
+            .await
+            .expect_err("the partial event overruns the cap");
+        assert!(
+            matches!(err, SseEnd::TooLarge(ref msg) if msg == "stream frame exceeded 16 bytes from mcp.example"),
+            "got a different ending"
+        );
+        assert!(buffer.is_empty(), "the oversized partial event is released");
     }
 
     #[tokio::test]

--- a/crates/leviath-mcp/src/transport/stdio.rs
+++ b/crates/leviath-mcp/src/transport/stdio.rs
@@ -8,8 +8,9 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use async_trait::async_trait;
+use leviath_net::read_caps::{MCP_LINE_CAP, line_cap_message};
 use serde_json::Value;
-use tokio::io::{AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
+use tokio::io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
 use tokio::process::{Child, ChildStdin, ChildStdout};
 
 use super::Transport;
@@ -107,6 +108,9 @@ pub(crate) struct StdioTransport {
     writer: BufWriter<ChildStdin>,
     reader: BufReader<ChildStdout>,
     stderr: StderrTail,
+    /// The longest line the server may write before the read fails:
+    /// [`MCP_LINE_CAP`], lowered only by a test.
+    line_cap: usize,
 }
 
 impl StdioTransport {
@@ -172,10 +176,21 @@ impl StdioTransport {
         // Drained continuously: an unread stderr pipe fills its buffer and then
         // blocks the server mid-write, which looks exactly like a hang.
         tokio::spawn(async move {
-            let mut lines = BufReader::new(stderr_pipe).lines();
-            while let Ok(Some(line)) = lines.next_line().await {
-                tracing::debug!(line = %line, "MCP server stderr");
-                sink.push(line);
+            let mut reader = BufReader::new(stderr_pipe);
+            loop {
+                match read_line_capped(&mut reader, MCP_LINE_CAP, "the MCP server's stderr").await {
+                    Ok(Some(line)) => {
+                        tracing::debug!(line = %line, "MCP server stderr");
+                        sink.push(line);
+                    }
+                    // An oversized line was discarded past the cap; the pipe
+                    // is still open and still has to be drained, or the server
+                    // blocks on its next write and looks hung.
+                    Err(e) if e.kind() == std::io::ErrorKind::FileTooLarge => {
+                        tracing::debug!(error = %e, "MCP server stderr line dropped");
+                    }
+                    Ok(None) | Err(_) => break,
+                }
             }
         });
 
@@ -184,6 +199,7 @@ impl StdioTransport {
             writer: BufWriter::new(stdin),
             reader: BufReader::new(stdout),
             stderr,
+            line_cap: MCP_LINE_CAP,
         }
     }
 
@@ -225,20 +241,19 @@ impl StdioTransport {
 
     /// Read one frame from the server, or `Ok(None)` at end of stream.
     async fn read_frame(&mut self) -> anyhow::Result<Option<Value>> {
-        let mut line = String::new();
         // Propagated, never unwrapped: an `.expect()` here turns a server dying
-        // mid-read into a whole-daemon panic rather than one failed call.
-        // `read_line` also fails outright on non-UTF-8 output, which a server
-        // writing raw bytes or a mis-encoded log line really does produce.
-        let read = self
-            .reader
-            .read_line(&mut line)
-            .await
-            .map_err(|e| self.with_stderr(format!("Failed to read from MCP server: {e}")))?;
-
-        if read == 0 {
+        // mid-read into a whole-daemon panic rather than one failed call. The
+        // read also fails outright on non-UTF-8 output, which a server writing
+        // raw bytes or a mis-encoded log line really does produce, and on a
+        // line past the cap, which is a server streaming a file where a frame
+        // should be. The rest of an oversized line is discarded before the
+        // error is returned, so the next request reads the next frame.
+        let line = read_line_capped(&mut self.reader, self.line_cap, "the MCP server").await;
+        let Some(line) =
+            line.map_err(|e| self.with_stderr(format!("Failed to read from MCP server: {e}")))?
+        else {
             return Ok(None);
-        }
+        };
         let trimmed = line.trim();
         if trimmed.is_empty() {
             // Blank keepalive line; not a frame.
@@ -311,6 +326,73 @@ impl StdioTransport {
             .await
             .map_err(|e| anyhow::anyhow!("{}: {}", flush_err, e))?;
         Ok(())
+    }
+}
+
+/// Read one line, up to `cap` bytes of it, or `Ok(None)` at end of stream.
+///
+/// `read_line` grows its string until the newline arrives, so a peer that
+/// never sends one owns the daemon's heap. This reads through the buffer
+/// piecewise with a running total; past `cap` the rest of the line is drained
+/// and dropped, chunk by chunk, so nothing larger than the reader's own buffer
+/// is ever held, and the error (kind `FileTooLarge`) names the cap and
+/// `peer`. A trait object rather than `impl AsyncBufRead` so production and
+/// each test share one instantiation.
+async fn read_line_capped(
+    reader: &mut (dyn AsyncBufRead + Unpin + Send),
+    cap: usize,
+    peer: &str,
+) -> std::io::Result<Option<String>> {
+    let mut line = Vec::new();
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            if line.is_empty() {
+                return Ok(None);
+            }
+            break;
+        }
+        let newline = available.iter().position(|&b| b == b'\n');
+        let take = newline.map_or(available.len(), |i| i + 1);
+        if line.len() + take > cap {
+            reader.consume(take);
+            if newline.is_none() {
+                discard_to_newline(reader).await?;
+            }
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::FileTooLarge,
+                line_cap_message(cap, peer),
+            ));
+        }
+        line.extend_from_slice(&available[..take]);
+        reader.consume(take);
+        if newline.is_some() {
+            break;
+        }
+    }
+    String::from_utf8(line)
+        .map(Some)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+/// Consume through the next newline (or the end of the stream), keeping none
+/// of it.
+async fn discard_to_newline(reader: &mut (dyn AsyncBufRead + Unpin + Send)) -> std::io::Result<()> {
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            return Ok(());
+        }
+        match available.iter().position(|&b| b == b'\n') {
+            Some(i) => {
+                reader.consume(i + 1);
+                return Ok(());
+            }
+            None => {
+                let len = available.len();
+                reader.consume(len);
+            }
+        }
     }
 }
 
@@ -880,6 +962,192 @@ sys.stdout.buffer.flush()
             .err()
             .expect("invalid UTF-8 should error");
         assert!(err.to_string().contains("Failed to read"), "got: {err}");
+    }
+
+    /// A server that answers with a 2 MiB line fails that one call with the
+    /// cap and the peer named, and the connection is still good for the next:
+    /// the rest of the oversized line was drained, not left in the pipe to
+    /// be read as the next reply.
+    #[tokio::test]
+    async fn an_oversized_line_fails_the_call_and_the_next_one_still_works() {
+        let _guard = always_on_tracing_guard();
+        let script = r#"
+import sys, json
+first = True
+for line in sys.stdin:
+    if not line.strip():
+        continue
+    req = json.loads(line)
+    if first:
+        first = False
+        pad = "x" * (2 * 1024 * 1024)
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req["id"], "result": {"pad": pad}}) + "\n")
+    else:
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req["id"], "result": {"short": True}}) + "\n")
+    sys.stdout.flush()
+"#;
+        let mut t = spawn_stub(script).await;
+        let err = t
+            .send_request(&init_request(), DEFAULT_REQUEST_TIMEOUT)
+            .await
+            .err()
+            .expect("a 2 MiB line must fail the call");
+        assert!(
+            err.to_string().contains(
+                "Failed to read from MCP server: line exceeded 1 MiB from the MCP server"
+            ),
+            "got: {err}"
+        );
+        let second = JsonRpcRequest::request(2, "tools/list", serde_json::json!({}));
+        let response = t
+            .send_request(&second, DEFAULT_REQUEST_TIMEOUT)
+            .await
+            .expect("the server is still usable after an oversized line");
+        assert_eq!(
+            response.into_result().expect("a result"),
+            serde_json::json!({"short": true})
+        );
+    }
+
+    /// A stderr line past the cap is dropped, and the drain keeps going: the
+    /// line after it still reaches the diagnostic, and the pipe never fills.
+    #[tokio::test]
+    async fn an_oversized_stderr_line_is_dropped_and_the_drain_continues() {
+        let _guard = always_on_tracing_guard();
+        let script = r#"
+import sys
+sys.stderr.write("y" * (2 * 1024 * 1024) + "\n")
+sys.stderr.write("after the flood\n")
+sys.stderr.flush()
+sys.stdin.readline()
+sys.stdout.close()
+"#;
+        let mut t = spawn_stub(script).await;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        let err = t
+            .send_request(&init_request(), DEFAULT_REQUEST_TIMEOUT)
+            .await
+            .err()
+            .expect("closed stdout should error");
+        let msg = err.to_string();
+        assert!(msg.contains("after the flood"), "got: {msg}");
+        assert!(
+            !msg.contains("yyyy"),
+            "the oversized line is not kept: {msg}"
+        );
+    }
+
+    /// The capped reader on an in-memory stream, chunked four bytes at a time
+    /// so an oversized line spans several `fill_buf` rounds.
+    #[tokio::test]
+    async fn read_line_capped_drains_past_the_cap_and_reads_the_next_line() {
+        let data: &[u8] = b"abcdefgh\nnext\n";
+        let mut reader = BufReader::with_capacity(4, data);
+        let err = read_line_capped(&mut reader, 5, "p")
+            .await
+            .expect_err("nine bytes overrun a cap of five");
+        assert_eq!(err.kind(), std::io::ErrorKind::FileTooLarge);
+        assert_eq!(err.to_string(), "line exceeded 5 bytes from p");
+        assert_eq!(
+            read_line_capped(&mut reader, 5, "p")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("next\n")
+        );
+        assert!(
+            read_line_capped(&mut reader, 5, "p")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_line_capped_with_the_newline_in_the_same_chunk_needs_no_drain() {
+        let data: &[u8] = b"abcdefgh\nnext\n";
+        let mut reader = BufReader::with_capacity(64, data);
+        let err = read_line_capped(&mut reader, 5, "p").await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::FileTooLarge);
+        assert_eq!(
+            read_line_capped(&mut reader, 5, "p")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("next\n")
+        );
+    }
+
+    #[tokio::test]
+    async fn read_line_capped_drain_stops_at_end_of_stream() {
+        let data: &[u8] = b"abcdefgh";
+        let mut reader = BufReader::with_capacity(4, data);
+        let err = read_line_capped(&mut reader, 5, "p").await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::FileTooLarge);
+        assert!(
+            read_line_capped(&mut reader, 5, "p")
+                .await
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn read_line_capped_returns_a_final_line_with_no_newline() {
+        let data: &[u8] = b"abc";
+        let mut reader = BufReader::with_capacity(2, data);
+        assert_eq!(
+            read_line_capped(&mut reader, 5, "p")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("abc")
+        );
+    }
+
+    /// A reader that hands out `chunks` and then fails, so the three `?`s on
+    /// `fill_buf` (the first read, the read inside the drain, and the drain's
+    /// failure surfacing through the cap arm) are each reachable.
+    struct ChunksThenError(std::collections::VecDeque<&'static [u8]>);
+
+    impl tokio::io::AsyncRead for ChunksThenError {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<std::io::Result<()>> {
+            match self.0.pop_front() {
+                Some(chunk) => {
+                    buf.put_slice(chunk);
+                    Poll::Ready(Ok(()))
+                }
+                None => Poll::Ready(Err(std::io::Error::other("pipe broke"))),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn read_line_capped_surfaces_a_read_error() {
+        let mut reader = BufReader::new(ChunksThenError(Default::default()));
+        let err = read_line_capped(&mut reader, 5, "p").await.unwrap_err();
+        assert_eq!(err.to_string(), "pipe broke");
+    }
+
+    #[tokio::test]
+    async fn read_line_capped_surfaces_a_read_error_while_draining() {
+        let mut reader = BufReader::new(ChunksThenError(
+            [&b"abcdefgh"[..], &b"ijkl"[..]].into_iter().collect(),
+        ));
+        let err = read_line_capped(&mut reader, 5, "p").await.unwrap_err();
+        assert_eq!(err.to_string(), "pipe broke");
+    }
+
+    #[tokio::test]
+    async fn read_line_capped_rejects_non_utf8() {
+        let data: &[u8] = b"\xff\xfe\n";
+        let mut reader = BufReader::new(data);
+        let err = read_line_capped(&mut reader, 5, "p").await.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
     }
 
     #[tokio::test]

--- a/crates/leviath-net/Cargo.toml
+++ b/crates/leviath-net/Cargo.toml
@@ -18,6 +18,9 @@ readme = "README.md"
 # holds plain serializable data with no async dependencies. Depending on
 # Leviath's data types cost a full HTTP client and everything under it.
 reqwest = { workspace = true }
+# The decoder `reqwest::Response::text` uses, so a capped read of a body
+# declaring `charset=` decodes it the same way the uncapped one did.
+encoding_rs = "0.8"
 tracing = { workspace = true }
 url = { workspace = true }
 

--- a/crates/leviath-net/src/lib.rs
+++ b/crates/leviath-net/src/lib.rs
@@ -23,6 +23,8 @@
 //! resolve privately, and redirects), which is the whole of the reachable
 //! surface for a model that is picking URLs rather than running an attack.
 
+pub mod read_caps;
+
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, ToSocketAddrs};
 use std::time::Duration;
 

--- a/crates/leviath-net/src/read_caps.rs
+++ b/crates/leviath-net/src/read_caps.rs
@@ -1,0 +1,323 @@
+//! How much the daemon will buffer from a remote peer before giving up.
+//!
+//! Every reader of a provider body, a streamed frame or an MCP line used to
+//! accumulate until the peer stopped sending. A peer that never stops (a
+//! misbehaving gateway, a compromised MCP server, a proxy replaying a file)
+//! therefore grew the daemon's heap until the kernel killed it, and it took
+//! every run down with it. The caps here are fixed numbers, not config keys:
+//! each is far above anything a well-formed reply needs, so a user has no
+//! reason to raise one, and a knob that only ever matters under attack is a
+//! knob an attacker gets to reason about.
+//!
+//! Over a cap is an error to the caller, never a hang and never a panic. The
+//! message names the cap and the peer, so a log line says which endpoint
+//! misbehaved.
+
+use std::fmt;
+
+/// The most the daemon reads of one buffered HTTP body (a JSON reply from a
+/// provider, an MCP HTTP response, an OAuth token exchange) before failing the
+/// call: 64 MiB.
+///
+/// The largest legitimate body on this path is a model listing from a big
+/// gateway, at well under 1 MiB, and a whole-turn reply from a 1M-context
+/// model tops out at a few MiB.
+pub const JSON_BODY_CAP: usize = 64 * 1024 * 1024;
+
+/// The most one streamed frame, or one accumulated partial line, may hold
+/// before the stream fails: 8 MiB.
+///
+/// A streaming parser keeps whatever has arrived since the last frame
+/// boundary. A peer that never sends a boundary (no `\n\n`, no newline) keeps
+/// that buffer growing, and a single frame that large is not one any wire
+/// format the daemon speaks produces: an SSE delta is a few hundred bytes and
+/// an NDJSON line is one chunk of a reply.
+pub const STREAM_FRAME_CAP: usize = 8 * 1024 * 1024;
+
+/// The longest line an MCP stdio server may write before the read fails:
+/// 1 MiB.
+///
+/// A JSON-RPC frame is one line. A tool result of a megabyte is already far
+/// past what a model can take in, and the runtime clips tool output well below
+/// that; a longer line is a server streaming a file where a frame should be.
+pub const MCP_LINE_CAP: usize = 1024 * 1024;
+
+/// A cap as a person reads it: `64 MiB`, `1 MiB`, or `4096 bytes` for a
+/// figure that is not a whole number of MiB (which only test-sized caps are).
+pub fn describe_cap(cap: usize) -> String {
+    const MIB: usize = 1024 * 1024;
+    if cap >= MIB && cap.is_multiple_of(MIB) {
+        format!("{} MiB", cap / MIB)
+    } else {
+        format!("{cap} bytes")
+    }
+}
+
+/// The name a cap error reports for a response: the host it came from.
+///
+/// Every URL `reqwest` will send to has a host, so the fallback is for a
+/// response built by hand in a test rather than one that came off a socket.
+pub fn peer_of(response: &reqwest::Response) -> String {
+    response
+        .url()
+        .host_str()
+        .unwrap_or("an unnamed peer")
+        .to_string()
+}
+
+/// Why a capped body read stopped short of a body.
+#[derive(Debug)]
+pub enum BodyReadError {
+    /// The peer sent more than `cap` bytes; the read stopped there.
+    TooLarge {
+        /// The cap that was hit.
+        cap: usize,
+        /// Who sent it, from [`peer_of`].
+        peer: String,
+    },
+    /// The connection failed before the body finished.
+    Transport(reqwest::Error),
+}
+
+impl fmt::Display for BodyReadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::TooLarge { cap, peer } => {
+                write!(
+                    f,
+                    "response body exceeded {} from {peer}",
+                    describe_cap(*cap)
+                )
+            }
+            Self::Transport(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for BodyReadError {}
+
+/// Read a response body to the end, or to `cap` bytes, whichever comes first.
+///
+/// Chunk by chunk with a running total rather than `bytes()` followed by a
+/// length check: the check after the fact only fires once the whole body is
+/// already on the heap, which is the allocation the cap exists to prevent.
+/// The connection is dropped with the response on the way out of the error
+/// arm, so the peer's remaining bytes are never read.
+pub async fn read_body_capped(
+    mut response: reqwest::Response,
+    cap: usize,
+) -> Result<Vec<u8>, BodyReadError> {
+    let mut body = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(BodyReadError::Transport)? {
+        if body.len() + chunk.len() > cap {
+            return Err(BodyReadError::TooLarge {
+                cap,
+                peer: peer_of(&response),
+            });
+        }
+        body.extend_from_slice(&chunk);
+    }
+    Ok(body)
+}
+
+/// [`read_body_capped`], decoded the way `reqwest::Response::text` decodes:
+/// by the `charset` the `Content-Type` header names, UTF-8 when it names
+/// none, with replacement characters for what does not decode.
+pub async fn read_text_capped(
+    response: reqwest::Response,
+    cap: usize,
+) -> Result<String, BodyReadError> {
+    let charset = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .and_then(charset_of)
+        .unwrap_or_else(|| "utf-8".to_string());
+    let body = read_body_capped(response, cap).await?;
+    let encoding =
+        encoding_rs::Encoding::for_label(charset.as_bytes()).unwrap_or(encoding_rs::UTF_8);
+    let (text, _, _) = encoding.decode(&body);
+    Ok(text.into_owned())
+}
+
+/// The `charset=` parameter of a `Content-Type` value, unquoted.
+fn charset_of(content_type: &str) -> Option<String> {
+    content_type.split(';').skip(1).find_map(|param| {
+        let (key, value) = param.trim().split_once('=')?;
+        key.eq_ignore_ascii_case("charset")
+            .then(|| value.trim().trim_matches('"').to_string())
+    })
+}
+
+/// The error a streaming parser returns once its partial-frame buffer has
+/// grown past `cap`, or `Ok` while it has not.
+pub fn frame_within_cap(buffered: usize, cap: usize, peer: &str) -> Result<(), String> {
+    if buffered > cap {
+        Err(format!(
+            "stream frame exceeded {} from {peer}",
+            describe_cap(cap)
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// The message for a line a stdio peer kept writing past `cap`.
+pub fn line_cap_message(cap: usize, peer: &str) -> String {
+    format!("line exceeded {} from {peer}", describe_cap(cap))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    /// Serve one connection with `headers` and then `body_len` bytes of
+    /// `x`, written in small pieces. The body is never all in one chunk, so
+    /// the running total is what stops the read.
+    async fn serve_body(headers: &'static str, body_len: usize) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock.write_all(headers.as_bytes()).await;
+            let mut sent = 0;
+            while sent < body_len {
+                let piece = (body_len - sent).min(1024);
+                // Errors are ignored: a client that stopped reading at its
+                // cap closes the socket, and that is the test passing.
+                let _ = sock.write_all(&vec![b'x'; piece]).await;
+                sent += piece;
+            }
+            let _ = sock.shutdown().await;
+        });
+        format!("http://{addr}/reply")
+    }
+
+    #[test]
+    fn caps_are_described_in_mib_or_bytes() {
+        assert_eq!(describe_cap(JSON_BODY_CAP), "64 MiB");
+        assert_eq!(describe_cap(STREAM_FRAME_CAP), "8 MiB");
+        assert_eq!(describe_cap(MCP_LINE_CAP), "1 MiB");
+        assert_eq!(describe_cap(4096), "4096 bytes");
+    }
+
+    #[tokio::test]
+    async fn a_body_under_the_cap_is_read_whole() {
+        let url = serve_body(
+            "HTTP/1.1 200 OK\r\nContent-Length: 3000\r\nConnection: close\r\n\r\n",
+            3000,
+        )
+        .await;
+        let response = reqwest::get(url).await.unwrap();
+        let body = read_text_capped(response, 4096).await.unwrap();
+        assert_eq!(body.len(), 3000);
+    }
+
+    #[tokio::test]
+    async fn a_body_over_the_cap_fails_naming_the_cap_and_the_peer() {
+        let url = serve_body(
+            "HTTP/1.1 200 OK\r\nContent-Length: 10000\r\nConnection: close\r\n\r\n",
+            10000,
+        )
+        .await;
+        let response = reqwest::get(url).await.unwrap();
+        let err = read_body_capped(response, 4096).await.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "response body exceeded 4096 bytes from 127.0.0.1"
+        );
+    }
+
+    #[tokio::test]
+    async fn text_past_the_cap_is_the_same_error() {
+        let url = serve_body(
+            "HTTP/1.1 200 OK\r\nContent-Length: 10000\r\nConnection: close\r\n\r\n",
+            10000,
+        )
+        .await;
+        let response = reqwest::get(url).await.unwrap();
+        let err = read_text_capped(response, 4096).await.unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "response body exceeded 4096 bytes from 127.0.0.1"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_body_that_stops_early_is_a_transport_failure() {
+        // Declares more than it sends, then hangs up.
+        let url = serve_body(
+            "HTTP/1.1 200 OK\r\nContent-Length: 10000\r\nConnection: close\r\n\r\n",
+            100,
+        )
+        .await;
+        let response = reqwest::get(url).await.unwrap();
+        let err = read_body_capped(response, 4096).await.unwrap_err();
+        // Told apart by what it says: the one message this module writes
+        // itself is the cap's, and a transport failure is reqwest's own.
+        assert!(!err.to_string().starts_with("response body exceeded"));
+        assert!(!err.to_string().is_empty());
+        assert!(std::error::Error::source(&err).is_none());
+    }
+
+    #[tokio::test]
+    async fn the_peer_is_the_host_or_the_whole_url() {
+        let url = serve_body(
+            "HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n",
+            0,
+        )
+        .await;
+        let response = reqwest::get(url).await.unwrap();
+        assert_eq!(peer_of(&response), "127.0.0.1");
+    }
+
+    #[tokio::test]
+    async fn text_is_decoded_by_the_declared_charset() {
+        // `caf\xe9` in Latin-1; read as UTF-8 it would be a replacement
+        // character, which is what `Response::text` also avoids.
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let (mut sock, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain; charset=\"iso-8859-1\"\r\n\
+                      Content-Length: 4\r\nConnection: close\r\n\r\ncaf\xe9",
+                )
+                .await;
+            let _ = sock.shutdown().await;
+        });
+        let response = reqwest::get(format!("http://{addr}/")).await.unwrap();
+        assert_eq!(read_text_capped(response, 4096).await.unwrap(), "caf\u{e9}");
+    }
+
+    #[test]
+    fn the_charset_parameter_is_found_or_absent() {
+        assert_eq!(
+            charset_of("text/html; Charset=UTF-8").as_deref(),
+            Some("UTF-8")
+        );
+        assert_eq!(charset_of("application/json"), None);
+        assert_eq!(charset_of("text/plain; boundary=x"), None);
+        assert_eq!(charset_of("text/plain; nonsense"), None);
+    }
+
+    #[test]
+    fn frames_and_lines_are_judged_against_the_cap() {
+        assert!(frame_within_cap(8, 8, "openai").is_ok());
+        assert_eq!(
+            frame_within_cap(9, 8, "openai").unwrap_err(),
+            "stream frame exceeded 8 bytes from openai"
+        );
+        assert_eq!(
+            line_cap_message(MCP_LINE_CAP, "mcp server 'fs'"),
+            "line exceeded 1 MiB from mcp server 'fs'"
+        );
+    }
+}

--- a/crates/leviath-providers/Cargo.toml
+++ b/crates/leviath-providers/Cargo.toml
@@ -17,6 +17,7 @@ debug-http = []
 
 [dependencies]
 leviath-core = { workspace = true }
+leviath-net = { workspace = true }
 # Owner-only writes for the opt-in request dump, which contains whole transcripts.
 leviath-sys = { workspace = true }
 # For the shared Rhai sandbox limits (`leviath_scripting::harden`), so provider

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -862,8 +862,9 @@ impl Provider for AnthropicProvider {
         )
         .await?;
 
+        let peer = leviath_net::read_caps::peer_of(&response);
         let byte_stream = response.bytes_stream();
-        let stream = anthropic_sse_stream(byte_stream);
+        let stream = anthropic_sse_stream(byte_stream).sent_by(peer);
 
         Ok(Box::pin(stream))
     }
@@ -1018,10 +1019,24 @@ impl AnthropicProvider {
         // fixable by the operator, the other by waiting.
         let response = crate::provider::check_http_response(response, None).await?;
 
-        response
-            .json()
-            .await
-            .map_err(|e| ProviderError::transport("reaching the provider", &e))
+        // Read through the cap; a body past it is `InvalidResponse` like any
+        // other provider's. A listing that arrived and does not parse keeps
+        // the classification it always had here (a transport failure, so the
+        // caller retries it) rather than picking up `decode_json`'s: this
+        // change is about the size of the read, not what a bad listing means.
+        let bytes = leviath_net::read_caps::read_body_capped(
+            response,
+            leviath_net::read_caps::JSON_BODY_CAP,
+        )
+        .await
+        .map_err(ProviderError::from)?;
+        serde_json::from_slice(&bytes).map_err(|e| {
+            ProviderError::labelled(
+                crate::failure::FailureKind::ConnectionDropped,
+                "reaching the provider",
+                &e.to_string(),
+            )
+        })
     }
 }
 
@@ -3346,6 +3361,15 @@ mod tests {
         let provider = provider_with_url(url);
         let msg = provider.list_models().await.unwrap_err().to_string();
         assert!(msg.contains("401"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn list_models_body_that_stops_early_is_a_transport_failure() {
+        let url = spawn_mock_server_truncated_error_body(200, "OK").await;
+        let provider = provider_with_url(url);
+        let err = provider.list_models().await.unwrap_err();
+        assert!(err.is_transient(), "{err}");
+        assert!(err.to_string().starts_with("Request failed:"), "{err}");
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/endpoint.rs
+++ b/crates/leviath-providers/src/endpoint.rs
@@ -240,10 +240,12 @@ impl EndpointProvider {
 
         let status = response.status();
         if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
+            let error_body = leviath_net::read_caps::read_text_capped(
+                response,
+                leviath_net::read_caps::JSON_BODY_CAP,
+            )
+            .await
+            .unwrap_or_else(|_| "unknown error".to_string());
             return Err(ProviderError::ApiError(format!(
                 "HTTP {status}: {error_body}"
             )));
@@ -349,7 +351,10 @@ impl Provider for EndpointProvider {
         crate::openai_compat::make_streaming(&mut body);
         let response = self.post_chat(request, body).await?;
 
-        Ok(Box::pin(openai_sse_stream(response.bytes_stream())))
+        let peer = leviath_net::read_caps::peer_of(&response);
+        Ok(Box::pin(
+            openai_sse_stream(response.bytes_stream()).sent_by(peer),
+        ))
     }
 
     async fn count_tokens(&self, text: &str, _model: &str) -> usize {

--- a/crates/leviath-providers/src/gemini.rs
+++ b/crates/leviath-providers/src/gemini.rs
@@ -312,8 +312,9 @@ impl Provider for GeminiProvider {
         )
         .await?;
 
+        let peer = leviath_net::read_caps::peer_of(&response);
         let byte_stream = response.bytes_stream();
-        let stream = openai_sse_stream(byte_stream);
+        let stream = openai_sse_stream(byte_stream).sent_by(peer);
 
         Ok(Box::pin(stream))
     }

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -357,7 +357,7 @@ impl OllamaProvider {
         else {
             return HashMap::new();
         };
-        let Ok(body) = response.json::<serde_json::Value>().await else {
+        let Ok(body) = crate::provider::decode_json::<serde_json::Value>(response).await else {
             return HashMap::new();
         };
         body.get("models")
@@ -697,8 +697,9 @@ impl Provider for OllamaProvider {
         .await
         .map_err(|e| self.explain_truncation(e, request))?;
 
+        let peer = leviath_net::read_caps::peer_of(&response);
         let byte_stream = response.bytes_stream();
-        let stream = ollama_ndjson_stream(byte_stream);
+        let stream = ollama_ndjson_stream(byte_stream).sent_by(peer);
 
         Ok(Box::pin(stream))
     }

--- a/crates/leviath-providers/src/openai.rs
+++ b/crates/leviath-providers/src/openai.rs
@@ -375,8 +375,9 @@ impl Provider for OpenAIProvider {
         crate::openai_compat::make_streaming(&mut body);
         let response = self.post_chat(request, body).await?;
 
+        let peer = leviath_net::read_caps::peer_of(&response);
         let byte_stream = response.bytes_stream();
-        let stream = openai_sse_stream(byte_stream);
+        let stream = openai_sse_stream(byte_stream).sent_by(peer);
 
         Ok(Box::pin(stream))
     }
@@ -533,10 +534,12 @@ impl OpenAIProvider {
 
         let status = response.status();
         if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
+            let error_body = leviath_net::read_caps::read_text_capped(
+                response,
+                leviath_net::read_caps::JSON_BODY_CAP,
+            )
+            .await
+            .unwrap_or_else(|_| "unknown error".to_string());
             return Err(ProviderError::ApiError(format!(
                 "HTTP {}: {}",
                 status, error_body

--- a/crates/leviath-providers/src/openrouter.rs
+++ b/crates/leviath-providers/src/openrouter.rs
@@ -516,10 +516,12 @@ impl OpenRouterProvider {
 
         let status = response.status();
         if !status.is_success() {
-            let error_body = response
-                .text()
-                .await
-                .unwrap_or_else(|_| "unknown error".to_string());
+            let error_body = leviath_net::read_caps::read_text_capped(
+                response,
+                leviath_net::read_caps::JSON_BODY_CAP,
+            )
+            .await
+            .unwrap_or_else(|_| "unknown error".to_string());
             return Err(ProviderError::ApiError(format!(
                 "HTTP {}: {}",
                 status, error_body
@@ -648,8 +650,9 @@ impl Provider for OpenRouterProvider {
         .await?;
 
         // Reuse OpenAI SSE parser since the format is identical
+        let peer = leviath_net::read_caps::peer_of(&response);
         let byte_stream = response.bytes_stream();
-        let stream = openai_sse_stream(byte_stream);
+        let stream = openai_sse_stream(byte_stream).sent_by(peer);
 
         Ok(Box::pin(stream))
     }

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -6,6 +6,7 @@ pub use crate::capabilities::{LimitsSource, ModelCapabilities, ModelCapabilityOv
 pub use crate::failure::FailureKind;
 use async_trait::async_trait;
 use futures_core::Stream;
+use leviath_net::read_caps::{BodyReadError, JSON_BODY_CAP, read_body_capped, read_text_capped};
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
 use thiserror::Error;
@@ -1042,7 +1043,11 @@ pub(crate) async fn check_http_response(
         });
     }
     if !status.is_success() {
-        let error_body = response.text().await.unwrap_or_else(|e| e.to_string());
+        // Capped like a good body: an error page is a body too, and a gateway
+        // that answers a 502 with its whole access log is still a peer.
+        let error_body = read_text_capped(response, JSON_BODY_CAP)
+            .await
+            .unwrap_or_else(|e| e.to_string());
         // The kind rides in front of the status so it survives every layer that
         // only passes strings - including a Rhai script, which sees the message
         // and nothing else. A bare status left "their endpoint is down" and
@@ -1089,11 +1094,39 @@ pub(crate) async fn check_http_response(
 pub(crate) async fn decode_json<T: serde::de::DeserializeOwned>(
     response: reqwest::Response,
 ) -> Result<T> {
-    let bytes = response
-        .bytes()
+    decode_json_capped(response, JSON_BODY_CAP).await
+}
+
+/// [`decode_json`] with the body cap as a parameter, so a test can hit the
+/// cap with a few kilobytes rather than 64 MiB.
+///
+/// A body past the cap is [`ProviderError::InvalidResponse`]: the same
+/// request would draw the same oversized answer, so retrying it only spends
+/// the attempts, and the message names the cap and the peer.
+pub(crate) async fn decode_json_capped<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+    cap: usize,
+) -> Result<T> {
+    let bytes = read_body_capped(response, cap)
         .await
-        .map_err(|e| ProviderError::transport("reading the response body", &e))?;
+        .map_err(ProviderError::from)?;
     serde_json::from_slice(&bytes).map_err(|e| ProviderError::InvalidResponse(e.to_string()))
+}
+
+impl From<BodyReadError> for ProviderError {
+    /// Bytes that never arrived are a transport failure (retried, counted
+    /// against the breaker); a body past the cap is the provider's own fault
+    /// and permanent, since the same request draws the same oversized answer.
+    fn from(e: BodyReadError) -> Self {
+        match e {
+            BodyReadError::Transport(e) => {
+                ProviderError::transport("reading the response body", &e)
+            }
+            too_large @ BodyReadError::TooLarge { .. } => {
+                ProviderError::InvalidResponse(too_large.to_string())
+            }
+        }
+    }
 }
 
 // Helper module for single-item streams
@@ -2596,6 +2629,30 @@ mod tests {
             err.unavailable_reason(),
             None,
             "the provider is fine: {err}"
+        );
+    }
+
+    /// A body that keeps coming past the cap stops the read where the cap
+    /// is, and the error says which cap and which peer.
+    #[tokio::test]
+    async fn decode_json_refuses_a_body_past_the_cap() {
+        let mut raw = b"HTTP/1.1 200 OK\r\nContent-Length: 20000\r\n\r\n".to_vec();
+        raw.extend(std::iter::repeat_n(b'[', 20000));
+        let url = serve_raw(raw.leak()).await;
+        let client = build_http_client(None).expect("an HTTPS client builds in tests");
+        let response = client.get(url).send().await.expect("headers arrive");
+
+        let err = decode_json_capped::<serde_json::Value>(response, 4096)
+            .await
+            .expect_err("a body past the cap cannot decode");
+
+        assert_eq!(
+            err.to_string(),
+            "Invalid response: response body exceeded 4096 bytes from 127.0.0.1"
+        );
+        assert!(
+            !err.is_transient(),
+            "the same request draws the same body: {err}"
         );
     }
 

--- a/crates/leviath-providers/src/provider/stream.rs
+++ b/crates/leviath-providers/src/provider/stream.rs
@@ -11,6 +11,7 @@
 //! finished response apart into one chunk.
 
 use super::*;
+use leviath_net::read_caps::{STREAM_FRAME_CAP, frame_within_cap};
 
 /// The raw bytes a provider's streaming endpoint sends back.
 ///
@@ -50,6 +51,12 @@ pub struct FramedStream {
     buffer: String,
     parse: FrameFn,
     flush: Option<FlushFn>,
+    /// The most `buffer` may hold between frames before the stream fails;
+    /// [`STREAM_FRAME_CAP`] in production, smaller in the test that hits it.
+    frame_cap: usize,
+    /// Who the bytes are from, for the cap error. The host, once a provider
+    /// has named it with [`FramedStream::sent_by`].
+    peer: String,
 }
 
 impl FramedStream {
@@ -63,7 +70,23 @@ impl FramedStream {
             buffer: String::new(),
             parse,
             flush,
+            frame_cap: STREAM_FRAME_CAP,
+            peer: "the provider".to_string(),
         }
+    }
+
+    /// Name the peer the cap error reports; every provider passes the host
+    /// it connected to.
+    pub fn sent_by(mut self, peer: String) -> Self {
+        self.peer = peer;
+        self
+    }
+
+    /// Lower the frame cap, so a test can overrun it with a few kilobytes.
+    #[cfg(test)]
+    pub fn with_frame_cap(mut self, cap: usize) -> Self {
+        self.frame_cap = cap;
+        self
     }
 }
 
@@ -83,6 +106,17 @@ impl Stream for FramedStream {
                 std::task::Poll::Ready(Some(Ok(bytes))) => {
                     if let Ok(text) = std::str::from_utf8(&bytes) {
                         this.buffer.push_str(text);
+                    }
+                    // Checked after the frames were cut (the top of the
+                    // loop), so what is measured is one partial frame: a peer
+                    // that never sends a boundary, not a fast one.
+                    if let Err(msg) =
+                        frame_within_cap(this.buffer.len(), this.frame_cap, &this.peer)
+                    {
+                        this.buffer.clear();
+                        return std::task::Poll::Ready(Some(Err(ProviderError::InvalidResponse(
+                            msg,
+                        ))));
                     }
                 }
                 std::task::Poll::Ready(Some(Err(e))) => {
@@ -253,6 +287,34 @@ mod tests {
 
     /// The whole point of the fold: a turn arrives in pieces and the runtime is
     /// handed one finished answer, indistinguishable from a buffered one.
+    /// A peer that streams forever without a frame boundary is stopped at
+    /// the cap with an error naming it, and the buffer it grew is let go.
+    #[tokio::test]
+    async fn a_frame_that_never_closes_fails_at_the_cap() {
+        use tokio_stream::StreamExt as _;
+        // 100 chunks of 100 bytes, no `\n\n` anywhere: one frame, 10 KB.
+        let chunks = (0..100)
+            .map(|_| Ok::<bytes::Bytes, reqwest::Error>(bytes::Bytes::from(vec![b'x'; 100])));
+        let mut stream = FramedStream::new(
+            tokio_stream::iter(chunks),
+            Box::new(|_buffer: &mut String| None),
+            None,
+        )
+        .sent_by("api.example".to_string())
+        .with_frame_cap(4096);
+
+        let err = stream
+            .next()
+            .await
+            .expect("the stream yields the cap error")
+            .expect_err("it is an error");
+        assert_eq!(
+            err.to_string(),
+            "Invalid response: stream frame exceeded 4096 bytes from api.example"
+        );
+        assert!(stream.buffer.is_empty(), "the oversized frame is released");
+    }
+
     #[tokio::test]
     async fn collect_stream_reassembles_text_and_a_tool_call() {
         let stream = chunks(vec![

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -7,6 +7,9 @@
 //! tests inject a fake so no socket is ever bound. Rate limiting lives in the
 //! provider (around the executor), not here - the executor is pure transport.
 
+use leviath_net::read_caps::{
+    BodyReadError, JSON_BODY_CAP, STREAM_FRAME_CAP, frame_within_cap, peer_of, read_text_capped,
+};
 use std::collections::BTreeMap;
 
 use async_trait::async_trait;
@@ -133,6 +136,9 @@ pub struct ReqwestExecutor {
     /// An HTTP/1.1-only client, used only to retry an HTTP/2 protocol fault.
     /// `None` when one could not be built, which just means no fallback.
     h1_client: Option<reqwest::Client>,
+    /// The most of a buffered body `execute` reads: [`JSON_BODY_CAP`],
+    /// lowered only by a test.
+    body_cap: usize,
 }
 
 impl ReqwestExecutor {
@@ -143,7 +149,15 @@ impl ReqwestExecutor {
         Self {
             client,
             h1_client: None,
+            body_cap: JSON_BODY_CAP,
         }
+    }
+
+    /// Lower the body cap, so a test can overrun it with a few kilobytes.
+    #[cfg(test)]
+    pub(crate) fn with_body_cap(mut self, cap: usize) -> Self {
+        self.body_cap = cap;
+        self
     }
 
     /// An executor that can fall back to `h1_client` when an origin negotiates
@@ -153,6 +167,7 @@ impl ReqwestExecutor {
         Self {
             client,
             h1_client: Some(h1_client),
+            body_cap: JSON_BODY_CAP,
         }
     }
 
@@ -224,7 +239,9 @@ async fn classify(resp: reqwest::Response) -> Result<reqwest::Response, HostHttp
         return Err(HostHttpError::RateLimited { retry_after });
     }
     if !status.is_success() {
-        let body = resp.text().await.unwrap_or_else(|e| e.to_string());
+        let body = read_text_capped(resp, JSON_BODY_CAP)
+            .await
+            .unwrap_or_else(|e| e.to_string());
         return Err(HostHttpError::Api(format!("HTTP {status}: {body}")));
     }
     Ok(resp)
@@ -381,10 +398,14 @@ impl HttpExecutor for ReqwestExecutor {
         if let Some(reason) = unsupported_content_type(content_type.as_deref()) {
             return Err(HostHttpError::Api(format!("unreadable body: {reason}")));
         }
-        let body = resp
-            .text()
+        let body = read_text_capped(resp, self.body_cap)
             .await
-            .map_err(|e| HostHttpError::Transport(e.to_string()))?;
+            .map_err(|e| match e {
+                BodyReadError::Transport(e) => HostHttpError::Transport(e.to_string()),
+                too_large @ BodyReadError::TooLarge { .. } => {
+                    HostHttpError::Api(too_large.to_string())
+                }
+            })?;
         // Named rather than returned. A caller cannot tell mojibake from a page
         // that genuinely says very little, and a model handed either will cite
         // whatever it remembers being at that URL.
@@ -420,16 +441,23 @@ impl HttpExecutor for ReqwestExecutor {
                 return;
             }
         };
-        forward_sse(resp.bytes_stream(), events).await;
+        let peer = peer_of(&resp);
+        forward_sse(resp.bytes_stream(), events, STREAM_FRAME_CAP, &peer).await;
     }
 }
 
 /// Drain a byte stream as Server-Sent Events, forwarding each `data:` payload
 /// into `events`. Stops on the `[DONE]` sentinel; on a read error sends one
 /// `Err` and stops. Dropping `events` on return signals stream end.
+///
+/// A partial event that grows past `frame_cap` (a peer that never sends the
+/// blank line) is reported as an `Api` error naming the cap and `peer`, and
+/// the stream stops there.
 pub(crate) async fn forward_sse<S, E>(
     stream: S,
     events: mpsc::Sender<Result<String, HostHttpError>>,
+    frame_cap: usize,
+    peer: &str,
 ) where
     S: futures_core::Stream<Item = Result<bytes::Bytes, E>>,
     E: std::fmt::Display,
@@ -443,7 +471,12 @@ pub(crate) async fn forward_sse<S, E>(
                 if let Ok(text) = std::str::from_utf8(&bytes) {
                     buffer.push_str(text);
                 }
-                for ev in drain_sse_events(&mut buffer) {
+                let events_drained = drain_sse_events(&mut buffer);
+                if let Err(msg) = frame_within_cap(buffer.len(), frame_cap, peer) {
+                    let _ = events.send(Err(HostHttpError::Api(msg))).await;
+                    return;
+                }
+                for ev in events_drained {
                     match ev {
                         SseEvent::Data(payload) => {
                             if events.send(Ok(payload)).await.is_err() {

--- a/crates/leviath-providers/src/rhai_provider/host/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/host/tests.rs
@@ -3,6 +3,7 @@
 //! cargo-llvm-cov's default ignore regex excludes `tests.rs` and
 //! `*_tests.rs` files, so only production code answers to the 100% gate.
 use super::*;
+use leviath_net::read_caps::STREAM_FRAME_CAP;
 
 fn ev(kind: &SseEvent) -> String {
     match kind {
@@ -49,6 +50,20 @@ fn final_event_flushes_untrimmed_tail() {
 }
 
 #[tokio::test]
+async fn forward_sse_fails_an_event_that_never_closes() {
+    // One `data:` line that keeps growing with no blank line to end it.
+    let chunks: Vec<Result<bytes::Bytes, String>> =
+        std::iter::repeat_n(Ok(bytes::Bytes::from(vec![b'x'; 100])), 100).collect();
+    let (tx, mut rx) = mpsc::channel(16);
+    forward_sse(tokio_stream::iter(chunks), tx, 4096, "api.example").await;
+    assert!(matches!(
+        rx.recv().await.unwrap(),
+        Err(HostHttpError::Api(msg)) if msg == "stream frame exceeded 4096 bytes from api.example"
+    ));
+    assert!(rx.recv().await.is_none(), "the stream stops at the cap");
+}
+
+#[tokio::test]
 async fn forward_sse_emits_payloads_then_stops_on_done() {
     let chunks: Vec<Result<bytes::Bytes, String>> = vec![
         Ok(bytes::Bytes::from("data: {\"a\":1}\n\n")),
@@ -57,7 +72,7 @@ async fn forward_sse_emits_payloads_then_stops_on_done() {
     ];
     let stream = tokio_stream::iter(chunks);
     let (tx, mut rx) = mpsc::channel(16);
-    forward_sse(stream, tx).await;
+    forward_sse(stream, tx, STREAM_FRAME_CAP, "test").await;
     let mut got = Vec::new();
     while let Some(item) = rx.recv().await {
         got.push(item.unwrap());
@@ -75,7 +90,7 @@ async fn forward_sse_reports_read_error() {
         Ok(bytes::Bytes::from("data: y\n\n")),
     ];
     let (tx, mut rx) = mpsc::channel(16);
-    forward_sse(tokio_stream::iter(chunks), tx).await;
+    forward_sse(tokio_stream::iter(chunks), tx, STREAM_FRAME_CAP, "test").await;
     assert_eq!(rx.recv().await.unwrap().unwrap(), "x");
     assert!(matches!(
         rx.recv().await.unwrap(),
@@ -90,7 +105,7 @@ async fn forward_sse_stops_when_receiver_dropped() {
         vec![Ok(bytes::Bytes::from("data: a\n\ndata: b\n\n"))];
     let (tx, rx) = mpsc::channel(1);
     drop(rx); // receiver gone before we forward
-    forward_sse(tokio_stream::iter(chunks), tx).await; // must return, not hang
+    forward_sse(tokio_stream::iter(chunks), tx, STREAM_FRAME_CAP, "test").await; // must return, not hang
 }
 
 #[tokio::test]
@@ -98,7 +113,7 @@ async fn forward_sse_flushes_trailing_event() {
     let chunks: Vec<Result<bytes::Bytes, String>> =
         vec![Ok(bytes::Bytes::from("data: {\"tail\":1}"))];
     let (tx, mut rx) = mpsc::channel(16);
-    forward_sse(tokio_stream::iter(chunks), tx).await;
+    forward_sse(tokio_stream::iter(chunks), tx, STREAM_FRAME_CAP, "test").await;
     assert_eq!(rx.recv().await.unwrap().unwrap(), "{\"tail\":1}");
 }
 
@@ -111,7 +126,7 @@ async fn forward_sse_skips_invalid_utf8_and_ends_clean() {
         Ok(bytes::Bytes::from("data: a\n\n")),
     ];
     let (tx, mut rx) = mpsc::channel(16);
-    forward_sse(tokio_stream::iter(chunks), tx).await;
+    forward_sse(tokio_stream::iter(chunks), tx, STREAM_FRAME_CAP, "test").await;
     assert_eq!(rx.recv().await.unwrap().unwrap(), "a");
     assert!(rx.recv().await.is_none());
 }
@@ -558,6 +573,27 @@ async fn flaky_server(fail_first: usize, body: &'static str) -> String {
         }
     });
     format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn a_body_past_the_cap_is_an_api_error_naming_the_peer() {
+    // 10 KB of body against a 4 KB cap: the read stops at the cap and the
+    // error says which cap and which host, without the body ever being held.
+    let url = flaky_server(0, "x".repeat(10 * 1024).leak()).await;
+    let err = ReqwestExecutor::new(
+        crate::provider::build_http_client(None).expect("a test client builds"),
+    )
+    .with_body_cap(4096)
+    .execute(req(HttpMethod::Get, url, None))
+    .await
+    .expect_err("a body past the cap fails");
+    assert!(
+        matches!(
+            &err,
+            HostHttpError::Api(msg) if msg == "response body exceeded 4096 bytes from 127.0.0.1"
+        ),
+        "got: {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -238,6 +238,20 @@ lev policy test bash --target example.com
 `lev policy add` and `lev policy test` take the tool name as a **positional** argument
 (`lev policy add <tool> …`, `lev policy test <tool> --target …`).
 
+## Response size caps
+
+The daemon stops reading a remote peer at a fixed size rather than buffering
+whatever it sends. A provider's buffered JSON reply (and any error page it
+quotes) is cut at **64 MiB**, one streamed frame or partial line on a
+streaming reply is cut at **8 MiB**, and one line from an MCP stdio server is
+cut at **1 MiB**. Past the cap the call fails with a message naming the cap
+and the peer (`response body exceeded 64 MiB from api.openai.com`, or `line
+exceeded 1 MiB from the MCP server`), and the connection is dropped so the
+rest is never read. The same caps apply to MCP HTTP replies, their SSE
+streams, and the OAuth exchanges behind `lev mcp login`. They are constants,
+not configuration: every well-formed reply is far below them, and a knob that
+only matters under attack would be a knob for the attacker.
+
 ## Threat model
 
 `lev serve` runs LLM-driven tools, so treat it as trusted-network only unless hardened. See

--- a/perf-tools/harness.sh
+++ b/perf-tools/harness.sh
@@ -6,6 +6,8 @@
 #   LEVIATH_SKIP_DOTENV  the repo-root .env holds a real key; never load it
 #   OPENAI_*       point the native OpenAI provider at mock.py
 #   LV_RUNS_DIR    optional; forwarded as LEVIATH_RUNS_DIR (the fake-runs corpus)
+#   LV_MOCK_OVERSIZE_MIB  optional; forwarded to mock.py, which then answers
+#                  every completion with one frame that never closes
 #
 # Nothing here reads the caller's environment: `env -i` first, then exactly
 # these names, so a probe cannot accidentally reach a real provider.
@@ -29,5 +31,8 @@ exec env -i \
   OPENAI_BASE_URL="http://127.0.0.1:$LV_MOCK_PORT/v1" \
   TERM="${TERM:-xterm-256color}" \
   ${LV_RUNS_DIR:+LEVIATH_RUNS_DIR="$LV_RUNS_DIR"} \
+  ${LV_MOCK_OVERSIZE_MIB:+LV_MOCK_OVERSIZE_MIB="$LV_MOCK_OVERSIZE_MIB"} \
+  LV_MOCK_PORT="$LV_MOCK_PORT" \
+  ${LV_SERVE_PORT:+LV_SERVE_PORT="$LV_SERVE_PORT"} \
   LV_BIN="$LV_BIN" \
   "$@"

--- a/perf-tools/mock.py
+++ b/perf-tools/mock.py
@@ -22,17 +22,26 @@ Routes:
                              were served (probe counters)
     POST /reset              zero the counters
 
+Set `LV_MOCK_OVERSIZE_MIB=N` to answer every completion with N MiB of one
+frame that never closes, for probing the daemon's read caps.
+
 The count tally is what makes the context-window guard measurable from the
 outside: a run whose request is under half the model's window must show zero
 count calls, and one above it exactly one per inference.
 """
 import json
+import os
 import sys
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 PORT = int(sys.argv[1])
 TOOL = sys.argv[2] if len(sys.argv) > 2 else None
 ARGS = sys.argv[3] if len(sys.argv) > 3 else "{}"
+# `LV_MOCK_OVERSIZE_MIB=N` makes every completion answer with N MiB of a single
+# never-ending frame (one `data:` line with no terminator when streaming, one
+# JSON string otherwise), which is what a peer that never stops looks like to
+# the daemon's read caps.
+OVERSIZE_MIB = int(os.environ.get("LV_MOCK_OVERSIZE_MIB", "0"))
 
 
 def tool_calls(streaming):
@@ -120,6 +129,8 @@ class Handler(BaseHTTPRequestHandler):
         if self.path.startswith("/v1/messages"):
             return self._anthropic(req)
         CALLS[0] += 1
+        if OVERSIZE_MIB:
+            return self._oversize(bool(req.get("stream")))
         seen_tool = any(m.get("role") == "tool" for m in req.get("messages", []))
         want_tool = TOOL is not None and not seen_tool
         if req.get("stream"):
@@ -155,6 +166,19 @@ class Handler(BaseHTTPRequestHandler):
                     "model": req.get("model", "gpt-mock"), "content": content,
                     "stop_reason": stop,
                     "usage": {"input_tokens": 12, "output_tokens": 3}})
+
+    def _oversize(self, streaming):
+        """One frame of OVERSIZE_MIB MiB that never closes."""
+        pad = b"x" * (OVERSIZE_MIB * 1024 * 1024)
+        if streaming:
+            body, content_type = b"data: " + pad, "text/event-stream"
+        else:
+            body, content_type = b'{"pad":"' + pad + b'"}', "application/json"
+        self.send_response(200)
+        self.send_header("content-type", content_type)
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
 
     def _sse(self, want_tool):
         if want_tool:


### PR DESCRIPTION
Security hardening plan item 5.8: cap every unbounded read from a remote peer.

## Premise check

Measured before changing anything. The premise held: every reader of a provider body, a streamed frame or an MCP line accumulated until the peer stopped sending. Three probes written against unfixed `main` with the real caps:

| Probe on `main` | What happened |
| --- | --- |
| MCP stdio stub answers with one 2 MiB line | accepted as the reply: `a 2 MiB line was accepted as a reply: result has 2097162 bytes` |
| 9 MiB SSE frame with no boundary through `FramedStream` | the stream ended silently: `expected the cap error, got None` (the buffer had grown to 9 MiB first) |
| 65 MiB JSON body through `decode_json` | buffered whole, then `Invalid response: recursion limit exceeded at line 1 column 128` (the read was never the limit; serde was) |

The same three probes pass against this branch. The probes themselves were then replaced by the small-cap regression tests below (the 2 MiB MCP one is kept as is, since the task asked for it at the real cap and it runs in well under a second).

## Inventory

The three caps are constants with doc comments in one module, `crates/leviath-net/src/read_caps.rs`: `JSON_BODY_CAP` (64 MiB), `STREAM_FRAME_CAP` (8 MiB), `MCP_LINE_CAP` (1 MiB). No config keys were added; they are fixed on purpose and the docs say so.

| Site | File:line (after) | Cap before | Cap after |
| --- | --- | --- | --- |
| Provider JSON body, every native client and `openai_compat` (`decode_json`) | `crates/leviath-providers/src/provider.rs:1110` | none (`bytes()`) | 64 MiB, streaming read with a running total |
| Provider error body quoted into `ApiError` / `Unavailable` (`check_http_response`) | `crates/leviath-providers/src/provider.rs:1048` | none (`text()`) | 64 MiB |
| Model-listing error bodies (openai, openrouter, endpoint) | `openai.rs:537`, `openrouter.rs:519`, `endpoint.rs:243` | none (`text()`) | 64 MiB |
| Ollama `/api/ps` listing | `crates/leviath-providers/src/ollama.rs:360` | none (`json()`) | 64 MiB via `decode_json` |
| Anthropic `/v1/models` listing | `crates/leviath-providers/src/anthropic.rs:1027` | none (`json()`) | 64 MiB; a malformed listing keeps its old transport classification |
| Streamed frames, all providers (`FramedStream::poll_next`: OpenAI SSE, Anthropic SSE, Ollama NDJSON, Gemini, OpenRouter, custom endpoint) | `crates/leviath-providers/src/provider/stream.rs:114` | none | 8 MiB per accumulated partial frame, peer named by each provider via `sent_by(peer_of(&response))` |
| Rhai provider script HTTP, buffered (`ReqwestExecutor::execute`) | `crates/leviath-providers/src/rhai_provider/host.rs:401` | none (`text()`) | 64 MiB |
| Rhai provider script HTTP, error body (`classify`) | `crates/leviath-providers/src/rhai_provider/host.rs:242` | none (`text()`) | 64 MiB |
| Rhai provider script SSE (`forward_sse`) | `crates/leviath-providers/src/rhai_provider/host.rs:475` | none | 8 MiB |
| MCP HTTP JSON reply (`read_json_reply`) | `crates/leviath-mcp/src/transport/http.rs:362` | none (`text()`) | 64 MiB |
| MCP HTTP error body (`error_for_status`) | `crates/leviath-mcp/src/transport/http.rs:624` | none (`text()`) | 64 MiB |
| MCP HTTP SSE reply and legacy event stream (`next_sse_event`) | `crates/leviath-mcp/src/transport/http.rs:714` | none | 8 MiB per partial event |
| MCP OAuth: registration, metadata GET, token POST | `crates/leviath-mcp/src/auth/mod.rs:548, 614, 867` | none (`text()` / `json()`) | 64 MiB |
| MCP stdio frame line (`read_frame`) | `crates/leviath-mcp/src/transport/stdio.rs:251` | none (`read_line`) | 1 MiB; the rest of the line is drained so the next call works |
| MCP stdio stderr tail drain | `crates/leviath-mcp/src/transport/stdio.rs:181` | none (`lines()`) | 1 MiB per line, oversized lines dropped, draining continues |

Already capped, left alone:

- Tool-script `web_fetch` (`crates/leviath-cli/src/daemon/script_host.rs`, `send_capped`) refuses by `Content-Length` before reading and clips the output afterwards. Its documented residual (a chunked body with no `Content-Length` is bounded only by the 30 s timeout) is unchanged; that is a different transport (`reqwest::blocking`) and out of this item's scope.

Not remote, not touched: the control socket line reader (`leviath-runtime/src/control_socket`) and the Agent Client Protocol stdio reader (`leviath-cli/src/commands/agent_client`) read from the local daemon and the local editor.

## Behaviour

- Over a cap is an error to the caller, never a hang, never a panic. Provider paths fail the inference with `Invalid response: response body exceeded 64 MiB from <host>` or `Invalid response: stream frame exceeded 8 MiB from <host>` (permanent: the same request draws the same body, so it is not retried). MCP stdio fails the one call with `Failed to read from MCP server: line exceeded 1 MiB from the MCP server` and stays usable. MCP HTTP fails the request with `MCP event stream frame exceeded 8 MiB from <host>`.
- Bodies are read with `Response::chunk()` and a running total, so memory is bounded at the cap rather than checked after `bytes()` had already allocated it.
- `read_text_capped` decodes by the declared `charset` the way `Response::text` did, so an error page in Latin-1 reads the same as before.
- Zero other behaviour change. The one place that could have drifted, Anthropic's model listing, keeps classifying a malformed body as a transport failure (its existing test pins that).

## Tests (fail first, then pass)

Small caps come from a cap parameter or a `#[cfg(test)]` builder, so nothing allocates 64 MiB:

- `leviath-net`: body under / over / truncated at a 4096-byte cap, charset decoding, cap descriptions.
- `leviath-providers`: `decode_json_refuses_a_body_past_the_cap` (4096), `a_frame_that_never_closes_fails_at_the_cap` (4096, and the buffer is released), `forward_sse_fails_an_event_that_never_closes`, `a_body_past_the_cap_is_an_api_error_naming_the_peer` (executor with a 4096 cap), `list_models_body_that_stops_early_is_a_transport_failure`.
- `leviath-mcp`: `an_oversized_line_fails_the_call_and_the_next_one_still_works` (a real 2 MiB line from a Python stub; the second request succeeds), `an_oversized_stderr_line_is_dropped_and_the_drain_continues`, five `read_line_capped` unit tests over an in-memory reader (including a read error during the drain), `a_reply_event_past_the_frame_cap_is_an_error` and `a_legacy_event_past_the_frame_cap_ends_the_stream` (axum, 8 MiB + 1), `next_sse_event_measures_the_partial_event_against_the_cap`, OAuth truncated-body and missing-field registration replies.

All tests are platform-neutral (no `#[cfg(unix)]`).

## Live check

Daemon built from this branch, driven through `perf-tools/harness.sh` and `daemon_drive.py` against `perf-tools/mock.py` with a new optional knob, `LV_MOCK_OVERSIZE_MIB=N`, which makes every completion one frame of N MiB that never closes (committed: it is a clean optional flag, off by default, and `harness.sh` forwards it along with `LV_MOCK_PORT` / `LV_SERVE_PORT`).

Streaming (default), `LV_MOCK_OVERSIZE_MIB=9`:

```
probe-1788042054-731cf1344ccc  error: Invalid response: stream frame exceeded 8 MiB from 127.0.0.1 (no output)  main  0  0  7s  0s  7s
```

`lev timeline probe-1788042054-731cf1344ccc` shows the run at `error` with zero model time. Buffered (`stream_inference = false`), `LV_MOCK_OVERSIZE_MIB=65`:

```
probe-1788042088-5e196455da3d  error: Invalid response: response body exceeded 64 MiB from 127.0.0.1 (no output)  main  0  0  5s  0s  5s
```

The daemon stayed up through both (286 MB RSS after the 65 MiB run, which is the cap's worth of buffer plus the baseline, released on the next allocation cycle).

## Docs

`docs/content/security.md` gains a "Response size caps" section listing the three numbers; CHANGELOG under Changed.

## Gates

- `cargo fmt --all` clean
- `cargo clippy --all-targets --all-features -p leviath-net -p leviath-providers -p leviath-mcp -- -D warnings` clean
- `cargo xtask structure`: 423 files, none over 1200 lines
- `cargo xtask docs`: 40 pages, no problems
- `cargo xtask coverage --package leviath-net` / `leviath-providers` / `leviath-mcp`: 100%
- pre-commit (full suite) passed on the commit
