### PR TITLE
fix(dash): help text that disagreed with the keys, and three fixed widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,23 @@ same list.
   or a dash cut at a socket boundary took the whole chunk around it with no
   error. The incomplete bytes are now carried into the next chunk, and bytes
   that could never be UTF-8 are marked with U+FFFD rather than dropped.
+- The dashboard's help said things its keys no longer do. The bottom bar
+  gave an in-place edit "[Enter] confirm" while Enter broke the line, the
+  Questions section of `?` offered `Space` to tick a "don't ask again" box
+  that #708 removed, and the detail view's help left out `t` (the band's
+  two pictures) and `R` (snake the path again). The docs page's Detail view
+  table was split in two by a blank line, its main-list table had no row
+  for `a`, and the Start button's `Esc` was undocumented.
+- A toast for work still in flight ("Starting…", "Logging in…", "Testing…")
+  wore the same green check as one for work that had finished, and starting
+  a run unattended was a green check while arming the toggle was a warning.
+  In-flight toasts now have their own glyph, and an unattended start is the
+  warning restated.
+- Three dashboard widths were fixed numbers with the frame in hand: a toast
+  was always 40 columns (off the right edge under 41), a stage tab's name was
+  cut at 10 or 12 columns however wide the strip was, and the kill and delete
+  dialogs cut the run id and title at 20 to 24 characters before the widget
+  had a chance to wrap them. Each is now sized from the area it draws into.
 - The dashboard's run detail strip could show a cache figure over 100%, such
   as `cache 152%`, on a run that was mostly served from the provider's cache.
   The prompt count every provider is normalised to is the fresh input only,

