### PR TITLE
feat(daemon): turning telemetry on reaches the next run, not the next restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,14 @@ same list.
   so. `lev policy add` printing the rule it just wrote while the gate went on blocking the call was
   the whole of the feedback. A `policy.toml` that will not parse keeps the policy already in force
   and warns once, rather than dropping an allowlist because a save landed half-written.
+- `[observability]` reloads. Turning export on, pointing it at another collector, renaming the
+  service, or turning it off reaches the next run instead of the next daemon restart. The sink and
+  the OTLP log bridge were built once at startup, so the common case failed in the worst way
+  available: you set `enabled = true`, start a run to watch it, and nothing arrives, which looks
+  exactly like a collector that is not listening. The outgoing exporter is flushed before it is
+  replaced, so what it had already recorded still reaches the old collector. The daemon's own log
+  level is not part of this and still needs a restart: the process subscriber is installed from
+  `--verbose` before any config is read.
 - The update check read the GitHub releases answer with no size cap, the one
   buffered remote read left after the daemon's caps landed. It now stops at
   the same 64 MiB as every other buffered body and reports the same

--- a/crates/leviath-cli/src/daemon/config_reload.rs
+++ b/crates/leviath-cli/src/daemon/config_reload.rs
@@ -15,16 +15,17 @@
 //!
 //! Provider credentials are rebuilt from the same reloaded config by the
 //! `provider_reload` module beside this one, so a key added or removed here
-//! reaches the next run too. Settings that live somewhere other than the
-//! spawn-time config follow it through [`ConfigReloader::with_reload_hook`]: a
-//! caller registers what to re-apply, and it runs on each successful reload.
-//! The daemon uses it for the process-wide network policy, which is mirrored
-//! into atomics the shared blocking HTTP client reads
-//! (`script_host::mirror_process_policy`).
+//! reaches the next run too, and `[observability]` is rebuilt by the
+//! `telemetry_reload` module next to that. Settings that live somewhere other
+//! than the spawn-time config follow it through
+//! [`ConfigReloader::with_reload_hook`]: a caller registers what to re-apply,
+//! and it runs on each successful reload. The daemon uses it for the
+//! process-wide network policy, which is mirrored into atomics the shared
+//! blocking HTTP client reads (`script_host::mirror_process_policy`).
 //!
-//! What is still established once at boot is MCP connections and the telemetry
-//! sink: those hold live connections and process-wide state, and adding an MCP
-//! server still needs a daemon restart; see `daemon.md`.
+//! What is still established once at boot is MCP connections: those hold live
+//! connections, and adding an MCP server still needs a daemon restart; see
+//! `daemon.md`.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -21,4 +21,5 @@ pub(crate) mod seed_tool;
 pub mod setup;
 pub(crate) mod spawn;
 pub(crate) mod subagent;
+pub(crate) mod telemetry_reload;
 pub(crate) mod tool_service;

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -384,9 +384,10 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // Config hot-reload: after boot, spawn-time parts.config (permissions,
     // `[read_paths]`, sandbox, limits, taint) is served from here, reloaded
     // when `parts.config.toml` changes on disk. The boot infrastructure that
-    // holds live connections - the MCP pool, the network policy, the telemetry
-    // sink - keeps the boot snapshot and needs a restart, so the reloader takes
-    // a clone and the boot snapshot stays usable below.
+    // holds live connections - the MCP pool, the network policy - keeps the
+    // boot snapshot and needs a restart, so the reloader takes a clone and the
+    // boot snapshot stays usable below. The telemetry sink follows the
+    // reloaded config too, through `telemetry_reload` below.
     //
     // Normally handed in: `setup_daemon_host_with` builds it before the
     // provider registry so the script-provider layer can follow it as well
@@ -446,14 +447,12 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // the daemon's own tracing events through the same pipeline. A pipeline
     // that fails to build logs a warning and leaves the no-op in place -
     // observability must never stop the work it observes.
