### PR TITLE
fix(serve): keep the request deadline off the routes that wait by design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,14 @@ same list.
   default, so the token window stayed empty and the limit did nothing in
   practice. A streamed call now books the total its usage frames name once
   the stream is done, for the built-in providers and script providers alike.
+- `lev serve` cut `POST /api/mcp/servers/{name}/login`, `POST
+  /api/mcp/servers/{name}/test` and `POST /api/doctor/live` at the 30 s
+  request deadline. The login waits up to 300 s for the browser's consent
+  page, so the handler was dropped, and the loopback listener and PKCE
+  state with it, while the operator was still authorizing, and the caller
+  got a 408. Those three routes now take an in-flight slot but no deadline;
+  each is bounded by its own longer one, and the API guide's Limits section
+  lists them.
 - The dashboard's run detail strip could show a cache figure over 100%, such
   as `cache 152%`, on a run that was mostly served from the provider's cache.
   The prompt count every provider is normalised to is the fresh input only,

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -759,6 +759,41 @@ mod tests {
         assert_eq!(routes_in("fn main() {}"), Vec::new());
     }
 
+    /// Every deadline exemption names a route the router serves, and the API
+    /// guide's Limits section names every exemption. A pattern for a route that
+    /// moved would exempt nothing, silently; an exemption the guide does not
+    /// mention is a limit the reader would state wrongly.
+    #[test]
+    fn every_deadline_exemption_is_a_served_route_the_guide_names() {
+        let declared = declared_routes();
+        let limits = API_GUIDE
+            .split("\n## Limits")
+            .nth(1)
+            .and_then(|rest| rest.split("\n## ").next())
+            .expect("api.md has a Limits section");
+        for pattern in request_limits::DEADLINE_EXEMPT {
+            let served = declared.iter().any(|(path, _)| {
+                let mut want = pattern.split('/');
+                let mut have = path.split('/');
+                loop {
+                    match (want.next(), have.next()) {
+                        (None, None) => break true,
+                        (Some("*"), Some(seg)) if seg.starts_with('{') => {}
+                        (Some(a), Some(b)) if a == b => {}
+                        _ => break false,
+                    }
+                }
+            });
+            assert!(served, "{pattern} exempts no route the router serves");
+            // The guide writes the parameter the way the router does.
+            let documented = pattern.replace('*', "{name}");
+            assert!(
+                limits.contains(&documented),
+                "the Limits section of api.md does not name {documented}"
+            );
+        }
+    }
+
     /// Extracted so the `assert!` failure-message region (only executed
     /// when the assertion fails) is covered by this function's own
     /// `#[should_panic]` test below, rather than showing as a

--- a/crates/leviath-cli/src/commands/serve/request_limits.rs
+++ b/crates/leviath-cli/src/commands/serve/request_limits.rs
@@ -18,6 +18,11 @@
 //! for hours, and it is the one place the API streams: every other route
 //! builds its whole body before answering, so cutting a handler at the deadline
 //! never cuts a body in half.
+//!
+//! A few routes are outside the deadline only, listed in [`DEADLINE_EXEMPT`]
+//! with the reason each: they wait on a browser, an MCP server's handshake or
+//! a spawned run, all of which take longer than the default 30 s by design.
+//! They still take a permit, so the cap holds over them.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -101,10 +106,56 @@ impl Gate {
     }
 }
 
