### PR TITLE
docs: the schemas name what the parsers read, with a drift test for each

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,16 @@ same list.
   `response body exceeded 64 MiB from api.github.com` message. The security
   page names it, and the one bounded-differently read (a chunked body on a
   script's `http_get`).
+- The published schemas had fallen behind the parsers. `config.schema.json`
+  refused `update_check`, four `[limits]` keys the daemon reads
+  (`max_agents_per_run`, `notify_spend_usd`, `script_http_timeout_secs`,
+  `script_http_max_per_host`) and the four per-model price overrides, so a
+  config the CLI loads failed schema validation; `blueprint.schema.json` refused
+  `describe_in_prompt` on a region, the key the context docs tell you to write;
+  and `openapi.json` named no `401`, `405`, `408` or `503` anywhere, listed
+  `200` on routes that answer `201`, `202` or `204`, and gave `GET /api/config`
+  no shape. Each gap now has a test that reads the parser and holds the schema
+  to it.
 - `requests_per_minute = 0` under `[rate_limits.<provider>]` hung every call
   to that provider: the limiter waited for the request count to drop under
   zero, which it never could, and the wait sat in front of any HTTP timeout.
@@ -3522,7 +3532,7 @@ same list.
 - `lev doctor` prints the provider and model it actually resolved to, not just
   "OK". A stage that names no model of its own falls back to `anthropic`, so a
   machine holding only an OpenRouter key can resolve to a provider it has no
-  credential for, spawn, and sit at iteration 0 — which is how a batch of runs
+  credential for, spawn, and sit at iteration 0, which is how a batch of runs
   once went nowhere at once. Now it says so, before anything is spawned.
 - A failing provider call is reported verbatim, status line and response body
   included, so a 402 naming the exhausted credit or a 404 naming the model

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Leviath is also a library: add the [`leviath`](https://crates.io/crates/leviath)
 
 ### 2. Configure a provider
 
-One provider is all you need: an API key from [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), [Google AI](https://aistudio.google.com/), or [OpenRouter](https://openrouter.ai/). No key at all? Run a local [Ollama](https://ollama.com), or opt into the [Claude Code transport](https://leviath.dev/docs/providers#claude-code-transport) to run on your Claude subscription (read its terms-of-service note first).
+One provider is all you need: an API key from [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), [Google AI](https://aistudio.google.com/), or [OpenRouter](https://openrouter.ai/). No key at all? Run a local [Ollama](https://ollama.com), or turn on the [Claude Code transport](https://leviath.dev/docs/providers#claude-code-transport) with `lev setup --claude-code true` to run on your Claude subscription (the wizard does not offer it; read its terms-of-service note first).
 
 ```bash
 lev setup      # interactive wizard
@@ -285,7 +285,7 @@ Leviath also connects to [Model Context Protocol](https://modelcontextprotocol.i
 
 ## Providers
 
-Anthropic, OpenAI, Google (Gemini), OpenRouter, local [Ollama](https://ollama.com) with no key, and the Claude Code subscription transport, with per-stage model fallback, optional client-side rate limits enforced before each call, and custom OpenAI-compatible providers as [Rhai scripts](https://leviath.dev/docs/rhai-providers). [Provider docs →](https://leviath.dev/docs/providers)
+Anthropic, OpenAI, Google (Gemini), OpenRouter, local [Ollama](https://ollama.com) with no key, the Claude Code subscription transport, and any OpenAI-compatible endpoint (llama.cpp, LM Studio, vLLM, an enterprise gateway) as a `kind = "openai-compatible"` entry in `[model_providers]`, with a [Rhai script](https://leviath.dev/docs/rhai-providers) for a wire format that is not OpenAI's. Per-stage model fallback and optional client-side rate limits enforced before each call. [Provider docs →](https://leviath.dev/docs/providers)
 
 ## Security
 

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -183,12 +183,71 @@ fn api_router() -> Router<AppState> {
 /// The same technique `xtask/src/docs.rs` uses on the docs.
 #[cfg(test)]
 fn declared_routes() -> Vec<(String, String)> {
+    routes_in(production_source())
+}
+
+/// This file above its test module. The tests below declare routes of their
+/// own as fixtures for the reader, and those are not served by anything;
+/// reading the whole file counted them as production routes.
+#[cfg(test)]
+fn production_source() -> &'static str {
     const SOURCE: &str = include_str!("mod.rs");
-    // Only the half above the test module. The tests below declare routes of
-    // their own as fixtures for the reader, and those are not served by
-    // anything. Reading the whole file counted them as production routes.
-    let production = SOURCE.split("\nmod tests {").next().unwrap_or(SOURCE);
-    routes_in(production)
+    SOURCE.split("\nmod tests {").next().unwrap_or(SOURCE)
+}
+
+/// [`routes_in`] with the handler each method names: every
+/// `(path, METHOD, module, function)` in `source`, for the test that holds
+/// the spec's status codes to what the handler can answer. A route whose
+/// handler is not written `module::function` is left out.
+#[cfg(test)]
+fn handlers_in(source: &str) -> Vec<(String, String, String, String)> {
+    let mut handlers = Vec::new();
+    for chunk in source.split(".route(").skip(1) {
+        let mut depth = 1usize;
+        let mut body = String::new();
+        for ch in chunk.chars() {
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            body.push(ch);
+        }
+        let Some(path) = body
+            .split_once('"')
+            .and_then(|(_, rest)| rest.split_once('"'))
+            .map(|(path, _)| path)
+        else {
+            continue;
+        };
+        if !path.starts_with('/') {
+            continue;
+        }
+        for method in ["get", "post", "put", "delete", "patch"] {
+            // `get(blueprints::list_blueprints)`: the call's argument up to
+            // its closing parenthesis, split at the path separator.
+            let call = format!("{method}(");
+            let named = body
+                .split(call.as_str())
+                .skip(1)
+                .filter_map(|rest| rest.split_once(')'))
+                .filter_map(|(target, _)| target.split_once("::"));
+            for (module, function) in named {
+                handlers.push((
+                    path.to_string(),
+                    method.to_uppercase(),
+                    module.trim().to_string(),
+                    function.trim().to_string(),
+                ));
+            }
+        }
+    }
+    handlers
 }
 
 /// The route reader itself, over arbitrary source text.
@@ -721,6 +780,158 @@ mod tests {
         let (missing, extra) = spec_drift();
         assert!(missing.is_empty());
         assert!(extra.is_empty());
+    }
+
+    /// The production half of every module that owns a handler, by name.
+    const HANDLER_SOURCES: &[(&str, &str)] = &[
+        ("agents", include_str!("agents.rs")),
+        ("blueprints", include_str!("blueprints.rs")),
+        ("config", include_str!("config.rs")),
+        ("doctor", include_str!("doctor.rs")),
+        ("fs", include_str!("fs.rs")),
+        ("interactions", include_str!("interactions.rs")),
+        ("mcp", include_str!("mcp.rs")),
+        ("runs", include_str!("runs.rs")),
+        ("scripts", include_str!("scripts.rs")),
+        ("tools", include_str!("tools.rs")),
+        ("tree", include_str!("tree.rs")),
+        ("update", include_str!("update.rs")),
+        ("websocket", include_str!("websocket.rs")),
+    ];
+
+    /// The `StatusCode::` constants a handler can name, as numbers. A
+    /// constant not listed here fails the lookup below, which is the prompt
+    /// to add it rather than a reason to guess.
+    const STATUS_CONSTANTS: &[(&str, u16)] = &[
+        ("OK", 200),
+        ("CREATED", 201),
+        ("ACCEPTED", 202),
+        ("NO_CONTENT", 204),
+        ("BAD_REQUEST", 400),
+        ("UNAUTHORIZED", 401),
+        ("FORBIDDEN", 403),
+        ("NOT_FOUND", 404),
+        ("METHOD_NOT_ALLOWED", 405),
+        ("REQUEST_TIMEOUT", 408),
+        ("CONFLICT", 409),
+        ("UNSUPPORTED_MEDIA_TYPE", 415),
+        ("RANGE_NOT_SATISFIABLE", 416),
+        ("INTERNAL_SERVER_ERROR", 500),
+        ("BAD_GATEWAY", 502),
+        ("SERVICE_UNAVAILABLE", 503),
+    ];
+
+    /// Every `StatusCode::` constant named in the body of `function` in
+    /// `module`: the text from `async fn <function>(` to the first
+    /// column-zero `}`.
+    fn handler_status_codes(module: &str, function: &str) -> Vec<u16> {
+        let (_, source) = HANDLER_SOURCES
+            .iter()
+            .find(|(name, _)| *name == module)
+            .expect("a handler module with a source entry");
+        let production = source.split("\nmod tests {").next().unwrap_or(source);
+        let (_, rest) = production
+            .split_once(&format!("async fn {function}("))
+            .expect("the handler is declared in its module");
+        let body = rest.split("\n}\n").next().unwrap_or(rest);
+        let mut codes: Vec<u16> = body
+            .split("StatusCode::")
+            .skip(1)
+            .map(|rest| {
+                rest.chars()
+                    .take_while(|c| c.is_ascii_uppercase() || *c == '_')
+                    .collect::<String>()
+            })
+            .map(|name| {
+                STATUS_CONSTANTS
+                    .iter()
+                    .find(|(known, _)| *known == name)
+                    .map(|(_, code)| *code)
+                    .expect("a StatusCode constant the table knows")
+            })
+            .collect();
+        codes.sort_unstable();
+        codes.dedup();
+        codes
+    }
+
+    /// Every status a route can answer is one the spec lists for it: the
+    /// constants its handler names, plus what the layers around every handler
+    /// add (401 from auth on all of them; 408 and 503 from the request limits
+    /// on all but the websocket; 405 on an admin method of a path that is
+    /// mounted without `--allow-admin`, where axum answers for the missing
+    /// method). The spec may list more, since a handler can answer through a
+    /// helper this reader cannot see into.
+    #[test]
+    fn the_openapi_spec_documents_every_status_a_handler_can_answer() {
+        let spec: serde_json::Value = serde_json::from_str(OPENAPI).expect("the spec is JSON");
+        let (open, admin) = production_source()
+            .split_once("match args.allow_admin")
+            .expect("the admin routes are mounted on allow_admin");
+        let open_routes = handlers_in(open);
+        let admin_routes = handlers_in(admin);
+        assert!(open_routes.len() > 25);
+        assert!(admin_routes.len() > 5);
+        let mut problems = Vec::new();
+        for (routes, is_admin) in [(&open_routes, false), (&admin_routes, true)] {
+            for (path, method, module, function) in routes {
+                let documented: Vec<u16> =
+                    spec["paths"][path.as_str()][method.to_lowercase()]["responses"]
+                        .as_object()
+                        .expect("the operation lists responses")
+                        .keys()
+                        .map(|code| code.parse::<u16>().expect("a status code"))
+                        .collect();
+                let mut required = handler_status_codes(module, function);
+                required.push(401);
+                if !path.starts_with("/ws") {
+                    required.push(408);
+                    required.push(503);
+                }
+                if is_admin && open_routes.iter().any(|(open, ..)| open == path) {
+                    required.push(405);
+                }
+                // Filtered rather than pushed inside an `if`: a branch only a
+                // failure reaches is a region the coverage gate reports.
+                let undocumented: Vec<u16> = required
+                    .into_iter()
+                    .filter(|code| !documented.contains(code))
+                    .collect();
+                problems.push((format!("{method} {path}"), undocumented));
+            }
+        }
+        let problems: Vec<(String, Vec<u16>)> = problems
+            .into_iter()
+            .filter(|(_, undocumented)| !undocumented.is_empty())
+            .collect();
+        assert_eq!(problems, Vec::new());
+    }
+
+    #[test]
+    fn the_handler_reader_names_the_function_behind_each_method() {
+        let source = concat!(
+            ".route(\"/a\", get(agents::list_agents).post(agents::spawn_agent))\n",
+            ".route(\"not a path\", get(h))\n",
+            ".route(\"/b\", delete(closure_handler))\n"
+        );
+        assert_eq!(
+            handlers_in(source),
+            vec![
+                (
+                    "/a".to_string(),
+                    "GET".to_string(),
+                    "agents".to_string(),
+                    "list_agents".to_string()
+                ),
+                (
+                    "/a".to_string(),
+                    "POST".to_string(),
+                    "agents".to_string(),
+                    "spawn_agent".to_string()
+                ),
+            ]
+        );
+        assert_eq!(handlers_in("fn main() {}"), Vec::new());
     }
 
     #[test]

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -183,16 +183,23 @@ fn api_router() -> Router<AppState> {
 /// The same technique `xtask/src/docs.rs` uses on the docs.
 #[cfg(test)]
 fn declared_routes() -> Vec<(String, String)> {
-    routes_in(production_source())
+    routes_in(&production_source())
 }
 
 /// This file above its test module. The tests below declare routes of their
 /// own as fixtures for the reader, and those are not served by anything;
 /// reading the whole file counted them as production routes.
 #[cfg(test)]
-fn production_source() -> &'static str {
+fn production_source() -> String {
     const SOURCE: &str = include_str!("mod.rs");
-    SOURCE.split("\nmod tests {").next().unwrap_or(SOURCE)
+    // `\n` line ends whatever the checkout gave it, so a Windows clone with
+    // `core.autocrlf` finds the same boundaries as the others.
+    let source = SOURCE.replace("\r\n", "\n");
+    source
+        .split("\nmod tests {")
+        .next()
+        .unwrap_or(&source)
+        .to_string()
 }
 
 /// [`routes_in`] with the handler each method names: every
@@ -829,7 +836,17 @@ mod tests {
             .iter()
             .find(|(name, _)| *name == module)
             .expect("a handler module with a source entry");
-        let production = source.split("\nmod tests {").next().unwrap_or(source);
+        status_codes_in(source, function)
+    }
+
+    /// [`handler_status_codes`] over source text a test can write. The text
+    /// is read with `\n` line ends whatever the checkout gave it: a Windows
+    /// clone with `core.autocrlf` carries `\r\n`, and the `\n}\n` that ends a
+    /// handler is then never found, so the scan ran on to the end of the
+    /// file and charged every handler with every code below it.
+    fn status_codes_in(source: &str, function: &str) -> Vec<u16> {
+        let source = source.replace("\r\n", "\n");
+        let production = source.split("\nmod tests {").next().unwrap_or(&source);
         let (_, rest) = production
             .split_once(&format!("async fn {function}("))
             .expect("the handler is declared in its module");
@@ -865,7 +882,8 @@ mod tests {
     #[test]
     fn the_openapi_spec_documents_every_status_a_handler_can_answer() {
         let spec: serde_json::Value = serde_json::from_str(OPENAPI).expect("the spec is JSON");
-        let (open, admin) = production_source()
+        let production = production_source();
+        let (open, admin) = production
             .split_once("match args.allow_admin")
             .expect("the admin routes are mounted on allow_admin");
         let open_routes = handlers_in(open);
@@ -905,6 +923,29 @@ mod tests {
             .filter(|(_, undocumented)| !undocumented.is_empty())
             .collect();
         assert_eq!(problems, Vec::new());
+    }
+
+    /// The same source with Windows line ends scans the same: a handler's
+    /// closing brace is found, so the next handler's codes stay its own.
+    #[test]
+    fn the_status_code_scan_reads_a_crlf_checkout_the_same() {
+        let unix = concat!(
+            "pub(super) async fn first() -> StatusCode {\n",
+            "    StatusCode::NO_CONTENT\n",
+            "}\n",
+            "\n",
+            "pub(super) async fn second() -> StatusCode {\n",
+            "    StatusCode::NOT_FOUND\n",
+            "}\n",
+            "\n",
+            "mod tests {\n",
+            "    StatusCode::BAD_GATEWAY\n",
+            "}\n"
+        );
+        let crlf = unix.replace('\n', "\r\n");
+        assert_eq!(status_codes_in(unix, "first"), vec![204]);
+        assert_eq!(status_codes_in(&crlf, "first"), vec![204]);
+        assert_eq!(status_codes_in(&crlf, "second"), vec![404]);
     }
 
     #[test]

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -1495,6 +1495,9 @@ some_custom_thing = \"forwarded to the script\"
     /// The same technique as the `RunMeta` guard in `serve/runs_tests.rs`.
     fn declared_fields(source: &str, struct_name: &str) -> Vec<String> {
         let header = format!("pub struct {struct_name} {{");
+        // A Windows checkout with `core.autocrlf` carries `\r\n`; read it
+        // with `\n` line ends so the header and the closing brace compare.
+        let source = source.replace("\r\n", "\n");
         let body: Vec<&str> = source
             .lines()
             .skip_while(|line| *line != header)
@@ -1515,6 +1518,14 @@ some_custom_thing = \"forwarded to the script\"
             .collect();
         fields.sort();
         fields
+    }
+
+    #[test]
+    fn declared_fields_reads_a_crlf_checkout_the_same() {
+        let unix = "pub struct Thing {\n    pub a: u8,\n    #[serde(flatten)]\n    pub b: u8,\n    pub c: u8,\n}\npub struct Other {\n    pub d: u8,\n}\n";
+        let crlf = unix.replace('\n', "\r\n");
+        assert_eq!(declared_fields(unix, "Thing"), vec!["a", "c"]);
+        assert_eq!(declared_fields(&crlf, "Thing"), vec!["a", "c"]);
     }
 
     /// Every field serde reads on `Config` and each section struct is a key

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -1489,6 +1489,221 @@ some_custom_thing = \"forwarded to the script\"
         assert_eq!(parsed.mcp_servers.len(), 2);
     }
 
+    /// The `pub` fields of `struct_name` as serde reads them, from `source`:
+    /// the struct's lines from its declaration to the first column-zero `}`,
+    /// minus a field marked `#[serde(flatten)]`, which is not a key of its own.
+    /// The same technique as the `RunMeta` guard in `serve/runs_tests.rs`.
+    fn declared_fields(source: &str, struct_name: &str) -> Vec<String> {
+        let header = format!("pub struct {struct_name} {{");
+        let body: Vec<&str> = source
+            .lines()
+            .skip_while(|line| *line != header)
+            .skip(1)
+            .take_while(|line| *line != "}")
+            .map(str::trim)
+            .collect();
+        let mut fields: Vec<String> = body
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| {
+                !i.checked_sub(1)
+                    .is_some_and(|p| body[p].contains("flatten"))
+            })
+            .filter_map(|(_, line)| line.strip_prefix("pub "))
+            .filter_map(|rest| rest.split_once(':'))
+            .map(|(name, _)| name.trim().to_string())
+            .collect();
+        fields.sort();
+        fields
+    }
+
+    /// Every field serde reads on `Config` and each section struct is a key
+    /// the published schema allows, and, where the schema closes the table,
+    /// every key it allows is a field. The example config only proves the
+    /// keys it happens to set, and four `[limits]` keys the daemon read for
+    /// months were refused by the schema because nothing set them there.
+    #[test]
+    fn every_config_field_is_in_the_published_schema() {
+        let schema: serde_json::Value =
+            serde_json::from_str(CONFIG_SCHEMA).expect("the schema is JSON");
+        let keys_at = |path: &[&str]| -> Vec<String> {
+            let mut node = &schema;
+            for step in path {
+                node = &node[step];
+            }
+            let mut keys: Vec<String> = node
+                .as_object()
+                .expect("an object of properties")
+                .keys()
+                .cloned()
+                .collect();
+            keys.sort();
+            keys
+        };
+        let crate_dir = env!("CARGO_MANIFEST_DIR");
+        // (struct, its source file, where its keys sit in the schema, whether
+        // the schema closes the table so the two lists must be equal)
+        let sections: Vec<(&str, &str, &[&str], bool)> = vec![
+            ("Config", "src/config/mod.rs", &["properties"], true),
+            (
+                "LimitsConfig",
+                "src/config/limits.rs",
+                &["properties", "limits", "properties"],
+                true,
+            ),
+            (
+                "WebhookConfig",
+                "src/config/limits.rs",
+                &["properties", "webhook", "properties"],
+                true,
+            ),
+            (
+                "ProviderConfig",
+                "src/config/providers.rs",
+                &["properties", "providers", "properties"],
+                true,
+            ),
+            // `[model_providers.<name>]` forwards unknown keys to a script,
+            // so the schema leaves it open and only the declared fields are
+            // held to it.
+            (
+                "ModelProviderConfig",
+                "src/config/providers.rs",
+                &[
+                    "properties",
+                    "model_providers",
+                    "additionalProperties",
+                    "properties",
+                ],
+                false,
+            ),
+            (
+                "SecurityConfig",
+                "src/config/security.rs",
+                &["properties", "security", "properties"],
+                true,
+            ),
+            (
+                "ReadPathGrants",
+                "src/config/security.rs",
+                &[
+                    "properties",
+                    "agent_read_paths",
+                    "additionalProperties",
+                    "properties",
+                ],
+                true,
+            ),
+            (
+                "ServeConfig",
+                "src/config/serve.rs",
+                &["properties", "serve", "properties"],
+                true,
+            ),
+            (
+                "ScriptToolPermissions",
+                "src/config/policy.rs",
+                &["properties", "tool_script_permissions", "properties"],
+                true,
+            ),
+            (
+                "SafeCommands",
+                "src/approvals.rs",
+                &["properties", "safe_commands", "properties"],
+                true,
+            ),
+            (
+                "AgentSafeCommands",
+                "src/approvals.rs",
+                &[
+                    "properties",
+                    "agent_safe_commands",
+                    "additionalProperties",
+                    "properties",
+                ],
+                true,
+            ),
+            (
+                "TitleConfig",
+                "../leviath-core/src/config.rs",
+                &["properties", "title", "properties"],
+                true,
+            ),
+            (
+                "ObservabilityConfig",
+                "../leviath-core/src/config.rs",
+                &["properties", "observability", "properties"],
+                true,
+            ),
+            (
+                "NudgeConfig",
+                "../leviath-core/src/blueprint/transition.rs",
+                &["properties", "nudge", "properties"],
+                true,
+            ),
+            (
+                "ToolSandboxConfig",
+                "../leviath-core/src/sandbox.rs",
+                &["properties", "sandbox", "properties"],
+                true,
+            ),
+            (
+                "RateLimitConfig",
+                "../leviath-providers/src/provider.rs",
+                &[
+                    "properties",
+                    "rate_limits",
+                    "additionalProperties",
+                    "properties",
+                ],
+                true,
+            ),
+            (
+                "ModelCapabilityOverride",
+                "../leviath-providers/src/capabilities.rs",
+                &[
+                    "properties",
+                    "model_capabilities",
+                    "additionalProperties",
+                    "properties",
+                ],
+                true,
+            ),
+            (
+                "MCPServerConfig",
+                "../leviath-mcp/src/discovery.rs",
+                &["properties", "mcp_servers", "items", "properties"],
+                true,
+            ),
+        ];
+        let mut problems = Vec::new();
+        for (struct_name, file, path, closed) in sections {
+            let source = std::fs::read_to_string(format!("{crate_dir}/{file}"))
+                .expect("the struct's source file");
+            let declared = declared_fields(&source, struct_name);
+            assert!(!declared.is_empty());
+            let allowed = keys_at(path);
+            // Filtered rather than pushed inside an `if`: a branch only a
+            // failure reaches is a region the coverage gate reports.
+            let not_in_schema: Vec<String> = declared
+                .iter()
+                .filter(|field| !allowed.contains(field))
+                .cloned()
+                .collect();
+            let read_by_nothing: Vec<String> = allowed
+                .iter()
+                .filter(|key| closed && !declared.contains(key))
+                .cloned()
+                .collect();
+            problems.push((struct_name, not_in_schema, read_by_nothing));
+        }
+        let problems: Vec<_> = problems
+            .into_iter()
+            .filter(|(_, missing, stray)| !missing.is_empty() || !stray.is_empty())
+            .collect();
+        assert_eq!(problems, Vec::new());
+    }
+
     #[test]
     fn the_config_schema_rejects_a_key_that_is_not_a_setting() {
         // Without `additionalProperties: false` the schema would accept any

--- a/crates/leviath-core/src/manifest.rs
+++ b/crates/leviath-core/src/manifest.rs
@@ -183,5 +183,22 @@ use regions::*;
 use sections::*;
 use stage::*;
 
+/// Every key `parse_manifest` reads off the `[agent]` table, for the schema
+/// guard in `tests.rs`. A list and not a check: the table ignores what it
+/// does not know.
+#[cfg(test)]
+const AGENT_KEYS: &[&str] = &[
+    "batch_tool_hint",
+    "description",
+    "dynamic_tools",
+    "entry_stage",
+    "max_child_depth",
+    "name",
+    "nudge",
+    "output",
+    "shell_hint",
+    "version",
+];
+
 #[cfg(test)]
 mod tests;

--- a/crates/leviath-core/src/manifest/model.rs
+++ b/crates/leviath-core/src/manifest/model.rs
@@ -109,3 +109,17 @@ pub(super) fn parse_stage_model(
         ))
     }
 }
