### PR TITLE
fix(providers): carry a split character across streamed chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,12 @@ same list.
   got a 408. Those three routes now take an in-flight slot but no deadline;
   each is bounded by its own longer one, and the API guide's Limits section
   lists them.
+- A streamed reply no longer loses text when the transport splits a
+  character across two chunks. The stream reader checked every chunk for
+  UTF-8 on its own and dropped any that failed, so a CJK character, an emoji
+  or a dash cut at a socket boundary took the whole chunk around it with no
+  error. The incomplete bytes are now carried into the next chunk, and bytes
+  that could never be UTF-8 are marked with U+FFFD rather than dropped.
 - The dashboard's run detail strip could show a cache figure over 100%, such
   as `cache 152%`, on a run that was mostly served from the provider's cache.
   The prompt count every provider is normalised to is the fresh input only,

--- a/crates/leviath-providers/src/anthropic.rs
+++ b/crates/leviath-providers/src/anthropic.rs
@@ -3520,20 +3520,24 @@ mod tests {
         assert!(sse.next().await.is_none());
     }
 
+    /// A character the transport cut in two arrives whole, and bytes that
+    /// could never be UTF-8 are marked rather than dropped with their frame.
     #[tokio::test]
-    async fn sse_stream_skips_invalid_utf8_bytes_and_continues() {
+    async fn sse_stream_keeps_a_split_character_and_marks_bad_bytes() {
         use tokio_stream::StreamExt;
-        // First chunk is invalid UTF-8 → skipped without adding to buffer.
-        // Second chunk is a valid SSE event.
-        let invalid = vec![0xFF, 0xFE, 0x00]; // invalid UTF-8
-        let valid = b"event: content_block_delta\ndata: {\"delta\":{\"type\":\"text_delta\",\"text\":\"ok\"}}\n\n".to_vec();
+        let mut first =
+            b"event: content_block_delta\ndata: {\"delta\":{\"type\":\"text_delta\",\"text\":\"o"
+                .to_vec();
+        first.extend_from_slice(&[0xFF, 0xE5, 0xAE]);
+        let mut second = vec![0x8C];
+        second.extend_from_slice(b"k\"}}\n\n");
         let stream = StaticByteStream {
-            data: vec![invalid, valid],
+            data: vec![first, second],
             idx: 0,
         };
         let mut sse = anthropic_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
-        assert_eq!(chunk.delta, "ok");
+        assert_eq!(chunk.delta, "o\u{FFFD}\u{5B8C}k");
     }
 
     #[test]

--- a/crates/leviath-providers/src/ollama.rs
+++ b/crates/leviath-providers/src/ollama.rs
@@ -2822,10 +2822,10 @@ mod tests {
         assert_eq!(models[0].id, "llama3-8b");
     }
 
+    /// A character the transport cut in two arrives whole through the framed
+    /// stream, and bytes that could never be UTF-8 are marked, not dropped.
     #[test]
-    fn ndjson_stream_skips_invalid_utf8_chunk_and_continues() {
-        // covers the implicit else of `if let Ok(text) = from_utf8(&bytes)` in
-        // the framed stream
+    fn ndjson_stream_keeps_a_split_character_and_marks_bad_bytes() {
         use futures_core::Stream;
         use std::pin::Pin;
         use std::task::{Context, Poll};
@@ -2850,11 +2850,12 @@ mod tests {
             }
         }
 
-        let invalid_utf8 = vec![0xFF, 0xFE, 0x00];
-        let valid_chunk =
-            b"{\"message\":{\"role\":\"assistant\",\"content\":\"ok\"},\"done\":false}\n".to_vec();
+        let mut first = b"{\"message\":{\"role\":\"assistant\",\"content\":\"o".to_vec();
+        first.extend_from_slice(&[0xFF, 0xF0, 0x9F]);
+        let mut second = vec![0x8E, 0x89];
+        second.extend_from_slice(b"k\"},\"done\":false}\n");
         let stream = StaticStream {
-            data: vec![invalid_utf8, valid_chunk],
+            data: vec![first, second],
             idx: 0,
         };
         let ndjson_stream = ollama_ndjson_stream(stream);
@@ -2863,7 +2864,7 @@ mod tests {
             use tokio_stream::StreamExt;
             let chunks: Vec<_> = ndjson_stream.collect().await;
             assert_eq!(chunks.len(), 1);
-            assert_eq!(chunks[0].as_ref().unwrap().delta, "ok");
+            assert_eq!(chunks[0].as_ref().unwrap().delta, "o\u{FFFD}\u{1F389}k");
         });
     }
 

