### PR TITLE
fix(daemon): let the outbound-network policy follow config.toml down as well as up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -321,6 +321,16 @@ same list.
   writes a timeout into a fresh config. A config with `interaction_timeout_secs
   = 0` keeps working (it means unset). The tool result for a prompt that closed
   without an answer only mentions a timeout when one is configured.
+- `[security] allow_local_network`, `[limits] script_http_timeout_secs` and
+  `[limits] script_http_max_per_host` follow `config.toml` instead of being
+  whatever the daemon booted with. All three are copied into process-wide state
+  because the shared HTTP client the script tools go through has no handle on
+  the config, and the copy was written once at start-up. The per-agent
+  `allow_local_network` check next to it already read the reloaded file, so the
+  two halves disagreed in the direction that matters: turning the switch off
+  refused the URL a script named, and went on following a redirect from a
+  permitted URL down to loopback until the daemon was restarted.
+
 - A `[model_providers.<name>]` entry with `kind = "openai-compatible"` no
   longer loads with a key the endpoint does not read; the error names the
   entry, the keys, and the ones it does read. Unrecognised keys on a script

--- a/crates/leviath-cli/src/daemon/config_reload.rs
+++ b/crates/leviath-cli/src/daemon/config_reload.rs
@@ -15,10 +15,16 @@
 //!
 //! Provider credentials are rebuilt from the same reloaded config by the
 //! `provider_reload` module beside this one, so a key added or removed here
-//! reaches the next run too. What is still established once at boot is MCP
-//! connections, the outbound-network policy and the telemetry sink: those hold
-//! live connections and process-wide state, and adding an MCP server still
-//! needs a daemon restart; see `daemon.md`.
+//! reaches the next run too. Settings that live somewhere other than the
+//! spawn-time config follow it through [`ConfigReloader::with_reload_hook`]: a
+//! caller registers what to re-apply, and it runs on each successful reload.
+//! The daemon uses it for the process-wide network policy, which is mirrored
+//! into atomics the shared blocking HTTP client reads
+//! (`script_host::mirror_process_policy`).
+//!
+//! What is still established once at boot is MCP connections and the telemetry
+//! sink: those hold live connections and process-wide state, and adding an MCP
+//! server still needs a daemon restart; see `daemon.md`.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};
@@ -35,6 +41,10 @@ struct Cached {
     config: Arc<Config>,
 }
 
+/// What to re-apply when `config.toml` reloads, for settings that live
+/// outside the config an agent reads at spawn.
+pub(crate) type ReloadHook = Box<dyn Fn(&Config) + Send + Sync>;
+
 /// Serves the freshest spawn-time [`Config`], reloading `config.toml` when it
 /// changes on disk.
 pub struct ConfigReloader {
@@ -42,6 +52,13 @@ pub struct ConfigReloader {
     /// `None` for a [`fixed`](Self::fixed) reloader that never watches a file.
     path: Option<PathBuf>,
     cache: Mutex<Cached>,
+    /// Run on each *successful* reload, with the config just loaded. `None`
+    /// for a caller with nothing outside the config to keep in step - which is
+    /// every caller but the daemon, and is why this is opt-in rather than
+    /// wired in here: the hook the daemon installs writes process-wide
+    /// atomics, and a test that stood up a host would otherwise write them
+    /// too, under every other test in the binary.
+    on_reload: Option<ReloadHook>,
 }
 
 impl ConfigReloader {
@@ -57,7 +74,18 @@ impl ConfigReloader {
                 mtime,
                 config: Arc::new(initial),
             }),
+            on_reload: None,
         }
+    }
+
+    /// Run `hook` with the new config every time this reloader picks up a
+    /// change, so a setting that has been copied somewhere else - a
+    /// process-wide atomic, a live resource - follows the file down as well as
+    /// up. Not called for the config the reloader was constructed with: that
+    /// one the caller already has, and applies itself.
+    pub(crate) fn with_reload_hook(mut self, hook: ReloadHook) -> Self {
+        self.on_reload = Some(hook);
+        self
     }
 
     /// A reloader that never watches a file: [`current`](Self::current) always
