### PR TITLE
feat(serve): cap requests in flight and give each a deadline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -235,6 +235,21 @@ same list.
 
 ### Added
 
+- `lev serve` holds at most 64 requests in flight and gives each 30 seconds; the
+  65th is answered 503 at once and a request past its deadline 408, both in the
+  usual `{"error": ...}` shape. `--max-concurrent-requests` and
+  `--request-timeout-secs` set them for one server, `[serve]
+  max_concurrent_requests` and `request_timeout_secs` for every one, a flag wins
+  over the config file, and `0` switches a limit off. The websocket routes are
+  outside both, and `GET /api/config` reports the values in force under
+  `limits`. Before this the router had an auth layer, an optional CORS layer
+  and axum's 2 MiB body limit, and nothing bounded how many handlers a client
+  could hold open or for how long.
+- `lev serve --no-remote-seed-commands` treats every spawn as if it carried
+  `"no_seed_commands": true`, so a blueprint's `seed = { command = ... }`
+  regions never run for a run started over the API. `lev run` on the host is
+  as it was; `[security] allow_seed_commands = false` remains the
+  machine-wide switch.
 - `[model_providers.<name>] kind = "openai-compatible"` reaches any server that speaks
   OpenAI's chat API (llama.cpp, LM Studio, vLLM, BionicGPT, a gateway) natively, with no
   Rhai script: `base_url`, an optional `api_key`, `headers` and a `models` fallback for a

--- a/crates/leviath-cli/src/commands/serve/agents.rs
+++ b/crates/leviath-cli/src/commands/serve/agents.rs
@@ -100,7 +100,9 @@ pub(super) async fn spawn_agent(
         callback_url: body.callback_url.clone(),
         callback_secret: body.callback_secret.clone(),
         yolo: body.yolo,
-        no_seed_commands: body.no_seed_commands,
+        // Either side may refuse: the caller for this run, or the operator
+        // for every run that comes in this way.
+        no_seed_commands: body.no_seed_commands || state.limits.no_remote_seed_commands,
         allow: body.allow.clone(),
         output: output_request(&body),
         max_depth: body.max_depth,
@@ -869,6 +871,8 @@ mod tests {
                 allow_local_network: false,
                 workdir_root: Some(root.path().to_path_buf()),
                 no_remote_yolo: true,
+                no_remote_seed_commands: false,
+                request_limits: Default::default(),
             }),
         };
 
@@ -964,6 +968,8 @@ mod tests {
             allow_local_network: false,
             workdir_root: None,
             no_remote_yolo: false,
+            no_remote_seed_commands: false,
+            request_limits: Default::default(),
         };
         assert!(
             permissive
@@ -1200,6 +1206,52 @@ system_prompt = "Plan the work"
             .await,
             StatusCode::OK
         );