--- a/crates/leviath-cli/src/commands/dashboard/mcp.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mcp.rs
@@ -124,7 +124,7 @@ impl Dashboard {
     pub(super) fn mcp_login_selected(&mut self) {
         if let Some(row) = self.mcp_rows.get(self.mcp_selected) {
             let name = row.name.clone();
-            self.toast(format!("Logging in to '{name}'…"), ToastLevel::Info);
+            self.toast(format!("Logging in to '{name}'…"), ToastLevel::Progress);
             let _ = self.mcp_cmd_tx.send(McpCommand::Login { name });
         }
     }
@@ -133,7 +133,7 @@ impl Dashboard {
     pub(super) fn mcp_test_selected(&mut self) {
         if let Some(row) = self.mcp_rows.get(self.mcp_selected) {
             let name = row.name.clone();
-            self.toast(format!("Testing '{name}'…"), ToastLevel::Info);
+            self.toast(format!("Testing '{name}'…"), ToastLevel::Progress);
             let _ = self.mcp_cmd_tx.send(McpCommand::Test { name });
         }
     }
@@ -600,6 +600,17 @@ mod tests {
             McpCommand::Test {
                 name: "remote".to_string()
             }
+        );
+        // Both are in flight, not done: neither toast wears the check.
+        let in_flight: Vec<_> = dash
+            .toasts
+            .iter()
+            .filter(|t| t.message.ends_with('…'))
+            .collect();
+        assert_eq!(in_flight.len(), 2, "{:?}", dash.toasts);
+        assert!(
+            in_flight.iter().all(|t| t.level == ToastLevel::Progress),
+            "{in_flight:?}"
         );
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/new_run.rs
+++ b/crates/leviath-cli/src/commands/dashboard/new_run.rs
@@ -176,11 +176,13 @@ impl Dashboard {
             workdir: self.new_run_ctx.workdir.display().to_string(),
             yolo: self.new_run_yolo,
         });
-        let how = match self.new_run_yolo {
-            true => " unattended",
-            false => "",
+        // An unattended start is the warning the toggle gave, restated at the
+        // moment it takes effect; an attended one is work in flight, not done.
+        let (how, level) = match self.new_run_yolo {
+            true => (" unattended", ToastLevel::Warning),
+            false => ("", ToastLevel::Progress),
         };
-        self.toast(format!("Starting '{}'{how}…", agent.name), ToastLevel::Info);
+        self.toast(format!("Starting '{}'{how}…", agent.name), level);
         self.add_log(format!("run requested: {}", agent.name));
         // Recorded on the launch rather than on the selection: moving the
         // cursor down the list to read a blueprint's preview is not a choice
@@ -397,8 +399,8 @@ impl Dashboard {
     /// Ctrl+Enter reaches the program only under the kitty keyboard protocol;
     /// a terminal without it sends Ctrl+Enter as a plain Enter, which is a
     /// newline here. That is what the Start button under the editor is for.
-    /// The response pane's editor keeps Enter as send: a reply is one line
-    /// far more often than a task is.
+    /// The response box in the detail view works the same way since #708,
+    /// with a Send button in place of Start.
     fn handle_new_run_task_key(&mut self, key: crossterm::event::KeyEvent) {
         use crossterm::event::{KeyCode, KeyModifiers};
         match key.code {
@@ -1642,5 +1644,32 @@ mod tests {
             .expect("a run was sent");
         assert!(cmd.yolo, "the run carries what the screen was set to");
         assert_eq!(cmd.task, "do the thing");
+        // The toast restates the warning the toggle gave, not a green check.
+        let start = dash
+            .toasts
+            .iter()
+            .find(|t| t.message.starts_with("Starting"))
+            .expect("a start toast");
+        assert!(start.message.contains("unattended"), "{}", start.message);
+        assert_eq!(start.level, ToastLevel::Warning);
+    }
+
+    /// An attended start is work in flight: its toast says so rather than
+    /// wearing the check of a run that has started.
+    #[test]
+    fn an_attended_start_toasts_progress() {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent(&dir.path().join("agents/alpha"), "alpha", "first");
+        let mut dash = dash_at(dir.path());
+        dash.open_new_run_screen();
+        dash.new_run_task.area_mut().insert_str("do the thing");
+        dash.submit_new_run();
+        let start = dash
+            .toasts
+            .iter()
+            .find(|t| t.message.starts_with("Starting"))
+            .expect("a start toast");
+        assert!(!start.message.contains("unattended"), "{}", start.message);
+        assert_eq!(start.level, ToastLevel::Progress);
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/overlays.rs
@@ -9,9 +9,32 @@ use ratatui::widgets::{Clear, Paragraph};
 use crate::commands::dashboard::helpers::truncate;
 use crate::commands::dashboard::state::Dashboard;
 use crate::commands::dashboard::theme::*;
-use crate::commands::dashboard::types::MainPane;
+use crate::commands::dashboard::types::{MainPane, ToastLevel};
 use crate::tui::widgets::help::{HelpSection, draw_help};
 use crate::tui::widgets::markdown_edit::{MODE_CHORD, shortcut_help};
+
+/// The widest a toast gets, and the narrowest one worth drawing: a glyph,
+/// its padding and a few characters of message.
+const TOAST_MAX_W: u16 = 40;
+const TOAST_MIN_W: u16 = 12;
+
+/// How wide a toast is on a frame `frame_width` columns across: one column
+/// of margin each side, capped at [`TOAST_MAX_W`], and zero when the frame
+/// is too narrow for [`TOAST_MIN_W`].
+fn toast_width(frame_width: u16) -> u16 {
+    let w = frame_width.saturating_sub(2).min(TOAST_MAX_W);
+    if w < TOAST_MIN_W { 0 } else { w }
+}
+
+/// The glyph and colour a toast level wears.
+fn toast_glyph(level: &ToastLevel) -> (&'static str, Color) {
+    match level {
+        ToastLevel::Info => ("✓", C_SUCCESS),
+        ToastLevel::Warning => ("!", C_WARN),
+        ToastLevel::Error => ("✗", C_ERROR),
+        ToastLevel::Progress => ("◌", C_ACTIVE),
+    }
+}
 
 impl Dashboard {
     pub(in crate::commands::dashboard) fn draw_toasts(&self, frame: &mut Frame) {
@@ -19,8 +42,15 @@ impl Dashboard {
             return;
         }
         let area = frame.area();
-        let toast_w: u16 = 40;
-        let toast_h: u16 = self.toasts.len() as u16;
+        // Sized to the frame: the usual width where there is room, narrower
+        // on a small terminal, and nothing at all where a toast could not
+        // hold its glyph and a word. A fixed 40 spilled past the right edge
+        // of anything under 41 columns.
+        let toast_w = toast_width(area.width);
+        if toast_w == 0 || area.height < 2 {
+            return;
+        }
+        let toast_h = (self.toasts.len() as u16).min(area.height - 1);
         let x = area.width.saturating_sub(toast_w + 1);
         let y: u16 = 1;
         let toast_area = Rect {
@@ -30,17 +60,8 @@ impl Dashboard {
             height: toast_h,
         };
         frame.render_widget(Clear, toast_area);
-        for (i, toast) in self.toasts.iter().enumerate() {
-            let color = match toast.level {
-                super::super::types::ToastLevel::Info => C_SUCCESS,
-                super::super::types::ToastLevel::Warning => C_WARN,
-                super::super::types::ToastLevel::Error => C_ERROR,
-            };
-            let icon = match toast.level {
-                super::super::types::ToastLevel::Info => "✓",
-                super::super::types::ToastLevel::Warning => "!",
-                super::super::types::ToastLevel::Error => "✗",
-            };
+        for (i, toast) in self.toasts.iter().take(toast_h as usize).enumerate() {
+            let (icon, color) = toast_glyph(&toast.level);
             let msg = truncate(&toast.message, (toast_w - 4) as usize);
             let line = Line::from(vec![
                 Span::styled(
@@ -351,6 +372,8 @@ fn detail_sections() -> Vec<HelpSection> {
                     "open a box for what the run should do instead; ^Enter or the Send button sends it with the deny, esc goes back to the prompt",
                 ),
                 ("g", "the stage graph explorer"),
+                ("t", "the band: the run's path, or the whole blueprint"),
+                ("R", "snake the path again, undoing boxes you moved"),
                 (", / .", "older / newer context point; opens Context"),
                 ("x", "kill the run (asks first)"),
                 ("p / r", "pause / resume"),
@@ -517,7 +540,6 @@ fn shared_sections() -> Vec<HelpSection> {
                 ("← → / tab", "choose a button"),
                 ("enter", "the focused button; it starts on the safe one"),
                 ("y / n", "answer without moving first"),
-                ("space", "tick \"don't ask again\", where offered"),
                 ("esc", "decline"),
             ],
         },
@@ -553,6 +575,7 @@ fn shared_sections() -> Vec<HelpSection> {
 
 #[cfg(test)]
 mod tests {
+    use super::{toast_glyph, toast_width};
     use crate::commands::dashboard::test_support::{make_test_dashboard, rendered_buffer};
     use crate::commands::dashboard::types::*;
     use crossterm::event::KeyCode;
@@ -897,5 +920,150 @@ mod tests {
         dash.handle_key(key(KeyCode::Char('?')));
         assert!(!dash.show_help);
         assert_eq!(dash.new_run_filter, "?");
+    }
+
+    /// Since #708 the unattended warning has no "don't ask again" box, so
+    /// the Questions section must not offer a key for it.
+    #[test]
+    fn the_questions_help_offers_no_dont_ask_again_box() {
+        let backend = TestBackend::new(120, 60);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let dash = make_test_dashboard();
+        terminal.draw(|f| dash.draw_help_overlay(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("y / n"), "the section is there: {buf}");
+        assert!(!buf.contains("don't ask again"), "{buf}");
+    }
+
+    /// `t` and `R` are bound in the detail view (`input.rs`), so its help
+    /// lists them the way the docs page does.
+    #[test]
+    fn the_detail_help_lists_the_band_keys() {
+        let backend = TestBackend::new(120, 80);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.detail_view = true;
+        terminal.draw(|f| dash.draw_help_overlay(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("the whole blueprint"), "t: {buf}");
+        assert!(buf.contains("snake the path again"), "R: {buf}");
+    }
+
+    /// Work in flight wears its own glyph, not the check of work that is done.
+    #[test]
+    fn a_progress_toast_does_not_wear_the_completion_check() {
+        assert_eq!(toast_glyph(&ToastLevel::Progress).0, "◌");
+        assert_eq!(toast_glyph(&ToastLevel::Info).0, "✓");
+        assert_eq!(toast_glyph(&ToastLevel::Warning).0, "!");
+        assert_eq!(toast_glyph(&ToastLevel::Error).0, "✗");
+        let backend = TestBackend::new(120, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        dash.toasts.push(Toast {
+            message: "Starting 'x'…".to_string(),
+            remaining_ticks: 25,
+            level: ToastLevel::Progress,
+        });
+        terminal.draw(|f| dash.draw_toasts(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("◌ Starting 'x'…"), "{buf}");
+        assert!(!buf.contains("✓"), "{buf}");
+    }
+
+    /// The toast is sized to the frame: 40 where there is room, narrower on
+    /// a small terminal, gone where it could not hold a word.
+    #[test]
+    fn the_toast_fits_the_frame() {
+        assert_eq!(toast_width(200), 40);
+        assert_eq!(toast_width(42), 40);
+        assert_eq!(toast_width(38), 36);
+        assert_eq!(toast_width(14), 12);
+        assert_eq!(toast_width(13), 0);
+        assert_eq!(toast_width(0), 0);
+
+        let mut dash = make_test_dashboard();
+        dash.toasts.push(Toast {
+            message: "Starting 'writer' unattended…".to_string(),
+            remaining_ticks: 25,
+            level: ToastLevel::Warning,
+        });
+        // At 38 columns the fixed width of 40 started past the left edge
+        // and ran off the right; now the message sits inside the frame.
+        let mut terminal = Terminal::new(TestBackend::new(38, 20)).unwrap();
+        terminal.draw(|f| dash.draw_toasts(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("! Starting 'writer' unattended…"), "{buf}");
+        let cells = terminal.backend().buffer();
+        assert_eq!(cells[(0, 1)].symbol(), " ", "one column of margin");
+        assert_eq!(cells[(1, 1)].symbol(), " ", "the toast's own padding");
+        assert_eq!(cells[(2, 1)].symbol(), "!", "then the glyph");
+
+        // Too narrow for a toast: nothing is drawn and nothing panics.
+        let mut terminal = Terminal::new(TestBackend::new(10, 20)).unwrap();
+        terminal.draw(|f| dash.draw_toasts(f)).unwrap();
+        assert!(rendered_buffer(&terminal).trim().is_empty());
+        // Too short for the row under the title: the same.
+        let mut terminal = Terminal::new(TestBackend::new(80, 1)).unwrap();
+        terminal.draw(|f| dash.draw_toasts(f)).unwrap();
+        assert!(rendered_buffer(&terminal).trim().is_empty());
+        // Four toasts on three rows: the last one waits its turn.
+        for i in 0..3 {
+            dash.toasts.push(Toast {
+                message: format!("toast {i}"),
+                remaining_ticks: 25,
+                level: ToastLevel::Info,
+            });
+        }
+        let mut terminal = Terminal::new(TestBackend::new(80, 3)).unwrap();
+        terminal.draw(|f| dash.draw_toasts(f)).unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("toast 0"), "{buf}");
+        assert!(!buf.contains("toast 2"), "{buf}");
+    }
+
+    /// The kill and delete dialogs carry the whole run id and title; the
+    /// widget wraps them to its popup instead of the caller guessing a width.
+    #[test]
+    fn the_kill_and_delete_dialogs_carry_the_whole_id() {
+        let long_id = "run-20260829-abcdefghijklmnopqrstuvwxyz-0123456789";
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent(long_id, AgentDisplayStatus::Active);
+        agent.title = None;
+        agent.blueprint_name = "a-blueprint-name-well-past-twenty-four-columns".to_string();
+        dash.agents.push(agent);
+        dash.update_display_indices();
+
+        dash.request_kill();
+        let (_, dialog) = dash.pending_confirm.take().expect("kill dialog");
+        let body: String = dialog.body[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(body.contains(long_id), "{body}");
+        assert!(
+            body.contains("a-blueprint-name-well-past-twenty-four-columns"),
+            "{body}"
+        );
+        assert!(!body.contains('…'), "{body}");
+
+        dash.request_delete();
+        let (_, dialog) = dash.pending_confirm.take().expect("delete dialog");
+        let body: String = dialog.body[0]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(body.contains(long_id), "{body}");
+
+        // On a narrow terminal the popup wraps it rather than losing it.
+        let mut terminal = Terminal::new(TestBackend::new(38, 20)).unwrap();
+        terminal.draw(|f| dialog.draw(f, f.area())).unwrap();
+        let text = rendered_buffer(&terminal);
+        assert!(text.contains("Delete run?"), "{text}");
+        assert!(
+            text.contains("0123456789"),
+            "the id's tail is on screen: {text}"
+        );
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/stages.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/stages.rs
@@ -12,6 +12,25 @@ use crate::commands::dashboard::theme::*;
 use crate::commands::dashboard::types::*;
 use crate::runstate::StageRunStatus;
 
+/// The most a stage name may take on the flat strip, and the least it gets.
+const STAGE_LABEL_MAX_W: usize = 32;
+const STAGE_LABEL_MIN_W: usize = 10;
+/// What a tab costs besides its name: the status glyph and its space, the
+/// live marker, a duration such as ` 12m 34s`, the `Tabs` padding and the
+/// divider to the next tab.
+const STAGE_TAB_OVERHEAD: usize = 16;
+
+/// How many columns each stage name may take on a strip whose inside is
+/// `inner_width` wide and holds `tabs` tabs. Wide strips show a long name
+/// whole; a crowded one falls back to the old fixed width, which the strip
+/// clips the same way it always did.
+fn stage_label_width(inner_width: u16, tabs: usize) -> usize {
+    let per_tab = usize::from(inner_width) / tabs.max(1);
+    per_tab
+        .saturating_sub(STAGE_TAB_OVERHEAD)
+        .clamp(STAGE_LABEL_MIN_W, STAGE_LABEL_MAX_W)
+}
+
 impl Dashboard {
     pub(in crate::commands::dashboard) fn render_stage_tabs(
         &mut self,
@@ -33,6 +52,12 @@ impl Dashboard {
     }
 
     fn draw_linear_tabs(&mut self, frame: &mut Frame, tabs_area: Rect, agent: &DashboardAgent) {
+        let tab_count = if agent.stages.is_empty() {
+            agent.num_stages.max(1)
+        } else {
+            agent.stages.len()
+        };
+        let label_w = stage_label_width(tabs_area.width.saturating_sub(2), tab_count);
         // Build tab titles with status glyphs
         let tab_titles: Vec<Line> = if agent.stages.is_empty() {
             // Fallback: synthesize stage names from RunMeta info
@@ -66,7 +91,7 @@ impl Dashboard {
                         Span::styled(format!("{} ", GLYPH_PENDING), Style::default().fg(C_DIM))
                     };
                     let stage_label = if i == agent.stage_index {
-                        truncate(&agent.stage, 12)
+                        truncate(&agent.stage, label_w)
                     } else {
                         format!("stage {}", i + 1)
                     };
@@ -99,7 +124,7 @@ impl Dashboard {
                 .stages
                 .iter()
                 .enumerate()
-                .map(|(i, s)| self.build_stage_tab_title(i, s, agent))
+                .map(|(i, s)| self.build_stage_tab_title(i, s, agent, label_w))
                 .collect()
         };
 
@@ -164,6 +189,7 @@ impl Dashboard {
         i: usize,
         s: &crate::runstate::StageRecord,
         agent: &DashboardAgent,
+        label_w: usize,
     ) -> Line<'static> {
         use leviath_core::duration::precise;
 
@@ -204,7 +230,7 @@ impl Dashboard {
                     return Line::from(vec![
                         Span::styled(format!("{} ", spin), Style::default().fg(C_ACTIVE)),
                         Span::styled(
-                            truncate(&s.name, 10),
+                            truncate(&s.name, label_w),
                             Style::default().fg(C_WHITE).add_modifier(Modifier::BOLD),
                         ),
                         Span::styled("*", Style::default().fg(C_WARN)),
@@ -236,7 +262,7 @@ impl Dashboard {
         };
         Line::from(vec![
             Span::styled(format!("{} ", glyph), glyph_style),
-            Span::styled(truncate(&s.name, 10), label_style),
+            Span::styled(truncate(&s.name, label_w), label_style),
             Span::styled(dur_str, Style::default().fg(C_DIM)),
         ])
     }
@@ -482,7 +508,7 @@ mod tests {
         let mut record = make_stage_record("plan", StageRunStatus::Complete);
         record.started_at = Some(0);
         record.ended_at = Some(125); // 2m5s
-        let line = dash.build_stage_tab_title(0, &record, &agent);
+        let line = dash.build_stage_tab_title(0, &record, &agent, 10);
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("2m5s"));
     }
@@ -503,7 +529,7 @@ mod tests {
             banked_secs: 40,
             since: None,
         });
-        let line = dash.build_stage_tab_title(0, &record, &agent);
+        let line = dash.build_stage_tab_title(0, &record, &agent, 10);
         let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(text.contains("40s"), "{text}");
     }
@@ -513,7 +539,7 @@ mod tests {
         let dash = make_test_dashboard();
         let agent = make_test_agent("run-t", AgentDisplayStatus::Active);
         let record = make_stage_record("plan", StageRunStatus::Complete);
-        let line = dash.build_stage_tab_title(0, &record, &agent);
+        let line = dash.build_stage_tab_title(0, &record, &agent, 10);
         assert!(!line.spans.is_empty());
     }
 
@@ -522,7 +548,7 @@ mod tests {
         let dash = make_test_dashboard();
         let agent = make_test_agent("run-t2", AgentDisplayStatus::Active);
         let record = make_stage_record("implement", StageRunStatus::Active);
-        let line = dash.build_stage_tab_title(0, &record, &agent);
+        let line = dash.build_stage_tab_title(0, &record, &agent, 10);
         assert!(!line.spans.is_empty());
     }
 
@@ -531,7 +557,7 @@ mod tests {
         let dash = make_test_dashboard();
         let agent = make_test_agent("run-t3", AgentDisplayStatus::Complete);
         let record = make_stage_record("implement", StageRunStatus::Active);
-        let line = dash.build_stage_tab_title(0, &record, &agent);
+        let line = dash.build_stage_tab_title(0, &record, &agent, 10);
         assert!(!line.spans.is_empty());
     }
 
@@ -552,7 +578,7 @@ mod tests {
         // on_stage_result was never called for an Interactive/InteractivePoints
         // stage.
         let stale_plan = make_stage_record("plan", StageRunStatus::Active);
-        let line = dash.build_stage_tab_title(0, &stale_plan, &agent);
+        let line = dash.build_stage_tab_title(0, &stale_plan, &agent, 10);
 
         let rendered: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(rendered.contains(GLYPH_COMPLETE));
@@ -563,8 +589,59 @@ mod tests {
 
         // The actually-live tab (index == agent.stage_index) should still spin.
         let live_implement = make_stage_record("implement", StageRunStatus::Active);
-        let live_line = dash.build_stage_tab_title(1, &live_implement, &agent);
+        let live_line = dash.build_stage_tab_title(1, &live_implement, &agent, 10);
         let live_rendered: String = live_line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(SPINNER.iter().any(|spin| live_rendered.contains(spin)));
+    }
+
+    /// A wide strip shows a long stage name whole; a crowded one falls back
+    /// to the old fixed width rather than to nothing.
+    #[test]
+    fn a_stage_name_gets_the_room_the_strip_has() {
+        // 118 inside columns across three tabs: 39 each, 23 for the name.
+        assert_eq!(stage_label_width(118, 3), 23);
+        // Never below the width the strip always used, never above the cap.
+        assert_eq!(stage_label_width(30, 6), STAGE_LABEL_MIN_W);
+        assert_eq!(stage_label_width(0, 0), STAGE_LABEL_MIN_W);
+        assert_eq!(stage_label_width(400, 1), STAGE_LABEL_MAX_W);
+    }
+
+    #[test]
+    fn a_long_stage_name_is_whole_on_a_wide_strip_and_cut_on_a_narrow_one() {
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-long", AgentDisplayStatus::Active);
+        let long = "gather-the-evidence-carefully";
+        agent.stages = vec![
+            make_stage_record("plan", StageRunStatus::Complete),
+            make_stage_record(long, StageRunStatus::Active),
+        ];
+        agent.num_stages = 2;
+        agent.stage_index = 1;
+        agent.stage = long.to_string();
+
+        let mut terminal = Terminal::new(TestBackend::new(120, 10)).unwrap();
+        terminal
+            .draw(|f| dash.draw_linear_tabs(f, Rect::new(0, 0, 120, 3), &agent))
+            .unwrap();
+        let wide = rendered_buffer(&terminal);
+        assert!(wide.contains(long), "the name fits at 120 columns: {wide}");
+
+        let mut terminal = Terminal::new(TestBackend::new(40, 10)).unwrap();
+        terminal
+            .draw(|f| dash.draw_linear_tabs(f, Rect::new(0, 0, 40, 3), &agent))
+            .unwrap();
+        let narrow = rendered_buffer(&terminal);
+        assert!(!narrow.contains(long), "{narrow}");
+        assert!(narrow.contains("gather-th"), "cut, not dropped: {narrow}");
+
+        // The fallback strip, for a run with no stage records, takes the
+        // same width for the live stage's name.
+        agent.stages.clear();
+        let mut terminal = Terminal::new(TestBackend::new(120, 10)).unwrap();
+        terminal
+            .draw(|f| dash.draw_linear_tabs(f, Rect::new(0, 0, 120, 3), &agent))
+            .unwrap();
+        let fallback = rendered_buffer(&terminal);
+        assert!(fallback.contains(long), "{fallback}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/render/table.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/table.rs
@@ -438,22 +438,25 @@ impl Dashboard {
                 ]),
                 // The response box since #708: Enter breaks the line and
                 // Ctrl+Enter sends, with the Send button for a terminal
-                // that cannot tell the two apart.
-                Some(InteractionKind::FreeText) | None => Line::from(vec![
-                    Span::styled(
-                        "[^Enter]",
-                        Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
-                    ),
-                    Span::raw(" send  "),
-                    Span::styled("[Enter]", Style::default().add_modifier(Modifier::BOLD)),
-                    Span::raw(" newline  "),
-                    Span::styled("[Tab]", Style::default().add_modifier(Modifier::BOLD)),
-                    Span::raw(" Send button  "),
-                    Span::styled("[PgUp/PgDn]", Style::default().add_modifier(Modifier::BOLD)),
-                    Span::raw(" scroll document  "),
-                    Span::styled("[Esc]", Style::default().add_modifier(Modifier::BOLD)),
-                    Span::raw(" cancel"),
-                ]),
+                // that cannot tell the two apart. An in-place edit is the
+                // same box with a Save button, so it takes the same bar.
+                Some(InteractionKind::FreeText) | Some(InteractionKind::EditText) | None => {
+                    Line::from(vec![
+                        Span::styled(
+                            "[^Enter]",
+                            Style::default().fg(C_ACCENT).add_modifier(Modifier::BOLD),
+                        ),
+                        Span::raw(" send  "),
+                        Span::styled("[Enter]", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(" newline  "),
+                        Span::styled("[Tab]", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(" Send button  "),
+                        Span::styled("[PgUp/PgDn]", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(" scroll document  "),
+                        Span::styled("[Esc]", Style::default().add_modifier(Modifier::BOLD)),
+                        Span::raw(" cancel"),
+                    ])
+                }
                 _ => Line::from(vec![
                     Span::styled(
                         "[↑↓]",
@@ -1845,5 +1848,44 @@ mod tests {
             "{wide}"
         );
         assert!(wide.contains("breaker opened"), "{wide}");
+    }
+
+    /// An in-place edit is the response box with a Save button, and takes
+    /// the same keys; the bar used to give it the choice list's "[Enter]
+    /// confirm" while Enter broke the line.
+    #[test]
+    fn draw_help_bar_input_mode_edit_text() {
+        let backend = TestBackend::new(120, 2);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut dash = make_test_dashboard();
+        let mut agent = make_test_agent("run-edit", AgentDisplayStatus::Waiting);
+        agent.pending_request = Some(interaction::InteractionRequest {
+            id: "req-e".to_string(),
+            kind: interaction::InteractionKind::EditText,
+            prompt: "Edit this".to_string(),
+            options: vec![],
+            tool_name: None,
+            tool_arguments: None,
+            required: true,
+            stage_name: "main".to_string(),
+            body: Some("draft".to_string()),
+            body_format: interaction::BodyFormat::Plain,
+        });
+        agent.waiting_prompt = Some("Edit this".to_string());
+        dash.agents.push(agent);
+        dash.update_display_indices();
+        dash.detail_view = true;
+        dash.input_mode = true;
+        terminal
+            .draw(|f| {
+                let area = Rect::new(0, 0, 120, 1);
+                dash.draw_help_bar(f, area);
+            })
+            .unwrap();
+        let buf = rendered_buffer(&terminal);
+        assert!(buf.contains("[^Enter] send"), "{buf}");
+        assert!(buf.contains("[Enter] newline"), "{buf}");
+        assert!(buf.contains("[Tab] Send button"), "{buf}");
+        assert!(!buf.contains("[Enter] confirm"), "{buf}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/run_actions.rs
+++ b/crates/leviath-cli/src/commands/dashboard/run_actions.rs
@@ -1,7 +1,6 @@
 //! Killing and deleting runs from the dashboard: the confirmations, and
 //! what runs when they are answered.
 
-use super::helpers::truncate;
 use super::state::Dashboard;
 use super::types::*;
 use crate::runstate;
@@ -41,15 +40,16 @@ impl Dashboard {
             return;
         }
         let run_id = agent.id.clone();
+        // The whole name and id: the dialog wraps its body to its popup, so
+        // nothing here needs to guess how wide the terminal is.
         let name = agent
             .title
             .clone()
-            .unwrap_or_else(|| truncate(&agent.blueprint_name, 24));
+            .unwrap_or_else(|| agent.blueprint_name.clone());
         let dialog = Confirm::new(
             "Kill run?",
             vec![Line::from(format!(
-                "Cancel '{name}' ({})? Its state stays on disk.",
-                truncate(&run_id, 20)
+                "Cancel '{name}' ({run_id})? Its state stays on disk."
             ))],
             "Kill",
             "Cancel",
@@ -94,10 +94,7 @@ impl Dashboard {
             return;
         };
         let run_id = agent.id.clone();
-        let body = format!(
-            "Delete '{}' and all of its on-disk state? This is permanent.",
-            truncate(&run_id, 24)
-        );
+        let body = format!("Delete '{run_id}' and all of its on-disk state? This is permanent.");
         let lines = self.delete_lines(body, std::slice::from_ref(&run_id));
         let dialog = Confirm::new("Delete run?", lines, "Delete", "Cancel").danger();
         self.pending_confirm = Some((

--- a/crates/leviath-cli/src/commands/dashboard/types.rs
+++ b/crates/leviath-cli/src/commands/dashboard/types.rs
@@ -618,9 +618,15 @@ pub(super) struct Toast {
 
 #[derive(Debug, Clone, PartialEq)]
 pub(super) enum ToastLevel {
+    /// Something finished well; drawn with the completion check.
     Info,
+    /// Something to notice, such as a setting that runs tools unasked.
     Warning,
     Error,
+    /// Something has been asked for and not yet answered: a run starting, a
+    /// login or a connection test in flight. Its own glyph, so a toast
+    /// that says "Starting…" does not wear the check of one that is done.
+    Progress,
 }
 
 #[cfg(test)]

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -77,6 +77,7 @@ the detail view).
 | `Enter` | Open detail view |
 | `←` / `→` | Fold / unfold the selected run's sub-agents. On a run that has none, `←` moves up to its parent and `→` down to its first worker |
 | `n` | Start a run: pick an agent, write the task, press Enter |
+| `a` | Your agents: the catalog and the editor |
 | `Tab` / `Shift-Tab` | Focus the log panel (keys below) |
 | `/` | Filter runs by name or status |
 | `s` | Cycle the sort: start time (default), recent activity, or status groups |
@@ -149,7 +150,7 @@ rather than back into the form.
 | `Tab` / `Enter` | Move from the agent list to the task |
 | `Ctrl+Enter` (in the task) | Start the run. Only a terminal with the kitty keyboard protocol (kitty, WezTerm, Ghostty, foot, recent Alacritty) can tell Ctrl+Enter from Enter; elsewhere it inserts a newline, and the Start button is the way to submit |
 | `Enter` / `Alt+Enter` | Newline |
-| `Tab` (in the task) | Move to the Start button under the editor. `Enter` or `Space` there starts the run, as does a click on it; `Tab` again returns to the agent list, `Shift+Tab` to the task |
+| `Tab` (in the task) | Move to the Start button under the editor. `Enter` or `Space` there starts the run, as does a click on it; `Tab` or `Esc` returns to the agent list, `Shift+Tab` to the task |
 | `@` | Reference a file from the working directory: `↑` / `↓` choose a path, `Enter` or `Tab` inserts it, `Backspace` over the `@` ends the reference, `Esc` dismisses the list and keeps what you typed |
 | `Ctrl-Y` | Run unattended, so the agent approves its own tool calls |
 | `F1` | Help. `?` types a question mark here |
@@ -187,7 +188,6 @@ for a run whose blueprint could not be read, the flat tab strip stays.
 | `Home` / `End` (or `b` / `e`) | Jump to the beginning / end |
 | `l` / `o` / `c` | Switch the pane to Logs / Output / Context |
 | `f` | Switch the pane to Final: the answer the run submitted, the same bytes `lev result` and the HTTP API return. The `[f] final` chip and the key are there only while the run has one; Output shows what the stage wrote along the way, which can differ |
-
 | `g` | Open the stage graph explorer |
 | `t` | Swap the band between the run's path and the whole blueprint |
 | `R` | Re-snake the path, undoing boxes you moved by hand |


### PR DESCRIPTION
Plan section 2, "Dashboard": text that disagreed with the code, and three fixed widths. No behaviour change beyond what is listed.

## Text

- `render/table.rs` help bar: `EditText` takes the response box's bar (`[^Enter] send  [Enter] newline  [Tab] Send button`) instead of the choice list's `[Enter] confirm`; `input.rs:336` already routed it to the response box. Test `draw_help_bar_input_mode_edit_text`.
- `render/overlays.rs`: the Questions section no longer offers `space` for the "don't ask again" box #708 removed. Test `the_questions_help_offers_no_dont_ask_again_box`.
- `render/overlays.rs`: the Detail view section lists `t` and `R` (bound at `input.rs:588-589`). Test `the_detail_help_lists_the_band_keys`.
- `new_run.rs:400`: the comment no longer says the response pane keeps Enter as send.
- Toasts: `ToastLevel::Progress` with its own glyph (`◌`, cyan) for "Starting…", "Logging in…" and "Testing…"; an unattended start is now a Warning, the same level as arming the toggle. The icon table became `toast_glyph`, with a test for all four glyphs, and the start and MCP tests pin the levels.
- `docs/content/dashboard.md`: the blank line splitting the Detail view table is gone, the main-list table has its `a` row, and the Start button row says `Esc` goes back to the agent list too.

## Widths

- `overlays.rs`: `toast_width(frame.width)` gives one column of margin each side, capped at 40, and zero (nothing drawn) under 14 columns; toasts are also capped to the rows below the title. Test `the_toast_fits_the_frame`.
- `stages.rs`: `stage_label_width(inner, tabs)` shares the strip's inside width between the tabs, less a per-tab overhead, clamped to 10..32; threaded from `draw_linear_tabs` into both the record and the fallback labels. Tests `a_stage_name_gets_the_room_the_strip_has`, `a_long_stage_name_is_whole_on_a_wide_strip_and_cut_on_a_narrow_one`.
- `run_actions.rs`: the kill and delete dialogs hand the whole id and title to `Confirm`, which already wraps its body to its popup. Test `the_kill_and_delete_dialogs_carry_the_whole_id` (also draws the delete dialog at 38 columns and finds the id's tail).

Nothing at the plan's sites had changed since the planner read them.

## pty transcripts (`perf-tools/dash_pty.py` + `fake_runs.py`, replayed into a grid)

120x36, detail view of a fake run with a 29-character stage name on a three-tab strip (23 columns for the name where the cap used to be 10):

```
╭ Stages ←/→ to switch  stage 2/3──────────────────────────────────────────────────────────────────────────────────────╮
│ ✓ gather 9m11s  │  ✓ gather-the-evidence-ca… 2h16m  │  ○ analyze                                                     │
```

38x20, new-run screen after `Ctrl-Y` then `y`: the warning toast sits inside the frame with a column of margin (a fixed 40 used to start at column 0 and run off the right):

```
╭ Agent Blueprin╮╭ coder · 8 stages ·╮
│ ! Unattended ON: runs approve the… │
│› cod bu v0.1.3││ ╭ ▶ ○ discover ───│
```

## Gates

`cargo fmt`, `clippy --all-targets --all-features -p leviath-cli -D warnings`, `cargo xtask structure`, `cargo xtask docs`, `cargo xtask coverage --package leviath-cli` at 100%, pre-commit full suite.