@@ -71,6 +99,7 @@ impl ConfigReloader {
                 mtime: None,
                 config: Arc::new(config),
             }),
+            on_reload: None,
         }
     }
 
@@ -109,6 +138,13 @@ impl ConfigReloader {
                 let config = Arc::new(config);
                 cached.mtime = mtime;
                 cached.config = config.clone();
+                // Under the cache lock on purpose: the hook re-applies settings
+                // that have been copied elsewhere, and two threads reloading at
+                // once must not install their configs in one order and their
+                // side effects in the other.
+                if let Some(hook) = &self.on_reload {
+                    hook(&config);
+                }
                 tracing::info!(path = %displayed, "reloaded config after an on-disk change");
                 config
             }
@@ -253,6 +289,54 @@ mod tests {
             vec!["~/good".to_string()],
             "a broken file must not break the spawn - keep the last good config"
         );
+    }
+
+    /// A setting the daemon has copied somewhere else - the process-wide
+    /// network atomics - has to follow the file, and the reloader is where
+    /// that is noticed. The hook fires once per successful reload: on every
+    /// read it would be pointless work, on none of them `allow_local_network`
+    /// would stay at its boot value for the daemon's life, and on a broken
+    /// save it would re-apply a policy parsed out of half a file.
+    #[test]
+    fn the_reload_hook_runs_once_per_good_save_and_never_on_a_bad_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &empty_config());
+        let seen: Arc<Mutex<Vec<bool>>> = Arc::new(Mutex::new(Vec::new()));
+        let recorder = seen.clone();
+        let reloader = ConfigReloader::new(path.clone(), Config::default()).with_reload_hook(
+            Box::new(move |config| {
+                recorder
+                    .lock()
+                    .unwrap_or_else(PoisonError::into_inner)
+                    .push(config.security.allow_local_network);
+            }),
+        );
+        let recorded = || seen.lock().unwrap_or_else(PoisonError::into_inner).clone();
+
+        // The config it was built with is the caller's own; no hook for it.
+        let _ = reloader.current();
+        assert!(recorded().is_empty());
+
+        let mut tightened = Config::default();
+        tightened.security.allow_local_network = true;
+        write(&path, &toml::to_string(&tightened).unwrap());
+        bump_mtime(&path);
+        let _ = reloader.current();
+        // Read again with the file unchanged: still one call.
+        let _ = reloader.current();
+        assert_eq!(
+            recorded(),
+            vec![true],
+            "the hook runs once per change, with the config that changed"
+        );
+
+        // A half-saved edit keeps the last good config, so it keeps the last
+        // good side effects too.
+        write(&path, "not : : toml");
+        bump_mtime(&path);
+        let _ = reloader.current();
+        assert_eq!(recorded(), vec![true], "a broken save applies nothing");
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/script_host.rs
+++ b/crates/leviath-cli/src/daemon/script_host.rs
@@ -28,9 +28,11 @@ use crate::daemon::sandbox_manager::SandboxManager;
 
 mod http_limits;
 mod permissions;
+pub(crate) use http_limits::mirror_process_policy;
 use http_limits::*;
 #[cfg(test)]
 pub(crate) use http_limits::{REDIRECT_MIRROR, lock_redirect_mirror};
+#[cfg(test)]
 pub(crate) use http_limits::{
     set_local_network_allowed, set_script_http_max_per_host, set_script_http_timeout,
 };
