### PR TITLE
fix(update): cap the release lookup's body like every other remote read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,12 @@ same list.
 
 ### Fixed
 
+- The update check read the GitHub releases answer with no size cap, the one
+  buffered remote read left after the daemon's caps landed. It now stops at
+  the same 64 MiB as every other buffered body and reports the same
+  `response body exceeded 64 MiB from api.github.com` message. The security
+  page names it, and the one bounded-differently read (a chunked body on a
+  script's `http_get`).
 - `requests_per_minute = 0` under `[rate_limits.<provider>]` hung every call
   to that provider: the limiter waited for the request count to drop under
   zero, which it never could, and the wait sat in front of any HTTP timeout.

--- a/crates/leviath-cli/src/commands/update/latest.rs
+++ b/crates/leviath-cli/src/commands/update/latest.rs
@@ -190,6 +190,12 @@ pub(crate) fn now_secs() -> u64 {
 /// GitHub refuses a request with no `User-Agent`, so it carries one naming the
 /// program doing the asking, which is what their guidance asks for.
 pub(crate) fn fetch_release(url: &str) -> Result<String, String> {
+    fetch_release_capped(url, leviath_net::read_caps::JSON_BODY_CAP)
+}
+
+/// [`fetch_release`] with the body cap as a parameter, so a test can hit it
+/// with a body of a few bytes rather than 64 MiB.
+fn fetch_release_capped(url: &str, cap: usize) -> Result<String, String> {
     let client = reqwest::blocking::Client::builder()
         .timeout(std::time::Duration::from_secs(FETCH_TIMEOUT_SECS))
         .user_agent(concat!("leviath/", env!("CARGO_PKG_VERSION")))
@@ -200,12 +206,31 @@ pub(crate) fn fetch_release(url: &str) -> Result<String, String> {
         // and a fast one the same way.
         .build()
         .unwrap_or_default();
-    let response = client.get(url).send().map_err(describe)?;
+    let mut response = client.get(url).send().map_err(describe)?;
     // A 404 is an answer - that channel has published nothing - and it arrives
     // as a body carrying no version, which reads the same as any other unusable
     // answer. Nothing here separates the failures, because no caller renders
     // them differently.
-    response.text().map_err(describe)
+    //
+    // Read through `take` rather than `text()`, which buffers whatever the peer
+    // sends: the same cap and message as every other buffered body the daemon
+    // reads (see `leviath_net::read_caps`). One byte past the cap is read so
+    // an over-long body is told apart from one that is exactly the cap.
+    let peer = response
+        .url()
+        .host_str()
+        .unwrap_or("an unnamed peer")
+        .to_string();
+    let mut body = Vec::new();
+    let limit = u64::try_from(cap).unwrap_or(u64::MAX).saturating_add(1);
+    std::io::Read::read_to_end(&mut std::io::Read::take(&mut response, limit), &mut body)
+        .map_err(describe)?;
+    if body.len() > cap {
+        return Err(leviath_net::read_caps::BodyReadError::TooLarge { cap, peer }.to_string());
+    }
+    // The releases API answers UTF-8 JSON; lossy so a stray byte reads as a
+    // body carrying no version rather than a second failure shape.
+    Ok(String::from_utf8_lossy(&body).into_owned())
 }
 
 /// Every failure in [`fetch_release`], flattened to its message.

--- a/crates/leviath-cli/src/commands/update/latest_tests.rs
+++ b/crates/leviath-cli/src/commands/update/latest_tests.rs
@@ -189,6 +189,74 @@ fn the_real_fetcher_reads_a_body_off_the_wire() {
     assert_eq!(got.as_deref(), Ok(r#"{"name": "1.2.3"}"#));
 }
 
+/// A loopback server that answers one request with `body` and the
+/// `Content-Length` to match, so the fetcher's read is exercised end to end.
+fn serve_once(body: &'static str) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
+    serve_once_declaring(body, body.len())
+}
+
+/// [`serve_once`] with the `Content-Length` chosen by the test, so a server
+/// that promises more than it sends can be stood up.
+fn serve_once_declaring(
+    body: &'static str,
+    declared: usize,
+) -> (std::net::SocketAddr, std::thread::JoinHandle<()>) {
+    use std::io::{Read, Write};
+
+    let listener =
+        std::net::TcpListener::bind("127.0.0.1:0").expect("a loopback port is available");
+    let addr = listener
+        .local_addr()
+        .expect("a bound listener has an address");
+    let server = std::thread::spawn(move || {
+        let (mut socket, _) = listener.accept().expect("the fetcher connects");
+        // Read just enough to let the client finish sending before answering.
+        let mut buf = [0_u8; 1024];
+        let _ = socket.read(&mut buf);
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {declared}\r\nContent-Type: application/json\r\n\r\n{body}"
+        );
+        let _ = socket.write_all(response.as_bytes());
+    });
+    (addr, server)
+}
+
+/// A connection that closes before the promised body arrives is an error
+/// from the read itself, reported like any other transport failure.
+#[test]
+fn the_real_fetcher_reports_a_body_cut_short_as_an_error() {
+    let body = r#"{"name": "1.2.3"}"#;
+    let (addr, server) = serve_once_declaring(body, body.len() + 100);
+    let got = fetch_release_capped(&format!("http://{addr}/releases/tags/latest"), 1024);
+    server.join().expect("the server thread does not panic");
+    assert!(got.is_err());
+}
+
+/// A body past the cap is an error naming the cap and the peer, in the shape
+/// every other capped read reports, rather than a body read whole. The cap
+/// is a test-sized one so the test allocates bytes, not 64 MiB.
+#[test]
+fn the_real_fetcher_stops_at_the_cap_and_names_it() {
+    let body = r#"{"name": "1.2.3", "padding": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}"#;
+    let (addr, server) = serve_once(body);
+    let got = fetch_release_capped(&format!("http://{addr}/releases/tags/latest"), 16);
+    server.join().expect("the server thread does not panic");
+    assert_eq!(
+        got,
+        Err("response body exceeded 16 bytes from 127.0.0.1".to_string())
+    );
+}
+
+/// A body exactly at the cap is whole: the cap is a ceiling, not a strict bound.
+#[test]
+fn the_real_fetcher_reads_a_body_exactly_at_the_cap() {
+    let body = r#"{"name": "1.2.3"}"#;
+    let (addr, server) = serve_once(body);
+    let got = fetch_release_capped(&format!("http://{addr}/releases/tags/latest"), body.len());
+    server.join().expect("the server thread does not panic");
+    assert_eq!(got.as_deref(), Ok(body));
+}
+
 /// A server that is not there is an error, not a hang and not a panic. The
 /// caller turns it into "cannot tell".
 #[test]

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -255,6 +255,16 @@ streams, and the OAuth exchanges behind `lev mcp login`. They are constants,
 not configuration: every well-formed reply is far below them, and a knob that
 only matters under attack would be a knob for the attacker.
 
+The update check (`lev update` and the daemon's cached `GET /api/update`)
+reads the GitHub releases answer under the same 64 MiB cap and reports the
+same message. One remote read stays bounded a different way: a Rhai script's
+`http_get` refuses a body whose `Content-Length` is over its 900 KB output
+cap before reading it, but a chunked response carries no length, so a body
+that lies about its size is buffered until the client's 30 s timeout or the
+peer's end of stream, then cut to 900 KB. Closing that needs a streaming
+decoder that keeps the charset handling scripts rely on, and it is a known
+residual rather than an oversight.
+
 ## Threat model
 
 `lev serve` runs LLM-driven tools, so treat it as trusted-network only unless hardened. See


### PR DESCRIPTION
Plan item 1.10 (audit round 4).

## Premise check

- `crates/leviath-cli/src/commands/update/latest.rs:208` `fetch_release` ends in `response.text().map_err(describe)` on a `reqwest::blocking` response: the whole body is buffered with no cap. Both callers are real: `commands/update.rs:559` (the CLI's `lev update`) and `serve/update_cache.rs:28` (the daemon's cached `GET /api/update`, off the request path via `spawn_blocking`).
- `crates/leviath-cli/src/daemon/script_host.rs:501` documents the chunked-body residual on a script's `http_get`: `Content-Length` is refused up front when over the 900 KB cap, a chunked body has none, and the client's 30 s timeout plus the post-read `cap_script_io` bound it. Left as it is, per the plan; now written down on the security page.

## Fix

`fetch_release` delegates to `fetch_release_capped(url, JSON_BODY_CAP)`, which reads the body through `Read::take(cap + 1)` and, past the cap, returns `BodyReadError::TooLarge { cap, peer }.to_string()` from `leviath_net::read_caps`, so the message is the same shape as every other capped read (`response body exceeded 64 MiB from api.github.com`). The body is decoded lossily as UTF-8 (the releases API answers UTF-8 JSON; the callers only look for a version in it). The cap is a parameter so no test allocates 64 MiB.

## Fail-first

`the_real_fetcher_stops_at_the_cap_and_names_it` (a loopback server answering a 66-byte body, cap of 16) against the same function with the cap plumbed but the read left whole:

```
thread '...the_real_fetcher_stops_at_the_cap_and_names_it' panicked at latest_tests.rs:225:5:
assertion `left == right` failed
  left: Ok("{\"name\": \"1.2.3\", \"padding\": \"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"}")
 right: Err("response body exceeded 16 bytes from 127.0.0.1")
```

Also added: a body exactly at the cap is read whole (the cap is a ceiling), and a body cut short of its declared `Content-Length` is a read error rather than a hang or a panic.

## Docs and changelog

`docs/content/security.md` "Response size caps": names the update check under the 64 MiB cap and describes the `http_get` chunked-body residual and why it stays. CHANGELOG under Fixed.

## Gates

`cargo fmt --all`, `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`, `cargo xtask structure`, `cargo xtask docs`, `cargo xtask coverage --package leviath-cli` (100%), pre-commit full suite. No `main.rs` touched. No live probe: the change is inside one blocking function exercised end to end over loopback by the tests above.
