### PR TITLE
fix(config): refuse unknown keys on an OpenAI-compatible endpoint entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,13 @@ same list.
 
 ### Changed
 
+- A `[model_providers.<name>]` entry with `kind = "openai-compatible"` no
+  longer loads with a key the endpoint does not read; the error names the
+  entry, the keys, and the ones it does read. Unrecognised keys on a script
+  entry are forwarded to the script's `initialize`, and the same field
+  carried them for an endpoint, where nothing read them: a misspelled
+  `models` left the endpoint with no catalogue and a misspelled `headers`
+  sent none, and the unknown-key warning could not see either.
 - `lev setup` no longer offers the Claude Code transport on its provider
   list, and with it the reasoning-effort row, the terms dialog on save, and
   the review-screen warning are gone. The transport itself stays: the

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -2774,6 +2774,43 @@ script = \"groq.rhai\"
         assert!(loaded.model_providers["mock"].is_endpoint());
     }
 
+    /// An endpoint has no script to forward `extra` to, so a key it does not
+    /// read is a misspelling that used to load clean and do nothing: `modles`
+    /// left the endpoint with no catalogue, `heaeders` sent no headers, and
+    /// `unknown_config_keys` could not see either because `flatten` writes
+    /// them back. The load now refuses, naming the entry, the keys, and the
+    /// ones it does read.
+    #[test]
+    fn an_endpoint_entry_with_unknown_keys_fails_the_load() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        std::fs::write(
+            &path,
+            "[model_providers.llama]\nkind = \"openai-compatible\"\n\
+             base_url = \"http://localhost:8080/v1\"\nmodles = [\"qwen3-8b\"]\n\
+             heaeders = { X-Org = \"research\" }\n",
+        )
+        .unwrap();
+        let err = Config::load_from_path(&path).unwrap_err().to_string();
+        assert!(err.contains("[model_providers.llama]"), "{err}");
+        assert!(err.contains("heaeders, modles"), "{err}");
+        assert!(err.contains("headers"), "{err}");
+        assert!(err.contains("models"), "{err}");
+
+        // A script entry keeps forwarding whatever it is given to `initialize`.
+        std::fs::write(
+            &path,
+            "[model_providers.groq]\nscript = \"groq.rhai\"\norg = \"research\"\n",
+        )
+        .unwrap();
+        let loaded = Config::load_from_path(&path).expect("a script entry forwards extra keys");
+        assert_eq!(
+            loaded.model_providers["groq"].extra["org"],
+            toml::Value::String("research".into())
+        );
+    }
+
     /// Unix-only: the assertion is about POSIX mode bits, which Windows does
     /// not have. `write_private`'s Windows path is a plain write, exercised by
     /// every other `save_to_path` test.

