### PR TITLE
fix(providers): bound the model listing by the entry's own timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,12 @@ same list.
   cut at 10 or 12 columns however wide the strip was, and the kill and delete
   dialogs cut the run id and title at 20 to 24 characters before the widget
   had a chance to wrap them. Each is now sized from the area it draws into.
+- `POST /api/models/probe` declared a 10 s timeout on the endpoint it built
+  for the form, but the model listing stamped the 30 s side-call default on
+  its own request, and a per-request timeout beats the client's, so a
+  server that never answered kept the form waiting 30 s. The entry's
+  `request_timeout_secs` now bounds the listing too, with the 30 s default
+  only for an entry that set none.
 - The dashboard's run detail strip could show a cache figure over 100%, such
   as `cache 152%`, on a run that was mostly served from the provider's cache.
   The prompt count every provider is normalised to is the fresh input only,

--- a/crates/leviath-providers/src/endpoint.rs
+++ b/crates/leviath-providers/src/endpoint.rs
@@ -83,6 +83,9 @@ pub struct EndpointProvider {
     warned_unknown: crate::provider::ModelMemo,
     /// What `GET /models` said, once priming has read it.
     learned: LearnedModels,
+    /// The entry's `request_timeout_secs`, which bounds the side calls this
+    /// provider makes on its own (the model listing) as well as inference.
+    request_timeout_secs: Option<u64>,
 }
 
 impl EndpointProvider {
@@ -112,7 +115,28 @@ impl EndpointProvider {
             temperature_unsupported: Default::default(),
             warned_unknown: Default::default(),
             learned: Default::default(),
+            request_timeout_secs: None,
         }
+    }
+
+    /// Bound the provider's own side calls by the entry's timeout.
+    ///
+    /// The inference path takes its deadline from each request; the model
+    /// listing has no request to take one from, so it used the side-call
+    /// default even when the entry set a shorter one. Reqwest's per-request
+    /// timeout wins over the client's, so a client built with the entry's
+    /// timeout was not enough on its own: the probe route's 10 s waited the
+    /// full 30 s.
+    pub fn with_request_timeout(mut self, secs: Option<u64>) -> Self {
+        self.request_timeout_secs = secs;
+        self
+    }
+
+    /// The deadline on the model listing: the entry's own, or the side-call
+    /// default when the entry set none.
+    fn listing_timeout_secs(&self) -> Option<u64> {
+        self.request_timeout_secs
+            .or(Some(crate::provider::SIDE_CALL_TIMEOUT_SECS))
     }
 
     /// Merge `[model_capabilities]` entries onto what the server reports.