+
+/// Every key [`parse_stage_model`] reads off a `[stages.<name>.model]`
+/// table, for the schema guard in `tests.rs`. Like `REGION_KEYS`, a list and
+/// not a check: the parser ignores what it does not know.
+#[cfg(test)]
+pub(super) const MODEL_KEYS: &[&str] = &[
+    "allow_user_default",
+    "fallbacks",
+    "model",
+    "models",
+    "parameters",
+    "provider",
+    "request_timeout_secs",
+];

--- a/crates/leviath-core/src/manifest/regions.rs
+++ b/crates/leviath-core/src/manifest/regions.rs
@@ -388,3 +388,35 @@ fn parse_seed_tool_call(value: &toml::Value) -> Option<SeedToolCall> {
         _ => None,
     }
 }
+
+/// Every key [`parse_region_layout`] reads off a region table. The parser
+/// does not refuse a key it does not know (a misspelled one has always
+/// loaded silently), so this list has one job: the schema guard in
+/// `tests.rs` holds the published schema to it, and a key read above that is
+/// missing here, or here that is not read above, is the drift it exists to
+/// catch.
+#[cfg(test)]
+pub(super) const REGION_KEYS: &[&str] = &[
+    "admission",
+    "budget",
+    "compact_at",
+    "compact_count",
+    "describe_in_prompt",
+    "description",
+    "kind",
+    "max_entries",
+    "max_items",
+    "max_tokens",
+    "min_tokens",
+    "overflow",
+    "persistent",
+    "required",
+    "required_message",
+    "script",
+    "seed",
+    "source_region",
+    "strategy",
+    "summarizable",
+    "threshold_tokens",
+    "volatility",
+];

