### PR TITLE
fix(daemon): a policy rule you add is in force for the next run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,6 @@ same list.
 
 ## Unreleased
 
-### Fixed
-
-- The daemon rebuilds its provider registry when `config.toml` changes, so a provider you
-  configure, replace or remove is picked up by the next run instead of at the next daemon
-  restart. The registry was built once at boot: a user who ran out of credits on one provider,
-  switched to another with `lev setup`, and started a new run watched it go to the old provider
-  and fail, and neither restarting `lev serve` nor removing the key helped - only killing the
-  daemon did. Every write path is covered, because they all write the same file: `lev setup`,
-  `PUT /api/config`, and an editor. A run already under way keeps the provider its current stage
-  started on, so nothing is swapped mid-stage, and a run parked because its provider had no
-  credits left moves to the new one when you `lev resume` it. A provider whose credentials
-  changed also has its circuit-breaker record cleared, so a replaced key is tried at once rather
-  than serving out the old key's cooldown.
-
 ### Breaking
 
 - `lev add` refuses an agent whose manifest name is not a single safe path
@@ -123,6 +109,33 @@ same list.
 
 ### Fixed
 
+- The daemon rebuilds its provider registry when `config.toml` changes, so a provider you
+  configure, replace or remove is picked up by the next run instead of at the next daemon
+  restart. The registry was built once at boot: a user who ran out of credits on one provider,
+  switched to another with `lev setup`, and started a new run watched it go to the old provider
+  and fail, and neither restarting `lev serve` nor removing the key helped - only killing the
+  daemon did. Every write path is covered, because they all write the same file: `lev setup`,
+  `PUT /api/config`, and an editor. A run already under way keeps the provider its current stage
+  started on, so nothing is swapped mid-stage, and a run parked because its provider had no
+  credits left moves to the new one when you `lev resume` it. A provider whose credentials
+  changed also has its circuit-breaker record cleared, so a replaced key is tried at once rather
+  than serving out the old key's cooldown.
+- `[security] allow_local_network`, `[limits] script_http_timeout_secs` and
+  `[limits] script_http_max_per_host` follow `config.toml` instead of being
+  whatever the daemon booted with. All three are copied into process-wide state
+  because the shared HTTP client the script tools go through has no handle on
+  the config, and the copy was written once at start-up. The per-agent
+  `allow_local_network` check next to it already read the reloaded file, so the
+  two halves disagreed in the direction that matters: turning the switch off
+  refused the URL a script named, and went on following a redirect from a
+  permitted URL down to loopback until the daemon was restarted.
+- The taint gate re-reads `policy.toml` and the `rules/*.rhai` beside it when they change, so a
+  rule you add is in force for the next run instead of at the next daemon restart. Both were read
+  once at startup. The scripted half failed silently on top of that: the rule sources were read
+  into the compiled checker, so editing a `.rhai` file changed nothing whatever and nothing said
+  so. `lev policy add` printing the rule it just wrote while the gate went on blocking the call was
+  the whole of the feedback. A `policy.toml` that will not parse keeps the policy already in force
+  and warns once, rather than dropping an allowlist because a save landed half-written.
 - The update check read the GitHub releases answer with no size cap, the one
   buffered remote read left after the daemon's caps landed. It now stops at
   the same 64 MiB as every other buffered body and reports the same
@@ -329,16 +342,6 @@ same list.
   writes a timeout into a fresh config. A config with `interaction_timeout_secs
   = 0` keeps working (it means unset). The tool result for a prompt that closed
   without an answer only mentions a timeout when one is configured.
-- `[security] allow_local_network`, `[limits] script_http_timeout_secs` and
-  `[limits] script_http_max_per_host` follow `config.toml` instead of being
-  whatever the daemon booted with. All three are copied into process-wide state
-  because the shared HTTP client the script tools go through has no handle on
-  the config, and the copy was written once at start-up. The per-agent
-  `allow_local_network` check next to it already read the reloaded file, so the
-  two halves disagreed in the direction that matters: turning the switch off
-  refused the URL a script named, and went on following a redirect from a
-  permitted URL down to loopback until the daemon was restarted.
-
 - A `[model_providers.<name>]` entry with `kind = "openai-compatible"` no
   longer loads with a key the endpoint does not read; the error names the
   entry, the keys, and the ones it does read. Unrecognised keys on a script
@@ -346,27 +349,6 @@ same list.
   carried them for an endpoint, where nothing read them: a misspelled
   `models` left the endpoint with no catalogue and a misspelled `headers`
   sent none, and the unknown-key warning could not see either.