@@ -1708,6 +1710,76 @@ mod tests {
         .await
         .unwrap();
         let err = out.expect_err("a redirect to loopback must not be followed");
+        assert!(err.contains("refused to follow redirect"), "got: {err}");
+    }
+
+    /// `[security] allow_local_network` has to travel **down** as well as up.
+    ///
+    /// The per-agent check reads the reloaded config, so tightening the switch
+    /// stopped a script naming a loopback URL straight away - but the redirect
+    /// policy is a process-wide mirror that was written once at daemon
+    /// start-up, so a permitted URL bouncing to loopback went on being
+    /// followed until the daemon was restarted. Loosening it worked (the
+    /// mirror defaults to the *safe* value, so boot could only widen it),
+    /// which is exactly why nobody noticed. Drives the real
+    /// `mirror_process_policy` in both directions over one live redirect.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn the_redirect_policy_follows_the_config_down_as_well_as_up() {
+        use axum::Router;
+        use axum::response::Redirect;
+        use axum::routing::get;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route(
+                "/bounce",
+                get(move || async move { Redirect::temporary(&format!("http://{addr}/ok")) }),
+            )
+            .route("/ok", get(|| async { "ARRIVED" }));
+        tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
+            listener, app,
+        )));
+
+        let mut permissive = crate::config::Config::default();
+        permissive.security.allow_local_network = true;
+        let strict = crate::config::Config::default();
+        assert!(
+            !strict.security.allow_local_network,
+            "the default is the closed one, which is what makes this a tightening"
+        );
+
+        // Both process-wide statics this writes have their own test lock; the
+        // guard covers the whole request, as in the tests above.
+        let guard = REDIRECT_MIRROR.lock().await;
+        let (opened, closed) = tokio::task::spawn_blocking(move || {
+            let _guard = guard;
+            let _limits = lock_http_limits();
+            let previous = local_network_allowed();
+            let previous_max = HTTP_MAX_PER_HOST.load(std::sync::atomic::Ordering::Relaxed);
+            let previous_timeout = HTTP_TIMEOUT_SECS.load(std::sync::atomic::Ordering::Relaxed);
+            let url = format!("http://{addr}/bounce");
+
+            mirror_process_policy(&permissive);
+            let opened = RealScriptIo.http_get(&url, BTreeMap::new());
+            // The tightening a user saves: same process, same client, no restart.
+            mirror_process_policy(&strict);
+            let closed = RealScriptIo.http_get(&url, BTreeMap::new());
+
+            set_local_network_allowed(previous);
+            set_script_http_max_per_host(previous_max);
+            set_script_http_timeout(previous_timeout);
+            (opened, closed)
+        })
+        .await
+        .unwrap();
+
+        assert_eq!(
+            opened.expect("a permitted hop is followed"),
+            "ARRIVED",
+            "the loosened config has to reach the client, or the tightening below proves nothing"
+        );
+        let err = closed.expect_err("the tightened config must stop the same hop");
         assert!(err.contains("refused to follow redirect"), "got: {err}");
     }
 