--- a/crates/leviath-core/src/manifest/stage.rs
+++ b/crates/leviath-core/src/manifest/stage.rs
@@ -57,6 +57,19 @@ pub(super) const STAGE_KEYS: &[&str] = &[
 /// about it instead of quietly carrying the region they meant to drop.
 pub(super) const CONTEXT_KEYS: &[&str] = &["regions", "hide"];
 
+/// The hooks this build implements, in the order the refusal names them.
+/// `parse_stage_hooks` matches on each, and the schema guard in `tests.rs`
+/// holds the published schema to the same list.
+pub(super) const HOOK_KEYS: &[&str] = &[
+    "on_stage_enter",
+    "on_stage_exit",
+    "before_inference",
+    "after_inference",
+    "on_tool_call",
+    "on_completion",
+    "on_error",
+];
+
 /// Every key read off `[stages.<name>.tool_routing]`.
 pub(super) const TOOL_ROUTING_KEYS: &[&str] = &[
     "default_region",
@@ -802,9 +815,8 @@ pub(super) fn parse_stage_hooks(
             other => {
                 return Err(Error::Other(format!(
                     "stage '{stage_name}': unknown hook '{other}' \
-                     (this build implements: on_stage_enter, on_stage_exit, \
-                     before_inference, after_inference, on_tool_call, \
-                     on_completion, on_error)"
+                     (this build implements: {})",
+                    HOOK_KEYS.join(", ")
                 )));
             }
         }
@@ -1055,3 +1067,23 @@ pub(super) fn parse_nudge_config(
     }
     Ok(nudge)
 }
+
+/// Every key `parse_stage` reads off one `[[stages.<name>.interaction_points]]`
+/// entry, for the schema guard in `tests.rs`. A list and not a check, like
+/// `REGION_KEYS`: `options` and `choices` are the same setting under two
+/// names, as are `directives` and `followups`.
+#[cfg(test)]
+pub(super) const INTERACTION_POINT_KEYS: &[&str] = &[
+    "abort_options",
+    "choices",
+    "directives",
+    "document_region",
+    "edit_options",
+    "followups",
+    "name",
+    "options",
+    "prompt",
+    "required",
+    "style",
+    "unattended",
+];

--- a/crates/leviath-core/src/manifest/tests.rs
+++ b/crates/leviath-core/src/manifest/tests.rs
@@ -5568,6 +5568,30 @@ fn the_published_schema_and_the_parser_agree_on_every_key() {
             &["$defs", "sandbox"][..],
             super::sections::SANDBOX_KEYS,
         ),
+        // The tables below are read key by key with nothing refusing a
+        // stranger, so their lists are kept by hand beside each parser and
+        // this is the only thing that checks them.
+        (
+            "region",
+            &["$defs", "region"][..],
+            super::regions::REGION_KEYS,
+        ),
+        (
+            "interaction point",
+            &["$defs", "interactionPoint"][..],
+            super::stage::INTERACTION_POINT_KEYS,
+        ),
+        (
+            "stage.model",
+            &["$defs", "modelConfig"][..],
+            super::model::MODEL_KEYS,
+        ),
+        (
+            "stage.hooks",
+            &["$defs", "stageHooks"][..],
+            super::stage::HOOK_KEYS,
+        ),
+        ("agent", &["$defs", "agent"][..], super::AGENT_KEYS),
     ] {
         assert_eq!(
             keys_at(schema_path),

--- a/docs/content/agents.md
+++ b/docs/content/agents.md
@@ -231,7 +231,7 @@ can only improve matters. A region that claims `stable` and then keeps changing 
 log, because a wrong declaration is worse than none - it puts churn at the front of the prompt,
 where it costs the most. See [what caching costs](/docs/context#what-caching-costs).
 
-A stage can override the whole layout for just itself with `[stages.<name>.context.regions]`. The
+A stage can override the whole layout for itself alone with `[stages.<name>.context.regions]`. The
 per-stage layout applies when the stage is entered, and uses the same syntax:
 
 ```toml

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -101,7 +101,7 @@ The short version: **`http://` only works on loopback.** Everything else needs H
 
 A browser treats `http://localhost` and `http://127.0.0.1` as potentially trustworthy, which is the
 only reason the default setup works from a page served over HTTPS. Every other address is blocked,
-and **a LAN address is blocked exactly like a public one**. `http://192.168.1.50:3000` fails just as
+and **a LAN address is blocked exactly like a public one**. `http://192.168.1.50:3000` fails the same way
 `http://203.0.113.10:8080` does:
 
 ```
@@ -436,7 +436,7 @@ DELETE /api/runs/deep-researcher-1786839472-d908ad2d9455
 
 - **409** if the run is still going. Removing a directory out from under a running agent is a much
   larger feature than this, so cancel it first and delete it after.
-- **404** if it is already gone, so a client that lost the response to its own delete can just send
+- **404** if it is already gone, so a client that lost the response to its own delete can send
   it again instead of treating a missing run as a failure.
 
 ### Sub-agent runs go with their parent
@@ -463,7 +463,7 @@ DELETE /api/runs/{id}?force=true
 A record that cannot be read says nothing about whether the run finished, and "cannot read it" must
 not quietly read as "finished" -- that is exactly what a live run looks like to a binary whose
 `RunMeta` has moved on. Such a run is also skipped by the listing, which would leave it both
-invisible and permanent, so the escape hatch stays; it is just something you type rather than
+invisible and permanent, so the escape hatch stays; it is something you type rather than
 something that happens to you. The bulk route never forces.
 
 ### Clearing out old runs
@@ -849,7 +849,7 @@ client can answer for itself. Every entry carries a `source`:
 
 Pass `?agent=<name>` to include the fourth. Script-backed entries also carry the `path` they came
 from. A separate `skipped` list carries the `.rhai` files that were found and cannot be offered,
-with the reason each was passed over, so a file with a syntax error does not simply look like a file
+with the reason each was passed over, so a file with a syntax error is told apart from a file
 nobody wrote. MCP tools are not here: they depend on a server being reachable rather than on
 anything installed, and `/api/mcp/servers/{name}` already answers for them.
 
@@ -1061,7 +1061,7 @@ run until it has a name. `title` is absent, not null, while a run has none.
 Naming can also fail. The call retries a transient refusal and then walks the run's own model
 candidates, the same chain its stage inference fails over along, so one provider being unreachable
 no longer costs the run its name. When every candidate is spent, `title_error` on the run says what
-stopped it, and stays `null` while titling is simply unfinished. Poll that field rather than waiting
+stopped it, and stays `null` while titling is still under way. Poll that field rather than waiting
 forever on a `run_renamed` frame that is not coming.
 
 `status`, on `agent_status` and on `agent_completed`, is the word `GET /api/runs` uses for the same
@@ -1100,7 +1100,7 @@ stream sends none, so a client that ignores the type sees exactly what it always
 
 Requests keep working across a version gap as long as the two ends still understand each other. A
 request that fails because they no longer do answers **502** with the same sentence, where a
-daemon that is simply not answering is a **503**. Retrying helps the second; only restarting
+daemon that is not answering at all is a **503**. Retrying helps the second; only restarting
 `lev serve` helps the first.
 
 ## Asking for a shape

--- a/docs/content/cli.md
+++ b/docs/content/cli.md
@@ -17,7 +17,8 @@ symptom, and `lev doctor` checks the usual causes for you.
 `-v` / `--verbose` is global and works on every subcommand.
 
 Scripting against the CLI? `--json` is on `run`, `ps`, `doctor`, `validate`, `list`, `models list`,
-`context`, `result`, `respond`, `stages`, `tools`, `approvals safe`, and `mcp list`. Everything else prints
+`context`, `result`, `respond`, `stages`, `timeline`, `tools`, `update`, `approvals safe`, and `mcp
+list`. Everything else prints
 for a person. Warnings go to stderr, so stdout parses on its own. A service that would rather
 speak HTTP should use [`lev serve`](/docs/api) instead.
 
@@ -313,7 +314,7 @@ a stage keeps in `required_tools`. Both are deliberate wherever they appear. It 
 | `--deny-warnings` | Exit non-zero on warnings too. Notes still never fail. |
 | `--json` | Print the report as one JSON object with `valid`, `blueprint`, `error`, and `findings` |
 | `--graph` | Draw the stage graph after the report, as plain text: the same picture the dashboard's stage explorer shows, escape edges included. Ignored with `--json` |
-| `--width <COLS>` | How many columns `--graph` may use (default 120); a wider graph is shrunk to fit |
+| `--width <COLS>` | How many columns `--graph` may use (default 120); a wider graph is shrunk to fit. Only with `--graph`: on its own it is refused |
 
 The same findings are written to `daemon.log` when a run spawns, so a blueprint that was never
 validated still says what is wrong with it. Nothing there refuses a spawn.
@@ -370,8 +371,8 @@ it returns `false`.
 
 | Command | Flags |
 |---|---|
-| `lev models list` | `-p/--provider <NAME>`, `--offline` (this build's table only, no network), `-a/--all` (include providers with no credential here), `--json` |
-| `lev models show <MODEL>` | `-p/--provider <NAME>` (ask only this provider), `--offline` |
+| `lev models list` | `-p/--provider <NAME>`, `--offline` (this build's table only, no network), `-a/--all` (include providers with no credential here), `--json`. `-r/--remote` is accepted and changes nothing: asking the providers is the default |
+| `lev models show <MODEL>` | `-p/--provider <NAME>` (ask only this provider), `--offline`. `-r/--remote` is accepted and changes nothing, as above |
 
 Both ask every configured provider for its own listing by default, waiting up to five seconds each,
 and print what the provider said: the columns include the release date and the input and output
@@ -736,7 +737,7 @@ nothing about what gets written.
 | `--anthropic-key`, `--openai-key`, `--google-key`, `--openrouter-key <KEY>` | Provider API keys |
 | `--ollama-url <URL>` | Ollama base URL |
 | `--default-model <MODEL>` | Default model override |
-| `--claude-code <true\|false>` | Enable the Claude Code CLI transport. Off unless set |
+| `--claude-code <true\|false>` | Enable the Claude Code CLI transport. Off unless set, and the wizard does not ask about it: this flag is the way to turn it on |
 | `--claude-code-effort <LEVEL>` | `low`, `medium`, `high`, `xhigh`, or `max` |
 | `--install-agents` | Install the bundled blueprints without asking |
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -169,6 +169,8 @@ cerebras = 1                     # every model this provider serves, together
 | `default_max_iterations` | `50` | A stage's own `max_iterations` always wins |
 | `stream_inference` | `true` | Ask a model that can stream to stream. See below |
 | `script_shell_timeout_secs` | `60` | Cap on a Rhai script tool's `shell()` host call |
+| `script_http_timeout_secs` | `30` | Seconds a Rhai script tool's `http_get()` or `http_post()` may take |
+| `script_http_max_per_host` | `4` | Script-tool HTTP requests in flight to one host at a time; the rest wait their turn. `0` is unbounded |
 | `mcp_idle_disconnect_secs` | `60` | Disconnect an [MCP server](/docs/mcp) no agent has used for this long. It reconnects on next use |
 | `stall_timeout_secs` | `60` | Fail a run that can never dispatch. See below |
 | `dead_cycles_before_relief` | `10` | 30-second cycles with a full [tool lane](/docs/engine#the-tool-lane) and nothing moving before the lane widens. `0` never widens it |
@@ -286,7 +288,7 @@ outside Leviath is tracking your slots. See [External work queues](/docs/work-qu
 
 **`provider_failures_before_open`** counts failures only you can fix, such as an exhausted account
 or a rejected key, before that provider is taken out of service for every run. Three rather than one,
-because a single payment error can just be one oversized request. `0` disables it and leaves per-run
+because a single payment error can be one oversized request. `0` disables it and leaves per-run
 failover to cope alone.
 
 A provider that answered the connection and then went quiet gets four times that budget, so the
@@ -344,7 +346,7 @@ call. That stops the call after the one that overran, not the one that did.
 
 Running out of disk is separate and **not configurable**. Leviath refuses any write that would leave
 under a gigabyte free, whatever these two say and whatever `--yolo` says, because filling the disk
-harms every other process on the machine rather than just the run. A filesystem whose free space
+harms every other process on the machine, not only the run. A filesystem whose free space
 cannot be read is treated as unknown and allowed, because a guard that cannot measure has nothing to
 say. The two ceilings above still apply to it.
 

--- a/docs/content/context.md
+++ b/docs/content/context.md
@@ -300,7 +300,7 @@ them.
 It costs a tool call per stage entry for the life of the run, and rewrites a region that would
 otherwise sit still in the cached prefix, so leave it at the default for anything that does not
 actually change. A call that fails leaves the region as it was rather than blanking it: the
-previous value is merely stale, and stale beats absent. `lev validate` marks a refreshing seed
+previous value is stale, and stale beats absent. `lev validate` marks a refreshing seed
 "on every stage entry".
 
 Seeds do not re-run when a run is reloaded from a snapshot, whatever their `refresh` setting.
@@ -612,7 +612,7 @@ needs its own region *and* its own ceiling:
 ```toml
 [stages.analyze.tool_routing.overrides]
 read_file = { region = "codebase", max_result_tokens = 20000 }
-grep = "scratch"                     # just route it
+grep = "scratch"                     # route it, no cap
 ```
 
 Either key on its own is fine: `{ region = "codebase" }` routes without capping, and

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -15,7 +15,7 @@ of runs, answer their questions, and steer them.
 lev dash
 ```
 
-It reads the same [daemon](/docs/daemon) that [The Lair](https://leviath.dev/lair) does, just over
+It reads the same [daemon](/docs/daemon) that [The Lair](https://leviath.dev/lair) does, over
 the local control socket instead of HTTP:
 
 ```mermaid

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -70,7 +70,7 @@ call until the answer comes back, then continues with it:
 > A stage that genuinely needs a person keeps the tools it names in
 > [`required_tools`](/docs/tools#these-tools-need-someone-there).
 >
-> Unattended applies to the whole run tree, not just the agent you launched: sub-agents and
+> Unattended applies to the whole run tree, not only the agent you launched: sub-agents and
 > fan-out workers inherit it, and it survives a daemon restart. Otherwise a child could stop
 > on a prompt nobody was watching for and take its parent down with it.
 
@@ -141,7 +141,7 @@ opt in, because otherwise any agent package could pre-approve its own shell with
 An `ask` gate raises a `tool_approval` prompt naming the tool and its telling argument (the shell
 command for `bash`/`shell`, the path for the file tools), with five options:
 
-- **Allow once**: permit just this one call.
+- **Allow once**: permit this one call and nothing more.
 - **Allow ... for this stage**: permit every later call this covers, until the run leaves the
   current stage. Re-entering the same stage keeps the grant, so a revision loop does not re-ask.
 - **Allow ... for this run**: permit every later call this covers, for the rest of the run.

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -123,8 +123,8 @@ sequenceDiagram
 
 `available_tools` is an exact-match list, so granting a server tool by tool means knowing what it
 advertises - and that is not yours to know. It is whatever the server ships today. GitHub's server
-has dozens; a house server gains one when somebody deploys. A tool added later is simply never
-offered, with nothing said, so the stage quietly cannot do a thing you believed it could.
+has dozens; a house server gains one when somebody deploys. A tool added later is never
+offered, and nothing says so, so the stage quietly cannot do a thing you believed it could.
 
 Name the server instead:
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -80,7 +80,7 @@ holds its place rather than burning tokens. See [Interaction](/docs/interaction)
 
 ## Runs hand back an answer
 
-A run's result is not just its logs. A stage can require a structured **output** in a shape you
+A run's result is more than its logs. A stage can require a structured **output** in a shape you
 name, validated before the run is allowed to finish, which is what makes a run safe to call from a
 script. See [Outputs](/docs/outputs).
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -193,7 +193,7 @@ your default still has the blueprint's own entries to fall back to.
 > [!IMPORTANT]
 > `default_model` pins **one** model across every stage, which is usually not what you want. A
 > blueprint picks per stage on purpose: `deep-researcher` gathers on a mid-tier model and analyses
-> on a top one. Setting `default_provider` alone keeps that shape and just moves it onto your
+> on a top one. Setting `default_provider` alone keeps that shape and moves it onto your
 > provider - gathering on that provider's mid-tier entry, analysing on its top one. Setting
 > `default_model` too flattens it, and the cheap stages start paying top-tier prices while the
 > deciding stage loses the model the author chose for it.

--- a/docs/content/rhai-tools.md
+++ b/docs/content/rhai-tools.md
@@ -34,7 +34,7 @@ object. The recognized directives:
   schema type: `string`, `integer`, `number`, `boolean`, `array`, `object`. A typo here produces a
   schema that does not compile, which switches off
   [argument validation](/docs/tools#argument-validation) for the tool (the daemon logs a warning);
-  calls still run, just unchecked.
+  calls still run, with no argument check.
 - `// @requires <cap> [<cap>...]` lists platform capabilities the tool needs (`network`, `shell`,
   `filesystem`), comma or space separated and repeatable. Leviath drops the tool where the platform
   cannot provide one.

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -282,7 +282,7 @@ directory, or drop them in `~/.leviath/tools/` to offer them to every agent.
 > [environment variables](/docs/configuration#environment-variables).
 
 > [!IMPORTANT]
-> The key itself is different: it has to be in **the daemon's** environment, not just the shell you
+> The key itself is different: it has to be in **the daemon's** environment, not only the shell you
 > type `lev` in. A process inherits its environment when it starts, so a daemon that was already
 > running when you exported the key cannot see it, and every search falls back to Wikipedia while
 > your own shell looks correctly configured.

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -613,7 +613,12 @@
         },
         "description": {
           "type": "string",
-          "description": "One line on what this region is for, shown to the model above the region's contents on every turn. Optional - most regions are named well enough that a sentence would only cost tokens; use it where the contents do not explain themselves."
+          "description": "One line on what this region is for. Documentation by default: it reaches the dashboard and the API, and the model only with `describe_in_prompt`. Optional - most regions are named well enough that a sentence would only cost tokens; use it where the contents do not explain themselves."
+        },
+        "describe_in_prompt": {
+          "type": "boolean",
+          "default": false,
+          "description": "Also show the `description` to the model, above the region's contents, on every turn. Off by default: a person reading the blueprint wants the sentence, a model re-reads it every request."
         },
         "admission": {
           "enum": [

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -12,6 +12,7 @@ openrouter_api_key = "sk-or-example"
 ollama_base_url = "http://localhost:11434"
 request_timeout_secs = 600
 taint_tracking = false
+update_check = true
 batch_tool_hint = true
 shell_hint = true
 
@@ -39,6 +40,9 @@ max_concurrent_tools = 8
 default_max_iterations = 50
 stream_inference = true
 script_shell_timeout_secs = 60
+script_http_timeout_secs = 30
+script_http_max_per_host = 4
+mcp_idle_disconnect_secs = 60
 stall_timeout_secs = 60
 dead_cycles_before_relief = 10
 finished_retention_secs = 300
@@ -48,6 +52,8 @@ provider_circuit_cooldown_secs = 300
 interaction_timeout_secs = 3600
 inference_retry_attempts = 4
 inference_retry_base_ms = 1000
+max_agents_per_run = 0
+notify_spend_usd = [1.0, 5.0]
 # How much an agent may write to disk. Unset in code and written by `lev setup`:
 # delete either line to remove that limit. Running out of disk is refused
 # separately and is not configurable.
@@ -66,6 +72,7 @@ max_run_write_bytes = 10737418240
 cerebras = 1
 
 [security]
+allowed_workdirs = ["~/work"]
 allow_seed_commands = true
 allow_local_network = false
 allow_env_vars = ["MY_BUILD_TOKEN"]
@@ -144,7 +151,6 @@ allow_blueprint = true
 
 [rate_limits.anthropic]
 requests_per_minute = 50
-# Parsed and recorded, not yet enforced: only requests_per_minute throttles.
 tokens_per_minute = 100000
 
 # Every field is optional: name only what you are correcting, and the rest keeps

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -212,6 +212,32 @@
             "type": "integer",
             "minimum": 1
           }
+        },
+        "script_http_timeout_secs": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 30,
+          "description": "Seconds a script tool's HTTP request may take."
+        },
+        "script_http_max_per_host": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 4,
+          "description": "Concurrent script-tool HTTP requests allowed per host. 0 is unbounded."
+        },
+        "max_agents_per_run": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0,
+          "description": "Most agents one run may create, sub-agents included. 0 is no ceiling."
+        },
+        "notify_spend_usd": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "minimum": 0
+          },
+          "description": "Dollar figures to be told about while a run is still going, each announced once as an agent_spend event."
         }
       }
     },