+    }
+
+    /// `--no-remote-seed-commands` reaches the daemon as `no_seed_commands`
+    /// on every spawn, whatever the body said; without the flag the body's
+    /// own answer is what goes through. Read off the request the fake daemon
+    /// receives, so this holds the wire rather than a local variable.
+    #[tokio::test]
+    async fn no_remote_seed_commands_marks_every_spawn() {
+        async fn seen(flag: bool, body: &str) -> bool {
+            let captured = Arc::new(std::sync::Mutex::new(None));
+            let sink = Arc::clone(&captured);
+            let (control, _dir, _srv) = fake_daemon(move |req| {
+                // Through its wire form rather than a pattern match: the only
+                // request this handler sends is a spawn, so an arm for any
+                // other would be one nothing runs.
+                let wire = serde_json::to_value(&req).unwrap();
+                *sink.lock().unwrap() = wire["args"]["no_seed_commands"].as_bool();
+                ControlResponse::Spawned {
+                    run_id: "run-1".to_string(),
+                }
+            });
+            let agents = tempfile::tempdir().unwrap();
+            write_test_blueprint(&agents.path().join("spawnable"), "spawnable");
+            let mut state = test_state_with_agent_paths(vec![agents.path().to_path_buf()], control);
+            state.limits = Arc::new(ServeLimits {
+                no_remote_seed_commands: flag,
+                ..Default::default()
+            });
+            let app = Router::new()
+                .route("/api/agents", axum::routing::post(spawn_agent))
+                .with_state(state);
+            assert_eq!(post_spawn(app, body).await, StatusCode::OK);
+            let seen = captured.lock().unwrap().take();
+            seen.expect("the daemon saw a spawn")
+        }
+
+        const PLAIN: &str = r#"{"blueprint":"spawnable","task":"t","workdir":"/tmp"}"#;
+        const OPTED_OUT: &str =
+            r#"{"blueprint":"spawnable","task":"t","workdir":"/tmp","no_seed_commands":true}"#;
+        assert!(!seen(false, PLAIN).await, "no flag, no request: seeds run");
+        assert!(
+            seen(false, OPTED_OUT).await,
+            "the body alone still opts out"
+        );
+        assert!(seen(true, PLAIN).await, "the flag opts out for the caller");
+        assert!(seen(true, OPTED_OUT).await, "both is still out");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -38,8 +38,10 @@ fn gateways_of(c: &Config) -> Vec<GatewayInfo> {
     gateways
 }
 
-/// Redacted view of a config — booleans for keys, never their values.
-fn redact(c: &Config) -> RedactedConfig {
+/// Redacted view of a config: booleans for keys, never their values.
+/// `requests` is what this server resolved at start-up, which no config
+/// file alone can say once a flag is involved.
+fn redact(c: &Config, requests: &super::request_limits::RequestLimits) -> RedactedConfig {
     RedactedConfig {
         default_provider: c.default_provider.clone(),
         has_anthropic_key: c.providers.anthropic_api_key.is_some(),
@@ -52,7 +54,7 @@ fn redact(c: &Config) -> RedactedConfig {
         mcp_server_count: c.mcp_servers.len(),
         api_version: API_VERSION.to_string(),
         capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
-        limits: ApiLimits::current(),
+        limits: ApiLimits::current(requests),
     }
 }
 
@@ -60,13 +62,17 @@ fn redact(c: &Config) -> RedactedConfig {
 /// made through [`put_config`] - or by anything else on the machine - is
 /// visible to the very next request (issue #532).
 pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedConfig> {
-    Json(redact(&state.current_config()))
+    Json(redact(
+        &state.current_config(),
+        &state.limits.request_limits,
+    ))
 }
 
 /// `PUT /api/config` (admin-only). Loads the on-disk config, applies every
 /// present field, and writes it back with the file's `0600` permissions — the
 /// same file `lev setup` and MCP admin edits. Returns the new redacted config.
 pub(super) async fn put_config(
+    State(state): State<AppState>,
     Json(req): Json<WriteConfigReq>,
 ) -> Result<Json<RedactedConfig>, ApiError> {
     let paths = super::mcp::admin_paths();
@@ -159,7 +165,7 @@ pub(super) async fn put_config(
             format!("failed to write config: {e}"),
         )
     })?;
-    Ok(Json(redact(&config)))
+    Ok(Json(redact(&config, &state.limits.request_limits)))
 }
 
 /// `POST /api/models/probe` (admin-only): what an OpenAI-compatible server
@@ -821,7 +827,7 @@ mod tests {
             mcp_server_count: 2,
             api_version: API_VERSION.to_string(),
             capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
-            limits: ApiLimits::current(),
+            limits: ApiLimits::current(&Default::default()),
         };
         let json = serde_json::to_string(&config).unwrap();
         // Must NOT contain actual key values
@@ -845,7 +851,7 @@ mod tests {
             mcp_server_count: 0,
             api_version: API_VERSION.to_string(),
             capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
-            limits: ApiLimits::current(),
+            limits: ApiLimits::current(&Default::default()),
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("\"ollama_base_url\":\"http://localhost:11434\""));
@@ -1396,7 +1402,7 @@ mod tests {
             },
         );
 
-        let redacted = redact(&config);
+        let redacted = redact(&config, &Default::default());
         let gateway = &redacted.gateways[0];
         assert_eq!(gateway.name, "groq");
         assert_eq!(gateway.kind, "script");

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -240,12 +240,19 @@ pub(super) struct ApiLimits {
     /// How many distinct modified paths a run records before
     /// `modified_files_truncated` is set.
     pub(super) max_tracked_modified_files: usize,
+    /// Requests this server holds in flight before answering 503. `0` means
+    /// there is no cap. `--max-concurrent-requests` over `[serve]`.
+    pub(super) max_concurrent_requests: u64,
+    /// Seconds a request may take before this server answers 408. `0` means
+    /// there is no deadline. `--request-timeout-secs` over `[serve]`.
+    pub(super) request_timeout_secs: u64,
 }
 
 impl ApiLimits {
     /// Read from the constants the handlers actually use, so the two cannot
-    /// drift into disagreeing.
-    pub(super) fn current() -> Self {
+    /// drift into disagreeing. The request limits are the ones this server
+    /// resolved at start-up, for the same reason.
+    pub(super) fn current(requests: &super::request_limits::RequestLimits) -> Self {
         Self {
             max_limit: super::runs::MAX_LIMIT,
             max_ids: super::runs::MAX_IDS,
@@ -255,6 +262,8 @@ impl ApiLimits {
             search_log_tail_bytes: super::runs::SEARCH_LOG_TAIL_BYTES,
             max_history_limit: super::agents::HISTORY_MAX_LIMIT,
             max_tracked_modified_files: leviath_core::run_meta::MAX_TRACKED_MODIFIED_FILES,
+            max_concurrent_requests: requests.max_concurrent_requests,
+            request_timeout_secs: requests.request_timeout_secs,
         }
     }
 }

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -15,6 +15,7 @@ mod fs;
 mod interactions;
 mod mcp;
 mod polling;
+mod request_limits;
 mod runs;
 mod scripts;
 mod search;
@@ -281,6 +282,11 @@ async fn execute_with_shutdown(
     let cfg = Config::load()?;
     // Read before `cfg` moves into the shared state below.
     let allow_local_network = cfg.security.allow_local_network;
+    let request_limits = request_limits::RequestLimits::resolve(
+        args.max_concurrent_requests,
+        args.request_timeout_secs,
+        &cfg.serve,
+    );
     for warning in cfg.validate_keys() {
         tracing::warn!("{}", warning);
     }
@@ -302,6 +308,8 @@ async fn execute_with_shutdown(
         limits: Arc::new(ServeLimits {
             workdir_root: args.workdir_root.clone(),
             no_remote_yolo: args.no_remote_yolo,
+            no_remote_seed_commands: args.no_remote_seed_commands,
+            request_limits,
             allow_local_network,
         }),
     };
@@ -429,6 +437,14 @@ async fn execute_with_shutdown(
     // and a visitor who can load it already knows the port is open - so it adds
     // no version, no run counts, no endpoint list.
     let app = app.merge(Router::new().route("/", get(status_page)));
+    // The in-flight cap and the per-request deadline, over everything above
+    // including the status page and the auth check, so a refused request
+    // still took a slot while it was being refused. Only the websocket routes
+    // pass through untouched; see `request_limits`.
+    let app = app.layer(axum::middleware::from_fn_with_state(
+        request_limits::Gate::new(request_limits),
+        request_limits::limit_requests,
+    ));
     // Applied by branching on the router rather than layering an `Option`:
     // `Option<CorsLayer>` is not a `Layer`, and a permissive-but-unused layer
     // would be exactly the default this change removes.
@@ -1355,6 +1371,9 @@ system_prompt = "Run"
             no_remote_yolo: false,
             tls_cert: None,
             tls_key: None,
+            no_remote_seed_commands: false,
+            max_concurrent_requests: None,
+            request_timeout_secs: None,
         };
         assert_eq!(args.port, 3000);
         assert_eq!(args.host, "127.0.0.1");
@@ -1455,6 +1474,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let handle = tokio::spawn(serve_for_test(
@@ -1530,6 +1552,9 @@ system_prompt = "Run"
                 no_remote_yolo: false,
                 tls_cert: Some(cert),
                 tls_key: Some(key),
+                no_remote_seed_commands: false,
+                max_concurrent_requests: None,
+                request_timeout_secs: None,
             };
             let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
             let handle = tokio::spawn(serve_for_test(
@@ -1607,6 +1632,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
 
                 // One flag without the other.
@@ -1676,6 +1704,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: Some(cert),
                     tls_key: Some(key),
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
@@ -1725,6 +1756,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let handle = tokio::spawn(serve_for_test(
@@ -1779,6 +1813,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
                 let handle = tokio::spawn(serve_for_test(
@@ -1815,6 +1852,9 @@ system_prompt = "Run"
                 no_remote_yolo: false,
                 tls_cert: None,
                 tls_key: None,
+                no_remote_seed_commands: false,
+                max_concurrent_requests: None,
+                request_timeout_secs: None,
             };
             let result = execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
             assert!(result.is_err());
@@ -1853,6 +1893,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let result =
                     execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
@@ -1886,6 +1929,9 @@ system_prompt = "Run"
             no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
         };
 
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -1940,6 +1986,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let result =
                     execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
@@ -1978,6 +2027,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let result =
                     execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
@@ -2007,6 +2059,9 @@ system_prompt = "Run"
                 no_remote_yolo: false,
                 tls_cert: None,
                 tls_key: None,
+                no_remote_seed_commands: false,
+                max_concurrent_requests: None,
+                request_timeout_secs: None,
             };
             let result = execute(args, no_daemon_control(), Arc::new(no_upgrade_in_tests)).await;
             assert!(result.is_err(), "must refuse to start unauthenticated");
@@ -2031,6 +2086,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -2081,6 +2139,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
 
                 let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<()>();
@@ -2128,6 +2189,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 }
             }
 
@@ -2197,6 +2261,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let server = tokio::spawn(serve_for_test(
                     args,
@@ -2269,6 +2336,9 @@ system_prompt = "Run"
                         no_remote_yolo: false,
                         tls_cert: None,
                         tls_key: None,
+                        no_remote_seed_commands: false,
+                        max_concurrent_requests: None,
+                        request_timeout_secs: None,
                     };
                     let server = tokio::spawn(serve_for_test(
                         args,
@@ -2368,6 +2438,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let server = tokio::spawn(serve_for_test(
                     args,
@@ -2422,6 +2495,9 @@ system_prompt = "Run"
                     no_remote_yolo: false,
                     tls_cert: None,
                     tls_key: None,
+                    no_remote_seed_commands: false,
+                    max_concurrent_requests: None,
+                    request_timeout_secs: None,
                 };
                 let server = tokio::spawn(serve_for_test(
                     args,
@@ -2466,6 +2542,161 @@ system_prompt = "Run"
                 let _ = server.await;
             }
         })
+        .await;
+    }
+
+    // ─── Request limits, through the real router ────────────────────────────
+
+    /// The `ServeArgs` every request-limit test starts from: a free port, the
+    /// test token, no TLS, nothing admin.
+    fn limits_args() -> ServeArgs {
+        ServeArgs {
+            port: 0,
+            host: "127.0.0.1".to_string(),
+            cors: None,
+            token: Some("test-token".to_string()),
+            allow_admin: false,
+            workdir_root: None,
+            no_remote_yolo: false,
+            tls_cert: None,
+            tls_key: None,
+            no_remote_seed_commands: false,
+            max_concurrent_requests: None,
+            request_timeout_secs: None,
+        }
+    }
+
+    /// Boot the real server with `args` and hand back its address and task.
+    async fn boot(args: ServeArgs) -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>) {
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let handle = tokio::spawn(serve_for_test(
+            args,
+            no_daemon_control(),
+            Box::pin(std::future::pending()),
+            Some(ready_tx),
+        ));
+        let addr = ready_rx
+            .await
+            .expect("server should report its bound address");
+        (addr, handle)
+    }
+
+    /// `GET /api/config` with the test token, as the raw response text.
+    async fn get_config_raw(addr: SocketAddr) -> String {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let mut stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        stream
+            .write_all(
+                b"GET /api/config HTTP/1.1\r\nHost: localhost\r\n\
+                  Authorization: Bearer test-token\r\nConnection: close\r\n\r\n",
+            )
+            .await
+            .unwrap();
+        let mut resp = Vec::new();
+        stream.read_to_end(&mut resp).await.unwrap();
+        String::from_utf8_lossy(&resp).into_owned()
+    }
+
+    /// The limits `GET /api/config` reports are the ones in force: a typed
+    /// flag over the config file, and the config file over the default. The
+    /// timeout comes from the flag, the cap from `[serve]`, and neither is
+    /// the default.
+    #[tokio::test]
+    async fn request_limits_come_from_the_flag_then_the_config_then_the_default() {
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-request-limits",
+            |_fake_dir| async move {
+                with_tracing(|| {});
+                std::fs::write(
+                    Config::config_path(),
+                    "[serve]\nmax_concurrent_requests = 8\nrequest_timeout_secs = 12\n",
+                )
+                .unwrap();
+                let (addr, handle) = boot(ServeArgs {
+                    request_timeout_secs: Some(3),
+                    ..limits_args()
+                })
+                .await;
+
+                let resp = get_config_raw(addr).await;
+                assert_response_ok(&resp);
+                let body = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap();
+                let json: serde_json::Value = serde_json::from_str(body).unwrap();
+                assert_eq!(json["limits"]["max_concurrent_requests"], 8, "{json}");
+                assert_eq!(json["limits"]["request_timeout_secs"], 3, "{json}");
+
+                handle.abort();
+            },
+        )
+        .await;
+    }
+
+    /// No config file and no flag: the defaults, reported as such.
+    #[tokio::test]
+    async fn request_limits_default_to_64_in_flight_and_30_seconds() {
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-request-limits-default",
+            |_fake_dir| async move {
+                with_tracing(|| {});
+                let (addr, handle) = boot(limits_args()).await;
+                let resp = get_config_raw(addr).await;
+                assert_response_ok(&resp);
+                let body = resp.split_once("\r\n\r\n").map(|(_, b)| b).unwrap();
+                let json: serde_json::Value = serde_json::from_str(body).unwrap();
+                assert_eq!(json["limits"]["max_concurrent_requests"], 64, "{json}");
+                assert_eq!(json["limits"]["request_timeout_secs"], 30, "{json}");
+                handle.abort();
+            },
+        )
+        .await;
+    }
+
+    /// A websocket is a request that never finishes, and it is meant not to:
+    /// with the deadline at one second and the cap at one, a subscription
+    /// is still answering after the deadline, and a request beside it is
+    /// still admitted.
+    #[tokio::test]
+    async fn the_websocket_outlives_the_deadline_and_holds_no_slot() {
+        crate::config::with_isolated_config_path_async(
+            "serve-mod-ws-outlives-timeout",
+            |_fake_dir| async move {
+                with_tracing(|| {});
+                let (addr, handle) = boot(ServeArgs {
+                    request_timeout_secs: Some(1),
+                    max_concurrent_requests: Some(1),
+                    ..limits_args()
+                })
+                .await;
+
+                let mut ws = crate::commands::serve::testutil::WsTestClient::connect(
+                    addr,
+                    "/ws?token=test-token",
+                )
+                .await;
+                tokio::time::sleep(std::time::Duration::from_millis(1500)).await;
+                // A ping is answered by the socket itself, so a pong proves the
+                // handler behind it is still running rather than dropped at
+                // the deadline.
+                ws.send_frame(0x9, b"still there?").await;
+                // The server greets a new subscriber with a text frame about
+                // the daemon link; the pong is whatever comes after that.
+                let payload = loop {
+                    let (opcode, payload) = ws.recv_frame().await;
+                    if opcode == 0xA {
+                        break payload;
+                    }
+                    assert_eq!(opcode, 0x1, "only text frames precede the pong");
+                };
+                assert_eq!(payload, b"still there?");
+
+                // The open socket is not one of the (one) slots.
+                let resp = get_config_raw(addr).await;
+                assert_response_ok(&resp);
+
+                ws.send_close().await;
+                handle.abort();
+            },
+        )
         .await;
     }
 }

--- a/crates/leviath-cli/src/commands/serve/request_limits.rs
+++ b/crates/leviath-cli/src/commands/serve/request_limits.rs
@@ -1,0 +1,404 @@
+//! How many requests `lev serve` takes on at once, and how long it gives each.
+//!
+//! Before this the router had an auth layer, an optional CORS layer, and
+//! axum's own 2 MiB body limit, and nothing else: a client that opened a
+//! thousand connections held a thousand handlers, and a route that never
+//! answered held its connection for as long as the client cared to wait.
+//!
+//! Two ceilings, both configurable in the config file and on the command line
+//! and both switched off with `0`:
+//!
+//! - a cap on requests in flight, over which the next request is answered
+//!   `503` at once rather than queued, so a flood is refused instead of
+//!   piling up behind whatever is slow;
+//! - a timeout per request, after which the handler is dropped and the client
+//!   gets `408`.
+//!
+//! The websocket routes are outside both. A subscription is meant to stay open
+//! for hours, and it is the one place the API streams: every other route
+//! builds its whole body before answering, so cutting a handler at the deadline
+//! never cuts a body in half.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::extract::{Request, State};
+use axum::http::StatusCode;
+use axum::middleware::Next;
+use axum::response::{IntoResponse, Response};
+use serde::{Deserialize, Serialize};
+use tokio::sync::Semaphore;
+
+use super::types::err;
+
+/// The two ceilings as numbers, the way the flags and `[serve]` state them.
+///
+/// `0` means "no limit" on either. This is what `GET /api/config` reports, so
+/// a client sees the value in force rather than the default it would guess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(super) struct RequestLimits {
+    /// Requests in flight at once before the next is refused with 503.
+    pub(super) max_concurrent_requests: u64,
+    /// Seconds a request may take before it is answered 408.
+    pub(super) request_timeout_secs: u64,
+}
+
+impl Default for RequestLimits {
+    fn default() -> Self {
+        Self {
+            max_concurrent_requests: crate::config::DEFAULT_MAX_CONCURRENT_REQUESTS,
+            request_timeout_secs: crate::config::DEFAULT_REQUEST_TIMEOUT_SECS,
+        }
+    }
+}
+
+impl RequestLimits {
+    /// Reconcile a flag with its config key: a flag that was typed wins, a
+    /// config value stands otherwise, and the config's own default fills in
+    /// when neither was set.
+    pub(super) fn resolve(
+        flag_max_concurrent: Option<u64>,
+        flag_timeout_secs: Option<u64>,
+        config: &crate::config::ServeConfig,
+    ) -> Self {
+        Self {
+            max_concurrent_requests: flag_max_concurrent.unwrap_or(config.max_concurrent_requests),
+            request_timeout_secs: flag_timeout_secs.unwrap_or(config.request_timeout_secs),
+        }
+    }
+
+    /// The per-request deadline, or `None` when it is switched off.
+    fn timeout(&self) -> Option<Duration> {
+        (self.request_timeout_secs > 0).then(|| Duration::from_secs(self.request_timeout_secs))
+    }
+
+    /// The in-flight cap, or `None` when it is switched off.
+    fn cap(&self) -> Option<usize> {
+        // A cap larger than the platform's `usize` is no cap at all.
+        (self.max_concurrent_requests > 0)
+            .then(|| usize::try_from(self.max_concurrent_requests).unwrap_or(usize::MAX))
+    }
+}
+
+/// The limits plus the semaphore that enforces the cap, shared by every
+/// request through the layer.
+pub(super) struct Gate {
+    limits: RequestLimits,
+    /// `None` when the cap is off, so a disabled cap costs nothing per request
+    /// rather than acquiring from a semaphore that can never run out.
+    in_flight: Option<Arc<Semaphore>>,
+}
+
+impl Gate {
+    pub(super) fn new(limits: RequestLimits) -> Arc<Self> {
+        // Tokio's semaphore holds at most `MAX_PERMITS` permits; a cap above
+        // that is clamped rather than panicking, which for a value nobody will
+        // ever reach in flight is the same thing.
+        let in_flight = limits
+            .cap()
+            .map(|cap| Arc::new(Semaphore::new(cap.min(Semaphore::MAX_PERMITS))));
+        Arc::new(Self { limits, in_flight })
+    }
+}
+
+/// Whether a path is one the limits leave alone: the websocket routes, which
+/// hold their connection open by design.
+fn is_exempt(path: &str) -> bool {
+    path == "/ws" || path.starts_with("/ws/")
+}
+
+/// The layer itself. Outermost after CORS, so a request the auth layer
+/// refuses still counted against the cap while it was being refused: a cap
+/// that only covered authenticated requests would be one an unauthenticated
+/// flood could walk straight past.
+pub(super) async fn limit_requests(
+    State(gate): State<Arc<Gate>>,
+    req: Request,
+    next: Next,
+) -> Response {
+    if is_exempt(req.uri().path()) {
+        return next.run(req).await;
+    }
+
+    // Held until the response is built, then released. The body is sent after
+    // that, which is fine: nothing but the websocket routes streams one.
+    let _permit = match &gate.in_flight {
+        None => None,
+        Some(semaphore) => match Arc::clone(semaphore).try_acquire_owned() {
+            Ok(permit) => Some(permit),
+            Err(_) => {
+                return err(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "too many requests in flight (the cap is {})",
+                        gate.limits.max_concurrent_requests
+                    ),
+                )
+                .into_response();
+            }
+        },
+    };
+
+    match gate.limits.timeout() {
+        None => next.run(req).await,
+        Some(deadline) => match tokio::time::timeout(deadline, next.run(req)).await {
+            Ok(response) => response,
+            Err(_) => err(
+                StatusCode::REQUEST_TIMEOUT,
+                format!(
+                    "request took longer than {} s",
+                    gate.limits.request_timeout_secs
+                ),
+            )
+            .into_response(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::Router;
+    use axum::body::Body;
+    use axum::routing::get;
+    use tokio::sync::Notify;
+    use tower::ServiceExt;
+
+    use crate::config::ServeConfig;
+
+    fn app(limits: RequestLimits, router: Router) -> Router {
+        router.layer(axum::middleware::from_fn_with_state(
+            Gate::new(limits),
+            limit_requests,
+        ))
+    }
+
+    fn request(path: &str) -> Request {
+        Request::builder().uri(path).body(Body::empty()).unwrap()
+    }
+
+    async fn error_of(response: Response) -> String {
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        parsed["error"].as_str().unwrap().to_string()
+    }
+
+    /// A handler that takes two seconds of (virtual) time.
+    async fn slow() -> &'static str {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        "done"
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_handler_past_the_deadline_is_answered_408_in_the_error_shape() {
+        let limits = RequestLimits {
+            max_concurrent_requests: 64,
+            request_timeout_secs: 1,
+        };
+        let app = app(limits, Router::new().route("/slow", get(slow)));
+        let response = app.oneshot(request("/slow")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+        assert_eq!(error_of(response).await, "request took longer than 1 s");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_timeout_of_zero_lets_a_slow_handler_finish() {
+        let limits = RequestLimits {
+            max_concurrent_requests: 64,
+            request_timeout_secs: 0,
+        };
+        let app = app(limits, Router::new().route("/slow", get(slow)));
+        let response = app.oneshot(request("/slow")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn a_handler_inside_the_deadline_is_untouched() {
+        let limits = RequestLimits {
+            max_concurrent_requests: 64,
+            request_timeout_secs: 5,
+        };
+        let app = app(limits, Router::new().route("/slow", get(slow)));
+        let response = app.oneshot(request("/slow")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    /// The websocket routes are what a client keeps open on purpose. Both
+    /// shapes: the global feed and a per-run one.
+    #[tokio::test(start_paused = true)]
+    async fn the_websocket_routes_outlive_the_deadline() {
+        let limits = RequestLimits {
+            max_concurrent_requests: 64,
+            request_timeout_secs: 1,
+        };
+        let router = Router::new()
+            .route("/ws", get(slow))
+            .route("/ws/agents/{id}", get(slow))
+            .route("/wsx", get(slow));
+        for path in ["/ws", "/ws/agents/run-1"] {
+            let response = app(limits, router.clone())
+                .oneshot(request(path))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{path}");
+        }
+        // A path that merely starts with the letters is not a websocket.
+        let response = app(limits, router).oneshot(request("/wsx")).await.unwrap();
+        assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+    }
+
+    /// A handler that parks until the test releases it, counting arrivals so
+    /// the test knows when every admitted request is truly in flight.
+    #[derive(Default)]
+    struct Parked {
+        arrived: AtomicUsize,
+        release: Notify,
+    }
+
+    async fn parked(State(parked): State<Arc<Parked>>) -> &'static str {
+        parked.arrived.fetch_add(1, Ordering::SeqCst);
+        parked.release.notified().await;
+        "released"
+    }
+
+    /// Sixty-five requests against a cap of sixty-four: exactly one is
+    /// refused, and it is refused while the others are still running rather
+    /// than after.
+    #[tokio::test]
+    async fn one_request_over_the_cap_is_answered_503() {
+        let limits = RequestLimits {
+            max_concurrent_requests: 64,
+            request_timeout_secs: 0,
+        };
+        let parked = Arc::new(Parked::default());
+        let app = app(
+            limits,
+            Router::new()
+                .route("/park", get(super::tests::parked))
+                .with_state(Arc::clone(&parked)),
+        );
+
+        let mut admitted = Vec::new();
+        for _ in 0..64 {
+            let app = app.clone();
+            admitted.push(tokio::spawn(async move {
+                app.oneshot(request("/park")).await.unwrap()
+            }));
+        }
+        while parked.arrived.load(Ordering::SeqCst) < 64 {
+            tokio::task::yield_now().await;
+        }
+
+        // Bounded, so a router that admits the 65th parks it and fails here
+        // rather than hanging the test binary.
+        let refused = tokio::time::timeout(
+            Duration::from_secs(5),
+            app.clone().oneshot(request("/park")),
+        )
+        .await
+        .expect("the 65th request is answered, not parked")
+        .unwrap();
+        assert_eq!(refused.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            error_of(refused).await,
+            "too many requests in flight (the cap is 64)"
+        );
+
+        parked.release.notify_waiters();
+        for task in admitted {
+            assert_eq!(task.await.unwrap().status(), StatusCode::OK);
+        }
+        assert_eq!(parked.arrived.load(Ordering::SeqCst), 64);
+
+        // Every permit came back: the next request is admitted again.
+        parked.release.notify_one();
+        let after = app.oneshot(request("/park")).await.unwrap();
+        assert_eq!(after.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn a_cap_of_zero_admits_everything() {
+        let limits = RequestLimits {
+            max_concurrent_requests: 0,
+            request_timeout_secs: 0,
+        };
+        let parked = Arc::new(Parked::default());
+        let app = app(
+            limits,
+            Router::new()
+                .route("/park", get(super::tests::parked))
+                .with_state(Arc::clone(&parked)),
+        );
+        let mut tasks = Vec::new();
+        for _ in 0..70 {
+            let app = app.clone();
+            tasks.push(tokio::spawn(async move {
+                app.oneshot(request("/park")).await.unwrap()
+            }));
+        }
+        while parked.arrived.load(Ordering::SeqCst) < 70 {
+            tokio::task::yield_now().await;
+        }
+        parked.release.notify_waiters();
+        for task in tasks {
+            assert_eq!(task.await.unwrap().status(), StatusCode::OK);
+        }
+    }
+
+    #[test]
+    fn a_flag_beats_the_config_and_the_config_beats_the_default() {
+        let config = ServeConfig {
+            max_concurrent_requests: 8,
+            request_timeout_secs: 120,
+        };
+        // Neither flag: the config stands.
+        assert_eq!(
+            RequestLimits::resolve(None, None, &config),
+            RequestLimits {
+                max_concurrent_requests: 8,
+                request_timeout_secs: 120,
+            }
+        );
+        // Each flag on its own, including `0` to switch a limit off.
+        assert_eq!(
+            RequestLimits::resolve(Some(0), None, &config),
+            RequestLimits {
+                max_concurrent_requests: 0,
+                request_timeout_secs: 120,
+            }
+        );
+        assert_eq!(
+            RequestLimits::resolve(None, Some(3), &config),
+            RequestLimits {
+                max_concurrent_requests: 8,
+                request_timeout_secs: 3,
+            }
+        );
+        // No config table and no flags: the defaults.
+        assert_eq!(
+            RequestLimits::resolve(None, None, &ServeConfig::default()),
+            RequestLimits::default()
+        );
+        assert_eq!(RequestLimits::default().max_concurrent_requests, 64);
+        assert_eq!(RequestLimits::default().request_timeout_secs, 30);
+    }
+
+    #[test]
+    fn a_cap_beyond_the_platform_is_no_cap() {
+        let limits = RequestLimits {
+            max_concurrent_requests: u64::MAX,
+            request_timeout_secs: 0,
+        };
+        assert_eq!(limits.cap(), Some(usize::MAX));
+        let gate = Gate::new(limits);
+        assert_eq!(
+            gate.in_flight.as_ref().map(|s| s.available_permits()),
+            Some(Semaphore::MAX_PERMITS)
+        );
+    }
+}

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -90,6 +90,31 @@ pub struct ServeArgs {
     /// same wildcard override `"yolo": true` writes.
     #[arg(long)]
     pub no_remote_yolo: bool,
+
+    /// Run every spawn as if it carried `"no_seed_commands": true`, so a
+    /// blueprint's `seed = { command = ... }` regions never execute for a
+    /// remotely started run.
+    ///
+    /// A command seed runs at spawn, before the first inference and so before
+    /// any approval prompt. `[security] allow_seed_commands = false` refuses
+    /// them machine-wide; this refuses them only for runs that arrive over
+    /// the API, leaving `lev run` on the host as it was.
+    #[arg(long)]
+    pub no_remote_seed_commands: bool,
+
+    /// Requests in flight at once before the next one is answered 503.
+    ///
+    /// Overrides `[serve] max_concurrent_requests` (default 64). `0` disables
+    /// the cap. The websocket routes are never counted.
+    #[arg(long, value_name = "N")]
+    pub max_concurrent_requests: Option<u64>,
+
+    /// Seconds one request may take before it is answered 408.
+    ///
+    /// Overrides `[serve] request_timeout_secs` (default 30). `0` disables the
+    /// timeout. The websocket routes are never timed.
+    #[arg(long, value_name = "SECS")]
+    pub request_timeout_secs: Option<u64>,
 }
 
 // ─── Shared state ────────────────────────────────────────────────────────────
@@ -163,6 +188,12 @@ pub(super) struct ServeLimits {
     /// `[security] allow_local_network`: whether a completion webhook may point
     /// at loopback, private or link-local addresses.
     pub(super) allow_local_network: bool,
+    /// `--no-remote-seed-commands`: whether every spawn is treated as having
+    /// asked for `"no_seed_commands": true`.
+    pub(super) no_remote_seed_commands: bool,
+    /// The request cap and timeout in force, after the flags and `[serve]`
+    /// have been reconciled. Reported by `GET /api/config`.
+    pub(super) request_limits: super::request_limits::RequestLimits,
 }
 
 impl ServeLimits {
@@ -1256,7 +1287,7 @@ mod tests {
             mcp_server_count: 0,
             api_version: API_VERSION.to_string(),
             capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
-            limits: ApiLimits::current(),
+            limits: ApiLimits::current(&Default::default()),
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: RedactedConfig = serde_json::from_str(&json).unwrap();

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -17,6 +17,8 @@ mod providers;
 pub(crate) use providers::*;
 mod security;
 pub(crate) use security::*;
+mod serve;
+pub(crate) use serve::*;
 
 // Two helpers with no `[table]` of their own: reading a repository's `.env`,
 // and hardening the config file's permissions. Private to this module; the
@@ -295,6 +297,11 @@ pub struct Config {
     #[serde(default)]
     pub security: SecurityConfig,
 
+    /// `[serve]`: the request cap and timeout `lev serve` applies. The flags
+    /// of the same name on `lev serve` win over these.
+    #[serde(default)]
+    pub serve: ServeConfig,
+
     /// Per-agent read grants, keyed by agent name - the itemized counterpart
     /// of `SecurityConfig::allow_blueprint_read_paths`, analogous to
     /// [`Self::agent_tool_permissions`]:
@@ -355,6 +362,7 @@ impl Default for Config {
             sandbox: None,
             tool_script_permissions: ScriptToolPermissions::default(),
             security: SecurityConfig::default(),
+            serve: ServeConfig::default(),
             agent_read_paths: HashMap::new(),
         }
     }
@@ -3684,6 +3692,10 @@ enabled = false
                 allow_blueprint_permissions: false,
                 shell_env: leviath_core::ShellEnvMode::default(),
                 shell_env_withhold: Vec::new(),
+            },
+            serve: ServeConfig {
+                max_concurrent_requests: 16,
+                request_timeout_secs: 5,
             },
             agent_read_paths: HashMap::from([(
                 "cto".to_string(),

--- a/crates/leviath-cli/src/config/serve.rs
+++ b/crates/leviath-cli/src/config/serve.rs
@@ -1,0 +1,69 @@
+//! `[serve]` in `~/.leviath/config.toml`: what `lev serve` will take on at
+//! once, and how long it gives any one request.
+
+use serde::{Deserialize, Serialize};
+
+/// In-flight requests `lev serve` admits before answering 503.
+pub(crate) const DEFAULT_MAX_CONCURRENT_REQUESTS: u64 = 64;
+
+/// Seconds a request may take before `lev serve` answers 408.
+pub(crate) const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// `[serve]` in `~/.leviath/config.toml`.
+///
+/// Both keys are ceilings on the HTTP API, not on the runs behind it: a spawn
+/// that takes the daemon a minute still spawns, because the route answers as
+/// soon as the daemon has accepted it. The websocket routes are outside both,
+/// since a subscription is meant to stay open. `0` disables a limit. The
+/// `lev serve` flags of the same name win over these.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServeConfig {
+    /// Requests in flight at once before the next one is answered 503.
+    #[serde(default = "default_max_concurrent_requests")]
+    pub max_concurrent_requests: u64,
+
+    /// Seconds one request may take before it is answered 408.
+    #[serde(default = "default_request_timeout_secs")]
+    pub request_timeout_secs: u64,
+}
+
+fn default_max_concurrent_requests() -> u64 {
+    DEFAULT_MAX_CONCURRENT_REQUESTS
+}
+
+fn default_request_timeout_secs() -> u64 {
+    DEFAULT_REQUEST_TIMEOUT_SECS
+}
+
+impl Default for ServeConfig {
+    fn default() -> Self {
+        Self {
+            max_concurrent_requests: DEFAULT_MAX_CONCURRENT_REQUESTS,
+            request_timeout_secs: DEFAULT_REQUEST_TIMEOUT_SECS,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn an_absent_table_and_an_empty_one_both_mean_the_defaults() {
+        let empty: ServeConfig = toml::from_str("").unwrap();
+        assert_eq!(empty, ServeConfig::default());
+        assert_eq!(empty.max_concurrent_requests, 64);
+        assert_eq!(empty.request_timeout_secs, 30);
+    }
+
+    #[test]
+    fn each_key_is_read_on_its_own() {
+        let only_cap: ServeConfig = toml::from_str("max_concurrent_requests = 8").unwrap();
+        assert_eq!(only_cap.max_concurrent_requests, 8);
+        assert_eq!(only_cap.request_timeout_secs, 30);
+
+        let only_timeout: ServeConfig = toml::from_str("request_timeout_secs = 0").unwrap();
+        assert_eq!(only_timeout.max_concurrent_requests, 64);
+        assert_eq!(only_timeout.request_timeout_secs, 0);
+    }
+}

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -512,6 +512,9 @@ mod tests {
             no_remote_yolo: false,
             tls_cert: None,
             tls_key: None,
+            no_remote_seed_commands: false,
+            max_concurrent_requests: None,
+            request_timeout_secs: None,
         };
         let result = dispatch(Commands::Serve(args), &MockRisky).await;
         assert!(result.is_ok());

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -53,10 +53,36 @@ a test, so a client generator or an agent can consume the contract directly.
   | `POST /api/models/probe` | 404, because nothing else is mounted on that path |
 - **`--workdir-root`** confines agent workdirs; **`--no-remote-yolo`** forbids `"yolo": true` and
   `"allow": [...]` on spawn, which are one lever rather than two.
+- **`--no-remote-seed-commands`** runs every spawn as if it carried `"no_seed_commands": true`, so
+  a blueprint's `seed = { command = ... }` regions, which execute at spawn before any approval
+  prompt, never run for a run that arrived over the API. `lev run` on the host is unaffected;
+  `[security] allow_seed_commands = false` is the machine-wide version.
 
 > [!CAUTION]
 > `lev serve` runs LLM-driven tools with whatever permissions the blueprint grants. Treat it as
 > trusted-network only unless hardened. See [Security](/docs/security).
+
+## Limits
+
+The server holds a bounded number of requests in flight and gives each one a deadline. Both have
+a default, both can be set in the config file or on the command line, and `0` switches either
+off. A flag wins over the config file, and the config file over the default.
+
+| Limit | Default | Flag | Config key | Over it |
+|---|---|---|---|---|
+| Requests in flight | 64 | `--max-concurrent-requests <N>` | `[serve] max_concurrent_requests` | 503 at once, not queued |
+| Seconds per request | 30 | `--request-timeout-secs <SECS>` | `[serve] request_timeout_secs` | 408, and the handler is dropped |
+
+Both answers carry the usual `{"error": "..."}` body. The websocket routes (`/ws` and
+`/ws/agents/{id}`) are outside both: a subscription is meant to stay open, and it is the only
+place the API streams, so every other route has built its whole body before the deadline could
+cut it. An unauthenticated request takes a slot while it is being refused, so a flood without a
+token is refused at the cap like any other.
+
+Neither limit is a ceiling on the runs behind the API. A spawn whose daemon takes a minute still
+spawns; the route answers as soon as the daemon has accepted it. `GET /api/config` reports the
+values in force under `limits.max_concurrent_requests` and `limits.request_timeout_secs`, so a
+client sees what this server resolved rather than the default it would guess.
 
 ## Reaching a Leviath on another machine
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -655,6 +655,9 @@ Start the [REST and WebSocket API](/docs/api).
 | `--allow-admin` | off | Mount the MCP administration and config-write routes |
 | `--workdir-root <PATH>` | unset | Restrict agent working directories to this root |
 | `--no-remote-yolo` | off | Refuse `"yolo": true` and `"allow": [...]` on spawn requests |
+| `--no-remote-seed-commands` | off | Treat every spawn as `"no_seed_commands": true`, so a blueprint's command seeds never run for a run started over the API |
+| `--max-concurrent-requests <N>` | `[serve]` key, else `64` | Requests in flight before the next is answered 503. `0` disables the cap. Websocket routes are not counted |
+| `--request-timeout-secs <SECS>` | `[serve]` key, else `30` | Seconds a request may take before it is answered 408. `0` disables the deadline. Websocket routes are not timed |
 | `--tls-cert <PATH>` | unset | PEM certificate chain. Serves HTTPS; needs `--tls-key` too |
 | `--tls-key <PATH>` | unset | PEM private key for `--tls-cert` |
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -406,6 +406,21 @@ the symlink-resolved real path and are written with `/` on every OS. `~/` expand
 a relative entry resolves against the run's workdir. Full walkthrough in
 [Security](/docs/security#reading-outside-the-workdir).
 
+## `[serve]`
+
+What `lev serve` takes on at once and how long it gives each request. Every key has a default,
+so the whole section can be omitted; the `lev serve` flags of the same name win over it, and `0`
+switches a limit off. See [Limits](/docs/api#limits) for what a client sees.
+
+```toml
+[serve]
+max_concurrent_requests = 64   # in flight at once; the next is answered 503
+request_timeout_secs    = 30   # per request; over it the client gets 408
+```
+
+The websocket routes are outside both limits. Neither is a ceiling on the runs behind the API:
+a spawn the daemon takes a minute to accept still spawns.
+
 ## `[agent_read_paths.<agent>]`
 
 Per-agent read grants, the itemized counterpart of `allow_blueprint_read_paths`.

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -77,6 +77,10 @@ shell_env_withhold = []
 read_paths = ["~/reference"]
 credential_store = "file"
 
+[serve]
+max_concurrent_requests = 64
+request_timeout_secs = 30
+
 [webhook]
 max_retries = 3
 base_delay_ms = 500

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -291,6 +291,25 @@
         }
       }
     },
+    "serve": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "What `lev serve` takes on at once and how long it gives each request. The `lev serve` flags of the same name win over these; `0` switches a limit off.",
+      "properties": {
+        "max_concurrent_requests": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 64,
+          "description": "Requests in flight at once before the next is answered 503. `0` disables the cap. Websocket routes are not counted."
+        },
+        "request_timeout_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 30,
+          "description": "Seconds a request may take before it is answered 408. `0` disables the deadline. Websocket routes are not timed."
+        }
+      }
+    },
     "webhook": {
       "type": "object",
       "additionalProperties": false,


### PR DESCRIPTION
Security hardening, plan item 5.6 ("serve request limits"), with the one instruction that applies: a sane default, configurable in both places.

## Premise check (measured)

`execute_with_shutdown` in `crates/leviath-cli/src/commands/serve/mod.rs` builds the router out of exactly three things on top of the routes:

- `axum::middleware::from_fn_with_state(auth_token, auth::require_auth)` (bearer token)
- an optional `tower_http::cors::CorsLayer`, only when `--cors` is passed
- axum's own implicit `DefaultBodyLimit` (2 MiB), which nothing in the tree sets or names

There is no timeout layer, no concurrency layer and no `tower` layer of any kind (`tower` is a dependency for `ServiceExt::oneshot` in tests only; `tower-http` is built with the `cors` feature alone). The security-audit PR #259 added the auth layer, `--workdir-root`, `--no-remote-yolo`, the callback-URL SSRF check and the admin gating; it did not add a request limit. Premise confirmed: no concurrency cap, no request timeout.

Streaming: the only routes that hold a response open are `/ws` and `/ws/agents/{id}`. `agent_logs`, `agent_file` and the rest build their whole body before answering (`api.md` documents the file route's `max_file_bytes` cap for exactly that reason), so a deadline on the handler never cuts a body in half. There is no SSE or long-poll route.

## Seed commands

`grep seed` in `serve/` finds one thing: `POST /api/agents` accepts `"no_seed_commands": true` in its body, forwarded to the daemon's `SpawnArgs` (`agents.rs:105`). There is no route that runs a seeded command directly; the exposure is that a remote caller can spawn an installed blueprint whose `seed = { command = ... }` regions execute at spawn, before any approval prompt. The plan's flag still makes sense in the same shape as `--no-remote-yolo`: `--no-remote-seed-commands` makes every spawn over the API behave as if it carried `"no_seed_commands": true`. `lev run` on the host is unchanged; `[security] allow_seed_commands = false` remains the machine-wide switch.

## Change

- `serve/request_limits.rs` (new): `RequestLimits` (the two numbers), `Gate` (limits plus a `tokio::sync::Semaphore` when the cap is on), and the `limit_requests` middleware. Over the cap: `503 {"error":"too many requests in flight (the cap is N)"}`, at once, not queued. Past the deadline: `408 {"error":"request took longer than N s"}` and the handler future is dropped. `/ws` and `/ws/...` pass straight through. `0` disables either. A cap above `Semaphore::MAX_PERMITS` clamps.
- The layer is applied after the `/` status page is merged and before CORS, so it wraps the auth check: an unauthenticated flood takes slots while being refused rather than walking past the cap.
- `config/serve.rs` (new): `[serve] max_concurrent_requests` (default 64) and `request_timeout_secs` (default 30), on `Config` as `serve`.
- `lev serve --max-concurrent-requests <N>` and `--request-timeout-secs <SECS>`; `RequestLimits::resolve` is flag over config over default.
- `GET /api/config` reports the values in force under `limits.max_concurrent_requests` and `limits.request_timeout_secs` (`ApiLimits` already carried the server's numeric caps). `put_config` now takes `State` so its response reports the same numbers.
- `--no-remote-seed-commands`, as above: `no_seed_commands: body.no_seed_commands || state.limits.no_remote_seed_commands`.
- Docs: `api.md` gets a "Limits" section and the new flag under the security model; `cli.md` flag table; `configuration.md` gets `[serve]`; `config.example.toml` and `config.schema.json` carry the keys (the drift test holds them together); CHANGELOG under Added.

Zero other behaviour change. No `main.rs` touched.

## Fail-first

The new tests were run with the layer left out of the router, the middleware short-circuited to `next.run(req)` and `redact` handed `RequestLimits::default()`, i.e. the unfixed router behind the new types:

```
test request_limits::tests::a_handler_past_the_deadline_is_answered_408_in_the_error_shape ... FAILED
test request_limits::tests::the_websocket_routes_outlive_the_deadline ... FAILED   (the /wsx control path was not cut)
test request_limits::tests::one_request_over_the_cap_is_answered_503 ... FAILED    (the 65th was admitted and parked)
test serve::tests::request_limits_come_from_the_flag_then_the_config_then_the_default ... FAILED
test result: FAILED. 6 passed; 5 failed
```

The first run of that suite hung instead of failing: with no cap the 65th request parks forever, so the test now bounds that request with a 5 s timeout and fails with "the 65th request is answered, not parked". The tests that pass on the unfixed code are the ones that assert an absence (a timeout of 0, a cap of 0, the defaults being 64/30) and the pure `resolve` precedence test.

The seed-commands test, with the `||` removed:

```
test agents::tests::no_remote_seed_commands_marks_every_spawn ... FAILED
panicked at agents.rs:1248: the flag opts out for the caller
```

With the fix: 11 of 11 request-limit tests pass, and the serve/config/dispatch suites (812 tests) pass.

The full-router websocket test (`the_websocket_outlives_the_deadline_and_holds_no_slot`) passes before and after by construction, since `/ws` is exempt either way; it is there to hold the exemption, not to prove the fix.

## Live

Debug `lev serve`, `LEVIATH_API_TOKEN` set, isolated `LEVIATH_HOME`, `LEVIATH_SKIP_DOTENV=1`, spawned with `start_new_session=True`, config file carrying `[serve] max_concurrent_requests = 7, request_timeout_secs = 9`:

```
lev serve --request-timeout-secs 2
GET /api/config -> 200 limits: {'max_concurrent_requests': 7, 'request_timeout_secs': 2}

lev serve --max-concurrent-requests 1 --request-timeout-secs 0
6 parallel GET /api/doctor -> [200, 503, 503, 503, 503, 503]
unauthenticated GET /api/doctor -> 401
GET /ws handshake -> HTTP/1.1 101 Switching Protocols
ws ping after 2.5 s -> opcode 0xa (pong)
GET /api/config beside the open socket, cap 1 -> 200
```

There is no slow route to draw a live 408 from without a daemon (the offline doctor answers in milliseconds), so the timeout is held by the unit test with a paused clock and the live run exercises the cap and the websocket exemption, as the task allowed.

## Gates

`cargo fmt --all`; `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings` clean; `cargo xtask structure` (424 files, none over 1200); `cargo xtask docs` (40 pages, 3 schemas, no problems); `cargo xtask coverage --package leviath-cli` at 100% (one pass needed: a match arm in the seed test that nothing could reach, replaced by reading the request's wire form); pre-commit ran the full suite.
