### PR TITLE
fix(daemon): keep an idle MCP server the pool could not take, and ask again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,13 @@ same list.
   runs before the submission is applied: a tainted answer raises the leak
   prompt (or the policy's verdict) like a `shell` call would, and an
   approved one is applied on the re-run.
+- A per-agent MCP server whose idle-disconnect tick fired while one of its
+  tools was still mid-call was kept by the executor but forgotten by the pool:
+  the pool dropped its lease row and cached tool defs before asking for the
+  client, so no later tick ever looked again, the stdio child process never got
+  its shutdown, and the tool stayed routable for a run that no longer leased
+  it. The client is now taken first, the bookkeeping goes only once it is, and
+  a busy server gets another grace window.
 - The dashboard's run detail strip could show a cache figure over 100%, such
   as `cache 152%`, on a run that was mostly served from the provider's cache.
   The prompt count every provider is normalised to is the fresh input only,

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -61,6 +61,19 @@ struct LeaseTable {
     global: HashSet<String>,
 }
 
+/// What an idle-disconnect tick found.
+#[derive(Debug, PartialEq, Eq)]
+enum IdleOutcome {
+    /// The server was idle: its client is taken and shut down.
+    Disconnected,
+    /// Something leased or released the server since the tick was scheduled,
+    /// or there was no client to take. Nothing to do, now or later.
+    Stale,
+    /// A call still held the client, so the server was kept as it was; worth
+    /// asking again after another grace window.
+    Busy,
+}
+
 /// One per-agent server's lease state.
 struct ServerLease {
     /// The server's name - the key the executor stores its client under.
@@ -234,11 +247,31 @@ impl McpPool {
             return; // no runtime (a sync test): bookkeeping only
         };
         for (sig, name, generation) in zeroed {
-            let pool = Arc::clone(self);
-            handle.spawn(async move {
-                tokio::time::sleep(pool.idle_disconnect).await;
-                pool.disconnect_if_still_idle(&sig, &name, generation).await;
-            });
+            handle.spawn(Arc::clone(self).grace_disconnect(
+                self.idle_disconnect,
+                sig,
+                name,
+                generation,
+            ));
+        }
+    }
+
+    /// The grace timer: wait `grace`, then tear the server down if it is still
+    /// idle. A server with a call in flight when the timer fires is left alone
+    /// and the wait starts over, so an idle disconnect that loses the race to a
+    /// late call is postponed, not forgotten.
+    async fn grace_disconnect(
+        self: Arc<Self>,
+        grace: std::time::Duration,
+        sig: String,
+        name: String,
+        generation: u64,
+    ) {
+        loop {
+            tokio::time::sleep(grace).await;
+            if self.disconnect_if_still_idle(&sig, &name, generation).await != IdleOutcome::Busy {
+                return;
+            }
         }
     }
 
@@ -264,39 +297,63 @@ impl McpPool {
         zeroed
     }
 
-    /// Tear a server down if nothing touched it since `generation`: forget its
-    /// cached defs (so the next spawn reconnects lazily), take its client out
-    /// of the shared executor, and shut it down - which is what actually ends
-    /// a stdio server's child process. Returns whether it disconnected.
-    pub(crate) async fn disconnect_if_still_idle(
+    /// Tear a server down if nothing touched it since `generation`: take its
+    /// client out of the shared executor, forget its cached defs (so the next
+    /// spawn reconnects lazily), and shut it down - which is what actually
+    /// ends a stdio server's child process. A server kept because a call is
+    /// in flight is [`IdleOutcome::Busy`], and the grace timer waits again for
+    /// that one.
+    ///
+    /// The client is taken before any pool bookkeeping goes. The other order
+    /// (forget the lease row and the cached defs, then ask the executor) lost
+    /// the server for the daemon's life whenever the executor kept it: the
+    /// next tick found no lease row and returned early, so nothing ever asked
+    /// again, the child process never got `shutdown()`, and the tool stayed
+    /// routable for a run that no longer leased it.
+    async fn disconnect_if_still_idle(
         &self,
         sig: &str,
         name: &str,
         generation: u64,
-    ) -> bool {
-        {
+    ) -> IdleOutcome {
+        // The executor lock first, so a lease taken while waiting for it is
+        // seen by the idle check below rather than after the client is gone.
+        let mut executor = self.shared.lock().await;
+        let client = {
             let mut table = self.leases.lock().unwrap_or_else(PoisonError::into_inner);
             let still_idle = table
                 .servers
                 .get(sig)
                 .is_some_and(|e| e.holders.is_empty() && e.generation == generation);
             if !still_idle {
-                return false;
+                return IdleOutcome::Stale;
+            }
+            let client = executor.remove_client(name);
+            if client.is_none() && executor.has_client(name) {
+                // A call still holds the client: keep the lease row and the
+                // cached defs so the next tick finds the server and retries.
+                return IdleOutcome::Busy;
             }
             table.servers.remove(sig);
-        }
+            client
+        };
+        // Still under the executor lock: `ensure` inserts into the cache only
+        // while holding that lock, so a spawn racing this tick sees either the
+        // old connection whole or nothing, never cached defs with no client.
         self.connected
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .remove(sig);
-        let client = self.shared.lock().await.remove_client(name);
+        drop(executor);
         match client {
             Some(mut client) => {
                 let _ = client.shutdown().await;
                 tracing::info!(server = %name, "disconnected idle per-agent MCP server");
-                true
+                IdleOutcome::Disconnected
             }
-            None => false,
+            // Leased but never connected (or its connect failed): nothing to
+            // shut down, and nothing left to retry.
+            None => IdleOutcome::Stale,
         }
     }
 
@@ -821,11 +878,17 @@ mod tests {
             let zeroed = pool.release_run_bookkeeping("run-b");
             assert_eq!(zeroed.len(), 1);
             let (sig, name, generation) = zeroed[0].clone();
-            assert!(pool.disconnect_if_still_idle(&sig, &name, generation).await);
+            assert_eq!(
+                pool.disconnect_if_still_idle(&sig, &name, generation).await,
+                IdleOutcome::Disconnected
+            );
             // Defs are forgotten, so the next spawn reconnects lazily...
             assert!(pool.cached_defs_for(&servers).is_empty());
             // ...and a replayed disconnect finds nothing to do.
-            assert!(!pool.disconnect_if_still_idle(&sig, &name, generation).await);
+            assert_eq!(
+                pool.disconnect_if_still_idle(&sig, &name, generation).await,
+                IdleOutcome::Stale
+            );
         })
         .await;
     }