--- a/crates/leviath-cli/src/config/providers.rs
+++ b/crates/leviath-cli/src/config/providers.rs
@@ -170,7 +170,8 @@ impl ModelProviderKind {
 /// Every field is optional. For a script, keys not recognized below flow into
 /// [`Self::extra`] and are forwarded to the script's `initialize(config)`
 /// alongside `base_url` and `api_key`. For an endpoint, `base_url` is required
-/// and `headers` and `models` are read; `extra` is ignored.
+/// and `headers` and `models` are read; a key that would land in `extra` is
+/// refused at load, since nothing would read it.
 #[derive(Clone, Serialize, Deserialize, Default)]
 pub struct ModelProviderConfig {
     /// What backs the entry. Absent means a script, so every existing config
@@ -240,6 +241,20 @@ pub struct ModelProviderConfig {
     pub extra: HashMap<String, toml::Value>,
 }
 
+/// The keys an OpenAI-compatible endpoint entry reads, for the refusal above
+/// to list. `script` is included because the struct accepts it on any entry,
+/// though an endpoint never runs one.
+const ENDPOINT_KEYS: &[&str] = &[
+    "kind",
+    "script",
+    "api_key",
+    "base_url",
+    "rate_limit",
+    "serves",
+    "headers",
+    "models",
+];
+
 impl ModelProviderConfig {
     /// The kind this entry is, with absent read as a script.
     pub fn kind(&self) -> ModelProviderKind {
@@ -269,6 +284,21 @@ impl ModelProviderConfig {
                 "[model_providers.{name}] has kind = \"openai-compatible\" but no \
                  base_url; set base_url to where the server listens, such as \
                  \"http://localhost:8080/v1\""
+            );
+        }
+        // `extra` exists to reach a script's `initialize`. An endpoint has no
+        // script, so a key landing there is one the endpoint will never read:
+        // `modles` leaves it with no catalogue and `heaeders` sends nothing,
+        // and both used to load clean. `Config::unknown_config_keys` cannot
+        // catch them either, because `flatten` writes them straight back.
+        if self.is_endpoint() && !self.extra.is_empty() {
+            let mut keys: Vec<&str> = self.extra.keys().map(String::as_str).collect();
+            keys.sort_unstable();
+            anyhow::bail!(
+                "[model_providers.{name}] has kind = \"openai-compatible\" and \
+                 unknown key(s) {}; an endpoint reads only {}",
+                keys.join(", "),
+                ENDPOINT_KEYS.join(", ")
             );
         }
         Ok(())

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -819,7 +819,10 @@ This is three providers: two llama.cpp servers under their own names, and Anthro
 reaches a model on one of them as `llama-cpp/qwen3-8b` or `llama-cpp-big/llama-3-70b`, and the
 `default_provider` above sends every stage that allows a user default to the first. `base_url` is
 required and includes the path prefix the server expects, usually `/v1`. Each entry may also carry
-`rate_limit` and `serves`, which mean what they mean for a script provider.
+`rate_limit` and `serves`, which mean what they mean for a script provider. An endpoint entry refuses
+to load with a key it does not read (a script entry forwards such keys to its `initialize`, an
+endpoint has nowhere to send them), so a misspelled `models` or `headers` is an error naming the
+entry rather than a catalogue or header that quietly never arrives.
 
 Streaming and tool calls are on. Each request carries the temperature the stage asks for, and a
 server that refuses one is asked again without it and remembered for the rest of the process.


### PR DESCRIPTION
Plan item 1.6.

## Premise check

Confirmed. `ModelProviderConfig::extra` (`crates/leviath-cli/src/config/providers.rs`) is `#[serde(flatten)]`, so any key the struct does not declare lands there. That is the design for a script entry (forwarded into `initialize`). For `kind = "openai-compatible"` there is no script, and nothing reads `extra`, so

```toml
[model_providers.llama]
kind = "openai-compatible"
base_url = "http://localhost:8080/v1"
modles = ["qwen3-8b"]
heaeders = { X-Org = "research" }
```

loaded clean, the endpoint had no catalogue and sent no headers, and `Config::unknown_config_keys` could not warn because `flatten` round-trips the keys. Same gap #705 closed for `[sandbox]`.

## Fix

`ModelProviderConfig::validate` bails when the entry is an endpoint and `extra` is non-empty, naming the entry, the keys (sorted), and the keys an endpoint reads:

```
[model_providers.llama] has kind = "openai-compatible" and unknown key(s) heaeders, modles; an endpoint reads only kind, script, api_key, base_url, rate_limit, serves, headers, models
```

Script entries keep forwarding. Behaviour change (approved): a misspelled endpoint key stops the config loading.

## Fail-first evidence

`an_endpoint_entry_with_unknown_keys_fails_the_load` against the unfixed code:

```
failures:
    config::tests::an_endpoint_entry_with_unknown_keys_fails_the_load
test result: FAILED. 0 passed; 1 failed
```

(`unwrap_err` panicked: the config loaded.) After the fix: `136 passed` across `config::tests`. The same test checks a script entry with `org = "research"` still loads with the key in `extra`.

## Docs and changelog

- `docs/content/configuration.md`, "OpenAI-compatible endpoints": one sentence that an endpoint entry refuses a key it does not read.
- CHANGELOG, Unreleased / Changed.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`: clean
- `cargo xtask structure`: 427 files, none over the limit
- `cargo xtask docs`: 40 pages, no problems
- `cargo xtask coverage --package leviath-cli`: passes
- Pre-commit full suite: passed
