### PR TITLE
test(daemon): assert the MCP grace timer without waiting out the wall clock

### DIFF
--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -117,8 +117,15 @@ impl McpPool {
 
     /// How long a per-agent server may sit unleased before disconnection.
     /// `0` disables it.
-    pub(crate) fn with_idle_disconnect_secs(mut self, secs: u64) -> Self {
-        self.idle_disconnect = std::time::Duration::from_secs(secs);
+    pub(crate) fn with_idle_disconnect_secs(self, secs: u64) -> Self {
+        self.with_idle_disconnect(std::time::Duration::from_secs(secs))
+    }
+
+    /// [`Self::with_idle_disconnect_secs`] at any resolution. Config only
+    /// speaks in whole seconds; a test of the scheduled path wants a window
+    /// short enough not to wait on the wall clock.
+    pub(crate) fn with_idle_disconnect(mut self, grace: std::time::Duration) -> Self {
+        self.idle_disconnect = grace;
         self
     }
 
@@ -1039,13 +1046,19 @@ mod tests {
     /// the grace timer, and after the window the server is gone. With the
     /// grace set to zero, releasing schedules nothing and the connection
     /// stays.
+    ///
+    /// The window is milliseconds and the teardown is awaited by polling with
+    /// a generous ceiling, not by sleeping past a fixed slack: the python
+    /// subprocess is real, so a paused clock is out, and a slow runner used to
+    /// turn a 1 s timer plus 2.5 s of slack into the suite's one flake.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn release_run_schedules_the_grace_disconnect() {
         with_tracing(|| {});
         with_temp_home(|| async {
             let (_sd, stub) = stub_py();
             let (_bd, bp) = blueprint_declaring("timedserver", &stub);
-            let timed = Arc::new(pool().with_idle_disconnect_secs(1));
+            let grace = std::time::Duration::from_millis(20);
+            let timed = Arc::new(pool().with_idle_disconnect(grace));
             let servers = parse_blueprint_mcp_servers(&std::fs::read_to_string(&bp).unwrap());
             assert_eq!(timed.ensure(&servers[0]).await.len(), 1);
             timed.lease_blueprint(&bp, "run-a");
@@ -1053,15 +1066,23 @@ mod tests {
             // Within the grace window the connection survives...
             assert!(!timed.cached_defs_for(&servers).is_empty());
             // ...and after it, the timer has torn it down.
-            tokio::time::sleep(std::time::Duration::from_millis(2500)).await;
-            assert!(timed.cached_defs_for(&servers).is_empty());
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            while !timed.cached_defs_for(&servers).is_empty() {
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "the grace timer never tore the server down"
+                );
+                tokio::time::sleep(grace).await;
+            }
 
-            // Grace zero: releasing disconnects nothing, ever.
+            // Grace zero: releasing disconnects nothing, ever. There is no
+            // timer to wait out; a few windows' worth is enough to catch one
+            // spawned by mistake.
             let keeper = Arc::new(pool().with_idle_disconnect_secs(0));
             assert_eq!(keeper.ensure(&servers[0]).await.len(), 1);
             keeper.lease_blueprint(&bp, "run-b");
             keeper.release_run("run-b");
-            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            tokio::time::sleep(grace * 5).await;
             assert!(!keeper.cached_defs_for(&servers).is_empty());
         })
         .await;


### PR DESCRIPTION
Audit round 4, section 3: the one real flake risk noted at `daemon/mcp_pool.rs:888`.

## What was wrong

`release_run_schedules_the_grace_disconnect` built a pool with a 1 s idle window, released a run, and then slept 2.5 s of real time before asserting the server was gone. The assertion held only if the timer, the python stub's shutdown and the executor all finished inside that fixed slack, on whichever runner drew the job. The grace-zero half added a fixed 200 ms on top.

## Change

- `McpPool::with_idle_disconnect(Duration)` beside the whole-seconds builder; `with_idle_disconnect_secs` delegates to it (so it is covered by every existing caller). Config still speaks in whole seconds; nothing outside tests uses the new one.
- The test asks for a 20 ms window and awaits the teardown by polling `cached_defs_for` with a 10 s ceiling, so a slow runner gets all the time it needs and a fast one waits about one window. The grace-zero half waits five windows (100 ms) instead of 200 ms.
- A paused tokio clock was considered and rejected: the stub is a real subprocess whose I/O has to happen in real time, and auto-advance would also fire the client's own handshake timeouts.

No production behaviour change. Independent of #720 (that PR touches `disconnect_if_still_idle` and `release_run`; this one touches the builder and the test).

## Measured

- `cargo test -p leviath-cli --lib release_run_schedules_the_grace_disconnect`: `finished in 0.21s` (was about 2.7 s)
- `cargo test -p leviath-cli --lib daemon::mcp_pool`: 17 passed, `finished in 0.31s` (was about 3 s)

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`
- `cargo xtask structure`, `cargo xtask docs`
- `cargo xtask coverage --package leviath-cli`: 100%
- pre-commit (full suite) passed on commit
