### PR TITLE
fix(daemon): a provider change reaches the next run without a daemon restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ same list.
 
 ## Unreleased
 
+### Fixed
+
+- The daemon rebuilds its provider registry when `config.toml` changes, so a provider you
+  configure, replace or remove is picked up by the next run instead of at the next daemon
+  restart. The registry was built once at boot: a user who ran out of credits on one provider,
+  switched to another with `lev setup`, and started a new run watched it go to the old provider
+  and fail, and neither restarting `lev serve` nor removing the key helped - only killing the
+  daemon did. Every write path is covered, because they all write the same file: `lev setup`,
+  `PUT /api/config`, and an editor. A run already under way keeps the provider its current stage
+  started on, so nothing is swapped mid-stage, and a run parked because its provider had no
+  credits left moves to the new one when you `lev resume` it. A provider whose credentials
+  changed also has its circuit-breaker record cleared, so a replaced key is tried at once rather
+  than serving out the old key's cooldown.
+
 ### Breaking
 
 - `lev add` refuses an agent whose manifest name is not a single safe path

--- a/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
+++ b/crates/leviath-cli/src/commands/serve/event_seam_tests.rs
@@ -139,6 +139,7 @@ async fn stand_up(runs_dir: &std::path::Path) -> Seam {
         // A fixed clock, so nothing here is a function of how long CI took.
         now_secs: || 1_700_000_000,
         reloader: None,
+        provider_reload: None,
     });
 
     // The daemon half: the host's own event sender served over a real control

--- a/crates/leviath-cli/src/daemon/config_reload.rs
+++ b/crates/leviath-cli/src/daemon/config_reload.rs
@@ -13,12 +13,12 @@
 //! (`leviath_runtime::script_provider`), and keeps the last good config if a
 //! reload fails so an edit saved mid-keystroke never breaks a spawn.
 //!
-//! What it deliberately does **not** reload is the infrastructure established
-//! once at boot: the provider registry, MCP connections, the outbound-network
-//! policy, and the telemetry sink. Those hold live connections and
-//! process-wide state; re-initializing them on a file write is a much larger
-//! change with its own failure modes. Adding a provider key or an MCP server
-//! still needs a daemon restart; see `daemon.md`.
+//! Provider credentials are rebuilt from the same reloaded config by the
+//! `provider_reload` module beside this one, so a key added or removed here
+//! reaches the next run too. What is still established once at boot is MCP
+//! connections, the outbound-network policy and the telemetry sink: those hold
+//! live connections and process-wide state, and adding an MCP server still
+//! needs a daemon restart; see `daemon.md`.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod fanout_spawner;
 pub(crate) mod gate_rules;
 pub mod lifecycle;
 pub mod mcp_pool;
+pub mod provider_reload;
 pub mod readiness;
 pub(crate) mod recovery;
 pub(crate) mod sandbox_manager;