@@ -848,12 +911,117 @@ mod tests {
             let (sig, name, generation) = zeroed[0].clone();
             // A new run leases before the timer would have fired.
             pool.lease_blueprint(&bp, "run-b");
-            assert!(
-                !pool.disconnect_if_still_idle(&sig, &name, generation).await,
+            assert_eq!(
+                pool.disconnect_if_still_idle(&sig, &name, generation).await,
+                IdleOutcome::Stale,
                 "a stale generation must not tear down a re-leased server"
             );
             assert_eq!(pool.leased_holders(cfg), 1);
             assert!(!pool.cached_defs_for(&servers).is_empty());
+        })
+        .await;
+    }
+
+    /// A call in flight when the idle tick fires keeps the server exactly as
+    /// it was: still leased, still cached, still routable. The next tick,
+    /// once the call has let go, tears it down. Before the fix the first tick
+    /// dropped the lease row and the cached defs and only then found the
+    /// executor would not give the client up, so the second tick found no
+    /// row, returned early, and the server (and its child process) lived for
+    /// the daemon's life while its tool stayed routable.
+    #[tokio::test]
+    async fn an_in_flight_call_postpones_the_idle_disconnect() {
+        with_tracing(|| {});
+        with_temp_home(|| async {
+            let (_sd, stub) = stub_py();
+            let (_bd, bp) = blueprint_declaring("busyserver", &stub);
+            let pool = Arc::new(pool());
+            let servers = parse_blueprint_mcp_servers(&std::fs::read_to_string(&bp).unwrap());
+            assert_eq!(pool.ensure(&servers[0]).await.len(), 1);
+            pool.lease_blueprint(&bp, "run-a");
+            let zeroed = pool.release_run_bookkeeping("run-a");
+            let (sig, name, generation) = zeroed[0].clone();
+
+            // A call holds the client the way `ToolExecutor::execute` does:
+            // a clone of the shared `Arc`, taken by `route` and kept for the
+            // duration of the call.
+            let held = pool.shared.lock().await.route("busyserver__echo");
+            let (held, _) = held.expect("the tool routes while connected");
+            assert_eq!(
+                pool.disconnect_if_still_idle(&sig, &name, generation).await,
+                IdleOutcome::Busy,
+                "a server with a call in flight is kept"
+            );
+            assert!(
+                !pool.cached_defs_for(&servers).is_empty(),
+                "the cached defs survive a refused disconnect"
+            );
+            assert!(
+                pool.shared.lock().await.has_client(&name),
+                "the executor still has the server"
+            );
+            assert!(
+                pool.leases
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .servers
+                    .contains_key(&sig),
+                "the lease row survives, so a later tick can find the server"
+            );
+
+            drop(held);
+            assert_eq!(
+                pool.disconnect_if_still_idle(&sig, &name, generation).await,
+                IdleOutcome::Disconnected,
+                "once the call lets go, the next tick disconnects"
+            );
+            assert!(pool.cached_defs_for(&servers).is_empty());
+            assert!(!pool.shared.lock().await.has_client(&name));
+            assert!(
+                pool.shared.lock().await.route("busyserver__echo").is_err(),
+                "a disconnected server's tool no longer routes"
+            );
+        })
+        .await;
+    }
+
+    /// The grace timer itself: finding the server busy, it waits another
+    /// window and asks again, and disconnects once the call has let go.
+    #[tokio::test]
+    async fn the_grace_timer_waits_again_for_a_busy_server() {
+        with_tracing(|| {});
+        with_temp_home(|| async {
+            let (_sd, stub) = stub_py();
+            let (_bd, bp) = blueprint_declaring("retryserver", &stub);
+            let pool = Arc::new(pool());
+            let servers = parse_blueprint_mcp_servers(&std::fs::read_to_string(&bp).unwrap());
+            assert_eq!(pool.ensure(&servers[0]).await.len(), 1);
+            pool.lease_blueprint(&bp, "run-a");
+            let zeroed = pool.release_run_bookkeeping("run-a");
+            let (sig, name, generation) = zeroed[0].clone();
+
+            let held = pool.shared.lock().await.route("retryserver__echo");
+            let (held, _) = held.expect("routes");
+            let grace = std::time::Duration::from_millis(20);
+            let timer = tokio::spawn(Arc::clone(&pool).grace_disconnect(
+                grace,
+                sig,
+                name.clone(),
+                generation,
+            ));
+            // Several windows pass with the call in flight: the server stays.
+            tokio::time::sleep(grace * 6).await;
+            assert!(!pool.cached_defs_for(&servers).is_empty());
+            assert!(pool.shared.lock().await.has_client(&name));
+
+            // The call ends; the next window tears the server down and the
+            // timer task finishes.
+            drop(held);
+            timer
+                .await
+                .expect("the timer task ends once it disconnected");
+            assert!(pool.cached_defs_for(&servers).is_empty());
+            assert!(!pool.shared.lock().await.has_client(&name));
         })
         .await;
     }