--- a/crates/leviath-providers/src/openai_compat.rs
+++ b/crates/leviath-providers/src/openai_compat.rs
@@ -2383,20 +2383,24 @@ mod tests {
         assert!(sse.next().await.is_none());
     }
 
+    /// A chunk that is not UTF-8 on its own is not thrown away: a character
+    /// cut by the transport is joined back together, and bytes that could
+    /// never be UTF-8 are marked in the text rather than dropped with the
+    /// frame around them.
     #[tokio::test]
-    async fn openai_sse_stream_skips_invalid_utf8_chunk_and_continues() {
-        // covers the implicit else of `if let Ok(text) = from_utf8(&bytes)`
+    async fn openai_sse_stream_keeps_a_split_character_and_marks_bad_bytes() {
         use tokio_stream::StreamExt;
+        let mut first = b"data: {\"choices\":[{\"delta\":{\"content\":\"o".to_vec();
+        first.extend_from_slice(&[0xFF, 0xF0, 0x9F]);
+        let mut second = vec![0x8E, 0x89];
+        second.extend_from_slice(b"k\"}}]}\n\n");
         let stream = StaticByteStream {
-            data: vec![
-                vec![0xFF, 0xFE, 0x00],
-                b"data: {\"choices\":[{\"delta\":{\"content\":\"ok\"}}]}\n\n".to_vec(),
-            ],
+            data: vec![first, second],
             idx: 0,
         };
         let mut sse = openai_sse_stream(stream);
         let chunk = sse.next().await.unwrap().unwrap();
-        assert_eq!(chunk.delta, "ok");
+        assert_eq!(chunk.delta, "o\u{FFFD}\u{1F389}k");
     }
 
     // ─── MessageContent::Blocks code paths in build_openai_request_body ────

--- a/crates/leviath-providers/src/provider/stream.rs
+++ b/crates/leviath-providers/src/provider/stream.rs
@@ -40,6 +40,74 @@ pub type FrameFn = Box<dyn FnMut(&mut String) -> Option<Option<Result<StreamChun
 /// trailing newline, so its last line can only be read here.
 pub type FlushFn = Box<dyn FnMut(&mut String) -> Option<StreamChunk> + Send>;
 
+/// The bytes of a character the transport cut in half, held until the rest
+/// arrives.
+///
+/// `bytes_stream()` hands over whatever the socket had, and the socket does
+/// not know where a character ends: a four-byte emoji, a CJK character or a
+/// dash inside a delta is routinely split over two chunks. Checking each
+/// chunk on its own and dropping the ones that failed lost the whole chunk
+/// around the split, silently. Decoding the longest valid prefix and carrying
+/// the rest into the next chunk loses nothing; bytes that could never be
+/// UTF-8 become U+FFFD, so a peer that sends garbage is visible in the
+/// output rather than absent from it.
+#[derive(Default)]
+pub(crate) struct Utf8Carry {
+    tail: Vec<u8>,
+}
+
+impl Utf8Carry {
+    /// Decode `bytes` (after whatever was carried) onto `out`, keeping an
+    /// incomplete trailing character back for the next call.
+    pub(crate) fn push(&mut self, bytes: &[u8], out: &mut String) {
+        let owned;
+        let mut input: &[u8] = if self.tail.is_empty() {
+            bytes
+        } else {
+            self.tail.extend_from_slice(bytes);
+            owned = std::mem::take(&mut self.tail);
+            &owned
+        };
+        loop {
+            match std::str::from_utf8(input) {
+                Ok(text) => {
+                    out.push_str(text);
+                    return;
+                }
+                Err(e) => {
+                    let valid = e.valid_up_to();
+                    // The prefix was checked by the failed call above.
+                    out.push_str(&String::from_utf8_lossy(&input[..valid]));
+                    match e.error_len() {
+                        Some(bad) => {
+                            out.push('\u{FFFD}');
+                            input = &input[valid + bad..];
+                        }
+                        None => {
+                            self.tail = input[valid..].to_vec();
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// How many bytes are held back, so a frame cap can count them.
+    pub(crate) fn pending(&self) -> usize {
+        self.tail.len()
+    }
+
+    /// The bytes are over: a character still waiting for its end is not
+    /// coming, so mark it rather than lose it.
+    pub(crate) fn finish(&mut self, out: &mut String) {
+        if !self.tail.is_empty() {
+            self.tail.clear();
+            out.push('\u{FFFD}');
+        }
+    }
+}
+
 /// A byte stream cut into [`StreamChunk`]s by a provider-specific framer.
 ///
 /// One `poll_next` for every provider. Three of them used to carry a copy of
@@ -49,6 +117,8 @@ pub type FlushFn = Box<dyn FnMut(&mut String) -> Option<StreamChunk> + Send>;
 pub struct FramedStream {
     inner: ByteStream,
     buffer: String,
+    /// A character the last chunk ended in the middle of.
+    carry: Utf8Carry,
     parse: FrameFn,
     flush: Option<FlushFn>,
     /// The most `buffer` may hold between frames before the stream fails;
@@ -68,6 +138,7 @@ impl FramedStream {
         Self {
             inner: Box::pin(inner),
             buffer: String::new(),
+            carry: Utf8Carry::default(),
             parse,
             flush,
             frame_cap: STREAM_FRAME_CAP,
@@ -104,15 +175,16 @@ impl Stream for FramedStream {
             }
             match this.inner.as_mut().poll_next(cx) {
                 std::task::Poll::Ready(Some(Ok(bytes))) => {
-                    if let Ok(text) = std::str::from_utf8(&bytes) {
-                        this.buffer.push_str(text);
-                    }
+                    this.carry.push(&bytes, &mut this.buffer);
                     // Checked after the frames were cut (the top of the
                     // loop), so what is measured is one partial frame: a peer
-                    // that never sends a boundary, not a fast one.
-                    if let Err(msg) =
-                        frame_within_cap(this.buffer.len(), this.frame_cap, &this.peer)
-                    {
+                    // that never sends a boundary, not a fast one. The bytes
+                    // held back for the next chunk are part of that frame.
+                    if let Err(msg) = frame_within_cap(
+                        this.buffer.len() + this.carry.pending(),
+                        this.frame_cap,
+                        &this.peer,
+                    ) {
                         this.buffer.clear();
                         return std::task::Poll::Ready(Some(Err(ProviderError::InvalidResponse(
                             msg,
@@ -128,6 +200,7 @@ impl Stream for FramedStream {
                 std::task::Poll::Ready(None) => {
                     // The bytes are over: a frame that arrived whole with the
                     // last of them, then whatever the format does with a tail.
+                    this.carry.finish(&mut this.buffer);
                     if let Some(item) = (this.parse)(&mut this.buffer) {
                         return std::task::Poll::Ready(item);
                     }
@@ -313,6 +386,94 @@ mod tests {
             "Invalid response: stream frame exceeded 4096 bytes from api.example"
         );
         assert!(stream.buffer.is_empty(), "the oversized frame is released");
+    }
+
+    // ─── UTF-8 across chunk boundaries ──────────────────────────────────────
+
+    /// A framed stream over `chunks`, cut on newlines: every line is one text
+    /// chunk, and a last line with no newline is flushed at the end.
+    fn line_framed(chunks: Vec<Vec<u8>>) -> FramedStream {
+        let bytes = chunks
+            .into_iter()
+            .map(|c| Ok::<bytes::Bytes, reqwest::Error>(bytes::Bytes::from(c)));
+        FramedStream::new(
+            tokio_stream::iter(bytes),
+            Box::new(|buffer: &mut String| {
+                let idx = buffer.find('\n')?;
+                let line: String = buffer.drain(..=idx).collect();
+                Some(Some(Ok(text_chunk(line.trim_end_matches('\n')))))
+            }),
+            Some(Box::new(|buffer: &mut String| {
+                if buffer.is_empty() {
+                    None
+                } else {
+                    Some(text_chunk(&std::mem::take(buffer)))
+                }
+            })),
+        )
+    }
+
+    async fn deltas(mut stream: FramedStream) -> Vec<String> {
+        use tokio_stream::StreamExt as _;
+        let mut out = Vec::new();
+        while let Some(item) = stream.next().await {
+            out.push(item.expect("a text chunk").delta);
+        }
+        out
+    }
+
+    /// The transport cuts wherever it likes, including through a character.
+    /// reqwest's `bytes_stream()` hands over whatever the socket had, so a
+    /// four-byte emoji is routinely two bytes in one chunk and two in the
+    /// next; both halves used to be thrown away, and the run lost the whole
+    /// chunk around them with no error.
+    #[tokio::test]
+    async fn a_character_split_across_two_chunks_arrives_whole() {
+        let text = "done 🎉\n".as_bytes();
+        // The emoji is bytes 5..9: split it 2+2.
+        let stream = line_framed(vec![text[..7].to_vec(), text[7..].to_vec()]);
+        assert_eq!(deltas(stream).await, vec!["done 🎉".to_string()]);
+    }
+
+    /// A three-byte CJK character cut 1+2, with the cut chunk carrying more
+    /// text on either side: the neighbours survive with it.
+    #[tokio::test]
+    async fn a_three_byte_character_split_one_and_two_arrives_whole() {
+        let text = "完成\n".as_bytes();
+        let stream = line_framed(vec![text[..4].to_vec(), text[4..].to_vec()]);
+        assert_eq!(deltas(stream).await, vec!["完成".to_string()]);
+    }
+
+    /// A stream that stops inside a character: what came before it is kept,
+    /// and the torn character is marked rather than silently gone.
+    #[tokio::test]
+    async fn a_partial_character_at_stream_end_is_marked_not_dropped() {
+        let text = "done 🎉".as_bytes();
+        let stream = line_framed(vec![text[..7].to_vec()]);
+        assert_eq!(deltas(stream).await, vec!["done \u{FFFD}".to_string()]);
+    }
+
+    /// Bytes that can never be UTF-8 are replaced, one marker per bad
+    /// sequence, and the good text around them is kept. The frame cap counts
+    /// the bytes held back for the next chunk.
+    #[test]
+    fn utf8_carry_replaces_invalid_bytes_and_counts_its_tail() {
+        let mut carry = Utf8Carry::default();
+        let mut out = String::new();
+        carry.push(&[b'a', 0xFF, 0xFE, b'b'], &mut out);
+        assert_eq!(out, "a\u{FFFD}\u{FFFD}b");
+        assert_eq!(carry.pending(), 0);
+        // One lead byte of a three-byte character is held, not decoded.
+        carry.push(&[0xE5], &mut out);
+        assert_eq!(out, "a\u{FFFD}\u{FFFD}b");
+        assert_eq!(carry.pending(), 1);
+        carry.push(&[0xAE, 0x8C], &mut out);
+        assert_eq!(out, "a\u{FFFD}\u{FFFD}b完");
+        assert_eq!(carry.pending(), 0);
+        carry.push(&[0xF0, 0x9F], &mut out);
+        carry.finish(&mut out);
+        assert_eq!(out, "a\u{FFFD}\u{FFFD}b完\u{FFFD}");
+        assert_eq!(carry.pending(), 0);
     }
 
     #[tokio::test]

--- a/crates/leviath-providers/src/rhai_provider/host.rs
+++ b/crates/leviath-providers/src/rhai_provider/host.rs
@@ -7,6 +7,7 @@
 //! tests inject a fake so no socket is ever bound. Rate limiting lives in the
 //! provider (around the executor), not here - the executor is pure transport.
 
+use crate::provider::stream::Utf8Carry;
 use leviath_net::read_caps::{
     BodyReadError, JSON_BODY_CAP, STREAM_FRAME_CAP, frame_within_cap, peer_of, read_text_capped,
 };
@@ -465,14 +466,14 @@ pub(crate) async fn forward_sse<S, E>(
     use tokio_stream::StreamExt;
     tokio::pin!(stream);
     let mut buffer = String::new();
+    let mut carry = Utf8Carry::default();
     while let Some(item) = stream.next().await {
         match item {
             Ok(bytes) => {
-                if let Ok(text) = std::str::from_utf8(&bytes) {
-                    buffer.push_str(text);
-                }
+                carry.push(&bytes, &mut buffer);
                 let events_drained = drain_sse_events(&mut buffer);
-                if let Err(msg) = frame_within_cap(buffer.len(), frame_cap, peer) {
+                if let Err(msg) = frame_within_cap(buffer.len() + carry.pending(), frame_cap, peer)
+                {
                     let _ = events.send(Err(HostHttpError::Api(msg))).await;
                     return;
                 }
@@ -496,6 +497,7 @@ pub(crate) async fn forward_sse<S, E>(
         }
     }
     // Flush a trailing event that had no final blank line.
+    carry.finish(&mut buffer);
     if let Some(SseEvent::Data(payload)) = final_sse_event(&buffer) {
         let _ = events.send(Ok(payload)).await;
     }

--- a/crates/leviath-providers/src/rhai_provider/host/tests.rs
+++ b/crates/leviath-providers/src/rhai_provider/host/tests.rs
@@ -117,17 +117,35 @@ async fn forward_sse_flushes_trailing_event() {
     assert_eq!(rx.recv().await.unwrap().unwrap(), "{\"tail\":1}");
 }
 
+/// A stream that ends after a complete event, with no `[DONE]` and nothing
+/// held back, flushes nothing and closes the channel.
 #[tokio::test]
-async fn forward_sse_skips_invalid_utf8_and_ends_clean() {
-    // First chunk is invalid UTF-8 (skipped); then a complete event and a
-    // clean end (no [DONE], empty buffer → no trailing flush).
-    let chunks: Vec<Result<bytes::Bytes, String>> = vec![
-        Ok(bytes::Bytes::from(vec![0xff, 0xfe])),
-        Ok(bytes::Bytes::from("data: a\n\n")),
-    ];
+async fn forward_sse_ends_clean_with_an_empty_buffer() {
+    let chunks: Vec<Result<bytes::Bytes, String>> = vec![Ok(bytes::Bytes::from("data: a\n\n"))];
     let (tx, mut rx) = mpsc::channel(16);
     forward_sse(tokio_stream::iter(chunks), tx, STREAM_FRAME_CAP, "test").await;
     assert_eq!(rx.recv().await.unwrap().unwrap(), "a");
+    assert!(rx.recv().await.is_none());
+}
+
+/// A character the transport cut in two arrives whole, bytes that could
+/// never be UTF-8 are marked rather than dropped, and a character the stream
+/// ended inside is marked in the trailing flush.
+#[tokio::test]
+async fn forward_sse_keeps_a_split_character_and_marks_bad_bytes() {
+    let mut first = b"data: a".to_vec();
+    first.extend_from_slice(&[0xff, 0xf0, 0x9f]);
+    let mut second = vec![0x8e, 0x89];
+    second.extend_from_slice(b"\n\ndata: b");
+    let chunks: Vec<Result<bytes::Bytes, String>> = vec![
+        Ok(bytes::Bytes::from(first)),
+        Ok(bytes::Bytes::from(second)),
+        Ok(bytes::Bytes::from(vec![0xe5])),
+    ];
+    let (tx, mut rx) = mpsc::channel(16);
+    forward_sse(tokio_stream::iter(chunks), tx, STREAM_FRAME_CAP, "test").await;
+    assert_eq!(rx.recv().await.unwrap().unwrap(), "a\u{FFFD}\u{1F389}");
+    assert_eq!(rx.recv().await.unwrap().unwrap(), "b\u{FFFD}");
     assert!(rx.recv().await.is_none());
 }
 

--- a/perf-tools/harness.sh
+++ b/perf-tools/harness.sh
@@ -8,6 +8,8 @@
 #   LV_RUNS_DIR    optional; forwarded as LEVIATH_RUNS_DIR (the fake-runs corpus)
 #   LV_MOCK_OVERSIZE_MIB  optional; forwarded to mock.py, which then answers
 #                  every completion with one frame that never closes
+#   LV_MOCK_SPLIT_UTF8  optional; forwarded to mock.py, which then streams a
+#                  reply with CJK and an emoji, flushed mid-character
 #
 # Nothing here reads the caller's environment: `env -i` first, then exactly
 # these names, so a probe cannot accidentally reach a real provider.
@@ -32,6 +34,7 @@ exec env -i \
   TERM="${TERM:-xterm-256color}" \
   ${LV_RUNS_DIR:+LEVIATH_RUNS_DIR="$LV_RUNS_DIR"} \
   ${LV_MOCK_OVERSIZE_MIB:+LV_MOCK_OVERSIZE_MIB="$LV_MOCK_OVERSIZE_MIB"} \
+  ${LV_MOCK_SPLIT_UTF8:+LV_MOCK_SPLIT_UTF8="$LV_MOCK_SPLIT_UTF8"} \
   LV_MOCK_PORT="$LV_MOCK_PORT" \
   ${LV_SERVE_PORT:+LV_SERVE_PORT="$LV_SERVE_PORT"} \
   LV_BIN="$LV_BIN" \

--- a/perf-tools/mock.py
+++ b/perf-tools/mock.py
@@ -25,6 +25,10 @@ Routes:
 Set `LV_MOCK_OVERSIZE_MIB=N` to answer every completion with N MiB of one
 frame that never closes, for probing the daemon's read caps.
 
+Set `LV_MOCK_SPLIT_UTF8=1` to answer a streamed completion with CJK and an
+emoji in the text, written to the socket in two flushes that cut the emoji
+in half, the way a transport boundary lands inside a character.
+
 The count tally is what makes the context-window guard measurable from the
 outside: a run whose request is under half the model's window must show zero
 count calls, and one above it exactly one per inference.
@@ -32,6 +36,7 @@ count calls, and one above it exactly one per inference.
 import json
 import os
 import sys
+import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
 PORT = int(sys.argv[1])
@@ -42,6 +47,11 @@ ARGS = sys.argv[3] if len(sys.argv) > 3 else "{}"
 # JSON string otherwise), which is what a peer that never stops looks like to
 # the daemon's read caps.
 OVERSIZE_MIB = int(os.environ.get("LV_MOCK_OVERSIZE_MIB", "0"))
+# `LV_MOCK_SPLIT_UTF8=1` makes the streamed answer "done 完成 🎉" and flushes
+# the body in two pieces, the cut two bytes into the four-byte emoji, so the
+# daemon's stream reader sees a chunk that is not UTF-8 on its own.
+SPLIT_UTF8 = os.environ.get("LV_MOCK_SPLIT_UTF8") == "1"
+SPLIT_TEXT = "done 完成 🎉"
 
 
 def tool_calls(streaming):
@@ -185,7 +195,7 @@ class Handler(BaseHTTPRequestHandler):
             delta = {"role": "assistant", "tool_calls": tool_calls(streaming=True)}
             finish = "tool_calls"
         else:
-            delta = {"role": "assistant", "content": "done"}
+            delta = {"role": "assistant", "content": SPLIT_TEXT if SPLIT_UTF8 else "done"}
             finish = "stop"
         chunks = [
             {"id": "c1", "object": "chat.completion.chunk", "model": "gpt-mock",
@@ -194,12 +204,20 @@ class Handler(BaseHTTPRequestHandler):
              "choices": [{"index": 0, "delta": {}, "finish_reason": finish}]},
             {"id": "c1", "object": "chat.completion.chunk", "model": "gpt-mock", "choices": [], "usage": USAGE},
         ]
-        body = "".join(f"data: {json.dumps(c)}\n\n" for c in chunks) + "data: [DONE]\n\n"
-        body = body.encode()
+        body = "".join(f"data: {json.dumps(c, ensure_ascii=False)}\n\n" for c in chunks)
+        body = (body + "data: [DONE]\n\n").encode()
         self.send_response(200)
         self.send_header("content-type", "text/event-stream")
         self.send_header("content-length", str(len(body)))
         self.end_headers()
+        if SPLIT_UTF8 and not want_tool:
+            # Two bytes into the emoji: the first flush ends mid-character.
+            cut = body.index("🎉".encode()) + 2
+            self.wfile.write(body[:cut])
+            self.wfile.flush()
+            time.sleep(0.2)
+            self.wfile.write(body[cut:])
+            return
         self.wfile.write(body)
 
 


### PR DESCRIPTION
Plan item 1.5: a streamed chunk that splits a multi-byte character was dropped.

## Premise check

Held, and in two places.

- `crates/leviath-providers/src/provider/stream.rs:107` (the single `FramedStream::poll_next` every provider parser shares since #689) did `if let Ok(text) = std::str::from_utf8(&bytes) { push }` and silently skipped any chunk that was not valid UTF-8 on its own.
- `crates/leviath-providers/src/rhai_provider/host.rs:471` (`forward_sse`, the Rhai provider's SSE path) had its own copy of the same check.
- Four tests pinned the drop as intended: `openai_compat.rs:2387`, `anthropic.rs:3521`, `ollama.rs:2826`, `rhai_provider/host/tests.rs:121`.
- The #709 frame cap (`frame_within_cap`) is applied after the push and measured only `buffer.len()`.

## Fix

`Utf8Carry` in `provider/stream.rs`: decode the longest valid prefix (`Utf8Error::valid_up_to`), replace a sequence that can never be UTF-8 (`error_len() == Some`) with U+FFFD, and hold an incomplete tail (`error_len() == None`) for the next chunk. At stream end a tail that never completed becomes U+FFFD. The frame cap now counts `buffer.len() + carry.pending()`. Both decoders use it.

The four pinned-drop tests now put the bad bytes and a split character inside a delta and assert `o\u{FFFD}\u{1F389}k` style replacement, not loss.

## Fail-first evidence

Three new tests in `provider/stream.rs`, run against the unfixed poll loop (the carry type present but not wired in):

```
test provider::stream::tests::a_partial_character_at_stream_end_is_marked_not_dropped ... FAILED
  left: []   right: ["done \u{FFFD}"]
test provider::stream::tests::a_three_byte_character_split_one_and_two_arrives_whole ... FAILED
  left: []   right: ["完成"]
test provider::stream::tests::a_character_split_across_two_chunks_arrives_whole ... FAILED
  left: []   right: ["done 🎉"]
```

Every one lost the whole delta, not just the split character. All pass after the fix.

## Live check

`perf-tools/mock.py` grew `LV_MOCK_SPLIT_UTF8=1` (forwarded by `harness.sh`): the streamed reply is `done 完成 🎉`, written in two flushes cut two bytes into the emoji. One probe run each through `harness.sh`, same mock, same knob, isolated homes:

Before (`~/.cargo/bin/lev` 0.5.5, unfixed):

```
"status": "paused", "output": "", "mock_completions": 5
```

with the run's pause reason `stream ended before the model said it had finished - the connection died before the answer finished arriving`: both halves were dropped, every retry looked like a dead connection, and the run parked.

After (this branch, release build):

```
"status": "complete", "output": "done 完成 🎉\ndone 完成 🎉\ndone 完成 🎉\ndone 完成 🎉\n", "mock_completions": 5
```

## Gates

`cargo fmt --all`; `cargo clippy --all-targets --all-features -p leviath-providers -- -D warnings`; `cargo xtask structure`; `cargo xtask docs`; `cargo xtask coverage --package leviath-providers` at 100% (992 tests). Pre-commit ran the full suite. CHANGELOG under Unreleased / Fixed.
