### PR TITLE
feat(daemon): make a global MCP server live, so lev mcp add reaches the next run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,21 @@ same list.
   replaced, so what it had already recorded still reaches the old collector. The daemon's own log
   level is not part of this and still needs a restart: the process subscriber is installed from
   `--verbose` before any config is read.
+- A global `[[mcp_servers]]` entry added, edited or removed under a running
+  daemon reaches the next run. The servers were connected once at boot and the
+  tools they advertise were cloned into the spawner, so `lev mcp add` and `POST
+  /api/mcp/servers` wrote the file and stopped there: the server was in the
+  config, `lev mcp list` showed it, and no run could call it until someone
+  restarted the daemon, with nothing anywhere saying so. A run already under
+  way keeps the servers it started with; a removed one stays connected for
+  `[limits] mcp_idle_disconnect_secs` so nothing loses a tool mid-call, and an
+  edited entry's old connection is replaced before the new one opens.
+- `[security] allow_env_vars` and `credential_store` are read when an MCP
+  server is connected rather than copied at boot, so a variable you have just
+  allowed reaches an MCP `${VAR}` header. `daemon.md` said the allowlist took
+  effect on the next load, which was true of script providers and not of MCP.
+  A global server whose headers interpolate is reconnected when the list moves,
+  which is what puts the new value in front of the next run.
 - The update check read the GitHub releases answer with no size cap, the one
   buffered remote read left after the daemon's caps landed. It now stops at
   the same 64 MiB as every other buffered body and reports the same