-- `lev setup` no longer offers the Claude Code transport on its provider
-  list, and with it the reasoning-effort row, the terms dialog on save, and
-  the review-screen warning are gone. The transport itself stays: the
-  `claude_code_enabled`, `claude_code_effort` and `claude_code_binary` keys,
-  the `--claude-code` and `--claude-code-effort` flags, and the MCP import
-  from Claude Code's own config all work as before, and a config that
-  already has it on comes out of the wizard with it still on.
-- A blueprint with a negative integer, or an unknown key under `[sandbox]`,
-  no longer loads; the error names the key. `max_items = -1` used to read as
-  the largest possible cap, and a few keys (a gate's `max_attempts`, a nudge
-  `max`, `request_timeout_secs`, a `stuck_after_*` threshold) dropped the
-  value without a word. A misspelled sandbox key such as `netwrok = false`
-  was ignored, so the sandbox ran looser than the file said.
-- Every read from a remote peer is capped. A provider's buffered JSON reply is
-  cut at 64 MiB, one streamed frame (SSE or NDJSON) at 8 MiB, and one line
-  from an MCP stdio server at 1 MiB; the same caps cover MCP HTTP replies and
-  their event streams. Past a cap the inference or tool call fails with a
-  message naming the cap and the peer instead of the daemon buffering until
-  it is killed. The rest of an oversized MCP line is drained, so the next
-  call to that server still works. The caps are constants in
-  `leviath_net::read_caps`, not configuration.
 - `lev models list` and `lev models show` ask the configured providers what
   they serve, by default. Each provider is asked side by side, within five
   seconds; what it says replaces the compiled-in rows for it, and one that
@@ -473,7 +455,6 @@ same list.
   detected models offered as the default. `GET /api/config` reports each gateway's `kind`,
   `header_names` and `models`, `PUT /api/config` accepts `kind`, `headers` and `models`,
   and `POST /api/models/probe` (admin) asks a server what it serves before the write.
-
 - `cargo xtask prices` refreshes the vendor price table from OpenRouter's
   public catalogue cross-checked against LiteLLM, writing a row only where
   the two agree within 5% and refusing a move it does not believe. A weekly

--- a/crates/leviath-cli/src/commands/policy.rs
+++ b/crates/leviath-cli/src/commands/policy.rs
@@ -97,7 +97,7 @@ fn leviath_config_dir(
 }
 
 /// Get the default policy file path.
-fn policy_path() -> std::path::PathBuf {
+pub(crate) fn policy_path() -> std::path::PathBuf {
     leviath_config_dir(dirs::config_dir(), dirs::home_dir()).join("policy.toml")
 }
 

--- a/crates/leviath-cli/src/daemon/gate_rules.rs
+++ b/crates/leviath-cli/src/daemon/gate_rules.rs
@@ -14,8 +14,21 @@ use leviath_runtime::taint::ScriptRuleChecker;
 /// unconditionally. Each script receives a `context` map
 /// (`tool` / `target` / `taint_level`) and should evaluate to `true` to allow the
 /// call; the first script that allows wins and its file stem is the rule name.
+///
+/// The sources are read once, here, and captured by the returned closure, so a
+/// checker built from a directory is a snapshot of it. That is why the daemon
+/// holds the sources too (`policy_reload`): re-reading them is how an edited
+/// rule reaches a run without a restart.
 pub(crate) fn build_gate_script_checker(rules_dir: &Path) -> Arc<ScriptRuleChecker> {
-    let scripts: Vec<(String, String)> = std::fs::read_dir(rules_dir)
+    checker_from_scripts(read_rule_scripts(rules_dir))
+}
+
+/// The `(rule name, source)` pairs in `rules_dir`, in file-name order so two
+/// reads of an unchanged directory compare equal and the "first rule that
+/// allows wins" verdict does not depend on the order the filesystem hands
+/// entries back. A missing or unreadable directory reads as no rules.
+pub(crate) fn read_rule_scripts(rules_dir: &Path) -> Vec<(String, String)> {
+    let mut scripts: Vec<(String, String)> = std::fs::read_dir(rules_dir)
         .ok()
         .into_iter()
         .flatten() // ReadDir → Result<DirEntry>
@@ -35,6 +48,13 @@ pub(crate) fn build_gate_script_checker(rules_dir: &Path) -> Arc<ScriptRuleCheck
                 .map(|source| (name, source))
         })
         .collect();