--- a/crates/leviath-cli/src/daemon/script_host/http_limits.rs
+++ b/crates/leviath-cli/src/daemon/script_host/http_limits.rs
@@ -163,3 +163,17 @@ pub(crate) fn set_local_network_allowed(allow: bool) {
 pub(super) fn local_network_allowed() -> bool {
     ALLOW_LOCAL_REDIRECTS.load(std::sync::atomic::Ordering::Relaxed)
 }
+
+/// Mirror the process-wide slice of `config` into the three atomics above.
+///
+/// Called at daemon start-up and again on every `config.toml` reload. The
+/// reload half is the security-relevant one. The per-agent check for
+/// `[security] allow_local_network` reads the reloaded config already, so a
+/// user who *tightened* the switch had the URL a script names refused while a
+/// redirect from a permitted URL to loopback was still followed - for as long
+/// as the daemon lived. Policy has to be able to travel down, not only up.
+pub(crate) fn mirror_process_policy(config: &crate::config::Config) {
+    set_local_network_allowed(config.security.allow_local_network);
+    set_script_http_max_per_host(config.limits.script_http_max_per_host);
+    set_script_http_timeout(config.limits.script_http_timeout_secs);
+}

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -136,24 +136,24 @@ pub(crate) async fn setup_daemon_host_with(
     build_client: leviath_providers::provider::HttpClientFactory<'_>,
 ) -> anyhow::Result<WorldHost> {
     // Apply the machine-wide outbound-network policy before anything can fetch.
-    // It lives in a process-wide atomic because the shared blocking HTTP client's
-    // redirect policy has no per-agent context to consult; see
-    // `script_host::set_local_network_allowed`.
-    crate::daemon::script_host::set_local_network_allowed(config.security.allow_local_network);
-    // Same mirror, same reason: the shared blocking client has no handle on the
-    // config by the time a script tool calls through it.
-    crate::daemon::script_host::set_script_http_max_per_host(
-        config.limits.script_http_max_per_host,
-    );
-    crate::daemon::script_host::set_script_http_timeout(config.limits.script_http_timeout_secs);
+    // These live in process-wide atomics because the shared blocking HTTP
+    // client's redirect policy and per-host gate have no per-agent context to
+    // consult; see `script_host::mirror_process_policy`.
+    crate::daemon::script_host::mirror_process_policy(&config);
     // Built before the registry, and shared with it: a script provider's
     // `[model_providers.<name>]` table is read through this, so editing it
     // takes effect on the next load exactly as editing the `.rhai` beside it
     // already did (issue #533).
-    let reloader = Arc::new(crate::daemon::config_reload::ConfigReloader::new(
-        Config::config_path(),
-        config.clone(),
-    ));
+    //
+    // The same mirror is re-applied on every reload. Without that, the three
+    // atomics were the config the daemon *booted* with for the rest of its
+    // life, while the per-agent `allow_local_network` check next to them read
+    // the reloaded file - so tightening the switch refused the URL a script
+    // named and went on following a redirect to loopback.
+    let reloader = Arc::new(
+        crate::daemon::config_reload::ConfigReloader::new(Config::config_path(), config.clone())
+            .with_reload_hook(Box::new(crate::daemon::script_host::mirror_process_policy)),
+    );
     let providers = crate::commands::run::session::build_provider_registry_live(
         &config,
         reloader.clone(),

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -177,8 +177,9 @@ file. Two details are deliberate:
   tried immediately instead of sitting out the rest of the old key's cooldown.
 
 Some changes do still need `lev daemon restart`. They set up connections and process-wide state
-once at startup rather than per run: `[[mcp_servers]]` (live MCP connections), `[observability]`
-(the telemetry pipeline), and `[security] allow_local_network` (the outbound-network policy).
+once at startup rather than per run:
+
+- `[[mcp_servers]]` (live MCP connections) and `[observability]` (the telemetry pipeline).
 - The `[limits]` the world itself is built with: `stall_timeout_secs`, `wedge_timeout_secs`,
   `dead_cycles_before_relief`, `max_concurrent_inferences`, `max_concurrent_tools`,
   `provider_failures_before_open`, `provider_circuit_cooldown_secs`,
@@ -186,6 +187,14 @@ once at startup rather than per run: `[[mcp_servers]]` (live MCP connections), `
 
 `[providers] fallback_order` is not one of them. It is per-run policy, so it reloads like everything
 else and a new fallback provider applies on the next `lev run`.
+
+Neither is the outbound-network policy. `[security] allow_local_network` and the two script-HTTP
+limits, `script_http_timeout_secs` and `script_http_max_per_host`, are copied into process-wide
+state because the shared HTTP client has no handle on your config by the time a script tool calls
+through it. That copy is now refreshed on every reload, so all three follow the file. It matters
+most in the direction nobody tests: turning `allow_local_network` **off** used to stop a script
+naming a loopback URL at once, while a redirect from a permitted URL down to loopback carried on
+being followed until you restarted the daemon.
 
 ## Control surface
 


### PR DESCRIPTION
The user asked whether anything still needs a daemon restart. Three settings in
my area did, silently, and one of them is security-relevant in the direction
that matters.

## What was boot-only, per setting

| Setting | Before | After |
|---|---|---|
| `[security] allow_local_network` | mirrored into `ALLOW_LOCAL_REDIRECTS` once at `setup.rs:~142` | re-mirrored on every `config.toml` reload |
| `[limits] script_http_max_per_host` | mirrored into `HTTP_MAX_PER_HOST` once at `setup.rs:~145` | re-mirrored on every reload |
| `[limits] script_http_timeout_secs` | mirrored into `HTTP_TIMEOUT_SECS` once at `setup.rs:~148` | re-mirrored on every reload |

All three live in process-wide atomics because the shared blocking HTTP client
that script tools call through has no per-agent context: the redirect callback
runs inside reqwest, and the per-host gate runs on a `spawn_blocking` thread.
That is fine. What was not fine is that the mirror was written once.

The per-agent check for `allow_local_network` (`spawn/mod.rs:~719`) already
reads the reloaded config, so the two halves of one switch disagreed. Turning
it **off** stopped a script naming a loopback URL at once, and left the
client's redirect policy permissive: a request to a permitted host that bounced
to loopback carried on being followed until the daemon was restarted. The
atomic defaults to the closed value, so start-up could only ever widen it -
which is why the gap opens only when tightening, and why nothing caught it.

## Shape

- `script_host::mirror_process_policy(&config)` is the one place all three are
  applied. `setup_daemon_host_with` calls it at boot, as before.
- `ConfigReloader` gains an opt-in `with_reload_hook`, run under the cache lock
  on each *successful* reload, so two threads reloading at once cannot install
  their configs in one order and their side effects in the other. A broken
  half-saved file keeps the last good config and runs no hook.
- Only the daemon installs a hook. It is opt-in rather than wired into
  `ConfigReloader::new` because the hook writes process-wide atomics: a test
  that stands up a host would otherwise write them under every other test in
  the binary, which is the exact hazard `REDIRECT_MIRROR` was added for.
- The three setters are now `#[cfg(test)]`-only outside the module; production
  goes through `mirror_process_policy`.

## Fail-first evidence

`the_redirect_policy_follows_the_config_down_as_well_as_up` stands up an axum
server with `/bounce` redirecting to `/ok`, drives the real
`mirror_process_policy` permissive-then-strict over one live redirect, and
asserts the hop is followed and then refused. The "up" half is asserted too, so
the "down" half cannot pass vacuously.

Against the old behaviour, modelled by making `mirror_process_policy` a no-op
after its first call (which is what "mirrored once at boot" means), tests kept:

```
test daemon::script_host::tests::the_redirect_policy_follows_the_config_down_as_well_as_up ... FAILED

panicked at crates/leviath-cli/src/daemon/script_host.rs:1782:26:
the tightened config must stop the same hop: "ARRIVED"
```

`the_reload_hook_runs_once_per_good_save_and_never_on_a_bad_one` covers the
reloader half: no hook for the config it was constructed with, one call per
change carrying the config that changed, none on a repeat read, none on an
unparseable save.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`
- `cargo test -p leviath-cli --lib daemon::config_reload` (6 passed),
  `--lib daemon::script_host::tests::the_redirect_policy` (1 passed)
- `cargo xtask structure` (427 files, none over 1200), `cargo xtask docs`
  (40 pages, no problems)
- `cargo xtask coverage --package leviath-cli`: 100%
- pre-commit (full suite) passed on commit

## Docs

`docs/content/daemon.md`: `[security] allow_local_network` comes off the
restart list, and a paragraph says what the process-wide copy is and which
direction used to be the broken one. CHANGELOG under Changed.

No `main.rs` touched.