-/// Whether a path is one the limits leave alone: the websocket routes, which
+/// Whether a path is one both limits leave alone: the websocket routes, which
 /// hold their connection open by design.
 fn is_exempt(path: &str) -> bool {
     path == "/ws" || path.starts_with("/ws/")
+}
+
+/// The routes that take a permit but get no deadline, as path patterns where
+/// `*` stands for one path segment.
+///
+/// Each of these waits on something slower than a request has any right to
+/// be, and cutting it at the deadline does worse than a slow answer: the
+/// handler future is dropped with whatever it was holding, and the client
+/// gets a 408 for work that was going fine. They still count against the cap,
+/// so a flood of them is refused like any other.
+pub(super) const DEADLINE_EXEMPT: &[&str] = &[
+    // The OAuth flow: opens the operator's browser and waits up to 300 s
+    // (`leviath_mcp::auth::CALLBACK_TIMEOUT`) for the consent page to redirect
+    // to the loopback listener. Dropping it mid-wait loses the listener and
+    // the PKCE state, so the redirect lands on a closed port.
+    "/api/mcp/servers/*/login",
+    // Connects to the server and lists its tools, under the MCP client's own
+    // deadlines: 30 s for the handshake and 120 s for the listing, both
+    // longer than the default request deadline.
+    "/api/mcp/servers/*/test",
+    // The billed doctor: two provider calls under the probe's 60 s request
+    // timeout, then a throwaway run through the daemon waited on for up to
+    // 90 s. It is admin-only and single-flight already.
+    "/api/doctor/live",
+];
+
+/// Whether `path` is one of the [`DEADLINE_EXEMPT`] routes.
+fn deadline_exempt(path: &str) -> bool {
+    DEADLINE_EXEMPT
+        .iter()
+        .any(|pattern| matches_route(pattern, path))
+}
+
+/// Segment-by-segment match of `path` against `pattern`, where `*` stands
+/// for exactly one non-empty segment. Nothing matches a prefix or a suffix.
+fn matches_route(pattern: &str, path: &str) -> bool {
+    let mut want = pattern.split('/');
+    let mut have = path.split('/');
+    loop {
+        match (want.next(), have.next()) {
+            (None, None) => return true,
+            (Some("*"), Some(segment)) if !segment.is_empty() => {}
+            (Some(expected), Some(segment)) if expected == segment => {}
+            _ => return false,
+        }
+    }
 }
 
 /// The layer itself. Outermost after CORS, so a request the auth layer
@@ -139,19 +190,20 @@ pub(super) async fn limit_requests(
         },
     };
 
-    match gate.limits.timeout() {
-        None => next.run(req).await,
-        Some(deadline) => match tokio::time::timeout(deadline, next.run(req)).await {
-            Ok(response) => response,
-            Err(_) => err(
-                StatusCode::REQUEST_TIMEOUT,
-                format!(
-                    "request took longer than {} s",
-                    gate.limits.request_timeout_secs
-                ),
-            )
-            .into_response(),
-        },
+    let deadline = match gate.limits.timeout() {
+        Some(deadline) if !deadline_exempt(req.uri().path()) => deadline,
+        _ => return next.run(req).await,
+    };
+    match tokio::time::timeout(deadline, next.run(req)).await {
+        Ok(response) => response,
+        Err(_) => err(
+            StatusCode::REQUEST_TIMEOUT,
+            format!(
+                "request took longer than {} s",
+                gate.limits.request_timeout_secs
+            ),
+        )
+        .into_response(),
     }
 }
 