--- a/crates/leviath-cli/src/daemon/provider_reload.rs
+++ b/crates/leviath-cli/src/daemon/provider_reload.rs
@@ -1,0 +1,417 @@
+//! Rebuilding the daemon's provider registry when `config.toml` changes.
+//!
+//! The registry is built once at boot from the config's keys, base URLs and
+//! `[model_providers]` entries, and was then fixed for the life of the
+//! process. Everything a person does to change where their runs go - `lev
+//! setup`, `PUT /api/config`, editing the file - writes that file and nothing
+//! else, so a user who moved off a provider whose credits had run out watched
+//! every new run go to it anyway, and the only thing that helped was killing
+//! the daemon. The config reloader beside this module already re-read the
+//! file for spawn-time settings; it deliberately stopped short of the
+//! registry, and this is the piece that finishes the job.
+//!
+//! The check is on the credentials themselves rather than the file's mtime: a
+//! save that changed a tool permission is not a reason to rebuild providers,
+//! and a rebuild that dropped a provider mid-flight would be worse than the
+//! bug. What changed is also *which* providers changed, so the circuit breaker
+//! can forget the failures that belong to a key the user has since replaced.
+
+use std::sync::{Arc, Mutex, PoisonError};
+
+use leviath_runtime::{ProviderCreds, ProviderRegistry};
+
+use crate::config::Config;
+
+/// How long the rebuilt registry gets to read the model lists of the providers
+/// that changed. The same budget the daemon's start-up prime uses, for the
+/// same reason: the answer is an optimisation over the table compiled into
+/// this build, so a provider that cannot answer in this long is better skipped
+/// than allowed to hold up a run.
+const PRIME_TIMEOUT_SECS: u64 = 10;
+
+/// What a rebuild produced: the registry to install, and the providers whose
+/// credentials are not the ones the old registry was built with.
+struct Pending {
+    registry: ProviderRegistry,
+    changed: Vec<String>,
+}
+
+struct State {
+    /// The credentials the current registry was built from, for comparison
+    /// with the ones the config holds now.
+    creds: Vec<ProviderCreds>,
+    /// The newest registry, installed into the world or about to be.
+    registry: ProviderRegistry,
+    /// Built but not yet installed into the world. Taken by [`ProviderReload::install`].
+    pending: Option<Pending>,
+}
+
+/// Keeps the daemon's provider registry in step with `config.toml`.
+///
+/// [`refresh`](Self::refresh) is the cheap synchronous check (rebuild only
+/// when the credentials actually differ) and [`install`](Self::install) puts
+/// the result into the world. They are separate because the world is only
+/// reachable from the host's sync hooks, while the priming that makes a new
+/// provider's model list known has to be awaited.
+pub struct ProviderReload {
+    state: Mutex<State>,
+    /// How an HTTP-backed provider's client is built, injected so a test can
+    /// build a registry without opening sockets.
+    build_client: leviath_providers::provider::HttpClientFactory<'static>,
+}
+
+impl ProviderReload {
+    /// Start from the registry the daemon booted with and the config it was
+    /// built from.
+    pub fn new(
+        config: &Config,
+        registry: ProviderRegistry,
+        build_client: leviath_providers::provider::HttpClientFactory<'static>,
+    ) -> Self {
+        Self {
+            state: Mutex::new(State {
+                creds: crate::commands::run::session::provider_creds_from_config(config),
+                registry,
+                pending: None,
+            }),
+            build_client,
+        }
+    }
+
+    /// The newest registry, for a caller that needs to ask a provider
+    /// something before the world has it (the spawn preprocessor's model
+    /// warming).
+    pub fn registry(&self) -> ProviderRegistry {
+        self.lock().registry.clone()
+    }
+
+    /// Rebuild from `config` when its provider credentials differ from the
+    /// ones the current registry was built with, and hold the result for
+    /// [`install`](Self::install). Returns the names whose credentials
+    /// changed, empty when nothing did.
+    ///
+    /// A rebuild that fails keeps the current registry: an unusable provider
+    /// entry should cost the run its new setting, not its providers.
+    pub fn refresh(&self, config: &Config) -> Vec<String> {
+        let creds = crate::commands::run::session::provider_creds_from_config(config);
+        let mut state = self.lock();
+        let changed = changed_names(&state.creds, &creds);
+        if changed.is_empty() {
+            return Vec::new();
+        }
+        // The script layer is carried over rather than rebuilt: it follows the
+        // config through its own source (issue #533) and holds the `.rhai`
+        // providers it has already compiled.
+        let built = leviath_runtime::provider_creds::build_provider_registry_with(
+            &creds,
+            self.build_client,
+        );
+        let registry = match built {
+            Ok(registry) => match state.registry.script_layer() {
+                Some(layer) => registry.with_script_layer(layer),
+                None => registry,
+            },
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "config.toml changed its providers but the new set could not be built; \
+                     keeping the ones already in service"
+                );
+                return Vec::new();
+            }
+        };
+        state.creds = creds;
+        state.registry = registry.clone();
+        state.pending = Some(Pending {
+            registry,
+            changed: changed.clone(),
+        });
+        changed
+    }
+
+    /// [`refresh`](Self::refresh), then read the model lists of the providers
+    /// it built, so a run resolving against the new set is sized against what
+    /// those providers actually serve rather than the table compiled into this
+    /// build.
+    pub async fn refresh_and_prime(&self, config: &Config) -> Vec<String> {
+        let changed = self.refresh(config);
+        if !changed.is_empty() {
+            let registry = self.registry();
+            let default = config.default_provider.clone();
+            registry
+                .prime_capabilities(
+                    std::time::Duration::from_secs(PRIME_TIMEOUT_SECS),
+                    &[default.as_str()],
+                )
+                .await;
+        }
+        changed
+    }
+
+    /// Install whatever [`refresh`](Self::refresh) built into `world`. Does
+    /// nothing when there is nothing pending, so it is safe to call before
+    /// every spawn.
+    pub fn install(&self, world: &mut leviath_runtime::PipelineWorld) {
+        let pending = self.lock().pending.take();
+        if let Some(Pending { registry, changed }) = pending {
+            world.replace_providers(registry, &changed);
+        }
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// The provider names whose credentials `new` states differently from `old`:
+/// added, removed, or the same name with a different key, URL, timeout or
+/// rate limit. Sorted, so the log line and the tests read the same way twice.
+fn changed_names(old: &[ProviderCreds], new: &[ProviderCreds]) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    for cred in new {
+        match old.iter().find(|c| c.name == cred.name) {
+            Some(before) if before == cred => {}
+            _ => names.push(cred.name.clone()),
+        }
+    }
+    for cred in old {
+        if !new.iter().any(|c| c.name == cred.name) {
+            names.push(cred.name.clone());
+        }
+    }
+    names.sort();
+    names.dedup();
+    names
+}
+
+/// Build one for a caller that has a config and wants the daemon's registry
+/// semantics, with the real HTTP client factory.
+pub fn for_daemon(config: &Config, registry: ProviderRegistry) -> Arc<ProviderReload> {
+    Arc::new(ProviderReload::new(
+        config,
+        registry,
+        &leviath_providers::provider::build_http_client,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client_factory() -> leviath_providers::provider::HttpClientFactory<'static> {
+        &leviath_providers::provider::build_http_client
+    }
+
+    fn config_with_key(key: &str) -> Config {
+        Config {
+            providers: crate::config::ProviderConfig {
+                anthropic_api_key: Some(key.to_string()),
+                ..Config::default().providers
+            },
+            ..Config::default()
+        }
+    }
+
+    fn boot(config: &Config) -> ProviderReload {
+        ProviderReload::new(config, boot_registry(config), client_factory())
+    }
+
+    /// The registry a daemon boots with, without the Ollama reachability probe
+    /// opening a socket.
+    fn boot_registry(config: &Config) -> ProviderRegistry {
+        leviath_runtime::provider_creds::build_provider_registry_probing(
+            &crate::commands::run::session::provider_creds_from_config(config),
+            client_factory(),
+            &|_| false,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn an_unchanged_config_rebuilds_nothing() {
+        let config = config_with_key("sk-ant");
+        let reload = boot(&config);
+        assert!(reload.refresh(&config).is_empty());
+        assert!(reload.lock().pending.is_none());
+    }
+
+    #[test]
+    fn a_new_provider_key_is_a_change_and_the_registry_gains_it() {
+        let config = config_with_key("sk-ant");
+        let reload = boot(&config);
+        assert!(!reload.registry().has("openrouter"));
+
+        let mut after = config.clone();
+        after.openrouter_api_key = Some("sk-or".to_string());
+        assert_eq!(reload.refresh(&after), vec!["openrouter".to_string()]);
+        assert!(
+            reload.registry().has("openrouter"),
+            "the provider the user just configured has to be usable without a restart"
+        );
+    }
+
+    #[test]
+    fn a_removed_key_drops_the_provider() {
+        let config = config_with_key("sk-ant");
+        let reload = boot(&config);
+        assert!(reload.registry().has("anthropic"));
+
+        let mut after = config.clone();
+        after.providers.anthropic_api_key = None;
+        assert_eq!(reload.refresh(&after), vec!["anthropic".to_string()]);
+        assert!(
+            !reload.registry().has("anthropic"),
+            "a provider the user untoggled must stop being a route"
+        );
+    }
+
+    #[test]
+    fn replacing_a_key_reports_that_provider_alone() {
+        let mut config = config_with_key("sk-ant-old");
+        config.openrouter_api_key = Some("sk-or".to_string());
+        let reload = boot(&config);
+
+        let mut after = config.clone();
+        after.providers.anthropic_api_key = Some("sk-ant-new".to_string());
+        assert_eq!(reload.refresh(&after), vec!["anthropic".to_string()]);
+    }
+
+    #[test]
+    fn a_change_elsewhere_in_the_config_is_not_a_provider_change() {
+        let config = config_with_key("sk-ant");
+        let reload = boot(&config);
+
+        let mut after = config.clone();
+        after.limits.max_concurrent_tools = 99;
+        assert!(
+            reload.refresh(&after).is_empty(),
+            "a limits edit must not rebuild the providers under a running daemon"
+        );
+    }
+
+    #[test]
+    fn an_endpoint_entrys_base_url_change_is_a_change() {
+        let mut config = Config::default();
+        config.model_providers.insert(
+            "gateway".to_string(),
+            crate::config::ModelProviderConfig {
+                kind: Some(crate::config::ModelProviderKind::OpenaiCompatible),
+                base_url: Some("http://127.0.0.1:9001/v1".to_string()),
+                ..Default::default()
+            },
+        );
+        let reload = boot(&config);
+
+        let mut after = config.clone();
+        after
+            .model_providers
+            .get_mut("gateway")
+            .unwrap()
+            .base_url
+            .replace("http://127.0.0.1:9002/v1".to_string());
+        assert_eq!(reload.refresh(&after), vec!["gateway".to_string()]);
+    }
+
+    #[test]
+    fn install_hands_the_pending_registry_to_the_world_once() {
+        let config = config_with_key("sk-ant");
+        let reload = boot(&config);
+        let mut after = config.clone();
+        after.openrouter_api_key = Some("sk-or".to_string());
+        reload.refresh(&after);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _guard = runtime.enter();
+        let mut world = leviath_runtime::PipelineWorld::new(
+            leviath_runtime::ProviderRegistry::new(),
+            std::sync::Arc::new(crate::daemon::tool_service::CliToolService::new()),
+            leviath_runtime::inference_pool::InferencePoolConfig::new(),
+            1,
+            None,
+            runtime.handle().clone(),
+        );
+        reload.install(&mut world);
+        assert!(world.providers().has("openrouter"));
+        assert!(
+            reload.lock().pending.is_none(),
+            "the pending rebuild is consumed, not re-applied on every spawn"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_and_prime_reports_the_same_names_as_refresh() {
+        let config = config_with_key("sk-ant");
+        let reload = boot(&config);
+        let mut after = config.clone();
+        after.providers.anthropic_api_key = None;
+        assert_eq!(
+            reload.refresh_and_prime(&after).await,
+            vec!["anthropic".to_string()]
+        );
+        // Nothing changed the second time, so nothing is primed either.
+        assert!(reload.refresh_and_prime(&after).await.is_empty());
+    }
+
+    #[test]
+    fn a_rebuild_keeps_the_script_provider_layer() {
+        // A `.rhai` provider the daemon has already compiled must survive a
+        // key change elsewhere: rebuilding the layer would drop it, and the
+        // layer follows the config on its own anyway (issue #533).
+        let config = config_with_key("sk-ant");
+        let dir = tempfile::tempdir().unwrap();
+        let layer =
+            std::sync::Arc::new(leviath_runtime::script_provider::ScriptProviderLayer::new(
+                dir.path().to_path_buf(),
+                Default::default(),
+                Default::default(),
+                None,
+                Vec::new(),
+            ));
+        let reload = ProviderReload::new(
+            &config,
+            boot_registry(&config).with_script_layer(layer),
+            client_factory(),
+        );
+
+        let mut after = config.clone();
+        after.openrouter_api_key = Some("sk-or".to_string());
+        reload.refresh(&after);
+        assert!(reload.registry().script_layer().is_some());
+    }
+
+    #[test]
+    fn a_registry_that_cannot_be_built_leaves_the_working_one_in_service() {
+        // The one failure this has: no usable HTTPS client. Losing the
+        // providers already in service over it would be worse than ignoring
+        // the edit, so the edit is what is dropped.
+        let config = config_with_key("sk-ant");
+        let reload = ProviderReload::new(&config, boot_registry(&config), &|_t| {
+            Err(leviath_providers::provider::malformed_url_error())
+        });
+
+        let mut after = config.clone();
+        after.openrouter_api_key = Some("sk-or".to_string());
+        assert!(reload.refresh(&after).is_empty());
+        assert!(
+            reload.registry().has("anthropic"),
+            "the registry the daemon has been running on is still there"
+        );
+    }
+
+    #[test]
+    fn for_daemon_starts_from_the_registry_it_is_given() {
+        let config = config_with_key("sk-ant");
+        let registry = leviath_runtime::provider_creds::build_provider_registry_probing(
+            &crate::commands::run::session::provider_creds_from_config(&config),
+            client_factory(),
+            &|_| false,
+        )
+        .unwrap();
+        let reload = for_daemon(&config, registry);
+        assert!(reload.registry().has("anthropic"));
+        assert!(
+            reload.refresh(&config).is_empty(),
+            "the config it was built from is not a change"
+        );
+    }
+}

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -176,6 +176,11 @@ pub(crate) async fn setup_daemon_host_with(
             &[config.default_provider.as_str()],
         )
         .await;
+    // Keeps that registry in step with `config.toml` from here on: a run
+    // started after a `lev setup`, a `PUT /api/config` or a hand edit resolves
+    // against the providers the file names now, without a daemon restart
+    // (issue #684).
+    let provider_reload = crate::daemon::provider_reload::for_daemon(&config, providers.clone());
     // MCP connections are shared across agents; the workdir here only seeds the
     // (discarded) built-ins - each agent gets its own over its own workdir.
     let registry = ToolRegistry::build(std::env::temp_dir(), &config).await;
@@ -203,6 +208,7 @@ pub(crate) async fn setup_daemon_host_with(
         runtime,
         now_secs: || chrono::Utc::now().timestamp(),
         reloader: Some(reloader),
+        provider_reload: Some(provider_reload),
     }))
 }
 
@@ -257,6 +263,10 @@ pub struct HostParts {
     /// script-provider layer can follow it too (issue #533); `None` builds a
     /// fixed one from `config`, for a caller with nothing to watch.
     pub reloader: Option<Arc<crate::daemon::config_reload::ConfigReloader>>,
+    /// Keeps the provider registry in step with `config.toml`. `None` builds
+    /// one over `config` and `providers`, which is the same thing for a caller
+    /// that booted them together.
+    pub provider_reload: Option<Arc<crate::daemon::provider_reload::ProviderReload>>,
 }
 
 /// Build the daemon's [`WorldHost`]: one world hosting every agent, its tool
@@ -388,6 +398,13 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         ))
     });
 
