### PR TITLE
fix(taint): gate submit_output as an outbound channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,14 @@ same list.
   server that never answered kept the form waiting 30 s. The entry's
   `request_timeout_secs` now bounds the listing too, with the 30 s default
   only for an entry that set none.
+- With taint tracking on, `submit_output` was classified with the context
+  and todo tools as internal, and was applied before the taint gate ran at
+  all, so a Private region could be submitted as the run's answer and read
+  off-host through `GET /api/agents/{id}/result` or the dashboard with no
+  prompt. It is now an outbound tool with Public clearance, and the gate
+  runs before the submission is applied: a tainted answer raises the leak
+  prompt (or the policy's verdict) like a `shell` call would, and an
+  approved one is applied on the re-run.
 - The dashboard's run detail strip could show a cache figure over 100%, such
   as `cache 152%`, on a run that was mostly served from the provider's cache.
   The prompt count every provider is normalised to is the fresh input only,

--- a/crates/leviath-core/src/taint.rs
+++ b/crates/leviath-core/src/taint.rs
@@ -509,13 +509,27 @@ pub fn classified_builtin(tool_name: &str) -> Option<ToolClassification> {
             ToolDirection::Internal,
             TaintLevel::Public,
         ),
-        // The context, todo and submit tools write the run's own state: the
-        // agent's regions, its checklist, the answer the caller gets back.
-        // Nothing leaves the machine, so none is a channel the gate watches.
+        // The context and todo tools write the run's own state: the agent's
+        // regions and its checklist. Nothing leaves the machine, so none is a
+        // channel the gate watches.
         "context_write" | "context_append" | "context_read" | "context_delete" | "context_list"
-        | "todo_add" | "todo_done" | "todo_note" | "submit_output" => ToolClassification::new(
+        | "todo_add" | "todo_done" | "todo_note" => ToolClassification::new(
             TaintLevel::Internal,
             ToolDirection::Internal,
+            TaintLevel::Public,
+        ),
+        // `submit_output` records the answer the caller gets back, and the
+        // caller is not always on this machine: `lev serve` hands it to any
+        // reader of `GET /api/agents/{id}/result`, and the dashboard shows
+        // it. It is the run's one deliberate channel out, so it takes the
+        // shape `shell` has, outbound with Public clearance, and a Private
+        // region in a submitted answer raises the leak prompt (or the
+        // policy's verdict) rather than leaving quietly. It sat with the
+        // context tools as internal before, which let Private context reach
+        // a remote reader with no prompt at all.
+        "submit_output" => ToolClassification::new(
+            TaintLevel::Public,
+            ToolDirection::Outbound,
             TaintLevel::Public,
         ),
         "list_dir" => ToolClassification::new(
@@ -1133,7 +1147,6 @@ mod tests {
             "todo_add",
             "todo_done",
             "todo_note",
-            "submit_output",
         ] {
             let tc = classified_builtin(name);
             assert!(tc.is_some(), "{name} has no arm");
@@ -1142,6 +1155,19 @@ mod tests {
             assert_eq!(tc.sensitivity, TaintLevel::Internal, "{name}");
             assert_eq!(tc.clearance, TaintLevel::Public, "{name}");
         }
+    }
+
+    /// The submitted answer is the one thing a run hands to whoever asked
+    /// for it, and over `lev serve` that reader is not on this machine. So
+    /// `submit_output` is an outbound channel with Public clearance, the
+    /// shape `shell` has, not the internal one the context tools share.
+    #[test]
+    fn submit_output_is_an_outbound_channel() {
+        assert_eq!(
+            classified_builtin("submit_output"),
+            classified_builtin("shell"),
+            "submit_output"
+        );
     }
 
     /// The split exists so a caller can tell an arm from the default.

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -5994,6 +5994,112 @@ async fn dispatch_tools_holds_batch_for_an_interactive_gate_prompt() {
     assert!(world.get::<AwaitingTools>(e).is_none());
 }
 
+/// A taint-tracking output window over Internal data: what a stage that read
+/// a workdir file holds when it comes to answer.
+fn tainted_output_window() -> ContextWindow {
+    let mut w = tainted_conv_window();
+    w.add_region(Region::new(
+        crate::output_tool::FINAL_OUTPUT_REGION.to_string(),
+        RegionKind::Pinned,
+        crate::output_tool::FINAL_OUTPUT_REGION_TOKENS,
+    ));
+    w
+}
+
+/// `submit_output` was applied inline before the gate ran, so its
+/// classification was never consulted in a live run: reclassifying it as
+/// outbound gated nothing. The gate now runs first. Headless, the block is
+/// the model's tool result and no answer is recorded.
+#[tokio::test]
+async fn dispatch_tools_gates_a_submission_over_tainted_context() {
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    let e = world
+        .spawn((
+            agent_state(),
+            infer_with(vec![submit_call("o1", "the secret")]),
+            tainted_output_window(),
+            ReadyForTools,
+            enabled_gate(),
+        ))
+        .id();
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+
+    assert!(jrx.try_recv().is_err(), "nothing reaches the lane");
+    assert!(
+        world.get::<crate::persistence::FinalOutput>(e).is_none(),
+        "a blocked submission is not the run's answer"
+    );
+    // A batch with nothing for the lane is applied straight to the window,
+    // and the model goes back to work with the block as its tool result.
+    assert!(world.get::<ReadyToInfer>(e).is_some());
+    let text = conversation_text(&world, e);
+    assert!(text.contains("[blocked]"), "{text}");
+    assert!(text.contains("submit_output"), "{text}");
+}
+
+/// With the daemon's prompt lane wired, the same submission is held for the
+/// leak prompt like any other outbound call, and once the user approves it
+/// the re-run applies it inline: the tool lane cannot handle `submit_output`,
+/// so an approved one must not be sent there.
+#[tokio::test]
+async fn dispatch_tools_prompts_for_a_tainted_submission_and_applies_it_once_approved() {
+    let (jtx, mut jrx) = mpsc::unbounded_channel();
+    let (gtx, _grx) = mpsc::unbounded_channel();
+    let mut world = World::new();
+    world.insert_resource(ToolServiceRes(std::sync::Arc::new(EchoService)));
+    world.insert_resource(ToolStage::detached(jtx));
+    world.insert_resource(crate::interaction_hub::InteractionHub::new());
+    world.insert_resource(crate::gate_prompt::GatePromptStage {
+        outcomes: gtx,
+        wake: std::sync::Arc::new(tokio::sync::Notify::new()),
+        runtime: tokio::runtime::Handle::current(),
+    });
+    let e = world
+        .spawn((
+            agent_state(),
+            infer_with(vec![submit_call("o1", "the secret")]),
+            tainted_output_window(),
+            ReadyForTools,
+            enabled_gate(),
+        ))
+        .id();
+    let mut s = Schedule::default();
+    s.add_systems(dispatch_tools);
+    s.run(&mut world);
+    assert_eq!(
+        world
+            .get::<crate::gate_prompt::AwaitingGatePrompt>(e)
+            .unwrap()
+            .0,
+        1
+    );
+    assert!(world.get::<crate::persistence::FinalOutput>(e).is_none());
+
+    // The user allowed it. The re-run applies the submission inline.
+    let mut resolved = crate::gate_prompt::GateResolved::default();
+    resolved.approved.insert("o1".to_string());
+    world
+        .entity_mut(e)
+        .remove::<crate::gate_prompt::AwaitingGatePrompt>()
+        .insert((resolved, ReadyForTools));
+    s.run(&mut world);
+
+    assert!(
+        jrx.try_recv().is_err(),
+        "an approved submission never reaches the lane"
+    );
+    let recorded = world
+        .get::<crate::persistence::FinalOutput>(e)
+        .expect("the approved submission became the run's answer");
+    assert_eq!(recorded.0.content, "the secret");
+    assert!(world.get::<crate::gate_prompt::GateResolved>(e).is_none());
+}
+
 #[tokio::test]
 async fn dispatch_tools_auto_approves_a_gate_block_under_yolo() {
     // Same blocked + interactive scenario as above, but the agent carries

--- a/crates/leviath-runtime/src/pipeline/tools.rs
+++ b/crates/leviath-runtime/src/pipeline/tools.rs
@@ -500,34 +500,6 @@ pub(crate) fn dispatch_tools(
                 context_results.push((c.tool_id.clone(), text));
                 continue;
             }
-            // Applied inline for the same reason the context tools are: it
-            // writes the live window and an ECS component, neither of which the
-            // async lane can reach. Recorded here and committed after the loop,
-            // because `commands` cannot be borrowed inside it.
-            if crate::output_tool::is_output_tool(&c.name) {
-                let stage_names: Vec<String> = blueprint
-                    .map(|bp| bp.0.stages.iter().map(|s| s.name.clone()).collect())
-                    .unwrap_or_default();
-                let (text, output) = crate::output_tool::handle_output_tool(
-                    &c.arguments,
-                    &crate::output_tool::OutputContext {
-                        spec: stage_inf.output.as_ref(),
-                        validators,
-                        stage: &state.current_stage,
-                        stage_names: &stage_names,
-                        workdir: metadata.map(|m| std::path::Path::new(&m.workdir)),
-                    },
-                    chrono::Utc::now().timestamp(),
-                    &mut window,
-                );
-                // A refused submission leaves any earlier one alone: a bad
-                // correction must not erase a good answer.
-                if let Some(output) = output {
-                    submitted = Some(output);
-                }
-                context_results.push((c.tool_id.clone(), text));
-                continue;
-            }
             // Read inline, started after the loop. Like `submit_output` it needs
             // world access the async lane does not have - it parks this agent on
             // its workers - and like the context tools it is applied here rather
@@ -554,23 +526,20 @@ pub(crate) fn dispatch_tools(
                 }
                 continue;
             }
-            // A call the user already resolved in a prior prompt round.
+            // A call the user already resolved in a prior prompt round. An
+            // approved one skips the gate and lands where it would have
+            // landed the first time: the lane, or the inline submission below.
+            let mut cleared = false;
             if let Some(resolved) = resolved {
                 if let Some(msg) = resolved.denied.get(&c.tool_id) {
                     context_results.push((c.tool_id.clone(), msg.clone()));
                     continue;
                 }
-                if resolved.approved.contains(&c.tool_id) {
-                    lane_calls.push(leviath_providers::ToolCall {
-                        id: c.tool_id.clone(),
-                        name: c.name.clone(),
-                        arguments: c.arguments.clone(),
-                        thought_signature: c.thought_signature.clone(),
-                    });
-                    continue;
-                }
+                cleared = resolved.approved.contains(&c.tool_id);
             }
-            if let Some(gate) = gate.as_deref_mut() {
+            if let Some(gate) = gate.as_deref_mut()
+                && !cleared
+            {
                 let decision = gate.check_with_policy(
                     &state.agent_id,
                     &c.name,
@@ -613,6 +582,41 @@ pub(crate) fn dispatch_tools(
                         continue;
                     }
                 }
+            }
+            // Applied inline for the same reason the context tools are: it
+            // writes the live window and an ECS component, neither of which the
+            // async lane can reach. Recorded here and committed after the loop,
+            // because `commands` cannot be borrowed inside it.
+            //
+            // After the gate, not before it with the other inline tools: the
+            // submitted answer leaves the machine (`GET /api/agents/{id}/result`,
+            // the dashboard), so `submit_output` is classified outbound, and a
+            // classification the gate never sees gates nothing. It used to be
+            // applied above the gate, which is what let a Private region reach a
+            // remote reader with no prompt however it was classified.
+            if crate::output_tool::is_output_tool(&c.name) {
+                let stage_names: Vec<String> = blueprint
+                    .map(|bp| bp.0.stages.iter().map(|s| s.name.clone()).collect())
+                    .unwrap_or_default();
+                let (text, output) = crate::output_tool::handle_output_tool(
+                    &c.arguments,
+                    &crate::output_tool::OutputContext {
+                        spec: stage_inf.output.as_ref(),
+                        validators,
+                        stage: &state.current_stage,
+                        stage_names: &stage_names,
+                        workdir: metadata.map(|m| std::path::Path::new(&m.workdir)),
+                    },
+                    chrono::Utc::now().timestamp(),
+                    &mut window,
+                );
+                // A refused submission leaves any earlier one alone: a bad
+                // correction must not erase a good answer.
+                if let Some(output) = output {
+                    submitted = Some(output);
+                }
+                context_results.push((c.tool_id.clone(), text));
+                continue;
             }
             lane_calls.push(leviath_providers::ToolCall {
                 id: c.tool_id.clone(),

--- a/crates/leviath-runtime/src/taint.rs
+++ b/crates/leviath-runtime/src/taint.rs
@@ -428,12 +428,39 @@ mod tests {
             "edit_document",
             "context_append",
             "todo_add",
-            "submit_output",
             "fan_out",
         ] {
             let decision = gate.check_traditional("agent-1", name, &window);
             assert!(decision.is_allowed(), "{name}: {decision:?}");
         }
+    }
+
+    /// `submit_output` was classed with the context tools as internal, but
+    /// the answer it records is served off-host by `GET
+    /// /api/agents/{id}/result` and shown in the dashboard, so with taint
+    /// tracking on a Private region could reach a remote reader with no
+    /// prompt. It is outbound with Public clearance now: the same block
+    /// `shell` gets over the same window.
+    #[test]
+    fn gate_blocks_submit_output_over_private_context() {
+        let mut gate = TaintGate::new(SecurityConfig::default());
+        let window = make_window_with_taint(TaintLevel::Private);
+        let decision = gate.check_traditional("agent-1", "submit_output", &window);
+        assert_eq!(
+            decision,
+            GateDecision::Blocked {
+                taint_level: TaintLevel::Private,
+                clearance: TaintLevel::Public,
+                source_regions: vec!["conv".to_string()],
+                tool_name: "submit_output".to_string(),
+            }
+        );
+        // A clean window submits without a prompt, as before.
+        let clean = make_window_with_taint(TaintLevel::Public);
+        assert!(
+            gate.check_traditional("agent-1", "submit_output", &clean)
+                .is_allowed()
+        );
     }
 
     #[test]

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -224,10 +224,13 @@ flowchart TD
 
 Taint recovers as entries evict, and an unrecognized tool **fails closed**: an MCP or script tool
 with no classification of its own is treated as outbound and gated. Every built-in tool carries its
-own classification, so only the ones that can carry bytes out (`shell`, `web_search`, `web_fetch`
-and the HTTP tools) are ever gated; the file, context, todo, sub-agent and interaction tools are
-not. Configure with a `[security]` block, layer on allowlists and Rhai policy rules, and dry-run
-any tool:
+own classification, so only the ones that can carry bytes out (`shell`, `web_search`, `web_fetch`,
+the HTTP tools, and `submit_output`) are ever gated; the file, context, todo, sub-agent and
+interaction tools are not. `submit_output` is on that list because the final output counts as
+leaving the machine: `lev serve` hands it to whoever reads `GET /api/agents/{id}/result` and the
+dashboard shows it, so a Private region in a submitted answer raises the same prompt a `shell`
+call would. Configure with a `[security]` block, layer on allowlists and Rhai policy rules, and
+dry-run any tool:
 
 ```bash
 lev policy list


### PR DESCRIPTION
Plan item 1.7.

## Premise check

Confirmed, and a little worse than stated. `classified_builtin` (`crates/leviath-core/src/taint.rs`) put `submit_output` with `context_*`/`todo_*` as internal, while the submitted answer is served off-host by `GET /api/agents/{id}/result` and shown in the dashboard. On top of that, `dispatch_tools` (`crates/leviath-runtime/src/pipeline/tools.rs`) applied `submit_output` inline *before* the taint gate ran, so reclassifying it alone would have gated nothing in a live run.

## Fix

- `submit_output` gets its own arm: outbound with Public clearance, the shape `shell` has, with a comment saying why.
- `dispatch_tools` runs the gate before the inline submission. An approved call from a prompt round is applied inline on the re-run (the tool lane refuses `submit_output`), a denied one gets its stored message, and headless the block is the model's tool result with no `FinalOutput` recorded.
- The #707 guard test (`the_remaining_builtins_are_classified_like_their_siblings`) still holds every built-in to an arm of its own; `submit_output` moved to its own assertion.

## Fail-first evidence

Against the unfixed code:

```
test taint::tests::submit_output_is_an_outbound_channel ... FAILED            (leviath-core)
test taint::tests::gate_blocks_submit_output_over_private_context ... FAILED  (leviath-runtime)
test pipeline::tests::dispatch_tools_gates_a_submission_over_tainted_context ... FAILED
test pipeline::tests::dispatch_tools_prompts_for_a_tainted_submission_and_applies_it_once_approved ... FAILED
```

`gate_blocks_submit_output_over_private_context` expects the same `Blocked { taint_level: Private, clearance: Public, .. }` shape the #707 test used for `read_files`. All green after the fix.

## Live check

Isolated home (`LEVIATH_HOME=/tmp/lvt`, `LEVIATH_SKIP_DOTENV=1`), mock OpenAI provider, blueprint with `[security] taint_tracking = true` and `[read_paths] allow = ["/tmp/lvt/secret"]` granted in `config.toml`. The mock asks for `read_file` on the secret (Private under the grant, `READS 1/1`), then `submit_output` of it.

Before (installed `lev 0.5.5`):

```
status: complete
RUN                                 STATUS    STAGE  ITER  TOOLS  AGE  WORK  MOVED  READS
taintprobe-1788059844-cc28d2656b61  complete  main   3     2      2s   0s    2s     1/1
GET /api/agents/.../result -> 200 {..."final_output":{"content":"The key is hunter2-the-private-key",...}}
secret served off-host: True
```

After (this branch):

```
status: waiting_input
RUN                                 STATUS               STAGE  ITER  TOOLS  AGE  WORK  MOVED  READS
taintprobe-1788060079-740cfe920041  waiting: taint gate  main   2     2      2s   0s    2s     1/1

1 run needs an answer: lev respond
$ lev timeline taintprobe-1788060079-740cfe920041
taintprobe-1788060079-740cfe920041 (taintprobe, waitinginput) ...
STAGE                MODEL TIME  CALLS     OUTPUT    LARGEST
(title)                   0:00      1          3          3
main                      0:00      2          6          3
GET /api/agents/.../result -> 200 {..."status":"waiting_input","output":"","final_output":null,...}
secret served off-host: False
```

## Docs and changelog

- `docs/content/security.md` taint section lists `submit_output` among the gated built-ins and says the final output counts as leaving the machine.
- CHANGELOG, Unreleased / Fixed.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-core` and `-p leviath-runtime -- -D warnings`: clean
- `cargo xtask structure`, `cargo xtask docs`: clean
- `cargo xtask coverage --package leviath-core` and `--package leviath-runtime`: pass
- Pre-commit full suite: passed