+    scripts.sort();
+    scripts
+}
+
+/// Compile `scripts` into the checker the gate consults. Empty ⇒ a checker that
+/// never allows anything, so the daemon can install one unconditionally.
+pub(crate) fn checker_from_scripts(scripts: Vec<(String, String)>) -> Arc<ScriptRuleChecker> {
     if scripts.is_empty() {
         return Arc::new(|_tool, _target, _taint| None);
     }
@@ -103,6 +123,38 @@ mod tests {
         let checker = build_gate_script_checker(dir.path());
         assert!(checker("send_email", Some("ops@corp"), TaintLevel::Internal).is_some());
         assert!(checker("send_email", Some("ops@corp"), TaintLevel::Private).is_none());
+    }
+
+    #[test]
+    fn a_built_checker_is_a_snapshot_of_the_directory() {
+        // Why `policy_reload` exists: the sources live in the closure, so a
+        // checker built at boot answers from the file as it was at boot no
+        // matter what is written over it afterwards.
+        let dir = tempfile::tempdir().unwrap();
+        write_rule(dir.path(), "company.rhai", r#"context.tool == "shell""#);
+        let checker = build_gate_script_checker(dir.path());
+        write_rule(
+            dir.path(),
+            "company.rhai",
+            r#"context.tool == "send_email""#,
+        );
+        assert_eq!(
+            checker("send_email", None, TaintLevel::Public),
+            None,
+            "an already-built checker cannot see the edit; something has to rebuild it"
+        );
+    }
+
+    #[test]
+    fn rule_sources_come_back_in_file_name_order() {
+        let dir = tempfile::tempdir().unwrap();
+        write_rule(dir.path(), "zulu.rhai", "false");
+        write_rule(dir.path(), "alpha.rhai", "true");
+        let names: Vec<String> = read_rule_scripts(dir.path())
+            .into_iter()
+            .map(|(name, _)| name)
+            .collect();
+        assert_eq!(names, vec!["alpha".to_string(), "zulu".to_string()]);
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod fanout_spawner;
 pub(crate) mod gate_rules;
 pub mod lifecycle;
 pub mod mcp_pool;
+pub(crate) mod policy_reload;
 pub mod provider_reload;
 pub mod readiness;
 pub(crate) mod recovery;

--- a/crates/leviath-cli/src/daemon/policy_reload.rs
+++ b/crates/leviath-cli/src/daemon/policy_reload.rs
@@ -1,0 +1,565 @@
+//! Keeping the taint gate's policy in step with the files it is written in.
+//!
+//! Two files decide whether a tainted outbound call is allowed: `policy.toml`
+//! (the static allowlist and the `[mcp_overrides]`) and `rules/*.rhai` (the
+//! scripted rules consulted after it). Both were read once at daemon startup
+//! and installed as world resources, and the scripted half was worse than
+//! boot-only in an invisible way: the sources are read into a closure, so an
+//! edited rule kept answering with the text it had at boot.
+//!
+//! That put `lev policy add` in a bad spot. It writes `policy.toml` and prints
+//! the rule it wrote, the gate goes on blocking the call the rule was written
+//! to permit, and nothing says why. The fix is the one the config reloader
+//! beside this module already uses for `config.toml`: stat the files, reload
+//! when they moved, compare, and swap the world resource before the next run
+//! resolves anything.
+//!
+//! These are not `config.toml`, so the reloader cannot carry them: they live
+//! under the platform config directory (`~/.config/leviath` on Linux) and get
+//! their own mtime check here.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+use std::time::SystemTime;
+
+use leviath_runtime::taint::ScriptRuleChecker;
+
+/// One `*.rhai` rule file as of a stat: which file, and when it last changed.
+/// Comparing the whole sorted list catches an edit, a new rule, and a deleted
+/// one, which a directory mtime alone does not (on most filesystems a write
+/// through an existing file does not touch its directory).
+type RulesStamp = Vec<(PathBuf, Option<SystemTime>)>;
+
+/// What a refresh built and `install` has yet to hand to the world.
+#[derive(Default)]
+struct Pending {
+    policy: Option<leviath_core::PolicyConfig>,
+    rules: Option<Arc<ScriptRuleChecker>>,
+}
+
+impl Pending {
+    fn is_empty(&self) -> bool {
+        self.policy.is_none() && self.rules.is_none()
+    }
+}
+
+struct State {
+    /// The mtime `policy` was read at. `None` means the file was absent, and
+    /// the empty default is in force until it appears.
+    policy_mtime: Option<SystemTime>,
+    policy: leviath_core::PolicyConfig,
+    /// The stat of the rules directory the current `scripts` were read at.
+    rules_stamp: RulesStamp,
+    /// The rule sources behind the installed checker, kept so a directory
+    /// whose mtimes moved without its contents changing (a `touch`, a rewrite
+    /// of the same bytes) does not recompile the engine.
+    scripts: Vec<(String, String)>,
+    pending: Pending,
+}
+
+/// Serves the freshest taint-gate policy, reloading `policy.toml` and
+/// `rules/*.rhai` when they change on disk.
+///
+/// Split into [`refresh`](Self::refresh) (stat, reload, compare) and
+/// [`install`](Self::install) (hand the result to the world) for the same
+/// reason the provider reload is: the world is only reachable from the host's
+/// synchronous hooks, and refreshing is the part a caller can do anywhere.
+pub struct PolicyReload {
+    policy_path: PathBuf,
+    rules_dir: PathBuf,
+    state: Mutex<State>,
+}
+
+/// What a [`refresh`](PolicyReload::refresh) found had changed. Both false is
+/// the usual answer and means `install` has nothing to do.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct PolicyChange {
+    /// `policy.toml` now says something different.
+    pub policy: bool,
+    /// The `rules/*.rhai` set now says something different.
+    pub rules: bool,
+}
+
+impl PolicyChange {
+    /// Whether anything at all changed.
+    pub fn any(&self) -> bool {
+        self.policy || self.rules
+    }
+}
+
+impl PolicyReload {
+    /// Start from what the two paths hold right now, with both halves pending
+    /// so the first [`install`](Self::install) seeds the world. That is the
+    /// daemon's boot install, expressed as the first refresh rather than as a
+    /// separate one-off load.
+    pub fn new(policy_path: PathBuf, rules_dir: PathBuf) -> Self {
+        let policy_mtime = file_mtime(&policy_path);
+        let policy = load_policy(&policy_path).unwrap_or_else(|e| {
+            warn_unloadable(&policy_path, &e);
+            leviath_core::PolicyConfig::default()
+        });
+        let rules_stamp = stamp_rules(&rules_dir);
+        let scripts = crate::daemon::gate_rules::read_rule_scripts(&rules_dir);
+        let checker = crate::daemon::gate_rules::checker_from_scripts(scripts.clone());
+        Self {
+            policy_path,
+            rules_dir,
+            state: Mutex::new(State {
+                policy_mtime,
+                policy: policy.clone(),
+                rules_stamp,
+                scripts,
+                pending: Pending {
+                    policy: Some(policy),
+                    rules: Some(checker),
+                },
+            }),
+        }
+    }
+
+    /// One over the paths the daemon really uses: `<config>/leviath/policy.toml`
+    /// and `<config>/leviath/rules`.
+    pub fn for_daemon() -> Arc<Self> {
+        Arc::new(Self::new(
+            crate::commands::policy::policy_path(),
+            crate::commands::policy::rules_dir(),
+        ))
+    }
+
+    /// Re-stat both paths and rebuild whatever moved, holding the result for
+    /// [`install`](Self::install).
+    ///
+    /// A `policy.toml` that will not parse keeps the policy already in force,
+    /// and records the broken file's mtime so the warning is logged once
+    /// rather than on every spawn until it is fixed. Losing an allowlist to a
+    /// half-saved edit would silently *tighten* the gate, which is the wrong
+    /// direction to fail in for a file people edit by hand.
+    pub fn refresh(&self) -> PolicyChange {
+        let policy_mtime = file_mtime(&self.policy_path);
+        let rules_stamp = stamp_rules(&self.rules_dir);
+        let mut state = self.lock();
+        let mut change = PolicyChange::default();
+
+        if policy_mtime != state.policy_mtime {
+            state.policy_mtime = policy_mtime;
+            match load_policy(&self.policy_path) {
+                Ok(policy) => {
+                    if policy != state.policy {
+                        // Bound in a plain statement rather than left as a lazy
+                        // `%path.display()` field: the method call inside a
+                        // structured field only runs when the callsite is
+                        // enabled, and tracing caches that interest globally,
+                        // so under a coverage run it can be unreachable. The
+                        // config reloader beside this does the same.
+                        let displayed = self.policy_path.display();
+                        tracing::info!(
+                            path = %displayed,
+                            "reloaded the taint policy after an on-disk change"
+                        );
+                        state.policy = policy.clone();
+                        state.pending.policy = Some(policy);
+                        change.policy = true;
+                    }
+                }
+                Err(e) => warn_unloadable(&self.policy_path, &e),
+            }
+        }
+
+        if rules_stamp != state.rules_stamp {
+            state.rules_stamp = rules_stamp;
+            let scripts = crate::daemon::gate_rules::read_rule_scripts(&self.rules_dir);
+            if scripts != state.scripts {
+                let displayed = self.rules_dir.display();
+                let count = scripts.len();
+                tracing::info!(
+                    path = %displayed,
+                    rules = count,
+                    "reloaded the scripted gate rules after an on-disk change"
+                );
+                state.scripts = scripts.clone();
+                state.pending.rules =
+                    Some(crate::daemon::gate_rules::checker_from_scripts(scripts));
+                change.rules = true;
+            }
+        }
+
+        change
+    }
+
+    /// [`refresh`](Self::refresh), then [`install`](Self::install) whatever it
+    /// built. What the daemon's spawn and reload hooks call: one statement, and
+    /// two stats when nothing moved.
+    pub fn refresh_into(&self, world: &mut leviath_runtime::PipelineWorld) {
+        if self.refresh().any() {
+            self.install(world);
+        }
+    }
+
+    /// Put whatever [`refresh`](Self::refresh) built into `world`. Does nothing
+    /// when nothing is pending, so it is safe to call before every spawn.
+    pub fn install(&self, world: &mut leviath_runtime::PipelineWorld) {
+        let pending = std::mem::take(&mut self.lock().pending);
+        if pending.is_empty() {
+            return;
+        }
+        let world = world.world_mut();
+        if let Some(policy) = pending.policy {
+            world.insert_resource(leviath_runtime::pipeline::PolicyGate(policy));
+        }
+        if let Some(rules) = pending.rules {
+            world.insert_resource(leviath_runtime::pipeline::GateScriptRules(rules));
+        }
+    }
+
+    fn lock(&self) -> MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// The policy file's contents, or the reason it could not be read. A missing
+/// file is not an error: no `policy.toml` means no allowlist.
+fn load_policy(path: &Path) -> Result<leviath_core::PolicyConfig, String> {
+    if !path.exists() {
+        return Ok(leviath_core::PolicyConfig::default());
+    }
+    let content = std::fs::read_to_string(path).map_err(|e| e.to_string())?;
+    leviath_core::PolicyConfig::from_toml(&content)
+}
+
+/// One warning per broken save, not one per spawn: the caller records the
+/// mtime either way, so the next stat of an unfixed file is a no-op.
+fn warn_unloadable(path: &Path, error: &str) {
+    let displayed = path.display();
+    tracing::warn!(
+        path = %displayed,
+        error = %error,
+        "policy.toml could not be read; keeping the policy already in force"
+    );
+}
+
+/// Every `*.rhai` file in `dir` with its mtime, sorted by path. A missing or
+/// unreadable directory stamps as empty, and starts being watched the moment
+/// it appears.
+fn stamp_rules(dir: &Path) -> RulesStamp {
+    let mut stamp: RulesStamp = std::fs::read_dir(dir)
+        .ok()
+        .into_iter()
+        .flatten()
+        .flatten()
+        .filter_map(|entry| {
+            let path = entry.path();
+            (path.extension().and_then(|e| e.to_str()) == Some("rhai"))
+                .then(|| (path.clone(), file_mtime(&path)))
+        })
+        .collect();
+    stamp.sort();
+    stamp
+}
+
+/// The file's mtime, or `None` when it does not exist or cannot be stat'd.
+fn file_mtime(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).and_then(|m| m.modified()).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::TaintLevel;
+    use std::time::Duration;
+
+    /// Force a file's mtime strictly newer, so an edit inside one clock tick is
+    /// still a change (the config reloader's tests do the same).
+    fn bump_mtime(path: &Path) {
+        let later = SystemTime::now() + Duration::from_secs(5);
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(later).unwrap();
+    }
+
+    fn write(path: &Path, body: &str) {
+        std::fs::write(path, body).unwrap();
+        bump_mtime(path);
+    }
+
+    /// A world with nothing in it but the resources under test.
+    fn world() -> (tokio::runtime::Runtime, leviath_runtime::PipelineWorld) {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let world = leviath_runtime::PipelineWorld::new(
+            leviath_runtime::ProviderRegistry::new(),
+            Arc::new(crate::daemon::tool_service::CliToolService::new()),
+            leviath_runtime::inference_pool::InferencePoolConfig::new(),
+            1,
+            None,
+            runtime.handle().clone(),
+        );
+        (runtime, world)
+    }
+
+    fn installed_rule_names(world: &mut leviath_runtime::PipelineWorld) -> Vec<String> {
+        world
+            .world_mut()
+            .get_resource::<leviath_runtime::pipeline::PolicyGate>()
+            .map(|p| p.0.allowlist.iter().map(|r| r.tool.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    fn installed_checker(world: &mut leviath_runtime::PipelineWorld) -> Arc<ScriptRuleChecker> {
+        world
+            .world_mut()
+            .get_resource::<leviath_runtime::pipeline::GateScriptRules>()
+            .expect("the daemon always installs a checker")
+            .0
+            .clone()
+    }
+
+    fn paths(dir: &Path) -> (PathBuf, PathBuf) {
+        let rules = dir.join("rules");
+        std::fs::create_dir_all(&rules).unwrap();
+        (dir.join("policy.toml"), rules)
+    }
+
+    #[test]
+    fn the_first_install_seeds_both_resources() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        write(
+            &policy_path,
+            "[[allowlist]]\ntool = \"send_email\"\nmax_sensitivity = \"internal\"\n",
+        );
+        write(
+            &rules_dir.join("company.rhai"),
+            r#"context.tool == "shell""#,
+        );
+
+        let reload = PolicyReload::new(policy_path, rules_dir);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+
+        assert_eq!(installed_rule_names(&mut world), vec!["send_email"]);
+        assert_eq!(
+            installed_checker(&mut world)("shell", None, TaintLevel::Internal),
+            Some("company".to_string())
+        );
+    }
+
+    #[test]
+    fn an_unchanged_pair_refreshes_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        write(&policy_path, "[[allowlist]]\ntool = \"shell\"\n");
+        write(&rules_dir.join("company.rhai"), "true");
+
+        let reload = PolicyReload::new(policy_path, rules_dir);
+        assert_eq!(reload.refresh(), PolicyChange::default());
+        assert!(!reload.refresh().any());
+    }
+
+    /// The bug: `lev policy add` writes the rule, prints it, and the gate goes
+    /// on blocking the call it was written to permit until the daemon is
+    /// killed.
+    #[test]
+    fn a_rule_added_after_boot_reaches_the_world() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        let reload = PolicyReload::new(policy_path.clone(), rules_dir);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+        assert!(installed_rule_names(&mut world).is_empty());
+
+        write(
+            &policy_path,
+            "[[allowlist]]\ntool = \"send_email\"\nmax_sensitivity = \"internal\"\n",
+        );
+        assert_eq!(
+            reload.refresh(),
+            PolicyChange {
+                policy: true,
+                rules: false
+            }
+        );
+        reload.install(&mut world);
+        assert_eq!(
+            installed_rule_names(&mut world),
+            vec!["send_email"],
+            "the rule the user just added has to be in force without a restart"
+        );
+    }
+
+    /// The scripted half, which was stale in a way no restart advice covered:
+    /// the sources live inside the compiled closure.
+    #[test]
+    fn an_edited_rule_script_reaches_the_world() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        let rule = rules_dir.join("company.rhai");
+        write(&rule, r#"context.tool == "shell""#);
+        let reload = PolicyReload::new(policy_path, rules_dir);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+        assert!(installed_checker(&mut world)("send_email", None, TaintLevel::Internal).is_none());
+
+        write(&rule, r#"context.tool == "send_email""#);
+        assert_eq!(
+            reload.refresh(),
+            PolicyChange {
+                policy: false,
+                rules: true
+            }
+        );
+        reload.install(&mut world);
+        assert_eq!(
+            installed_checker(&mut world)("send_email", None, TaintLevel::Internal),
+            Some("company".to_string()),
+            "the edited rule has to be the one the gate consults"
+        );
+    }
+
+    #[test]
+    fn a_deleted_rule_file_stops_allowing() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        let rule = rules_dir.join("company.rhai");
+        write(&rule, r#"context.tool == "shell""#);
+        let reload = PolicyReload::new(policy_path, rules_dir);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+
+        std::fs::remove_file(&rule).unwrap();
+        assert!(reload.refresh().rules);
+        reload.install(&mut world);
+        assert_eq!(
+            installed_checker(&mut world)("shell", None, TaintLevel::Internal),
+            None,
+            "a rule the user deleted must stop permitting the call"
+        );
+    }
+
+    #[test]
+    fn touching_a_rule_without_changing_it_is_not_a_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        let rule = rules_dir.join("company.rhai");
+        write(&rule, "true");
+        let reload = PolicyReload::new(policy_path, rules_dir);
+
+        // Same bytes, newer mtime: the stat moves, the sources do not, and
+        // recompiling the engine over it would be work for nothing.
+        write(&rule, "true");
+        assert!(
+            !reload.refresh().any(),
+            "an identical rewrite must not rebuild the checker"
+        );
+    }
+
+    #[test]
+    fn rewriting_the_policy_with_the_same_content_is_not_a_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        write(&policy_path, "[[allowlist]]\ntool = \"shell\"\n");
+        let reload = PolicyReload::new(policy_path.clone(), rules_dir);
+        write(&policy_path, "[[allowlist]]\ntool = \"shell\"\n");
+        assert!(!reload.refresh().any());
+    }
+
+    #[test]
+    fn a_broken_policy_save_keeps_the_one_in_force_and_warns_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        write(
+            &policy_path,
+            "[[allowlist]]\ntool = \"send_email\"\nmax_sensitivity = \"internal\"\n",
+        );
+        let reload = PolicyReload::new(policy_path.clone(), rules_dir);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+
+        write(&policy_path, "this is not : : toml");
+        assert!(!reload.refresh().any());
+        // The mtime was recorded even though the load failed, so a file left
+        // broken is stat'd once more and never re-read.
+        assert!(!reload.refresh().any());
+        reload.install(&mut world);
+        assert_eq!(
+            installed_rule_names(&mut world),
+            vec!["send_email"],
+            "a half-saved edit must not quietly drop the user's allowlist"
+        );
+    }
+
+    #[test]
+    fn a_good_save_after_a_broken_one_recovers() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        write(&policy_path, "[[allowlist]]\ntool = \"a\"\n");
+        let reload = PolicyReload::new(policy_path.clone(), rules_dir);
+        write(&policy_path, "broken : :");
+        let _ = reload.refresh();
+        write(&policy_path, "[[allowlist]]\ntool = \"b\"\n");
+        assert!(reload.refresh().policy);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+        assert_eq!(installed_rule_names(&mut world), vec!["b"]);
+    }
+
+    #[test]
+    fn a_policy_file_that_appears_after_boot_is_picked_up() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        let reload = PolicyReload::new(policy_path.clone(), rules_dir);
+        std::fs::write(&policy_path, "[[allowlist]]\ntool = \"shell\"\n").unwrap();
+        assert!(reload.refresh().policy);
+    }
+
+    #[test]
+    fn a_policy_file_that_cannot_be_read_falls_back_to_an_empty_one() {
+        // A directory where the file should be: `exists()` is true and the read
+        // fails, which is the io-error arm rather than the parse-error one.
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        std::fs::create_dir(&policy_path).unwrap();
+        let reload = PolicyReload::new(policy_path, rules_dir);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+        assert!(installed_rule_names(&mut world).is_empty());
+    }
+
+    #[test]
+    fn install_hands_each_rebuild_over_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        let reload = PolicyReload::new(policy_path, rules_dir);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+        assert!(reload.lock().pending.is_empty());
+        // Nothing pending: a second install before any refresh is a no-op.
+        reload.install(&mut world);
+        assert!(reload.lock().pending.is_empty());
+    }
+
+    #[test]
+    fn refresh_into_installs_a_change_and_leaves_an_unchanged_world_alone() {
+        let dir = tempfile::tempdir().unwrap();
+        let (policy_path, rules_dir) = paths(dir.path());
+        let reload = PolicyReload::new(policy_path.clone(), rules_dir);
+        let (_rt, mut world) = world();
+        reload.install(&mut world);
+
+        // Nothing moved: the world keeps what it has and no rebuild happens.
+        reload.refresh_into(&mut world);
+        assert!(installed_rule_names(&mut world).is_empty());
+
+        write(&policy_path, "[[allowlist]]\ntool = \"shell\"\n");
+        reload.refresh_into(&mut world);
+        assert_eq!(installed_rule_names(&mut world), vec!["shell"]);
+    }
+
+    #[test]
+    fn for_daemon_watches_the_real_policy_paths() {
+        let reload = PolicyReload::for_daemon();
+        assert_eq!(
+            reload.policy_path,
+            crate::commands::policy::policy_path(),
+            "the daemon has to watch the file `lev policy add` writes"
+        );
+        assert_eq!(reload.rules_dir, crate::commands::policy::rules_dir());
+    }
+}

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -424,13 +424,14 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         .world_mut()
         .insert_resource(FanOutSpawnerRes(Arc::new(fanout_spawner)));
 