@@ -163,7 +215,7 @@ mod tests {
 
     use axum::Router;
     use axum::body::Body;
-    use axum::routing::get;
+    use axum::routing::{get, post};
     use tokio::sync::Notify;
     use tower::ServiceExt;
 
@@ -178,6 +230,14 @@ mod tests {
 
     fn request(path: &str) -> Request {
         Request::builder().uri(path).body(Body::empty()).unwrap()
+    }
+
+    fn post_request(path: &str) -> Request {
+        Request::builder()
+            .method("POST")
+            .uri(path)
+            .body(Body::empty())
+            .unwrap()
     }
 
     async fn error_of(response: Response) -> String {
@@ -250,6 +310,109 @@ mod tests {
         // A path that merely starts with the letters is not a websocket.
         let response = app(limits, router).oneshot(request("/wsx")).await.unwrap();
         assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT);
+    }
+
+    /// The routes that legitimately outlive the deadline: an OAuth login waits
+    /// on a person at a consent page, an MCP test on a server's handshake, a
+    /// live doctor on provider calls and a spawned run. Each finishes under a
+    /// deadline it would otherwise have blown, and a lookalike path does not.
+    #[tokio::test(start_paused = true)]
+    async fn the_long_routes_outlive_the_deadline() {
+        let limits = RequestLimits {
+            max_concurrent_requests: 64,
+            request_timeout_secs: 1,
+        };
+        let router = Router::new()
+            .route("/api/mcp/servers/{name}/login", post(slow))
+            .route("/api/mcp/servers/{name}/test", post(slow))
+            .route("/api/doctor/live", post(slow))
+            .route("/api/doctor", get(slow))
+            .route("/api/mcp/servers/{name}/status", get(slow));
+        for path in [
+            "/api/mcp/servers/navigator/login",
+            "/api/mcp/servers/navigator/test",
+            "/api/doctor/live",
+        ] {
+            let response = app(limits, router.clone())
+                .oneshot(post_request(path))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "{path}");
+        }
+        // The offline doctor and a status read are ordinary routes.
+        for path in ["/api/doctor", "/api/mcp/servers/navigator/status"] {
+            let response = app(limits, router.clone())
+                .oneshot(request(path))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::REQUEST_TIMEOUT, "{path}");
+        }
+    }
+
+    /// A route outside the deadline is still inside the cap: a parked login
+    /// holds the only permit, so the next request is refused.
+    #[tokio::test]
+    async fn a_deadline_exempt_route_still_takes_a_permit() {
+        let limits = RequestLimits {
+            max_concurrent_requests: 1,
+            request_timeout_secs: 1,
+        };
+        let parked = Arc::new(Parked::default());
+        let app = app(
+            limits,
+            Router::new()
+                .route("/api/mcp/servers/{name}/login", post(super::tests::parked))
+                .route("/api/agents", get(super::tests::parked))
+                .with_state(Arc::clone(&parked)),
+        );
+        let login = {
+            let app = app.clone();
+            tokio::spawn(async move {
+                app.oneshot(post_request("/api/mcp/servers/navigator/login"))
+                    .await
+                    .unwrap()
+            })
+        };
+        while parked.arrived.load(Ordering::SeqCst) < 1 {
+            tokio::task::yield_now().await;
+        }
+        let refused = app.clone().oneshot(request("/api/agents")).await.unwrap();
+        assert_eq!(refused.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(
+            error_of(refused).await,
+            "too many requests in flight (the cap is 1)"
+        );
+        parked.release.notify_waiters();
+        assert_eq!(login.await.unwrap().status(), StatusCode::OK);
+        // The permit came back with the response.
+        parked.release.notify_one();
+        let after = app.oneshot(request("/api/agents")).await.unwrap();
+        assert_eq!(after.status(), StatusCode::OK);
+    }
+
+    /// The pattern matcher, segment by segment: `*` stands for one segment,
+    /// never zero and never several, and nothing matches a prefix.
+    #[test]
+    fn an_exempt_pattern_matches_one_segment_per_star() {
+        assert!(matches_route(
+            "/api/mcp/servers/*/login",
+            "/api/mcp/servers/a/login"
+        ));
+        assert!(!matches_route(
+            "/api/mcp/servers/*/login",
+            "/api/mcp/servers//login"
+        ));
+        assert!(!matches_route(
+            "/api/mcp/servers/*/login",
+            "/api/mcp/servers/a/b/login"
+        ));
+        assert!(!matches_route(
+            "/api/mcp/servers/*/login",
+            "/api/mcp/servers/a/login/x"
+        ));
+        assert!(!matches_route("/api/doctor/live", "/api/doctor"));
+        assert!(!matches_route("/api/doctor/live", "/api/doctor/liver"));
+        assert!(matches_route("/api/doctor/live", "/api/doctor/live"));
     }
 
     /// A handler that parks until the test releases it, counting arrivals so

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -79,6 +79,17 @@ place the API streams, so every other route has built its whole body before the 
 cut it. An unauthenticated request takes a slot while it is being refused, so a flood without a
 token is refused at the cap like any other.
 
+Three routes take a slot but have no deadline, because each waits on something slower than the
+default by design and dropping it partway does damage a late answer would not:
+
+| Route | What it waits on |
+|---|---|
+| `POST /api/mcp/servers/{name}/login` | The operator at the consent page, up to 300 s. Dropping it closes the loopback listener the browser redirects to. |
+| `POST /api/mcp/servers/{name}/test` | The MCP server's handshake and tool listing, under the MCP client's own 30 s and 120 s deadlines. |
+| `POST /api/doctor/live` | Two billed provider calls and a throwaway run, up to the doctor's own 90 s. |
+
+Each is bounded by the deadline named in the table, so none can hold its slot forever.
+
 Neither limit is a ceiling on the runs behind the API. A spawn whose daemon takes a minute still
 spawns; the route answers as soon as the daemon has accepted it. `GET /api/config` reports the
 values in force under `limits.max_concurrent_requests` and `limits.request_timeout_secs`, so a


### PR DESCRIPTION
Plan item 1.2 (audit round 4).

## Premise check

- `crates/leviath-cli/src/commands/serve/request_limits.rs:106` `is_exempt` covers only `/ws` and `/ws/*`; every other route runs under `tokio::time::timeout(deadline, next.run(req))`, and the handler future is dropped at the deadline (default 30 s).
- `crates/leviath-mcp/src/auth/mod.rs:43` `CALLBACK_TIMEOUT = 300 s`; `:207` `wait_for_callback(listener, ...)` holds the loopback listener and the PKCE state inside the handler future. Dropping the future closes the port the browser redirects to.
- Every route in `serve/mod.rs` was read for anything that awaits a daemon run, a browser or a remote handshake. Three can legitimately exceed 30 s:

| Route | What it waits on | Bounded by |
|---|---|---|
| `POST /api/mcp/servers/{name}/login` | the operator at the consent page | `CALLBACK_TIMEOUT` 300 s |
| `POST /api/mcp/servers/{name}/test` | the MCP handshake and tool listing (`serve/mcp.rs:373`) | `DEFAULT_CONNECT_TIMEOUT` 30 s + `DEFAULT_REQUEST_TIMEOUT` 120 s (`leviath-mcp/src/transport/mod.rs:38,45`) |
| `POST /api/doctor/live` | two provider calls and a spawned run (`serve/doctor.rs:50-55`) | the probe's 60 s and the doctor's 90 s |

  Not exempted, measured: `POST /api/update` returns a job id at once; `POST /api/models/probe` carries its own 10 s deadline (see #1.9); `GET /api/doctor` is offline only; spawn, pause, resume, message and interaction routes are a single control-socket round trip.

## Fix

`DEADLINE_EXEMPT`, a table of path patterns beside `is_exempt` with a comment per route, and `deadline_exempt()` matching segment by segment (`*` is exactly one non-empty segment; no prefix matches). An exempt route still takes the in-flight permit; only the `timeout` wrap is skipped. The websocket routes are unchanged.

## Fail-first

`the_long_routes_outlive_the_deadline` against the unfixed layer:

```
thread '...the_long_routes_outlive_the_deadline' panicked at request_limits.rs:334:13:
assertion `left == right` failed: /api/mcp/servers/navigator/login
  left: 408
 right: 200
```

Also added: `a_deadline_exempt_route_still_takes_a_permit` (cap 1, login parked, a second request gets 503 with the cap message, and the permit comes back), `an_exempt_pattern_matches_one_segment_per_star`, and in `serve/mod.rs` `every_deadline_exemption_is_a_served_route_the_guide_names` (each pattern matches a declared route, and the Limits section of `docs/content/api.md` names it).

## Live

`lev serve --allow-admin --request-timeout-secs 1` (`LEVIATH_API_TOKEN`, short `LEVIATH_HOME`, `LEVIATH_SKIP_DOTENV=1`, `start_new_session=True`), one HTTP MCP server configured whose stub answers every request after a 3 s sleep, so the login blocks on discovery for 3 s without opening a browser.

Unfixed `request_limits.rs` (origin/main), same binary otherwise:

```
POST /api/mcp/servers/stub/login -> 408 after 1.02 s: {"error":"request took longer than 1 s"}
POST /api/mcp/servers/stub/test  -> 408 after 1.00 s: {"error":"request took longer than 1 s"}
```

This branch:

```
POST /api/mcp/servers/stub/login -> 200 after 3.04 s: {"server":"stub","status":"not_required"}
POST /api/mcp/servers/stub/test  -> 502 after 6.02 s: {"error":"MCP server rejected the event stream with HTTP 404 Not Found"}
```

## Docs and changelog

`docs/content/api.md` Limits section: a table of the three routes and what bounds each. CHANGELOG under Fixed.

## Gates

`cargo fmt --all`, `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`, `cargo xtask structure`, `cargo xtask docs`, `cargo xtask coverage --package leviath-cli` (100%), pre-commit full suite. No `main.rs` touched.