@@ -596,6 +622,26 @@
           "max_output_tokens": {
             "type": "integer",
             "minimum": 1
+          },
+          "input_per_mtok": {
+            "type": "number",
+            "minimum": 0,
+            "description": "USD per million fresh input tokens. Overrides the shipped rate table; the only place a negotiated price can be recorded."
+          },
+          "cached_input_per_mtok": {
+            "type": "number",
+            "minimum": 0,
+            "description": "USD per million cached input tokens. Defaults to the input rate."
+          },
+          "cache_write_per_mtok": {
+            "type": "number",
+            "minimum": 0,
+            "description": "USD per million tokens written to cache. Defaults to the input rate."
+          },
+          "output_per_mtok": {
+            "type": "number",
+            "minimum": 0,
+            "description": "USD per million output tokens."
           }
         }
       }
@@ -707,6 +753,11 @@
           }
         }
       }
+    },
+    "update_check": {
+      "type": "boolean",
+      "default": true,
+      "description": "Whether lev asks GitHub for a newer release once a day and says so under a command's output. Set false where reaching out is the problem rather than the answer."
     }
   },
   "$defs": {

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -139,6 +139,15 @@
           },
           "400": {
             "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -173,6 +182,21 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -211,6 +235,15 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -230,6 +263,18 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -241,6 +286,24 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -250,8 +313,23 @@
         ],
         "summary": "Uninstall a blueprint",
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/Ok"
+          "204": {
+            "description": "Done. No body."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -374,6 +452,15 @@
           },
           "400": {
             "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -415,6 +502,15 @@
           },
           "400": {
             "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -450,11 +546,20 @@
           "204": {
             "description": "Deleted. No body."
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "404": {
             "$ref": "#/components/responses/Error"
           },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
           "409": {
             "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -480,6 +585,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -512,6 +626,21 @@
           },
           "400": {
             "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -525,6 +654,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -544,8 +682,17 @@
           "200": {
             "$ref": "#/components/responses/Ok"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "404": {
             "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -555,8 +702,17 @@
         ],
         "summary": "Cancel a run",
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/Ok"
+          "204": {
+            "description": "Done. No body."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -575,6 +731,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -593,6 +758,18 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -650,8 +827,17 @@
           "400": {
             "$ref": "#/components/responses/Error"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "404": {
             "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -715,14 +901,29 @@
           "200": {
             "$ref": "#/components/responses/Ok"
           },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "403": {
             "$ref": "#/components/responses/Error"
           },
           "404": {
             "$ref": "#/components/responses/Error"
           },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "415": {
+            "$ref": "#/components/responses/Error"
+          },
           "416": {
             "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -778,6 +979,18 @@
           },
           "400": {
             "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -803,6 +1016,18 @@
                 }
               }
             }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -821,6 +1046,18 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -837,8 +1074,17 @@
         ],
         "summary": "Pause a run after its in-flight step",
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/Ok"
+          "204": {
+            "description": "Done. No body."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -855,8 +1101,17 @@
         ],
         "summary": "Un-pause a run",
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/Ok"
+          "204": {
+            "description": "Done. No body."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -891,8 +1146,17 @@
           }
         },
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/Ok"
+          "202": {
+            "description": "Accepted: the daemon holds it, and the work happens after the response."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -911,6 +1175,18 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -920,8 +1196,23 @@
         ],
         "summary": "Answer the pending question",
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/Ok"
+          "202": {
+            "description": "Accepted: the daemon holds it, and the work happens after the response."
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         },
         "description": "Body: `request_id` (the open request's id) plus one of `value`, `choice_index`, or `approved` with an optional `scope` (`once`, `stage`, `session`). A deny (`approved: false`) may carry `feedback`, a string the model reads inside the tool result for the refused call: `[denied] User declined tool call '<tool>'. Feedback: <text>`. `feedback` beside `approved: true` is a 400. 202 once the daemon holds the answer, 404 when nothing with that id is open. Announced as `interaction.feedback`."
@@ -936,6 +1227,18 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -946,8 +1249,29 @@
         "summary": "Add an MCP server",
         "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because adding a stdio server is arbitrary code execution by construction.",
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/Ok"
+          "201": {
+            "description": "Created."
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "409": {
+            "$ref": "#/components/responses/Error"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -965,8 +1289,23 @@
         "summary": "Remove an MCP server",
         "description": "Admin only. See POST /api/mcp/servers.",
         "responses": {
-          "200": {
-            "$ref": "#/components/responses/Ok"
+          "204": {
+            "description": "Done. No body."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -985,6 +1324,21 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1003,6 +1357,27 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "502": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         },
         "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because it opens the operator's browser on the host running the server and completes an OAuth flow there. Returns `{\"status\": \"authenticated\"}` when the browser flow completed and credentials were stored, or `{\"status\": \"not_required\"}` when the server answered a probe carrying its configured headers, which means there is no OAuth flow to run."
@@ -1022,6 +1397,24 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "502": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         },
         "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed, because it connects to the server and, for a stdio server, spawns its configured command."
@@ -1037,6 +1430,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1052,8 +1454,17 @@
           "200": {
             "$ref": "#/components/responses/Ok"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
           "409": {
             "description": "Another live doctor run is already in progress"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1068,6 +1479,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -1106,8 +1526,20 @@
           "400": {
             "$ref": "#/components/responses/Error"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
           "409": {
             "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1134,8 +1566,17 @@
           "200": {
             "$ref": "#/components/responses/Ok"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "404": {
             "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1166,6 +1607,24 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -1201,6 +1660,30 @@
         "responses": {
           "201": {
             "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Error"
+          },
+          "404": {
+            "$ref": "#/components/responses/Error"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "409": {
+            "$ref": "#/components/responses/Error"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1213,7 +1696,23 @@
         "summary": "The active configuration, with credentials redacted",
         "responses": {
           "200": {
-            "$ref": "#/components/responses/Ok"
+            "description": "The configuration, redacted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedactedConfig"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -1225,7 +1724,32 @@
         "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed.",
         "responses": {
           "200": {
-            "$ref": "#/components/responses/Ok"
+            "description": "The configuration as written, redacted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RedactedConfig"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1246,6 +1770,15 @@
               }
             },
             "description": "Whether the key and value are usable."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1259,6 +1792,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1277,8 +1819,17 @@
           "400": {
             "$ref": "#/components/responses/BadRequest"
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
           "502": {
             "$ref": "#/components/responses/BadGateway"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1303,6 +1854,9 @@
         "responses": {
           "101": {
             "description": "Switching protocols."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -1332,6 +1886,9 @@
         "responses": {
           "101": {
             "description": "Switching protocols."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
           }
         }
       }
@@ -1359,6 +1916,9 @@
               }
             }
           },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
           "404": {
             "description": "No run with that id.",
             "content": {
@@ -1368,6 +1928,12 @@
                 }
               }
             }
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1392,6 +1958,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1416,6 +1991,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1430,6 +2014,18 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "400": {
+            "$ref": "#/components/responses/Error"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1477,6 +2073,15 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -1523,6 +2128,21 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/Ok"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "500": {
+            "$ref": "#/components/responses/Error"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       },
@@ -1569,6 +2189,18 @@
         "responses": {
           "204": {
             "description": "Deleted."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "405": {
+            "$ref": "#/components/responses/NotMounted"
+          },
+          "408": {
+            "$ref": "#/components/responses/Timeout"
+          },
+          "503": {
+            "$ref": "#/components/responses/Overloaded"
           }
         }
       }
@@ -1614,6 +2246,46 @@
       },
       "Error": {
         "description": "The request failed.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "The bearer token is missing or wrong. Every route, the websocket included.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "NotMounted": {
+        "description": "The method is mounted only with `lev serve --allow-admin`; without it the path exists for its other methods and this one is refused.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Timeout": {
+        "description": "The request ran past `[serve] request_timeout_secs` and its work was dropped. Not on the websocket routes.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "Overloaded": {
+        "description": "More requests in flight than `[serve] max_concurrent_requests` allows, or the daemon is not answering. Retry after a moment.",
         "content": {
           "application/json": {
             "schema": {
@@ -2127,6 +2799,180 @@
               "$ref": "#/components/schemas/SkippedRun"
             },
             "description": "Ids that were left alone, each with a reason. A live run and a run that was already gone are both non-deletions, and a caller needs to tell them apart."
+          }
+        }
+      },
+      "ApiLimits": {
+        "type": "object",
+        "description": "The caps this server enforces, so a client can size its requests instead of discovering a 400.",
+        "required": [
+          "max_limit",
+          "max_ids",
+          "max_file_bytes",
+          "max_listing_entries",
+          "max_search_scan",
+          "search_log_tail_bytes",
+          "max_history_limit",
+          "max_tracked_modified_files",
+          "max_concurrent_requests",
+          "request_timeout_secs"
+        ],
+        "properties": {
+          "max_limit": {
+            "type": "integer",
+            "description": "Largest `limit` on a paginated listing."
+          },
+          "max_ids": {
+            "type": "integer",
+            "description": "Most ids one bulk request may name."
+          },
+          "max_file_bytes": {
+            "type": "integer",
+            "description": "Largest file `GET /api/agents/{id}/files` serves whole."
+          },
+          "max_listing_entries": {
+            "type": "integer",
+            "description": "Most entries a directory listing returns."
+          },
+          "max_search_scan": {
+            "type": "integer",
+            "description": "Most runs a search reads before it stops."
+          },
+          "search_log_tail_bytes": {
+            "type": "integer",
+            "description": "How much of each log a search reads, from the end."
+          },
+          "max_history_limit": {
+            "type": "integer",
+            "description": "Largest `limit` on the context history route."
+          },
+          "max_tracked_modified_files": {
+            "type": "integer",
+            "description": "Most modified files a run reports."
+          },
+          "max_concurrent_requests": {
+            "type": "integer",
+            "description": "Requests in flight before a 503; 0 is no cap."
+          },
+          "request_timeout_secs": {
+            "type": "integer",
+            "description": "Seconds before a request is dropped with a 408; 0 is no deadline."
+          }
+        }
+      },
+      "GatewayInfo": {
+        "type": "object",
+        "description": "One `[model_providers.<name>]` entry, with its credential reduced to whether one is set.",
+        "required": [
+          "name",
+          "has_api_key",
+          "kind"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "base_url": {
+            "type": "string",
+            "description": "Absent when the entry has none."
+          },
+          "has_api_key": {
+            "type": "boolean"
+          },
+          "kind": {
+            "type": "string",
+            "enum": [
+              "script",
+              "openai-compatible"
+            ],
+            "description": "How the entry reaches its provider: a Rhai script, or an OpenAI-compatible endpoint spoken to directly."
+          },
+          "script": {
+            "type": "string",
+            "description": "The script path, for `kind = \"script\"`."
+          },
+          "header_names": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The names of the extra headers an endpoint sends, never their values. Absent when there are none."
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "The model ids the entry declares it serves. Absent when it declares none."
+          }
+        }
+      },
+      "RedactedConfig": {
+        "type": "object",
+        "description": "The active configuration with every credential reduced to whether one is set, plus what this server can do and how much it accepts.",
+        "required": [
+          "default_provider",
+          "has_anthropic_key",
+          "has_openai_key",
+          "has_google_key",
+          "has_openrouter_key",
+          "gateways",
+          "agent_paths",
+          "mcp_server_count",
+          "api_version",
+          "capabilities",
+          "limits"
+        ],
+        "properties": {
+          "default_provider": {
+            "type": "string"
+          },
+          "has_anthropic_key": {
+            "type": "boolean"
+          },
+          "has_openai_key": {
+            "type": "boolean"
+          },
+          "has_google_key": {
+            "type": "boolean"
+          },
+          "has_openrouter_key": {
+            "type": "boolean"
+          },
+          "ollama_base_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "gateways": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GatewayInfo"
+            }
+          },
+          "agent_paths": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "mcp_server_count": {
+            "type": "integer"
+          },
+          "api_version": {
+            "type": "string",
+            "description": "The version of this document the server implements; equal to `info.version` here."
+          },
+          "capabilities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Feature names a client may rely on. Each is explained in the API guide."
+          },
+          "limits": {
+            "$ref": "#/components/schemas/ApiLimits"
           }
         }
       }


### PR DESCRIPTION
Plan section 2, "Docs and schemas": every bullet, with a drift test for each schema gap so it cannot reopen. No behaviour change.

## Schemas

- `docs/schema/config.schema.json`: `update_check` at the top level; `max_agents_per_run`, `notify_spend_usd`, `script_http_timeout_secs`, `script_http_max_per_host` under `[limits]`; and, found by the new test, the four per-model price overrides (`input_per_mtok`, `cached_input_per_mtok`, `cache_write_per_mtok`, `output_per_mtok`) under `[model_capabilities.<model>]`, which the schema also refused. `configuration.md`'s `[limits]` table gains rows for the two script HTTP limits (the prices were already on the costs page).
- `docs/schema/config.example.toml`: the "not yet enforced" comment on `tokens_per_minute` is gone; `update_check`, `allowed_workdirs`, `mcp_idle_disconnect_secs` and the four limits keys are set.
- Drift test `every_config_field_is_in_the_published_schema` (`config/mod.rs`): reads the `pub` fields of `Config` and 17 section structs out of their source files (the `RunMeta` guard's technique; cross-crate via `CARGO_MANIFEST_DIR/../`), skipping the one `#[serde(flatten)]` field, and holds the schema to them in both directions wherever the schema closes the table (`model_providers[*]` is open on purpose).
- `docs/schema/blueprint.schema.json`: `$defs.region` gains `describe_in_prompt`; the `description` property's own description said it reached the model on every turn, which is what `describe_in_prompt` is for, so it now says documentation by default.
- `REGION_KEYS` beside `parse_region_layout`, `INTERACTION_POINT_KEYS` and `HOOK_KEYS` in `stage.rs`, `MODEL_KEYS` in `model.rs`, `AGENT_KEYS` in `manifest.rs`, each a row in the drift loop at `manifest/tests.rs`. None of these parsers refuses an unknown key today and this PR does not change that, so four of the five lists are `#[cfg(test)]` and documented as the list the schema is held to; `HOOK_KEYS` is live, because the hooks refusal message spelled the same seven names by hand and now joins the list.
- `docs/schema/openapi.json`: `401` on every operation, `408` and `503` on everything but the two websocket routes, `405` on the five admin methods whose path is also mounted without `--allow-admin` (`POST /api/mcp/servers`, `PUT /api/config`, `POST /api/update`, `PUT` and `DELETE /api/scripts/{kind}/{name}`; the plan counted three, the router has five), `202`/`400`/`404` on the interaction route, and the codes each handler names that the spec did not list (mostly `404` and `500`). Seven operations listed `200` where the handler returns a bare status or a different 2xx (`204` on kill, pause, resume, blueprint delete, MCP server delete; `202` on message; `201` on MCP server add); those `200`s are replaced. `RedactedConfig`, `GatewayInfo` and `ApiLimits` schemas back `GET` and `PUT /api/config`.
- Drift test `the_openapi_spec_documents_every_status_a_handler_can_answer` (`serve/mod.rs`): `handlers_in` reads `(path, METHOD, module, function)` out of the router source; for each, the handler's `StatusCode::` constants (from its own module's `include_str!`, mapped through a table that panics on a constant it does not know) plus the layered codes must all appear in the operation's responses. One-directional, since a handler can answer through a helper the reader cannot see into.

Each drift test was run against the schema with its gap reintroduced and failed there (`update_check` removed, a `401` removed, `describe_in_prompt` removed).

## Docs

- `cli.md`: `timeline` and `update` in the `--json` list; `--width` only with `--graph`; `-r/--remote` named as inert on `models list` and `models show`; the `--claude-code` row says the wizard does not ask.
- `README.md`: `:98` points at `lev setup --claude-code true`; `:288` names the `kind = "openai-compatible"` route (llama.cpp, LM Studio, vLLM, a gateway) with Rhai for other wire formats.
- `CHANGELOG.md:3455` em dash rewritten (the plan said `:3443`; the file had moved).
- Sweep per `docs/README.md` rule 7 (the plan said rule 9; the file numbers it 7): 20 of the 26 uses of "just" / "merely" / "simply" rewritten as sentences. The six left mean "a moment ago" (`containers.md:41`, `stages.md:63`, `security.md:164,173`, `work-queues.md:71`, `troubleshooting.md:22`), which is not the dismissive sense the rule is about.

Nothing at the plan's sites had changed since the planner read them, apart from the two line numbers above.

## Gates

`cargo fmt`, `clippy --all-targets --all-features -D warnings` on `leviath-core` and `leviath-cli`, `cargo xtask structure`, `cargo xtask docs`, `cargo xtask coverage --package leviath-core` and `--package leviath-cli` at 100%, pre-commit full suite.