-    // The tool allowlist policy (`policy.toml`), for the taint gate. A malformed
-    // file falls back to an empty policy (deny-by-clearance only) rather than
-    // failing daemon startup.
-    let policy = crate::commands::policy::load_policy().unwrap_or_default();
-    host.world_mut()
-        .world_mut()
-        .insert_resource(leviath_runtime::pipeline::PolicyGate(policy));
+    // The taint gate's two files: the tool allowlist (`policy.toml`) and the
+    // scripted rules (`<config>/leviath/rules/*.rhai`). Reading them is this
+    // reload's first refresh, so the boot install and every later one go
+    // through the same seam and an edit reaches the next run without a daemon
+    // restart. A malformed `policy.toml` falls back to an empty policy
+    // (deny-by-clearance only) rather than failing startup.
+    let policy_reload = crate::daemon::policy_reload::PolicyReload::for_daemon();
+    policy_reload.install(host.world_mut());
 
     // Run-title generation settings; spawn only marks a run for titling when
     // `[title]` is enabled, and the dispatch system reads provider/model here.
@@ -439,14 +440,6 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         .insert_resource(leviath_runtime::title::TitleSettings(
             parts.config.title.clone(),
         ));
-
-    // Scripted gate rules (`<parts.config>/leviath/rules/*.rhai`), consulted by the gate
-    // after the static allowlist (a no-op checker when there are none).
-    let script_checker =
-        crate::daemon::gate_rules::build_gate_script_checker(&crate::commands::policy::rules_dir());
-    host.world_mut()
-        .world_mut()
-        .insert_resource(leviath_runtime::pipeline::GateScriptRules(script_checker));
 
     // Structured observability (`[observability]`): replace the world's no-op
     // telemetry sink with the configured exporter, and - for OTLP - forward