--- a/crates/leviath-cli/src/daemon/fanout_spawner.rs
+++ b/crates/leviath-cli/src/daemon/fanout_spawner.rs
@@ -36,10 +36,10 @@ pub(crate) struct DaemonFanOutSpawner {
     pub config: Arc<crate::daemon::config_reload::ConfigReloader>,
     /// The daemon-wide MCP executor, for servers configured globally.
     pub shared_mcp: Arc<Mutex<leviath_mcp::ToolExecutor>>,
-    /// Tool definitions from `shared_mcp`, resolved once rather than per worker.
-    pub mcp_tool_defs: Vec<Tool>,
-    /// Which server advertises each of them, for a stage granting a connector.
-    pub mcp_tool_owners: leviath_runtime::pipeline::ToolOwners,
+    /// The global `[[mcp_servers]]` as a live set. Read per worker rather than
+    /// captured, so a server added to `config.toml` after this daemon started
+    /// reaches a fan-out worker as it reaches any other run.
+    pub mcp_global: Arc<crate::daemon::mcp_reload::McpReload>,
     /// Shared MCP pool for per-agent `[[mcp_servers]]` - a fan-out worker
     /// advertises its blueprint's already-connected servers and lazily warms any
     /// uncached ones for subsequent workers of the same type.
@@ -69,8 +69,7 @@ impl DaemonFanOutSpawner {
         &self,
         blueprint_path: &str,
     ) -> (Vec<Tool>, leviath_runtime::pipeline::ToolOwners) {
-        let mut defs = self.mcp_tool_defs.clone();
-        let mut owners = self.mcp_tool_owners.clone();
+        let (mut defs, mut owners) = self.mcp_global.current();
         let Ok(toml) = std::fs::read_to_string(blueprint_path) else {
             return (defs, owners);
         };
@@ -376,6 +375,24 @@ mod tests {
             .to_string()
     }
 
+    /// A live global-MCP handle over `defs`, standing in for the servers
+    /// `config.toml` declares.
+    fn global_mcp(defs: Vec<Tool>) -> Arc<crate::daemon::mcp_reload::McpReload> {
+        let owners = defs
+            .iter()
+            .map(|t| (t.name.clone(), "global".to_string()))
+            .collect();
+        crate::daemon::mcp_reload::McpReload::new(
+            &Config::default(),
+            crate::daemon::mcp_pool::McpPool::for_daemon(
+                Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+                &[],
+            ),
+            defs,
+            owners,
+        )
+    }
+
     fn spawner_with(tool_service: Arc<CliToolService>) -> DaemonFanOutSpawner {
         let shared_mcp = Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new()));
         DaemonFanOutSpawner {
@@ -383,8 +400,7 @@ mod tests {
                 Config::default(),
             )),
             shared_mcp: shared_mcp.clone(),
-            mcp_tool_defs: vec![],
-            mcp_tool_owners: Default::default(),
+            mcp_global: global_mcp(vec![]),
             mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(shared_mcp, &[]),
             hub: InteractionHub::new(),
             subagent_tx: tokio::sync::mpsc::unbounded_channel().0,
@@ -397,11 +413,11 @@ mod tests {
     #[tokio::test]
     async fn worker_mcp_defs_advertises_cached_servers_and_falls_back_to_global() {
         let mut spawner = spawner_with(Arc::new(CliToolService::new()));
-        spawner.mcp_tool_defs = vec![Tool {
+        spawner.mcp_global = global_mcp(vec![Tool {
             name: "global_tool".to_string(),
             description: String::new(),
             parameters: serde_json::json!({}),
-        }];
+        }]);
         // A worker blueprint declaring an MCP server.
         let dir = tempfile::tempdir().unwrap();
         let manifest = dir.path().join("agent.leviath");
@@ -491,14 +507,15 @@ mod tests {
             parent_run_id: None,
             output: None,
         };
+        let (global_defs, global_owners) = spawner.mcp_global.current();
         let parent = build_agent(
             world.world_mut(),
             SpawnDeps {
                 tool_service: cli.as_ref(),
                 config: &spawner.config.current(),
                 shared_mcp: spawner.shared_mcp.clone(),
-                mcp_tool_defs: &spawner.mcp_tool_defs,
-                mcp_tool_owners: &spawner.mcp_tool_owners,
+                mcp_tool_defs: &global_defs,
+                mcp_tool_owners: &global_owners,
                 hub: &spawner.hub,
                 now_secs: 100,
                 subagent_tx: spawner.subagent_tx.clone(),

--- a/crates/leviath-cli/src/daemon/mcp_pool.rs
+++ b/crates/leviath-cli/src/daemon/mcp_pool.rs
@@ -29,13 +29,16 @@ pub struct McpPool {
     /// mutex (held only briefly, never across `.await`) so the sync spawner can
     /// read it from a runtime thread without `blocking_lock`'s panic.
     connected: StdMutex<HashMap<String, Vec<Tool>>>,
-    /// Where MCP OAuth grants are kept, so a refreshed token is written back to
-    /// the backend it came from. Defaults to the file store, which is also the
-    /// config default - a pool built without being told reads `mcp-auth.json`.
-    credential_store: leviath_core::CredentialStoreKind,
-    /// `[security] allow_env_vars`: which credential-shaped variables an MCP
-    /// server's `${VAR}` headers may interpolate.
-    allow_env_vars: Vec<String>,
+    /// The `[security]` settings that shape a *connection* rather than the
+    /// pool: where MCP OAuth grants are kept, and which credential-shaped
+    /// variables a server's `${VAR}` headers may interpolate.
+    ///
+    /// Behind a lock because they were boot copies, and the docs said
+    /// otherwise: naming a variable in `allow_env_vars` was supposed to take
+    /// effect on the next load, and for an MCP server it took effect on the
+    /// next daemon restart. `mcp_reload` writes them on each config reconcile,
+    /// and they are read when a server is connected.
+    security: StdMutex<PoolSecurity>,
     /// Per-run leases on per-agent servers (see [`Self::lease_blueprint`]).
     /// Same `std` mutex discipline as `connected`: held briefly, never across
     /// an `.await`.
@@ -46,6 +49,17 @@ pub struct McpPool {
     /// server any blueprint ever declared stayed connected for the daemon's
     /// life.
     idle_disconnect: std::time::Duration,
+}
+
+/// The connection-shaping half of `[security]`, as of the last config
+/// reconcile.
+struct PoolSecurity {
+    /// Where MCP OAuth grants are read from and written back to. Defaults to
+    /// the file store, which is also the config default - a pool built without
+    /// being told reads `mcp-auth.json`.
+    credential_store: leviath_core::CredentialStoreKind,
+    /// `[security] allow_env_vars`.
+    allow_env_vars: Vec<String>,
 }
 
 /// Which runs hold which per-agent servers open.
@@ -88,7 +102,7 @@ struct ServerLease {
 /// A stable dedup key for a server config: its full serialized form. Two
 /// blueprints declaring an identical server share one connection; a difference in
 /// name/command/url/args/env/headers is a distinct server.
-fn signature(config: &MCPServerConfig) -> String {
+pub(crate) fn signature(config: &MCPServerConfig) -> String {
     // Serializing a plain config never fails; fall back to an empty key rather
     // than carry a dead error closure.
     serde_json::to_string(config).unwrap_or_default()
@@ -108,8 +122,10 @@ impl McpPool {
             shared,
             reserved,
             connected: StdMutex::new(HashMap::new()),
-            credential_store: leviath_core::CredentialStoreKind::default(),
-            allow_env_vars: Vec::new(),
+            security: StdMutex::new(PoolSecurity {
+                credential_store: leviath_core::CredentialStoreKind::default(),
+                allow_env_vars: Vec::new(),
+            }),
             leases: StdMutex::new(LeaseTable::default()),
             idle_disconnect: std::time::Duration::from_secs(DEFAULT_MCP_IDLE_DISCONNECT_SECS),
         }
@@ -130,15 +146,33 @@ impl McpPool {
     }
 
     /// Allow these credential-shaped variables in MCP `${VAR}` headers.
-    pub(crate) fn with_env_allowlist(mut self, allow: Vec<String>) -> Self {
-        self.allow_env_vars = allow;
+    pub(crate) fn with_env_allowlist(self, allow: Vec<String>) -> Self {
+        self.lock_security().allow_env_vars = allow;
         self
     }
 
     /// Read and write MCP grants through `kind`'s backend.
-    pub(crate) fn with_credential_store(mut self, kind: leviath_core::CredentialStoreKind) -> Self {
-        self.credential_store = kind;
+    pub(crate) fn with_credential_store(self, kind: leviath_core::CredentialStoreKind) -> Self {
+        self.lock_security().credential_store = kind;
         self
+    }
+
+    /// Adopt `config`'s `[security]` for every connection opened from now on.
+    ///
+    /// Called from the config reconcile beside this, before anything is
+    /// connected: a server whose `${VAR}` header the user has just allowed is
+    /// reconnected there, and this is what makes the reconnect see the new
+    /// allowlist.
+    pub(crate) fn apply_security(&self, config: &crate::config::Config) {
+        let mut security = self.lock_security();
+        security.credential_store = config.security.credential_store;
+        security
+            .allow_env_vars
+            .clone_from(&config.security.allow_env_vars);
+    }
+
+    fn lock_security(&self) -> std::sync::MutexGuard<'_, PoolSecurity> {
+        self.security.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
     /// Build the daemon's shared pool over `shared_mcp`: reserve built-in and
@@ -205,6 +239,91 @@ impl McpPool {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .insert(sig, defs);
+    }
+
+    /// Seed every global server in `servers` with the defs it contributed to
+    /// `defs`, worked out from `owners`.
+    ///
+    /// The alternative is [`seed`](Self::seed)'s empty vec, which is what the
+    /// startup path used while the global servers' defs lived in a separate
+    /// list beside the pool. Filing each server's own defs under its signature
+    /// makes [`cached_defs_for`](Self::cached_defs_for) the single answer to
+    /// "what does this set of servers advertise", for the global set as much as
+    /// a blueprint's - which is what lets the global set change under a running
+    /// daemon without a second list to keep in step.
+    pub(crate) fn seed_all(
+        &self,
+        servers: &[MCPServerConfig],
+        defs: &[Tool],
+        owners: &leviath_runtime::pipeline::ToolOwners,
+    ) {
+        for server in servers {
+            let mine: Vec<Tool> = defs
+                .iter()
+                .filter(|t| owners.get(&t.name).is_some_and(|o| *o == server.name))
+                .cloned()
+                .collect();
+            self.seed(server, mine);
+        }
+    }
+
+    /// [`ensure`](Self::ensure) for a server the *config* declares: the
+    /// connection belongs to the daemon rather than to any run, so it is exempt
+    /// from lease-driven idle disconnection, and a pending retirement from a
+    /// moment ago (the user removed it and put it back) is cancelled.
+    pub(crate) async fn ensure_global(&self, config: &MCPServerConfig) -> Vec<Tool> {
+        let sig = signature(config);
+        {
+            let mut table = self.leases.lock().unwrap_or_else(PoisonError::into_inner);
+            table.global.insert(sig.clone());
+            // Dropping the row is what makes a scheduled disconnect a no-op:
+            // it looks for the row before it touches anything.
+            table.servers.remove(&sig);
+        }
+        self.ensure(config).await
+    }
+
+    /// Stop holding `config`'s server open on the daemon's behalf: it is no
+    /// longer in `[[mcp_servers]]`.
+    ///
+    /// `at_once` tears the connection down before returning, for an *edited*
+    /// entry - the replacement connects under the same name straight
+    /// afterwards, and a delayed teardown would take that one down with it.
+    /// Otherwise the server is handed to the same grace timer an unleased
+    /// per-agent server gets, so a run part-way through a stage keeps the tool
+    /// working for that window rather than losing it mid-call.
+    pub(crate) async fn retire_global(self: &Arc<Self>, config: &MCPServerConfig, at_once: bool) {
+        let sig = signature(config);
+        let name = config.name.clone();
+        let generation = {
+            let mut table = self.leases.lock().unwrap_or_else(PoisonError::into_inner);
+            table.global.remove(&sig);
+            let entry = table
+                .servers
+                .entry(sig.clone())
+                .or_insert_with(|| ServerLease {
+                    name: name.clone(),
+                    holders: HashSet::new(),
+                    generation: 0,
+                });
+            entry.generation += 1;
+            entry.generation
+        };
+        let handle = tokio::runtime::Handle::try_current().ok();
+        match (at_once, handle) {
+            // No runtime to schedule on (a sync test) is the immediate case too:
+            // a deferred teardown that never runs is a leaked child process.
+            (true, _) | (false, None) => {
+                self.disconnect_if_still_idle(&sig, &name, generation).await;
+            }
+            (false, Some(handle)) => {
+                let pool = Arc::clone(self);
+                handle.spawn(async move {
+                    tokio::time::sleep(pool.idle_disconnect).await;
+                    pool.disconnect_if_still_idle(&sig, &name, generation).await;
+                });
+            }
+        }
     }
 
     /// Record `run_id` as holding every per-agent server `blueprint_path`
@@ -364,6 +483,14 @@ impl McpPool {
         }
     }
 
+    /// Whether the shared executor can still dispatch `tool`. The
+    /// advertisement and the connection are separate records, and the bug this
+    /// distinguishes is one going stale without the other.
+    #[cfg(test)]
+    pub(crate) async fn routes(&self, tool: &str) -> bool {
+        self.shared.lock().await.route(tool).is_ok()
+    }
+
     /// The signatures currently holding leases, for tests and diagnostics.
     #[cfg(test)]
     fn leased_holders(&self, config: &MCPServerConfig) -> usize {
@@ -394,9 +521,14 @@ impl McpPool {
         // static-header servers. Mirrors `ToolRegistry::build`.
         let oauth = leviath_mcp::OAuthClient::new();
         let store_path = leviath_mcp::AuthStore::default_path();
-        let credentials = crate::tools::credential_store_or_warn(crate::credentials::store_for(
-            self.credential_store,
-        ));
+        // Read out before the connect: both sit behind a `std` mutex, and the
+        // connect awaits.
+        let (store_kind, allow_env) = {
+            let security = self.lock_security();
+            (security.credential_store, security.allow_env_vars.clone())
+        };
+        let credentials =
+            crate::tools::credential_store_or_warn(crate::credentials::store_for(store_kind));
         let auth = match crate::tools::resolve_bearer(
             &oauth,
             &config.name,
@@ -416,7 +548,7 @@ impl McpPool {
         let auth_was_resolved = auth.is_some();
         let mut discovery = ToolDiscovery::new();
         match discovery
-            .discover_from_config_with_auth(config, auth, &self.allow_env_vars)
+            .discover_from_config_with_auth(config, auth, &allow_env)
             .await
         {
             Ok((_metas, mut client)) => {

--- a/crates/leviath-cli/src/daemon/mcp_reload.rs
+++ b/crates/leviath-cli/src/daemon/mcp_reload.rs
@@ -1,0 +1,583 @@
+//! Keeping the daemon's global `[[mcp_servers]]` in step with `config.toml`.
+//!
+//! The global servers were connected once, by `ToolRegistry::build` at boot,
+//! and the tools they advertise were cloned into the spawner as a plain
+//! `Vec<Tool>` that nothing ever wrote to again. So `lev mcp add` and
+//! `POST /api/mcp/servers` wrote the file and stopped there: the server was in
+//! the config, `lev mcp list` showed it, and no run could call it until the
+//! daemon was restarted - with nothing anywhere saying so.
+//!
+//! This module reconciles that set against the reloaded config before each
+//! spawn. The pool beside it already knows how to connect a server lazily,
+//! dedupe it by signature and tear an unused one down, so the work here is
+//! deciding *what* changed and letting the pool do the rest. The advertised
+//! defs are then read back off the pool's own cache rather than kept in a
+//! second list, because two lists of the same thing is how the old one went
+//! stale.
+
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, PoisonError};
+
+use leviath_mcp::MCPServerConfig;
+use leviath_providers::Tool;
+
+use crate::config::Config;
+use crate::daemon::mcp_pool::{McpPool, signature};
+
+/// The global MCP set as it currently stands, and what it advertises.
+struct State {
+    /// The `[[mcp_servers]]` entries the defs below were built from.
+    installed: Vec<MCPServerConfig>,
+    /// `[security] allow_env_vars` as of that reconcile. A server's `${VAR}`
+    /// headers are resolved at connect time, so a change here is a change to
+    /// the connection even when the entry itself is untouched.
+    allow_env_vars: Vec<String>,
+    /// What those servers advertise, and which of them advertises each tool.
+    defs: Vec<Tool>,
+    owners: leviath_runtime::pipeline::ToolOwners,
+}
+
+/// Reconciles the daemon's global MCP servers with `config.toml`.
+pub struct McpReload {
+    pool: Arc<McpPool>,
+    state: Mutex<State>,
+}
+
+impl McpReload {
+    /// Start from the servers the daemon booted with and the tools they
+    /// advertised.
+    pub(crate) fn new(
+        config: &Config,
+        pool: Arc<McpPool>,
+        defs: Vec<Tool>,
+        owners: leviath_runtime::pipeline::ToolOwners,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            pool,
+            state: Mutex::new(State {
+                installed: config.mcp_servers.clone(),
+                allow_env_vars: config.security.allow_env_vars.clone(),
+                defs,
+                owners,
+            }),
+        })
+    }
+
+    /// What the global servers advertise right now, for the sync spawner.
+    pub(crate) fn current(&self) -> (Vec<Tool>, leviath_runtime::pipeline::ToolOwners) {
+        let state = self.lock();
+        (state.defs.clone(), state.owners.clone())
+    }
+
+    /// Bring the connected global set in line with `config`, so the next run
+    /// sees the servers the file names now.
+    ///
+    /// Connecting is lazy in the sense that matters: a server already up under
+    /// the same signature is left alone, and a new one is connected here, once,
+    /// rather than on the spawn that needs it. A connection that fails is not
+    /// cached, so the next spawn tries again - a server whose command is not
+    /// installed yet costs a run its tools, never its spawn.
+    pub(crate) async fn refresh(&self, config: &Config) {
+        // First, so every connection opened below - including a per-agent
+        // server the blueprint warmer connects a moment later - is opened under
+        // the `[security]` the file names now.
+        self.pool.apply_security(config);
+        let wanted = config.mcp_servers.clone();
+        let allow = config.security.allow_env_vars.clone();
+        let (installed, allow_before) = {
+            let state = self.lock();
+            (state.installed.clone(), state.allow_env_vars.clone())
+        };
+        // Compared by the pool's own signature, which is the key the
+        // connections are stored under: two entries the pool would dedupe into
+        // one connection are the same entry here too, whatever else differs.
+        let wanted_sigs: HashSet<String> = wanted.iter().map(signature).collect();
+        let installed_sigs: Vec<String> = installed.iter().map(signature).collect();
+        let unchanged = installed_sigs.len() == wanted.len()
+            && installed_sigs.iter().all(|sig| wanted_sigs.contains(sig));
+        if unchanged && allow == allow_before {
+            return;
+        }
+        let env_changed = allow != allow_before;
+        let wanted_names: HashSet<&str> = wanted.iter().map(|s| s.name.as_str()).collect();
+        for (old, sig) in installed.iter().zip(&installed_sigs) {
+            // An entry whose exact form is still in the file stays connected,
+            // unless the allowlist that resolved its headers has moved: the
+            // header was interpolated at connect time and nothing revisits it.
+            let kept = wanted_sigs.contains(sig);
+            let stale_headers = env_changed && interpolates_env(old);
+            if kept && !stale_headers {
+                continue;
+            }
+            // Same name, different entry: the replacement connects under this
+            // name in a moment, so the old connection has to be gone first.
+            let replaced = wanted_names.contains(old.name.as_str());
+            self.pool
+                .retire_global(old, replaced || stale_headers)
+                .await;
+        }
+        for server in &wanted {
+            self.pool.ensure_global(server).await;
+        }
+        // Read back off the pool rather than accumulated above: what a run can
+        // actually call is what the pool has connected, and a def list built
+        // from the config would claim a server that failed to start.
+        let defs = self.pool.cached_defs_for(&wanted);
+        let owners = self.pool.cached_owners_for(&wanted);
+        let count = defs.len();
+        let servers = wanted.len();
+        tracing::info!(
+            servers,
+            tools = count,
+            "reconciled the global MCP servers with config.toml"
+        );
+        let mut state = self.lock();
+        state.installed = wanted;
+        state.allow_env_vars = allow;
+        state.defs = defs;
+        state.owners = owners;
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+}
+
+/// Whether any of `config`'s headers reference an environment variable, and so
+/// answer to `[security] allow_env_vars`. Only HTTP headers do; a stdio
+/// server's environment is filtered by a different rule that the allowlist has
+/// no part in.
+fn interpolates_env(config: &MCPServerConfig) -> bool {
+    config.headers.values().any(|v| v.contains("${"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::with_tracing;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A stub MCP server over HTTP rather than a spawned script: every case
+    /// here turns on *when* a connection is opened, and an in-process server
+    /// can count that. It also keeps the whole module off `python3`, which is
+    /// not a name Windows has.
+    struct Stub {
+        base: String,
+        /// How many MCP handshakes this server has answered, which is how many
+        /// times the pool has connected to it.
+        connects: Arc<AtomicUsize>,
+    }
+
+    impl Stub {
+        /// An entry naming this server, advertising one tool called `tool`
+        /// unless an `X-Token` header says otherwise.
+        fn entry(&self, name: &str, tool: &str) -> MCPServerConfig {
+            MCPServerConfig::http(name, format!("{}/mcp/{tool}", self.base))
+        }
+
+        fn connects(&self) -> usize {
+            self.connects.load(Ordering::Relaxed)
+        }
+    }
+
+    /// Stand one up. `tools/list` answers with a single tool named after the
+    /// `X-Token` header when it carries one, and after the URL's last segment
+    /// otherwise - so the header the daemon actually sent is readable straight
+    /// off the advertised tool list.
+    async fn stub_server() -> Stub {
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::{Json, Router};
+        let connects = Arc::new(AtomicUsize::new(0));
+        let counter = connects.clone();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let app = Router::new().route(
+            "/mcp/{fallback}",
+            post(
+                move |axum::extract::Path(fallback): axum::extract::Path<String>,
+                      headers: axum::http::HeaderMap,
+                      body: String| {
+                    let counter = counter.clone();
+                    async move {
+                        let req: serde_json::Value = serde_json::from_str(&body).unwrap();
+                        let id = req.get("id").cloned().unwrap_or(serde_json::json!(1));
+                        let result = match req.get("method").and_then(|m| m.as_str()) {
+                            Some("initialize") => {
+                                counter.fetch_add(1, Ordering::Relaxed);
+                                serde_json::json!({
+                                    "capabilities": {}, "protocolVersion": "2024-11-05"
+                                })
+                            }
+                            Some("tools/list") => {
+                                let name = headers
+                                    .get("x-token")
+                                    .and_then(|v| v.to_str().ok())
+                                    .filter(|v| !v.is_empty())
+                                    .map_or(fallback, str::to_string);
+                                serde_json::json!({"tools": [{"name": name, "inputSchema": {}}]})
+                            }
+                            _ => serde_json::json!({}),
+                        };
+                        (
+                            [(axum::http::header::CONTENT_TYPE, "application/json")],
+                            Json(serde_json::json!({"jsonrpc": "2.0", "id": id, "result": result}))
+                                .into_response()
+                                .into_body(),
+                        )
+                            .into_response()
+                    }
+                },
+            ),
+        );
+        tokio::spawn(std::future::IntoFuture::into_future(axum::serve(
+            listener, app,
+        )));
+        Stub { base, connects }
+    }
+
+    fn config_with(servers: Vec<MCPServerConfig>) -> Config {
+        Config {
+            mcp_servers: servers,
+            ..Config::default()
+        }
+    }
+
+    /// A pool whose retired servers wait `idle` seconds before the connection
+    /// is torn down, the same window an unleased per-agent server gets.
+    fn pool_with_idle(idle: u64) -> Arc<McpPool> {
+        McpPool::for_daemon_with(
+            Arc::new(tokio::sync::Mutex::new(leviath_mcp::ToolExecutor::new())),
+            &[],
+            Default::default(),
+            Vec::new(),
+            idle,
+        )
+    }
+
+    fn pool() -> Arc<McpPool> {
+        pool_with_idle(crate::daemon::mcp_pool::DEFAULT_MCP_IDLE_DISCONNECT_SECS)
+    }
+
+    /// A reload starting from a daemon that booted with no MCP servers at all.
+    fn booted_empty_on(pool: Arc<McpPool>) -> Arc<McpReload> {
+        McpReload::new(
+            &config_with(Vec::new()),
+            pool,
+            Vec::new(),
+            Default::default(),
+        )
+    }
+
+    fn booted_empty() -> Arc<McpReload> {
+        booted_empty_on(pool())
+    }
+
+    /// A reload as the daemon really boots one: `ToolRegistry::build` has
+    /// connected `server` and the pool has been seeded with what it
+    /// advertises, so the handle starts out holding that server's tools.
+    async fn booted_with(pool: Arc<McpPool>, server: &MCPServerConfig) -> Arc<McpReload> {
+        let defs = pool.ensure_global(server).await;
+        let owners = pool.cached_owners_for(std::slice::from_ref(server));
+        McpReload::new(&config_with(vec![server.clone()]), pool, defs, owners)
+    }
+
+    /// Wait until `pool` can no longer dispatch `tool`. The teardown of a
+    /// retired server runs on its own task, so the assertion is about it
+    /// having happened rather than about when the scheduler got to it.
+    async fn until_disconnected(pool: &McpPool, tool: &str) {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while pool.routes(tool).await {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("a server the config no longer names has to be disconnected");
+    }
+
+    /// The advertised tool names, sorted so an assertion does not depend on
+    /// connection order.
+    fn names(reload: &McpReload) -> Vec<String> {
+        let mut out: Vec<String> = reload.current().0.into_iter().map(|t| t.name).collect();
+        out.sort();
+        out
+    }
+
+    /// `LEVIATH_HOME` at a fresh temp dir, so the OAuth store the connect path
+    /// reads is empty rather than the real `~/.leviath`.
+    async fn with_temp_home<F, Fut, T>(body: F) -> T
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        let dir = tempfile::tempdir().unwrap();
+        temp_env::async_with_vars(
+            [("LEVIATH_HOME", Some(dir.path().to_str().unwrap()))],
+            body(),
+        )
+        .await
+    }
+
+    /// The hole this module exists for. `lev mcp add` and `POST
+    /// /api/mcp/servers` write `[[mcp_servers]]` and nothing else, so the
+    /// server was in the config, listed by `lev mcp list`, and uncallable by
+    /// every run until someone restarted the daemon - with nothing saying so.
+    #[tokio::test]
+    async fn a_server_added_after_boot_is_callable_by_the_next_run() {
+        with_tracing(|| {});
+        let stub = stub_server().await;
+        with_temp_home(|| async {
+            let reload = booted_empty();
+            assert!(names(&reload).is_empty());
+
+            reload
+                .refresh(&config_with(vec![stub.entry("added", "echo")]))
+                .await;
+            assert_eq!(
+                names(&reload),
+                vec!["added__echo".to_string()],
+                "a server the user just added has to be advertised without a restart"
+            );
+            assert!(
+                reload.pool.routes("added__echo").await,
+                "and it has to actually route, not just appear in the list"
+            );
+        })
+        .await;
+    }
+
+    /// And the other direction: a server taken out of the config stops being
+    /// offered, rather than lingering for the daemon's life because its defs
+    /// were cloned into the spawner at boot.
+    #[tokio::test]
+    async fn a_server_removed_from_the_config_is_gone_from_the_next_run() {
+        with_tracing(|| {});
+        let stub = stub_server().await;
+        with_temp_home(|| async {
+            let reload = booted_with(pool(), &stub.entry("gone", "echo")).await;
+            assert_eq!(names(&reload), vec!["gone__echo".to_string()]);
+
+            reload.refresh(&config_with(Vec::new())).await;
+            assert!(
+                names(&reload).is_empty(),
+                "the entry the user deleted must stop being advertised"
+            );
+        })
+        .await;
+    }
+
+    /// The connection outlives the advertisement by the pool's idle window,
+    /// which is the point: a run part-way through a stage keeps calling the
+    /// tool it was given rather than losing it mid-call, while the next run
+    /// never sees it. The window is `[limits] mcp_idle_disconnect_secs`, the
+    /// same one an unleased per-agent server gets; zero here so the test does
+    /// not wait a minute for it.
+    #[tokio::test]
+    async fn a_removed_server_is_disconnected_after_its_grace_window() {
+        with_tracing(|| {});
+        let stub = stub_server().await;
+        with_temp_home(|| async {
+            let reload = booted_with(pool_with_idle(0), &stub.entry("gone", "echo")).await;
+            assert!(reload.pool.routes("gone__echo").await);
+
+            reload.refresh(&config_with(Vec::new())).await;
+            until_disconnected(&reload.pool, "gone__echo").await;
+        })
+        .await;
+    }
+
+    /// A reconcile that changes nothing must not churn the connections. Every
+    /// teardown costs a child process, and for an OAuth-backed server it risks
+    /// a fresh interactive grant - on a path that runs before every spawn.
+    #[tokio::test]
+    async fn an_unchanged_config_leaves_the_connections_alone() {
+        with_tracing(|| {});
+        let stub = stub_server().await;
+        with_temp_home(|| async {
+            let config = config_with(vec![stub.entry("keep", "echo")]);
+            let reload = booted_empty();
+            reload.refresh(&config).await;
+            assert_eq!(stub.connects(), 1);
+
+            reload.refresh(&config).await;
+            reload.refresh(&config).await;
+            assert_eq!(stub.connects(), 1, "the same connection, not one per spawn");
+            assert_eq!(names(&reload), vec!["keep__echo".to_string()]);
+        })
+        .await;
+    }
+
+    /// An *edited* entry keeps its name, so the old connection has to be gone
+    /// before the new one opens: they are stored under one key, and a deferred
+    /// teardown would take the replacement down with it a minute later.
+    #[tokio::test]
+    async fn an_edited_entry_replaces_its_connection_rather_than_racing_it() {
+        with_tracing(|| {});
+        let stub = stub_server().await;
+        with_temp_home(|| async {
+            let reload = booted_empty();
+            reload
+                .refresh(&config_with(vec![stub.entry("srv", "before")]))
+                .await;
+            assert_eq!(names(&reload), vec!["srv__before".to_string()]);
+
+            reload
+                .refresh(&config_with(vec![stub.entry("srv", "after")]))
+                .await;
+            assert_eq!(
+                names(&reload),
+                vec!["srv__after".to_string()],
+                "the edited entry's tools, not the ones it replaced"
+            );
+            assert!(reload.pool.routes("srv__after").await);
+            assert_eq!(stub.connects(), 2);
+        })
+        .await;
+    }
+
+    /// A server that cannot be reached costs the run its tools and nothing
+    /// else, and the failure is not cached - fixing the URL and saving again
+    /// is enough, with no restart in that loop either.
+    #[tokio::test]
+    async fn a_server_that_will_not_connect_costs_its_tools_and_not_the_spawn() {
+        with_tracing(|| {});
+        with_temp_home(|| async {
+            let reload = booted_empty();
+            let dead = MCPServerConfig::http("dead", "http://127.0.0.1:1/mcp");
+            reload.refresh(&config_with(vec![dead])).await;
+            assert!(names(&reload).is_empty());
+        })
+        .await;
+    }
+
+    /// `[security] allow_env_vars` was a boot copy inside the pool, while
+    /// `daemon.md` said it took effect on the next load. Naming a variable
+    /// there now reaches an MCP server's `${VAR}` header: the server
+    /// reconnects because the allowlist that resolved its headers moved, even
+    /// though its own entry did not.
+    ///
+    /// `MY_MCP_TOKEN` is credential-shaped, so it is refused until it is
+    /// named - which is what makes the first half a real "before" rather than
+    /// an unset variable.
+    #[tokio::test]
+    async fn a_newly_allowed_env_var_reaches_an_mcp_header() {
+        with_tracing(|| {});
+        let stub = stub_server().await;
+        let mut server = stub.entry("hdr", "nothing");
+        server
+            .headers
+            .insert("X-Token".to_string(), "${MY_MCP_TOKEN}".to_string());
+
+        with_temp_home(|| async {
+            temp_env::async_with_vars([("MY_MCP_TOKEN", Some("letmein"))], async {
+                let denied = config_with(vec![server.clone()]);
+                let reload = booted_empty();
+                reload.refresh(&denied).await;
+                assert_eq!(
+                    names(&reload),
+                    vec!["hdr__nothing".to_string()],
+                    "a credential-shaped variable nobody allowed must not be sent"
+                );
+
+                let mut allowed = denied.clone();
+                allowed.security.allow_env_vars = vec!["MY_MCP_TOKEN".to_string()];
+                reload.refresh(&allowed).await;
+                assert_eq!(
+                    names(&reload),
+                    vec!["hdr__letmein".to_string()],
+                    "the variable the user just allowed has to reach the header, no restart"
+                );
+                assert_eq!(stub.connects(), 2, "the header is resolved at connect time");
+            })
+            .await;
+        })
+        .await;
+    }
+
+    /// The allowlist only reaches HTTP headers, so a change to it is no reason
+    /// to tear down a server that interpolates nothing. Same reconcile, same
+    /// connection.
+    #[tokio::test]
+    async fn an_allowlist_change_leaves_a_server_with_no_interpolation_alone() {
+        with_tracing(|| {});
+        let stub = stub_server().await;
+        with_temp_home(|| async {
+            let plain = config_with(vec![stub.entry("plain", "echo")]);
+            let reload = booted_empty();
+            reload.refresh(&plain).await;
+            assert_eq!(stub.connects(), 1);
+
+            let mut widened = plain.clone();
+            widened.security.allow_env_vars = vec!["SOMETHING_ELSE_TOKEN".to_string()];
+            reload.refresh(&widened).await;
+            assert_eq!(stub.connects(), 1, "nothing about this server changed");
+            assert_eq!(names(&reload), vec!["plain__echo".to_string()]);
+        })
+        .await;
+    }
+
+    /// Only HTTP headers answer to the allowlist, so only they mark an entry
+    /// stale when it moves.
+    #[test]
+    fn only_a_header_that_interpolates_is_stale_when_the_allowlist_moves() {
+        let mut http = MCPServerConfig::http("h", "https://example.test/mcp");
+        assert!(!interpolates_env(&http));
+        // A stdio server's environment is filtered by a different rule that
+        // the allowlist has no part in, even when it names variables.
+        let mut stdio = MCPServerConfig::stdio("s", "true", vec![]);
+        stdio
+            .env
+            .insert("TOKEN".to_string(), "${MY_TOKEN}".to_string());
+        assert!(!interpolates_env(&stdio));
+
+        http.headers.insert(
+            "Authorization".to_string(),
+            "Bearer ${MY_TOKEN}".to_string(),
+        );
+        assert!(interpolates_env(&http));
+        http.headers
+            .insert("Authorization".to_string(), "Bearer literal".to_string());
+        assert!(!interpolates_env(&http));
+    }
+
+    /// The boot path: the global servers `ToolRegistry::build` already
+    /// connected are filed under their own signatures, each with the defs it
+    /// contributed, so the pool alone can answer what the set advertises and
+    /// there is no second list to fall out of step.
+    #[test]
+    fn seeding_files_each_global_servers_own_defs_under_it() {
+        let a = MCPServerConfig::http("a", "https://a.test/mcp");
+        let b = MCPServerConfig::http("b", "https://b.test/mcp");
+        let defs: Vec<Tool> = ["a__one", "b__two"]
+            .into_iter()
+            .map(|name| Tool {
+                name: name.to_string(),
+                description: String::new(),
+                parameters: serde_json::json!({}),
+            })
+            .collect();
+        let owners: leviath_runtime::pipeline::ToolOwners = [
+            ("a__one".to_string(), "a".to_string()),
+            ("b__two".to_string(), "b".to_string()),
+        ]
+        .into_iter()
+        .collect();
+        let pool = pool();
+        pool.seed_all(&[a.clone(), b.clone()], &defs, &owners);
+
+        assert_eq!(
+            pool.cached_defs_for(&[a.clone(), b.clone()])
+                .into_iter()
+                .map(|t| t.name)
+                .collect::<Vec<_>>(),
+            vec!["a__one".to_string(), "b__two".to_string()],
+            "the whole set reads back, in config order"
+        );
+        assert_eq!(
+            pool.cached_owners_for(&[b]).get("b__two"),
+            Some(&"b".to_string()),
+            "and each tool still names the server it came from"
+        );
+        assert_eq!(pool.cached_defs_for(&[a]).len(), 1);
+    }
+}

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod fanout_spawner;
 pub(crate) mod gate_rules;
 pub mod lifecycle;
 pub mod mcp_pool;
+pub mod mcp_reload;
 pub(crate) mod policy_reload;
 pub mod provider_reload;
 pub mod readiness;

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -196,6 +196,15 @@ pub(crate) async fn setup_daemon_host_with(
         config.security.allow_env_vars.clone(),
         config.limits.mcp_idle_disconnect_secs,
     );
+    // File each global server's own defs under its signature. They were
+    // connected a moment ago by `ToolRegistry::build`, and the pool has to know
+    // what each one contributed for `mcp_reload` to reconcile the set later
+    // without keeping a second list of the same tools.
+    mcp_pool.seed_all(
+        &config.mcp_servers,
+        &registry.mcp_tool_defs,
+        &registry.mcp_tool_owners,
+    );
     mcp_pool.warm_recovered(&runs_dir).await;
     Ok(build_host(HostParts {
         config,
@@ -406,14 +415,23 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         crate::daemon::provider_reload::for_daemon(&parts.config, pp_providers.clone())
     });
 
+    // The global `[[mcp_servers]]` as a live set rather than the boot copy.
+    // Reconciled against the reloaded config before each spawn, so `lev mcp
+    // add`, `POST /api/mcp/servers` and a hand edit all reach the next run.
+    let mcp_global = crate::daemon::mcp_reload::McpReload::new(
+        &parts.config,
+        parts.mcp_pool.clone(),
+        parts.mcp_tool_defs.clone(),
+        parts.mcp_tool_owners.clone(),
+    );
+
     // Install the fan-out spawner as a world resource so the parts.runtime's fan-out
     // systems can start workers (it captures the same context as the spawner
     // below, cloned before those move into the closure).
     let fanout_spawner = DaemonFanOutSpawner {
         config: reloader.clone(),
         shared_mcp: parts.shared_mcp.clone(),
-        mcp_tool_defs: parts.mcp_tool_defs.clone(),
-        mcp_tool_owners: parts.mcp_tool_owners.clone(),
+        mcp_global: mcp_global.clone(),
         mcp_pool: parts.mcp_pool.clone(),
         hub: hub.clone(),
         subagent_tx: subagent_tx.clone(),
@@ -460,8 +478,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let reload_tools = tool_service.clone();
     let reload_reloader = reloader.clone();
     let reload_mcp = parts.shared_mcp.clone();
-    let reload_defs = parts.mcp_tool_defs.clone();
-    let reload_owners = parts.mcp_tool_owners.clone();
+    let reload_global = mcp_global.clone();
     let reload_hub = hub.clone();
     let reload_tx = subagent_tx.clone();
     let reload_runs = parts.runs_dir.clone();
@@ -483,6 +500,9 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // the files name now rather than the one this daemon booted with.
         reload_policy.refresh_into(world);
         reload_telemetry.refresh_into(world, &reload_config.observability);
+        // The global MCP set as it stands now, not as it stood at boot: a run
+        // paged back in is rebuilt with the tools a fresh spawn would get.
+        let (reload_defs, reload_owners) = reload_global.current();
         let entity = crate::daemon::recovery::reload_run(
             world,
             crate::daemon::spawn::SpawnDeps {
@@ -533,13 +553,19 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // against a guess from its name, and nothing later corrects it.
     let pp_reloader = reloader.clone();
     let pp_reload = provider_reload.clone();
+    let pp_global = mcp_global.clone();
     host.set_spawn_preprocessor(Box::new(move |args| {
         let pool = pp_pool.clone();
         let blueprint_path = args.blueprint_path.clone();
         let agents_dir = pp_agents_dir.clone();
         let config = pp_reloader.current();
         let reload = pp_reload.clone();
+        let global = pp_global.clone();
         Box::pin(async move {
+            // Before the blueprint's own servers, and before the sync spawner
+            // reads the set: connecting is async, and this is the only hook on
+            // the spawn path that can await (issue #684's MCP half).
+            global.refresh(&config).await;
             warm_blueprint_mcp(&pool, &blueprint_path).await;
             warm_fanout_worker_mcp(&pool, &blueprint_path, agents_dir.as_deref()).await;
             // Before the models are warmed, not after: a provider the user
@@ -565,6 +591,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let spawn_provider_reload = provider_reload.clone();
     let spawn_policy = policy_reload.clone();
     let spawn_telemetry = telemetry_reload.clone();
+    let spawn_global = mcp_global.clone();
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
@@ -573,10 +600,13 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // The reload path deliberately doesn't do this: it must not overwrite a
         // recovering run's own metadata.
         write_placeholder_meta(&spawn_runs_dir, args);
+        // The global set the preprocessor just reconciled, plus this
+        // blueprint's own servers.
+        let (global_defs, global_owners) = spawn_global.current();
         let (defs, owners) = per_agent_mcp_defs(
             &spawn_pool,
-            &parts.mcp_tool_defs,
-            &parts.mcp_tool_owners,
+            &global_defs,
+            &global_owners,
             &args.blueprint_path,
         );
         // Hold the blueprint's per-agent servers open for this run's life;

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -18,13 +18,14 @@ where you look up the exact name, type, and default. The same contract ships mac
 
 > [!NOTE]
 > The daemon watches this file and reloads it when it changes, so an edit takes effect on the
-> **next** `lev run` with no restart. That includes providers: a key you add, replace or remove,
-> a changed `default_provider`, and a `[model_providers]` entry you add or delete are all picked
-> up by the next run started, whether it came from `lev run`, the API or the dashboard, and it
-> makes no difference whether the edit came from `lev setup`, `PUT /api/config` or an editor. A
-> run already under way keeps the provider its current stage started on. `lev serve` reads the
-> file per request, so an edit is on the next page load. MCP connections are still boot-time
-> wiring and need `lev daemon restart`. See
+> **next** `lev run` with no restart. That includes providers, `[[mcp_servers]]` and
+> `[observability]`: a key you add, replace or remove, a changed `default_provider`, a
+> `[model_providers]` entry, an MCP server, or a collector to export to are all picked up by the
+> next run started, whether it came from `lev run`, the API or the dashboard, and it makes no
+> difference whether the edit came from `lev setup`, `PUT /api/config` or an editor. A run already
+> under way keeps the provider and the servers its current stage started on. `lev serve` reads the
+> file per request, so an edit is on the next page load. The short list of settings still read once
+> at start-up is in
 > [the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run).
 
 ## Top level

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -160,8 +160,19 @@ an in-progress edit never breaks a spawn.
 `[model_providers.<name>]` reloads too, as of this release. A script provider's own `.rhai` file
 has always been re-read on each use, so a table beside it that needed a restart made two halves of
 one feature disagree in silence - setting a `base_url` and watching it do nothing looked exactly
-like having typed the key wrong. Both halves are now live: edit the script, the table, or
-`[security] allow_env_vars`, and the next provider load uses it.
+like having typed the key wrong. Both halves are now live: edit the script or the table, and the
+next provider load uses it.
+
+`[security] allow_env_vars` is live for both things that read it: a Rhai script's `env_var()`, and
+the `${VAR}` in an MCP server's `headers`. Naming a variable there reaches the next provider load
+and the next MCP connection. A server already connected keeps the header it was given, so a global
+`[[mcp_servers]]` entry that interpolates a variable is reconnected when you change the list, which
+is what puts the new value in front of the next run.
+
+`[[mcp_servers]]` is live as well. Add, edit or remove a global server - with `lev mcp add`, `POST
+/api/mcp/servers`, or by hand - and the next run gets the tools the file names now. A run already
+under way keeps the servers it started with: a removed one stays connected for
+`[limits] mcp_idle_disconnect_secs` so nothing loses a tool mid-call, and is torn down after that.
 
 Provider credentials reload as well. Add a key, replace one, remove one by untoggling it in
 `lev setup`, point a provider at another base URL, or change `default_provider`: the daemon
@@ -191,7 +202,6 @@ only be set once per process. Changing that still means restarting the daemon.
 Some changes do still need `lev daemon restart`. They set up connections and process-wide state
 once at startup rather than per run:
 
-- `[[mcp_servers]]`, which hold live MCP connections.
 - The `[limits]` the world itself is built with: `stall_timeout_secs`, `wedge_timeout_secs`,
   `dead_cycles_before_relief`, `max_concurrent_inferences`, `max_concurrent_tools`,
   `provider_failures_before_open`, `provider_circuit_cooldown_secs`,

--- a/docs/content/mcp.md
+++ b/docs/content/mcp.md
@@ -71,6 +71,10 @@ url = "https://mcp.example.com"
 headers = { Authorization = "Bearer ${MY_TOKEN}" }   # ${VAR} is expanded
 ```
 
+Either way, the next run picks it up. The daemon watches `config.toml`, so a server you add, edit
+or remove takes effect without `lev daemon restart` - see
+[the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run).
+
 ## Discovery and invocation
 
 On connect, Leviath discovers the server's tools and exposes them to any stage whose


### PR DESCRIPTION
The user asked whether anything still needs a daemon restart. `[[mcp_servers]]`
was the biggest hole in my area, and `[security] allow_env_vars` was a
documented promise the MCP half did not keep.

## What was boot-only, per setting

| Setting | Before | After |
|---|---|---|
| `[[mcp_servers]]` (add) | `ToolRegistry::build` connected them once at `setup.rs:~181`; `mcp_tool_defs`/`owners` cloned into the spawner at `~:540` | reconciled against the reloaded config in the spawn preprocessor; the next run gets it |
| `[[mcp_servers]]` (remove) | the boot defs kept advertising it and the connection stayed for the daemon's life | dropped from advertisement at once, disconnected after the pool's idle window |
| `[[mcp_servers]]` (edit) | ignored entirely | old connection replaced before the new one opens |
| `[security] allow_env_vars` | boot copy in `McpPool`, so an MCP `${VAR}` header was resolved with the allowlist as of start-up | read at connect time; a global server that interpolates is reconnected when the list moves |
| `[security] credential_store` | boot copy in `McpPool` | read at connect time |

`lev mcp add` and `POST /api/mcp/servers` write the file and nothing else, so
the server was in the config, `lev mcp list` showed it, and no run could call
it. Nothing said a restart was needed.

## Shape

`daemon/mcp_reload.rs` holds the global set and what it advertises.
`refresh(&config)` runs in the spawn preprocessor - the one hook on the spawn
path that can await - and the sync spawner, the fan-out spawner and the
run-recovery reloader all read `current()` instead of the boot vectors.

- **Nothing new for connecting.** The pool already connects lazily, dedupes by
  signature and tears an unused server down. `ensure_global` marks a signature
  as the daemon's (exempt from lease-driven disconnection, and cancels a
  pending retirement); `retire_global` un-marks it and hands it to the same
  grace timer.
- **One list, not two.** The global servers are seeded under their own
  signatures with the defs each contributed, so `cached_defs_for` answers for
  the global set exactly as it does for a blueprint's. Keeping a second list
  beside the pool is how the first one went stale.
- **A run keeps what it started with.** A removed server stays connected for
  `[limits] mcp_idle_disconnect_secs` (default 60), so a stage part-way through
  a tool call does not lose it. The exception is an *edited* entry: its
  replacement connects under the same name, and a deferred teardown would take
  that one down a minute later, so the old connection goes first.
- **Compared by signature**, which is the key the connections are stored under
  (`MCPServerConfig` has no `PartialEq`). An unchanged config touches nothing.
- **A failed connect is not cached**, so a server whose command is not
  installed yet costs a run its tools and never its spawn, and fixing the entry
  is enough.
- `allow_env_vars` and `credential_store` moved into a lock the reconcile
  writes before anything connects, so a per-agent server the blueprint warmer
  connects a moment later gets the same values.

## Fail-first evidence

`daemon::mcp_reload` has 10 tests, all over in-process HTTP MCP stubs (no
`python3`, which Windows does not have) that count handshakes, so "did it
reconnect" is measured rather than assumed.

With the reconcile disabled - the boot-copy world, tests kept:

```
test a_server_added_after_boot_is_callable_by_the_next_run ... FAILED
  assertion failed: a server the user just added has to be advertised without a restart
  left: []   right: ["added__echo"]

test a_server_removed_from_the_config_is_gone_from_the_next_run ... FAILED
  the entry the user deleted must stop being advertised

test a_removed_server_is_disconnected_after_its_grace_window ... FAILED
test an_edited_entry_replaces_its_connection_rather_than_racing_it ... FAILED
test an_unchanged_config_leaves_the_connections_alone ... FAILED
test a_newly_allowed_env_var_reaches_an_mcp_header ... FAILED
test an_allowlist_change_leaves_a_server_with_no_interpolation_alone ... FAILED
```

With the reconcile restored and only `apply_security` disabled (the boot-copy
allowlist), one test remains failing, which is the point:

```
test a_newly_allowed_env_var_reaches_an_mcp_header ... FAILED
  assertion failed: the variable the user just allowed has to reach the header, no restart
  left: ["hdr__nothing"]   right: ["hdr__letmein"]
```

`MY_MCP_TOKEN` is credential-shaped, so it is refused until it is named - the
"before" is a real refusal, not an unset variable.

## Live check

Isolated home `/tmp/lv7`, `LEVIATH_SKIP_DOTENV=1`, `perf-tools/mock.py` asking
for `livemcp__echo`, a python stdio MCP stub answering `LIVE-MCP-ANSWER`, one
foreground `lev daemon` started once. Between runs the `[[mcp_servers]]` block
is written to and removed from `config.toml` the way `lev mcp add` writes it.
Nothing restarts the daemon.

This branch, release build:

```
[daemon] pid=75920  daemon running (0 agents)

--- run 1: config.toml has no [[mcp_servers]] ---
[run-1] run=mcpprobe-...e66eb83133c5 status=complete tool_offered=True mcp_answered=False

--- the entry is written (what `lev mcp add` does); NO restart ---
[daemon] pid=75920 still up: True

--- run 2: same daemon, entry now in config.toml ---
[run-2] run=mcpprobe-...4cb7cca84c47 status=complete tool_offered=True mcp_answered=True

--- the entry is removed again; still no restart ---
[daemon] pid=75920 still up: True
[run-3] run=mcpprobe-...1638dd4292d4 status=complete tool_offered=True mcp_answered=False

RESULT: as intended
```

The same script against the installed pre-fix `~/.cargo/bin/lev` (0.5.5), same
stub, same config edits:

```
[run-1] status=complete tool_offered=True mcp_answered=False
[run-2] status=complete tool_offered=True mcp_answered=False
[run-3] status=complete tool_offered=True mcp_answered=False
RESULT: NOT as intended
```

Run 2 is the whole difference: same daemon pid, same file edit, the tool
answers on this branch and does not on the released one.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`
- `cargo test -p leviath-cli` (4148 lib + all integration targets green)
- `cargo xtask structure` (428 files, none over 1200), `cargo xtask docs`
  (40 pages, no problems)
- `cargo xtask coverage --package leviath-cli`: 100%
- pre-commit (full suite) passed on commit

## Docs

`daemon.md`: `[[mcp_servers]]` comes off the restart list, with a paragraph on
what a run already under way keeps; the `allow_env_vars` sentence now says
exactly what is live (a Rhai `env_var()` and an MCP `${VAR}` header, and that a
connected server keeps the header it was given). `mcp.md` says the next run
picks a server up. `configuration.md` drops "MCP connections" from its
boot-time-wiring note. CHANGELOG under Changed.

No `main.rs` touched.

## Notes for review

- Builds on the pattern PR #729 set for providers, and is deliberately the same
  shape: a small module beside `config_reload` that compares and swaps.
- PR #720 reworks `disconnect_if_still_idle`'s locking. My removal path goes
  through that same function, so it inherits the fix; if #720 lands first this
  branch rebases onto it with no change of its own.
- PR #730 (mine) edits the adjacent line of `daemon.md`'s restart list, so
  whichever lands second wants a one-line rebase.
