### PR TITLE
fix(providers): a zero requests_per_minute is no limit, not a hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,11 @@ same list.
 
 ### Fixed
 
+- `requests_per_minute = 0` under `[rate_limits.<provider>]` hung every call
+  to that provider: the limiter waited for the request count to drop under
+  zero, which it never could, and the wait sat in front of any HTTP timeout.
+  A zero on either key now means no limit on that side, as
+  `tokens_per_minute = 0` already did, and the config schema accepts it.
 - The dashboard's run detail strip could show a cache figure over 100%, such
   as `cache 152%`, on a run that was mostly served from the provider's cache.
   The prompt count every provider is normalised to is the fresh input only,

--- a/crates/leviath-providers/src/rate_limit.rs
+++ b/crates/leviath-providers/src/rate_limit.rs
@@ -88,9 +88,11 @@ impl RateLimiter {
 
             let current_rpm = state.request_timestamps.len() as u32;
             let current_tpm: usize = state.token_counts.iter().map(|(_, t)| t).sum();
-            let rpm_ok = current_rpm < self.rpm_limit;
-            // A zero `tokens_per_minute` is no token limit at all, the way a
-            // provider without a `[rate_limits]` table has none.
+            // A zero limit on either key is no limit at all, the way a
+            // provider without a `[rate_limits]` table has none. Without the
+            // guard a zero `requests_per_minute` could never be satisfied and
+            // this loop never returned.
+            let rpm_ok = self.rpm_limit == 0 || current_rpm < self.rpm_limit;
             let tpm_ok = self.tpm_limit == 0 || current_tpm < self.tpm_limit as usize;
 
             if rpm_ok && tpm_ok {
@@ -128,25 +130,6 @@ impl RateLimiter {
     pub async fn record_tokens(&self, tokens: usize) {
         let mut state = self.state.lock().await;
         state.token_counts.push_back((Instant::now(), tokens));
-    }
-
-    /// Check current TPM usage against limit.
-    pub async fn check_tpm(&self) -> bool {
-        let now = Instant::now();
-        let window = self.window;
-        let mut state = self.state.lock().await;
-
-        // Prune old entries; see `acquire` for why this is not `now - window`.
-        while state
-            .token_counts
-            .front()
-            .is_some_and(|(t, _)| now.duration_since(*t) > window)
-        {
-            state.token_counts.pop_front();
-        }
-
-        let current_tpm: usize = state.token_counts.iter().map(|(_, t)| t).sum();
-        current_tpm < self.tpm_limit as usize
     }
 
     /// Handle a 429 rate limit response.
@@ -199,20 +182,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_rate_limiter_tpm_check() {
-        let limiter = RateLimiter::new(&RateLimitConfig {
-            requests_per_minute: 100,
-            tokens_per_minute: 1000,
-        });
-
-        assert!(limiter.check_tpm().await);
-        limiter.record_tokens(500).await;
-        assert!(limiter.check_tpm().await);
-        limiter.record_tokens(600).await;
-        assert!(!limiter.check_tpm().await);
-    }
-
-    #[tokio::test]
     async fn a_fresh_limiter_admits_the_first_request() {
         let limiter = RateLimiter::new(&RateLimitConfig {
             requests_per_minute: 60,
@@ -258,6 +227,20 @@ mod tests {
             started.elapsed() >= Duration::from_millis(350),
             "waited for the window"
         );
+    }
+
+    /// A zero `requests_per_minute` means no request limit; only tokens
+    /// count. Without the guard `acquire` loops on a limit no count can stay
+    /// under, so the test is bounded rather than left to hang.
+    #[tokio::test]
+    async fn a_zero_requests_per_minute_is_no_request_limit() {
+        let limiter = short_window(0, 0);
+        for _ in 0..3 {
+            tokio::time::timeout(Duration::from_secs(1), limiter.acquire())
+                .await
+                .expect("a zero request limit admits the call at once")
+                .expect("acquire succeeds");
+        }
     }
 
     /// A zero `tokens_per_minute` means no token limit; only requests count.
@@ -359,29 +342,6 @@ mod tests {
         assert_eq!(state.token_counts.len(), 1);
     }
 
-    #[tokio::test]
-    async fn tpm_check_empty_is_under_limit() {
-        let limiter = RateLimiter::new(&RateLimitConfig {
-            requests_per_minute: 60,
-            tokens_per_minute: 100,
-        });
-        assert!(limiter.check_tpm().await);
-    }
-
-    #[tokio::test]
-    async fn record_tokens_accumulates() {
-        let limiter = RateLimiter::new(&RateLimitConfig {
-            requests_per_minute: 60,
-            tokens_per_minute: 1000,
-        });
-        limiter.record_tokens(300).await;
-        limiter.record_tokens(400).await;
-        limiter.record_tokens(200).await;
-        assert!(limiter.check_tpm().await); // 900 < 1000
-        limiter.record_tokens(200).await;
-        assert!(!limiter.check_tpm().await); // 1100 >= 1000
-    }
-
     // ── Additional coverage tests ──────────────────────────────────────────
 
     #[tokio::test]
@@ -422,16 +382,6 @@ mod tests {
         let clone = limiter.clone();
         assert_eq!(clone.rpm_limit, 42);
         assert_eq!(clone.tpm_limit, 12345);
-    }
-
-    #[tokio::test]
-    async fn record_tokens_zero() {
-        let limiter = RateLimiter::new(&RateLimitConfig {
-            requests_per_minute: 60,
-            tokens_per_minute: 100,
-        });
-        limiter.record_tokens(0).await;
-        assert!(limiter.check_tpm().await);
     }
 
     #[tokio::test]
@@ -488,11 +438,9 @@ mod tests {
 
     #[tokio::test]
     async fn acquire_prunes_expired_token_count_entries() {
-        // acquire()'s pruning loop also prunes `token_counts` (shared state
-        // with check_tpm()'s own, separate pruning loop) - no other test
-        // seeds an expired token_counts entry before calling acquire()
-        // itself, so that pop_front() call is otherwise unexercised from this
-        // function.
+        // acquire()'s pruning loop also prunes `token_counts`; no other test
+        // seeds an expired token_counts entry before calling acquire(), so
+        // that pop_front() call is otherwise unexercised.
         let limiter = RateLimiter::new(&RateLimitConfig {
             requests_per_minute: 60,
             tokens_per_minute: 100_000,
@@ -504,25 +452,6 @@ mod tests {
                 .push_back((Instant::now() - Duration::from_secs(61), 500));
         }
         limiter.acquire().await.unwrap();
-        let state = limiter.state.lock().await;
-        assert!(state.token_counts.is_empty());
-    }
-
-    #[tokio::test]
-    async fn check_tpm_prunes_expired_token_entries() {
-        let limiter = RateLimiter::new(&RateLimitConfig {
-            requests_per_minute: 60,
-            tokens_per_minute: 100,
-        });
-        {
-            let mut state = limiter.state.lock().await;
-            state
-                .token_counts
-                .push_back((Instant::now() - Duration::from_secs(61), 90));
-        }
-        // The stale entry is outside the 60s window and should be pruned,
-        // leaving the limiter under its TPM limit.
-        assert!(limiter.check_tpm().await);
         let state = limiter.state.lock().await;
         assert!(state.token_counts.is_empty());
     }

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -636,7 +636,9 @@ Both are enforced before every call. `requests_per_minute` counts calls made in
 the last minute; `tokens_per_minute` counts the tokens those calls reported
 back, so it lags the request window by one call and errs on the provider's
 side. When either window is full the call waits for the oldest entry to leave
-it. A `tokens_per_minute` of `0` means no token limit.
+it. A `0` on either key means no limit on that side: `requests_per_minute = 0`
+leaves only the token window in force, and `tokens_per_minute = 0` only the
+request window.
 
 This shapes request *rate*. `[limits] max_concurrent_inferences` and
 `[limits.max_concurrent_inferences_by_provider]` bound *concurrency*. Both apply. Script providers

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -561,11 +561,11 @@
         "properties": {
           "requests_per_minute": {
             "type": "integer",
-            "minimum": 1
+            "minimum": 0
           },
           "tokens_per_minute": {
             "type": "integer",
-            "minimum": 1
+            "minimum": 0
           }
         }
       }
@@ -650,11 +650,11 @@
             "properties": {
               "requests_per_minute": {
                 "type": "integer",
-                "minimum": 1
+                "minimum": 0
               },
               "tokens_per_minute": {
                 "type": "integer",
-                "minimum": 1
+                "minimum": 0
               }
             }
           }


### PR DESCRIPTION
## Premise check

`crates/leviath-providers/src/rate_limit.rs:91` read `rpm_ok = current_rpm < self.rpm_limit` with no zero guard, while the tokens line three lines down had one. With `requests_per_minute = 0` the request count can never be under the limit, so `acquire()` loops on its 50 ms sleep forever, ahead of any HTTP timeout. Confirmed by the regression test below.

`docs/schema/config.schema.json:564` and `:568` (and the per-endpoint copy at `:653`/`:657`) had `minimum: 1` on both keys, contradicting `configuration.md`, which already said a zero `tokens_per_minute` means no token limit.

`check_tpm` (`rate_limit.rs:134`) had no callers outside its own tests.

## Fix

- Zero on `requests_per_minute` means no request limit, the same as `tokens_per_minute` already did (decided with the user).
- Schema: `minimum: 0` on both keys at both sites.
- `configuration.md`: the sentence next to the token one now says a zero on either key means no limit on that side.
- `check_tpm` and the five tests that only existed to exercise it are deleted.
- CHANGELOG entry under Fixed.

## Fail-first evidence

`a_zero_requests_per_minute_is_no_request_limit` builds a limiter with rpm 0 and wraps `acquire()` in a 1 s `tokio::time::timeout`. Against the unfixed code:

```
thread 'rate_limit::tests::a_zero_requests_per_minute_is_no_request_limit' panicked at crates/leviath-providers/src/rate_limit.rs:272:18:
a zero request limit admits the call at once: Elapsed(())
test result: FAILED. 0 passed; 1 failed
```

With the fix: 40 passed in `rate_limit`.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-providers -- -D warnings`
- `cargo test -p leviath-providers --lib rate_limit` (40 passed)
- `cargo xtask structure`, `cargo xtask docs`
- `cargo xtask coverage --package leviath-providers` at 100% (after clearing a stale `target/llvm-cov-target`)
- Pre-commit full suite passed.

Plan item 1.1 of the round 4 audit.