@@ -228,7 +252,7 @@ impl EndpointProvider {
     async fn fetch_models_json(&self) -> Result<serde_json::Value> {
         let mut builder = crate::provider::apply_request_timeout(
             self.client.get(format!("{}/models", self.base_url)),
-            Some(crate::provider::SIDE_CALL_TIMEOUT_SECS),
+            self.listing_timeout_secs(),
         );
         for (name, value) in self.request_headers() {
             builder = builder.header(name, value);
@@ -449,6 +473,7 @@ mod tests {
     use super::*;
     use crate::test_support::always_on_tracing_guard;
     use leviath_testkit::{spawn_mock_sequence, spawn_mock_server};
+    use std::time::Duration;
 
     fn client() -> reqwest::Client {
         crate::provider::build_http_client(None).expect("a test client builds")
@@ -639,6 +664,47 @@ mod tests {
         // it did not size it.
         provider.capabilities("gpt-mock");
         assert!(provider.warned_unknown.is_empty());
+    }
+
+    /// The entry's timeout bounds the listing. It used to stamp the 30 s
+    /// side-call default on the request, which beats any client-level timeout,
+    /// so a 1 s entry against a server that never answers waited 30 s.
+    #[tokio::test]
+    async fn the_listing_is_bounded_by_the_entry_timeout_not_the_side_call_default() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("a loopback port is available");
+        let addr = listener
+            .local_addr()
+            .expect("a bound listener has an address");
+        // Accept every connection and hold it open without answering.
+        let hold = tokio::spawn(async move {
+            let mut held = Vec::new();
+            loop {
+                let (socket, _) = listener.accept().await.expect("accept");
+                held.push(socket);
+            }
+        });
+        let provider = provider_at(&format!("http://{addr}/v1")).with_request_timeout(Some(1));
+        let started = std::time::Instant::now();
+        let result = provider.list_models().await;
+        let waited = started.elapsed();
+        hold.abort();
+        assert!(result.is_err(), "a server that never answers is an error");
+        // Well under the 30 s the side-call default would have waited, with
+        // room for a slow runner.
+        assert!(waited < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn an_entry_without_a_timeout_keeps_the_side_call_default_on_the_listing() {
+        let plain = provider_at("http://h/v1");
+        assert_eq!(
+            plain.listing_timeout_secs(),
+            Some(crate::provider::SIDE_CALL_TIMEOUT_SECS)
+        );
+        let bounded = provider_at("http://h/v1").with_request_timeout(Some(7));
+        assert_eq!(bounded.listing_timeout_secs(), Some(7));
     }
 
     #[tokio::test]

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -361,6 +361,7 @@ pub fn build_provider_registry_probing(
                     )
                     .with_overrides(caps)
                     .with_rate_limit(c.rate_limit.as_ref())
+                    .with_request_timeout(timeout)
                     .with_models(endpoint.models)
                     .with_serves(endpoint.serves),
                 ),


### PR DESCRIPTION
Plan item 1.9 (audit round 4).

## Premise check

- `crates/leviath-cli/src/commands/serve/config.rs:204` sets `creds.request_timeout_secs = Some(PROBE_TIMEOUT_SECS)` (10) for `POST /api/models/probe`; `provider_creds.rs:347-356` builds the HTTP client with that timeout but passes nothing of it to `EndpointProvider::new`.
- `crates/leviath-providers/src/endpoint.rs:229-232` `fetch_models_json` stamps `apply_request_timeout(builder, Some(SIDE_CALL_TIMEOUT_SECS))` (30 s) on the listing request. `provider/http.rs:66-68` documents that reqwest's per-request timeout beats the client's, so the 30 s wins over the 10 s. Confirmed by the fail-first run below: 30.00 s measured.

## Fix

`EndpointProvider` carries `request_timeout_secs`, set through `with_request_timeout(Option<u64>)` from the cred in `provider_creds.rs`, and the listing uses `listing_timeout_secs()` = `self.request_timeout_secs.or(Some(SIDE_CALL_TIMEOUT_SECS))`. Inference already took its deadline per request and is unchanged.

## Fail-first

`the_listing_is_bounded_by_the_entry_timeout_not_the_side_call_default`: a loopback listener that accepts and never answers, an endpoint built with a 1 s timeout, bound of 5 s in the assertion. Against the unfixed listing call:

```
thread 'endpoint::tests::the_listing_is_bounded_by_the_entry_timeout_not_the_side_call_default' panicked at crates/leviath-providers/src/endpoint.rs:692:9:
the listing waited 30.003618041s on a 1 s timeout
test result: FAILED. 0 passed; 1 failed; ... finished in 30.08s
```

With the fix: passes in about 1 s. `an_entry_without_a_timeout_keeps_the_side_call_default_on_the_listing` pins the `None` arm at 30 s.

## Changelog

Under Fixed.

## Gates

`cargo fmt --all`, `cargo clippy --all-targets --all-features -D warnings` on leviath-providers and leviath-runtime, `cargo xtask structure`, `cargo xtask docs`, `cargo xtask coverage --package leviath-providers` and `--package leviath-runtime` (100%), pre-commit full suite. No `main.rs` touched. No live probe: the path is a single provider call with no daemon in it, and the wire test above is the real HTTP stack.