+    // Same fallback as the config reloader above: a caller that booted its
+    // registry and its config together is already consistent, so one built
+    // over both is the right starting point.
+    let provider_reload = parts.provider_reload.clone().unwrap_or_else(|| {
+        crate::daemon::provider_reload::for_daemon(&parts.config, pp_providers.clone())
+    });
+
     // Install the fan-out spawner as a world resource so the parts.runtime's fan-out
     // systems can start workers (it captures the same context as the spawner
     // below, cloned before those move into the closure).
@@ -457,10 +474,17 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let reload_tx = subagent_tx.clone();
     let reload_runs = parts.runs_dir.clone();
     let reload_pool = parts.mcp_pool.clone();
+    let reload_provider_reload = provider_reload.clone();
     host.set_reloader(Box::new(move |world, run_id| {
         // Pages a run back in with the current on-disk parts.config, matching what a
         // real restart would restore it with.
         let reload_config = reload_reloader.current();
+        // A run parked on a provider that has since been replaced re-resolves
+        // its stages here, so the new set has to be in the world first: this
+        // is what lets `lev resume` move a credits-paused run onto the
+        // provider the config names now (issue #684).
+        reload_provider_reload.refresh(&reload_config);
+        reload_provider_reload.install(world);
         let entity = crate::daemon::recovery::reload_run(
             world,
             crate::daemon::spawn::SpawnDeps {
@@ -509,17 +533,28 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // A model whose real window is only knowable once it is loaded - which is
     // every Ollama model - would otherwise have every region in the run sized
     // against a guess from its name, and nothing later corrects it.
-    let pp_default_provider = parts.config.default_provider.clone();
+    let pp_reloader = reloader.clone();
+    let pp_reload = provider_reload.clone();
     host.set_spawn_preprocessor(Box::new(move |args| {
         let pool = pp_pool.clone();
         let blueprint_path = args.blueprint_path.clone();
         let agents_dir = pp_agents_dir.clone();
-        let providers = pp_providers.clone();
-        let default_provider = pp_default_provider.clone();
+        let config = pp_reloader.current();
+        let reload = pp_reload.clone();
         Box::pin(async move {
             warm_blueprint_mcp(&pool, &blueprint_path).await;
             warm_fanout_worker_mcp(&pool, &blueprint_path, agents_dir.as_deref()).await;
-            warm_blueprint_models(&providers, &blueprint_path, &default_provider).await;
+            // Before the models are warmed, not after: a provider the user
+            // configured since this daemon started has to exist before anyone
+            // asks it what its models are. The sync spawner installs whatever
+            // this built (issue #684).
+            reload.refresh_and_prime(&config).await;
+            warm_blueprint_models(
+                &reload.registry(),
+                &blueprint_path,
+                &config.default_provider,
+            )
+            .await;
         })
     }));
 
@@ -529,6 +564,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let spawn_pool = parts.mcp_pool.clone();
     let spawn_runs_dir = parts.runs_dir.clone();
     let spawn_reloader = reloader.clone();
+    let spawn_provider_reload = provider_reload.clone();
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
@@ -550,6 +586,12 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // grant, a permission change) takes effect on the next `lev run`
         // without a daemon restart.
         let config = spawn_reloader.current();
+        // The registry, before the stages resolve against it. The preprocessor
+        // has usually built it already; refreshing here too covers the paths
+        // that do not run one (a sub-agent spawn, a fan-out worker) and costs
+        // a credential comparison when nothing changed (issue #684).
+        spawn_provider_reload.refresh(&config);
+        spawn_provider_reload.install(world);
         let built = build_agent(
             world.world_mut(),
             crate::daemon::spawn::SpawnDeps {
@@ -1494,6 +1536,7 @@ system_prompt = "x"
             runtime: Handle::current(),
             now_secs: || 0,
             reloader: None,
+            provider_reload: None,
         });
     }
 
@@ -1524,6 +1567,7 @@ system_prompt = "x"
             runtime: Handle::current(),
             now_secs: || 0,
             reloader: None,
+            provider_reload: None,
         });
         assert!(
             host.world_mut()
@@ -1564,6 +1608,7 @@ system_prompt = "x"
             runtime: Handle::current(),
             now_secs: || 0,
             reloader: None,
+            provider_reload: None,
         });
         assert!(
             host.world_mut()
@@ -1599,6 +1644,7 @@ system_prompt = "x"
             runtime: Handle::current(),
             now_secs: || 0,
             reloader: None,
+            provider_reload: None,
         });
         let (ctl_tx, ctl_rx) = tokio::sync::mpsc::unbounded_channel();
         let (reply, reply_rx) = oneshot::channel();