@@ -475,6 +468,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let reload_runs = parts.runs_dir.clone();
     let reload_pool = parts.mcp_pool.clone();
     let reload_provider_reload = provider_reload.clone();
+    let reload_policy = policy_reload.clone();
     host.set_reloader(Box::new(move |world, run_id| {
         // Pages a run back in with the current on-disk parts.config, matching what a
         // real restart would restore it with.
@@ -485,6 +479,9 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // provider the config names now (issue #684).
         reload_provider_reload.refresh(&reload_config);
         reload_provider_reload.install(world);
+        // A run paged back in is rebuilt from scratch, so it gets the policy
+        // the files name now rather than the one this daemon booted with.
+        reload_policy.refresh_into(world);
         let entity = crate::daemon::recovery::reload_run(
             world,
             crate::daemon::spawn::SpawnDeps {
@@ -565,6 +562,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let spawn_runs_dir = parts.runs_dir.clone();
     let spawn_reloader = reloader.clone();
     let spawn_provider_reload = provider_reload.clone();
+    let spawn_policy = policy_reload.clone();
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
@@ -592,6 +590,10 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // a credential comparison when nothing changed (issue #684).
         spawn_provider_reload.refresh(&config);
         spawn_provider_reload.install(world);
+        // Same for the taint gate: `lev policy add` and an edited `.rhai` rule
+        // are in force for this run, without a daemon restart. Both are a stat
+        // of two paths when nothing changed.
+        spawn_policy.refresh_into(world);
         let built = build_agent(
             world.world_mut(),
             crate::daemon::spawn::SpawnDeps {

--- a/crates/leviath-core/src/policy.rs
+++ b/crates/leviath-core/src/policy.rs
@@ -87,7 +87,7 @@ pub struct McpToolOverride {
 }
 
 /// Complete policy configuration loaded from policy.toml.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct PolicyConfig {
     /// Static allowlist rules.
     #[serde(default)]
@@ -437,6 +437,19 @@ send_email = { sensitivity = "private", direction = "egress", clearance = "publi
         // `channel` operand in the "patterns set but no target" guard; with no
         // target the rule must not match.
         assert!(!rule.matches("post_message", None, TaintLevel::Public));
+    }
+
+    #[test]
+    fn two_policies_compare_by_what_they_say() {
+        // The daemon reloads this file and only swaps the gate's copy when the
+        // contents differ, so equality has to mean "says the same thing"
+        // rather than "came from the same bytes".
+        let one = PolicyConfig::from_toml("[[allowlist]]\ntool = \"shell\"\n").unwrap();
+        let same = PolicyConfig::from_toml("[[allowlist]]\ntool   =   \"shell\"\n").unwrap();
+        let other = PolicyConfig::from_toml("[[allowlist]]\ntool = \"web_fetch\"\n").unwrap();
+        assert_eq!(one, same);
+        assert_ne!(one, other);
+        assert_ne!(one, PolicyConfig::default());
     }
 
     #[test]

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -1064,3 +1064,8 @@ clearance   = "internal"
 Scripted rules live as `.rhai` files in a `rules/` directory beside `policy.toml`, so
 `~/Library/Application Support/leviath/rules/` on macOS and `~/.config/leviath/rules/` on Linux. See
 [Rhai tools](/docs/rhai-tools#policy-rules) and [Security](/docs/security#taint-tracking-experimental).
+
+Both are re-read when they change: add an allowlist rule, edit a `.rhai` rule, or delete one, and
+the next run is gated against what the files say now. No daemon restart. A `policy.toml` that will
+not parse is ignored in favour of the policy already in force, so a half-typed edit never quietly
+widens or narrows the gate.

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -176,6 +176,12 @@ file. Two details are deliberate:
 - A provider whose key changed has its circuit-breaker record cleared, so a key you just replaced is
   tried immediately instead of sitting out the rest of the old key's cooldown.
 
+The taint gate's own two files reload as well: `policy.toml` and the `.rhai` files in the `rules/`
+directory beside it. `lev policy add` writes a rule and the next run is gated against it, with no
+restart. The scripted half needed this most, because it failed in a way no restart advice covered:
+the rule sources were read into the compiled checker at boot, so editing a `.rhai` file changed
+nothing at all and the gate went on answering from the text it started with.
+
 Some changes do still need `lev daemon restart`. They set up connections and process-wide state
 once at startup rather than per run:
 


### PR DESCRIPTION
## What

`policy.toml` (the tool allowlist and `[mcp_overrides]`) and the `rules/*.rhai` beside it now
reload when they change, so a rule you add is in force for the next run instead of at the next
daemon restart.

## Why

Both were read once in `daemon/setup.rs` at boot and installed as world resources. The scripted
half was stale in a way nothing documented: `build_gate_script_checker` reads every `.rhai` source
into the closure it returns, so editing a rule file changed nothing at all for the life of the
process.

From outside, `lev policy add` writes the rule, prints it back, and the gate goes on blocking the
call the rule was written to permit. Nothing distinguishes that from having typed the rule wrong.

## How

`daemon/policy_reload.rs` follows the `provider_reload` pattern PR #729 established: `refresh()`
stats both paths, reloads what moved, compares what came back, and holds the result;
`refresh_into(world)` swaps the world resource. The daemon calls it before each spawn and on the
reload-on-demand path.

Details that matter:

- These are not `config.toml`, so `ConfigReloader` cannot carry them. They live under the platform
  config dir and get their own mtime check.
- The rules directory is stamped per file, not by directory mtime: on most filesystems a write
  through an existing file leaves the directory's mtime alone.
- The sources are compared after reading, so a `touch` or an identical rewrite does not recompile
  the Rhai engine.
- A `policy.toml` that will not parse keeps the policy already in force and warns once, recording
  the broken file's mtime so it is not re-read on every spawn. Failing the other way would silently
  drop an allowlist because a save landed half-written.
- The boot install is now the reload's first `install`, so there is one seam rather than two.

## Tests

New in `policy_reload.rs`: a rule added after boot reaching the world, an edited `.rhai` reaching
it, a deleted rule ceasing to allow, a touch and an identical rewrite being no change, the broken
save keeping the policy in force and recovering on the next good one, and the file appearing after
boot. `gate_rules.rs` gains a test that pins the old snapshot behaviour, which is what the reload
exists to work around.

**Fails first**: with `refresh()` stubbed to return "nothing changed" (the boot-only behaviour on
`main`), five of the new tests fail, naming exactly the live half:

```
a_rule_added_after_boot_reaches_the_world
an_edited_rule_script_reaches_the_world
a_deleted_rule_file_stops_allowing
a_good_save_after_a_broken_one_recovers
a_policy_file_that_appears_after_boot_is_picked_up
```

**Live probe** (mock harness, isolated `LEVIATH_HOME`, `LEVIATH_SKIP_DOTENV=1`): a real daemon runs
four probe runs. Between them the probe writes `policy.toml`, then a `.rhai` rule, then edits that
rule again. The daemon logs each reload, its pid never changes, and nothing reloaded before the
first edit.

```
own_daemon_spawned_it: true
reload_before_edit:    false
policy_reloaded:       true
rules_reloaded:        true
rules_reloaded_twice:  true
pid_unchanged:         true
```

## Gates

`cargo fmt`, `clippy -D warnings` on `leviath-cli` and `leviath-core`, `xtask structure`,
`xtask docs`, and `xtask coverage` at 100% for both crates.

## Notes

Expect a small conflict with #729 in `daemon/setup.rs`: both add a reload to the spawn and
reload-on-demand hooks, in the same two places.
