### PR TITLE
fix: a run that needs you waits for you, with no timeout by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,17 @@ same list.
 
 ### Changed
 
+- Runs now wait for you. A prompt that needs a person (a tool approval, an
+  `ask_user_*` question, a taint gate, an interaction point) waits until it is
+  answered, however long that takes; it used to be denied after an hour by
+  default, which failed the run the moment you were away for longer than
+  that. `[limits] interaction_timeout_secs` is now unset by default and is the
+  opt-in: set it to bound the wait for a run nobody will be watching. The
+  wait is not counted against a `stuck_after_minutes` edge, a run parked on a
+  prompt is still parked after a daemon restart, and `lev setup` no longer
+  writes a timeout into a fresh config. A config with `interaction_timeout_secs
+  = 0` keeps working (it means unset). The tool result for a prompt that closed
+  without an answer only mentions a timeout when one is configured.
 - A `[model_providers.<name>]` entry with `kind = "openai-compatible"` no
   longer loads with a key the endpoint does not read; the error names the
   entry, the keys, and the ones it does read. Unrecognised keys on a script

--- a/crates/leviath-cli/src/bundled.rs
+++ b/crates/leviath-cli/src/bundled.rs
@@ -469,6 +469,24 @@ mod tests {
     /// Every assertion here is an invariant over *all* discovered blueprints.
     /// Naming individual agents would turn adding or renaming one into a test
     /// edit, and would stop testing the property the moment the list drifted.
+    /// No bundled blueprint puts a deadline on a person. A prompt waits until
+    /// somebody answers unless the operator's own `[limits]
+    /// interaction_timeout_secs` says otherwise, and a shipped agent must not
+    /// decide that for them through any key that names the timeout.
+    #[test]
+    fn no_bundled_agent_sets_an_interaction_timeout() {
+        assert!(!BUNDLED_AGENTS.is_empty());
+        for agent in BUNDLED_AGENTS {
+            for (rel, contents) in agent.files {
+                assert!(
+                    !contents.contains("interaction_timeout"),
+                    "bundled agent {} sets an interaction timeout in {rel}",
+                    agent.name
+                );
+            }
+        }
+    }
+
     #[test]
     fn every_bundled_agent_has_a_name_version_and_manifest() {
         assert!(

--- a/crates/leviath-cli/src/commands/run/mod.rs
+++ b/crates/leviath-cli/src/commands/run/mod.rs
@@ -44,8 +44,8 @@ pub struct RunArgs {
     /// point declaring `unattended = "ask"` still holds for a person. The
     /// bundled coder's plan approval can, deliberately, because
     /// everything after it writes code. Such a run parks in `Waiting` until
-    /// `[limits] interaction_timeout_secs` (default 3600) releases it. Lower
-    /// that to bound the wait.
+    /// somebody answers; set `[limits] interaction_timeout_secs` to bound the
+    /// wait.
     #[arg(long)]
     pub yolo: bool,
 

--- a/crates/leviath-cli/src/commands/setup/state/limits.rs
+++ b/crates/leviath-cli/src/commands/setup/state/limits.rs
@@ -57,8 +57,8 @@ pub(super) fn limits_fields(config: &Config) -> Vec<Field> {
         },
         Field {
             label: "Interaction timeout (seconds)",
-            help: "Resolve a prompt nobody answered after this long, so the run carries on. 0 waits for ever.",
-            value: FieldValue::Number(Some(config.limits.interaction_timeout_secs)),
+            help: "Leave empty and a run waits for you however long it takes. Set it to resolve a prompt nobody answered after this long instead.",
+            value: FieldValue::Number(config.limits.interaction_timeout_secs),
         },
         // The two write ceilings are unset in code and offered with a value
         // here, so a fresh install has one written down where it can be seen
@@ -142,12 +142,10 @@ pub(super) fn apply_limits_fields(config: &mut Config, fields: &[Field]) {
                 config.limits.wedge_timeout_secs =
                     n.unwrap_or(Config::default().limits.wedge_timeout_secs)
             }
-            // Same rule again: unset keeps the default hour, 0 is an explicit
-            // "wait for a person however long it takes".
-            (9, FieldValue::Number(n)) => {
-                config.limits.interaction_timeout_secs =
-                    n.unwrap_or(Config::default().limits.interaction_timeout_secs)
-            }
+            // Unset is the default and means "wait for a person however long
+            // it takes"; a number bounds the wait. Nothing is written unless
+            // the user typed one, so a fresh install carries no timeout.
+            (9, FieldValue::Number(n)) => config.limits.interaction_timeout_secs = *n,
             // The write ceilings break the rule above, and deliberately: here
             // an unset field means *no limit*, not "keep the default". They are
             // the only two settings whose absence is a real choice a user makes

--- a/crates/leviath-cli/src/commands/setup/state/mod.rs
+++ b/crates/leviath-cli/src/commands/setup/state/mod.rs
@@ -2622,6 +2622,37 @@ pub(super) mod tests {
         );
     }
 
+    /// `lev setup` writes no interaction timeout unless the user types one.
+    /// The field is offered blank; blank stays unset (the run waits for a
+    /// person), and the written config carries no line for it, so a fresh
+    /// install is not handed a deadline it never asked for.
+    #[test]
+    fn setup_leaves_the_interaction_timeout_unset_unless_the_user_sets_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut wizard = test_wizard(dir.path());
+        wizard.enter(Step::Limits);
+        assert_eq!(
+            wizard.limits[9].value,
+            FieldValue::Number(None),
+            "the field is offered blank"
+        );
+
+        let config = wizard.build_config();
+        assert_eq!(config.limits.interaction_timeout_secs, None);
+        let written = toml::to_string_pretty(&config).unwrap();
+        assert!(
+            !written.contains("interaction_timeout_secs"),
+            "nothing written for an unset timeout: {written}"
+        );
+
+        wizard.limits[9].value = FieldValue::Number(Some(900));
+        assert_eq!(
+            wizard.build_config().limits.interaction_timeout_secs,
+            Some(900),
+            "a number the user typed is stored"
+        );
+    }
+
     #[test]
     fn a_field_of_the_wrong_kind_is_ignored_when_writing_limits() {
         // Defensive: nothing builds this shape today, but a future edit that

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -72,10 +72,6 @@ fn default_provider_circuit_cooldown_secs() -> u64 {
     leviath_runtime::pipeline::DEFAULT_CIRCUIT_COOLDOWN_SECS
 }
 
-fn default_interaction_timeout_secs() -> u64 {
-    leviath_runtime::interaction_hub::DEFAULT_INTERACTION_TIMEOUT_SECS
-}
-
 /// Streamed inference is on unless the operator says otherwise.
 fn default_stream_inference() -> bool {
     true
@@ -263,20 +259,27 @@ pub struct LimitsConfig {
     ///
     /// Covers every prompt that waits on a person: an agent's `ask_user_*` /
     /// `present_for_review` call, a tool-approval prompt, a taint gate, and a
-    /// blueprint interaction point. Before this existed, a run whose operator
-    /// had walked away sat in `WaitingInput` holding its slot until the daemon
-    /// restarted - hours, in the report that prompted it (issue #204).
+    /// blueprint interaction point.
+    ///
+    /// Unset, a prompt waits for a person for as long as it takes: a run that
+    /// needs you is still waiting when you get back, whether that is in ten
+    /// minutes or on Monday. Nothing else in the daemon fails, reaps, or marks
+    /// stuck a run that is waiting on a person; only cancelling it ends the
+    /// wait. Set this to bound the wait for a run nobody will be watching
+    /// (issue #204).
     ///
     /// Expiry resolves the prompt exactly as cancelling it would: a tool
     /// approval and a taint gate **deny**, an `ask_user_*` call is told nobody
     /// answered, and an interaction point proceeds with no user text. Nothing is
     /// approved on the strength of a timeout.
     ///
-    /// Defaults to `3600` (one hour); `0` waits indefinitely.
+    /// Unset by default. `0` is read as unset (wait indefinitely), never as
+    /// "expire at once", so a config that spelled the wait that way keeps
+    /// working.
     ///
     /// Read once at daemon start, so a change needs a daemon restart.
-    #[serde(default = "default_interaction_timeout_secs")]
-    pub interaction_timeout_secs: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interaction_timeout_secs: Option<u64>,
 
     /// How many times an inference is attempted, the first try included,
     /// before the agent is failed with whatever the provider last said.
@@ -524,7 +527,7 @@ impl Default for LimitsConfig {
             wedge_timeout_secs: default_wedge_timeout_secs(),
             provider_failures_before_open: default_provider_failures_before_open(),
             provider_circuit_cooldown_secs: default_provider_circuit_cooldown_secs(),
-            interaction_timeout_secs: default_interaction_timeout_secs(),
+            interaction_timeout_secs: None,
             inference_retry_attempts: default_inference_retry_attempts(),
             inference_retry_base_ms: default_inference_retry_base_ms(),
             max_concurrent_inferences_by_model: BTreeMap::new(),

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -1485,7 +1485,10 @@ some_custom_thing = \"forwarded to the script\"
         // A couple of spot checks that the values landed where the schema says,
         // rather than being silently dropped into nothing.
         assert_eq!(parsed.default_provider, "anthropic");
-        assert_eq!(parsed.limits.interaction_timeout_secs, 3600);
+        assert_eq!(
+            parsed.limits.interaction_timeout_secs, None,
+            "the example only shows the timeout commented out"
+        );
         assert_eq!(parsed.mcp_servers.len(), 2);
     }
 
@@ -2077,9 +2080,9 @@ some_custom_thing = \"forwarded to the script\"
         // A finished run stays listed for five minutes, so a scheduler polling
         // about once a minute still learns how it ended.
         assert_eq!(limits.finished_retention_secs, 300);
-        // An unanswered prompt releases after an hour rather than holding its
-        // run's slot until the daemon restarts (issue #204).
-        assert_eq!(limits.interaction_timeout_secs, 3600);
+        // A prompt waits for a person until answered; only an operator who
+        // sets a timeout gets one.
+        assert_eq!(limits.interaction_timeout_secs, None);
         // And the top-level Config carries the same defaults.
         assert_eq!(Config::default().limits.max_concurrent_inferences, Some(8));
     }
@@ -2144,8 +2147,9 @@ some_custom_thing = \"forwarded to the script\"
         );
     }
 
-    /// A config written before the field existed still gets the hour, and an
-    /// explicit `0` still means "wait for a person however long it takes".
+    /// A config that never mentions the field waits for a person; an explicit
+    /// `0` (how "wait for ever" used to be spelled) parses as `Some(0)`, which
+    /// the hub reads the same way; a number is a deadline.
     #[test]
     fn interaction_timeout_defaults_and_parses() {
         let dir = tempfile::tempdir().unwrap();
@@ -2159,13 +2163,24 @@ some_custom_thing = \"forwarded to the script\"
             "{}\n[limits]\nmax_concurrent_tools = 4\n",
             config_toml_without_limits()
         ));
-        assert_eq!(old.limits.interaction_timeout_secs, 3600);
+        assert_eq!(old.limits.interaction_timeout_secs, None);
 
         let disabled = load(format!(
             "{}\n[limits]\ninteraction_timeout_secs = 0\n",
             config_toml_without_limits()
         ));
-        assert_eq!(disabled.limits.interaction_timeout_secs, 0);
+        assert_eq!(disabled.limits.interaction_timeout_secs, Some(0));
+
+        let bounded = load(format!(
+            "{}\n[limits]\ninteraction_timeout_secs = 900\n",
+            config_toml_without_limits()
+        ));
+        assert_eq!(bounded.limits.interaction_timeout_secs, Some(900));
+
+        // Written back, an unset timeout stays unset: the default is not
+        // spelled out as a number the user then has to delete.
+        let written = toml::to_string_pretty(&Config::default()).unwrap();
+        assert!(!written.contains("interaction_timeout_secs"), "{written}");
     }
 
     /// The retry schedule is the shipped one unless someone says otherwise, so