@@ -1628,6 +1674,168 @@ system_prompt = "x"
         drop(ctl_tx);
         host.serve(ctl_rx).await;
         assert_eq!(reply_rx.await.unwrap(), Ok("run-mcp".to_string()));
+    }
+
+    /// A config that names one endpoint provider, written to `path`.
+    fn config_naming(path: &std::path::Path, providers: &[(&str, &str)], default: &str) -> Config {
+        let mut config = Config {
+            default_provider: default.to_string(),
+            default_model: Some("m".to_string()),
+            ..Config::default()
+        };
+        for (name, url) in providers {
+            config.model_providers.insert(
+                (*name).to_string(),
+                crate::config::ModelProviderConfig {
+                    kind: Some(crate::config::ModelProviderKind::OpenaiCompatible),
+                    base_url: Some((*url).to_string()),
+                    api_key: Some(format!("key-{name}")),
+                    models: Some(vec!["m".to_string()]),
+                    ..Default::default()
+                },
+            );
+        }
+        std::fs::write(path, toml::to_string(&config).unwrap()).unwrap();
+        // Strictly newer, so a rewrite inside one clock tick is still seen.
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(5))
+            .unwrap();
+        config
+    }
+
+    /// A one-stage blueprint pinned to `provider`, with the user default
+    /// refused: the only way it can run is if that provider is registered.
+    fn blueprint_pinned_to(dir: &std::path::Path, provider: &str) -> std::path::PathBuf {
+        let manifest = dir.join("agent.leviath");
+        std::fs::write(
+            &manifest,
+            format!(
+                r#"
+[agent]
+name = "pinned"
+entry_stage = "work"
+
+[stages.work]
+mode = "autonomous"
+model = {{ models = [{{ provider = "{provider}", model = "m" }}], allow_user_default = false }}
+available_tools = []
+system_prompt = "reply"
+
+[context.regions]
+task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
+"#
+            ),
+        )
+        .unwrap();
+        manifest
+    }
+
+    fn spawn_op(
+        run_id: &str,
+        manifest: &std::path::Path,
+    ) -> (ControlOp, oneshot::Receiver<Result<String, String>>) {
+        let (reply, reply_rx) = oneshot::channel();
+        let op = ControlOp::Spawn {
+            args: Box::new(SpawnArgs {
+                run_id: run_id.to_string(),
+                blueprint_path: manifest.to_string_lossy().to_string(),
+                task: "t".to_string(),
+                regions: Default::default(),
+                model: None,
+                workdir: std::env::temp_dir().to_string_lossy().to_string(),
+                metadata: Default::default(),
+                callback_url: None,
+                callback_secret: None,
+                yolo: false,
+                no_seed_commands: false,
+                allow: Vec::new(),
+                max_depth: None,
+                parent_run_id: None,
+                output: None,
+            }),
+            reply,
+        };
+        (op, reply_rx)
+    }
+
+    /// The bug this whole file's provider reload exists for: the daemon boots
+    /// with one provider configured, the user configures another (`lev setup`,
+    /// `PUT /api/config`, an editor - they all write this file), and the very
+    /// next run has to be able to use it. Before the registry was rebuilt, the
+    /// second spawn was refused with "no usable provider" until the daemon was
+    /// killed and restarted (issue #684).
+    #[tokio::test]
+    async fn a_provider_configured_after_boot_is_usable_on_the_next_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let config = config_naming(&config_path, &[("alpha", "http://127.0.0.1:9/v1")], "alpha");
+        let manifest = blueprint_pinned_to(dir.path(), "beta");
+        let runs = tempfile::tempdir().unwrap();
+        let providers = leviath_runtime::provider_creds::build_provider_registry_probing(
+            &crate::commands::run::session::provider_creds_from_config(&config),
+            &leviath_providers::provider::build_http_client,
+            &|_| false,
+        )
+        .unwrap();
+        let mut host = build_host(HostParts {
+            config: config.clone(),
+            providers: providers.clone(),
+            runs_dir: runs.path().to_path_buf(),
+            shared_mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            mcp_tool_defs: Vec::new(),
+            mcp_tool_owners: Default::default(),
+            mcp_pool: Arc::new(empty_pool()),
+            runtime: Handle::current(),
+            now_secs: || 0,
+            reloader: Some(Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+                config_path.clone(),
+                config.clone(),
+            ))),
+            provider_reload: Some(crate::daemon::provider_reload::for_daemon(
+                &config, providers,
+            )),
+        });
+
+        // Both spawns go through one `serve()`: it flushes the persistence
+        // lane on the way out, so a host only ever serves once. The driver
+        // task rewrites the config between the two, which is the whole point.
+        let (ctl_tx, ctl_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (first, first_reply) = spawn_op("run-before", &manifest);
+        ctl_tx.send(first).unwrap();
+        let driver_tx = ctl_tx.clone();
+        let driver_config = config_path.clone();
+        let driver_manifest = manifest.clone();
+        let driver = tokio::spawn(async move {
+            let before = first_reply.await.unwrap();
+            // What `lev setup` (or `PUT /api/config`) does: rewrite the file.
+            config_naming(&driver_config, &[("beta", "http://127.0.0.1:9/v1")], "beta");
+            let (second, second_reply) = spawn_op("run-after", &driver_manifest);
+            driver_tx.send(second).unwrap();
+            let after = second_reply.await.unwrap();
+            drop(driver_tx);
+            (before, after)
+        });
+        drop(ctl_tx);
+        host.serve(ctl_rx).await;
+        let (before, after) = driver.await.unwrap();
+
+        assert!(
+            before.is_err(),
+            "beta is not configured yet, so the spawn has nowhere to go: {before:?}"
+        );
+        assert_eq!(
+            after,
+            Ok("run-after".to_string()),
+            "the provider the user just configured has to work without a daemon restart"
+        );
+        assert!(
+            host.world_mut().providers().has("beta"),
+            "the rebuilt registry is the one the world resolves against"
+        );
+        assert!(
+            !host.world_mut().providers().has("alpha"),
+            "and the provider they removed is no longer a route"
+        );
     }
 
     #[tokio::test]