-    if let Some(built) = leviath_telemetry::build_sink(&parts.config.observability) {
-        host.world_mut()
-            .world_mut()
-            .insert_resource(leviath_runtime::telemetry::Telemetry(built.sink));
-        if let Some(layer) = built.log_layer {
-            crate::logging::install_otel_layer(layer);
-        }
-    }
+    //
+    // Boot is this reload's first refresh, so turning export on, moving it to
+    // another collector, or turning it off reaches the next run without a
+    // daemon restart.
+    let telemetry_reload = crate::daemon::telemetry_reload::TelemetryReload::for_daemon();
+    telemetry_reload.refresh_into(host.world_mut(), &parts.config.observability);
 
     // Reload-on-demand: an op targeting an unloaded run pages it back in from
     // disk. Capture the shared context (cloned before the spawner moves the
@@ -469,6 +468,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let reload_pool = parts.mcp_pool.clone();
     let reload_provider_reload = provider_reload.clone();
     let reload_policy = policy_reload.clone();
+    let reload_telemetry = telemetry_reload.clone();
     host.set_reloader(Box::new(move |world, run_id| {
         // Pages a run back in with the current on-disk parts.config, matching what a
         // real restart would restore it with.
@@ -482,6 +482,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // A run paged back in is rebuilt from scratch, so it gets the policy
         // the files name now rather than the one this daemon booted with.
         reload_policy.refresh_into(world);
+        reload_telemetry.refresh_into(world, &reload_config.observability);
         let entity = crate::daemon::recovery::reload_run(
             world,
             crate::daemon::spawn::SpawnDeps {
@@ -563,6 +564,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let spawn_reloader = reloader.clone();
     let spawn_provider_reload = provider_reload.clone();
     let spawn_policy = policy_reload.clone();
+    let spawn_telemetry = telemetry_reload.clone();
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
@@ -594,6 +596,8 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // are in force for this run, without a daemon restart. Both are a stat
         // of two paths when nothing changed.
         spawn_policy.refresh_into(world);
+        // The exporter the file names now, before this run emits anything.
+        spawn_telemetry.refresh_into(world, &config.observability);
         let built = build_agent(
             world.world_mut(),
             crate::daemon::spawn::SpawnDeps {

--- a/crates/leviath-cli/src/daemon/telemetry_reload.rs
+++ b/crates/leviath-cli/src/daemon/telemetry_reload.rs
@@ -1,0 +1,284 @@
+//! Rebuilding the telemetry pipeline when `[observability]` changes.
+//!
+//! The sink was built once at daemon startup and installed as the world's
+//! `Telemetry` resource, and for OTLP a `tracing` layer went into the CLI's
+//! reload slot beside it. Both were then fixed for the life of the process, so
+//! turning export on, pointing it at a different collector, or turning it off
+//! again all needed `lev daemon restart` - and the failure mode for the first
+//! one is the worst kind: you set `enabled = true`, start a run to watch it,
+//! and nothing arrives at the collector. Nothing distinguishes that from a
+//! collector that is not listening.
+//!
+//! Both halves turn out to be swappable. The sink is a world resource like any
+//! other, and the OTLP log bridge already lives in a `tracing_subscriber`
+//! reload layer, which is what `set_otel_layer` fills at boot and what
+//! this refills (or empties) afterwards.
+//!
+//! What does **not** move is the base subscriber `logging::init` installs
+//! before any config is read: the fmt layer, its stderr writer, and its
+//! `info`/`debug` filter. Those come from `--verbose` on the process's own
+//! command line, not from `[observability]`, and a `tracing` subscriber can
+//! only be set once per process. Changing how verbose the daemon's own log is
+//! still means restarting it.
+
+use std::sync::{Arc, Mutex, MutexGuard, PoisonError};
+
+use leviath_core::config::ObservabilityConfig;
+use leviath_core::telemetry::NoopSink;
+
+/// How the OTLP log bridge reaches the process subscriber. Injected so a test
+/// can watch what a rebuild asked for without racing other tests over the
+/// process-wide reload handle, which only one of them can ever park.
+type InstallLayer = fn(Option<leviath_telemetry::LogLayer>) -> bool;
+
+/// Keeps the telemetry pipeline in step with `[observability]`.
+pub struct TelemetryReload {
+    /// The config the installed pipeline was built from. `None` before the
+    /// first refresh, which is what makes the boot install go through the same
+    /// path as every later change.
+    applied: Mutex<Option<ObservabilityConfig>>,
+    install_layer: InstallLayer,
+}
+
+impl TelemetryReload {
+    /// One that forwards the OTLP log bridge to the process subscriber.
+    pub fn for_daemon() -> Arc<Self> {
+        Arc::new(Self::with_installer(crate::logging::set_otel_layer))
+    }
+
+    /// One that reports its layer changes to `install_layer` instead.
+    fn with_installer(install_layer: InstallLayer) -> Self {
+        Self {
+            applied: Mutex::new(None),
+            install_layer,
+        }
+    }
+
+    /// Rebuild and install the pipeline when `cfg` differs from the one in
+    /// service. Returns whether anything was swapped.
+    ///
+    /// The outgoing sink is flushed before it is dropped, so spans and metrics
+    /// already recorded reach the old collector rather than dying with it.
+    ///
+    /// A pipeline that cannot be built (an OTLP exporter that will not
+    /// construct) leaves the no-op sink in place and warns, which is what boot
+    /// did too: observability must never stop the work it observes. The config
+    /// is recorded as applied either way, so a setting that cannot work is not
+    /// retried on every spawn.
+    pub fn refresh_into(
+        &self,
+        world: &mut leviath_runtime::PipelineWorld,
+        cfg: &ObservabilityConfig,
+    ) -> bool {
+        let mut applied = self.lock();
+        if applied.as_ref() == Some(cfg) {
+            return false;
+        }
+        *applied = Some(cfg.clone());
+        drop(applied);
+
+        let ecs = world.world_mut();
+        // Whatever is buffered belongs to the exporter on its way out. Read
+        // rather than tested for: every world carries a sink from the moment
+        // it is built, the no-op one until something replaces it.
+        ecs.resource::<leviath_runtime::telemetry::Telemetry>()
+            .0
+            .force_flush();
+        // Built before the swap: on OTLP this constructs an exporter, and a
+        // failure has to leave the caller with a working (if silent) sink
+        // rather than a half-installed one.
+        let built = leviath_telemetry::build_sink(cfg);
+        let sink: Arc<dyn leviath_core::telemetry::TelemetrySink> = match built {
+            Some(built) => {
+                // `None` for the stdout exporter clears a bridge a previous
+                // OTLP config left behind, which is the point: the daemon's own
+                // log lines must stop going to a collector the user turned off.
+                (self.install_layer)(built.log_layer);
+                built.sink
+            }
+            None => {
+                (self.install_layer)(None);
+                Arc::new(NoopSink)
+            }
+        };
+        ecs.insert_resource(leviath_runtime::telemetry::Telemetry(sink));
+        true
+    }
+
+    fn lock(&self) -> MutexGuard<'_, Option<ObservabilityConfig>> {
+        self.applied.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_core::config::TelemetryExporterKind;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// What the last injected install call asked for: 1 for a layer, 2 for
+    /// clearing the slot. A static because the injection point is a plain `fn`
+    /// pointer (a closure would need the layer type to be nameable at the call
+    /// site), and the tests that read it run in one thread each.
+    static LAST_INSTALL: AtomicUsize = AtomicUsize::new(0);
+
+    fn record_install(layer: Option<leviath_telemetry::LogLayer>) -> bool {
+        LAST_INSTALL.store(if layer.is_some() { 1 } else { 2 }, Ordering::SeqCst);
+        true
+    }
+
+    fn reload() -> TelemetryReload {
+        LAST_INSTALL.store(0, Ordering::SeqCst);
+        TelemetryReload::with_installer(record_install)
+    }
+
+    fn cfg(enabled: bool, exporter: TelemetryExporterKind) -> ObservabilityConfig {
+        ObservabilityConfig {
+            enabled,
+            exporter,
+            endpoint: None,
+            service_name: None,
+        }
+    }
+
+    fn world() -> (tokio::runtime::Runtime, leviath_runtime::PipelineWorld) {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let world = leviath_runtime::PipelineWorld::new(
+            leviath_runtime::ProviderRegistry::new(),
+            Arc::new(crate::daemon::tool_service::CliToolService::new()),
+            leviath_runtime::inference_pool::InferencePoolConfig::new(),
+            1,
+            None,
+            runtime.handle().clone(),
+        );
+        (runtime, world)
+    }
+
+    /// The installed sink's identity, so a test can say "this is not the one
+    /// that was there before" without the sink having to be downcastable.
+    fn sink_ptr(world: &mut leviath_runtime::PipelineWorld) -> *const () {
+        Arc::as_ptr(
+            &world
+                .world_mut()
+                .get_resource::<leviath_runtime::telemetry::Telemetry>()
+                .expect("the world always has a sink")
+                .0,
+        ) as *const ()
+    }
+
+    #[test]
+    fn the_first_refresh_installs_and_a_repeat_of_it_does_not() {
+        let reload = reload();
+        let (_rt, mut world) = world();
+        let enabled = cfg(true, TelemetryExporterKind::Stdout);
+        assert!(reload.refresh_into(&mut world, &enabled));
+        let after = sink_ptr(&mut world);
+
+        assert!(
+            !reload.refresh_into(&mut world, &enabled),
+            "an unchanged [observability] must not rebuild the exporter"
+        );
+        assert_eq!(sink_ptr(&mut world), after);
+    }
+
+    /// The bug: `enabled = true` reached the file, the run went out with the
+    /// no-op sink, and the collector stayed empty.
+    #[test]
+    fn turning_export_on_after_boot_swaps_the_sink() {
+        let reload = reload();
+        let (_rt, mut world) = world();
+        assert!(reload.refresh_into(&mut world, &cfg(false, TelemetryExporterKind::Stdout)));
+        let off = sink_ptr(&mut world);
+
+        assert!(reload.refresh_into(&mut world, &cfg(true, TelemetryExporterKind::Stdout)));
+        assert_ne!(
+            sink_ptr(&mut world),
+            off,
+            "the run after the edit has to emit into the exporter the user just asked for"
+        );
+    }
+
+    #[test]
+    fn turning_export_off_puts_the_noop_sink_back_and_clears_the_bridge() {
+        let reload = reload();
+        let (_rt, mut world) = world();
+        reload.refresh_into(&mut world, &cfg(true, TelemetryExporterKind::Stdout));
+        let on = sink_ptr(&mut world);
+
+        assert!(reload.refresh_into(&mut world, &cfg(false, TelemetryExporterKind::Stdout)));
+        assert_ne!(sink_ptr(&mut world), on);
+        assert_eq!(
+            LAST_INSTALL.load(Ordering::SeqCst),
+            2,
+            "the daemon's own log lines must stop reaching a collector that was turned off"
+        );
+    }
+
+    #[test]
+    fn an_exporter_that_builds_nothing_leaves_a_working_silent_sink() {
+        // `exporter = "none"` with `enabled = true` is the config-level way to
+        // say "build no pipeline"; a failed OTLP construction reaches the same
+        // arm, having warned.
+        let reload = reload();
+        let (_rt, mut world) = world();
+        assert!(reload.refresh_into(&mut world, &cfg(true, TelemetryExporterKind::None)));
+        assert_eq!(LAST_INSTALL.load(Ordering::SeqCst), 2);
+        // Emitting into it is a no-op rather than a panic.
+        world
+            .world_mut()
+            .get_resource::<leviath_runtime::telemetry::Telemetry>()
+            .unwrap()
+            .0
+            .force_flush();
+    }
+
+    /// Moving to OTLP installs the daemon-log bridge as well as the sink, and
+    /// moving off it takes the bridge back out. Port 9 (discard) is never
+    /// connected until an export flush, which nothing here triggers.
+    #[test]
+    fn the_otlp_exporter_brings_the_daemon_log_bridge_with_it() {
+        let reload = reload();
+        let (_rt, mut world) = world();
+        let otlp = ObservabilityConfig {
+            enabled: true,
+            exporter: TelemetryExporterKind::Otlp,
+            endpoint: Some("http://127.0.0.1:9".to_string()),
+            service_name: Some("leviath-test".to_string()),
+        };
+        assert!(reload.refresh_into(&mut world, &otlp));
+        assert_eq!(
+            LAST_INSTALL.load(Ordering::SeqCst),
+            1,
+            "the daemon's own log lines go to the collector the user just named"
+        );
+
+        assert!(reload.refresh_into(&mut world, &cfg(true, TelemetryExporterKind::Stdout)));
+        assert_eq!(
+            LAST_INSTALL.load(Ordering::SeqCst),
+            2,
+            "and stop when the exporter they go through is no longer configured"
+        );
+    }
+
+    #[test]
+    fn a_changed_endpoint_is_a_change() {
+        let reload = reload();
+        let (_rt, mut world) = world();
+        let mut first = cfg(true, TelemetryExporterKind::Stdout);
+        reload.refresh_into(&mut world, &first);
+        first.service_name = Some("leviath-b".to_string());
+        assert!(
+            reload.refresh_into(&mut world, &first),
+            "a rename has to reach the exporter's resource attributes"
+        );
+    }
+
+    #[test]
+    fn for_daemon_starts_with_nothing_applied() {
+        let reload = TelemetryReload::for_daemon();
+        assert!(
+            reload.lock().is_none(),
+            "so the boot install goes through the same path as every later change"
+        );
+    }
+}

--- a/crates/leviath-cli/src/logging.rs
+++ b/crates/leviath-cli/src/logging.rs
@@ -6,7 +6,7 @@
 //! OTLP is only read later (by the daemon, after `Config::load`). Bridging
 //! that gap is what the reload slot is for: [`init`] installs the fmt layer
 //! plus an empty slot and parks the reload handle in a static;
-//! `install_otel_layer` fills the slot once the daemon has built its
+//! `set_otel_layer` fills the slot once the daemon has built its
 //! exporter. Everything stays on **stderr** - `lev agent-client` uses stdout
 //! as its JSON-RPC channel, and a stray log line there would corrupt the
 //! stream a host is parsing.
@@ -36,7 +36,7 @@ use tracing_subscriber::{EnvFilter, Layer, Registry, reload};
 /// What the reload slot holds: nothing, or the installed OTLP layer.
 type OtelSlot = Option<leviath_telemetry::LogLayer>;
 
-/// The handle [`install_otel_layer`] reloads through, parked by [`init`].
+/// The handle [`set_otel_layer`] reloads through, parked by [`init`].
 static OTEL_HANDLE: OnceLock<reload::Handle<OtelSlot, Registry>> = OnceLock::new();
 
 /// Whether a TUI currently owns the terminal.
@@ -172,12 +172,19 @@ pub fn init(verbose: bool) {
     let _ = OTEL_HANDLE.set(handle);
 }
 
-/// Fill the reload slot with the daemon's OTLP log-export layer. Returns
-/// whether the layer was installed - `false` when [`init`] hasn't run (a
-/// library consumer with its own subscriber) or the slot is gone.
-pub(crate) fn install_otel_layer(layer: leviath_telemetry::LogLayer) -> bool {
+/// Put the daemon's OTLP log-export layer in the reload slot, or `None` to
+/// empty it. Returns whether the slot was written - `false` when [`init`]
+/// hasn't run (a library consumer with its own subscriber) or the slot is
+/// gone.
+///
+/// Takes an `Option` because `[observability]` reloads: a user who turns
+/// export off, or moves from the OTLP exporter to the stdout one, has to stop
+/// the daemon's own log lines reaching a collector they are no longer pointing
+/// at. The slot is a `reload::Layer`, so emptying it is the same operation as
+/// filling it.
+pub(crate) fn set_otel_layer(layer: Option<leviath_telemetry::LogLayer>) -> bool {
     match OTEL_HANDLE.get() {
-        Some(handle) => handle.reload(Some(layer)).is_ok(),
+        Some(handle) => handle.reload(layer).is_ok(),
         None => false,
     }
 }
@@ -211,7 +218,7 @@ mod tests {
     fn init_parks_the_handle_and_install_forwards_events() {
         // Before any handle is parked: nothing to install into.
         let (layer, _exporter) = bridge_with_exporter();
-        assert!(!install_otel_layer(layer));
+        assert!(!set_otel_layer(Some(layer)));
 
         // Park a handle whose subscriber this thread controls.
         let (otel_layer, handle) = reload::Layer::new(None as OtelSlot);
@@ -223,7 +230,7 @@ mod tests {
         let _guard = tracing::subscriber::set_default(subscriber);
 
         let (layer, exporter) = bridge_with_exporter();
-        assert!(install_otel_layer(layer));
+        assert!(set_otel_layer(Some(layer)));
         tracing::info!(target: "leviath::logging::test", "forwarded line");
         let emitted = exporter.get_emitted_logs().unwrap();
         assert!(
@@ -246,7 +253,7 @@ mod tests {
         init(false);
         init(true);
         let (layer, _exporter) = bridge_with_exporter();
-        assert!(install_otel_layer(layer));
+        assert!(set_otel_layer(Some(layer)));
     }
 
     /// The hold is what keeps a log line out of a wizard someone is reading,

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -23,8 +23,8 @@ where you look up the exact name, type, and default. The same contract ships mac
 > up by the next run started, whether it came from `lev run`, the API or the dashboard, and it
 > makes no difference whether the edit came from `lev setup`, `PUT /api/config` or an editor. A
 > run already under way keeps the provider its current stage started on. `lev serve` reads the
-> file per request, so an edit is on the next page load. MCP connections and telemetry exporters
-> are still boot-time wiring and need `lev daemon restart`. See
+> file per request, so an edit is on the next page load. MCP connections are still boot-time
+> wiring and need `lev daemon restart`. See
 > [the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run).
 
 ## Top level

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -182,10 +182,16 @@ restart. The scripted half needed this most, because it failed in a way no resta
 the rule sources were read into the compiled checker at boot, so editing a `.rhai` file changed
 nothing at all and the gate went on answering from the text it started with.
 
+`[observability]` reloads too. Turn export on, point it at a different collector, rename the
+service, or turn it off, and the next run emits into what the file says now. The one thing that
+does not move is how verbose the daemon's own log is: the process subscriber is installed before
+any config is read, from `--verbose` on the daemon's command line, and a `tracing` subscriber can
+only be set once per process. Changing that still means restarting the daemon.
+
 Some changes do still need `lev daemon restart`. They set up connections and process-wide state
 once at startup rather than per run:
 
-- `[[mcp_servers]]` (live MCP connections) and `[observability]` (the telemetry pipeline).
+- `[[mcp_servers]]`, which hold live MCP connections.
 - The `[limits]` the world itself is built with: `stall_timeout_secs`, `wedge_timeout_secs`,
   `dead_cycles_before_relief`, `max_concurrent_inferences`, `max_concurrent_tools`,
   `provider_failures_before_open`, `provider_circuit_cooldown_secs`,

--- a/docs/content/observability.md
+++ b/docs/content/observability.md
@@ -32,6 +32,11 @@ value beats the environment.
 To see what would be exported without sending it anywhere, set `exporter = "stdout"`. It narrates
 the same events as readable lines on stderr.
 
+This block reloads: the daemon re-reads it and the next run emits into whatever it now names, with
+no restart. Turning export off puts the daemon's own log lines back on stderr alone. The one part
+that is fixed for the process's life is the log level, which comes from `--verbose` on the daemon's
+own command line rather than from here.
+
 > [!WARNING]
 > Export is OTLP over HTTP, on port **4318**. Many collector examples use 4317, which is the gRPC
 > port, and Leviath does not speak it. Pointing at 4317 fails silently from the outside.


### PR DESCRIPTION
## What

`[observability]` reloads. Turning export on, moving it to another collector, renaming the service,
or turning it off reaches the next run instead of the next daemon restart.

## Why

`daemon/setup.rs` called `leviath_telemetry::build_sink` once at boot and installed the result as
the world's `Telemetry` resource, with the OTLP log bridge going into the CLI's reload slot beside
it. Both were then fixed for the life of the process.

The common case fails in the worst way available: you set `enabled = true`, start a run to watch it
arrive, and nothing does. From outside that is indistinguishable from a collector on the wrong port,
which is the first thing anyone checks and the thing that was already right.

## How

`daemon/telemetry_reload.rs` follows the pattern PR #729 established for providers: compare the
config in service with the one the file names now, rebuild only on a difference, and swap the world
resource. Boot is the reload's first refresh, so there is one seam rather than two, and the daemon
re-checks at the two points everything else does: before a spawn, and when a run is paged back in.

Both halves turn out to be swappable, so nothing here is a partial fix:

- The sink is a world resource like `PolicyGate`.
- The OTLP log bridge already lives in a `tracing_subscriber` `reload::Layer`. `install_otel_layer`
  became `set_otel_layer` and takes an `Option`: turning export off has to stop the daemon's own
  log lines reaching a collector nobody is pointing at any more.
- The outgoing sink is flushed before it is dropped, so what it had already recorded still reaches
  the old collector.

## What stays fixed for the process's life

The base subscriber `logging::init` installs before any config is read: the fmt layer, its stderr
writer, and the `info`/`debug` filter. A `tracing` subscriber can only be set once per process, and
that filter comes from `--verbose` on the daemon's own command line, not from `[observability]`.
Changing how verbose the daemon's log is still needs a restart. `daemon.md` and `observability.md`
say exactly that rather than implying the whole block is live.

## Tests

New in `telemetry_reload.rs`: the first refresh installing and a repeat of it not, turning export on
swapping the sink, turning it off restoring the no-op sink and clearing the bridge, the OTLP
exporter bringing the log bridge with it and losing it again, a rename counting as a change, and a
config that builds no pipeline leaving a working silent sink.

**Fails first**: with `refresh_into` reduced to "apply once, then never again" (the boot-only
behaviour on `main`), three of the new tests fail:

```
turning_export_on_after_boot_swaps_the_sink
turning_export_off_puts_the_noop_sink_back_and_clears_the_bridge
a_changed_endpoint_is_a_change
```

**Live probe** (mock harness, isolated `LEVIATH_HOME`, `LEVIATH_SKIP_DOTENV=1`): a real daemon runs
with observability off, then the probe turns the stdout exporter on in `config.toml`, then off
again. The stdout exporter narrates every event through `tracing`, so the daemon's own log counts
them:

```
own_daemon_spawned_it:      true
events_while_off:           0
events_after_turning_on:    16
events_after_turning_off:   0
pid_unchanged:              true
```

## Gates

`cargo fmt`, `clippy -D warnings` on `leviath-cli`, `xtask structure`, `xtask docs`, and
`xtask coverage` at 100% for `leviath-cli`.

## Notes

Touches the same two hooks in `daemon/setup.rs` as #729 and #731, so expect a small conflict with
each.
