### PR TITLE
feat(approval): deny a tool call with feedback for the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -250,6 +250,13 @@ same list.
   regions never run for a run started over the API. `lev run` on the host is
   as it was; `[security] allow_seed_commands = false` remains the
   machine-wide switch.
+- A tool approval can be denied with feedback. The prompt's fifth option, "Deny with feedback",
+  opens the dashboard's response box; `lev respond <id> --deny --feedback "..."` and `feedback`
+  beside `approved: false` on `POST /api/agents/{id}/interaction` send the same thing. The text
+  reaches the model inside the refused call's tool result, as
+  `[denied] User declined tool call 'bash'. Feedback: <text>`, so its next turn is a redirect
+  rather than a guess; it is in the run's journal and on the `tool_call_finished` event with the
+  rest of the result. A deny without feedback is unchanged. Announced as `interaction.feedback`.
 - `[model_providers.<name>] kind = "openai-compatible"` reaches any server that speaks
   OpenAI's chat API (llama.cpp, LM Studio, vLLM, BionicGPT, a gateway) natively, with no
   Rhai script: `base_url`, an optional `api_key`, `headers` and a `models` fallback for a

--- a/crates/leviath-cli/src/commands/agent_client/mod.rs
+++ b/crates/leviath-cli/src/commands/agent_client/mod.rs
@@ -705,6 +705,9 @@ impl Server {
             choice_index: None,
             approved: Some(approved),
             scope: Some(scope),
+            // The protocol's permission outcome is an option id and nothing
+            // else, so a host cannot say why it refused.
+            feedback: None,
         };
         let _ = self
             .control

--- a/crates/leviath-cli/src/commands/ctl.rs
+++ b/crates/leviath-cli/src/commands/ctl.rs
@@ -65,6 +65,10 @@ pub struct RespondArgs {
     /// Deny a tool-approval / confirm interaction.
     #[arg(long)]
     pub deny: bool,
+    /// With `--deny`, tell the model what to do instead. Reaches it as part of
+    /// the tool result, so its next turn is a redirect rather than a guess.
+    #[arg(long, requires = "deny", value_name = "TEXT")]
+    pub feedback: Option<String>,
     /// With `--approve`, allow what this call runs for the rest of the run.
     #[arg(long, visible_alias = "run")]
     pub session: bool,
@@ -264,12 +268,27 @@ fn build_response(request_id: &str, args: &RespondArgs) -> InteractionResponse {
             (_, true) => ApprovalScope::Stage,
             _ => ApprovalScope::Once,
         };
-        InteractionResponse::approval(request_id, args.approve, scope)
+        match args.feedback.as_deref() {
+            // `requires = "deny"` keeps this off the approve path, so a
+            // feedback here is always a deny.
+            Some(feedback) => InteractionResponse::deny_with_feedback(request_id, feedback),
+            None => InteractionResponse::approval(request_id, args.approve, scope),
+        }
     } else if let Some(index) = args.choice {
         InteractionResponse::choice(request_id, index)
     } else {
         InteractionResponse::text(request_id, args.value.clone().unwrap_or_default())
     }
+}
+
+/// `--feedback` is a deny's message and nothing else. clap's `requires`
+/// catches it on its own; beside `--approve` the parser lets it through, and
+/// a redirect silently dropped on a grant is the one outcome nobody asked for.
+fn check_feedback_flag(args: &RespondArgs) -> anyhow::Result<()> {
+    if args.feedback.is_some() && !args.deny {
+        bail!("--feedback goes with --deny: it tells the model what to do instead of the call");
+    }
+    Ok(())
 }
 
 /// List the interactions the daemon is currently holding.