@@ -1666,6 +1874,7 @@ system_prompt = "x"
             runtime: Handle::current(),
             now_secs: || 100,
             reloader: None,
+            provider_reload: None,
         });
 
         // Drive a Spawn control op through the host.
@@ -1779,6 +1988,7 @@ system_prompt = "x"
             runtime: Handle::current(),
             now_secs: || 100,
             reloader: None,
+            provider_reload: None,
         });
 
         // The reloaded run is registered → Status resolves it.
@@ -1817,6 +2027,7 @@ system_prompt = "x"
             runtime: Handle::current(),
             now_secs: || 100,
             reloader: None,
+            provider_reload: None,
         });
 
         // Persist a running run only now - build_host's startup reload already ran,

--- a/crates/leviath-cli/tests/agent_end_to_end.rs
+++ b/crates/leviath-cli/tests/agent_end_to_end.rs
@@ -216,6 +216,7 @@ async fn an_agent_runs_a_tool_and_the_file_lands_on_disk() {
         // A fixed clock, so nothing here is a function of how long CI took.
         now_secs: || 1_700_000_000,
         reloader: None,
+        provider_reload: None,
     });
 
     let (reply, spawned) = oneshot::channel();

--- a/crates/leviath-providers/src/provider.rs
+++ b/crates/leviath-providers/src/provider.rs
@@ -725,7 +725,7 @@ pub struct ToolCallDelta {
 }
 
 /// Rate limit configuration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RateLimitConfig {
     /// Maximum requests per minute
     pub requests_per_minute: u32,

--- a/crates/leviath-runtime/src/pipeline/circuit.rs
+++ b/crates/leviath-runtime/src/pipeline/circuit.rs
@@ -194,6 +194,14 @@ impl ProviderCircuits {
         self.0.clear();
     }
 
+    /// Drop everything recorded against one provider. For a provider whose
+    /// credentials just changed: the failures that opened its circuit were
+    /// the old key's, and holding the new key out of service for the rest
+    /// of the cooldown would make a fixed key look still broken.
+    pub fn forget(&mut self, provider: &str) {
+        self.0.remove(provider);
+    }
+
     /// Whether `provider` should be skipped right now.
     ///
     /// False once the cooldown has elapsed, which is what makes the next