@@ -3898,7 +3913,7 @@ enabled = false
                 wedge_timeout_secs: 420,
                 provider_failures_before_open: 5,
                 provider_circuit_cooldown_secs: 120,
-                interaction_timeout_secs: 120,
+                interaction_timeout_secs: Some(120),
                 inference_retry_attempts: 6,
                 inference_retry_base_ms: 250,
                 max_concurrent_inferences_by_model: std::collections::BTreeMap::from([(

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -302,8 +302,8 @@ fn held_checkpoint_warning_for_spawn(spawn_args: &SpawnArgs) -> Vec<String> {
             .collect();
     if spawn_args.yolo {
         let timeout = crate::config::Config::load()
-            .map(|c| c.limits.interaction_timeout_secs)
-            .unwrap_or(leviath_runtime::interaction_hub::DEFAULT_INTERACTION_TIMEOUT_SECS);
+            .ok()
+            .and_then(|c| c.limits.interaction_timeout_secs);
         lines.extend(crate::held_checkpoints::preflight_lines(
             &blueprint, timeout,
         ));
@@ -1393,9 +1393,9 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
             .is_empty()
         );
 
-        // A config that will not load falls back to the default deadline rather
-        // than saying nothing: the checkpoints still hold, and naming them
-        // matters more than naming the exact timeout.
+        // A config that will not load reads as no deadline, which is also the
+        // default: the checkpoints still hold, and naming them matters more
+        // than naming a timeout the operator may not have set.
         let held = manifest_with_a_held_checkpoint(dir.path());
         crate::config::with_isolated_config_path("spawn-held-broken-config", |fake_dir| {
             std::fs::write(fake_dir.join("config.toml"), "not = valid = toml").unwrap();
@@ -1406,7 +1406,7 @@ conversation = { kind = "sliding_window", max_items = 50, max_tokens = 10000 }
             })
             .join("\n");
             assert!(joined.contains("plan_approval"), "{joined}");
-            assert!(joined.contains("after 1h"), "{joined}");
+            assert!(joined.contains("until somebody answers"), "{joined}");
         });
     }
 

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -265,9 +265,9 @@ pub struct HostParts {
 /// are built once at startup and reused by every agent.
 pub fn build_host(parts: HostParts) -> WorldHost {
     let hub = InteractionHub::new();
-    // How long a prompt may go unanswered before the hub resolves it itself, so
-    // an operator who walked away costs the run a delay rather than its slot
-    // for as long as the daemon lives (issue #204).
+    // A prompt waits for a person until answered unless the operator bounded
+    // the wait with `[limits] interaction_timeout_secs`, in which case the hub
+    // resolves it itself once that passes (issue #204).
     hub.set_timeout_secs(parts.config.limits.interaction_timeout_secs);
     let tool_service = Arc::new(CliToolService::new());
     // The configured global fallback bounds concurrent inference for any model

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -199,6 +199,27 @@ pub(crate) struct AgentToolState {
     pub dynamic: Option<Arc<DynamicToolCtx>>,
 }
 
+/// The tool result for an approval prompt that resolved with no answer: the
+/// prompt was cancelled, or a configured `[limits] interaction_timeout_secs`
+/// ran out. The timeout is named only when there is one; with none set a
+/// prompt cannot expire, and blaming a timeout would send the operator looking
+/// for a setting that does not exist in their config.
+fn unanswered_approval_result(tool: &str, timeout_secs: Option<u64>) -> String {
+    match timeout_secs {
+        Some(secs) => format!(
+            "[denied] no one answered the approval prompt for '{tool}' before the \
+             interaction timeout ({secs} s, `[limits] interaction_timeout_secs`); \
+             the call did not run. Answer prompts in `lev dash`, raise the \
+             timeout, or set this tool to \"allow\" for the stage."
+        ),
+        None => format!(
+            "[denied] the approval prompt for '{tool}' was closed without an answer; \
+             the call did not run. Answer prompts in `lev dash`, or set this tool \
+             to \"allow\" for the stage."
+        ),
+    }
+}
+
 /// The tool result a declined approval hands the model.
 ///
 /// Without feedback it is the exact sentence it has always been (tests and
@@ -559,24 +580,19 @@ pub(crate) async fn dispatch_tools(
                         progress(&tc.id, &result);
                         slots.push((tc.id.clone(), Some(result)));
                     }
-                    // The hub's neutral answer: the prompt was cancelled or
-                    // nobody answered it before the interaction timeout. Saying
-                    // "declined" here blamed a person who never saw the prompt.
+                    // The hub's neutral answer: the prompt was cancelled, or
+                    // (only when a timeout is configured) nobody answered it in
+                    // time. Saying "declined" here blamed a person who never
+                    // saw the prompt.
                     None => {
-                        let secs = state.interaction.timeout_secs();
+                        let timeout = state.interaction.timeout_secs();
                         tracing::warn!(
                             tool = %tc.name,
                             stage = %stage_name,
-                            timeout_secs = secs,
-                            "approval prompt expired unanswered; the call did not run"
+                            timeout_secs = timeout,
+                            "approval prompt resolved unanswered; the call did not run"
                         );
-                        let result = format!(
-                            "[denied] no one answered the approval prompt for '{}' before the \
-                             interaction timeout ({secs} s, `[limits] interaction_timeout_secs`); \
-                             the call did not run. Answer prompts in `lev dash`, raise the \
-                             timeout, or set this tool to \"allow\" for the stage.",
-                            tc.name
-                        );
+                        let result = unanswered_approval_result(&tc.name, timeout);
                         progress(&tc.id, &result);
                         slots.push((tc.id.clone(), Some(result)));
                     }
@@ -1431,6 +1447,49 @@ mod tests {
         assert!(out[0].1.contains("[denied]"));
     }
 
+    /// With nothing configured, a tool approval waits for a person. The clock
+    /// is paused and advanced past the hour that used to be the default, and
+    /// the prompt is still open; the answer that then arrives runs the call.
+    #[tokio::test(start_paused = true)]
+    async fn an_approval_with_no_timeout_configured_waits_past_the_old_default() {
+        let hub = InteractionHub::new();
+        hub.set_timeout_secs(
+            crate::config::Config::default()
+                .limits
+                .interaction_timeout_secs,
+        );
+        let mut ask = HashMap::new();
+        ask.insert("echo".to_string(), ToolPolicy::Ask);
+        let names: HashSet<String> = ["echo".to_string()].into_iter().collect();
+        let (state, _dir) =
+            script_state(&hub, &[("echo", "\"x\"")], names, no_script_fields().2, ask);
+        let task = tokio::spawn(async move {
+            dispatch_tools(
+                state,
+                vec![call("c1", "echo", serde_json::json!({}))],
+                noop_progress(),
+            )
+            .await
+        });
+        while hub.pending().is_empty() {
+            tokio::task::yield_now().await;
+        }
+        tokio::time::advance(std::time::Duration::from_secs(3600 + 1)).await;
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+        let pending = hub.pending();
+        assert_eq!(pending.len(), 1, "an hour later the approval is still open");
+        assert!(hub.answer(InteractionResponse::approval(
+            &pending[0].1.id,
+            true,
+            leviath_core::interaction::ApprovalScope::Once
+        )));
+        let out = task.await.unwrap();
+        let result = &out[0].1;
+        assert!(!result.contains("[denied]"), "{result}");
+    }
+
     /// A prompt nobody answered before `[limits] interaction_timeout_secs`
     /// comes back as the hub's neutral response (`approved: None`). That is
     /// not a decline, and the tool result must not say the user declined:
@@ -1439,7 +1498,7 @@ mod tests {
     #[tokio::test]
     async fn an_unanswered_approval_says_so_instead_of_blaming_the_user() {
         let hub = InteractionHub::new();
-        hub.set_timeout_secs(3600);
+        hub.set_timeout_secs(Some(3600));
         let mut ask = HashMap::new();
         ask.insert("echo".to_string(), ToolPolicy::Ask);
         let names: HashSet<String> = ["echo".to_string()].into_iter().collect();
@@ -1460,6 +1519,38 @@ mod tests {
                 && result.contains("3600")
                 && result.contains("interaction_timeout_secs"),
             "{result}"
+        );
+    }
+
+    /// With no timeout configured a prompt cannot expire, so the neutral
+    /// answer means it was closed (cancelled) and the result must not send
+    /// the operator chasing a timeout that is not set.
+    #[tokio::test]
+    async fn a_closed_approval_with_no_timeout_does_not_mention_one() {
+        let hub = InteractionHub::new();
+        let mut ask = HashMap::new();
+        ask.insert("echo".to_string(), ToolPolicy::Ask);
+        let names: HashSet<String> = ["echo".to_string()].into_iter().collect();
+        let (state, _dir) =
+            script_state(&hub, &[("echo", "\"x\"")], names, no_script_fields().2, ask);
+        let out = dispatch_answering(
+            state,
+            vec![call("c1", "echo", serde_json::json!({}))],
+            |req| InteractionResponse::text(&req.id, ""),
+            hub,
+        )
+        .await;
+        let result = &out[0].1;
+        assert!(result.starts_with("[denied]"), "{result}");
+        assert!(!result.contains("declined"), "not a decline: {result}");
+        assert!(
+            result.contains("closed without an answer") && !result.contains("timeout"),
+            "{result}"
+        );
+        assert_eq!(
+            unanswered_approval_result("echo", None),
+            result.as_str(),
+            "the wording is the helper's, verbatim"
         );
     }
 

--- a/crates/leviath-cli/src/held_checkpoints.rs
+++ b/crates/leviath-cli/src/held_checkpoints.rs
@@ -77,7 +77,6 @@ pub(crate) fn held_tools(blueprint: &Blueprint) -> Vec<Held> {
 /// rather than a number to divide.
 fn human_timeout(secs: u64) -> String {
     match secs {
-        0 => "indefinitely".to_string(),
         s if s % 3600 == 0 => format!("{}h", s / 3600),
         s if s % 60 == 0 => format!("{}m", s / 60),
         s => format!("{s}s"),
@@ -87,7 +86,7 @@ fn human_timeout(secs: u64) -> String {
 /// The stderr block for a `--yolo` spawn. Empty when nothing holds.
 ///
 /// Pure, so the wording is testable without a daemon or a manifest on disk.
-pub(crate) fn preflight_lines(blueprint: &Blueprint, timeout_secs: u64) -> Vec<String> {
+pub(crate) fn preflight_lines(blueprint: &Blueprint, timeout_secs: Option<u64>) -> Vec<String> {
     let points = held_points(blueprint);
     let tools = held_tools(blueprint);
     if points.is_empty() && tools.is_empty() {
@@ -106,9 +105,9 @@ pub(crate) fn preflight_lines(blueprint: &Blueprint, timeout_secs: u64) -> Vec<S
     for t in &tools {
         lines.push(format!("  {}: {} (if the model calls it)", t.stage, t.name));
     }
-    lines.push(match timeout_secs {
-        0 => "  nothing expires these; the run waits until somebody answers".to_string(),
-        secs => format!(
+    lines.push(match timeout_secs.filter(|secs| *secs > 0) {
+        None => "  nothing expires these; the run waits until somebody answers".to_string(),
+        Some(secs) => format!(
             "  unanswered after {}, the run stops with an error; `lev respond` lists them",
             human_timeout(secs)
         ),

--- a/crates/leviath-cli/src/held_checkpoints/tests.rs
+++ b/crates/leviath-cli/src/held_checkpoints/tests.rs
@@ -78,12 +78,15 @@ fn only_a_blocking_tool_counts_as_held() {
 /// checkpoints must not print a block explaining that it has none.
 #[test]
 fn a_blueprint_that_holds_nothing_prints_nothing() {
-    assert!(preflight_lines(&parse("", ""), 3600).is_empty());
+    assert!(preflight_lines(&parse("", ""), Some(3600)).is_empty());
 }
 
 #[test]
 fn the_preflight_names_every_checkpoint_and_the_deadline() {
-    let lines = preflight_lines(&parse(r#"unattended = "ask""#, r#""ask_user_text""#), 3600);
+    let lines = preflight_lines(
+        &parse(r#"unattended = "ask""#, r#""ask_user_text""#),
+        Some(3600),
+    );
     let block = lines.join("\n");
     assert!(block.contains("2 checkpoints"), "{block}");
     assert!(block.contains("plan: plan_approval"), "{block}");
@@ -92,22 +95,26 @@ fn the_preflight_names_every_checkpoint_and_the_deadline() {
     assert!(block.contains("lev respond"), "{block}");
 
     // One checkpoint reads as one, not "1 checkpoints".
-    let one = preflight_lines(&parse(r#"unattended = "ask""#, ""), 3600).join("\n");
+    let one = preflight_lines(&parse(r#"unattended = "ask""#, ""), Some(3600)).join("\n");
     assert!(one.contains("1 checkpoint:"), "{one}");
 }
 
-/// `interaction_timeout_secs = 0` means wait forever, and saying "after 0s"
-/// would be the opposite of the truth.
+/// No `interaction_timeout_secs` means the run waits for a person, and so
+/// does an explicit `0`; saying "after 0s" would be the opposite of the truth.
 #[test]
 fn a_disabled_timeout_says_the_run_waits() {
-    let block = preflight_lines(&parse(r#"unattended = "ask""#, ""), 0).join("\n");
-    assert!(block.contains("until somebody answers"), "{block}");
-    assert!(!block.contains("stops with an error"), "{block}");
+    for unset in [None, Some(0)] {
+        let block = preflight_lines(&parse(r#"unattended = "ask""#, ""), unset).join("\n");
+        assert!(
+            block.contains("until somebody answers"),
+            "{unset:?}: {block}"
+        );
+        assert!(!block.contains("stops with an error"), "{unset:?}: {block}");
+    }
 }
 
 #[test]
 fn a_timeout_reads_as_the_operator_wrote_it() {
-    assert_eq!(human_timeout(0), "indefinitely");
     assert_eq!(human_timeout(7200), "2h");
     assert_eq!(human_timeout(300), "5m");
     assert_eq!(human_timeout(45), "45s");

--- a/crates/leviath-cli/src/lint/security.rs
+++ b/crates/leviath-cli/src/lint/security.rs
@@ -197,9 +197,10 @@ pub(super) fn lint_held_checkpoints(blueprint: &Blueprint) -> Vec<LintFinding> {
         )
         .in_stage(&h.stage)
         .with_fix(
-            "this is deliberate if the checkpoint needs a person. `[limits] \
-             interaction_timeout_secs` bounds the wait, and an unanswered \
-             checkpoint stops the run with an error rather than approving it",
+            "this is deliberate if the checkpoint needs a person; the run waits \
+             until one answers. Set `[limits] interaction_timeout_secs` to bound \
+             the wait, and an unanswered checkpoint then stops the run with an \
+             error rather than approving it",
         )
     })
     .collect()

--- a/crates/leviath-core/src/blueprint/stage.rs
+++ b/crates/leviath-core/src/blueprint/stage.rs
@@ -298,8 +298,8 @@ pub enum UnattendedPolicy {
 
     /// Open the prompt anyway and wait for a person, even under `--yolo`. For a
     /// checkpoint whose whole purpose is a human decision - a plan the user
-    /// signs off before any code is written. Pair it with `[limits]
-    /// interaction_timeout_secs` so an unanswered gate still releases.
+    /// signs off before any code is written. The run waits until somebody
+    /// answers; set `[limits] interaction_timeout_secs` to bound that wait.
     Ask,
 }
 
@@ -485,8 +485,8 @@ pub struct Stage {
     /// blocking human tool from the stage's advertised set, because a call to
     /// one can only park the agent until the daemon dies (issue #204). Naming a
     /// tool here says this stage genuinely needs a person and the run should
-    /// wait for one anyway. Pair it with `[limits] interaction_timeout_secs` so
-    /// an unanswered prompt still releases eventually.
+    /// wait for one anyway, for as long as it takes; set `[limits]
+    /// interaction_timeout_secs` to bound that wait.
     ///
     /// Entries must also appear in `available_tools` - listing a tool the stage
     /// can't call in the first place is a validation error, not a silent no-op.

--- a/crates/leviath-runtime/src/host/types.rs
+++ b/crates/leviath-runtime/src/host/types.rs
@@ -62,9 +62,9 @@ pub struct SpawnArgs {
     ///
     /// An interaction point may opt out with `unattended = "ask"`, and then it
     /// parks anyway: the point exists precisely because auto-approving it is
-    /// the wrong answer. Such a run waits for `[limits]
-    /// interaction_timeout_secs` (default 3600) rather than forever, but from
-    /// the outside an hour of `Waiting` is indistinguishable from a hang.
+    /// the wrong answer. Such a run waits until somebody answers (or until
+    /// `[limits] interaction_timeout_secs`, when one is set), and from the
+    /// outside that `Waiting` is indistinguishable from a hang.
     #[serde(default)]
     pub yolo: bool,
     /// Refuse this run's `seed = { command = ... }` regions (the

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -13,10 +13,11 @@
 //! batch it waits [`off_lane`](crate::tool_bridge::off_lane), so a prompt nobody
 //! has answered yet costs the tool lane no capacity.
 //!
-//! "A very long time" used to mean "for ever": a run whose operator had walked
-//! away sat in `WaitingInput` until the daemon died, holding its slot the whole
-//! time (issue #204). [`InteractionHub::set_timeout_secs`] puts a deadline on
-//! that wait.
+//! "A very long time" is, by default, exactly that: a prompt waits until a
+//! person answers it or the run is cancelled, however long that takes. An
+//! operator who wants an unattended run to release its slot instead sets
+//! `[limits] interaction_timeout_secs`, and [`InteractionHub::set_timeout_secs`]
+//! puts that deadline on the wait (issue #204).
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -52,17 +53,11 @@ pub struct InteractionHub {
     /// (while otherwise parked) and reflects the change into agent status.
     wake: Arc<OnceLock<Arc<Notify>>>,
     /// How long an open request may go unanswered before the hub resolves it
-    /// itself, in seconds. `0` (the default) waits indefinitely. Set once at
+    /// itself, in seconds. `0` (the default) waits indefinitely: it is how
+    /// [`set_timeout_secs`](Self::set_timeout_secs) stores `None`. Set once at
     /// daemon start from `[limits] interaction_timeout_secs`.
     timeout_secs: Arc<AtomicU64>,
 }
-
-/// The default deadline on an unanswered prompt, in seconds.
-///
-/// An hour is long enough that a person who is actually there answers well
-/// inside it, and short enough that a run whose operator has gone home releases
-/// its slot the same day rather than holding it until the daemon restarts.
-pub const DEFAULT_INTERACTION_TIMEOUT_SECS: u64 = 3600;
 
 impl InteractionHub {
     /// A fresh, empty hub.
@@ -77,25 +72,29 @@ impl InteractionHub {
     }
 
     /// Set how long an open request may go unanswered before the hub resolves it
-    /// itself. `0` waits indefinitely - the behaviour before issue #204.
+    /// itself. `None` waits indefinitely, which is also the default; `Some(0)`
+    /// is read the same way, so a config that spells "no timeout" as `0` is
+    /// not turned into "expire at once".
     ///
     /// Applies to requests opened from here on; a request already parked keeps
     /// the deadline it was opened with.
-    pub fn set_timeout_secs(&self, secs: u64) {
-        self.timeout_secs.store(secs, Ordering::Relaxed);
+    pub fn set_timeout_secs(&self, secs: Option<u64>) {
+        self.timeout_secs
+            .store(secs.unwrap_or(0), Ordering::Relaxed);
     }
 
-    /// The configured deadline in seconds; `0` means the hub waits indefinitely.
-    pub fn timeout_secs(&self) -> u64 {
-        self.timeout_secs.load(Ordering::Relaxed)
+    /// The configured deadline in seconds; `None` means the hub waits
+    /// indefinitely.
+    pub fn timeout_secs(&self) -> Option<u64> {
+        match self.timeout_secs.load(Ordering::Relaxed) {
+            0 => None,
+            secs => Some(secs),
+        }
     }
 
     /// The current deadline, or `None` when the hub waits indefinitely.
     fn timeout(&self) -> Option<Duration> {
-        match self.timeout_secs.load(Ordering::Relaxed) {
-            0 => None,
-            secs => Some(Duration::from_secs(secs)),
-        }
+        self.timeout_secs().map(Duration::from_secs)
     }
 
     /// Wake the tick loop if a handle is attached (no-op otherwise).
@@ -257,9 +256,9 @@ pub struct HubInteractionBackend {
 }
 
 impl HubInteractionBackend {
-    /// The hub's prompt deadline in seconds (`0`: it waits indefinitely), so a
-    /// caller can say in its own words how long an unanswered prompt waited.
-    pub fn timeout_secs(&self) -> u64 {
+    /// The hub's prompt deadline in seconds (`None`: it waits indefinitely), so
+    /// a caller can say in its own words how long an unanswered prompt waited.
+    pub fn timeout_secs(&self) -> Option<u64> {
         self.hub.timeout_secs()
     }
 }

--- a/crates/leviath-runtime/src/interaction_hub_tests.rs
+++ b/crates/leviath-runtime/src/interaction_hub_tests.rs
@@ -224,7 +224,7 @@ async fn a_prompt_nobody_answers_is_released_when_the_deadline_passes() {
     // because nothing ever aged the request out. Now the hub resolves it
     // itself and the agent goes back to work.
     let hub = InteractionHub::new();
-    hub.set_timeout_secs(60);
+    hub.set_timeout_secs(Some(60));
     let backend = hub.backend_for("agent-a");
     let asking = tokio::spawn(async move { backend.ask(req("q1")).await });
 
@@ -248,7 +248,7 @@ async fn a_deadline_changes_nothing_for_a_prompt_that_is_answered() {
     // Setting a deadline must not alter the ordinary paths. Both of them run
     // here: one prompt answered by a person, one cancelled under it.
     let hub = InteractionHub::new();
-    hub.set_timeout_secs(3600);
+    hub.set_timeout_secs(Some(3600));
 
     let answered_backend = hub.backend_for("agent-a");
     let answered = tokio::spawn(async move { answered_backend.ask(req("q1")).await });
@@ -263,21 +263,74 @@ async fn a_deadline_changes_nothing_for_a_prompt_that_is_answered() {
     assert_eq!(cancelled.await.unwrap().value.as_deref(), Some(""));
 }
 
+/// With no deadline set, a prompt waits for a person however long that takes.
+/// The clock is paused and advanced well past the hour that used to be the
+/// default, and the prompt is still open; the answer that then arrives is the
+/// one the caller gets.
 #[tokio::test(start_paused = true)]
-async fn a_zero_deadline_waits_for_a_person_however_long_it_takes() {
-    // `0` is the explicit "I will be here" setting, and it has to keep the
-    // old behaviour exactly: the prompt stays open until answered.
+async fn with_no_deadline_a_prompt_waits_for_a_person_however_long_it_takes() {
     let hub = InteractionHub::new();
-    hub.set_timeout_secs(0);
+    assert_eq!(hub.timeout_secs(), None, "nothing set: no deadline");
     let backend = hub.backend_for("agent-a");
     let asking = tokio::spawn(async move { backend.ask(req("q1")).await });
 
     settle().await;
     tokio::time::advance(Duration::from_secs(86_400)).await;
+    settle().await;
+    assert_eq!(hub.pending().len(), 1, "a day later, still waiting");
+
+    assert!(hub.answer(InteractionResponse::text("q1", "here I am")));
+    let response = asking.await.unwrap();
+    assert_eq!(response.value.as_deref(), Some("here I am"));
+    assert!(hub.pending().is_empty());
+}
+
+/// `Some(0)` is read as "no deadline", not "expire at once": a config that
+/// spelled the wait as `interaction_timeout_secs = 0` keeps waiting.
+#[tokio::test(start_paused = true)]
+async fn a_zero_deadline_waits_for_a_person_however_long_it_takes() {
+    let hub = InteractionHub::new();
+    hub.set_timeout_secs(Some(0));
+    assert_eq!(hub.timeout_secs(), None);
+    let backend = hub.backend_for("agent-a");
+    let asking = tokio::spawn(async move { backend.ask(req("q1")).await });
+
+    settle().await;
+    tokio::time::advance(Duration::from_secs(86_400)).await;
+    settle().await;
     assert_eq!(hub.pending().len(), 1, "a day later, still waiting");
 
     assert!(hub.answer(InteractionResponse::text("q1", "here I am")));
     assert_eq!(asking.await.unwrap().value.as_deref(), Some("here I am"));
+}
+
+/// A configured deadline still fires when it says: two seconds means two
+/// seconds, not the hour it used to default to and not for ever.
+#[tokio::test(start_paused = true)]
+async fn a_two_second_deadline_fires_at_two_seconds() {
+    let hub = InteractionHub::new();
+    hub.set_timeout_secs(Some(2));
+    let backend = hub.backend_for("agent-a");
+    let asking = tokio::spawn(async move { backend.ask(req("q1")).await });
+
+    settle().await;
+    tokio::time::advance(Duration::from_millis(1_900)).await;
+    settle().await;
+    assert_eq!(
+        hub.pending().len(),
+        1,
+        "still open just short of the deadline"
+    );
+
+    tokio::time::advance(Duration::from_millis(200)).await;
+    settle().await;
+    assert!(
+        hub.pending().is_empty(),
+        "released once two seconds have passed"
+    );
+    let response = asking.await.unwrap();
+    assert_eq!(response.approved, None);
+    assert_eq!(response.value.as_deref(), Some(""));
 }
 
 #[tokio::test(start_paused = true)]
@@ -286,7 +339,7 @@ async fn the_deadline_denies_rather_than_approves() {
     // taint gate both go through `response_approved`, which reads the
     // neutral response as "no".
     let hub = InteractionHub::new();
-    hub.set_timeout_secs(30);
+    hub.set_timeout_secs(Some(30));
     let backend = hub.backend_for("agent-a");
     let asking = tokio::spawn(async move {
         backend
@@ -324,10 +377,12 @@ async fn an_answer_that_lands_as_the_deadline_passes_still_wins() {
 #[test]
 fn the_timeout_reads_back_through_the_hub_and_its_backends() {
     let hub = InteractionHub::new();
-    assert_eq!(hub.timeout_secs(), 0, "a fresh hub waits indefinitely");
-    hub.set_timeout_secs(7);
-    assert_eq!(hub.timeout_secs(), 7);
-    assert_eq!(hub.backend_for("agent-a").timeout_secs(), 7);
+    assert_eq!(hub.timeout_secs(), None, "a fresh hub waits indefinitely");
+    hub.set_timeout_secs(Some(7));
+    assert_eq!(hub.timeout_secs(), Some(7));
+    assert_eq!(hub.backend_for("agent-a").timeout_secs(), Some(7));
+    hub.set_timeout_secs(None);
+    assert_eq!(hub.timeout_secs(), None, "cleared again");
 }
 
 /// A deny that carries feedback comes out of `ask` exactly as it went into

--- a/crates/leviath-runtime/src/interaction_points.rs
+++ b/crates/leviath-runtime/src/interaction_points.rs
@@ -580,8 +580,8 @@ pub(crate) fn dispatch_interaction_point(
         // Unless the point declares `unattended = "ask"`: some checkpoints exist
         // precisely because a person has to look - a plan signed off before any
         // code is written - and their author would rather the run wait than have
-        // it wave itself through. `[limits] interaction_timeout_secs` is what
-        // keeps that wait from lasting for ever.
+        // it wave itself through. That wait lasts until somebody answers,
+        // unless `[limits] interaction_timeout_secs` bounds it.
         if auto_approve.is_some() && point.unattended == UnattendedPolicy::AutoApprove {
             tracing::info!(
                 agent = %state.agent_id,

--- a/crates/leviath-runtime/src/pipeline/persist.rs
+++ b/crates/leviath-runtime/src/pipeline/persist.rs
@@ -114,6 +114,7 @@ type ReflectInteractionStatusQuery = (
     Entity,
     &'static mut AgentState,
     Option<&'static AwaitingInteraction>,
+    Option<&'static mut StageProgress>,
 );
 
 /// Copy the scripts a run could not use onto its flags.
@@ -158,6 +159,12 @@ fn fold_broken_scripts(
 /// set it, and the clearing arm below would otherwise walk them back to `Active`
 /// the moment an unrelated prompt of theirs resolved, un-parking a run whose
 /// children are still going.
+///
+/// The wait is also kept off the stage clock. A prompt waits for a person for
+/// as long as it takes, and `stuck_after_minutes` measures the agent, not the
+/// person: when the prompt resolves, the stage's `stage_started_at` moves
+/// forward by however long it was parked, so the next `detect_stuck_stage` sees
+/// the same elapsed time it would have seen had the answer been instant.
 pub(crate) fn reflect_interaction_status(
     hub: Option<Res<InteractionHub>>,
     mut agents: Query<
@@ -170,7 +177,8 @@ pub(crate) fn reflect_interaction_status(
     let Some(hub) = hub else { return };
     let pending: std::collections::HashSet<String> =
         hub.pending().into_iter().map(|(id, _)| id).collect();
-    for (entity, mut state, marked) in agents.iter_mut() {
+    let now = chrono::Utc::now().timestamp();
+    for (entity, mut state, marked, progress) in agents.iter_mut() {
         crate::tick_scope::enter(entity);
         match (pending.contains(&state.agent_id), marked.is_some()) {
             // Newly blocked on a prompt: surface it as Waiting.
@@ -178,6 +186,9 @@ pub(crate) fn reflect_interaction_status(
                 if state.status == AgentStatus::Active {
                     state.status = AgentStatus::Waiting;
                     commands.entity(entity).insert(AwaitingInteraction);
+                    if let Some(mut progress) = progress {
+                        progress.waiting_since = Some(now);
+                    }
                 }
             }
             // Request cleared (answered / cancelled): return to Active, unless
@@ -187,9 +198,27 @@ pub(crate) fn reflect_interaction_status(
                 if state.status == AgentStatus::Waiting {
                     state.status = AgentStatus::Active;
                 }
+                if let Some(mut progress) = progress {
+                    credit_wait_to_stage_clock(&mut progress, now);
+                }
             }
             _ => {}
         }
+    }
+}
+
+/// Move the stage clock past a wait on a person that has just ended.
+///
+/// `stage_started_at` is stamped lazily by `detect_stuck_stage`, so a stage
+/// that parked before its first inference has no clock yet and nothing to
+/// credit. Only a wait that actually started (`waiting_since` set) counts.
+fn credit_wait_to_stage_clock(progress: &mut StageProgress, now: i64) {
+    let Some(since) = progress.waiting_since.take() else {
+        return;
+    };
+    let waited = (now - since).max(0);
+    if let Some(started) = progress.stage_started_at.as_mut() {
+        *started += waited;
     }
 }
 

--- a/crates/leviath-runtime/src/pipeline/response.rs
+++ b/crates/leviath-runtime/src/pipeline/response.rs
@@ -596,6 +596,12 @@ pub(crate) struct StageProgress {
     /// [`force_transition`] all get a fresh clock from the `Default` reset
     /// without threading a clock through their signatures.
     pub stage_started_at: Option<i64>,
+    /// Unix seconds at which the agent last parked on a person (a tool
+    /// approval, an `ask_user_*` question, a checkpoint). Stamped and cleared
+    /// by `reflect_interaction_status`, which moves `stage_started_at` forward
+    /// by the time the wait took when the prompt resolves: a person's hour is
+    /// not the agent's, and a `stuck_after_minutes` edge must not fire on it.
+    pub waiting_since: Option<i64>,
     /// `write_file`/`edit_file` calls made in this stage, keyed by target path.
     /// Feeds the `stuck_after_same_file_edits` threshold.
     pub edits_by_path: std::collections::HashMap<String, usize>,

--- a/crates/leviath-runtime/src/pipeline/tests.rs
+++ b/crates/leviath-runtime/src/pipeline/tests.rs
@@ -11863,6 +11863,121 @@ async fn reflect_flips_active_to_waiting_and_back_when_prompt_clears() {
     let _ = asking.await;
 }
 
+/// Time spent waiting on a person is not time the agent spent stuck. An
+/// implement stage with `stuck_after_minutes = 15` whose operator took an hour
+/// to answer a write approval used to trip its stuck edge on the very next tick
+/// after the answer, because the stage clock kept running through the wait.
+/// The wait is now credited back to the clock when the prompt resolves.
+#[tokio::test]
+async fn reflect_keeps_a_wait_on_a_person_off_the_stage_clock() {
+    let hub = InteractionHub::new();
+    let asking = open_request(&hub, "a", "q1").await;
+
+    let mut world = World::new();
+    world.insert_resource(hub.clone());
+    let now = chrono::Utc::now().timestamp();
+    // Two minutes into the stage when the prompt opens.
+    let e = world
+        .spawn((
+            reflect_state("a", AgentStatus::Active),
+            StageProgress {
+                stage_started_at: Some(now - 120),
+                ..Default::default()
+            },
+        ))
+        .id();
+
+    run_reflect(&mut world);
+    let since = world
+        .get::<StageProgress>(e)
+        .unwrap()
+        .waiting_since
+        .expect("parking stamps when the wait began");
+    assert!((since - now).abs() <= 1);
+
+    // The person takes an hour. Backdate both stamps rather than sleep: the
+    // stage clock started two minutes before the prompt opened, an hour ago.
+    {
+        let mut progress = world.get_mut::<StageProgress>(e).unwrap();
+        progress.stage_started_at = Some(now - 3600 - 120);
+        progress.waiting_since = Some(now - 3600);
+    }
+    assert!(
+        hub.answer(leviath_core::interaction::InteractionResponse::text(
+            "q1", "ok"
+        ))
+    );
+    run_reflect(&mut world);
+
+    let progress = world.get::<StageProgress>(e).unwrap();
+    assert_eq!(progress.waiting_since, None, "the wait is over");
+    let started = progress.stage_started_at.expect("the clock is kept");
+    let elapsed = chrono::Utc::now().timestamp() - started;
+    assert!(
+        (0..=3).contains(&(elapsed - 120)),
+        "the stage is still two minutes in, not an hour and two: elapsed {elapsed}s"
+    );
+    let _ = asking.await;
+}
+
+/// A stage that parks before its first inference has no clock yet; the wait
+/// leaves it unset and the lazy stamp gives it a fresh one afterwards.
+#[tokio::test]
+async fn reflect_credits_nothing_to_a_stage_clock_that_was_never_stamped() {
+    let hub = InteractionHub::new();
+    let asking = open_request(&hub, "a", "q1").await;
+
+    let mut world = World::new();
+    world.insert_resource(hub.clone());
+    let e = world
+        .spawn((
+            reflect_state("a", AgentStatus::Active),
+            StageProgress::default(),
+        ))
+        .id();
+    run_reflect(&mut world);
+    assert!(
+        world
+            .get::<StageProgress>(e)
+            .unwrap()
+            .waiting_since
+            .is_some()
+    );
+    hub.cancel("q1");
+    run_reflect(&mut world);
+    let progress = world.get::<StageProgress>(e).unwrap();
+    assert_eq!(progress.waiting_since, None);
+    assert_eq!(progress.stage_started_at, None);
+    let _ = asking.await;
+}
+
+/// The clearing arm on an agent that never parked (no `waiting_since`): there
+/// is no wait to credit and the stage clock is left exactly as it was.
+#[test]
+fn reflect_credits_nothing_when_no_wait_was_recorded() {
+    let hub = InteractionHub::new(); // empty: nothing pending
+    let mut world = World::new();
+    world.insert_resource(hub);
+    let started = chrono::Utc::now().timestamp() - 300;
+    let e = world
+        .spawn((
+            reflect_state("a", AgentStatus::Waiting),
+            AwaitingInteraction,
+            StageProgress {
+                stage_started_at: Some(started),
+                waiting_since: None,
+                ..Default::default()
+            },
+        ))
+        .id();
+
+    run_reflect(&mut world);
+
+    let progress = world.get::<StageProgress>(e).unwrap();
+    assert_eq!(progress.stage_started_at, Some(started));
+    assert_eq!(progress.waiting_since, None);
+}
+
 #[tokio::test]
 async fn reflect_does_not_flip_a_non_active_agent_with_an_open_prompt() {
     // A terminal agent that happens to still have an open hub entry is left

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -727,6 +727,8 @@ impl PipelineWorld {
         // Dispatch anything that settled between the last park and now (e.g. an
         // inference result that woke the loop the same instant shutdown fired).
         self.run_to_fixed_point();
+        // Drop every in-flight job, which is what makes the line below finish.
+        self.abort_in_flight_work();
         // Drop the *only* `PersistJob` sender so the worker's `recv()` loop drains
         // its queue and then ends.
         self.world.remove_resource::<PersistenceStage>();
@@ -741,6 +743,29 @@ impl PipelineWorld {
             .resource::<crate::telemetry::Telemetry>()
             .0
             .force_flush();
+    }
+
+    /// Cancel every job still in flight, so shutdown does not wait on one.
+    ///
+    /// `remove_resource::<PersistenceStage>` drops the world's sender, but a
+    /// dispatched tool batch carries its own clone (the progress callback that
+    /// journals each call as it finishes). While that batch is alive the channel
+    /// stays open, so awaiting the persistence worker waits on the batch - and a
+    /// batch parked on an approval prompt is waiting on a person. `lev daemon
+    /// stop` then hung until somebody answered, which with no interaction
+    /// timeout is for ever.
+    ///
+    /// Cancelling drops the batch instead. Its calls are not marked done and its
+    /// assistant turn is already journalled with the batch pending, so the run
+    /// reloads on the next daemon start exactly where it was: parked, and asking
+    /// again.
+    fn abort_in_flight_work(&mut self) {
+        let mut agents = self.world.query::<&crate::pipeline::InFlightWork>();
+        for in_flight in agents.iter(&self.world) {
+            for token in &in_flight.0 {
+                token.cancel();
+            }
+        }
     }
 
     /// A point-in-time read of what the world is holding and what it is waiting
@@ -2463,6 +2488,43 @@ mod tests {
         assert_eq!(s.cursor, 0);
         assert_eq!(s.round, 0);
         assert_eq!(s.body, "## Plan\n1. do it");
+    }
+
+    /// A daemon must be able to stop while a run is parked on a person.
+    ///
+    /// The batch on the tool lane carries a clone of the persistence sender (it
+    /// journals each call as it finishes), so awaiting the persistence worker
+    /// waits on the batch - and a batch parked on an approval prompt waits on a
+    /// person, which with no interaction timeout is for ever. `lev daemon stop`
+    /// hung for exactly that reason. Shutdown now cancels in-flight work first.
+    #[tokio::test]
+    async fn flush_and_stop_does_not_wait_on_a_batch_parked_on_a_person() {
+        let mut world = build_world(registry_with(vec![]));
+        let entity = spawn(&mut world).entity();
+
+        // Stand in for the dispatched batch: something that holds a clone of
+        // the persistence sender until its cancel token fires, which is what a
+        // batch on the lane does (the lane drops a cancelled batch, and its
+        // progress callback goes with it).
+        let persist = world.world.resource::<PersistenceStage>().0.clone();
+        let cancel = crate::cancel::CancelToken::new();
+        let holder = tokio::spawn({
+            let cancel = cancel.clone();
+            async move {
+                cancel.cancelled().await;
+                drop(persist);
+            }
+        });
+        world
+            .world
+            .entity_mut(entity)
+            .insert(crate::pipeline::InFlightWork(vec![cancel.clone()]));
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), world.flush_and_stop())
+            .await
+            .expect("shutdown must not wait for the person to answer");
+        assert!(cancel.is_cancelled(), "the parked batch was dropped");
+        holder.await.expect("the holder ended with its batch");
     }
 
     #[tokio::test]

--- a/docs/content/agent-client-protocol.md
+++ b/docs/content/agent-client-protocol.md
@@ -91,9 +91,10 @@ Hosts that implement the client-side methods advertise capabilities at `initiali
 surfaces tool approvals as `session/request_permission` requests the host answers. OpenClaw's acpx
 backend answers them. Hosts that send no capabilities (Gas City sends none) cannot answer such a
 request, so instead of deadlocking, the question is surfaced as output and the turn stays in
-flight. Answer it from Leviath's own surfaces, `lev respond` or `lev dash`, and the run continues;
-unanswered, it is denied after `[limits] interaction_timeout_secs`. Use `--yolo` (or scoped
-`--allow` flags) to run unattended against such a host.
+flight. Answer it from Leviath's own surfaces, `lev respond` or `lev dash`, and the run continues.
+It waits until you do, unless `[limits] interaction_timeout_secs` is set, in which case an
+unanswered request is denied when that passes. Use `--yolo` (or scoped `--allow` flags) to run
+unattended against such a host.
 
 ## Connecting a host
 

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -149,7 +149,7 @@ finished_retention_secs   = 300  # keep a finished run in `lev ps` this long
 wedge_timeout_secs        = 0    # fail a run nothing can reach any more; 0 is off
 provider_failures_before_open  = 3     # pull a provider after this many failures in a row
 provider_circuit_cooldown_secs = 300   # how long before it is tried again
-interaction_timeout_secs  = 3600 # release a prompt nobody answered
+# interaction_timeout_secs = 3600 # unset: a prompt waits for you until answered
 inference_retry_attempts  = 4    # tries per inference, the first one included
 inference_retry_base_ms   = 1000 # first retry wait for an ordinary blip; it doubles
 max_tool_call_write_bytes = 2147483648   # 2 GiB; delete the line for no limit
@@ -178,7 +178,7 @@ cerebras = 1                     # every model this provider serves, together
 | `wedge_timeout_secs` | `0` (off) | Fail a run nothing can reach any more. See below |
 | `provider_failures_before_open` | `3` | Failures in a row before a provider is pulled. See below |
 | `provider_circuit_cooldown_secs` | `300` | How long a pulled provider waits before one request tests it. A success restores it, a failure restarts the wait |
-| `interaction_timeout_secs` | `3600` | How long a prompt may go unanswered. See below |
+| `interaction_timeout_secs` | unset | Bound how long a prompt waits for a person. Unset waits until answered. See below |
 | `inference_retry_attempts` | `4` | Tries per inference, the first included. See below |
 | `inference_retry_base_ms` | `1000` | First retry wait for an ordinary blip, doubling each retry. See below |
 | `max_tool_call_write_bytes` | unset | Most one tool call may write. See below |
@@ -321,11 +321,13 @@ capacity failure about four minutes of waiting rather than about one and a half.
 the retries of a single request sleep **at most five minutes in total**, and the request itself is
 still bounded by its stage's `request_timeout_secs`, so a run can never wait indefinitely.
 
-**`interaction_timeout_secs`** puts a deadline on any prompt that waits on a person: `ask_user_*`,
-tool approvals, taint gates, and interaction points. When it expires the daemon resolves the prompt
-and lets the run continue. An expiry *denies* an approval and tells the model no answer came. It
-never counts as consent. `0` waits indefinitely. See
-[when nobody answers](/docs/interaction#when-nobody-answers).
+**`interaction_timeout_secs`** bounds how long a prompt waits on a person: `ask_user_*`, tool
+approvals, taint gates, and interaction points. Leave it unset and the run waits for you until you
+answer, whether that is in ten minutes or on Monday; nothing else in the daemon fails, reaps, or
+marks stuck a run that is waiting on a person, and only cancelling it ends the wait. Set a number
+and a prompt nobody answered in that many seconds is resolved so the run can continue. An expiry
+*denies* an approval and tells the model no answer came. It never counts as consent. `0` is read as
+unset. See [when nobody answers](/docs/interaction#when-nobody-answers).
 
 <a id="security"></a>
 

--- a/docs/content/gas-city.md
+++ b/docs/content/gas-city.md
@@ -63,8 +63,8 @@ ask. Gas City sends no client capabilities, so there is nobody to ask.
 
 Leviath does not deadlock on that. It surfaces the approval as output and keeps the turn in
 flight, waiting for an answer from somewhere else: `lev respond` or `lev dash` on the same
-machine. Unanswered, the approval is denied after `[limits] interaction_timeout_secs`, an hour by
-default. A timeout is never read as consent.
+machine. It waits until answered, or until `[limits] interaction_timeout_secs` if you set one, and
+then it is denied. A timeout is never read as consent.
 
 `--yolo` approves every tool call so nothing stops to ask. If that is more trust than you want to
 extend, name the tools you are happy with instead:

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -76,11 +76,15 @@ call until the answer comes back, then continues with it:
 
 ## When nobody answers
 
-Every prompt on this page waits on a person, and nobody is always there. A run whose operator has
-gone home should not sit in `WaitingInput` holding its slot until the daemon restarts.
+Every prompt on this page waits on a person, and by default it waits until one answers. A run
+parked on an approval is still parked when you get back, whether that is ten minutes or a weekend
+later; it is not failed, reaped, or marked stuck by any timer while it waits, and it survives a
+daemon restart still waiting. The only things that end the wait are an answer and `lev cancel`.
 
-`[limits] interaction_timeout_secs` puts a deadline on that wait: one hour by default, and `0`
-waits indefinitely. When it passes, the prompt resolves exactly as cancelling it would:
+That is the right default for a person at a keyboard and the wrong one for a run nobody is
+watching, where a prompt would hold a slot until the daemon restarts. For those, `[limits]
+interaction_timeout_secs` puts a deadline on the wait. Unset means no deadline (`0` is read the same
+way). When a deadline passes, the prompt resolves exactly as cancelling it would:
 
 | Prompt | What an expiry means |
 |---|---|
@@ -92,7 +96,8 @@ waits indefinitely. When it passes, the prompt resolves exactly as cancelling it
 An interaction point that declared `unattended = "ask"` behaves differently on a timeout: the run
 **stops with an error**, rather than approving a checkpoint nobody made.
 
-The deadline is read once when the daemon starts, so changing it needs a daemon restart.
+The deadline is read once when the daemon starts, so changing it needs a daemon restart. Neither
+`lev setup` nor any bundled agent sets one for you.
 
 ## Tool approval
 
@@ -224,9 +229,9 @@ as approved without opening a prompt: nobody is watching, and a checkpoint that 
 the run. Set it to `ask` for a gate whose whole purpose is a human decision, such as a plan signed
 off before any code is written. The prompt then opens even under `--yolo`. The bundled `coder`
 leaves its plan checkpoint on the default, so an unattended run proceeds; set `ask` on your own
-blueprint when the decision genuinely cannot be made without you. Give a run like that an
-[`interaction_timeout_secs`](/docs/configuration#limits), so an unanswered gate releases on its own
-terms instead of waiting for ever.
+blueprint when the decision genuinely cannot be made without you. Such a run waits until you
+answer; give it an [`interaction_timeout_secs`](/docs/configuration#limits) if you would rather an
+unanswered gate released on its own terms.
 
 Know what that looks like before you meet it. A `--yolo` run holding an `ask` gate shows
 `waiting: checkpoint` in `lev ps` (the JSON wait reason is `interaction_point`), and does nothing

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -174,8 +174,9 @@ that grants one of these tools without saying it meant to. Naming the tool in `r
 settles that, and keeps the tool through an unattended run; `allow_blocking_tools = true` on the
 stage settles the warning alone, for a stage that only ever runs attended.
 
-Pair the opt-out with [`interaction_timeout_secs`](/docs/configuration#limits) so a prompt nobody
-answers still releases the run rather than parking it for good.
+The run then waits for a person however long it takes. Pair the opt-out with
+[`interaction_timeout_secs`](/docs/configuration#limits) if a prompt nobody answers should release
+the run instead.
 
 ## Sub-agents
 
@@ -404,10 +405,11 @@ may do internally, such as whether it can run a shell command or read a file. Se
 [Rhai tools](/docs/rhai-tools).
 
 > [!WARNING]
-> A tool set to `ask` in a headless context blocks until someone answers. It never auto-denies. For
-> unattended runs, either grant the tools explicitly with `--allow` or use `--yolo`, which cannot
-> override a `deny`. Set [`interaction_timeout_secs`](/docs/configuration#limits) to put a deadline
-> on any prompt that goes unanswered, whichever way it was raised.
+> A tool set to `ask` in a headless context blocks until someone answers. It never auto-denies, and
+> by default it never times out. For unattended runs, either grant the tools explicitly with
+> `--allow` or use `--yolo`, which cannot override a `deny`. Set
+> [`interaction_timeout_secs`](/docs/configuration#limits) to put a deadline on any prompt that
+> goes unanswered, whichever way it was raised.
 
 ## Argument validation
 

--- a/docs/schema/blueprint.schema.json
+++ b/docs/schema/blueprint.schema.json
@@ -893,7 +893,7 @@
           "default": true
         },
         "unattended": {
-          "description": "What a --yolo run does here. `auto_approve` (the default) resolves it without asking. `ask` holds for a person even unattended, and the run then waits for [limits] interaction_timeout_secs.",
+          "description": "What a --yolo run does here. `auto_approve` (the default) resolves it without asking. `ask` holds for a person even unattended, and the run then waits until somebody answers (or until [limits] interaction_timeout_secs, if set).",
           "enum": [
             "ask",
             "auto_approve"

--- a/docs/schema/config.example.toml
+++ b/docs/schema/config.example.toml
@@ -49,7 +49,9 @@ finished_retention_secs = 300
 wedge_timeout_secs = 0
 provider_failures_before_open = 3
 provider_circuit_cooldown_secs = 300
-interaction_timeout_secs = 3600
+# Unset, a prompt waits for a person until answered. Set this to bound the
+# wait for a run nobody will be watching; an expiry denies, never approves.
+# interaction_timeout_secs = 3600
 inference_retry_attempts = 4
 inference_retry_base_ms = 1000
 max_agents_per_run = 0

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -172,8 +172,7 @@
         "interaction_timeout_secs": {
           "type": "integer",
           "minimum": 0,
-          "default": 3600,
-          "description": "How long a prompt waits for a person before resolving as cancelled. `0` waits forever. This is what releases an interaction point that holds under --yolo, so the default means such a run sits for an hour looking dead."
+          "description": "How long a prompt (a tool approval, an ask_user_* question, a taint gate, an interaction point) waits for a person before resolving as cancelled. Unset by default: the run waits until somebody answers, however long that takes, and nothing else fails or reaps it while it waits. `0` is read as unset. Set a number to bound the wait for a run nobody will be watching; an expiry denies, it never approves."
         },
         "inference_retry_attempts": {
           "type": "integer",


### PR DESCRIPTION
A prompt that needs a person now waits for one. `[limits] interaction_timeout_secs` is unset by
default and is the opt-in for bounding that wait.

## What it did before (measured, not assumed)

| Timer | Where | Could it end a run waiting on a person? |
|---|---|---|
| Interaction timeout | `crates/leviath-runtime/src/interaction_hub.rs:95` (`timeout()`), `:147` (`tokio::time::timeout` around the wait), `:161` (`expire`) | **Yes.** The prompt resolved to the neutral response (`approved: None`, empty text): an approval and a taint gate deny, `ask_user_*` is told nobody answered, an interaction point proceeds with no text. |
| Its default | `crates/leviath-cli/src/config/limits.rs:75` (`default_interaction_timeout_secs`) → `interaction_hub.rs` `DEFAULT_INTERACTION_TIMEOUT_SECS = 3600`, installed at `crates/leviath-cli/src/daemon/setup.rs:271` | **Yes.** The old default was **3600 s (one hour)**, applied whether or not the operator had ever heard of the setting. |
| The #696 message | `crates/leviath-cli/src/daemon/tool_service.rs:566-580` | Named the timeout unconditionally, including in the cancel case where no timeout exists. |
| Stuck detection | `crates/leviath-runtime/src/pipeline/watchdog.rs:163` (`detect_stuck`), `:322` (`detect_stuck_stage`) | **Not directly** (it skips a non-`Active` agent, and a waiting agent is `Waiting`), **but the clock kept running.** `stage_started_at` is wall clock, so an hour spent waiting on a person counted toward `stuck_after_minutes` and the edge could fire on the first tick after the answer. The bundled coder's `implement` stage sets `stuck_after_minutes = 15` (`crates/leviath-cli/agents/coder/agent.leviath:436`). Fixed here. |
| Wedge watchdog | `crates/leviath-runtime/src/pipeline/wedge.rs:145` | No. `Unreachable` excludes `AwaitingInteraction`, `AwaitingGatePrompt`, `AwaitingInteractionPoint`, `InFlightWork`. A prompt-parked agent is never selected. |
| Stall watchdog | `crates/leviath-runtime/src/pipeline/stall.rs:260` (`fail_stalled_dispatch`) | No. It only selects agents ready to dispatch that cannot (unconfigured provider). |
| Max iterations | `watchdog.rs:87` | No. Counted per inference, not per wall-clock second. |
| Reaper / finished retention | `crates/leviath-cli/src/daemon/setup.rs:209` (`make_reaper`), `host.set_finished_retention_secs` at `:348` | No. Both act on terminal agents. |
| Unload of idle agents | `crates/leviath-runtime/src/host/mod.rs:288` | No, and deliberately: an agent carrying `AwaitingInteraction` is never unloaded (`host_tests.rs:3327`). |
| `ask_user_*` / taint gate / interaction points | `dynamic_interaction.rs`, `gate_prompt.rs`, `interaction_points.rs` | They have no clock of their own; they all wait on the hub, so the hub's deadline was the only one. |
| **Daemon shutdown** | `crates/leviath-runtime/src/world.rs:724` (`flush_and_stop`) | **It hung.** Found while testing the restart requirement, and fixed here (see below). |

## The change

- `InteractionHub::set_timeout_secs` / `timeout_secs` take and return `Option<u64>`. `None` waits
  indefinitely, `Some(0)` is read as `None` (a config that spelled "wait for ever" as `0` keeps
  working), `Some(n)` is today's behaviour exactly.
- `[limits] interaction_timeout_secs` is `Option<u64>`, `#[serde(default, skip_serializing_if = "Option::is_none")]`.
  `DEFAULT_INTERACTION_TIMEOUT_SECS` is deleted, so nothing installs an hour on a user's behalf.
- Nothing sets one for you: `lev setup` offers the field blank and writes nothing unless a number is
  typed (`setup/state/limits.rs`), `Config::default()` leaves it `None`, `config.example.toml` shows
  it commented out, the schema has no `default`, and a test asserts none of the seven bundled
  blueprints mentions an interaction timeout in any file.
- The #696 tool result names the timeout only when one is configured. With none set it reads
  `[denied] the approval prompt for 'x' was closed without an answer; ...`.
- A wait on a person is credited back to the stage clock when the prompt resolves
  (`reflect_interaction_status`), so `stuck_after_minutes` measures the agent, not the person.
- **Shutdown fix (`flush_and_stop`).** Awaiting the persistence worker is really awaiting the
  in-flight tool batch: the batch holds a clone of the persistence sender (the progress callback
  that journals each call). A batch parked on an approval waits on a person, so `lev daemon stop`
  hung. Measured on `main` with a parked approval: stop refused at 5 s, the daemon still alive
  120 s later, and it exited only when the prompt expired (`daemon exited rc=0 after 20.1s` with
  `interaction_timeout_secs = 20`). With no timeout that is for ever, so with this PR's default a
  daemon could never have been stopped or restarted while a run was parked. Shutdown now cancels
  in-flight work first; the lane drops the batch and the worker drains.

## Tests, run against the unfixed code first

| Test | Against old code |
|---|---|
| `tool_service::an_approval_with_no_timeout_configured_waits_past_the_old_default` (paused clock, advance 3601 s, prompt still open, then approve and see the call run) | FAILED: `an hour later the approval is still open: left: 0, right: 1` |
| `world::flush_and_stop_does_not_wait_on_a_batch_parked_on_a_person` | FAILED: `shutdown must not wait for the person to answer: Elapsed(())` (10 s timeout) |
| `interaction_hub::with_no_deadline_a_prompt_waits_for_a_person_however_long_it_takes` (advance 24 h, still waiting, then the answer is honoured) | new API, could not exist before |
| `interaction_hub::a_two_second_deadline_fires_at_two_seconds` (open at 1.9 s, released at 2.1 s) | passes both ways, and is the guard that `Some(n)` still works |
| `interaction_hub::a_zero_deadline_waits_for_a_person_however_long_it_takes` | pins `Some(0) == no deadline` |
| `pipeline::reflect_keeps_a_wait_on_a_person_off_the_stage_clock` | the behaviour it pins did not exist |
| `bundled::no_bundled_agent_sets_an_interaction_timeout`, `setup::setup_leaves_the_interaction_timeout_unset_unless_the_user_sets_one` | would have failed: the wizard wrote `3600` |

No `#[cfg(unix)]`-only tests were added.

## Live, against a real daemon (mock provider, isolated `LEVIATH_HOME`)

Harness: `perf-tools/harness.sh` + `mock.py` + a probe blueprint, `LEVIATH_SKIP_DOTENV=1`,
`start_new_session=True`, `[tool_permissions] write_file = "ask"`.

**Control, installed `~/.cargo/bin/lev` 0.5.5, `interaction_timeout_secs = 20`** (the real default is
3600 s; shortened so the expiry is observable):

```
[21:53:57] lev ps: probe-1788065635-b9b01b13523d waiting: tool approval main 1 1 2s 0s 2s
[21:54:14] lev ps: probe-1788065635-b9b01b13523d waiting: tool approval main 1 1 19s 0s 19s
[21:54:16] lev ps: probe-1788065635-b9b01b13523d complete (no output) main 2 1 21s 0s 1s
[21:54:16] stage log: [tool] write_file: [denied] no one answered the approval prompt for
           'write_file' before the interaction timeout (20 s, `[limits] interaction_timeout_secs`)
```

**This branch, no timeout configured**: parked, waited past the control's deadline, daemon stopped
and started while parked, still waiting, then answered:

```
[22:23:42] lev ps: probe-1788067420-4fc1200c987b waiting: tool approval main 1 1 2s 0s 2s
[22:24:10] after 30s: probe-1788067420-4fc1200c987b waiting: tool approval main 1 1 30s 0s 30s
[22:24:10] lev daemon stop rc=0 daemon stopped
[22:24:10] old daemon pid 79432 gone after 0.1s      <- on main this hung; see the shutdown fix
[22:30:45] lev respond approve-call_1 --approve: rc=0 answered
[22:30:45] lev ps: probe-1788067778-1006d7983f02 complete main 2 1 1m 0s 0s
```

**Parked across a restart, still waiting** (a `--yolo` run holding an `unattended = "ask"`
checkpoint, no timeout configured):

```
[22:29:00] lev ps 20s later:            checkpoint-...29325dfa15de waiting: checkpoint main 1 0 22s
[22:29:00] lev daemon stop rc=0 'daemon shutting down\ndaemon stopped'
[22:29:05] lev ps after restart:        checkpoint-...29325dfa15de waiting: checkpoint main 1 0 27s
[22:29:25] lev ps 20s after restart:    checkpoint-...29325dfa15de waiting: checkpoint main 1 0 47s
[22:29:25] lev respond checkpoint-...-point-hold-0 --choice 0: rc=0 answered
[22:29:27] lev ps after answering:      checkpoint-...29325dfa15de complete main 1 0 49s
```

One honest limitation, unchanged by this PR and worth knowing: a *tool approval* is not a persisted
prompt. A run parked on one reloads through the issue-#96 replay path
(`restore::restore_pending_batch`), which lands a verify-first `[error] interrupted` result for the
call that had not finished and re-infers, so whether the operator is asked again is the model's
call. Stage-boundary interaction points are persisted (`interactions.json`) and come back parked, as
the transcript above shows.

## Gates

`cargo fmt --all`; `cargo clippy --all-targets --all-features` clean for `leviath-runtime`,
`leviath-cli`, `leviath-core`; full `cargo test` green for all three (4138 + 1649 + 922);
`cargo xtask structure`; `cargo xtask docs`; `cargo xtask coverage --package` at 100% for
`leviath-runtime`, `leviath-cli`, `leviath-core`. No em dashes.

Docs: `configuration.md` (`[limits]` table and the prose), `interaction.md` ("when nobody answers"),
`tools.md`, `gas-city.md`, `agent-client-protocol.md`, `config.example.toml` (commented out),
`config.schema.json` (no `default`, description says unset waits), `blueprint.schema.json`
(`unattended`), and the CHANGELOG under Changed.