@@ -306,6 +325,7 @@ async fn list_interactions(client: &ControlClient, json: bool) -> anyhow::Result
 /// `lev respond`: answer a pending interaction, or list open ones when no
 /// `request_id` is given.
 pub async fn respond(client: &ControlClient, args: &RespondArgs) -> anyhow::Result<()> {
+    check_feedback_flag(args)?;
     match &args.request_id {
         None => list_interactions(client, args.json).await,
         Some(request_id) => {
@@ -683,10 +703,87 @@ mod tests {
             choice: None,
             approve: false,
             deny: false,
+            feedback: None,
             session: false,
             stage: false,
             json: false,
         }
+    }
+
+    /// `lev respond <id> --deny --feedback TEXT` is a deny carrying the text;
+    /// blank text is the plain deny, the same rule every other client follows.
+    #[test]
+    fn build_response_deny_with_feedback() {
+        let r = build_response(
+            "q1",
+            &RespondArgs {
+                deny: true,
+                feedback: Some("use git log, not git show".to_string()),
+                ..respond_args()
+            },
+        );
+        assert_eq!(
+            r,
+            InteractionResponse::deny_with_feedback("q1", "use git log, not git show")
+        );
+        let blank = build_response(
+            "q1",
+            &RespondArgs {
+                deny: true,
+                feedback: Some("  ".to_string()),
+                ..respond_args()
+            },
+        );
+        assert_eq!(
+            blank,
+            InteractionResponse::approval("q1", false, ApprovalScope::Once)
+        );
+    }
+
+    /// `--feedback` without `--deny` is refused at the parser, with `--deny`
+    /// named in the message, and it never combines with `--approve`.
+    #[test]
+    fn feedback_flag_is_only_valid_with_deny() {
+        use clap::Parser;
+        #[derive(Parser, Debug)]
+        struct Cli {
+            #[command(flatten)]
+            respond: RespondArgs,
+        }
+        let ok = Cli::try_parse_from(["lev", "q1", "--deny", "--feedback", "why"]).unwrap();
+        assert!(ok.respond.deny);
+        assert_eq!(ok.respond.feedback.as_deref(), Some("why"));
+
+        let alone = Cli::try_parse_from(["lev", "q1", "--feedback", "why"]).unwrap_err();
+        assert!(alone.to_string().contains("--deny"), "{alone}");
+
+        // clap lets `--approve --feedback` through, so the command checks.
+        let with_approve =
+            Cli::try_parse_from(["lev", "q1", "--approve", "--feedback", "why"]).unwrap();
+        let err = check_feedback_flag(&with_approve.respond).unwrap_err();
+        assert!(err.to_string().contains("--deny"), "{err}");
+        assert!(check_feedback_flag(&ok.respond).is_ok());
+        assert!(check_feedback_flag(&respond_args()).is_ok());
+    }
+
+    /// The check runs before anything is sent: a bad flag combination is an
+    /// error with no daemon involved.
+    #[tokio::test]
+    async fn respond_refuses_feedback_without_deny_before_contacting_the_daemon() {
+        let client = ControlClient::new(leviath_runtime::control_socket::control_id(
+            std::path::Path::new("/no/such/daemon"),
+        ));
+        let err = respond(
+            &client,
+            &RespondArgs {
+                approve: true,
+                feedback: Some("why".to_string()),
+                ..respond_args()
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("--deny"), "{err}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -123,6 +123,7 @@ impl Dashboard {
             input_textarea: MarkdownEdit::default(),
             input_mode: false,
             response_focus_send: false,
+            deny_feedback_open: false,
             detail_view: false,
             cmd_tx,
             pending_interactions: HashMap::new(),

--- a/crates/leviath-cli/src/commands/dashboard/deny_feedback.rs
+++ b/crates/leviath-cli/src/commands/dashboard/deny_feedback.rs
@@ -1,0 +1,270 @@
+//! The "Deny with feedback" path of a tool-approval prompt.
+//!
+//! The prompt is a list of choices; the plain choices answer on Enter. This
+//! one cannot, because the answer is a deny plus a message the model will read
+//! as its redirect, and the message has to be typed first. So Enter on that
+//! row opens the same long-form response box the free-text answers use, and
+//! sending from it answers with [`InteractionResponse::deny_with_feedback`].
+//! Esc in the box goes back to the prompt with the other choices still there,
+//! not out of input mode: a person who changes their mind about explaining is
+//! not a person who changes their mind about answering.
+
+use leviath_core::interaction::InteractionResponse;
+
+use super::helpers::truncate;
+use super::state::Dashboard;
+use crate::tui::widgets::markdown_edit::MarkdownEdit;
+
+impl Dashboard {
+    /// Enter on a choice prompt: answer it, unless the highlighted row is the
+    /// deny that needs a message first, which opens the box instead.
+    pub(super) fn confirm_choice(&mut self) {
+        let opens_box = self
+            .selected_agent()
+            .and_then(|a| a.pending_request.as_ref())
+            .is_some_and(|r| r.is_deny_with_feedback(self.choice_selected));
+        if opens_box {
+            self.open_deny_feedback_box();
+        } else {
+            self.submit_input();
+        }
+    }
+
+    /// Open the response box under the approval prompt, empty and in the
+    /// person's preferred markdown mode, to collect the deny's message.
+    fn open_deny_feedback_box(&mut self) {
+        let mode = self.md_mode();
+        self.input_textarea = MarkdownEdit::default().in_mode(mode);
+        self.response_focus_send = false;
+        self.deny_feedback_open = true;
+    }
+
+    /// Esc in the response box. Under an approval prompt that is "back to the
+    /// choices", with the highlighted row where it was; anywhere else it is
+    /// what it always was, out of input mode with nothing sent.
+    pub(super) fn cancel_response_box(&mut self) {
+        if self.deny_feedback_open {
+            self.deny_feedback_open = false;
+            self.response_focus_send = false;
+            self.input_textarea = MarkdownEdit::default();
+        } else {
+            self.close_input_box();
+        }
+    }
+
+    /// The answer the open feedback box sends for request `id`, and the label
+    /// the activity log shows for it. Internal newlines are kept: the model
+    /// reads the text as written.
+    pub(super) fn deny_feedback_response(&self, id: &str) -> (InteractionResponse, String) {
+        let text = self.input_textarea.lines().join("\n");
+        let response = InteractionResponse::deny_with_feedback(id, &text);
+        let label = match response.feedback.as_deref() {
+            Some(feedback) => format!("Deny: {}", truncate(feedback, 34)),
+            None => "Deny".to_string(),
+        };
+        (response, label)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use leviath_core::interaction::{ApprovalScope, InteractionRequest, InteractionResponse};
+    use tokio::sync::mpsc;
+
+    use super::super::state::Dashboard;
+    use super::super::types::{AgentDisplayStatus, DaemonCommand, DashboardAgent};
+
+    fn agent_with_approval(id: &str) -> DashboardAgent {
+        DashboardAgent {
+            id: id.to_string(),
+            blueprint_name: "probe".to_string(),
+            stage: "main".to_string(),
+            stage_index: 0,
+            num_stages: 1,
+            status: AgentDisplayStatus::Waiting,
+            tokens_in: 0,
+            tokens_out: 0,
+            cached_tokens: 0,
+            iteration: 1,
+            broken_scripts: Vec::new(),
+            waiting_prompt: Some("Allow tool call: `bash`?".to_string()),
+            wait_reason: None,
+            pending_request: Some(InteractionRequest::tool_approval(
+                "ta1",
+                "bash",
+                serde_json::json!({"command": "rm -rf build"}),
+                "main",
+                &["shell:rm".to_string()],
+            )),
+            last_answered_request_id: None,
+            context_snapshot: None,
+            stages: vec![],
+            workdir: "/tmp/test".to_string(),
+            task: "task".to_string(),
+            title: None,
+            model: None,
+            parent_id: None,
+            started_at: 0,
+            last_progress_at: None,
+            runtime_secs: 0,
+            clock_now: 0,
+            graph: None,
+            accepts_messages: true,
+        }
+    }
+
+    /// A dashboard on the approval prompt of one waiting run, in input mode,
+    /// with the deny-with-feedback row highlighted.
+    fn on_the_prompt() -> (Dashboard, mpsc::UnboundedReceiver<DaemonCommand>) {
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let mut dash = Dashboard::new(cmd_tx);
+        dash.agents.push(agent_with_approval("run-1"));
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+        dash.choice_selected = 4;
+        (dash, cmd_rx)
+    }
+
+    fn press(dash: &mut Dashboard, code: KeyCode, modifiers: KeyModifiers) {
+        dash.handle_input_mode_key(code, KeyEvent::new(code, modifiers));
+    }
+
+    fn type_text(dash: &mut Dashboard, text: &str) {
+        for ch in text.chars() {
+            press(dash, KeyCode::Char(ch), KeyModifiers::NONE);
+        }
+    }
+
+    /// The whole path: Enter on the row opens the box instead of answering,
+    /// two typed lines, Ctrl+Enter sends a deny carrying both lines, and the
+    /// prompt is gone.
+    #[test]
+    fn enter_on_the_row_opens_the_box_and_ctrl_enter_sends_the_deny() {
+        let (mut dash, mut cmd_rx) = on_the_prompt();
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        assert!(dash.deny_feedback_open, "the box opened");
+        assert!(dash.input_mode, "still in input mode");
+        assert!(cmd_rx.try_recv().is_err(), "nothing was answered yet");
+
+        type_text(&mut dash, "keep build/");
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        type_text(&mut dash, "clean only dist/");
+        assert_eq!(
+            dash.input_textarea.lines().len(),
+            2,
+            "Enter is a newline in the box"
+        );
+        assert!(cmd_rx.try_recv().is_err(), "Enter did not send");
+
+        press(&mut dash, KeyCode::Enter, KeyModifiers::CONTROL);
+        assert_eq!(
+            cmd_rx.try_recv().expect("the deny was sent"),
+            DaemonCommand::Answer {
+                response: InteractionResponse::deny_with_feedback(
+                    "ta1",
+                    "keep build/\nclean only dist/"
+                ),
+            }
+        );
+        assert!(!dash.input_mode);
+        assert!(!dash.deny_feedback_open);
+        assert!(dash.agents[0].pending_request.is_none());
+        assert_eq!(dash.choice_selected, 0);
+    }
+
+    /// The Send button under the box sends the same answer, for a terminal
+    /// that cannot tell Ctrl+Enter from Enter.
+    #[test]
+    fn tab_then_enter_sends_from_the_button() {
+        let (mut dash, mut cmd_rx) = on_the_prompt();
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        type_text(&mut dash, "use the API");
+        press(&mut dash, KeyCode::Tab, KeyModifiers::NONE);
+        assert!(dash.response_focus_send);
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(
+            cmd_rx.try_recv().expect("sent from the button"),
+            DaemonCommand::Answer {
+                response: InteractionResponse::deny_with_feedback("ta1", "use the API"),
+            }
+        );
+    }
+
+    /// Esc in the box is "back to the prompt": input mode stays, the choices
+    /// are back, the highlighted row is unchanged, and nothing was answered.
+    /// A second Esc, on the prompt, leaves input mode as it always did.
+    #[test]
+    fn esc_returns_to_the_prompt_without_answering() {
+        let (mut dash, mut cmd_rx) = on_the_prompt();
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        type_text(&mut dash, "half a thou");
+        press(&mut dash, KeyCode::Esc, KeyModifiers::NONE);
+        assert!(!dash.deny_feedback_open);
+        assert!(dash.input_mode, "back on the prompt, not out of it");
+        assert_eq!(dash.choice_selected, 4);
+        assert!(
+            dash.input_textarea.lines().concat().is_empty(),
+            "the draft is gone"
+        );
+        assert!(cmd_rx.try_recv().is_err());
+        assert!(dash.agents[0].pending_request.is_some());
+
+        // The same Esc from the Send button.
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        press(&mut dash, KeyCode::Tab, KeyModifiers::NONE);
+        press(&mut dash, KeyCode::Esc, KeyModifiers::NONE);
+        assert!(!dash.deny_feedback_open);
+        assert!(dash.input_mode);
+
+        press(&mut dash, KeyCode::Esc, KeyModifiers::NONE);
+        assert!(!dash.input_mode, "Esc on the prompt leaves input mode");
+    }
+
+    /// Sending an empty box is the plain deny: the model must not read an
+    /// empty "Feedback:".
+    #[test]
+    fn an_empty_box_sends_the_plain_deny() {
+        let (mut dash, mut cmd_rx) = on_the_prompt();
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        type_text(&mut dash, "   ");
+        press(&mut dash, KeyCode::Enter, KeyModifiers::CONTROL);
+        assert_eq!(
+            cmd_rx.try_recv().expect("sent"),
+            DaemonCommand::Answer {
+                response: InteractionResponse::approval("ta1", false, ApprovalScope::Once),
+            }
+        );
+    }
+
+    /// Enter on any other row still answers at once, as it always did.
+    #[test]
+    fn enter_on_the_plain_deny_answers_without_a_box() {
+        let (mut dash, mut cmd_rx) = on_the_prompt();
+        dash.choice_selected = 3;
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        assert!(!dash.deny_feedback_open);
+        assert_eq!(
+            cmd_rx.try_recv().expect("answered"),
+            DaemonCommand::Answer {
+                response: InteractionResponse::approval("ta1", false, ApprovalScope::Once),
+            }
+        );
+    }
+
+    /// The activity-log label names the deny and quotes the feedback, cut to
+    /// fit the log line.
+    #[test]
+    fn the_log_label_quotes_the_feedback() {
+        let (mut dash, _rx) = on_the_prompt();
+        press(&mut dash, KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(dash.deny_feedback_response("ta1").1, "Deny");
+        type_text(&mut dash, "short");
+        assert_eq!(dash.deny_feedback_response("ta1").1, "Deny: short");
+        type_text(&mut dash, &"x".repeat(60));
+        let label = dash.deny_feedback_response("ta1").1;
+        assert!(label.starts_with("Deny: short"), "{label}");
+        assert!(label.len() < 50, "{label}");
+    }
+}

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -1083,6 +1083,7 @@ impl Dashboard {
                         choice_index: None,
                         approved: None,
                         scope: None,
+                        feedback: None,
                     },
                     d,
                 )

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -303,7 +303,11 @@ impl Dashboard {
         };
     }
 
-    fn handle_input_mode_key(&mut self, key_code: KeyCode, key: crossterm::event::KeyEvent) {
+    pub(super) fn handle_input_mode_key(
+        &mut self,
+        key_code: KeyCode,
+        key: crossterm::event::KeyEvent,
+    ) {
         use interaction::InteractionKind;
         let kind = self
             .selected_agent()
@@ -322,15 +326,19 @@ impl Dashboard {
             self.remember_md_mode(outcome);
             return;
         }
+        // The feedback box under an approval prompt is the response box with
+        // a different destination, so it takes the response box's keys.
+        if self.deny_feedback_open {
+            self.handle_response_box_key(key);
+            return;
+        }
         match &kind {
             Some(InteractionKind::FreeText) | Some(InteractionKind::EditText) | None => {
                 self.handle_response_box_key(key);
             }
             _ => match key_code {
                 KeyCode::Esc => self.close_input_box(),
-                KeyCode::Enter => {
-                    self.submit_input();
-                }
+                KeyCode::Enter => self.confirm_choice(),
                 KeyCode::Up => {
                     if self.choice_selected > 0 {
                         self.choice_selected -= 1;
@@ -366,7 +374,7 @@ impl Dashboard {
             match key.code {
                 KeyCode::Enter | KeyCode::Char(' ') => self.submit_input(),
                 KeyCode::Tab | KeyCode::BackTab => self.response_focus_send = false,
-                KeyCode::Esc => self.close_input_box(),
+                KeyCode::Esc => self.cancel_response_box(),
                 _ => {}
             }
             return;
@@ -376,7 +384,7 @@ impl Dashboard {
                 self.submit_input();
             }
             KeyCode::Tab => self.response_focus_send = true,
-            KeyCode::Esc => self.close_input_box(),
+            KeyCode::Esc => self.cancel_response_box(),
             KeyCode::PageUp if self.has_scrollable_document() => self.scroll_by(10),
             KeyCode::PageDown if self.has_scrollable_document() => self.scroll_by(-10),
             _ => {
@@ -391,6 +399,7 @@ impl Dashboard {
     pub(super) fn close_input_box(&mut self) {
         self.input_mode = false;
         self.response_focus_send = false;
+        self.deny_feedback_open = false;
         self.input_textarea = MarkdownEdit::default();
         self.choice_selected = 0;
     }
@@ -1042,6 +1051,9 @@ impl Dashboard {
                     let label = r.options.get(idx).cloned().unwrap_or(idx.to_string());
                     let d = truncate(&label, 40);
                     (InteractionResponse::choice(&r.id, idx), d)
+                }
+                InteractionKind::ToolApproval if self.deny_feedback_open => {
+                    self.deny_feedback_response(&r.id)
                 }
                 InteractionKind::ToolApproval => {
                     let idx = self.choice_selected;

--- a/crates/leviath-cli/src/commands/dashboard/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/input.rs
@@ -2899,18 +2899,18 @@ mod tests {
         dash.input_mode = true;
         dash.choice_selected = 0;
 
-        // Down through once / stage / run / deny
-        for expected in 1..=3 {
+        // Down through once / stage / run / deny / deny with feedback
+        for expected in 1..=4 {
             dash.handle_key(key(KeyCode::Down));
             assert_eq!(dash.choice_selected, expected);
         }
         // Can't go past last
         dash.handle_key(key(KeyCode::Down));
-        assert_eq!(dash.choice_selected, 3);
+        assert_eq!(dash.choice_selected, 4);
 
         // Up back
         dash.handle_key(key(KeyCode::Up));
-        assert_eq!(dash.choice_selected, 2);
+        assert_eq!(dash.choice_selected, 3);
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -4,6 +4,7 @@ mod agents;
 mod click;
 mod construct;
 mod context_tree;
+mod deny_feedback;
 mod detail_band;
 mod explorer;
 mod graph;

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -104,17 +104,20 @@ impl Dashboard {
         use interaction::InteractionKind;
 
         if self.input_mode
-            && matches!(
-                kind,
-                Some(InteractionKind::FreeText) | Some(InteractionKind::EditText) | None
-            )
+            && (self.deny_feedback_open
+                || matches!(
+                    kind,
+                    Some(InteractionKind::FreeText) | Some(InteractionKind::EditText) | None
+                ))
         {
             // ── FreeText / EditText: render the multi-line tui-textarea widget ──
             // No pending interaction request/prompt means this is a mid-run
             // message to a still-running agent rather than a response to a
             // specific question - label it accordingly for consistent UX.
             let is_message_mode = pending_req.is_none() && agent.waiting_prompt.is_none();
-            let hint = if is_message_mode {
+            let hint = if self.deny_feedback_open {
+                " Deny with feedback: what should it do instead?  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] back "
+            } else if is_message_mode {
                 " Provide input while this is running  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel "
             } else {
                 " Response  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel "

--- a/crates/leviath-cli/src/commands/dashboard/render/input.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/input.rs
@@ -116,7 +116,7 @@ impl Dashboard {
             // specific question - label it accordingly for consistent UX.
             let is_message_mode = pending_req.is_none() && agent.waiting_prompt.is_none();
             let hint = if self.deny_feedback_open {
-                " Deny with feedback: what should it do instead?  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] back "
+                " Deny with feedback: what should it do instead?  [^Enter] send  [Enter] newline  [Tab] Send  [Esc] back "
             } else if is_message_mode {
                 " Provide input while this is running  [^Enter] send  [Enter] newline  [Tab] Send button  [Esc] cancel "
             } else {
@@ -392,6 +392,35 @@ mod tests {
             .unwrap();
         let buf = rendered_buffer(&terminal);
         assert!(buf.contains("Review content"), "{buf}");
+    }
+
+    /// With the feedback box open under a tool approval, the pane is the
+    /// response box labelled for the deny, not the choice list.
+    #[test]
+    fn render_input_pane_deny_feedback_box() {
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.input_mode = true;
+        dash.deny_feedback_open = true;
+        let agent = make_test_agent("run-df", AgentDisplayStatus::Waiting);
+        let pending = Some(make_pending_req(interaction::InteractionKind::ToolApproval));
+        let kind = Some(interaction::InteractionKind::ToolApproval);
+        let options = vec!["Allow once".to_string(), "Deny with feedback".to_string()];
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 110, 11);
+                dash.render_input_pane(f, area, &agent, &pending, &kind, &options);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("Deny with feedback"), "{buf}");
+        assert!(buf.contains("[Esc] back"), "{buf}");
+        assert!(buf.contains("Send"), "{buf}");
+        assert!(
+            !buf.contains("[1] Allow once"),
+            "the choice list is gone: {buf}"
+        );
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -346,6 +346,10 @@ fn detail_sections() -> Vec<HelpSection> {
                 ("/", "search; n / N step through matches"),
                 ("y", "copy this pane to the clipboard"),
                 ("i", "respond, or send a message to a running agent run"),
+                (
+                    "enter on Deny with feedback",
+                    "open a box for what the run should do instead; ^Enter or the Send button sends it with the deny, esc goes back to the prompt",
+                ),
                 ("g", "the stage graph explorer"),
                 (", / .", "older / newer context point; opens Context"),
                 ("x", "kill the run (asks first)"),

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -421,6 +421,21 @@ impl Dashboard {
                 .and_then(|a| a.pending_request.as_ref())
                 .map(|r| r.kind.clone());
             match kind {
+                // The feedback box under an approval prompt: the response
+                // box's keys, and Esc is back to the choices, not out.
+                _ if self.deny_feedback_open => Line::from(vec![
+                    Span::styled(
+                        "[^Enter]",
+                        Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(" send with the deny  "),
+                    Span::styled("[Enter]", Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(" newline  "),
+                    Span::styled("[Tab]", Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(" Send button  "),
+                    Span::styled("[Esc]", Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(" back to the prompt"),
+                ]),
                 Some(InteractionKind::FreeText) | None => Line::from(vec![
                     Span::styled(
                         "[Enter]",
@@ -1225,6 +1240,38 @@ mod tests {
             .unwrap();
         let buf = rendered_buffer(&terminal);
         assert!(buf.contains("select"), "{buf}");
+    }
+
+    /// With the feedback box open the bar names the box's keys, and says
+    /// where Esc goes, because it does not go where it goes on the prompt.
+    #[test]
+    fn draw_help_bar_deny_feedback_box() {
+        let backend = TestBackend::new(120, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-df", AgentDisplayStatus::Waiting);
+        agent.pending_request = Some(interaction::InteractionRequest::tool_approval(
+            "ta1",
+            "bash",
+            serde_json::json!({"command": "ls"}),
+            "main",
+            &[],
+        ));
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+        dash.deny_feedback_open = true;
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 120, 1);
+                dash.draw_help_bar(f, area);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("[^Enter] send with the deny"), "{buf}");
+        assert!(buf.contains("[Esc] back to the prompt"), "{buf}");
+        assert!(!buf.contains("select"), "{buf}");
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -436,12 +436,19 @@ impl Dashboard {
                     Span::styled("[Esc]", Style::default().add_modifier(Modifier::BOLD)),
                     Span::raw(" back to the prompt"),
                 ]),
+                // The response box since #708: Enter breaks the line and
+                // Ctrl+Enter sends, with the Send button for a terminal
+                // that cannot tell the two apart.
                 Some(InteractionKind::FreeText) | None => Line::from(vec![
                     Span::styled(
-                        "[Enter]",
+                        "[^Enter]",
                         Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
                     ),
                     Span::raw(" send  "),
+                    Span::styled("[Enter]", Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(" newline  "),
+                    Span::styled("[Tab]", Style::default().add_modifier(Modifier::BOLD)),
+                    Span::raw(" Send button  "),
                     Span::styled("[PgUp/PgDn]", Style::default().add_modifier(Modifier::BOLD)),
                     Span::raw(" scroll document  "),
                     Span::styled("[Esc]", Style::default().add_modifier(Modifier::BOLD)),
@@ -1205,7 +1212,11 @@ mod tests {
             })
             .unwrap();
         let buf = rendered_buffer(&terminal);
-        assert!(buf.contains("send"), "{buf}");
+        // Enter is a newline in the box since #708; the bar must not say it sends.
+        assert!(buf.contains("[^Enter] send"), "{buf}");
+        assert!(buf.contains("[Enter] newline"), "{buf}");
+        assert!(buf.contains("[Tab] Send button"), "{buf}");
+        assert!(!buf.contains("[Enter] send"), "{buf}");
         assert!(buf.contains("[PgUp/PgDn] scroll document"), "{buf}");
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -26,6 +26,10 @@ pub(crate) struct Dashboard {
     /// Whether Tab has moved the keys from the response box to the Send
     /// button under it. Enter there sends; Enter in the box breaks the line.
     pub(super) response_focus_send: bool,
+    /// The response box is open under a tool-approval prompt to collect the
+    /// text for a "Deny with feedback": the answer it sends is a deny, and
+    /// Esc goes back to the prompt rather than out of input mode.
+    pub(super) deny_feedback_open: bool,
     /// True when the full-screen detail view is open for the selected agent
     pub(super) detail_view: bool,
     pub(super) cmd_tx: mpsc::UnboundedSender<DaemonCommand>,

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -212,6 +212,12 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // 404s. The `GET` half is deliberately not announced: it shipped
     // unannounced, so its absence from this list proves nothing.
     "fs.mkdir",
+    // `feedback` on `POST /api/agents/{id}/interaction` beside
+    // `approved: false`, and the "Deny with feedback" option on a tool
+    // approval request. Announced because an older daemon drops the field
+    // without a word: a console that offered the box against one would send
+    // the person's redirect nowhere.
+    "interaction.feedback",
 ];
 
 /// The server's numeric limits.

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -66,6 +66,7 @@ pub(super) async fn submit_interaction(
         choice_index: body.choice_index,
         approved: body.approved,
         scope,
+        feedback: body.feedback,
     };
     let reply = state
         .control

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -59,6 +59,13 @@ pub(super) async fn submit_interaction(
     AxumPath(_id): AxumPath<String>,
     Json(body): Json<SubmitInteractionReq>,
 ) -> Result<StatusCode, ApiError> {
+    if body.approved == Some(true) && body.feedback.is_some() {
+        return Err(err(
+            StatusCode::BAD_REQUEST,
+            "feedback goes with a deny: send it with \"approved\": false, or drop it to approve"
+                .to_string(),
+        ));
+    }
     let scope = body.scope.as_deref().map(approval_scope_from_wire);
     let response = InteractionResponse {
         request_id: body.request_id,
@@ -295,6 +302,73 @@ mod tests {
             .await,
             StatusCode::ACCEPTED
         );
+    }
+
+    /// Post `body` to a fresh one-request daemon: the status, and the answer
+    /// the daemon saw (None when the server refused it first).
+    async fn answered_with(body: &'static str) -> (StatusCode, Option<InteractionResponse>) {
+        use std::sync::{Arc, Mutex};
+        let seen: Arc<Mutex<Option<InteractionResponse>>> = Arc::default();
+        let sink = seen.clone();
+        let (control, _dir, _srv) = fake_daemon(move |req| {
+            if let ControlRequest::AnswerInteraction { response } = req {
+                *sink.lock().unwrap() = Some(response);
+            }
+            ControlResponse::Ok { ok: true }
+        });
+        let status = status_of(
+            app_with(control),
+            "POST",
+            "/api/agents/a/interaction",
+            Body::from(body),
+        )
+        .await;
+        let seen = seen.lock().unwrap().take();
+        (status, seen)
+    }
+
+    /// The three body shapes on a deny: bare, with feedback, and feedback on a
+    /// grant. The first two reach the daemon as the response they name; the
+    /// third is refused before the daemon sees it.
+    #[tokio::test]
+    async fn submit_interaction_feedback_shapes() {
+        let (status, seen) = answered_with(r#"{"request_id":"q1","approved":false}"#).await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        let seen = seen.expect("reached the daemon");
+        assert_eq!((seen.approved, seen.feedback), (Some(false), None));
+
+        let (status, seen) = answered_with(
+            r#"{"request_id":"q1","approved":false,"feedback":"use the API instead"}"#,
+        )
+        .await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        let seen = seen.expect("reached the daemon");
+        assert_eq!(seen.approved, Some(false));
+        assert_eq!(seen.feedback.as_deref(), Some("use the API instead"));
+
+        let (status, seen) =
+            answered_with(r#"{"request_id":"q1","approved":true,"feedback":"why"}"#).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(seen.is_none(), "the 400 never reached the daemon");
+    }
+
+    /// The 400 says what to change.
+    #[tokio::test]
+    async fn feedback_on_a_grant_names_the_fix() {
+        let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::Ok { ok: true });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/agents/a/interaction")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"request_id":"q1","approved":true,"feedback":"why"}"#,
+            ))
+            .unwrap();
+        let resp = app_with(control).oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("feedback goes with a deny"), "{text}");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/commands/serve/interactions.rs
+++ b/crates/leviath-cli/src/commands/serve/interactions.rs
@@ -304,16 +304,15 @@ mod tests {
         );
     }
 
-    /// Post `body` to a fresh one-request daemon: the status, and the answer
-    /// the daemon saw (None when the server refused it first).
-    async fn answered_with(body: &'static str) -> (StatusCode, Option<InteractionResponse>) {
+    /// Post `body` to a fresh one-request daemon: the status, and the control
+    /// request the daemon saw, as JSON text (empty when the server refused the
+    /// body before asking).
+    async fn answered_with(body: &'static str) -> (StatusCode, String) {
         use std::sync::{Arc, Mutex};
-        let seen: Arc<Mutex<Option<InteractionResponse>>> = Arc::default();
+        let seen: Arc<Mutex<String>> = Arc::default();
         let sink = seen.clone();
         let (control, _dir, _srv) = fake_daemon(move |req| {
-            if let ControlRequest::AnswerInteraction { response } = req {
-                *sink.lock().unwrap() = Some(response);
-            }
+            *sink.lock().unwrap() = serde_json::to_string(&req).unwrap();
             ControlResponse::Ok { ok: true }
         });
         let status = status_of(
@@ -323,7 +322,7 @@ mod tests {
             Body::from(body),
         )
         .await;
-        let seen = seen.lock().unwrap().take();
+        let seen = std::mem::take(&mut *seen.lock().unwrap());
         (status, seen)
     }
 
@@ -334,28 +333,30 @@ mod tests {
     async fn submit_interaction_feedback_shapes() {
         let (status, seen) = answered_with(r#"{"request_id":"q1","approved":false}"#).await;
         assert_eq!(status, StatusCode::ACCEPTED);
-        let seen = seen.expect("reached the daemon");
-        assert_eq!((seen.approved, seen.feedback), (Some(false), None));
+        assert!(seen.contains(r#""approved":false"#), "{seen}");
+        assert!(!seen.contains("feedback"), "absent stays absent: {seen}");
 
         let (status, seen) = answered_with(
             r#"{"request_id":"q1","approved":false,"feedback":"use the API instead"}"#,
         )
         .await;
         assert_eq!(status, StatusCode::ACCEPTED);
-        let seen = seen.expect("reached the daemon");
-        assert_eq!(seen.approved, Some(false));
-        assert_eq!(seen.feedback.as_deref(), Some("use the API instead"));
+        assert!(seen.contains(r#""approved":false"#), "{seen}");
+        assert!(
+            seen.contains(r#""feedback":"use the API instead""#),
+            "{seen}"
+        );
 
         let (status, seen) =
             answered_with(r#"{"request_id":"q1","approved":true,"feedback":"why"}"#).await;
         assert_eq!(status, StatusCode::BAD_REQUEST);
-        assert!(seen.is_none(), "the 400 never reached the daemon");
+        assert!(seen.is_empty(), "the 400 never reached the daemon: {seen}");
     }
 
     /// The 400 says what to change.
     #[tokio::test]
     async fn feedback_on_a_grant_names_the_fix() {
-        let (control, _dir, _srv) = fake_daemon(|_| ControlResponse::Ok { ok: true });
+        // No daemon: the refusal happens before one would be asked.
         let req = Request::builder()
             .method("POST")
             .uri("/api/agents/a/interaction")
@@ -364,7 +365,7 @@ mod tests {
                 r#"{"request_id":"q1","approved":true,"feedback":"why"}"#,
             ))
             .unwrap();
-        let resp = app_with(control).oneshot(req).await.unwrap();
+        let resp = app_with(no_daemon()).oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let bytes = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
         let text = String::from_utf8_lossy(&bytes);

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1114,6 +1114,10 @@ pub(super) struct SubmitInteractionReq {
     pub(super) choice_index: Option<usize>,
     pub(super) approved: Option<bool>,
     pub(super) scope: Option<String>,
+    /// On a deny, what the model should do instead. Optional, and absent is
+    /// the plain deny every existing caller sends.
+    #[serde(default)]
+    pub(super) feedback: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -199,6 +199,20 @@ pub(crate) struct AgentToolState {
     pub dynamic: Option<Arc<DynamicToolCtx>>,
 }
 
+/// The tool result a declined approval hands the model.
+///
+/// Without feedback it is the exact sentence it has always been (tests and
+/// docs quote it). With feedback the person's words follow a `Feedback:`
+/// marker on the same line, so the model reads the redirect as part of the
+/// refusal rather than as a stray user message somewhere later in the
+/// context.
+fn declined_result(tool: &str, feedback: Option<&str>) -> String {
+    match feedback {
+        Some(text) => format!("[denied] User declined tool call '{tool}'. Feedback: {text}"),
+        None => format!("[denied] User declined tool call '{tool}'."),
+    }
+}
+
 impl AgentToolState {
     /// Whether every key this call needs is already covered, by the safe list or
     /// by a grant.
@@ -541,7 +555,7 @@ pub(crate) async fn dispatch_tools(
                         queued.push((slot, is_builtin, tc));
                     }
                     Some(false) => {
-                        let result = format!("[denied] User declined tool call '{}'.", tc.name);
+                        let result = declined_result(&tc.name, response.deny_feedback());
                         progress(&tc.id, &result);
                         slots.push((tc.id.clone(), Some(result)));
                     }
@@ -1447,6 +1461,72 @@ mod tests {
                 && result.contains("interaction_timeout_secs"),
             "{result}"
         );
+    }
+
+    /// The two strings a decline can put in front of the model. The plain one
+    /// is pinned word for word: the tests above and the docs quote it. The
+    /// other carries what the person typed, verbatim after the marker, so the
+    /// next turn has a redirect rather than a refusal to guess at.
+    #[test]
+    fn a_decline_names_the_feedback_when_there_is_some() {
+        assert_eq!(
+            declined_result("bash", None),
+            "[denied] User declined tool call 'bash'."
+        );
+        assert_eq!(
+            declined_result("bash", Some("read the README first, then use git log")),
+            "[denied] User declined tool call 'bash'. Feedback: read the README first, then use git log"
+        );
+    }
+
+    /// The claim this feature makes: what the person typed at the deny reaches
+    /// the model inside the tool result for that call. Failed before the
+    /// `Some(false)` arm read `feedback` (the result was the bare decline).
+    #[tokio::test]
+    async fn a_deny_with_feedback_puts_the_text_in_the_tool_result() {
+        let hub = InteractionHub::new();
+        let mut ask = HashMap::new();
+        ask.insert("echo".to_string(), ToolPolicy::Ask);
+        let names: HashSet<String> = ["echo".to_string()].into_iter().collect();
+        let (state, _dir) =
+            script_state(&hub, &[("echo", "\"x\"")], names, no_script_fields().2, ask);
+        let out = dispatch_answering(
+            state,
+            vec![call("c1", "echo", serde_json::json!({}))],
+            |req| {
+                InteractionResponse::deny_with_feedback(&req.id, "try `ls -la` instead\nand stop")
+            },
+            hub,
+        )
+        .await;
+        assert_eq!(
+            out[0].1,
+            "[denied] User declined tool call 'echo'. Feedback: try `ls -la` instead\nand stop"
+        );
+    }
+
+    /// Feedback that arrives beside a grant is a client bug, not a redirect:
+    /// the call runs and the model never hears the word "declined".
+    #[tokio::test]
+    async fn feedback_beside_a_grant_is_ignored() {
+        let hub = InteractionHub::new();
+        let mut ask = HashMap::new();
+        ask.insert("echo".to_string(), ToolPolicy::Ask);
+        let names: HashSet<String> = ["echo".to_string()].into_iter().collect();
+        let (state, _dir) =
+            script_state(&hub, &[("echo", "\"x\"")], names, no_script_fields().2, ask);
+        let out = dispatch_answering(
+            state,
+            vec![call("c1", "echo", serde_json::json!({}))],
+            |req| InteractionResponse {
+                feedback: Some("not a redirect".to_string()),
+                ..InteractionResponse::approval(&req.id, true, ApprovalScope::Once)
+            },
+            hub,
+        )
+        .await;
+        assert!(!out[0].1.contains("declined"), "{}", out[0].1);
+        assert!(!out[0].1.contains("Feedback"), "{}", out[0].1);
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -1525,8 +1525,9 @@ mod tests {
             hub,
         )
         .await;
-        assert!(!out[0].1.contains("declined"), "{}", out[0].1);
-        assert!(!out[0].1.contains("Feedback"), "{}", out[0].1);
+        let result = &out[0].1;
+        assert!(!result.contains("declined"), "not a decline: {result}");
+        assert!(!result.contains("Feedback"), "no redirect: {result}");
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/dispatch.rs
+++ b/crates/leviath-cli/src/dispatch.rs
@@ -420,6 +420,7 @@ mod tests {
             choice: None,
             approve: false,
             deny: false,
+            feedback: None,
             session: false,
             stage: false,
             json: false,

--- a/crates/leviath-core/src/interaction.rs
+++ b/crates/leviath-core/src/interaction.rs
@@ -302,6 +302,7 @@ impl InteractionRequest {
                 stage_label,
                 run_label,
                 "Deny".to_string(),
+                DENY_WITH_FEEDBACK.to_string(),
             ],
             tool_name: Some(tool),
             tool_arguments: Some(arguments),
@@ -311,7 +312,29 @@ impl InteractionRequest {
             body_format: BodyFormat::Plain,
         }
     }
+
+    /// Whether option `index` of this request is the deny that takes a
+    /// message for the model.
+    ///
+    /// A client that offers it has to open a text box before answering, so it
+    /// needs to know which row that is. Keyed on the label rather than a fixed
+    /// position because the taint gate's approval has no such row, and a
+    /// client that assumed index four on every approval would open the box on
+    /// a request that cannot carry the text.
+    pub fn is_deny_with_feedback(&self, index: usize) -> bool {
+        self.kind == InteractionKind::ToolApproval
+            && self.options.get(index).map(String::as_str) == Some(DENY_WITH_FEEDBACK)
+    }
 }
+
+/// The label of the tool-approval option that denies and tells the model why.
+///
+/// The plain "Deny" hands the model nothing but the refusal, and its next turn
+/// is a guess at what it should have done instead. This one carries a line
+/// from the person into the tool result, so the next turn is a redirect. Every
+/// client renders it from the request's `options`, so this is where the words
+/// live.
+pub const DENY_WITH_FEEDBACK: &str = "Deny with feedback";
 
 /// The scope a tool-approval option index means, or `None` for deny.
 ///
@@ -369,6 +392,15 @@ pub struct InteractionResponse {
     pub approved: Option<bool>,
     /// Scope of a tool approval decision.
     pub scope: Option<ApprovalScope>,
+    /// What the person wants the model to do instead, on a denied tool
+    /// approval. Reaches the model as part of the tool result.
+    ///
+    /// Absent (the default) is the plain deny every existing client sends, so
+    /// an answer written before this field existed still means what it meant.
+    /// Only ever read alongside `approved: Some(false)`: a grant has nothing to
+    /// redirect.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feedback: Option<String>,
 }
 
 impl InteractionResponse {
@@ -380,6 +412,7 @@ impl InteractionResponse {
             choice_index: None,
             approved: None,
             scope: None,
+            feedback: None,
         }
     }
 
@@ -391,6 +424,7 @@ impl InteractionResponse {
             choice_index: Some(index),
             approved: None,
             scope: None,
+            feedback: None,
         }
     }
 
@@ -402,6 +436,40 @@ impl InteractionResponse {
             choice_index: None,
             approved: Some(approved),
             scope: Some(scope),
+            feedback: None,
+        }
+    }
+
+    /// Build a deny that tells the model what to do instead.
+    ///
+    /// The text is trimmed, and an answer that is all whitespace is the plain
+    /// deny: the tool result must not carry an empty "Feedback:" for the model
+    /// to puzzle over.
+    pub fn deny_with_feedback(request_id: impl Into<String>, feedback: &str) -> Self {
+        let feedback = feedback.trim();
+        Self {
+            request_id: request_id.into(),
+            value: None,
+            choice_index: None,
+            approved: Some(false),
+            scope: Some(ApprovalScope::Once),
+            feedback: (!feedback.is_empty()).then(|| feedback.to_string()),
+        }
+    }
+
+    /// The redirect a denied tool approval carries, if the person wrote one.
+    ///
+    /// `None` on a grant, whatever the field says: feedback beside
+    /// `approved: true` is a client bug, and the model must not be told the
+    /// call it just ran was refused.
+    pub fn deny_feedback(&self) -> Option<&str> {
+        match self.approved {
+            Some(false) => self
+                .feedback
+                .as_deref()
+                .map(str::trim)
+                .filter(|f| !f.is_empty()),
+            _ => None,
         }
     }
 }
@@ -593,6 +661,8 @@ mod tests {
         assert_eq!(approval_choice(2), Some(ApprovalScope::Run));
         assert_eq!(req.options[3], "Deny");
         assert_eq!(approval_choice(3), None);
+        assert_eq!(req.options[4], DENY_WITH_FEEDBACK);
+        assert_eq!(approval_choice(4), None, "feedback is still a deny");
         assert_eq!(
             approval_choice(99),
             None,
@@ -654,7 +724,7 @@ mod tests {
             &[],
         );
         assert_eq!(r.kind, InteractionKind::ToolApproval);
-        assert_eq!(r.options.len(), 4);
+        assert_eq!(r.options.len(), 5);
     }
 
     #[test]
@@ -700,6 +770,7 @@ mod tests {
             choice_index: None,
             approved: None,
             scope: None,
+            feedback: None,
         };
         assert_eq!(response_as_text(&empty), "");
     }
@@ -763,7 +834,7 @@ mod tests {
         assert_eq!(r.kind, InteractionKind::ToolApproval);
         assert_eq!(r.tool_name.as_deref(), Some("write_file"));
         assert!(r.tool_arguments.is_some());
-        assert_eq!(r.options.len(), 4);
+        assert_eq!(r.options.len(), 5);
         assert!(r.prompt.contains("write_file"));
     }
 
@@ -1062,5 +1133,81 @@ mod tests {
         }"#;
         let req: InteractionRequest = serde_json::from_str(json).unwrap();
         assert!(req.required);
+    }
+    // ─── deny with feedback ──────────────────────────────────────────────────
+
+    /// The wire shape every existing client sends has no `feedback` key, and
+    /// the shape a new one sends adds exactly that key and nothing else.
+    #[test]
+    fn feedback_is_absent_from_the_wire_unless_given() {
+        let plain = InteractionResponse::approval("q1", false, ApprovalScope::Once);
+        let json = serde_json::to_value(&plain).unwrap();
+        assert!(json.get("feedback").is_none(), "{json}");
+        let old_wire: InteractionResponse =
+            serde_json::from_str(r#"{"request_id":"q1","value":null,"choice_index":null,"approved":false,"scope":"once"}"#)
+                .unwrap();
+        assert_eq!(old_wire, plain);
+
+        let with = InteractionResponse::deny_with_feedback("q1", "  use git log instead \n");
+        let json = serde_json::to_value(&with).unwrap();
+        assert_eq!(json["feedback"], "use git log instead");
+        assert_eq!(json["approved"], false);
+        let back: InteractionResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(back, with);
+        assert_eq!(back.deny_feedback(), Some("use git log instead"));
+    }
+
+    /// Whitespace is not a message: the constructor and the reader both turn
+    /// it into the plain deny.
+    #[test]
+    fn blank_feedback_is_the_plain_deny() {
+        let blank = InteractionResponse::deny_with_feedback("q1", "   \n\t");
+        assert_eq!(blank.feedback, None);
+        assert_eq!(blank.approved, Some(false));
+        assert_eq!(blank.deny_feedback(), None);
+        let padded = InteractionResponse {
+            feedback: Some("  \n ".to_string()),
+            ..InteractionResponse::approval("q1", false, ApprovalScope::Once)
+        };
+        assert_eq!(padded.deny_feedback(), None);
+    }
+
+    /// Feedback beside a grant, or beside no decision at all, is never read.
+    #[test]
+    fn feedback_is_only_read_on_a_deny() {
+        let granted = InteractionResponse {
+            feedback: Some("why".to_string()),
+            ..InteractionResponse::approval("q1", true, ApprovalScope::Run)
+        };
+        assert_eq!(granted.deny_feedback(), None);
+        let undecided = InteractionResponse {
+            feedback: Some("why".to_string()),
+            ..InteractionResponse::text("q1", "")
+        };
+        assert_eq!(undecided.deny_feedback(), None);
+    }
+
+    /// Only a tool approval has the feedback row, and only at the position
+    /// the label sits at.
+    #[test]
+    fn the_feedback_row_is_found_by_label_on_tool_approvals_only() {
+        let tool =
+            InteractionRequest::tool_approval("id", "shell", serde_json::json!({}), "s", &[]);
+        assert!(tool.is_deny_with_feedback(4));
+        assert!(!tool.is_deny_with_feedback(3));
+        assert!(!tool.is_deny_with_feedback(99));
+        let gate = InteractionRequest::gate_approval("id", "web_fetch", serde_json::json!({}), "s");
+        assert!(!gate.is_deny_with_feedback(2));
+        assert!(!gate.is_deny_with_feedback(4));
+        let choice = InteractionRequest::multiple_choice(
+            "id",
+            "?",
+            vec![DENY_WITH_FEEDBACK.to_string()],
+            "s",
+        );
+        assert!(
+            !choice.is_deny_with_feedback(0),
+            "the label alone is not the row"
+        );
     }
 }

--- a/crates/leviath-runtime/src/control_socket/mod.rs
+++ b/crates/leviath-runtime/src/control_socket/mod.rs
@@ -2371,6 +2371,7 @@ mod tests {
                     choice_index: None,
                     approved: None,
                     scope: None,
+                    feedback: None,
                 },
             },
             ControlRequest::CancelInteraction { request_id: run() },

--- a/crates/leviath-runtime/src/interaction_hub_tests.rs
+++ b/crates/leviath-runtime/src/interaction_hub_tests.rs
@@ -329,3 +329,62 @@ fn the_timeout_reads_back_through_the_hub_and_its_backends() {
     assert_eq!(hub.timeout_secs(), 7);
     assert_eq!(hub.backend_for("agent-a").timeout_secs(), 7);
 }
+
+/// A deny that carries feedback comes out of `ask` exactly as it went into
+/// `answer`: the hub is a channel, and the text is part of the answer.
+#[tokio::test]
+async fn a_deny_with_feedback_round_trips_through_the_hub() {
+    let hub = InteractionHub::new();
+    let backend = hub.backend_for("agent-a");
+    let asking = tokio::spawn(async move {
+        backend
+            .ask(InteractionRequest::tool_approval(
+                "q1",
+                "bash",
+                serde_json::json!({"command": "rm -rf build"}),
+                "stage",
+                &[],
+            ))
+            .await
+    });
+    settle().await;
+    let sent = InteractionResponse::deny_with_feedback("q1", "keep build/, clean only dist/");
+    assert!(hub.answer(sent.clone()));
+    let got = asking.await.unwrap();
+    assert_eq!(got, sent);
+    assert_eq!(got.deny_feedback(), Some("keep build/, clean only dist/"));
+    assert!(hub.pending().is_empty());
+}
+
+/// The same answer over the control socket's wire shape and through the
+/// run journal: what `lev respond` or the API sends is what the daemon reads,
+/// and the tool result it becomes survives the archive a resumed run replays.
+#[test]
+fn a_deny_with_feedback_survives_the_wire_and_the_journal() {
+    use leviath_core::run_archive::{
+        RUN_ARCHIVE_VERSION, RunRecord, read_archive, write_archive_start, write_record,
+    };
+    let wire = r#"{"request_id":"q1","value":null,"choice_index":null,"approved":false,"scope":"once","feedback":"use the API"}"#;
+    let parsed: InteractionResponse = serde_json::from_str(wire).unwrap();
+    assert_eq!(
+        parsed,
+        InteractionResponse::deny_with_feedback("q1", "use the API")
+    );
+    let mut buf = Vec::new();
+    write_archive_start(&mut buf, RUN_ARCHIVE_VERSION).unwrap();
+    write_record(
+        &mut buf,
+        &RunRecord::ToolCallDone {
+            iteration: 1,
+            call_id: "c1".to_string(),
+            result: "[denied] User declined tool call 'bash'. Feedback: use the API".to_string(),
+            at: 0,
+        },
+    )
+    .unwrap();
+    let (_, records) = read_archive(&mut buf.as_slice()).unwrap();
+    assert!(matches!(
+        &records[0],
+        RunRecord::ToolCallDone { result, .. } if result.ends_with("Feedback: use the API")
+    ));
+}

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -200,7 +200,7 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/agents/tree` · `/{id}/tree-status` · `/{id}/children` | Sub-agent tree + token roll-ups |
 | `POST /api/agents/{id}/pause` · `/resume` | Pause a run · resume it |
 | `POST /api/agents/{id}/message` | Steer a running agent |
-| `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question |
+| `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question. See [below](#answering-a-question) |
 | `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q`; the detail carries the manifest, the regions and the [fan-out limits](#fan-out-limits) |
 | `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
 | `GET /api/models` | Enumerate models, with each one's token limits and where they came from. An OpenAI-compatible gateway's detected models are listed under the gateway's name |
@@ -214,6 +214,28 @@ Base path `/api`; all JSON unless noted.
 | `GET /api/fs/dirs?path=&hidden=` | One directory level of subdirectory names, for a folder picker. Absolute paths only, fenced by `--workdir-root`; `hidden=true` includes dot-prefixed names |
 | `POST /api/fs/dirs` | Make one directory: `{"path": "<absolute parent>", "name": "<one segment>"}` → `201 {"path", "parent"}`. The same fence as the `GET`; `409` if it already exists. Announced as `fs.mkdir` |
 | `GET /ws` · `GET /ws/agents/{id}` | Live event stream (all agents / one run) |
+
+### Answering a question
+
+`GET /api/agents/{id}/interaction` is the request the run is parked on: its `id`, `kind`, `prompt`
+and `options`, plus `tool_name` and `tool_arguments` on a tool approval. `POST` the answer with
+the request's id as `request_id` and one of `value` (free text, an edited document), `choice_index`
+(a multiple choice, zero-based), or `approved` with an optional `scope` (`once`, `stage` or
+`session`) for a tool approval or a confirm. It answers `202` once the daemon has it and `404`
+when nothing with that id is open.
+
+A deny may carry `feedback`, a string the model reads as part of the tool result for the refused
+call, so its next turn is a redirect rather than a guess:
+
+```json
+{"request_id": "approve-call_1", "approved": false, "feedback": "use git log, not git show"}
+```
+
+The model sees `[denied] User declined tool call 'bash'. Feedback: use git log, not git show`.
+Without `feedback` the result is the plain `[denied] User declined tool call 'bash'.` it always was.
+`feedback` beside `approved: true` is a `400`, because there is nothing to redirect. The same text
+is what the tool approval's fifth option, "Deny with feedback", collects in the dashboard, and
+what `lev respond <id> --deny --feedback "..."` sends. Announced as `interaction.feedback`.
 
 On `/logs`, `stage` takes a stage index or `all`, and defaults to the current stage. `stream` is
 either `output`, the assistant's own text, or `logs`, which carries tool calls, token counts and
@@ -965,6 +987,7 @@ than that feature, not broken.
 | `config.gateways.kinds` | `kind`, `header_names` and `models` on each gateway, and `kind`, `headers` and `models` accepted by `PUT /api/config`: a gateway can be an OpenAI-compatible endpoint rather than a script |
 | `models.probe` | `POST /api/models/probe`, which asks an OpenAI-compatible server what it serves before a gateway for it is written; admin only |
 | `fs.mkdir` | `POST /api/fs/dirs`, so a folder picker can offer "New Folder" rather than one that 404s |
+| `interaction.feedback` | `feedback` beside `approved: false` on `POST /api/agents/{id}/interaction`, and the "Deny with feedback" option on a tool approval. An older daemon drops the field without a word, so a console should only offer the box where this is announced. See [answering a question](#answering-a-question) |
 
 ## Live updates over WebSocket
 

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -466,6 +466,7 @@ Answer an interaction the daemon is holding. With no `REQUEST_ID`, lists the ope
 | `--choice <INDEX>` | Answer a multiple-choice interaction by zero-based option index |
 | `--approve` | Approve a tool-approval or confirm interaction. Conflicts with `--deny` |
 | `--deny` | Deny it |
+| `--feedback <TEXT>` | With `--deny`, what the model should do instead. It reads the text inside the refused call's tool result. An error with anything but `--deny` |
 | `--stage` | With `--approve`, allow what this call runs until the run leaves the current stage |
 | `--session` | With `--approve`, allow what this call runs for the rest of the run (alias `--run`) |
 

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -211,6 +211,12 @@ or `Space` sends, as does a click on it. `PgUp` / `PgDn` scroll the document abo
 document edit takes the same keys, with a Save button in place of Send. Single-line boxes (a
 rename, a filter, a server URL) still submit on `Enter`.
 
+A tool approval is a list of choices: `↑` / `↓` pick one and `Enter` answers. Its last row, "Deny
+with feedback", opens the same response box instead of answering, for the line or two that tells
+the run what to do instead of the call. `Ctrl+Enter` or the Send button sends it with the deny, and
+`Esc` goes back to the choices with nothing sent. The text reaches the model inside the refused
+call's tool result; see [Human-in-the-loop](/docs/interaction#tool-approval).
+
 Destructive keys always confirm on a dialog with real buttons: `←`/`→` pick an answer, `Enter`
 activates it, and a stray keypress does nothing. The safe answer holds focus to start.
 

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -139,13 +139,19 @@ opt in, because otherwise any agent package could pre-approve its own shell with
 ### The prompt
 
 An `ask` gate raises a `tool_approval` prompt naming the tool and its telling argument (the shell
-command for `bash`/`shell`, the path for the file tools), with four options:
+command for `bash`/`shell`, the path for the file tools), with five options:
 
 - **Allow once**: permit just this one call.
 - **Allow ... for this stage**: permit every later call this covers, until the run leaves the
   current stage. Re-entering the same stage keeps the grant, so a revision loop does not re-ask.
 - **Allow ... for this run**: permit every later call this covers, for the rest of the run.
-- **Deny**: reject the call.
+- **Deny**: reject the call. The model sees `[denied] User declined tool call 'bash'.` and
+  decides for itself what to try next.
+- **Deny with feedback**: reject the call and say what to do instead. The dashboard opens the
+  response box for the text; `lev respond` takes it as `--feedback`; the API takes `feedback`.
+  The model sees `[denied] User declined tool call 'bash'. Feedback: <your text>` as the tool
+  result, so its next turn starts from your redirect rather than from a guess. The text is in the
+  run's journal with the rest of the tool result.
 
 The two scoped options name what they grant, because a grant is not keyed on the tool. Approving
 `ls && git status` for the run grants `ls` and `git status`, not "the shell": a later
@@ -267,6 +273,7 @@ lev respond <request-id> --approve       # tool-approval / confirm
 lev respond <request-id> --approve --stage     # and every later call this covers, this stage
 lev respond <request-id> --approve --session   # and every later call this covers, this run
 lev respond <request-id> --deny          # reject
+lev respond <request-id> --deny --feedback "use git log, not git show"   # reject and redirect
 ```
 
 You don't have to use the CLI. The same open questions can be answered interactively from the

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -923,7 +923,8 @@
           "200": {
             "$ref": "#/components/responses/Ok"
           }
-        }
+        },
+        "description": "Body: `request_id` (the open request's id) plus one of `value`, `choice_index`, or `approved` with an optional `scope` (`once`, `stage`, `session`). A deny (`approved: false`) may carry `feedback`, a string the model reads inside the tool result for the refused call: `[denied] User declined tool call '<tool>'. Feedback: <text>`. `feedback` beside `approved: true` is a 400. 202 once the daemon holds the answer, 404 when nothing with that id is open. Announced as `interaction.feedback`."
       }
     },
     "/api/mcp/servers": {


### PR DESCRIPTION
## Deny with feedback

A tool approval can now be refused with a line for the model. The text reaches it inside the tool result for the refused call, so its next turn starts from the redirect rather than from a guess. The plain deny is unchanged, and every existing `{approved: bool}` caller keeps working.

## The approval path, measured before the change

| Step | Where |
|---|---|
| Request and response types; `approved: Option<bool>` | `crates/leviath-core/src/interaction.rs:384` (`InteractionResponse`), `tool_approval()` builds the four fixed-position options, `approval_choice()` at `:345` maps an index to a scope and denies on anything else |
| The hub: a prompt is `submit`ted and awaited, `answer()` resolves it | `crates/leviath-runtime/src/interaction_hub.rs:117` (`submit`), `:192` (`answer`). An unanswered prompt times out at `:160` (`expire`) to the neutral `InteractionResponse::text(id, "")`, which is `approved: None` |
| Raising and consuming a tool approval | `crates/leviath-cli/src/daemon/tool_service.rs:537` (`ToolPolicy::Ask` arm). `Some(false)` at `:557` yielded `[denied] User declined tool call '<tool>'.`; `None` at `:565` is the timeout message from #696 |
| Persistence of the answer | There is no interaction sidecar for a tool approval: the answer becomes the tool result, which is written as `RunRecord::ToolCallDone { result }` at `crates/leviath-runtime/src/pipeline/tools.rs:797` and replayed on resume by `crates/leviath-cli/src/daemon/recovery.rs:1364`. Stage-boundary interaction points (`restore_interaction_point`, `crates/leviath-runtime/src/interaction_points.rs:379`) are the `project_persist_interaction_points` era mechanism and do not carry tool approvals |
| TUI approval prompt | `crates/leviath-cli/src/commands/dashboard/input.rs` (`handle_input_mode_key`, `submit_input`), rendered by `render/input.rs:95` (`render_input_pane`), footer by `render/table.rs:371` (`draw_help_bar`), F1 by `render/overlays.rs` |
| CLI answer | `lev respond <id> --approve/--deny [--stage/--session]`, `crates/leviath-cli/src/commands/ctl.rs:264` (`build_response`), sent as `ControlRequest::AnswerInteraction { response }` (`crates/leviath-runtime/src/control_socket/mod.rs`) |
| HTTP | `POST /api/agents/{id}/interaction`, `crates/leviath-cli/src/commands/serve/interactions.rs:57` (`submit_interaction`); body `SubmitInteractionReq` at `serve/types.rs`, `request_id` selects the prompt |
| WebSocket | `crates/leviath-cli/src/commands/serve/events.rs:117` `InteractionNeeded { request }` reports the prompt; there is no "interaction answered" frame. The answer's effect is `tool_call_finished { summary }` (`events.rs:203`, fed by `WorldEvent::ToolCallFinished` at `crates/leviath-runtime/src/pipeline/tool_results.rs:640`, `one_line(result, 200)`). `to_server_event` matches `WorldEvent` exhaustively; no variant is added |
| Agent Client Protocol | `crates/leviath-agent-client/src/mapping.rs:172` (`permission_request`) offers allow-once / allow-always / reject; the host's outcome is an option id with no text, so the bridge (`commands/agent_client/mod.rs:701`) sends the plain deny |
| OpenAPI + guide | `docs/schema/openapi.json:900`, `docs/content/api.md` route table (no body description existed) |

## What changed

- `InteractionResponse.feedback: Option<String>` (`interaction.rs:403`), `#[serde(default, skip_serializing_if = "Option::is_none")]`. `deny_with_feedback()` (`:448`) trims and drops blank text; `deny_feedback()` (`:465`) reads it only beside `approved: Some(false)`.
- The tool approval request has a fifth option, `"Deny with feedback"` (`DENY_WITH_FEEDBACK`, `:337`), found by label through `is_deny_with_feedback()` (`:324`) because the taint gate's approval has no such row. `approval_choice(4)` is `None`, so any index-based client still denies on it.
- `tool_service.rs:209` `declined_result()`: `[denied] User declined tool call '<tool>'.` without feedback (pinned), `[denied] User declined tool call '<tool>'. Feedback: <text>` with it. That string is what the journal, the `tool_call_finished` summary, the logs stream and the next model turn carry.
- TUI: `dashboard/deny_feedback.rs` (new, because `input.rs` is at the file-size cap). Enter on the row opens the same response box and Send button (`render/button.rs`), Ctrl+Enter or the button sends, Esc returns to the prompt. `render/input.rs:107`, `render/table.rs:426` (help bar), `render/overlays.rs` (F1).
- CLI: `lev respond <id> --deny --feedback TEXT` (`ctl.rs:71`). clap `requires = "deny"` refuses it alone; `check_feedback_flag()` (`:287`) refuses it beside `--approve`, which clap let through. No stdin convention existed on this command, so none was added.
- HTTP: `feedback` on the body (`serve/types.rs:1089`), 400 beside `approved: true` (`interactions.rs:64`), announced as `interaction.feedback` (`config_types.rs:220`). OpenAPI `post` description and an "Answering a question" section in `api.md`.
- ACP unchanged (plain deny, `feedback: None`). Timeout unchanged.

## Wire shapes

Answer body, unchanged callers:

```json
{"request_id": "approve-call_1", "approved": false}
{"request_id": "approve-call_1", "approved": true, "scope": "session"}
```

Deny with feedback:

```json
{"request_id": "approve-call_1", "approved": false, "feedback": "list only the top level with `ls`\nand never remove anything"}
```

Refused with 400:

```json
{"request_id": "approve-call_1", "approved": true, "feedback": "x"}
-> {"error": "feedback goes with a deny: send it with \"approved\": false, or drop it to approve"}
```

The response over the control socket serializes the same way (`feedback` absent unless set). The pending listing (`GET .../interaction`, `lev respond --json`) carries the fifth option. `tool_call_finished.summary` and `ToolCallDone.result` carry `[denied] User declined tool call 'shell'. Feedback: ...`.

## Fail-first

`daemon::tool_service::tests::a_deny_with_feedback_puts_the_text_in_the_tool_result`, run with the `Some(false)` arm reverted to ignore the field:

```
panicked at crates/leviath-cli/src/daemon/tool_service.rs:1500:9:
  left: "[denied] User declined tool call 'echo'."
 right: "[denied] User declined tool call 'echo'. Feedback: try `ls -la` instead\nand stop"
```

Restored, it passes with the other 61 tool_service tests.

## Live checks

All three against a real daemon and `lev serve` with a mock OpenAI provider (`perf-tools/harness.sh`, short `LEVIATH_HOME`, `LEVIATH_SKIP_DOTENV=1`, `LEVIATH_API_TOKEN`, processes started with `start_new_session=True`). The mock is `mock.py` with two additions: it logs every request body, and once a `role: tool` message is in the conversation it replies `echo: <that tool message>`, so the run's output is exactly the tool result the model was handed. The blueprint is the probe agent with `[stages.main.tool_permissions] shell = "ask"`, and the mock asks for `shell {"command": "rm -rf build"}`.


### HTTP

```
## the pending approval, GET /api/agents/{id}/interaction
{
  "id": "approve-call_1",
  "kind": "tool_approval",
  "prompt": "Allow tool call: `shell` - `rm -rf build`?",
  "options": [
    "Allow once",
    "Allow rm for this stage",
    "Allow rm for this run",
    "Deny",
    "Deny with feedback"
  ]
}

## POST with feedback beside approved:true
400 {"error": "feedback goes with a deny: send it with \"approved\": false, or drop it to approve"}

## POST the deny with feedback
{"request_id": "approve-call_1", "approved": false, "feedback": "list only the top level with `ls`\nand never remove anything"}
202 null

## run result (the mock echoes the tool result it was handed)
{
  "run_id": "w6bprobe-1788050116-98c028203c7d",
  "status": "complete",
  "output": "echo: [denied] User declined tool call 'shell'. Feedback: list only the top level with `ls`\nand never remove anythin
  "final_output": null,
  "error": null,
  "prompt_tokens": 36,
  "completion_tokens": 9
}

## the next model turn's request, as the mock logged it (tool message)
{"content": "[denied] User declined tool call 'shell'. Feedback: list only the top level with `ls`\nand never remove anything", "r

## lev timeline
w6bprobe-1788050116-98c028203c7d (w6bprobe, complete) wall 0:00 = model calls 0:00 + tools 0:00 + waiting on children or prompts 0

STAGE                MODEL TIME  CALLS     OUTPUT    LARGEST
main                      0:00      2          6          3
(title)                   0:00      1          3          3
2026-08-30T00:35:16.934624Z  INFO lev: Leviath CLI v0.5.5

## run journal (run.lvr) lines carrying the feedback
{"ToolCallDone":{"iteration":1,"call_id":"call_1","result":"[denied] User declined tool call 'shell'. Feedback: list only the top 

## GET /api/agents/{id}/logs?stream=logs
Traceback (most recent call last):
  File "/private/tmp/claude-501/-Users-gemisis-Documents-projects-ai-personal-leviath/eae1f501-698b-4d5a-be24-bdf061ba13d4/scratch
    main()
  File "/private/tmp/claude-501/-Users-gemisis-Documents-projects-ai-personal-leviath/eae1f501-698b-4d5a-be24-bdf061ba13d4/scratch
    evidence(run_id)
  File "/private/tmp/claude-501/-Users-gemisis-Documents-projects-ai-personal-leviath/eae1f501-698b-4d5a-be24-bdf061ba13d4/scratch
    _, logs = api("GET", f"/api/agents/{run_id}/logs?stream=logs")
  File "/private/tmp/claude-501/-Users-gemisis-Documents-projects-ai-personal-leviath/eae1f501-698b-4d5a-be24-bdf061ba13d4/scratch
    return r.status, json.loads(r.read() or b"null")
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/json/__init__.p
    return _default_decoder.decode(s)
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/json/decoder.py
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/json/decoder.py
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 2 (char 1)
```

### CLI

```
## the pending approval, GET /api/agents/{id}/interaction
{
  "id": "approve-call_1",
  "kind": "tool_approval",
  "prompt": "Allow tool call: `shell` - `rm -rf build`?",
  "options": [
    "Allow once",
    "Allow rm for this stage",
    "Allow rm for this run",
    "Deny",
    "Deny with feedback"
  ]
}

## lev respond (listing)
approve-call_1  [tool-approval]  agent=w6bprobe-1788050142-6bbc80e400f8  stage=main
  Allow tool call: `shell` - `rm -rf build`?
    0) Allow once
    1) Allow rm for this stage
    2) Allow rm for this run
    3) Deny
    4) Deny with feedback
    tool: shell
2026-08-30T00:35:42.658190Z  INFO lev: Leviath CLI v0.5.5

## lev respond <id> --approve --feedback x
exit 1: 2026-08-30T00:35:42.667217Z  INFO lev: Leviath CLI v0.5.5
Error: --feedback goes with --deny: it tells the model what to do instead of the call

## lev respond <id> --feedback x (no --deny)
exit 2: error: the following required arguments were not provided:

## lev respond <id> --deny --feedback <two lines>
exit 0: answered
2026-08-30T00:35:42.680824Z  INFO lev: Leviath CLI v0.5.5

## run result (the mock echoes the tool result it was handed)
{
  "run_id": "w6bprobe-1788050142-6bbc80e400f8",
  "status": "complete",
  "output": "echo: [denied] User declined tool call 'shell'. Feedback: list only the top level with `ls`\nand never remove anythin
  "final_output": null,
  "error": null,
  "prompt_tokens": 36,
  "completion_tokens": 9
}

## the next model turn's request, as the mock logged it (tool message)
{"content": "[denied] User declined tool call 'shell'. Feedback: list only the top level with `ls`\nand never remove anything", "r

## lev timeline
w6bprobe-1788050142-6bbc80e400f8 (w6bprobe, complete) wall 0:00 = model calls 0:00 + tools 0:00 + waiting on children or prompts 0

STAGE                MODEL TIME  CALLS     OUTPUT    LARGEST
main                      0:00      2          6          3
(title)                   0:00      1          3          3
2026-08-30T00:35:42.913980Z  INFO lev: Leviath CLI v0.5.5

## run journal (run.lvr) lines carrying the feedback
{"ToolCallDone":{"iteration":1,"call_id":"call_1","result":"[denied] User declined tool call 'shell'. Feedback: list only the top 

## GET /api/agents/{id}/logs?stream=logs (lines naming the denial)
[tool] shell: [denied] User declined tool call 'shell'. Feedback: list only the top level with `ls` and never remove anything
```

### TUI over a pty (120x36, pyte replay; the run list and prompt screens are cut, the rest is verbatim)

```
## the pending approval (from the API, before the dashboard is opened)
['Allow once', 'Allow rm for this stage', 'Allow rm for this run', 'Deny', 'Deny with feedback']

## screen: Deny with feedback highlighted
 w6bprobe · ⏸WAITING · 24↑ 6↓ · 0s work · 6s old 💬 · w6bprobe-1788050400-3e4da52f3349
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│  task  probe                                                                                                         │
│  dir   ~/work  ·  stage 12↑ 3↓  ·  total 24↑ 6↓  ·  openai/gpt-mock                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ Stages stage 1/1  ·  [g] graph───────────────────────────────────────────────────────────────────────────────────────╮
│ ⏸ main                                                                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ ctx ─────────────────────────────────────────────────────────╮
│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  1%                          │
│26 / 2k tokens   [P · S P P]                                  │
╰──────────────────────────────────────────────────────────────╯
╭ Output  [l] logs  [c] ctx ───────────────────────────────────────────────────────────────────────────────────────────╮
│ No output yet for main.                                                                                              │
╰ ~/.leviath/runs/w6bprobe-1788050400-3e4da52f3349/stages/0/output.log ────────────────────────────────────────────────╯
╭ Response ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│[1] Allow once                                                                                                        │
│[2] Allow rm for this stage                                                                                           │
│[3] Allow rm for this run                                                                                             │
│[4] Deny                                                                                                              │
│> [5] Deny with feedback                                                                                              │
│[↑↓] select  [Enter] confirm  [Esc] cancel                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
[↑↓] select  [Enter] confirm  [PgUp/PgDn] scroll document  [Esc] cancel

## screen: the feedback box open
 w6bprobe · ⏸WAITING · 24↑ 6↓ · 0s work · 6s old 💬 · w6bprobe-1788050400-3e4da52f3349
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│  task  probe                                                                                                         │
│  dir   ~/work  ·  stage 12↑ 3↓  ·  total 24↑ 6↓  ·  openai/gpt-mock                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ Stages stage 1/1  ·  [g] graph───────────────────────────────────────────────────────────────────────────────────────╮
│ ⏸ main                                                                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ ctx ─────────────────────────────────────────────────────────╮
│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  1%                          │
│26 / 2k tokens   [P · S P P]                                  │
╰──────────────────────────────────────────────────────────────╯
╭ Output  [l] logs  [c] ctx ───────────────────────────────────────────────────────────────────────────────────────────╮
│ No output yet for main.                                                                                              │
╰ ~/.leviath/runs/w6bprobe-1788050400-3e4da52f3349/stages/0/output.log ────────────────────────────────────────────────╯
╭ Deny with feedback: what should it do instead?  [^Enter] send  [Enter] newline  [Tab] Send  [Esc] back ──────────────╮
│   Edit ⇄    │ B  i  S  U │ <>  ```  [] │ ▦  ◇ │ H  •  1.  >                                                          │
╰ markdown · ⌘P previews it ───────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                [ Send ]
[^Enter] send with the deny  [Enter] newline  [Tab] Send button  [Esc] back to the prompt

## screen: two lines typed
 w6bprobe · ⏸WAITING · 24↑ 6↓ · 0s work · 10s old 💬 · w6bprobe-1788050400-3e4da52f3349
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│  task  probe                                                                                                         │
│  dir   ~/work  ·  stage 12↑ 3↓  ·  total 24↑ 6↓  ·  openai/gpt-mock                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ Stages stage 1/1  ·  [g] graph───────────────────────────────────────────────────────────────────────────────────────╮
│ ⏸ main                                                                                                               │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ ctx ─────────────────────────────────────────────────────────╮
│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  1%                          │
│26 / 2k tokens   [P · S P P]                                  │
╰──────────────────────────────────────────────────────────────╯
╭ Output  [l] logs  [c] ctx ───────────────────────────────────────────────────────────────────────────────────────────╮
│ No output yet for main.                                                                                              │
╰ ~/.leviath/runs/w6bprobe-1788050400-3e4da52f3349/stages/0/output.log ────────────────────────────────────────────────╯
╭ Deny with feedback: what should it do instead?  [^Enter] send  [Enter] newline  [Tab] Send  [Esc] back ──────────────╮
│   Edit ⇄    │ B  i  S  U │ <>  ```  [] │ ▦  ◇ │ H  •  1.  >                                                          │
│keep the build dir                                                                                                    │
│clean only dist/                                                                                                      │
╰ markdown · ⌘P previews it ───────────────────────────────────────────────────────────────────────────────────────────╯
                                                                                                                [ Send ]
[^Enter] send with the deny  [Enter] newline  [Tab] Send button  [Esc] back to the prompt

## screen: after sending
 w6bprobe · ✓COMPLETE · 36↑ 9↓ · 0s work · 12s old 💬 · w6bprobe-1788050400-3e4da52f3349
╭────────────────────────────────────────────────────────────────────────────── ✓ Agent run 'w6bprobe' completed       ╮
│  task  probe                                                                                                         │
│  dir   ~/work  ·  stage 24↑ 6↓  ·  total 36↑ 9↓  ·  openai/gpt-mock                                                  │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ Stages stage 1/1  ·  [g] graph───────────────────────────────────────────────────────────────────────────────────────╮
│ ✓ main 0s                                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭ ctx ─────────────────────────────────────────────────────────╮
│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  3%                          │
│72 / 2k tokens   [P · S P P]                                  │
╰──────────────────────────────────────────────────────────────╯
╭ Output  [l] logs  [c] ctx ───────────────────────────────────────────────────────────────────────────────────────────╮
│echo: [denied] User declined tool call 'shell'. Feedback: keep the build dir clean only dist/                         │
╰ ~/.leviath/runs/w6bprobe-1788050400-3e4da52f3349/stages/0/output.log ────────────────────────────────────────────────╯
[←/→] stage  [1-9] jump  [g] graph  [↑/↓] scroll  [/] search  [y] yank  [l/o/c] logs/out/ctx  [?] help  [Esc] back

## run result (the mock echoes the tool result it was handed)
{
  "run_id": "w6bprobe-1788050400-3e4da52f3349",
  "status": "complete",
  "output": "echo: [denied] User declined tool call 'shell'. Feedback: keep the build dir\nclean only dist/\n",
  "final_output": null,
  "error": null,
  "prompt_tokens": 36,
  "completion_tokens": 9
}

## the next model turn's request, as the mock logged it (tool message)
{"content": "[denied] User declined tool call 'shell'. Feedback: keep the build dir\nclean only dist/", "role": "tool", "tool_call

## lev timeline
w6bprobe-1788050400-3e4da52f3349 (w6bprobe, complete) wall 0:10 = model calls 0:00 + tools 0:10 + waiting on children or prompts 0

STAGE                MODEL TIME  CALLS     OUTPUT    LARGEST
main                      0:00      2          6          3
(title)                   0:00      1          3          3
2026-08-30T00:40:12.904862Z  INFO lev: Leviath CLI v0.5.5

## run journal (run.lvr) lines carrying the feedback
{"ToolCallDone":{"iteration":1,"call_id":"call_1","result":"[denied] User declined tool call 'shell'. Feedback: keep the build dir

## GET /api/agents/{id}/logs?stream=logs (lines naming the denial)
[tool] shell: [denied] User declined tool call 'shell'. Feedback: keep the build dir clean only dist/
```

## Tests

- core: wire shape with and without the field, blank feedback is the plain deny, feedback is only read on a deny, the fifth row is found by label on tool approvals only.
- runtime: a deny with feedback round-trips through the hub; the control-socket JSON and a `ToolCallDone` record through the archive codec.
- tool_service: both result strings pinned; the fail-first above; feedback beside a grant is ignored.
- dashboard: Enter on the row opens the box, two lines typed, Ctrl+Enter sends the deny with both; Send button; Esc back to the prompt without answering, then Esc out; empty box is the plain deny; plain Deny still answers at once; render of the box and of the help bar.
- ctl: the flag builds the response; refused alone and beside `--approve`, before the daemon is contacted.
- serve: the three body shapes and the 400's message; the route-drift and capability tests pass with the new capability documented.

No `#[cfg(unix)]`-only tests; nothing touches `main.rs`.

## Gates

- `cargo fmt --all`; `cargo clippy --all-targets --all-features -p leviath-core -p leviath-runtime -p leviath-cli -- -D warnings` clean.
- `cargo xtask structure`: 424 files, none over the 1200-line limit (the new dashboard logic is its own module because `input.rs` is at the cap).
- `cargo xtask docs`: 40 pages, 3 schemas, no problems.
- `cargo xtask coverage --package leviath-core`, `--package leviath-runtime`, `--package leviath-cli`: all 100% (a stale `target/llvm-cov-target` reported nonsense the first time; cleared and rerun).
- Pre-commit ran the full suite on each of the four commits.

## Notes

- `lev timeline` reports time per stage and does not print tool results; the transcripts show the journal record (`ToolCallDone.result`), the logs stream, the run output and the mock's copy of the next model request instead, which is where the text has to be.
- The FreeText footer in `render/table.rs` still says `[Enter] send`, which predates #708 (Enter is a newline there now). Left alone here; it is a one-line fix if wanted.
- Docs: `docs/content/interaction.md`, `cli.md`, `dashboard.md`, `api.md`, `docs/schema/openapi.json`, CHANGELOG under Added.
