### PR TITLE
fix(runtime): a malformed endpoint option fails the entry, not loosens it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -238,6 +238,14 @@ same list.
   its shutdown, and the tool stayed routable for a run that no longer leased
   it. The client is now taken first, the bookkeeping goes only once it is, and
   a busy server gets another grace window.
+- An OpenAI-compatible endpoint entry whose `models`, `serves` or header
+  options did not read back out of the provider credentials was quietly
+  loosened: an unreadable `models` list became "the config did not say", so
+  the endpoint routed any id where the list would have refused the rest, and
+  a header with a bad position was dropped. Those options are written by the
+  runtime itself, so the failure is a bug; the registry now refuses the
+  entry with an error naming it and the option instead of registering a more
+  permissive provider.
 - The dashboard's run detail strip could show a cache figure over 100%, such
   as `cache 152%`, on a run that was mostly served from the provider's cache.
   The prompt count every provider is normalised to is the fresh input only,

--- a/crates/leviath-cli/src/commands/run/session.rs
+++ b/crates/leviath-cli/src/commands/run/session.rs
@@ -692,8 +692,9 @@ mod tests {
         assert_eq!(names, ["alpha", "zeta"], "name order, no broken entry");
 
         let zeta = creds.iter().find(|c| c.name == "zeta").expect("zeta");
-        let spec =
-            leviath_runtime::provider_creds::EndpointSpec::from_creds(zeta).expect("an endpoint");
+        let spec = leviath_runtime::provider_creds::EndpointSpec::from_creds(zeta)
+            .expect("decodes")
+            .expect("an endpoint");
         assert_eq!(spec.base_url, "http://localhost:8080/v1", "trimmed");
         assert_eq!(zeta.api_key, None, "a blank key is no key");
         assert_eq!(spec.headers, vec![("X-Org".to_string(), "r".to_string())]);

--- a/crates/leviath-cli/src/commands/setup/state/endpoints.rs
+++ b/crates/leviath-cli/src/commands/setup/state/endpoints.rs
@@ -775,6 +775,7 @@ mod tests {
         let request = requests.recv().await.expect("sent");
         assert_eq!(request.provider_id, "openai-compatible");
         let spec = leviath_runtime::provider_creds::EndpointSpec::from_creds(&request.creds)
+            .expect("decodes")
             .expect("an endpoint cred");
         assert_eq!(spec.base_url, "http://127.0.0.1:1/v1");
         assert_eq!(spec.headers, vec![("X-Org".to_string(), "r".to_string())]);

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -78,43 +78,67 @@ pub struct EndpointSpec {
 }
 
 impl EndpointSpec {
-    /// The endpoint `creds` describes, or `None` when it is not one.
+    /// The endpoint `creds` describes, or `Ok(None)` when it is not one.
     ///
     /// An endpoint with no base URL is not an endpoint: the config layer
     /// refuses to load one, so this is a second guard rather than the first.
-    pub fn from_creds(creds: &ProviderCreds) -> Option<Self> {
+    ///
+    /// An option that is there but does not read back is an error, not an
+    /// absence. The runtime wrote these from the config, so a failure is a
+    /// bug, and reading past it used to change what the entry meant: a
+    /// `models` list that did not parse became "the config did not say",
+    /// which lets the endpoint route any id where the list would have
+    /// refused the rest, and a header with a bad position was a header the
+    /// server never saw. The error names the entry and the option.
+    pub fn from_creds(
+        creds: &ProviderCreds,
+    ) -> Result<Option<Self>, leviath_providers::ProviderError> {
         if creds.options.get(KIND_OPTION).map(String::as_str) != Some(OPENAI_COMPATIBLE) {
-            return None;
+            return Ok(None);
         }
-        let base_url = creds.base_url.clone()?;
+        let Some(base_url) = creds.base_url.clone() else {
+            return Ok(None);
+        };
+        let malformed = |option: &str, what: &str| {
+            leviath_providers::ProviderError::Other(format!(
+                "endpoint '{}': the '{option}' option is not {what}; the runtime wrote it \
+                 from the config, so this is a bug in leviath rather than in the config",
+                creds.name
+            ))
+        };
         // Sorted by the position the encoder stamped, so the config's own
         // order is what the wire sees whatever order the map iterates in.
-        let mut headers: Vec<(usize, String, String)> = creds
-            .options
-            .iter()
-            .filter_map(|(key, value)| {
-                let rest = key.strip_prefix(HEADER_PREFIX)?;
-                let (position, name) = rest.split_once(':')?;
-                Some((position.parse().ok()?, name.to_string(), value.clone()))
-            })
-            .collect();
+        let mut headers: Vec<(usize, String, String)> = Vec::new();
+        for (key, value) in &creds.options {
+            let Some(rest) = key.strip_prefix(HEADER_PREFIX) else {
+                continue;
+            };
+            let position = rest
+                .split_once(':')
+                .and_then(|(position, name)| Some((position.parse().ok()?, name)));
+            let Some((position, name)) = position else {
+                return Err(malformed(key, "a numbered header (header:<n>:<name>)"));
+            };
+            headers.push((position, name.to_string(), value.clone()));
+        }
         headers.sort();
-        Some(Self {
+        let list = |option: &str| -> Result<Option<Vec<String>>, _> {
+            creds
+                .options
+                .get(option)
+                .map(|json| serde_json::from_str(json))
+                .transpose()
+                .map_err(|_| malformed(option, "a JSON list of strings"))
+        };
+        Ok(Some(Self {
             base_url,
             headers: headers
                 .into_iter()
                 .map(|(_, name, value)| (name, value))
                 .collect(),
-            models: creds
-                .options
-                .get(MODELS_OPTION)
-                .and_then(|json| serde_json::from_str(json).ok()),
-            serves: creds
-                .options
-                .get(SERVES_OPTION)
-                .and_then(|json| serde_json::from_str(json).ok())
-                .unwrap_or_default(),
-        })
+            models: list(MODELS_OPTION)?,
+            serves: list(SERVES_OPTION)?.unwrap_or_default(),
+        }))
     }
 }
 
@@ -350,7 +374,7 @@ pub fn build_provider_registry_probing(
         // Decided by kind before the name is looked at: an endpoint is
         // registered under whatever name the config gave it, and that name is
         // the user's to choose.
-        if let Some(endpoint) = EndpointSpec::from_creds(c) {
+        if let Some(endpoint) = EndpointSpec::from_creds(c)? {
             registry.register(
                 c.name.clone(),
                 Arc::new(
@@ -558,7 +582,9 @@ mod tests {
             Some(vec!["llama-3".to_string()]),
             vec!["llama".to_string()],
         );
-        let spec = EndpointSpec::from_creds(&creds).expect("an endpoint");
+        let spec = EndpointSpec::from_creds(&creds)
+            .expect("decodes")
+            .expect("an endpoint");
         assert_eq!(
             spec,
             EndpointSpec {
@@ -574,38 +600,67 @@ mod tests {
 
         // Nothing configured stays nothing rather than becoming an empty list.
         let bare = ProviderCreds::openai_compatible("x", "http://h", None, vec![], None, vec![]);
-        let spec = EndpointSpec::from_creds(&bare).expect("an endpoint");
+        let spec = EndpointSpec::from_creds(&bare)
+            .expect("decodes")
+            .expect("an endpoint");
         assert_eq!(spec.models, None);
         assert!(spec.serves.is_empty());
         assert!(spec.headers.is_empty());
     }
 
-    /// Not an endpoint: a native provider, an endpoint that lost its address,
-    /// and options written by hand that do not decode.
+    /// Not an endpoint: a native provider, and an endpoint that lost its
+    /// address.
     #[test]
     fn a_cred_that_is_not_an_endpoint_yields_no_spec() {
         assert_eq!(
-            EndpointSpec::from_creds(&ProviderCreds::simple("anthropic")),
+            EndpointSpec::from_creds(&ProviderCreds::simple("anthropic")).expect("decodes"),
             None
         );
 
         let mut no_url =
             ProviderCreds::openai_compatible("x", "http://h", None, vec![], None, vec![]);
         no_url.base_url = None;
-        assert_eq!(EndpointSpec::from_creds(&no_url), None);
+        assert_eq!(EndpointSpec::from_creds(&no_url).expect("decodes"), None);
+    }
 
-        let mut odd = ProviderCreds::openai_compatible("x", "http://h", None, vec![], None, vec![]);
-        odd.options
-            .insert("header:X-No-Position".to_string(), "v".to_string());
-        odd.options
-            .insert("header:notanumber:X-Bad".to_string(), "v".to_string());
-        odd.options
-            .insert("models".to_string(), "not json".to_string());
-        odd.options.insert("serves".to_string(), "[".to_string());
-        let spec = EndpointSpec::from_creds(&odd).expect("still an endpoint");
-        assert!(spec.headers.is_empty());
-        assert_eq!(spec.models, None);
-        assert!(spec.serves.is_empty());
+    /// An option the runtime wrote that does not read back is a bug, and it
+    /// must not turn into a looser entry: `models` going from "this complete
+    /// list" to "the config did not say" lets the endpoint route any id, and
+    /// a header that lost its position is a header the server never sees.
+    /// The registry refuses the entry and names it and the option.
+    #[test]
+    fn a_malformed_endpoint_option_fails_the_registry_rather_than_loosening_it() {
+        for (option, value) in [
+            ("models", "not json"),
+            ("serves", "["),
+            ("header:notanumber:X-Bad", "v"),
+            ("header:X-No-Position", "v"),
+        ] {
+            let mut bad = ProviderCreds::openai_compatible(
+                "gw",
+                "http://127.0.0.1:1/v1",
+                None,
+                vec![],
+                Some(vec!["m".to_string()]),
+                vec![],
+            );
+            bad.options.insert(option.to_string(), value.to_string());
+            let decoded = EndpointSpec::from_creds(&bad);
+            assert!(decoded.is_err(), "{option}={value:?} must not decode");
+            let text = decoded.expect_err("checked above").to_string();
+            assert!(text.contains("'gw'"), "{option}: names the entry: {text}");
+            assert!(text.contains(option), "names the option: {text}");
+            let registry = build_provider_registry(&[bad]);
+            assert!(
+                registry.is_err(),
+                "{option}={value:?} must fail the registry"
+            );
+            assert_eq!(
+                registry.map(drop).expect_err("checked above").to_string(),
+                text,
+                "the registry passes it on as is"
+            );
+        }
     }
 
     /// A header value is a credential as often as not.


### PR DESCRIPTION
Plan item 1.8: a malformed endpoint encoding silently flipped strict to permissive.

## Premise check

Held.

- `crates/leviath-runtime/src/provider_creds.rs:106-114`: `models` and `serves` were read back with `serde_json::from_str(json).ok()`. `EndpointProvider.configured_models` (`crates/leviath-providers/src/endpoint.rs:74-76`) documents `Some` as "a complete catalogue" and `None` as "the config did not say", so a `models` value that failed to parse made the endpoint route any id where the list would have refused the rest.
- `provider_creds.rs:96`: a `header:<n>:<name>` key whose position did not parse was `filter_map`ped away, so the header never reached the wire.
- The test `a_cred_that_is_not_an_endpoint_yields_no_spec` pinned both as intended ("options written by hand that do not decode").
- Only one production caller: `build_provider_registry_probing` (`provider_creds.rs:351`), which already returns `Result<_, ProviderError>`. The other two `from_creds` calls are CLI tests.

## Fix

`EndpointSpec::from_creds` returns `Result<Option<Self>, ProviderError>`. Not an endpoint (no `kind`, no base URL) is still `Ok(None)`. An option that is present but does not read back is `Err(ProviderError::Other(..))` naming the entry and the option, for example:

```
endpoint 'gw': the 'models' option is not a JSON list of strings; the runtime wrote it from the config, so this is a bug in leviath rather than in the config
```

The registry builder propagates it with `?`, so provider construction fails with that message rather than registering a looser provider. The pinned test lost its "does not decode" half; the new test covers `models`, `serves`, a header with a non-numeric position and a header with no position, at both the spec and the registry level. CHANGELOG under Unreleased / Fixed.

## Fail-first evidence

The registry-level assertion, run against the unfixed code (it compiles against both signatures):

```
test provider_creds::tests::a_malformed_endpoint_option_fails_the_registry_rather_than_loosening_it ... FAILED
models="not json" must fail the registry
```

The unfixed registry registered `gw` as a provider with `configured_models = None`. Passes after the fix for all four malformed shapes.

## Live check

None possible from outside: the only writer of these options is `ProviderCreds::openai_compatible`, which serialises a `Vec<String>` with `serde_json::to_string` and numbers the headers itself, so no config file can produce the malformed encoding. The fix is for the day a future change to the encoding breaks the round trip, and the test is what catches that day; the registry test above stands in for the daemon boot, whose provider construction is the same call.

## Gates

`cargo fmt --all`; `cargo clippy --all-targets --all-features -p leviath-runtime -p leviath-cli -- -D warnings`; `cargo xtask structure`; `cargo xtask docs`; `cargo xtask coverage --package leviath-runtime` and `--package leviath-cli` both at 100%. Pre-commit ran the full suite.