--- a/crates/leviath-runtime/src/pipeline/resolve.rs
+++ b/crates/leviath-runtime/src/pipeline/resolve.rs
@@ -651,7 +651,8 @@ pub fn resolve_stages(
             if !registry.has(&head.provider) {
                 return Err(format!(
                     "stage '{}' has no usable provider (tried: {}). Configure one \
-                     with `lev setup`, or add it to config.toml and restart the daemon.",
+                     with `lev setup`, or add it to config.toml; the next run \
+                     picks it up, with no daemon restart.",
                     stage.name,
                     providers_tried(&stage.model, model_override, defaults)
                 ));

--- a/crates/leviath-runtime/src/pipeline/stall.rs
+++ b/crates/leviath-runtime/src/pipeline/stall.rs
@@ -64,7 +64,8 @@ impl StallReason {
             // the missing-provider wording covers the remaining case.
             _ => format!(
                 "provider '{provider}' is not configured, so this run has no way to \
-                 go on; add it to config.toml (or run `lev setup`) and restart the daemon"
+                 go on; add it to config.toml (or run `lev setup`), then \
+                 `lev resume` this run"
             ),
         }
     }

--- a/crates/leviath-runtime/src/provider_creds.rs
+++ b/crates/leviath-runtime/src/provider_creds.rs
@@ -14,7 +14,9 @@ use std::sync::Arc;
 /// depending on the CLI's `Config`/`ProviderConfig` types. Build one per
 /// provider that should be registered.
 /// `Debug` is hand-written (below) so `api_key` cannot be printed.
-#[derive(Clone)]
+/// `PartialEq` is what lets the daemon tell whether a config edit changed a
+/// provider at all, key included, without printing one.
+#[derive(Clone, PartialEq)]
 pub struct ProviderCreds {
     /// Provider identifier: `anthropic` | `openai` | `google` | `openrouter` |
     /// `ollama` | `claude-code`. Selects which provider is instantiated.

--- a/crates/leviath-runtime/src/providers.rs
+++ b/crates/leviath-runtime/src/providers.rs
@@ -15,6 +15,14 @@ use std::sync::Arc;
 #[derive(Clone, Default)]
 pub struct ProviderRegistry {
     providers: HashMap<String, Arc<dyn Provider>>,
+    /// Providers a previous registry had that this one was built without: a
+    /// key the user removed with `lev setup`, an endpoint entry deleted from
+    /// `config.toml`. A run already mid-stage on one keeps calling it through
+    /// [`get`](Self::get), so its stage finishes on the provider it started
+    /// on; nothing new resolves to it, because [`has`](Self::has),
+    /// [`native_providers`](Self::native_providers) and
+    /// [`resolvable_names`](Self::resolvable_names) leave it out.
+    retired: HashMap<String, Arc<dyn Provider>>,
     /// Lazy, hot-reloading resolver for `.rhai` script providers. Shared across
     /// registry clones (one compile cache daemon-wide).
     script_layer: Option<Arc<ScriptProviderLayer>>,
@@ -45,7 +53,40 @@ impl ProviderRegistry {
         if let Some(p) = self.providers.get(name) {
             return Some(p.clone());
         }
+        if let Some(p) = self.retired.get(name) {
+            return Some(p.clone());
+        }
         self.script_layer.as_ref()?.get_or_load(name)
+    }
+
+    /// The script layer this registry loads `.rhai` providers through, if any.
+    /// A rebuilt registry takes the old one's layer rather than compiling a
+    /// new one, so the scripts it already loaded stay loaded.
+    pub fn script_layer(&self) -> Option<Arc<ScriptProviderLayer>> {
+        self.script_layer.clone()
+    }
+
+    /// Carry forward, as retired, every native provider `previous` had that
+    /// this registry does not. Runs that are mid-stage on one of them finish
+    /// that stage on it; no new resolution reaches it. A provider this
+    /// registry registers again under the same name is live, not retired,
+    /// whatever `previous` held.
+    pub fn retiring_from(mut self, previous: &ProviderRegistry) -> Self {
+        for (name, provider) in previous.providers.iter().chain(previous.retired.iter()) {
+            if !self.providers.contains_key(name) {
+                self.retired
+                    .entry(name.clone())
+                    .or_insert_with(|| provider.clone());
+            }
+        }
+        self
+    }
+
+    /// The names of the retired providers, sorted; for logs and tests.
+    pub fn retired_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.retired.keys().cloned().collect();
+        names.sort();
+        names
     }
 
     /// Let every registered provider learn what its own API says about its

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -303,6 +303,8 @@ pub struct PipelineWorld {
 /// Agent status control: read a status, set one, and pause/resume/cancel.
 /// Split out to keep this file inside the workspace structure limit.
 mod control;
+/// Swapping the provider registry for one built from a newer config.
+mod providers;
 
 impl PipelineWorld {
     /// Build a world: wire the pool/bridge resources, register the providers and

--- a/crates/leviath-runtime/src/world/providers.rs
+++ b/crates/leviath-runtime/src/world/providers.rs
@@ -1,0 +1,250 @@
+//! Swapping the world's provider registry for one built from a newer config.
+//!
+//! The daemon builds its registry from `config.toml` once at boot and holds
+//! it as the [`Providers`] resource. A user who then ran `lev setup` to move
+//! to another provider, or removed a key, found every new run still resolving
+//! against the boot-time set: the file had changed, the registry had not, and
+//! nothing short of a daemon restart rebuilt it. [`PipelineWorld::replace_providers`]
+//! is the seam that rebuild goes through.
+
+use super::*;
+use crate::pipeline::ProviderCircuits;
+
+impl PipelineWorld {
+    /// Install `registry` as the world's providers, retiring rather than
+    /// dropping whatever the old one had that the new one lacks (see
+    /// [`ProviderRegistry::retiring_from`]), and forget the circuit-breaker
+    /// record of every provider named in `credentials_changed`: the failures
+    /// that opened that circuit belong to the old key.
+    ///
+    /// A run that is mid-stage keeps its `provider_name`, so it finishes the
+    /// stage on the provider it started on (through the retired entry when
+    /// the provider is gone from the config); only resolution for a new run,
+    /// a new stage or a reloaded run sees the new set.
+    pub fn replace_providers(
+        &mut self,
+        registry: ProviderRegistry,
+        credentials_changed: &[String],
+    ) {
+        // Every `PipelineWorld` has the resource from construction, so there
+        // is always a previous set to retire from.
+        let registry = registry.retiring_from(self.providers());
+        if !credentials_changed.is_empty()
+            && let Some(mut circuits) = self.world.get_resource_mut::<ProviderCircuits>()
+        {
+            for name in credentials_changed {
+                circuits.forget(name);
+            }
+        }
+        tracing::info!(
+            providers = ?registry.resolvable_names(),
+            retired = ?registry.retired_names(),
+            credentials_changed = ?credentials_changed,
+            "provider registry rebuilt from the current config"
+        );
+        self.world.insert_resource(Providers(registry));
+        self.wake.notify_one();
+    }
+
+    /// The world's current provider registry.
+    pub fn providers(&self) -> &ProviderRegistry {
+        &self
+            .world
+            .get_resource::<Providers>()
+            .expect("Providers resource present in a PipelineWorld")
+            .0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::CircuitPolicy;
+    use crate::tool_bridge::BoxedToolExec;
+    use leviath_providers::{
+        InferenceRequest, InferenceResponse, ModelCapabilities, Provider, UnavailableReason,
+    };
+
+    struct Named(&'static str);
+
+    #[async_trait::async_trait]
+    impl Provider for Named {
+        async fn infer(
+            &self,
+            _req: &InferenceRequest,
+        ) -> leviath_providers::Result<InferenceResponse> {
+            Err(ProviderError::Other("never called".to_string()))
+        }
+        async fn count_tokens(&self, _t: &str, _m: &str) -> usize {
+            1
+        }
+        fn max_context_tokens(&self, _m: &str) -> usize {
+            1000
+        }
+        fn name(&self) -> &str {
+            self.0
+        }
+        fn capabilities(&self, _m: &str) -> ModelCapabilities {
+            ModelCapabilities::default()
+        }
+    }
+
+    struct NoTools;
+    impl ToolService for NoTools {
+        fn exec_for(
+            &self,
+            _entity: Entity,
+            _calls: Vec<leviath_providers::ToolCall>,
+            _progress: crate::pipeline::ToolProgress,
+        ) -> BoxedToolExec {
+            Box::new(move || Box::pin(async move { Vec::new() }))
+        }
+    }
+
+    fn registry_of(names: &[&'static str]) -> ProviderRegistry {
+        let mut r = ProviderRegistry::new();
+        for n in names {
+            r.register(n.to_string(), Arc::new(Named(n)));
+        }
+        r
+    }
+
+    fn world_with(names: &[&'static str], circuits: bool) -> PipelineWorld {
+        let mut world = PipelineWorld::new(
+            registry_of(names),
+            Arc::new(NoTools),
+            InferencePoolConfig::new(),
+            1,
+            None,
+            Handle::current(),
+        );
+        if circuits {
+            world.world_mut().init_resource::<ProviderCircuits>();
+        }
+        world
+    }
+
+    #[tokio::test]
+    async fn a_rebuilt_registry_replaces_the_resource_and_retires_what_it_lost() {
+        let mut world = world_with(&["anthropic"], true);
+        world.replace_providers(registry_of(&["openrouter"]), &[]);
+        let providers = world.providers();
+        assert!(providers.has("openrouter"), "the new provider resolves");
+        assert!(
+            !providers.has("anthropic"),
+            "the removed one no longer resolves"
+        );
+        assert!(
+            providers.get("anthropic").is_some(),
+            "but a run mid-stage on it can still call it"
+        );
+        assert_eq!(providers.retired_names(), vec!["anthropic".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn a_provider_registered_again_is_live_not_retired() {
+        let mut world = world_with(&["anthropic"], true);
+        world.replace_providers(registry_of(&["openrouter"]), &[]);
+        world.replace_providers(registry_of(&["anthropic"]), &[]);
+        let providers = world.providers();
+        assert!(providers.has("anthropic"));
+        assert_eq!(providers.retired_names(), vec!["openrouter".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn a_changed_credential_clears_that_providers_circuit_and_no_other() {
+        let mut world = world_with(&["anthropic", "openai"], true);
+        let policy = CircuitPolicy {
+            failures_before_open: 1,
+            cooldown_secs: 300,
+        };
+        {
+            let mut circuits = world.world_mut().resource_mut::<ProviderCircuits>();
+            circuits.record_failure(
+                "anthropic",
+                UnavailableReason::CreditsExhausted,
+                None,
+                0,
+                &policy,
+            );
+            circuits.record_failure("openai", UnavailableReason::AuthFailed, None, 0, &policy);
+        }
+        world.replace_providers(
+            registry_of(&["anthropic", "openai"]),
+            &["anthropic".to_string()],
+        );
+        let circuits = world.world().resource::<ProviderCircuits>();
+        assert!(
+            !circuits.is_open("anthropic", 1, &policy),
+            "the new key starts with a clean record"
+        );
+        assert!(
+            circuits.is_open("openai", 1, &policy),
+            "an untouched provider keeps its record"
+        );
+    }
+
+    #[tokio::test]
+    async fn replacing_with_no_circuits_resource_still_installs_the_registry() {
+        // An embedded world that never installed the breaker: a credential
+        // change has no record to forget, and must not panic looking for one.
+        let mut world = world_with(&["a"], false);
+        world.replace_providers(registry_of(&["b"]), &["a".to_string()]);
+        assert!(world.providers().has("b"));
+    }
+
+    #[tokio::test]
+    async fn the_stand_in_tool_service_answers_nothing() {
+        // The world needs a tool service and these tests never call a tool, so
+        // this one exists to be handed over. Driving it once keeps it honest
+        // rather than untested.
+        let exec = NoTools.exec_for(
+            Entity::PLACEHOLDER,
+            Vec::new(),
+            crate::pipeline::noop_progress(),
+        );
+        assert!(exec().await.is_empty());
+    }
+
+    /// The stand-in provider answers like a provider, so the registry it is
+    /// registered in behaves like a real one (and the trait methods this file
+    /// leans on are not untested code).
+    #[tokio::test]
+    async fn the_stand_in_provider_answers_every_call() {
+        let world = world_with(&["a"], false);
+        let provider = world.providers().get("a").unwrap();
+        assert_eq!(provider.name(), "a");
+        assert_eq!(provider.max_context_tokens("m"), 1000);
+        assert_eq!(provider.count_tokens("hello", "m").await, 1);
+        assert_eq!(provider.capabilities("m").max_context_tokens, 8192);
+        let request = InferenceRequest {
+            system: Vec::new(),
+            messages: Vec::new(),
+            model: "m".to_string(),
+            max_tokens: 16,
+            temperature: 0.0,
+            tools: Vec::new(),
+            extra: Default::default(),
+            request_timeout_secs: None,
+        };
+        assert!(provider.infer(&request).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn a_script_layer_is_carried_across_a_rebuild() {
+        let dir = tempfile::tempdir().unwrap();
+        let layer = Arc::new(crate::script_provider::ScriptProviderLayer::new(
+            dir.path().to_path_buf(),
+            Default::default(),
+            Default::default(),
+            None,
+            Vec::new(),
+        ));
+        let mut world = world_with(&["a"], false);
+        world.replace_providers(registry_of(&["b"]).with_script_layer(layer), &[]);
+        assert!(
+            world.providers().script_layer().is_some(),
+            "the rebuilt registry keeps loading .rhai providers"
+        );
+    }
+}

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -213,7 +213,7 @@ Base path `/api`; all JSON unless noted.
 | `POST /api/agents/{id}/message` | Steer a running agent |
 | `GET/POST /api/agents/{id}/interaction` | Read / answer a pending question. See [below](#answering-a-question) |
 | `GET/POST/PUT/DELETE /api/blueprints[/{name}]` · `/validate` | Blueprint CRUD + validation. The listing is paginated and takes `q`; the detail carries the manifest, the regions and the [fan-out limits](#fan-out-limits) |
-| `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key |
+| `GET /api/config` · `PUT /api/config` *(admin)* · `POST /api/config/validate` | Read redacted config · write keys · validate a key. A `PUT` that changes a provider key, a gateway or `default_provider` applies to the next run spawned, with no daemon restart |
 | `GET /api/models` | Enumerate models, with each one's token limits and where they came from. An OpenAI-compatible gateway's detected models are listed under the gateway's name |
 | `POST /api/models/probe` *(admin)* | Ask an OpenAI-compatible server what it serves before writing a gateway for it: `{"base_url", "api_key"?, "headers"?}` → `{"models": [ids]}`, or 502 carrying the server's own error text. See [below](#gateways) |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -18,9 +18,13 @@ where you look up the exact name, type, and default. The same contract ships mac
 
 > [!NOTE]
 > The daemon watches this file and reloads it when it changes, so an edit takes effect on the
-> **next** `lev run` with no restart. `lev serve` reads it per request, so an edit - through
-> `PUT /api/config` or from anywhere else - is on the next page load. Boot-time wiring (native
-> provider keys, MCP connections, telemetry exporters) still needs `lev daemon restart`. See
+> **next** `lev run` with no restart. That includes providers: a key you add, replace or remove,
+> a changed `default_provider`, and a `[model_providers]` entry you add or delete are all picked
+> up by the next run started, whether it came from `lev run`, the API or the dashboard, and it
+> makes no difference whether the edit came from `lev setup`, `PUT /api/config` or an editor. A
+> run already under way keeps the provider its current stage started on. `lev serve` reads the
+> file per request, so an edit is on the next page load. MCP connections and telemetry exporters
+> are still boot-time wiring and need `lev daemon restart`. See
 > [the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run).
 
 ## Top level

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -163,13 +163,22 @@ one feature disagree in silence - setting a `base_url` and watching it do nothin
 like having typed the key wrong. Both halves are now live: edit the script, the table, or
 `[security] allow_env_vars`, and the next provider load uses it.
 
-Some changes do still need `lev daemon restart`. They set up connections and process-wide state
-once at startup rather than per run:
+Provider credentials reload as well. Add a key, replace one, remove one by untoggling it in
+`lev setup`, point a provider at another base URL, or change `default_provider`: the daemon
+compares the file's credentials against the ones its registry was built from, and rebuilds the
+registry when they differ, before the next run resolves its stages. It makes no difference whether
+the write came from `lev setup`, `PUT /api/config` or an editor, because all three write the same
+file. Two details are deliberate:
 
-- **Native** provider keys (`[providers]`, `openrouter_api_key`, `ollama_base_url`), which build the
-  provider registry at boot.
-- `[[mcp_servers]]` (live MCP connections), `[observability]` (the telemetry pipeline), and
-  `[security] allow_local_network` (the outbound-network policy).
+- A run **already under way** keeps calling the provider its current stage started on, even one you
+  removed, so a config edit never pulls a provider out from under a stage mid-flight. New runs, new
+  stages, and a parked run you `lev resume` all resolve against the new set.
+- A provider whose key changed has its circuit-breaker record cleared, so a key you just replaced is
+  tried immediately instead of sitting out the rest of the old key's cooldown.
+
+Some changes do still need `lev daemon restart`. They set up connections and process-wide state
+once at startup rather than per run: `[[mcp_servers]]` (live MCP connections), `[observability]`
+(the telemetry pipeline), and `[security] allow_local_network` (the outbound-network policy).
 - The `[limits]` the world itself is built with: `stall_timeout_secs`, `wedge_timeout_secs`,
   `dead_cycles_before_relief`, `max_concurrent_inferences`, `max_concurrent_tools`,
   `provider_failures_before_open`, `provider_circuit_cooldown_secs`,

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -114,7 +114,10 @@ on its next start.
 
 Check its provider first, with `lev doctor`. If a stage's model list names only providers you
 haven't configured, `lev run` refuses the spawn outright and tells you which ones it tried.
-Configure one with `lev setup`, or add it to `config.toml` and restart the daemon.
+Configure one with `lev setup`, or add it to `config.toml`. Either way the next run you start
+uses it: the daemon rebuilds its providers from the file, so there is nothing to restart. A run
+that parked because its provider ran out of credits moves to whatever the file names now when you
+`lev resume` it.
 
 A run that gets past that and still can't dispatch (say you removed a provider key after it
 started) is failed after `[limits] stall_timeout_secs`, 60 seconds by default. Its `meta.json`


### PR DESCRIPTION
## The report

> user setup with anthropic key; user did a run which used all credits with timeouts; user ran
> setup to switch to open router as their default provider instead; upon start a new run via http
> APIs, it tried to use the anthropic key which errored about no credits; user tried updating via
> http APIs and by restarting serve, issue persists; user tried to remove the anthropic key in
> setup by untoggling it, then restarted the serve, and it still said the same error in another new
> run; user had to kill the daemon and restart it to make it take effect.

Their read - "the daemon is not updating dynamically" - is exactly right, and the trace below says
where.

## Trace

- The registry is built once, at daemon start:
  `crates/leviath-cli/src/daemon/setup.rs:157` calls `build_provider_registry_live`, which is
  `crates/leviath-cli/src/commands/run/session.rs:244` over
  `provider_creds_from_config` (`session.rs:32`) and
  `leviath_runtime::provider_creds::build_provider_registry_probing`.
- It is then moved into the world as a resource and never replaced:
  `crates/leviath-runtime/src/world.rs:365` (`world.insert_resource(Providers(providers))`).
  Every consumer reads that one value: stage resolution at
  `crates/leviath-cli/src/daemon/spawn/mod.rs:548`, dispatch at
  `crates/leviath-runtime/src/pipeline/inference.rs:375`, plus title, compaction and transition.
- The hot reload from #180 **deliberately** stopped short of it. Its own module header said so:
  `crates/leviath-cli/src/daemon/config_reload.rs:16-22` - "What it deliberately does not reload is
  the infrastructure established once at boot: the provider registry ... Adding a provider key
  still needs a daemon restart". So `lev setup` writing the file changed spawn-time settings and
  nothing about providers.
- `lev setup` writes `~/.leviath/config.toml` and signals nobody
  (`crates/leviath-cli/src/commands/setup/mod.rs:188,197`). Untoggling a provider clears the key
  from the file (`setup/catalog.rs:197`), so the file was right the whole time.
- `PUT /api/config` writes the same file and returns
  (`crates/leviath-cli/src/commands/serve/config.rs:74-166`, ending at `save_to_path_public`).
  Restarting `lev serve` could never help: it is a separate process that holds a `ConfigReloader`
  (`serve/types.rs:139`) and no registry at all.
- Default-provider resolution is a function of the registry, so a stale registry defeats it:
  `crates/leviath-runtime/src/pipeline/resolve.rs:253` promotes `default_provider` only
  `if registry.has(&defaults.provider)` - with openrouter absent from the boot registry the
  promotion silently did nothing and the blueprint's own anthropic entry won.
- The credits pause compounded it. A 402 is `UnavailableReason::CreditsExhausted`
  (`crates/leviath-providers/src/provider.rs:88`), which opens the circuit
  (`pipeline/circuit.rs:117`) and parks the run (`pipeline/stall.rs:290-345`). A parked run is
  despawned (`host/emit.rs:275-283`), and resuming it re-resolves through the reload hook
  (`daemon/setup.rs`, `set_reloader`) - against the same stale registry, so it re-parked.

Nothing caches a key anywhere else: `lev serve` holds no registry, and the script-provider layer
already follows the config (#533). One stale value, three entry points.

## Before (measured, live)

Two mock providers on two ports, each logging which one served each completion. The daemon boots
with only A configured; each step rewrites `config.toml` the way `lev setup` does and starts a run
through `POST /api/agents`. Harness: `perf-tools/harness.sh` conventions (short `LEVIATH_HOME`,
`LEVIATH_SKIP_DOTENV=1`, `start_new_session=True`, `LEVIATH_API_TOKEN`).

Run twice: **endpoint** mode (A and B are `[model_providers.<name>] kind = "openai-compatible"`)
and **native** mode (A is `openai`, B is `openrouter`, keys and base URLs under `[providers]`).

| # | Step | endpoint: served by | native: served by |
|---|---|---|---|
| 1 | boot, only A configured, `default_provider = A` | a | openai |
| 2 | config rewritten: B key added, `default_provider = B` | **a** | **openai** |
| 3 | config rewritten: A key removed (untoggled) | **a** | **openai** |
| 4 | `PUT /api/config` adds B and sets it default | **a** | **openai** |
| 5 | `lev serve` restarted, daemon untouched | **a** | **openai** |
| 6a | only A, A answers 402 | a, run **paused** | openai, run **paused** |
| 6b | config -> B only, then resume the parked run | **a, still paused** | **openai, still paused** |
| 6c | blueprint pinned to A, A removed from config | **a** (ran on a removed provider) | **openai** |
| 7 | daemon killed and restarted (the user's workaround) | b | openrouter |

Every step reproduces the report, including "restarting serve does not help" and "removing the key
does not help".

## The fix

- `crates/leviath-runtime/src/world/providers.rs` (new): `PipelineWorld::replace_providers` swaps
  the `Providers` resource and forgets the circuit-breaker record of every provider whose
  credentials changed - the failures that opened that circuit belong to the key that was replaced.
- `ProviderRegistry::retiring_from` / `retired_names` (`crates/leviath-runtime/src/providers.rs`):
  a provider the new config dropped stays reachable through `get` but disappears from `has`,
  `native_providers` and `resolvable_names`. A run mid-stage on it finishes that stage on it;
  nothing new resolves to it. **Zero swapping under a running stage.**
- `crates/leviath-cli/src/daemon/provider_reload.rs` (new): compares the credentials the file holds
  now against the ones the registry was built from (`ProviderCreds` gained `PartialEq`), rebuilds
  when they differ, carries the script layer across, and reports which providers changed. Comparing
  credentials rather than the file's mtime means a limits or permissions edit does not rebuild
  providers under a running daemon.
- Wired at three points in `crates/leviath-cli/src/daemon/setup.rs`: the spawn preprocessor (async,
  so the new providers' model lists are primed before the run is sized), the spawner (covers
  sub-agent and fan-out spawns that run no preprocessor - a credential comparison when nothing
  changed), and the reload hook (so a parked run resumes against the current config).
- `lev setup` and `PUT /api/config` need no new message: they write the file, and the daemon reads
  the file. There is no reload op on the control socket (#180 added none), and adding one would
  have covered strictly less than the file check - an editor writes no message either.
- Two remedy strings that told people to restart the daemon are now correct
  (`pipeline/resolve.rs:654`, `pipeline/stall.rs:67`).

## Fail-first evidence

`daemon::setup::tests::a_provider_configured_after_boot_is_usable_on_the_next_spawn` drives two
real spawns through `host.serve()` with a config rewrite between them. With the three
`refresh`/`install` calls removed and everything else intact:

```
assertion `left == right` failed: the provider the user just configured has to work without a daemon restart
  left: Err("stage 'work' has no usable provider (tried: beta). Configure one with `lev setup`, or add it to config.toml and restart the daemon.")
 right: Ok("run-after")
```

That is the user's error, reproduced in a unit test. With the fix: passes. The other new tests
(`daemon::provider_reload::tests::*`, `world::providers::tests::*`) cover the pieces: a new key is
used, a removed key stops being a route, a replaced key reports that provider alone, an unrelated
config edit changes nothing, the breaker is cleared for the changed provider and no other, a
registry that cannot be built leaves the working one in service, and the script layer survives a
rebuild. No `#[cfg(unix)]` anywhere - all of it runs on Windows.

## After (same harness, same steps)

| # | Step | endpoint: served by | native: served by |
|---|---|---|---|
| 1 | boot, only A configured, `default_provider = A` | a | openai |
| 2 | config rewritten: B key added, `default_provider = B` | **b** | **openrouter** |
| 3 | config rewritten: A key removed (untoggled) | **b** | **openrouter** |
| 4 | `PUT /api/config` adds B and sets it default | **b** | **openrouter** |
| 5 | `lev serve` restarted, daemon untouched | **b** | **openrouter** |
| 6a | only A, A answers 402 | a, run paused | openai, run paused |
| 6b | config -> B only, then resume the parked run | **b, run completes** | **openrouter, completes** |
| 6c | blueprint pinned to A, A removed from config | **spawn refused, naming A** | **spawn refused, naming A** |
| 7 | daemon restarted | b | openrouter |

Step 6c is the pinned case: the blueprint names A with `allow_user_default = false` and A is gone
from the config, so the spawn is refused with `stage 'main' has no usable provider (tried: a)`
rather than silently running on a provider the user removed. Step 7, the old workaround, is now
indistinguishable from every other row.

## Gates

`cargo fmt --all`; `cargo clippy --all-targets --all-features -D warnings` on leviath-runtime,
leviath-providers and leviath-cli; `cargo test -p leviath-runtime --lib` (1651) and
`-p leviath-cli --lib` (4146); `cargo xtask structure` (429 files, none over 1200);
`cargo xtask docs` (40 pages, no problems); `cargo xtask coverage --package` at 100% for
leviath-runtime, leviath-providers and leviath-cli. Pre-commit ran the full suite on all three
commits. No `main.rs` touched. No em dashes.