@@ -913,8 +1081,9 @@ mod tests {
             pool.lease_blueprint(&bp, "run-a");
             let zeroed = pool.release_run_bookkeeping("run-a");
             let (sig, name, generation) = zeroed[0].clone();
-            assert!(
-                !pool.disconnect_if_still_idle(&sig, &name, generation).await,
+            assert_eq!(
+                pool.disconnect_if_still_idle(&sig, &name, generation).await,
+                IdleOutcome::Stale,
                 "no client to remove is a no-op, not an error"
             );
 

--- a/crates/leviath-mcp/src/execution.rs
+++ b/crates/leviath-mcp/src/execution.rs
@@ -287,6 +287,16 @@ impl ToolExecutor {
         Ok(())
     }
 
+    /// Whether a server is registered under `server_name`, busy or not.
+    ///
+    /// The distinction [`remove_client`](Self::remove_client) cannot make on
+    /// its own: `None` from it means either "no such server" or "a call is in
+    /// flight, so it stayed". A caller that wants to try again later needs to
+    /// know which.
+    pub fn has_client(&self, server_name: &str) -> bool {
+        self.clients.contains_key(server_name)
+    }
+
     /// Get the number of connected servers.
     pub fn server_count(&self) -> usize {
         self.clients.len()
@@ -635,11 +645,16 @@ mod tests {
             "a busy server is kept"
         );
         assert_eq!(executor.server_count(), 1);
+        assert!(
+            executor.has_client("slow"),
+            "kept, which is how a caller tells a busy server from an unknown one"
+        );
         in_flight
             .await
             .expect("task")
             .expect("the call still completes");
         let mut taken = executor.remove_client("slow").expect("idle now, so taken");
+        assert!(!executor.has_client("slow"));
         taken.shutdown().await.expect("best-effort shutdown");
     }
 


### PR DESCRIPTION
Audit round 4, item 1.3.

## Trace

`McpPool::disconnect_if_still_idle` (`crates/leviath-cli/src/daemon/mcp_pool.rs`) is the grace timer's callback, spawned by `release_run`, which the daemon's reap hook (`daemon/setup.rs` `make_reaper`) calls once a run's entity is despawned. Before this change the tick did, in order:

1. under the lease lock: check the row is idle at this generation, then `table.servers.remove(sig)`;
2. `connected.remove(sig)` (the cached tool defs);
3. `self.shared.lock().await.remove_client(name)`.

`ToolExecutor::remove_client` (`crates/leviath-mcp/src/execution.rs`) does `Arc::try_unwrap` on the stored client. When a call still holds a clone (every MCP call goes `route()` to clone the `Arc`, then `call_routed` on it) it puts the client back and returns `None`. The pool then returned `false` with its bookkeeping already gone, so:

- the next tick (there was none scheduled, but even a replay) found no lease row and returned early;
- the child process never received `shutdown()`;
- `ToolExecutor.clients` and `aliases` kept the entry for the daemon's life, and `route()` still resolved the tool for a run that no longer leased the server.

`remove_client`'s own comment documents this arm as "a race that was lost by a hair" and expects the caller to come back; the caller never did.

## Fix

- The tick takes the executor lock first, then checks the lease row under it, then `remove_client`. Only on `Some` does it drop the lease row and the cached defs (still under the executor lock, so a racing `ensure` sees either the whole old connection or nothing), then shuts the client down outside the lock as before.
- `None` while the executor still has the server means a call is in flight: the tick returns `IdleOutcome::Busy` and leaves everything as it was. The grace timer (`grace_disconnect`, the body `release_run` spawns) waits another window and asks again until it gets anything but `Busy`.
- `None` with no such server (leased but never connected, or its connect failed) still clears the row, as before.
- `ToolExecutor::has_client` is the one addition to `leviath-mcp`: `remove_client`'s `None` cannot distinguish "busy" from "unknown", and the retry needs to.

No config or wire change. CHANGELOG under Fixed.

## Fail-first evidence

`an_in_flight_call_postpones_the_idle_disconnect` holds a `route()` clone across the tick, asserts the tick refuses and the server is still tracked and routable, drops the clone, and asserts the second tick disconnects and the tool no longer routes. Against the old ordering (tests kept, production body reverted):

```
test daemon::mcp_pool::tests::an_in_flight_call_postpones_the_idle_disconnect ... FAILED
panicked at crates/leviath-cli/src/daemon/mcp_pool.rs:959:13:
the lease row survives, so a later tick can find the server
```

With the fix, all 19 `daemon::mcp_pool` tests pass. `the_grace_timer_waits_again_for_a_busy_server` drives `grace_disconnect` with a 20 ms window, holds the clone across several windows, releases it, and awaits the timer task ending with the server gone. `remove_client_keeps_a_server_with_a_call_in_flight` in `leviath-mcp` now also asserts `has_client` both ways.

## Live check

Isolated home `/tmp/lvC`, `perf-tools/mock.py` asking for `slowmcp__echo`, a blueprint declaring one stdio `[[mcp_servers]]` whose `tools/call` sleeps 8 s, `[limits] mcp_idle_disconnect_secs = 2`, runs spawned over `lev serve`, `ps` sampled every 250 ms for the stub's pid.

Fixed binary (this branch, release build):

```
[A-complete] t=  0.00s status=starting     stub_pids=['41829']
[A-complete] t=  8.26s status=complete     stub_pids=['41829']
[A-complete] t= 10.09s status=complete     stub_pids=[]
[B-cancel]   t=  3.17s lev cancel -> cancelled
[B-cancel]   t=  3.51s status=cancelled    stub_pids=['42206']
[B-cancel]   t=  5.46s status=cancelled    stub_pids=[]
```

The child is gone within the 2 s grace of the run going terminal, whether the run finished or was cancelled mid-call. The same script against the installed pre-fix `~/.cargo/bin/lev` gives the same timeline, and that is worth stating plainly: through a run, the busy tick is not reachable in the daemon with a grace of 1 s or more, because `abort_terminal_work` cancels a terminal agent's in-flight token on the next tick and the tool lane's `run_batch` drops the batch future (and with it the `Arc` clone) when that token fires. The window in which `remove_client` finds the `Arc` held is one scheduler hop wide from a run's point of view. The leak is real for any holder of a `route()` clone that outlives the reap, which is what the unit test models, but a live run does not produce one today. The live check therefore shows the reordered locking still disconnects on both paths, not a before/after difference.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-cli -p leviath-mcp -- -D warnings`
- `cargo test -p leviath-cli --lib daemon::mcp_pool` (19 passed), `cargo test -p leviath-mcp --lib remove_client` (2 passed)
- `cargo xtask structure`, `cargo xtask docs`
- `cargo xtask coverage --package leviath-mcp` and `--package leviath-cli`: both at 100%
- pre-commit (full suite) passed on commit
