### PR TITLE
test: give every temp path a unique name

### DIFF
--- a/crates/leviath-cli/src/blueprint_edit/tests.rs
+++ b/crates/leviath-cli/src/blueprint_edit/tests.rs
@@ -1381,8 +1381,8 @@ fn odd_content_is_refused_rather_than_clobbered() {
 
 #[test]
 fn check_reports_parse_validate_and_lint_in_that_order() {
-    let dir = std::env::temp_dir().join("lev-blueprint-edit-check");
-    let _ = std::fs::create_dir_all(&dir);
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().to_path_buf();
     let parse = check("not = [toml", &dir);
     assert_eq!(parse.error_count(), 1);
     assert_eq!(parse.items[0].code, "parse");
@@ -1466,7 +1466,6 @@ fn check_reports_parse_validate_and_lint_in_that_order() {
     assert_eq!(problems.items[0].severity, Severity::Error);
     assert_eq!(problems.items[0].code, "unknown-tool");
     assert!(problems.items[0].fix.is_some() || problems.items[0].message.contains("no_such_tool"));
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // ─── templates ───────────────────────────────────────────────────────────────
@@ -1505,8 +1504,8 @@ fn the_starter_and_the_clone() {
 
 #[test]
 fn the_layout_store_remembers_per_agent_and_survives_a_reload() {
-    let dir = std::env::temp_dir().join("lev-blueprint-edit-layouts");
-    let _ = std::fs::remove_dir_all(&dir);
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().to_path_buf();
     let path = dir.join("nested").join("graph-layouts.json");
     let mut store = LayoutStore::open(path.clone());
     assert_eq!(store.path(), Some(path.as_path()));
@@ -1551,7 +1550,6 @@ fn the_layout_store_remembers_per_agent_and_survives_a_reload() {
     mem.save().unwrap();
     assert_eq!(mem.path(), None);
     assert!(LayoutStore::default_path().is_some_and(|p| p.ends_with("dash/graph-layouts.json")));
-    let _ = std::fs::remove_dir_all(&dir);
 }
 
 // ─── catalog ─────────────────────────────────────────────────────────────────

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -44,18 +44,16 @@ impl Dashboard {
     /// Test-only: production always goes through `new_with_log_path`.
     #[cfg(test)]
     pub(super) fn new(cmd_tx: mpsc::UnboundedSender<DaemonCommand>) -> Self {
-        let log_path = std::env::temp_dir()
-            .join("leviath-test-dashboard")
-            .join("dashboard.log");
+        // Per process, so two test binaries (parallel checkouts, or a coverage
+        // run beside a plain one) never append to the same activity log.
+        let base =
+            std::env::temp_dir().join(format!("leviath-test-dashboard-{}", std::process::id()));
+        let log_path = base.join("dashboard.log");
         // A test MCP context: temp paths, a no-op browser, and a fixed clock so
         // no test touches the real home directory, a browser, or the wall clock.
         let ctx = McpContext {
-            config_path: std::env::temp_dir()
-                .join("leviath-test-dashboard")
-                .join("config.toml"),
-            store_path: std::env::temp_dir()
-                .join("leviath-test-dashboard")
-                .join("mcp-auth.json"),
+            config_path: base.join("config.toml"),
+            store_path: base.join("mcp-auth.json"),
             opener: std::sync::Arc::new(|_| false),
             clock: || 1_000,
             // No test built this way reaches a real handshake; the production
@@ -66,15 +64,9 @@ impl Dashboard {
         // the `@` completion never read the real agents dir or working
         // directory. Tests that need either point these at their own tempdir.
         let new_run_ctx = NewRunContext {
-            agents_dir: std::env::temp_dir()
-                .join("leviath-test-dashboard")
-                .join("agents"),
-            config_path: std::env::temp_dir()
-                .join("leviath-test-dashboard")
-                .join("config.toml"),
-            workdir: std::env::temp_dir()
-                .join("leviath-test-dashboard")
-                .join("workdir"),
+            agents_dir: base.join("agents"),
+            config_path: base.join("config.toml"),
+            workdir: base.join("workdir"),
         };
         Self::new_with_log_path(cmd_tx, log_path, |_| false, ctx, new_run_ctx)
     }

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -482,7 +482,8 @@ mod tests {
     /// A control client pointing at a socket with no daemon behind it; requests
     /// fail fast, which the dashboard treats as "nothing to observe".
     fn no_daemon_control() -> ControlClient {
-        let dir = std::env::temp_dir().join("leviath-dash-no-daemon");
+        let dir =
+            std::env::temp_dir().join(format!("leviath-dash-no-daemon-{}", std::process::id()));
         ControlClient::new(leviath_runtime::control_socket::control_id(&dir))
     }
 

--- a/crates/leviath-cli/src/commands/dashboard/render/content.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/content.rs
@@ -1434,6 +1434,13 @@ mod tests {
         );
     }
 
+    /// Pane width for the tests that assert on the file-path hint. The hint
+    /// is a block title, which ratatui clips at the pane's right edge, and it
+    /// carries the run's real on-disk path: under macOS's temp dir
+    /// (`/var/folders/xy/.../T/`) that runs well past 100 columns, which would
+    /// clip the file name the assertion looks for. Wide enough for any OS.
+    const HINT_PANE_WIDTH: u16 = 260;
+
     /// The view shows the bytes `runstate::read_final_output` returns, which
     /// is what the HTTP API serves, under a header naming the submitting
     /// stage and the format, with the sidecar named in the file-path hint.
@@ -1459,9 +1466,16 @@ mod tests {
 
                 let mut dash = make_test_dashboard();
                 dash.stage_content_mode = StageContentMode::FinalOutput;
-                let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+                let mut terminal = Terminal::new(TestBackend::new(HINT_PANE_WIDTH, 20)).unwrap();
                 terminal
-                    .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &agent, 100))
+                    .draw(|f| {
+                        dash.render_content_pane(
+                            f,
+                            Rect::new(0, 0, HINT_PANE_WIDTH, 20),
+                            &agent,
+                            100,
+                        )
+                    })
                     .unwrap();
                 let buf = rendered_buffer(&terminal);
                 assert_eq!(dash.stage_content_mode, StageContentMode::FinalOutput);
@@ -1502,9 +1516,16 @@ mod tests {
                 let agent = setup_run_state_agent_with_logs("final-fallback", &[], Some("plain"));
                 let mut dash = make_test_dashboard();
                 dash.stage_content_mode = StageContentMode::FinalOutput;
-                let mut terminal = Terminal::new(TestBackend::new(100, 20)).unwrap();
+                let mut terminal = Terminal::new(TestBackend::new(HINT_PANE_WIDTH, 20)).unwrap();
                 terminal
-                    .draw(|f| dash.render_content_pane(f, Rect::new(0, 0, 100, 20), &agent, 100))
+                    .draw(|f| {
+                        dash.render_content_pane(
+                            f,
+                            Rect::new(0, 0, HINT_PANE_WIDTH, 20),
+                            &agent,
+                            100,
+                        )
+                    })
                     .unwrap();
                 assert_eq!(dash.stage_content_mode, StageContentMode::Output);
                 let buf = rendered_buffer(&terminal);
@@ -1588,13 +1609,13 @@ mod tests {
                 let run_id = "test-content-output-hint";
                 let agent = setup_run_state_agent_with_logs(run_id, &[], Some("hello output"));
 
-                let backend = TestBackend::new(120, 40);
+                let backend = TestBackend::new(HINT_PANE_WIDTH, 40);
                 let mut terminal = Terminal::new(backend).unwrap();
                 let mut dash = make_test_dashboard();
                 dash.stage_content_mode = StageContentMode::Output;
                 terminal
                     .draw(|f| {
-                        let area = Rect::new(0, 0, 100, 20);
+                        let area = Rect::new(0, 0, HINT_PANE_WIDTH, 20);
                         dash.render_content_pane(f, area, &agent, 100);
                     })
                     .unwrap();
@@ -1836,13 +1857,13 @@ mod tests {
                     setup_run_state_agent_with_final_output(run_id, "present", "the answer");
                 agent.stages = vec![make_stage_record("present")];
 
-                let backend = TestBackend::new(120, 40);
+                let backend = TestBackend::new(HINT_PANE_WIDTH, 40);
                 let mut terminal = Terminal::new(backend).unwrap();
                 let mut dash = make_test_dashboard();
                 dash.stage_content_mode = StageContentMode::Output;
                 terminal
                     .draw(|f| {
-                        let area = Rect::new(0, 0, 100, 20);
+                        let area = Rect::new(0, 0, HINT_PANE_WIDTH, 20);
                         dash.render_content_pane(f, area, &agent, 100);
                     })
                     .unwrap();

--- a/crates/leviath-cli/src/commands/list.rs
+++ b/crates/leviath-cli/src/commands/list.rs
@@ -877,11 +877,9 @@ system = { kind = "pinned", max_tokens = 1000 }
             // test in the crate and restores CWD automatically on drop, so it's
             // safe to hold across the `.await` below.
             let _guard = crate::config::isolate_cwd_for_test();
-            let dir = std::env::temp_dir().join("lev-test-list-cwd-gone");
-            let _ = std::fs::remove_dir_all(&dir);
-            std::fs::create_dir_all(&dir).unwrap();
-            std::env::set_current_dir(&dir).unwrap();
-            std::fs::remove_dir_all(&dir).unwrap();
+            let dir = tempfile::tempdir().unwrap();
+            std::env::set_current_dir(dir.path()).unwrap();
+            std::fs::remove_dir_all(dir.path()).unwrap();
 
             let args = ListArgs {
                 filter: ListFilter::All,

--- a/crates/leviath-cli/src/commands/run/manifest.rs
+++ b/crates/leviath-cli/src/commands/run/manifest.rs
@@ -73,30 +73,26 @@ mod tests {
 
     #[test]
     fn find_manifest_with_file_path() {
-        let dir = std::env::temp_dir().join("lev-test-find-manifest-file");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let manifest = dir.join("agent.leviath");
         std::fs::write(&manifest, "[agent]\nname = \"test\"").unwrap();
 
         let result = find_manifest(manifest.to_str().unwrap());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), manifest);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn find_manifest_with_directory_path() {
-        let dir = std::env::temp_dir().join("lev-test-find-manifest-dir");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let manifest = dir.join("agent.leviath");
         std::fs::write(&manifest, "[agent]\nname = \"test\"").unwrap();
 
         let result = find_manifest(dir.to_str().unwrap());
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), manifest);
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -141,13 +137,11 @@ mod tests {
         let _guard = CWD_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let dir = std::env::temp_dir().join("lev-test-dir-no-manifest-9z7q");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         // No agent.leviath inside - the dir branch falls through to the error.
         let result = find_manifest(dir.to_str().unwrap());
         assert!(result.is_err());
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// Covers branch 3 (installed agent by name) when the agent is NOT installed.
@@ -167,9 +161,8 @@ mod tests {
     /// Uses `CWD_LOCK` to prevent parallel tests from interfering.
     #[test]
     fn find_manifest_cwd_agent_leviath_found() {
-        let dir = std::env::temp_dir().join("lev-test-cwd-manifest-a1b2");
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let manifest = dir.join("agent.leviath");
         std::fs::write(&manifest, "[agent]\nname = \"cwd-test\"").unwrap();
 
@@ -186,7 +179,6 @@ mod tests {
 
         // Always restore CWD before asserting so cleanup runs even on failure.
         std::env::set_current_dir(&original_cwd).unwrap();
-        let _ = std::fs::remove_dir_all(&dir);
 
         assert!(result.is_ok());
         assert_eq!(result.unwrap().file_name().unwrap(), "agent.leviath");

--- a/crates/leviath-cli/src/commands/run/task.rs
+++ b/crates/leviath-cli/src/commands/run/task.rs
@@ -266,13 +266,12 @@ mod tests {
 
     #[test]
     fn read_region_value_at_path_reads_and_trims() {
-        let dir = std::env::temp_dir().join("lev-test-region-value");
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("r.md");
         std::fs::write(&file, "  hello region  \n").unwrap();
         let raw = format!("@{}", file.to_string_lossy());
         assert_eq!(read_region_value(&raw).unwrap(), "hello region");
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -283,14 +282,13 @@ mod tests {
 
     #[test]
     fn read_region_value_at_empty_file_errors() {
-        let dir = std::env::temp_dir().join("lev-test-region-empty");
-        std::fs::create_dir_all(&dir).unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("empty.md");
         std::fs::write(&file, "   \n").unwrap();
         let raw = format!("@{}", file.to_string_lossy());
         let err = read_region_value(&raw).unwrap_err();
         assert!(err.to_string().contains("is empty"));
-        std::fs::remove_dir_all(&dir).ok();
     }
 
     #[test]
@@ -301,29 +299,25 @@ mod tests {
 
     #[test]
     fn resolve_task_with_file_path() {
-        let dir = std::env::temp_dir().join("lev-test-resolve-task");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("task.txt");
         std::fs::write(&file, "task from file\n").unwrap();
 
         let result = resolve_task(Some(file.to_str().unwrap()), "test", "", &never_a_tty);
         assert_eq!(result.unwrap(), "task from file");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn resolve_task_with_empty_file_errors() {
-        let dir = std::env::temp_dir().join("lev-test-resolve-empty");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("empty.txt");
         std::fs::write(&file, "   \n  ").unwrap();
 
         let result = resolve_task(Some(file.to_str().unwrap()), "test", "", &never_a_tty);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("empty"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A bare word that names no file is prompt text. It has no separator, so
@@ -381,29 +375,25 @@ mod tests {
 
     #[test]
     fn resolve_task_file_with_whitespace_only_errors() {
-        let dir = std::env::temp_dir().join("lev-test-resolve-ws");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("whitespace.txt");
         std::fs::write(&file, "   \n\t\n  \n").unwrap();
 
         let result = resolve_task(Some(file.to_str().unwrap()), "test", "", &never_a_tty);
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("empty"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
     fn resolve_task_file_trims_content() {
-        let dir = std::env::temp_dir().join("lev-test-resolve-trim");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("trimme.txt");
         std::fs::write(&file, "  hello world  \n\n").unwrap();
 
         let result = resolve_task(Some(file.to_str().unwrap()), "test", "", &never_a_tty);
         assert_eq!(result.unwrap(), "hello world");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
@@ -414,8 +404,8 @@ mod tests {
 
     #[test]
     fn resolve_task_multiline_file() {
-        let dir = std::env::temp_dir().join("lev-test-resolve-multiline");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("multi.txt");
         std::fs::write(&file, "line one\nline two\nline three\n").unwrap();
 
@@ -424,8 +414,6 @@ mod tests {
         assert!(task.contains("line one"));
         assert!(task.contains("line two"));
         assert!(task.contains("line three"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ─── resolve_task: literal string with special chars ────────────────
@@ -454,23 +442,21 @@ mod tests {
 
     #[test]
     fn resolve_task_file_with_multiple_trailing_newlines() {
-        let dir = std::env::temp_dir().join("lev-test-resolve-trail");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("trail.txt");
         std::fs::write(&file, "task content\n\n\n\n").unwrap();
 
         let result = resolve_task(Some(file.to_str().unwrap()), "test", "", &never_a_tty);
         assert_eq!(result.unwrap(), "task content");
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ─── build_provider_registry: model_capabilities propagated ──────────
 
     #[test]
     fn resolve_task_file_with_real_content() {
-        let dir = std::env::temp_dir().join("lev-test-resolve-real");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("real.txt");
         std::fs::write(&file, "Implement a REST API server\nwith authentication\n").unwrap();
 
@@ -483,8 +469,6 @@ mod tests {
         let task = result.unwrap();
         assert!(task.contains("Implement a REST API server"));
         assert!(task.contains("with authentication"));
-
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // ─── build_provider_registry: all providers registered ───────────────
@@ -540,8 +524,8 @@ mod tests {
         // A tiny "editor" script that appends a non-comment line to
         // whatever file it's invoked on ($1) - standing in for a real
         // interactive editor session.
-        let dir = std::env::temp_dir().join("lev-test-resolve-task-editor-happy");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let script = dir.join("fake-editor.sh");
         std::fs::write(
             &script,
@@ -555,8 +539,6 @@ mod tests {
         temp_env::with_vars([("VISUAL", Some(&script)), ("EDITOR", None)], || {
             let result = resolve_task_with(None, "test-agent", "a non-empty description", &|| true);
             assert_eq!(result.unwrap(), "task body from editor");
-
-            let _ = std::fs::remove_dir_all(&dir);
         });
     }
 
@@ -688,16 +670,14 @@ mod tests {
         // file it's invoked on (%~1) - standing in for a real interactive
         // editor session. `%~1` strips any surrounding quotes Windows adds
         // around a path containing spaces.
-        let dir = std::env::temp_dir().join("lev-test-resolve-task-editor-happy-win");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let script = dir.join("fake-editor.bat");
         write_bat(&script, "echo task body from editor>>\"%~1\"");
 
         temp_env::with_vars([("VISUAL", Some(&script)), ("EDITOR", None)], || {
             let result = resolve_task_with(None, "test-agent", "a non-empty description", &|| true);
             assert_eq!(result.unwrap(), "task body from editor");
-
-            let _ = std::fs::remove_dir_all(&dir);
         });
     }
 
@@ -707,8 +687,8 @@ mod tests {
         // A no-op batch file "opens" the file and does nothing to it, so
         // only the commented-out template remains - stripped down to an
         // empty task.
-        let dir = std::env::temp_dir().join("lev-test-resolve-task-editor-empty-win");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let ok_bat = dir.join("ok.bat");
         write_bat(&ok_bat, "exit /b 0");
 
@@ -716,8 +696,6 @@ mod tests {
             let result = resolve_task_with(None, "test-agent", "", &|| true);
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("Aborting run"));
-
-            let _ = std::fs::remove_dir_all(&dir);
         });
     }
 
@@ -766,8 +744,8 @@ mod tests {
     #[test]
     fn resolve_task_unreadable_file_returns_error() {
         use std::os::unix::fs::PermissionsExt;
-        let dir = std::env::temp_dir().join("lev-test-resolve-unreadable");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("secret.txt");
         std::fs::write(&file, "secret content").unwrap();
         let mut perms = std::fs::metadata(&file).unwrap().permissions();
@@ -779,7 +757,6 @@ mod tests {
         let mut perms2 = std::fs::metadata(&file).unwrap().permissions();
         perms2.set_mode(0o644);
         std::fs::set_permissions(&file, perms2).ok();
-        let _ = std::fs::remove_dir_all(&dir);
 
         assert!(result.is_err());
         assert!(
@@ -802,8 +779,8 @@ mod tests {
         use std::fs::OpenOptions;
         use std::os::windows::fs::OpenOptionsExt;
 
-        let dir = std::env::temp_dir().join("lev-test-resolve-unreadable-win");
-        let _ = std::fs::create_dir_all(&dir);
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let file = dir.join("secret.txt");
         std::fs::write(&file, "secret content").unwrap();
 
@@ -818,7 +795,6 @@ mod tests {
         let result = resolve_task_with(Some(file.to_str().unwrap()), "test-agent", "", &|| false);
 
         drop(_locked);
-        let _ = std::fs::remove_dir_all(&dir);
 
         assert!(result.is_err());
         assert!(

--- a/crates/leviath-cli/src/commands/serve/blueprints.rs
+++ b/crates/leviath-cli/src/commands/serve/blueprints.rs
@@ -1281,7 +1281,10 @@ system_prompt = "p"
     /// decoded form is what has to be rejected.
     #[tokio::test]
     async fn delete_blueprint_rejects_traversing_names() {
-        let victim = std::env::temp_dir().join("leviath-delete-probe");
+        // Named per process so two checkouts running this test at once
+        // cannot delete each other's probe and fake a traversal.
+        let probe = format!("leviath-delete-probe-{}", std::process::id());
+        let victim = std::env::temp_dir().join(&probe);
         std::fs::create_dir_all(&victim).unwrap();
 
         let app = Router::new().route(
@@ -1290,7 +1293,7 @@ system_prompt = "p"
         );
         let req = Request::builder()
             .method("DELETE")
-            .uri("/api/blueprints/..%2f..%2f..%2f..%2ftmp%2fleviath-delete-probe")
+            .uri(format!("/api/blueprints/..%2f..%2f..%2f..%2ftmp%2f{probe}"))
             .body(Body::empty())
             .unwrap();
         let resp = app.oneshot(req).await.unwrap();

--- a/crates/leviath-cli/src/runstate.rs
+++ b/crates/leviath-cli/src/runstate.rs
@@ -948,27 +948,25 @@ pub(crate) fn tail_run_logs(
 }
 
 /// Build the isolated base directory for a run-state test and create its
-/// `runs/` subdir. Returned so the caller's closure can plant fixtures under it.
+/// `runs/` subdir. Returned as a [`tempfile::TempDir`] so the tree lives
+/// exactly as long as the closure that uses it and is removed on drop even
+/// when that closure panics.
 ///
-/// Rooted under `~/.leviath-test/rs-<hash>` rather than `std::env::temp_dir()`:
-/// some dashboard render tests display a real on-disk path inside a fixed-width
-/// terminal area and assert on a substring near its *end*, and macOS's real
-/// temp dir (`/var/folders/xy/.../T/`) is long enough to push realistic paths
-/// past the render width and truncate the asserted suffix. `unique` is hashed
-/// short for the same reason (test names run 60+ chars). `.leviath-test` is a
-/// sibling of `.leviath`, never read by `lev dash`/`lev serve`, so even if a
-/// killed test process skips cleanup it can't leak into the real dashboard.
+/// `unique` (the test name, typically) is hashed into the directory prefix so
+/// a stray tree in the temp dir can still be traced back to the test that
+/// left it, without pushing the path length up by the 60+ characters a test
+/// name runs to.
 #[cfg(test)]
-fn make_runs_base_dir(unique: &str) -> std::path::PathBuf {
+fn make_runs_base_dir(unique: &str) -> tempfile::TempDir {
     use std::hash::{Hash, Hasher};
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
     unique.hash(&mut hasher);
     let short = format!("{:x}", hasher.finish() & 0xffff_ffff);
-    let base_dir = dirs::home_dir()
-        .unwrap_or_default()
-        .join(".leviath-test")
-        .join(format!("rs-{short}"));
-    let _ = std::fs::create_dir_all(base_dir.join("runs"));
+    let base_dir = tempfile::Builder::new()
+        .prefix(&format!("rs-{short}-"))
+        .tempdir()
+        .expect("create an isolated runs dir");
+    let _ = std::fs::create_dir_all(base_dir.path().join("runs"));
     base_dir
 }
 
@@ -997,9 +995,9 @@ fn runs_dir_isolation_vars(
 #[cfg(test)]
 pub(crate) fn with_isolated_runs_dir<R>(unique: &str, f: impl FnOnce(&std::path::Path) -> R) -> R {
     let base_dir = make_runs_base_dir(unique);
-    let result = temp_env::with_vars(runs_dir_isolation_vars(&base_dir), || f(&base_dir));
-    let _ = std::fs::remove_dir_all(&base_dir);
-    result
+    temp_env::with_vars(runs_dir_isolation_vars(base_dir.path()), || {
+        f(base_dir.path())
+    })
 }
 
 /// Async counterpart of [`with_isolated_runs_dir`] for `#[tokio::test]`s.
@@ -1012,10 +1010,11 @@ where
     Fut: std::future::Future<Output = R>,
 {
     let base_dir = make_runs_base_dir(unique);
-    let result =
-        temp_env::async_with_vars(runs_dir_isolation_vars(&base_dir), f(base_dir.clone())).await;
-    let _ = std::fs::remove_dir_all(&base_dir);
-    result
+    temp_env::async_with_vars(
+        runs_dir_isolation_vars(base_dir.path()),
+        f(base_dir.path().to_path_buf()),
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/crates/leviath-sys/src/tty.rs
+++ b/crates/leviath-sys/src/tty.rs
@@ -97,16 +97,30 @@ mod tests {
     // rather than `/dev/null` keeps these tests - and thus `osc52_write_via`'s
     // tty-success and tty-write-fails branches - covered on every OS, not just
     // Unix.
+    //
+    // Each call gets its own file, named by process id plus a counter, so
+    // parallel tests (or two checkouts sharing one temp dir) never truncate
+    // each other's stand-in mid-write.
+    fn fake_tty_path(kind: &str) -> std::path::PathBuf {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        static NEXT: AtomicUsize = AtomicUsize::new(0);
+        let n = NEXT.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "lev_sys_osc52_fake_tty_{kind}_{}_{n}",
+            std::process::id()
+        ))
+    }
+
     fn open_temp_writable() -> io::Result<File> {
         std::fs::OpenOptions::new()
             .create(true)
             .write(true)
             .truncate(true)
-            .open(std::env::temp_dir().join("lev_sys_osc52_fake_tty_w"))
+            .open(fake_tty_path("w"))
     }
 
     fn open_temp_readonly() -> io::Result<File> {
-        let path = std::env::temp_dir().join("lev_sys_osc52_fake_tty_ro");
+        let path = fake_tty_path("ro");
         let _ = std::fs::write(&path, b"");
         std::fs::OpenOptions::new().read(true).open(&path)
     }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -502,8 +502,8 @@ mod tests {
 
     #[test]
     fn resolve_rejects_path_escape() {
-        let dir = std::env::temp_dir().join("leviath_test_sandbox");
-        fs::create_dir_all(&dir).ok();
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
         let tools = make_tools(&dir);
         let result = tools.resolve("../../etc/passwd");
         assert!(result.is_err());


### PR DESCRIPTION
## Summary

Test-only. Every test that built its scratch path as a fixed name under `std::env::temp_dir()` now gets a unique one, so two checkouts (or a coverage run beside a plain `cargo test`) cannot create, fill and delete each other's directory.

- `tempfile::tempdir()` where the test only needs a directory: `run/task.rs` (13 sites), `run/manifest.rs` (4), `blueprint_edit/tests.rs` (2), `leviath-tools/src/lib.rs`, `commands/list.rs`. The hand-written `remove_dir_all` cleanups go with them; the guard removes the tree on drop, panic or not.
- Process id (plus a counter where one process opens several) where the name is part of what the test exercises: the serve `DELETE` traversal probe (its name is encoded into the request URI), the `#[cfg(test)]` dashboard fixture paths in `construct.rs`, the no-daemon control id in `dashboard/mod.rs`, and the fake-tty files in `leviath-sys/src/tty.rs`.
- `runstate::make_runs_base_dir` wrote under the real `$HOME/.leviath-test` because four `render/content.rs` tests render the run's on-disk path into a 100-column pane and assert on the file name at its end, which macOS's long temp dir clipped. The helper now returns a `tempfile::TempDir` like everything else, and those four tests render into a pane wide enough for any OS temp path (`HINT_PANE_WIDTH`). Every assertion is unchanged.

Left alone on purpose: sites that join a fixed name and assert the path does *not* exist (`claude_code.rs`, `script_host.rs`, `serve/mod.rs`, `construct.rs:320`). Nothing creates them, so nothing can collide.

## Measured first

With the run-state helper switched to a tempdir and the render tests untouched, `cargo test -p leviath-cli` failed exactly the four content tests named above and nothing else. That is the whole dependency on the short path.

## Verification

- `cargo clippy --all-targets --all-features -p leviath-cli -p leviath-sys -p leviath-tools -- -D warnings`: clean.
- `cargo test` for the three crates: 4133 + 111 + 206 passed.
- `cargo xtask structure`, `cargo xtask docs`: clean.
- `cargo xtask coverage --package` for `leviath-cli`, `leviath-sys`, `leviath-tools`: gate passes.
- No CHANGELOG entry: no user-facing change.
