### PR TITLE
fix(daemon): the limits the world is built with follow config.toml, with no restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,25 @@ same list.
   effect on the next load, which was true of script providers and not of MCP.
   A global server whose headers interpolate is reconnected when the list moves,
   which is what puts the new value in front of the next run.
+- The `[limits]` the daemon's world is built with, and the whole `[title]`
+  section, now follow `config.toml` while the daemon runs. That covers the
+  inference pools (`max_concurrent_inferences` and its `_by_model` and
+  `_by_provider` tables), the tool lane (`max_concurrent_tools`),
+  `stream_inference`, the stall and wedge watchdogs, the provider circuit
+  breaker, the inference retry schedule, `dead_cycles_before_relief`,
+  `notify_spend_usd`, `max_agents_per_run`, `finished_retention_secs` and
+  `interaction_timeout_secs`. Each was read once at boot and then fixed for the
+  life of the process, so editing any of them and starting a run did nothing at
+  all, with nothing to say so. Most of them reach the runs already going, since
+  the engine reads them on every pass; the ones that only apply to what starts
+  next are the ones nothing can change retroactively, such as a request already
+  on the wire or a prompt already waiting. Lowering a concurrency limit takes
+  back the slots nobody is holding and then narrows as the requests and tool
+  batches in flight finish, so no work is cancelled to make room for the new
+  number. Turning `[title]` on had been worse than doing nothing: spawn already
+  read a fresh config, so the run was marked for a title, and the part that
+  makes titles read the boot-time setting, saw titling switched off, and dropped
+  the marker in silence. Both halves read the same file now.
 - The update check read the GitHub releases answer with no size cap, the one
   buffered remote read left after the daemon's caps landed. It now stops at
   the same 64 MiB as every other buffered body and reports the same

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -90,7 +90,7 @@ fn default_inference_retry_base_ms() -> u64 {
 /// Both fields default to a bounded value so a fresh install can't accidentally
 /// run unbounded inference concurrency or an unbounded agent loop. Set a field
 /// explicitly in `[limits]` to raise or lower it.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct LimitsConfig {
     /// Global fallback cap on concurrent inference requests for any model
     /// without its own entry in `max_concurrent_inferences_by_model`. Defaults
@@ -100,6 +100,10 @@ pub struct LimitsConfig {
     /// their in-flight calls occupies a blocking-pool thread, and the daemon's
     /// runtime provisions 2048 of those. Pools above 2048 only run that wide
     /// for HTTP providers, whose calls are fully async.
+    ///
+    /// Reloaded with `config.toml`. A raised limit is usable at once; a
+    /// lowered one takes back the slots nobody is holding and narrows as
+    /// the requests in flight finish, so nothing running is cancelled.
     #[serde(default = "default_max_concurrent_inferences")]
     pub max_concurrent_inferences: Option<usize>,
 
@@ -107,6 +111,9 @@ pub struct LimitsConfig {
     /// tool batches may run concurrently across the whole daemon (the tool-lane
     /// counterpart of `max_concurrent_inferences`). Defaults to `8`. Clamped to at
     /// least 1.
+    ///
+    /// Reloaded with `config.toml`. Widening is immediate; narrowing waits for
+    /// the batches already running to finish rather than interrupting them.
     #[serde(default = "default_max_concurrent_tools")]
     pub max_concurrent_tools: usize,
 
@@ -130,7 +137,9 @@ pub struct LimitsConfig {
     /// stays as it was. A provider that does not advertise streaming for the
     /// model in hand is called the old way regardless.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`: the next inference any run makes uses
+    /// the new setting, and one already on the wire finishes the way it
+    /// started.
     #[serde(default = "default_stream_inference")]
     pub stream_inference: bool,
 
@@ -163,7 +172,8 @@ pub struct LimitsConfig {
     /// matter how long it takes. Defaults to `60`; `0` disables the watchdog and
     /// restores the old behaviour of waiting indefinitely.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`, and read on every pass, so a change
+    /// reaches the runs already going as well as the next one.
     #[serde(default = "default_stall_timeout_secs")]
     pub stall_timeout_secs: u64,
 
@@ -178,7 +188,8 @@ pub struct LimitsConfig {
     /// `0` turns relief off. Detection and reporting stay on either way, so
     /// `lev ps` and the metrics still show the streak.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`; read once per safety re-drive, so a
+    /// change applies from the next one.
     #[serde(default = "default_dead_cycles_before_relief")]
     pub dead_cycles_before_relief: u32,
 
@@ -195,7 +206,8 @@ pub struct LimitsConfig {
     /// old behaviour. The record lives in memory, so a restart clears it
     /// whatever this is set to.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`; read on every prune, so shortening the
+    /// window drops the rows that have already outlived it.
     #[serde(default = "default_finished_retention_secs")]
     pub finished_retention_secs: u64,
     /// How long (seconds) a per-agent MCP server may sit with zero live runs
@@ -227,7 +239,8 @@ pub struct LimitsConfig {
     /// whether it is happening to you, since it says so in the log and in the
     /// run's error.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`, and read on every pass, so a change
+    /// reaches the runs already going as well as the next one.
     #[serde(default = "default_wedge_timeout_secs")]
     pub wedge_timeout_secs: u64,
     /// How many consecutive provider-fatal failures (out of credits, rejected
@@ -240,7 +253,8 @@ pub struct LimitsConfig {
     ///
     /// `0` disables the breaker, leaving per-run failover on its own.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`, and read on every pass, so a change
+    /// reaches the runs already going as well as the next one.
     #[serde(default = "default_provider_failures_before_open")]
     pub provider_failures_before_open: u32,
 
@@ -251,7 +265,8 @@ pub struct LimitsConfig {
     /// the provider straight back into service, or fails and restarts the wait,
     /// so topping up an account brings the factory back with no restart.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`, and read on every pass, so a change
+    /// reaches the runs already going as well as the next one.
     #[serde(default = "default_provider_circuit_cooldown_secs")]
     pub provider_circuit_cooldown_secs: u64,
     /// How long (seconds) a prompt may go unanswered before the daemon resolves
@@ -277,7 +292,8 @@ pub struct LimitsConfig {
     /// "expire at once", so a config that spelled the wait that way keeps
     /// working.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`; read when a prompt opens, so a prompt
+    /// already waiting keeps the deadline it opened with.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub interaction_timeout_secs: Option<u64>,
 
@@ -298,7 +314,8 @@ pub struct LimitsConfig {
     /// key exists (issue #417). Whatever this is set to, the retries of one
     /// request may sleep at most five minutes in total.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`; read when a request is dispatched, so
+    /// a change applies to the next attempt any run makes.
     #[serde(default = "default_inference_retry_attempts")]
     pub inference_retry_attempts: u32,
 
@@ -311,7 +328,8 @@ pub struct LimitsConfig {
     /// this to wait out an outage is the wrong lever and only delays ordinary
     /// failures.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`; read when a request is dispatched, so
+    /// a change applies to the next attempt any run makes.
     #[serde(default = "default_inference_retry_base_ms")]
     pub inference_retry_base_ms: u64,
 
@@ -406,7 +424,9 @@ pub struct LimitsConfig {
     ///
     /// A `BTreeMap` so the file this is written back to keeps its order.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`. A raised limit is usable at once; a
+    /// lowered one takes back the slots nobody is holding and narrows as
+    /// the requests in flight finish, so nothing running is cancelled.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub max_concurrent_inferences_by_model: BTreeMap<String, usize>,
 
@@ -431,7 +451,9 @@ pub struct LimitsConfig {
     /// is deliberately not applied per provider: it is a per-model number, and
     /// applying it twice would tighten every install that never asked for it.
     ///
-    /// Read once at daemon start, so a change needs a daemon restart.
+    /// Reloaded with `config.toml`. A raised limit is usable at once; a
+    /// lowered one takes back the slots nobody is holding and narrows as
+    /// the requests in flight finish, so nothing running is cancelled.
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub max_concurrent_inferences_by_provider: BTreeMap<String, usize>,
 }

--- a/crates/leviath-cli/src/daemon/live_limits.rs
+++ b/crates/leviath-cli/src/daemon/live_limits.rs
@@ -1,0 +1,393 @@
+//! Keeping the world the daemon runs in step with `[limits]` and `[title]`.
+//!
+//! The settings in this module are the ones the world is *built* with: pool
+//! sizes, lane widths, watchdog timeouts, the circuit breaker, the retry
+//! schedule, the fan-out ceiling, the listing window, the spend figures and
+//! whether runs get titles. Every one of them was read once in
+//! [`build_host`](crate::daemon::setup::build_host) and then fixed for the life
+//! of the process, so editing any of them and starting a run did nothing at
+//! all, with nothing to say so.
+//!
+//! One of those was worse than doing nothing. Spawn already reads a fresh
+//! config, so turning `[title]` on made spawn mark the new run `PendingTitle` -
+//! and the dispatch system, reading the boot-time `TitleSettings`, saw titling
+//! switched off and quietly dropped the marker. The run was marked for a title
+//! that could never be made. Applying the same config to the world before the
+//! spawner reads it is what closes that: both halves now answer from one
+//! document.
+//!
+//! The comparison is on the settings themselves rather than the file's mtime,
+//! so a save that only changed a tool permission does not touch the pools. Each
+//! setting says for itself whether it reaches a run already under way: a world
+//! resource is read every tick, so the watchdogs, the breaker, the retry
+//! schedule and the fan-out ceiling do; a pool or lane width applies to the
+//! next request that asks for a slot, never to one already in flight.
+
+use std::sync::{Arc, Mutex};
+
+use leviath_runtime::PipelineWorld;
+use leviath_runtime::host::HostSettings;
+use leviath_runtime::interaction_hub::InteractionHub;
+
+use crate::config::Config;
+
+/// The settings this module owns, as of the last time they were applied.
+///
+/// Whole config sections rather than a hand-listed subset: a key added to
+/// `[limits]` later is then compared for free, and the cost of comparing one
+/// this module does not install is a re-apply that changes nothing.
+#[derive(Clone, PartialEq)]
+struct Applied {
+    limits: crate::config::LimitsConfig,
+    title: leviath_core::config::TitleConfig,
+}
+
+impl Applied {
+    fn of(config: &Config) -> Self {
+        Self {
+            limits: config.limits.clone(),
+            title: config.title.clone(),
+        }
+    }
+}
+
+/// Applies `[limits]` and `[title]` to a live world.
+///
+/// Built once at boot and consulted wherever the daemon has a freshly reloaded
+/// config and the world in hand: the spawner, and the reloader that pages a run
+/// back in.
+pub struct LiveLimits {
+    /// The prompt hub, which holds its own timeout rather than living in the
+    /// world.
+    hub: InteractionHub,
+    /// The host's own settings, shared out of [`WorldHost::settings`].
+    ///
+    /// [`WorldHost::settings`]: leviath_runtime::host::WorldHost::settings
+    host: HostSettings,
+    /// What was applied last, or `None` before the first application, which is
+    /// why boot applies everything.
+    applied: Mutex<Option<Applied>>,
+}
+
+impl LiveLimits {
+    /// A fresh applier over `hub` and `host`, which has applied nothing yet.
+    pub fn new(hub: InteractionHub, host: HostSettings) -> Self {
+        Self {
+            hub,
+            host,
+            applied: Mutex::new(None),
+        }
+    }
+
+    /// Put `config`'s limits and title settings into `world`, if they are not
+    /// the ones already in it. Reports whether anything was applied.
+    ///
+    /// Cheap enough to call before every spawn: an unchanged config costs one
+    /// comparison. The lock is held across the whole application so two spawns
+    /// arriving together cannot interleave halves of two different configs.
+    pub fn apply(&self, config: &Config, world: &mut PipelineWorld) -> bool {
+        let next = Applied::of(config);
+        let mut applied = leviath_core::sync::lock(&self.applied);
+        if applied.as_ref() == Some(&next) {
+            return false;
+        }
+        *applied = Some(next);
+
+        // Concurrency. A raised limit is usable at once; a lowered one narrows
+        // as the requests and batches in flight finish, so nothing running is
+        // interrupted and no slot is taken back from work already under way.
+        world.set_inference_pool_config(config.limits.inference_pools());
+        world.set_tool_concurrency(config.limits.max_concurrent_tools);
+        // Read when a request is assembled, so this reaches the next inference
+        // any run makes rather than one already on the wire.
+        world.set_stream_inference(config.limits.stream_inference);
+
+        // World resources, every one of them read by a system on each tick, so
+        // these reach the runs already in flight as well as the next one.
+        let ecs = world.world_mut();
+        ecs.insert_resource(leviath_runtime::pipeline::StallTimeout(
+            config.limits.stall_timeout_secs,
+        ));
+        ecs.insert_resource(leviath_runtime::pipeline::WedgeTimeout(
+            config.limits.wedge_timeout_secs,
+        ));
+        ecs.insert_resource(leviath_runtime::pipeline::CircuitPolicy {
+            failures_before_open: config.limits.provider_failures_before_open,
+            cooldown_secs: config.limits.provider_circuit_cooldown_secs,
+        });
+        ecs.insert_resource(leviath_runtime::pipeline::InferenceRetryTuning {
+            max_attempts: config.limits.inference_retry_attempts,
+            base_delay_ms: config.limits.inference_retry_base_ms,
+        });
+        // Read at every fan-out split, so a ceiling lowered mid-run stops the
+        // next split rather than waiting for the next run.
+        ecs.insert_resource(leviath_runtime::fanout::FanOutBudget(
+            config.limits.max_agents_per_run,
+        ));
+        // The half of the title split that used to be stuck at boot: the
+        // dispatcher and the spawner now read the same document.
+        ecs.insert_resource(leviath_runtime::title::TitleSettings(config.title.clone()));
+
+        // Read when a prompt opens, so a prompt already waiting keeps the
+        // deadline it opened with.
+        self.hub
+            .set_timeout_secs(config.limits.interaction_timeout_secs);
+
+        // The host's own settings, read once per re-drive or per event pass.
+        self.host
+            .set_dead_cycles_before_relief(config.limits.dead_cycles_before_relief);
+        self.host
+            .set_spend_notify_usd(config.limits.notify_spend_usd.clone());
+        self.host
+            .set_finished_retention_secs(config.limits.finished_retention_secs);
+        true
+    }
+}
+
+/// One applier for the daemon to share between its spawn and reload hooks.
+pub fn for_daemon(hub: InteractionHub, host: HostSettings) -> Arc<LiveLimits> {
+    Arc::new(LiveLimits::new(hub, host))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use leviath_runtime::ProviderRegistry;
+    use leviath_runtime::inference_pool::InferencePoolConfig;
+
+    /// A bare world, with the tool lane at `tools` and the inference pools at
+    /// whatever `PipelineWorld::new` is handed.
+    fn world(runtime: &tokio::runtime::Runtime, tools: usize) -> PipelineWorld {
+        let _guard = runtime.enter();
+        PipelineWorld::new(
+            ProviderRegistry::new(),
+            Arc::new(crate::daemon::tool_service::CliToolService::new()),
+            InferencePoolConfig::new().with_default(Some(1)),
+            tools,
+            None,
+            runtime.handle().clone(),
+        )
+    }
+
+    fn applier() -> LiveLimits {
+        LiveLimits::new(InteractionHub::new(), HostSettings::default())
+    }
+
+    #[test]
+    fn the_first_apply_installs_everything_and_a_repeat_does_nothing() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 8);
+        let live = applier();
+        let config = Config::default();
+        assert!(live.apply(&config, &mut world), "boot applies");
+        assert!(
+            !live.apply(&config, &mut world),
+            "an unchanged config must not touch the pools of a running daemon"
+        );
+    }
+
+    #[test]
+    fn the_inference_pool_limits_follow_the_config() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 8);
+        let live = applier();
+        let mut config = Config::default();
+        config.limits.max_concurrent_inferences = Some(1);
+        live.apply(&config, &mut world);
+        assert_eq!(world.inference_pool_config().limit_for("m"), Some(1));
+
+        config.limits.max_concurrent_inferences = Some(4);
+        config
+            .limits
+            .max_concurrent_inferences_by_model
+            .insert("m".to_string(), 2);
+        config
+            .limits
+            .max_concurrent_inferences_by_provider
+            .insert("slow".to_string(), 1);
+        assert!(live.apply(&config, &mut world));
+        let pools = world.inference_pool_config();
+        assert_eq!(pools.limit_for("other"), Some(4), "the global fallback");
+        assert_eq!(pools.limit_for("m"), Some(2), "the per-model override");
+        assert_eq!(pools.provider_limit_for("slow"), Some(1));
+
+        config
+            .limits
+            .max_concurrent_inferences_by_provider
+            .remove("slow");
+        assert!(live.apply(&config, &mut world));
+        assert_eq!(
+            world.inference_pool_config().provider_limit_for("slow"),
+            None,
+            "a cap the user deleted stops applying without a restart"
+        );
+    }
+
+    #[test]
+    fn the_tool_lane_widens_and_narrows_with_the_config() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 2);
+        let live = applier();
+        let mut config = Config::default();
+        config.limits.max_concurrent_tools = 2;
+        live.apply(&config, &mut world);
+        assert_eq!(world.tool_concurrency(), 2);
+
+        config.limits.max_concurrent_tools = 6;
+        live.apply(&config, &mut world);
+        assert_eq!(world.tool_concurrency(), 6, "widened without a restart");
+
+        config.limits.max_concurrent_tools = 3;
+        live.apply(&config, &mut world);
+        assert_eq!(world.tool_concurrency(), 3, "and narrowed again");
+    }
+
+    #[test]
+    fn the_watchdog_timeouts_follow_the_config() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 1);
+        let live = applier();
+        let mut config = Config::default();
+        config.limits.stall_timeout_secs = 60;
+        config.limits.wedge_timeout_secs = 0;
+        live.apply(&config, &mut world);
+
+        config.limits.stall_timeout_secs = 5;
+        config.limits.wedge_timeout_secs = 300;
+        assert!(live.apply(&config, &mut world));
+        assert_eq!(
+            world
+                .world()
+                .resource::<leviath_runtime::pipeline::StallTimeout>()
+                .0,
+            5
+        );
+        assert_eq!(
+            world
+                .world()
+                .resource::<leviath_runtime::pipeline::WedgeTimeout>()
+                .0,
+            300
+        );
+    }
+
+    #[test]
+    fn the_circuit_policy_and_retry_schedule_follow_the_config() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 1);
+        let live = applier();
+        let mut config = Config::default();
+        live.apply(&config, &mut world);
+
+        config.limits.provider_failures_before_open = 9;
+        config.limits.provider_circuit_cooldown_secs = 42;
+        config.limits.inference_retry_attempts = 7;
+        config.limits.inference_retry_base_ms = 250;
+        assert!(live.apply(&config, &mut world));
+        let policy = world
+            .world()
+            .resource::<leviath_runtime::pipeline::CircuitPolicy>();
+        assert_eq!(policy.failures_before_open, 9);
+        assert_eq!(policy.cooldown_secs, 42);
+        let retry = world
+            .world()
+            .resource::<leviath_runtime::pipeline::InferenceRetryTuning>();
+        assert_eq!(retry.max_attempts, 7);
+        assert_eq!(retry.base_delay_ms, 250);
+    }
+
+    #[test]
+    fn the_fan_out_budget_follows_the_config() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 1);
+        let live = applier();
+        let mut config = Config::default();
+        live.apply(&config, &mut world);
+        assert_eq!(
+            world
+                .world()
+                .resource::<leviath_runtime::fanout::FanOutBudget>()
+                .0,
+            0
+        );
+
+        config.limits.max_agents_per_run = 20;
+        assert!(live.apply(&config, &mut world));
+        assert_eq!(
+            world
+                .world()
+                .resource::<leviath_runtime::fanout::FanOutBudget>()
+                .0,
+            20
+        );
+    }
+
+    #[test]
+    fn title_settings_follow_the_config() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 1);
+        let live = applier();
+        let mut config = Config::default();
+        config.title.enabled = false;
+        live.apply(&config, &mut world);
+        assert!(
+            !world
+                .world()
+                .resource::<leviath_runtime::title::TitleSettings>()
+                .0
+                .enabled
+        );
+
+        config.title.enabled = true;
+        config.title.provider = Some("anthropic".to_string());
+        assert!(live.apply(&config, &mut world));
+        let settings = world
+            .world()
+            .resource::<leviath_runtime::title::TitleSettings>();
+        assert!(settings.0.enabled);
+        assert_eq!(settings.0.provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn the_host_settings_and_the_prompt_timeout_follow_the_config() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 1);
+        let hub = InteractionHub::new();
+        let host = HostSettings::default();
+        let live = LiveLimits::new(hub.clone(), host.clone());
+        let mut config = Config::default();
+        live.apply(&config, &mut world);
+
+        config.limits.dead_cycles_before_relief = 3;
+        config.limits.finished_retention_secs = 30;
+        config.limits.notify_spend_usd = vec![25.0, 5.0];
+        assert!(live.apply(&config, &mut world));
+        assert_eq!(host.dead_cycles_before_relief(), 3);
+        assert_eq!(host.finished_retention_secs(), 30);
+        assert_eq!(*host.spend_notify_usd(), vec![5.0, 25.0]);
+        // The hub reads its own field, so it is checked through the hub.
+        assert_eq!(hub.timeout_secs(), config.limits.interaction_timeout_secs);
+    }
+
+    #[test]
+    fn stream_inference_can_be_turned_off_without_a_restart() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 1);
+        let live = applier();
+        let mut config = Config::default();
+        live.apply(&config, &mut world);
+        assert!(world.stream_inference());
+
+        config.limits.stream_inference = false;
+        assert!(live.apply(&config, &mut world));
+        assert!(!world.stream_inference());
+    }
+
+    #[test]
+    fn for_daemon_builds_one_that_has_applied_nothing_yet() {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let mut world = world(&runtime, 1);
+        let live = for_daemon(InteractionHub::new(), HostSettings::default());
+        assert!(live.apply(&Config::default(), &mut world));
+    }
+}

--- a/crates/leviath-cli/src/daemon/mod.rs
+++ b/crates/leviath-cli/src/daemon/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod config_reload;
 pub(crate) mod fanout_spawner;
 pub(crate) mod gate_rules;
 pub mod lifecycle;
+pub mod live_limits;
 pub mod mcp_pool;
 pub mod mcp_reload;
 pub(crate) mod policy_reload;

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -284,10 +284,6 @@ pub struct HostParts {
 /// are built once at startup and reused by every agent.
 pub fn build_host(parts: HostParts) -> WorldHost {
     let hub = InteractionHub::new();
-    // A prompt waits for a person until answered unless the operator bounded
-    // the wait with `[limits] interaction_timeout_secs`, in which case the hub
-    // resolves it itself once that passes (issue #204).
-    hub.set_timeout_secs(parts.config.limits.interaction_timeout_secs);
     let tool_service = Arc::new(CliToolService::new());
     // The configured global fallback bounds concurrent inference for any model
     // without its own per-model pool entry (defaults to a small cap so a fresh
@@ -306,65 +302,23 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         Some(parts.runs_dir.clone()),
         parts.runtime,
     );
-    // Streamed inference (on by default), so a long generation keeps bytes
-    // moving instead of holding a socket that looks idle to everything between
-    // here and the provider.
-    world.set_stream_inference(parts.config.limits.stream_inference);
-    // How long a run may sit unable to dispatch before the watchdog fails it
-    // rather than leaving it "running" for ever (issue #190).
-    world
-        .world_mut()
-        .insert_resource(leviath_runtime::pipeline::StallTimeout(
-            parts.config.limits.stall_timeout_secs,
-        ));
-    // How long a run may sit in a state nothing can reach at all before the
-    // watchdog fails it and releases what it was holding (issue #202). Off
-    // unless the operator sets it.
-    world
-        .world_mut()
-        .insert_resource(leviath_runtime::pipeline::WedgeTimeout(
-            parts.config.limits.wedge_timeout_secs,
-        ));
-    // Take a provider out of service after it has failed this many times in a
-    // row for a reason only a person can fix, so the next run does not have to
-    // rediscover it (issue #201).
-    world
-        .world_mut()
-        .insert_resource(leviath_runtime::pipeline::CircuitPolicy {
-            failures_before_open: parts.config.limits.provider_failures_before_open,
-            cooldown_secs: parts.config.limits.provider_circuit_cooldown_secs,
-        });
     world
         .world_mut()
         .init_resource::<leviath_runtime::pipeline::ProviderCircuits>();
-    // How hard a transient inference failure is retried before the agent is
-    // failed and its finished work discarded (issue #417).
-    world
-        .world_mut()
-        .insert_resource(leviath_runtime::pipeline::InferenceRetryTuning {
-            max_attempts: parts.config.limits.inference_retry_attempts,
-            base_delay_ms: parts.config.limits.inference_retry_base_ms,
-        });
     // Share the hub with the tick loop so a blocked agent's open prompt is
     // reflected into its status (Active ↔ Waiting) for the dashboard to surface.
     world.insert_interaction_hub(hub.clone());
     let mut host = WorldHost::with_interactions(world, hub.clone());
-    // How long the daemon may sit with a full tool lane and no run moving before
-    // it widens the lane to break the jam (issue #191).
-    host.set_dead_cycles_before_relief(parts.config.limits.dead_cycles_before_relief);
-    // Told once at start, like the other limits: a run that crosses one of these
-    // says so while it is still running, which is the whole point (#573).
-    host.set_spend_notify_usd(parts.config.limits.notify_spend_usd.clone());
-    // Read at every fan-out spawn, so a run cannot widen past the operator's
-    // ceiling however many sub-questions its workers think are worth asking.
-    host.world_mut()
-        .world_mut()
-        .insert_resource(leviath_runtime::fanout::FanOutBudget(
-            parts.config.limits.max_agents_per_run,
-        ));
-    // How long a finished run keeps its place in the listing, so a scheduler
-    // polling on an interval can see how a run ended (issue #205).
-    host.set_finished_retention_secs(parts.config.limits.finished_retention_secs);
+    // Everything the world is *tuned* with - the pools and the tool lane, the
+    // stall and wedge watchdogs, the circuit breaker, the retry schedule, the
+    // fan-out ceiling, the relief threshold, the spend figures, the listing
+    // window, the prompt timeout and `[title]` - is installed from one place,
+    // and reinstalled from the same place whenever `config.toml` changes. Each
+    // of these used to be read exactly here and then fixed for the life of the
+    // process, so an edit to any of them did nothing until the daemon was
+    // restarted, with nothing to say so (issue #684).
+    let live_limits = crate::daemon::live_limits::for_daemon(hub.clone(), host.settings());
+    live_limits.apply(&parts.config, host.world_mut());
     // Handed to each agent's tool state so its sub-agent tools reach the world
     // through the host.
     let subagent_tx = host.subagent_sender();
@@ -486,6 +440,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let reload_provider_reload = provider_reload.clone();
     let reload_policy = policy_reload.clone();
     let reload_telemetry = telemetry_reload.clone();
+    let reload_limits = live_limits.clone();
     host.set_reloader(Box::new(move |world, run_id| {
         // Pages a run back in with the current on-disk parts.config, matching what a
         // real restart would restore it with.
@@ -500,6 +455,10 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         // the files name now rather than the one this daemon booted with.
         reload_policy.refresh_into(world);
         reload_telemetry.refresh_into(world, &reload_config.observability);
+        // Including its limits: a run being paged back in is as much a fresh
+        // start as a spawn, and it must not resume against the numbers the
+        // daemon booted with (issue #684).
+        reload_limits.apply(&reload_config, world);
         // The global MCP set as it stands now, not as it stood at boot: a run
         // paged back in is rebuilt with the tools a fresh spawn would get.
         let (reload_defs, reload_owners) = reload_global.current();
@@ -592,6 +551,7 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     let spawn_policy = policy_reload.clone();
     let spawn_telemetry = telemetry_reload.clone();
     let spawn_global = mcp_global.clone();
+    let spawn_limits = live_limits.clone();
     host.set_spawner(Box::new(move |world, args| {
         // Stake out the run directory before anything that can fail: blueprint
         // parsing, sandbox creation, provider resolution and seed validation all
@@ -628,6 +588,11 @@ pub fn build_host(parts: HostParts) -> WorldHost {
         spawn_policy.refresh_into(world);
         // The exporter the file names now, before this run emits anything.
         spawn_telemetry.refresh_into(world, &config.observability);
+        // Before the agent is built, not after: `build_agent` decides from this
+        // same config whether the run is marked for a title, and the system
+        // that makes titles reads the world. Applying here is what stops those
+        // two reading different documents (issue #684).
+        spawn_limits.apply(&config, world);
         let built = build_agent(
             world.world_mut(),
             crate::daemon::spawn::SpawnDeps {
@@ -2213,5 +2178,184 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
             .err()
             .expect("a failing client factory should stop the daemon starting");
         assert!(err.to_string().contains("root certificate store"));
+    }
+
+    /// Write `config` to `path` with a strictly newer mtime, so a rewrite
+    /// inside one clock tick is still seen as a change (the reloader polls the
+    /// mtime, exactly as `config_reload`'s own tests do).
+    fn save_config(path: &std::path::Path, config: &Config) {
+        std::fs::write(path, toml::to_string(config).unwrap()).unwrap();
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(5))
+            .unwrap();
+    }
+
+    /// A host whose spawn-time config is read from `path`, the way the daemon's
+    /// is, with a stand-in for the manifest's provider so a spawn resolves.
+    fn host_watching(path: &std::path::Path, boot: Config, runs: &std::path::Path) -> WorldHost {
+        let mut providers = ProviderRegistry::new();
+        providers.register("anthropic".to_string(), Arc::new(fake_provider()));
+        build_host(HostParts {
+            config: boot.clone(),
+            providers,
+            runs_dir: runs.to_path_buf(),
+            shared_mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+            mcp_tool_defs: Vec::new(),
+            mcp_tool_owners: Default::default(),
+            mcp_pool: crate::daemon::mcp_pool::McpPool::for_daemon(
+                Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
+                &[],
+            ),
+            runtime: Handle::current(),
+            now_secs: || 0,
+            reloader: Some(Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+                path.to_path_buf(),
+                boot,
+            ))),
+        })
+    }
+
+    /// Spawn `run_id` through the host's real spawner and assert it took.
+    async fn spawn_ok(host: &mut WorldHost, run_id: &str, manifest: &std::path::Path) {
+        let (reply, rx) = oneshot::channel();
+        host.handle(ControlOp::Spawn {
+            args: Box::new(SpawnArgs {
+                run_id: run_id.to_string(),
+                blueprint_path: manifest.to_string_lossy().to_string(),
+                task: "name this run".to_string(),
+                workdir: std::env::temp_dir().to_string_lossy().to_string(),
+                ..Default::default()
+            }),
+            reply,
+        });
+        assert_eq!(rx.await.unwrap(), Ok(run_id.to_string()));
+    }
+
+    /// A `[limits]` edit is picked up by the next spawn, with no daemon
+    /// restart: the pools, the tool lane, the watchdogs, the breaker, the retry
+    /// schedule and the fan-out ceiling all move to what the file says now.
+    /// Every one of these was read once at boot and then fixed for the life of
+    /// the process (issue #684).
+    #[tokio::test]
+    async fn a_limits_edit_reaches_the_world_on_the_next_spawn() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut boot = config_with_anthropic_key();
+        boot.limits.max_concurrent_tools = 2;
+        boot.limits.max_concurrent_inferences = Some(1);
+        boot.limits.stall_timeout_secs = 60;
+        boot.limits.max_agents_per_run = 0;
+        boot.limits.provider_failures_before_open = 3;
+        boot.limits.inference_retry_attempts = 4;
+        boot.limits.finished_retention_secs = 300;
+        boot.limits.notify_spend_usd = Vec::new();
+        save_config(&path, &boot);
+
+        let runs = tempfile::tempdir().unwrap();
+        let mut host = host_watching(&path, boot.clone(), runs.path());
+        assert_eq!(host.world_mut().tool_concurrency(), 2, "the boot width");
+
+        // The operator edits the file while the daemon runs.
+        let mut after = boot.clone();
+        after.limits.max_concurrent_tools = 6;
+        after.limits.max_concurrent_inferences = Some(4);
+        after.limits.stall_timeout_secs = 5;
+        after.limits.wedge_timeout_secs = 300;
+        after.limits.max_agents_per_run = 20;
+        after.limits.provider_failures_before_open = 9;
+        after.limits.provider_circuit_cooldown_secs = 42;
+        after.limits.inference_retry_attempts = 7;
+        after.limits.inference_retry_base_ms = 250;
+        after.limits.finished_retention_secs = 30;
+        after.limits.dead_cycles_before_relief = 3;
+        after.limits.notify_spend_usd = vec![5.0];
+        save_config(&path, &after);
+
+        let agent = tempfile::tempdir().unwrap();
+        let manifest = agent.path().join("agent.leviath");
+        std::fs::write(&manifest, crate::test_support::inline_coder_manifest()).unwrap();
+        spawn_ok(&mut host, "limits-1234-ab12", &manifest).await;
+
+        let settings = host.settings();
+        let world = host.world_mut();
+        assert_eq!(world.tool_concurrency(), 6, "the tool lane widened");
+        assert_eq!(
+            world.inference_pool_config().limit_for("m"),
+            Some(4),
+            "the inference pool followed"
+        );
+        let ecs = world.world();
+        assert_eq!(
+            ecs.resource::<leviath_runtime::pipeline::StallTimeout>().0,
+            5
+        );
+        assert_eq!(
+            ecs.resource::<leviath_runtime::pipeline::WedgeTimeout>().0,
+            300
+        );
+        let circuit = ecs.resource::<leviath_runtime::pipeline::CircuitPolicy>();
+        assert_eq!(
+            (circuit.failures_before_open, circuit.cooldown_secs),
+            (9, 42)
+        );
+        let retry = ecs.resource::<leviath_runtime::pipeline::InferenceRetryTuning>();
+        assert_eq!((retry.max_attempts, retry.base_delay_ms), (7, 250));
+        assert_eq!(
+            ecs.resource::<leviath_runtime::fanout::FanOutBudget>().0,
+            20
+        );
+        assert_eq!(settings.dead_cycles_before_relief(), 3);
+        assert_eq!(settings.finished_retention_secs(), 30);
+        assert_eq!(*settings.spend_notify_usd(), vec![5.0]);
+    }
+
+    /// Turning `[title]` on used to leave a run marked for a title nobody would
+    /// ever make. Spawn reads a fresh config, so it marked the run
+    /// `PendingTitle`; the system that makes titles read the boot-time
+    /// `TitleSettings`, saw titling switched off, and dropped the marker
+    /// without a word. Both halves now read the same document (issue #684).
+    #[tokio::test]
+    async fn enabling_titles_reaches_the_system_that_makes_them() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut boot = config_with_anthropic_key();
+        boot.title.enabled = false;
+        save_config(&path, &boot);
+
+        let runs = tempfile::tempdir().unwrap();
+        let mut host = host_watching(&path, boot.clone(), runs.path());
+        assert!(
+            !host
+                .world_mut()
+                .world()
+                .resource::<leviath_runtime::title::TitleSettings>()
+                .0
+                .enabled,
+            "titling is off to begin with"
+        );
+
+        let mut after = boot.clone();
+        after.title.enabled = true;
+        save_config(&path, &after);
+
+        let agent = tempfile::tempdir().unwrap();
+        let manifest = agent.path().join("agent.leviath");
+        std::fs::write(&manifest, crate::test_support::inline_coder_manifest()).unwrap();
+        spawn_ok(&mut host, "titled-1234-ab12", &manifest).await;
+
+        let world = host.world_mut().world_mut();
+        let mut pending = world.query::<&leviath_runtime::title::PendingTitle>();
+        assert_eq!(
+            pending.iter(world).count(),
+            1,
+            "spawn read the new config and marked the run for a title"
+        );
+        assert!(
+            world
+                .resource::<leviath_runtime::title::TitleSettings>()
+                .0
+                .enabled,
+            "and the dispatcher agrees, so the marker is acted on rather than dropped"
+        );
     }
 }

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -2212,6 +2212,7 @@ task = {{ kind = "pinned", max_tokens = 200, seed = {{ caller = "task" }} }}
                 path.to_path_buf(),
                 boot,
             ))),
+            provider_reload: None,
         })
     }
 

--- a/crates/leviath-core/src/config.rs
+++ b/crates/leviath-core/src/config.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 /// provider = "anthropic"
 /// model = "claude-haiku-4-5-20251001"
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct TitleConfig {
     /// Whether to generate titles at all (default: true).
     #[serde(default = "crate::default_true")]

--- a/crates/leviath-runtime/src/host/emit.rs
+++ b/crates/leviath-runtime/src/host/emit.rs
@@ -39,6 +39,10 @@ impl WorldHost {
         let mut to_reap: Vec<(String, Entity, RunListEntry)> = Vec::new();
         let mut to_park: Vec<(String, Entity, RunListEntry)> = Vec::new();
         let now = chrono::Utc::now().timestamp();
+        // Read once for the whole pass: the operator can change these while
+        // the daemon runs, and a pass that used two different lists partway
+        // through would announce one run's threshold and not another's.
+        let spend_notify = self.settings.spend_notify_usd();
         for (run_id, agent) in pairs {
             // Unwrapped once: everything below reaches into this world's ECS,
             // where same-world is true by construction.
@@ -174,7 +178,7 @@ impl WorldHost {
             // "highest seen", so a threshold is announced once and a run that
             // jumps several in one pass announces each of them.
             let spent_before = prev.as_ref().map(|e| e.cost_micros).unwrap_or(0);
-            for threshold in &self.spend_notify_usd {
+            for threshold in spend_notify.iter() {
                 let crossing = super::events::usd_to_micros(*threshold);
                 if spent_before < crossing && cur.cost_micros >= crossing {
                     let _ = self.events.send(WorldEvent::Spend {

--- a/crates/leviath-runtime/src/host/health.rs
+++ b/crates/leviath-runtime/src/host/health.rs
@@ -84,7 +84,7 @@ impl WorldHost {
     /// Capped at one extra lane's worth over the daemon's life. If that is not
     /// enough, the problem is not capacity and more of it will not help.
     pub(super) fn relieve_if_wedged(&mut self, snapshot: &LaneSnapshot) -> usize {
-        let threshold = self.dead_cycles_before_relief;
+        let threshold = self.settings.dead_cycles_before_relief();
         if threshold == 0 || self.dead_cycles < threshold || !snapshot.tools_saturated {
             return 0;
         }
@@ -115,7 +115,7 @@ impl WorldHost {
     /// `0` disables relief; detection and reporting are unaffected. Served from
     /// `[limits] dead_cycles_before_relief`.
     pub fn set_dead_cycles_before_relief(&mut self, cycles: u32) {
-        self.dead_cycles_before_relief = cycles;
+        self.settings.set_dead_cycles_before_relief(cycles);
     }
 
     /// Hand one daemon-wide health sample to the telemetry sink.

--- a/crates/leviath-runtime/src/host/listing.rs
+++ b/crates/leviath-runtime/src/host/listing.rs
@@ -179,7 +179,7 @@ impl WorldHost {
     /// keeps none, which is how the listing behaved before issue #205. Served
     /// from `[limits] finished_retention_secs`.
     pub fn set_finished_retention_secs(&mut self, secs: u64) {
-        self.finished_retention_secs = secs;
+        self.settings.set_finished_retention_secs(secs);
     }
 
     /// Keep `entry` in the listing as a run that finished at `at`.
@@ -194,7 +194,7 @@ impl WorldHost {
     /// run that failed instantly. For a run being unloaded, the unload is the
     /// last thing that happened to it.
     pub(super) fn record_finished(&mut self, mut entry: RunListEntry, at: i64) {
-        if self.finished_retention_secs == 0 {
+        if self.settings.finished_retention_secs() == 0 {
             return;
         }
         entry.last_progress_at.get_or_insert(at);
@@ -214,7 +214,7 @@ impl WorldHost {
     /// serve loop runs before it handles any control op, so a listing never has
     /// to prune on the way out.
     pub(super) fn prune_finished(&mut self, now: i64) {
-        let window = self.finished_retention_secs as i64;
+        let window = self.settings.finished_retention_secs() as i64;
         while let Some(&(at, _)) = self.finished.front() {
             if now.saturating_sub(at) <= window {
                 break;

--- a/crates/leviath-runtime/src/host/mod.rs
+++ b/crates/leviath-runtime/src/host/mod.rs
@@ -36,6 +36,8 @@ mod events;
 pub use events::*;
 mod types;
 pub use types::*;
+mod settings;
+pub use settings::HostSettings;
 
 /// Owns the world and the run-id map; drives the world and services control ops.
 pub struct WorldHost {
@@ -49,10 +51,11 @@ pub struct WorldHost {
     reaper: Option<Reaper>,
     events: broadcast::Sender<WorldEvent>,
     emitted: HashMap<String, Emitted>,
-    /// Dollar figures the operator wants to hear about, ascending. Empty by
-    /// default, which is the current behaviour: no events, no cost to anyone
-    /// who has not asked.
-    spend_notify_usd: Vec<f64>,
+    /// The `[limits]` settings the host itself runs on: relief threshold,
+    /// listing retention, and the spend figures worth an event. Shared rather
+    /// than owned so a config reload can move them without reaching the host -
+    /// see [`HostSettings`].
+    settings: HostSettings,
     emitted_interactions: HashSet<String>,
     /// Sub-agent world-access requests from tool lanes. The host holds a `tx`
     /// clone so the receiver never closes (its `recv` never yields `None`).
@@ -73,16 +76,10 @@ pub struct WorldHost {
     /// Consecutive re-drives that found the lane healthy (no dead cycles, no
     /// queue) while relief was outstanding - the decay countdown.
     healthy_cycles: u32,
-    /// Dead cycles the daemon tolerates before widening the tool lane. `0`
-    /// disables relief. See [`Self::set_dead_cycles_before_relief`].
-    dead_cycles_before_relief: u32,
     /// Runs unloaded recently enough to still be worth reporting, oldest first,
     /// each paired with the unix second it was unloaded. See
     /// [`Self::record_finished`].
     finished: VecDeque<(i64, RunListEntry)>,
-    /// How long an unloaded run stays in [`Self::finished`]. `0` keeps none.
-    /// See [`Self::set_finished_retention_secs`].
-    finished_retention_secs: u64,
     /// Paused runs the host has paged out of the world, by run id, each holding
     /// its last listing row. A parked run's full state is on disk; `Resume`,
     /// `Message` and `Cancel` all page it back through
@@ -179,7 +176,7 @@ impl WorldHost {
             reaper: None,
             events,
             emitted: HashMap::new(),
-            spend_notify_usd: Vec::new(),
+            settings: HostSettings::default(),
             emitted_interactions: HashSet::new(),
             parked: HashMap::new(),
             subagent_tx,
@@ -189,10 +186,15 @@ impl WorldHost {
             last_progress: None,
             relief_granted: 0,
             healthy_cycles: 0,
-            dead_cycles_before_relief: DEFAULT_DEAD_CYCLES_BEFORE_RELIEF,
             finished: VecDeque::new(),
-            finished_retention_secs: DEFAULT_FINISHED_RETENTION_SECS,
         }
+    }
+
+    /// A handle on the `[limits]` settings this host runs on, for whatever
+    /// keeps them in step with `config.toml`. Every clone reads and writes the
+    /// same values, so a change made through one is the change the host sees.
+    pub fn settings(&self) -> HostSettings {
+        self.settings.clone()
     }
 }
 
@@ -331,11 +333,8 @@ impl WorldHost {
     ///
     /// A threshold is reported once per run, the first time the total passes
     /// it, so a long run does not repeat itself every pass.
-    pub fn set_spend_notify_usd(&mut self, mut thresholds: Vec<f64>) {
-        thresholds.retain(|t| t.is_finite() && *t > 0.0);
-        thresholds.sort_by(|a, b| a.partial_cmp(b).expect("finite, filtered above"));
-        thresholds.dedup();
-        self.spend_notify_usd = thresholds;
+    pub fn set_spend_notify_usd(&mut self, thresholds: Vec<f64>) {
+        self.settings.set_spend_notify_usd(thresholds);
     }
 
     /// Install the spawner used to service `Spawn` control ops. Without one, a

--- a/crates/leviath-runtime/src/host/settings.rs
+++ b/crates/leviath-runtime/src/host/settings.rs
@@ -1,0 +1,119 @@
+//! The host's own `[limits]` settings, in a handle that can be shared.
+//!
+//! Three of the numbers [`WorldHost`] runs on come from `config.toml` and are
+//! not world resources: how many dead cycles buy the tool lane some relief, how
+//! long a finished run stays in the listing, and the spend figures worth an
+//! event. They used to be plain fields, which meant the only way to change one
+//! was to restart the daemon - the host is reachable from its own serve loop
+//! and nowhere else, while a config reload happens on the spawn path, which is
+//! handed the world and not the host.
+//!
+//! Putting them behind a shared handle is what closes that gap. The host reads
+//! through it, a clone of it goes to whatever watches `config.toml`, and a
+//! change lands without either side having to reach the other.
+
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use super::{DEFAULT_DEAD_CYCLES_BEFORE_RELIEF, DEFAULT_FINISHED_RETENTION_SECS};
+
+/// The host settings an operator can change while the daemon runs. Cheap to
+/// clone: every clone reads and writes the same values.
+#[derive(Clone, Debug)]
+pub struct HostSettings(Arc<Inner>);
+
+#[derive(Debug)]
+struct Inner {
+    dead_cycles_before_relief: AtomicU32,
+    finished_retention_secs: AtomicU64,
+    /// Behind an `Arc` inside the lock so a reader takes a cheap snapshot
+    /// rather than holding the lock across the events it emits.
+    spend_notify_usd: Mutex<Arc<Vec<f64>>>,
+}
+
+impl Default for HostSettings {
+    fn default() -> Self {
+        Self(Arc::new(Inner {
+            dead_cycles_before_relief: AtomicU32::new(DEFAULT_DEAD_CYCLES_BEFORE_RELIEF),
+            finished_retention_secs: AtomicU64::new(DEFAULT_FINISHED_RETENTION_SECS),
+            spend_notify_usd: Mutex::new(Arc::new(Vec::new())),
+        }))
+    }
+}
+
+impl HostSettings {
+    /// Dead cycles tolerated before the tool lane is widened.
+    pub fn dead_cycles_before_relief(&self) -> u32 {
+        self.0.dead_cycles_before_relief.load(Ordering::Relaxed)
+    }
+
+    /// Set that. Read once per safety re-drive, so it applies from the next one.
+    pub fn set_dead_cycles_before_relief(&self, cycles: u32) {
+        self.0
+            .dead_cycles_before_relief
+            .store(cycles, Ordering::Relaxed);
+    }
+
+    /// How long an unloaded run stays in the listing.
+    pub fn finished_retention_secs(&self) -> u64 {
+        self.0.finished_retention_secs.load(Ordering::Relaxed)
+    }
+
+    /// Set that. Applied on the next prune, so shortening the window drops the
+    /// rows that have already outlived it.
+    pub fn set_finished_retention_secs(&self, secs: u64) {
+        self.0
+            .finished_retention_secs
+            .store(secs, Ordering::Relaxed);
+    }
+
+    /// The spend thresholds to announce, ascending.
+    pub fn spend_notify_usd(&self) -> Arc<Vec<f64>> {
+        leviath_core::sync::lock(&self.0.spend_notify_usd).clone()
+    }
+
+    /// Set them, in any order. Sorted and de-duplicated here so a caller can
+    /// pass a config list as written; figures that are not a positive finite
+    /// number are dropped.
+    pub fn set_spend_notify_usd(&self, mut thresholds: Vec<f64>) {
+        thresholds.retain(|t| t.is_finite() && *t > 0.0);
+        thresholds.sort_by(|a, b| a.partial_cmp(b).expect("finite, filtered above"));
+        thresholds.dedup();
+        *leviath_core::sync::lock(&self.0.spend_notify_usd) = Arc::new(thresholds);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_clone_reads_what_the_original_was_told() {
+        let settings = HostSettings::default();
+        assert_eq!(
+            settings.dead_cycles_before_relief(),
+            DEFAULT_DEAD_CYCLES_BEFORE_RELIEF
+        );
+        assert_eq!(
+            settings.finished_retention_secs(),
+            DEFAULT_FINISHED_RETENTION_SECS
+        );
+        assert!(settings.spend_notify_usd().is_empty());
+
+        let handed_out = settings.clone();
+        settings.set_dead_cycles_before_relief(2);
+        settings.set_finished_retention_secs(30);
+        settings.set_spend_notify_usd(vec![5.0]);
+
+        assert_eq!(handed_out.dead_cycles_before_relief(), 2);
+        assert_eq!(handed_out.finished_retention_secs(), 30);
+        assert_eq!(*handed_out.spend_notify_usd(), vec![5.0]);
+    }
+
+    #[test]
+    fn spend_thresholds_are_sorted_deduped_and_filtered() {
+        let settings = HostSettings::default();
+        settings.set_spend_notify_usd(vec![25.0, 5.0, 5.0, 0.0, -1.0, f64::NAN]);
+        assert_eq!(*settings.spend_notify_usd(), vec![5.0, 25.0]);
+    }
+}

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -802,6 +802,27 @@ async fn release_the_lane(host: &mut WorldHost, releases: &[crate::cancel::Cance
     .await;
 }
 
+/// The host's `[limits]` settings live in a shared handle, so whatever keeps
+/// them in step with `config.toml` can change them without reaching the host,
+/// and the host acts on what either side wrote.
+#[tokio::test]
+async fn the_hosts_limits_settings_are_shared_with_whoever_holds_them() {
+    let mut host = host_with_full_pool(1);
+    let settings = host.settings();
+    host.set_dead_cycles_before_relief(7);
+    assert_eq!(settings.dead_cycles_before_relief(), 7);
+
+    // And back the other way, which is the direction that matters: a change
+    // made through the handle is the one the host acts on.
+    settings.set_dead_cycles_before_relief(0);
+    let snapshot = host.world_mut().lane_snapshot();
+    assert_eq!(
+        host.relieve_if_wedged(&snapshot),
+        0,
+        "relief is switched off, so nothing is granted"
+    );
+}
+
 /// The relief valve: a tool lane that has not drained in long enough gets
 /// wider, so whatever is queued behind the jam can run.
 ///

--- a/crates/leviath-runtime/src/inference_pool.rs
+++ b/crates/leviath-runtime/src/inference_pool.rs
@@ -130,26 +130,83 @@ impl InferencePoolConfig {
 /// `Arc`; semaphores are created lazily the first time a model is seen.
 #[derive(Debug)]
 pub struct InferencePools {
-    config: InferencePoolConfig,
-    semaphores: Mutex<HashMap<String, Arc<Semaphore>>>,
-    /// Per-provider semaphores and their caps, created lazily and only for a
-    /// provider that has a configured cap. A provider absent from here is
-    /// unbounded, and its models are bounded by their own pools alone.
-    ///
-    /// The cap is stored beside the semaphore rather than looked up again when
-    /// occupancy is read: an entry only exists because a cap did, so carrying
-    /// it removes an `Option` nothing could ever make `None`.
-    provider_semaphores: Mutex<HashMap<String, (usize, Arc<Semaphore>)>>,
+    /// The limits in force. Behind a lock rather than owned outright because
+    /// `[limits]` is re-read whenever `config.toml` changes, and a pool that
+    /// went on serving the number the daemon booted with would make the edit
+    /// look like it did nothing.
+    config: Mutex<InferencePoolConfig>,
+    semaphores: Mutex<HashMap<String, Pool>>,
+    /// Per-provider pools, created lazily and only for a provider that has a
+    /// configured cap. A provider absent from here is unbounded, and its
+    /// models are bounded by their own pools alone.
+    provider_semaphores: Mutex<HashMap<String, Pool>>,
     /// The tick-loop wake handle, handed to every permit so that releasing one
     /// re-drives dispatch. See [`InferencePools::with_wake`].
     wake: Option<Arc<Notify>>,
+}
+
+/// One pool: its semaphore, the ceiling it is meant to have, and how many
+/// permits it actually has right now.
+///
+/// The last two stop being the same number the moment an operator lowers a
+/// limit on a busy daemon. A semaphore can only give back permits nobody is
+/// holding, so a shrink takes what is idle now and leaves the rest to be taken
+/// as the requests in flight finish. Nothing in flight is cancelled and no
+/// slot is pulled out from under it: the pool narrows as it drains. The
+/// leftover is collected the next time this pool is touched, which is the next
+/// acquire against it.
+#[derive(Debug)]
+struct Pool {
+    semaphore: Arc<Semaphore>,
+    /// The ceiling asked for. `None` is unbounded.
+    cap: Option<usize>,
+    /// Permits the semaphore holds, held and free together.
+    granted: usize,
+}
+
+impl Pool {
+    /// A pool sized to `cap`, unbounded when that is `None`.
+    fn new(cap: Option<usize>) -> Self {
+        let granted = cap.unwrap_or(UNBOUNDED_PERMITS);
+        Self {
+            semaphore: Arc::new(Semaphore::new(granted)),
+            cap,
+            granted,
+        }
+    }
+
+    /// Aim the pool at `cap` and move it as far that way as it can go without
+    /// disturbing anything in flight.
+    fn retarget(&mut self, cap: Option<usize>) {
+        self.cap = cap;
+        let target = cap.unwrap_or(UNBOUNDED_PERMITS);
+        match target.cmp(&self.granted) {
+            std::cmp::Ordering::Greater => {
+                let extra = target - self.granted;
+                self.semaphore.add_permits(extra);
+                self.granted = target;
+            }
+            // `forget_permits` only ever takes *available* permits, so what it
+            // returns is how much of the shrink actually landed.
+            std::cmp::Ordering::Less => {
+                self.granted -= self.semaphore.forget_permits(self.granted - target);
+            }
+            std::cmp::Ordering::Equal => {}
+        }
+    }
+
+    /// Slots handed out and not yet returned.
+    fn in_use(&self) -> usize {
+        self.granted
+            .saturating_sub(self.semaphore.available_permits())
+    }
 }
 
 impl InferencePools {
     /// Build the pools from a configuration.
     pub(crate) fn new(config: InferencePoolConfig) -> Self {
         Self {
-            config,
+            config: Mutex::new(config),
             semaphores: Mutex::new(HashMap::new()),
             provider_semaphores: Mutex::new(HashMap::new()),
             wake: None,
@@ -252,16 +309,13 @@ impl InferencePools {
         let map = leviath_core::sync::lock(&self.semaphores);
         let mut out: Vec<PoolOccupancy> = map
             .iter()
-            .map(|(model, semaphore)| {
-                let cap = self.config.limit_for(model);
-                let free = semaphore.available_permits();
-                PoolOccupancy {
-                    model: model.clone(),
-                    // An unbounded pool starts at `UNBOUNDED_PERMITS`, so its
-                    // in-use count is the shortfall from that, not from a cap.
-                    in_use: cap.unwrap_or(UNBOUNDED_PERMITS).saturating_sub(free),
-                    cap,
-                }
+            .map(|(model, pool)| PoolOccupancy {
+                model: model.clone(),
+                // Counted against what the pool actually holds rather than
+                // against the cap: mid-shrink those differ, and the shortfall
+                // from the cap would read as slots nobody ever took.
+                in_use: pool.in_use(),
+                cap: pool.cap,
             })
             .collect();
         out.sort_by(|a, b| a.model.cmp(&b.model)); // stable output for logs and tests
@@ -280,10 +334,11 @@ impl InferencePools {
         let map = leviath_core::sync::lock(&self.provider_semaphores);
         let mut out: Vec<ProviderPoolOccupancy> = map
             .iter()
-            .map(|(provider, (cap, semaphore))| ProviderPoolOccupancy {
+            .map(|(provider, pool)| ProviderPoolOccupancy {
                 provider: provider.clone(),
-                in_use: cap.saturating_sub(semaphore.available_permits()),
-                cap: *cap,
+                in_use: pool.in_use(),
+                // A provider is only in this map because it has a cap.
+                cap: pool.cap.unwrap_or(UNBOUNDED_PERMITS),
             })
             .collect();
         out.sort_by(|a, b| a.provider.cmp(&b.provider)); // stable output
@@ -293,26 +348,67 @@ impl InferencePools {
     /// Fetch (or lazily create) the semaphore bounding `provider` as a whole,
     /// or `None` when that provider has no configured cap.
     fn provider_semaphore_for(&self, provider: &str) -> Option<Arc<Semaphore>> {
-        let permits = self.config.provider_limit_for(provider)?;
+        // Config first, then the map, in every path here: one lock order, so
+        // two of these running at once can never wait on each other.
+        // A provider whose cap has been taken out of the config has already had
+        // its pool released and dropped by `reconfigure`, so there is nothing
+        // to look up here.
+        let cap = leviath_core::sync::lock(&self.config).provider_limit_for(provider)?;
         let mut map = leviath_core::sync::lock(&self.provider_semaphores);
-        if let Some((_, existing)) = map.get(provider) {
-            return Some(existing.clone());
-        }
-        let semaphore = Arc::new(Semaphore::new(permits));
-        map.insert(provider.to_string(), (permits, semaphore.clone()));
-        Some(semaphore)
+        let pool = map
+            .entry(provider.to_string())
+            .or_insert_with(|| Pool::new(Some(cap)));
+        pool.retarget(Some(cap));
+        Some(pool.semaphore.clone())
     }
 
-    /// Fetch (or lazily create) the semaphore for `model`.
+    /// Fetch (or lazily create) the semaphore for `model`, sized to whatever
+    /// the config says now.
     fn semaphore_for(&self, model: &str) -> Arc<Semaphore> {
+        let cap = leviath_core::sync::lock(&self.config).limit_for(model);
         let mut map = leviath_core::sync::lock(&self.semaphores);
-        if let Some(existing) = map.get(model) {
-            return existing.clone();
+        let pool = map
+            .entry(model.to_string())
+            .or_insert_with(|| Pool::new(cap));
+        pool.retarget(cap);
+        pool.semaphore.clone()
+    }
+
+    /// The limits in force, as a copy. The reader beside
+    /// [`reconfigure`](Self::reconfigure), so a caller can ask what a model or
+    /// a provider is capped at without reaching into the pools.
+    pub(crate) fn config(&self) -> InferencePoolConfig {
+        leviath_core::sync::lock(&self.config).clone()
+    }
+
+    /// Serve `config` from here on: every pool already created moves to its new
+    /// ceiling, and every one created later starts at it.
+    ///
+    /// This is what lets `[limits] max_concurrent_inferences` and its per-model
+    /// and per-provider tables take effect on a running daemon. A raised limit
+    /// is available at once. A lowered one takes back the slots nobody is using
+    /// and then narrows as the rest come back, so an inference already in
+    /// flight runs to its end.
+    pub(crate) fn reconfigure(&self, config: InferencePoolConfig) {
+        let mut current = leviath_core::sync::lock(&self.config);
+        *current = config;
+        let mut models = leviath_core::sync::lock(&self.semaphores);
+        for (model, pool) in models.iter_mut() {
+            pool.retarget(current.limit_for(model));
         }
-        let permits = self.config.limit_for(model).unwrap_or(UNBOUNDED_PERMITS);
-        let semaphore = Arc::new(Semaphore::new(permits));
-        map.insert(model.to_string(), semaphore.clone());
-        semaphore
+        let mut providers = leviath_core::sync::lock(&self.provider_semaphores);
+        providers.retain(
+            |provider, pool| match current.provider_limit_for(provider) {
+                Some(cap) => {
+                    pool.retarget(Some(cap));
+                    true
+                }
+                None => {
+                    pool.retarget(None);
+                    false
+                }
+            },
+        );
     }
 }
 
@@ -808,5 +904,149 @@ mod tests {
         assert!(pools.occupancy()[0].is_full(), "2 of 2 is full");
         drop(held);
         assert!(!pools.occupancy()[0].is_full(), "and not full once freed");
+    }
+
+    /// Raising `[limits] max_concurrent_inferences` under a running daemon
+    /// widens a pool that is already in use, rather than waiting for a restart.
+    #[tokio::test]
+    async fn a_raised_limit_widens_a_pool_already_in_use() {
+        let pools = InferencePools::new(InferencePoolConfig::new().with_default(Some(1)));
+        let held = pools.try_acquire("p", "m").expect("the one slot");
+        assert!(pools.try_acquire("p", "m").is_none(), "one wide");
+
+        pools.reconfigure(InferencePoolConfig::new().with_default(Some(3)));
+        let _b = pools
+            .try_acquire("p", "m")
+            .expect("the widened pool has room");
+        let _c = pools.try_acquire("p", "m").expect("and again");
+        assert!(pools.try_acquire("p", "m").is_none(), "three wide now");
+        drop(held);
+    }
+
+    /// Lowering it takes back the slots nobody is using and then narrows as the
+    /// requests in flight finish. Nothing is cancelled and no request loses the
+    /// slot it is holding.
+    #[tokio::test]
+    async fn a_lowered_limit_drains_rather_than_cancelling() {
+        let pools = InferencePools::new(InferencePoolConfig::new().with_default(Some(3)));
+        let a = pools.try_acquire("p", "m").expect("a slot");
+        let b = pools.try_acquire("p", "m").expect("another");
+
+        pools.reconfigure(InferencePoolConfig::new().with_default(Some(1)));
+        assert!(
+            pools.try_acquire("p", "m").is_none(),
+            "the third, idle slot is taken back at once"
+        );
+        drop(a);
+        assert!(
+            pools.try_acquire("p", "m").is_none(),
+            "the slot the first request gave back goes to the shrink, not to a new request"
+        );
+        drop(b);
+        let _last = pools.try_acquire("p", "m").expect("one slot is left");
+        assert!(pools.try_acquire("p", "m").is_none(), "and one is all");
+    }
+
+    /// A pool with no limit at all can be given one, and have it taken away.
+    #[tokio::test]
+    async fn an_unbounded_pool_can_be_capped_and_uncapped() {
+        let pools = InferencePools::new(InferencePoolConfig::new());
+        let _a = pools.try_acquire("p", "m").expect("unbounded");
+        let _b = pools.try_acquire("p", "m").expect("still unbounded");
+
+        pools.reconfigure(InferencePoolConfig::new().with_default(Some(1)));
+        assert!(
+            pools.try_acquire("p", "m").is_none(),
+            "the new cap is already exceeded, so nothing more gets in"
+        );
+
+        pools.reconfigure(InferencePoolConfig::new());
+        assert!(
+            pools.try_acquire("p", "m").is_some(),
+            "and removing the cap makes room again"
+        );
+    }
+
+    /// The same for a per-provider cap, which is the pool that only exists
+    /// while the config names it.
+    #[tokio::test]
+    async fn a_provider_cap_can_be_added_and_taken_away() {
+        let pools = InferencePools::new(InferencePoolConfig::new().with_default(Some(4)));
+        let _warm = pools.try_acquire("slow", "m").expect("no provider cap yet");
+
+        let mut capped = InferencePoolConfig::new().with_default(Some(4));
+        capped.set_provider_limit("slow", 1);
+        pools.reconfigure(capped);
+        let held = pools
+            .try_acquire("slow", "m")
+            .expect("the provider's one slot");
+        assert!(
+            pools.try_acquire("slow", "other").is_none(),
+            "the provider cap bounds every model it serves"
+        );
+
+        // Raised, with the pool now in existence and one slot of it held: the
+        // arm that keeps a pool it already has rather than making a new one.
+        let mut wider = InferencePoolConfig::new().with_default(Some(4));
+        wider.set_provider_limit("slow", 2);
+        pools.reconfigure(wider);
+        let second = pools
+            .try_acquire("slow", "other")
+            .expect("the raised provider cap has room");
+        assert!(
+            pools.try_acquire("slow", "third").is_none(),
+            "and two is all it has"
+        );
+        drop(held);
+        drop(second);
+
+        pools.reconfigure(InferencePoolConfig::new().with_default(Some(4)));
+        assert!(
+            pools.try_acquire("slow", "other").is_some(),
+            "with the cap deleted the provider is unbounded again"
+        );
+        assert!(
+            pools.provider_occupancy().is_empty(),
+            "and it is no longer reported as a pool"
+        );
+    }
+
+    /// Reconfiguring with the same numbers is a no-op, so a config save that
+    /// changed something else entirely cannot disturb a pool.
+    #[tokio::test]
+    async fn reconfiguring_with_the_same_limits_changes_nothing() {
+        let pools = InferencePools::new(InferencePoolConfig::new().with_default(Some(2)));
+        let _held = pools.try_acquire("p", "m").expect("a slot");
+        pools.reconfigure(InferencePoolConfig::new().with_default(Some(2)));
+        assert_eq!(
+            pools.occupancy(),
+            vec![PoolOccupancy {
+                model: "m".to_string(),
+                in_use: 1,
+                cap: Some(2),
+            }]
+        );
+        assert!(
+            pools.try_acquire("p", "m").is_some(),
+            "the free slot is untouched"
+        );
+    }
+
+    /// Occupancy reports the cap the operator set most recently, not the one
+    /// the daemon started with.
+    #[tokio::test]
+    async fn occupancy_reports_the_cap_in_force_now() {
+        let pools = InferencePools::new(InferencePoolConfig::new().with_default(Some(2)));
+        let _held = pools.try_acquire("p", "m").expect("a slot");
+        pools.reconfigure(InferencePoolConfig::new().with_default(Some(5)));
+        assert_eq!(
+            pools.occupancy(),
+            vec![PoolOccupancy {
+                model: "m".to_string(),
+                in_use: 1,
+                cap: Some(5),
+            }]
+        );
+        assert_eq!(pools.config().limit_for("m"), Some(5));
     }
 }

--- a/crates/leviath-runtime/src/tool_bridge.rs
+++ b/crates/leviath-runtime/src/tool_bridge.rs
@@ -191,6 +191,9 @@ impl ToolLaneStats {
 pub struct ToolLane {
     /// One permit per concurrent batch.
     permits: Arc<Semaphore>,
+    /// The width `[limits] max_concurrent_tools` asks for, and how much of a
+    /// shrink is still owed. See [`Width`].
+    width: std::sync::Mutex<Width>,
     /// Shared with the world so `lane_snapshot` can read it.
     stats: Arc<ToolLaneStats>,
     /// Where finished batches report.
@@ -214,6 +217,10 @@ impl ToolLane {
     ) -> Arc<Self> {
         Arc::new(Self {
             permits: Arc::new(Semaphore::new(concurrency.max(1))),
+            width: std::sync::Mutex::new(Width {
+                target: concurrency.max(1),
+                owed: 0,
+            }),
             stats,
             results,
             wake,
@@ -246,6 +253,11 @@ impl ToolLane {
         extra
     }
 
+    /// How wide the lane is right now, relief capacity included.
+    pub(crate) fn workers(&self) -> usize {
+        self.stats.workers()
+    }
+
     /// Take up to `upto` *idle* permits back out of the lane, returning how many
     /// were reclaimed.
     ///
@@ -261,6 +273,63 @@ impl ToolLane {
         self.stats.narrowed(taken);
         taken
     }
+
+    /// Set the lane's configured width, which is what `[limits]
+    /// max_concurrent_tools` names.
+    ///
+    /// Widening is immediate. Narrowing takes back the permits nobody is
+    /// holding and remembers the rest, so a batch already running finishes on
+    /// the capacity it took; [`settle_width`](Self::settle_width) collects the
+    /// remainder as batches return their permits.
+    ///
+    /// Clamped to at least one, matching [`ToolLane::new`]: a lane of zero
+    /// would park every batch for the life of the daemon.
+    ///
+    /// Relief capacity is untouched. This moves the *configured* width, and
+    /// the relief valve accounts for what it granted separately, so a lane
+    /// widened to break a jam stays widened by exactly that much either side
+    /// of a config change.
+    pub(crate) fn set_configured(&self, workers: usize) {
+        let workers = workers.max(1);
+        let mut width = leviath_core::sync::lock(&self.width);
+        let up = workers.saturating_sub(width.target);
+        let down = width.target.saturating_sub(workers);
+        width.target = workers;
+        // A widening first cancels whatever shrink is still owed, since that
+        // debt was recorded against a ceiling that no longer applies.
+        let cancelled = up.min(width.owed);
+        width.owed -= cancelled;
+        if up - cancelled > 0 {
+            self.relieve(up - cancelled);
+        }
+        width.owed += down;
+        self.settle(&mut width);
+    }
+
+    /// Take back as much of an owed shrink as the lane can spare right now.
+    /// Called whenever a batch is handed to the lane, which is the moment
+    /// after finished batches have returned their permits.
+    pub(crate) fn settle_width(&self) {
+        let mut width = leviath_core::sync::lock(&self.width);
+        self.settle(&mut width);
+    }
+
+    fn settle(&self, width: &mut Width) {
+        width.owed -= self.narrow(width.owed);
+    }
+}
+
+/// What the operator asked the tool lane to be, and how far it still has to go.
+///
+/// `owed` is only ever non-zero between lowering `max_concurrent_tools` and the
+/// batches that were running at the time finishing. It exists so a shrink
+/// requested while the lane was full is not silently dropped: the permits are
+/// collected as they come back rather than taken from work in progress.
+struct Width {
+    /// The configured width, relief capacity excluded.
+    target: usize,
+    /// Permits a shrink has not managed to take back yet.
+    owed: usize,
 }
 
 /// Read jobs off the channel, spawning one task per batch, then wait for the
@@ -271,6 +340,11 @@ async fn serve_lane(lane: Arc<ToolLane>, mut jobs: UnboundedReceiver<ToolJob>) {
         tokio::select! {
             job = jobs.recv() => match job {
                 Some(job) => {
+                    // Before the batch goes out, not after: this is the point
+                    // where the permits of everything that has finished are
+                    // back, so a `max_concurrent_tools` cut that could not be
+                    // taken in full when it was made is completed here.
+                    lane.settle_width();
                     batches.spawn_on(run_batch(lane.clone(), job), &lane.runtime);
                 }
                 None => break, // channel closed → shutting down
@@ -961,5 +1035,142 @@ mod tests {
         stats.finished();
         stats.abandoned();
         assert_eq!((stats.queued(), stats.busy()), (0, 0));
+    }
+
+    /// Raising `[limits] max_concurrent_tools` releases a batch that is already
+    /// queued behind the old width, with no daemon restart and nothing rebuilt.
+    #[tokio::test]
+    async fn widening_the_lane_releases_a_batch_already_waiting() {
+        let mut h = Harness::new(1);
+        assert_eq!(h.lane.workers(), 1);
+        let first = Arc::new(Notify::new());
+        let second = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        h.submit(held_job(
+            1,
+            first.clone(),
+            release.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        timeout(first.notified()).await;
+        h.submit(held_job(
+            2,
+            second.clone(),
+            release.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), second.notified())
+                .await
+                .is_err(),
+            "the lane is one wide, so the second batch cannot have started"
+        );
+
+        h.lane.set_configured(2);
+        timeout(second.notified()).await;
+        assert_eq!(h.lane.workers(), 2);
+        release.notify_waiters();
+        let _ = h.next_indices(2).await;
+        h.drain().await;
+    }
+
+    /// Lowering it takes back what is idle and leaves the rest to the batches
+    /// that are running, which finish on the capacity they took.
+    #[tokio::test]
+    async fn narrowing_the_lane_waits_for_the_batches_already_running() {
+        let mut h = Harness::new(2);
+        let first = Arc::new(Notify::new());
+        let second = Arc::new(Notify::new());
+        let release_first = Arc::new(Notify::new());
+        let release_second = Arc::new(Notify::new());
+        h.submit(held_job(
+            1,
+            first.clone(),
+            release_first.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        h.submit(held_job(
+            2,
+            second.clone(),
+            release_second.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        timeout(first.notified()).await;
+        timeout(second.notified()).await;
+
+        h.lane.set_configured(1);
+        assert_eq!(
+            h.lane.workers(),
+            2,
+            "both permits are held, so nothing is taken from work in flight"
+        );
+
+        release_first.notify_waiters();
+        let _ = h.next_outcome().await;
+        h.lane.settle_width();
+        assert_eq!(
+            h.lane.workers(),
+            1,
+            "the permit that came back is collected, not handed out again"
+        );
+
+        release_second.notify_waiters();
+        let _ = h.next_outcome().await;
+        h.drain().await;
+    }
+
+    /// An idle lane narrows the moment it is told to.
+    #[tokio::test]
+    async fn an_idle_lane_narrows_immediately() {
+        let mut h = Harness::new(4);
+        h.lane.set_configured(2);
+        assert_eq!(h.lane.workers(), 2);
+        h.drain().await;
+    }
+
+    /// Widening again cancels a shrink that has not landed, rather than
+    /// applying both and ending up narrower than the operator asked for.
+    #[tokio::test]
+    async fn widening_cancels_a_shrink_that_has_not_landed() {
+        let mut h = Harness::new(2);
+        let first = Arc::new(Notify::new());
+        let second = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        h.submit(held_job(
+            1,
+            first.clone(),
+            release.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        h.submit(held_job(
+            2,
+            second.clone(),
+            release.clone(),
+            crate::cancel::CancelToken::new(),
+        ));
+        timeout(first.notified()).await;
+        timeout(second.notified()).await;
+
+        h.lane.set_configured(1); // owed, and unable to land
+        h.lane.set_configured(2); // thought better of it
+        release.notify_waiters();
+        let _ = h.next_indices(2).await;
+        h.lane.settle_width();
+        assert_eq!(
+            h.lane.workers(),
+            2,
+            "the cancelled shrink must not be collected later"
+        );
+        h.drain().await;
+    }
+
+    /// A width of zero would park every batch for the life of the daemon, so
+    /// it is clamped exactly as `ToolLane::new` clamps its own argument.
+    #[tokio::test]
+    async fn a_configured_width_of_zero_is_clamped_to_one() {
+        let mut h = Harness::new(4);
+        h.lane.set_configured(0);
+        assert_eq!(h.lane.workers(), 1);
+        h.drain().await;
     }
 }

--- a/crates/leviath-runtime/src/world.rs
+++ b/crates/leviath-runtime/src/world.rs
@@ -624,8 +624,11 @@ impl PipelineWorld {
     }
 
     /// Turn streamed inference off (or back on) for this world - see
-    /// `inference_bridge::InferenceJob::stream`. Call once at startup, before
-    /// serving.
+    /// `inference_bridge::InferenceJob::stream`.
+    ///
+    /// Read when a request is assembled, so a change reaches the next
+    /// inference any run makes; the one already on the wire finishes the way
+    /// it started.
     pub fn set_stream_inference(&mut self, enabled: bool) {
         // `InferenceStage` is inserted by every `PipelineWorld::new` path, so it
         // is a hard invariant here - `resource_mut` (which panics if absent) is
@@ -633,6 +636,56 @@ impl PipelineWorld {
         self.world
             .resource_mut::<crate::pipeline::InferenceStage>()
             .stream_inference = enabled;
+    }
+
+    /// Move the inference pools to `config`.
+    ///
+    /// The pools follow `[limits] max_concurrent_inferences` and its per-model
+    /// and per-provider tables, which an operator can change while the daemon
+    /// is running. A raised limit is usable at once; a lowered one narrows as
+    /// the requests in flight finish, never by taking a slot back from one
+    /// (see `InferencePools::reconfigure`).
+    pub fn set_inference_pool_config(&mut self, config: InferencePoolConfig) {
+        // `InferenceStage` is inserted by every `PipelineWorld::new` path, the
+        // same hard invariant `set_stream_inference` relies on.
+        self.world
+            .resource::<crate::pipeline::InferenceStage>()
+            .pools
+            .reconfigure(config);
+    }
+
+    /// The inference limits in force. The reader beside
+    /// [`set_inference_pool_config`](Self::set_inference_pool_config).
+    pub fn inference_pool_config(&self) -> InferencePoolConfig {
+        self.world
+            .resource::<crate::pipeline::InferenceStage>()
+            .pools
+            .config()
+    }
+
+    /// Whether streamed inference is on. The reader beside
+    /// [`set_stream_inference`](Self::set_stream_inference).
+    pub fn stream_inference(&self) -> bool {
+        self.world
+            .resource::<crate::pipeline::InferenceStage>()
+            .stream_inference
+    }
+
+    /// How many tool batches may run at once right now, relief capacity
+    /// included. The reader beside
+    /// [`set_tool_concurrency`](Self::set_tool_concurrency).
+    pub fn tool_concurrency(&self) -> usize {
+        self.tool_lane.workers()
+    }
+
+    /// Set how many tool batches may run at once, which is what `[limits]
+    /// max_concurrent_tools` names.
+    ///
+    /// Widening is immediate. Narrowing waits for the batches already running
+    /// to finish rather than interrupting them, so the lane reaches its new
+    /// width as it drains.
+    pub fn set_tool_concurrency(&mut self, workers: usize) {
+        self.tool_lane.set_configured(workers);
     }
 
     /// Install the shared interaction hub as a world resource and attach this
@@ -1351,6 +1404,25 @@ mod tests {
             None,
             Handle::current(),
         )
+    }
+
+    /// The pools, the tool lane and the streaming switch all move when the
+    /// operator's `[limits]` do, which is what lets a daemon pick up a
+    /// `config.toml` edit without being restarted.
+    #[tokio::test]
+    async fn the_worlds_tuning_can_be_changed_after_it_is_built() {
+        let mut world = build_world(ProviderRegistry::new());
+        assert_eq!(world.inference_pool_config().limit_for("m"), None);
+        assert_eq!(world.tool_concurrency(), 1);
+        assert!(world.stream_inference());
+
+        world.set_inference_pool_config(InferencePoolConfig::new().with_default(Some(3)));
+        world.set_tool_concurrency(4);
+        world.set_stream_inference(false);
+
+        assert_eq!(world.inference_pool_config().limit_for("m"), Some(3));
+        assert_eq!(world.tool_concurrency(), 4);
+        assert!(!world.stream_inference());
     }
 
     #[tokio::test]

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -194,29 +194,52 @@ the rule sources were read into the compiled checker at boot, so editing a `.rha
 nothing at all and the gate went on answering from the text it started with.
 
 `[observability]` reloads too. Turn export on, point it at a different collector, rename the
-service, or turn it off, and the next run emits into what the file says now. The one thing that
-does not move is how verbose the daemon's own log is: the process subscriber is installed before
-any config is read, from `--verbose` on the daemon's command line, and a `tracing` subscriber can
-only be set once per process. Changing that still means restarting the daemon.
+service, or turn it off, and the next run emits into what the file says now. The verbosity of the
+daemon's own log is not part of that; it is one of the two things below that still need a restart.
 
-Some changes do still need `lev daemon restart`. They set up connections and process-wide state
-once at startup rather than per run:
+Some changes do still need `lev daemon restart`, and after this release neither of them is a
+setting in `config.toml`. One is how verbose the daemon's own log is: its `tracing` subscriber is
+installed from `--verbose` on the command line before any config is read, and a process can install
+one only once. The other is a provider key you exported as an environment variable instead of
+writing it to the file: the daemon inherited its environment when it started, and an export in your
+shell afterwards never reaches it.
 
-- The `[limits]` the world itself is built with: `stall_timeout_secs`, `wedge_timeout_secs`,
-  `dead_cycles_before_relief`, `max_concurrent_inferences`, `max_concurrent_tools`,
-  `provider_failures_before_open`, `provider_circuit_cooldown_secs`,
-  `interaction_timeout_secs`, and `finished_retention_secs`.
+`[providers] fallback_order` needs no restart either. It is per-run policy, so it reloads like
+everything else and a new fallback provider applies on the next `lev run`.
 
-`[providers] fallback_order` is not one of them. It is per-run policy, so it reloads like everything
-else and a new fallback provider applies on the next `lev run`.
-
-Neither is the outbound-network policy. `[security] allow_local_network` and the two script-HTTP
+Nor does the outbound-network policy. `[security] allow_local_network` and the two script-HTTP
 limits, `script_http_timeout_secs` and `script_http_max_per_host`, are copied into process-wide
 state because the shared HTTP client has no handle on your config by the time a script tool calls
 through it. That copy is now refreshed on every reload, so all three follow the file. It matters
 most in the direction nobody tests: turning `allow_local_network` **off** used to stop a script
 naming a loopback URL at once, while a redirect from a permitted URL down to loopback carried on
 being followed until you restarted the daemon.
+
+### The `[limits]` the world is built with
+
+These used to need a restart and no longer do, as of this release: the inference pools
+(`max_concurrent_inferences` and its `_by_model` and `_by_provider` tables), the tool lane
+(`max_concurrent_tools`), `stream_inference`, the two watchdogs (`stall_timeout_secs`,
+`wedge_timeout_secs`), the provider circuit breaker (`provider_failures_before_open`,
+`provider_circuit_cooldown_secs`), the inference retry schedule (`inference_retry_attempts`,
+`inference_retry_base_ms`), `dead_cycles_before_relief`, `notify_spend_usd`, `max_agents_per_run`,
+`finished_retention_secs`, `interaction_timeout_secs`, and the whole `[title]` section.
+
+Most of them reach the runs already going, not only the next one, because the engine reads them on
+every pass: lower `stall_timeout_secs` and the watchdog is stricter with the run in front of it,
+lower `max_agents_per_run` and the next fan-out split stops at the new ceiling. The ones that only
+apply to what starts next are the ones nothing can retroactively change: a request already on the
+wire keeps the streaming setting, the retry schedule and the pool slot it started with, and a prompt
+already waiting keeps the deadline it opened with.
+
+Lowering a concurrency limit never interrupts anything. The slots nobody is holding are taken back
+at once and the rest as the requests and tool batches in flight finish, so the pool narrows by
+draining rather than by cancelling work you are paying for.
+
+`[title]` had a worse failure than doing nothing. Turning it on marked each new run for a title,
+because spawn already read a fresh config, and then the part that actually makes titles read the
+value from boot, saw titling switched off, and dropped the marker without a word. Both halves read
+the same file now.
 
 ## Control surface
 


### PR DESCRIPTION
Every `[limits]` key the daemon's world is *built* with, and the whole `[title]`
section, was read once in `build_host` and then fixed for the life of the
process. The config reloader beside it has been re-reading `config.toml` since
#180, but only for what a spawn reads directly, so editing a pool size, a
watchdog, the circuit breaker, the retry schedule, the fan-out ceiling, the
listing window, the spend figures or the prompt timeout and starting a run did
nothing at all, with nothing to say so. Killing the daemon was the only thing
that helped.

`[title]` was worse than doing nothing. Spawn reads a fresh config, so turning
titling on marked the new run `PendingTitle`; `dispatch_title` reads the world,
found the boot-time `TitleSettings` with titling off, and dropped the marker
without a word. The run was marked for a title that could never be made.

`crates/leviath-cli/src/daemon/live_limits.rs` is the one place that turns a
`Config` into live world state, following the shape #729 established for
providers: compare, apply if it differs, call it from the same hooks. It runs
at every spawn *before* `build_agent`, which is what puts the spawner and the
title dispatcher on one document, and on the reload hook so a run paged back in
does not resume against the numbers the daemon booted with. `build_host` now
installs the boot values through it too, so there is one description of how a
config becomes a world rather than two that can drift.

## Per setting

Whether a change reaches a run already in flight is decided by where the value
is read, not by a policy choice. A world resource is read by a system on every
tick; a pool or lane permit is taken once per request.

| Setting | Reaches a run in flight? | Why |
|---|---|---|
| `max_concurrent_inferences` (+ `_by_model`, `_by_provider`) | Next request only | A permit is taken once, for the length of the call. A raised limit is usable at once; a lowered one takes back the idle slots now and the rest as the calls in flight finish |
| `max_concurrent_tools` | Next batch only | Same bargain on the tool lane: widening is immediate, narrowing waits for the batches already running |
| `stream_inference` | Next inference only | Read when a request is assembled; one already on the wire finishes the way it started |
| `stall_timeout_secs` | **Yes** | `StallTimeout` is read by the watchdog every tick |
| `wedge_timeout_secs` | **Yes** | `WedgeTimeout`, same |
| `provider_failures_before_open` / `provider_circuit_cooldown_secs` | **Yes** | `CircuitPolicy` is read whenever a failure is recorded or a circuit consulted |
| `inference_retry_attempts` / `inference_retry_base_ms` | **Yes**, from the next dispatch | `InferenceRetryTuning` is read when a request is dispatched, so the next attempt uses the new schedule |
| `max_agents_per_run` | **Yes** | `FanOutBudget` is read at every fan-out split |
| `dead_cycles_before_relief` | **Yes**, from the next re-drive | Read once per safety re-drive |
| `notify_spend_usd` | **Yes**, from the next event pass | Read once per `emit_events` pass |
| `finished_retention_secs` | **Yes** | Read on every prune, so shortening the window drops rows that have already outlived it |
| `interaction_timeout_secs` | Next prompt only | Read when a prompt opens; one already waiting keeps the deadline it opened with |
| `[title]` | **Yes** for a run not yet titled | `TitleSettings` is read by `dispatch_title` every tick. This is the split above: spawn and dispatch now read the same config |

No default changes and nothing is read differently. `mcp_idle_disconnect_secs`
still needs a restart and still says so: it belongs to the MCP pool's live
connections, not to the world.

Shrinking a pool or the lane never interrupts anything. `forget_permits` only
ever takes *available* permits, so a shrink under load takes what is idle and
records the rest; the pool collects it the next time something acquires against
it, and the tool lane each time a batch is handed to it.

## Composing with the open PRs

- **#728** turns `interaction_timeout_secs` into an `Option<u64>`. Both its call
  site and mine are `hub.set_timeout_secs(config.limits.interaction_timeout_secs)`,
  so the expression composes as written; a rebase is a textual conflict on the
  doc lines above the field and nothing else. My `Applied` snapshot compares the
  whole `LimitsConfig`, so the `Option` needs no change there either.
- **#729** adds `provider_reload` on the same hooks. The two are independent
  calls in the same two closures.

## Fail-first

Every new test was run against unfixed code first, by putting the three
mechanisms back the way they were: `LiveLimits::apply` applying only once (the
boot-only behaviour), `InferencePools::reconfigure` a no-op, and
`ToolLane::set_configured` a no-op.

```
failures:
    inference_pool::tests::a_lowered_limit_drains_rather_than_cancelling
    inference_pool::tests::a_provider_cap_can_be_added_and_taken_away
    inference_pool::tests::a_raised_limit_widens_a_pool_already_in_use
    inference_pool::tests::an_unbounded_pool_can_be_capped_and_uncapped
    inference_pool::tests::occupancy_reports_the_cap_in_force_now
    tool_bridge::tests::a_configured_width_of_zero_is_clamped_to_one
    tool_bridge::tests::an_idle_lane_narrows_immediately
    tool_bridge::tests::narrowing_the_lane_waits_for_the_batches_already_running
    tool_bridge::tests::widening_the_lane_releases_a_batch_already_waiting

test result: FAILED. 37 passed; 9 failed
```

```
failures:
    daemon::live_limits::tests::stream_inference_can_be_turned_off_without_a_restart
    daemon::live_limits::tests::the_circuit_policy_and_retry_schedule_follow_the_config
    daemon::live_limits::tests::the_fan_out_budget_follows_the_config
    daemon::live_limits::tests::the_host_settings_and_the_prompt_timeout_follow_the_config
    daemon::live_limits::tests::the_inference_pool_limits_follow_the_config
    daemon::live_limits::tests::the_tool_lane_widens_and_narrows_with_the_config
    daemon::live_limits::tests::the_watchdog_timeouts_follow_the_config
    daemon::live_limits::tests::title_settings_follow_the_config
    daemon::setup::tests::a_limits_edit_reaches_the_world_on_the_next_spawn
    daemon::setup::tests::enabling_titles_reaches_the_system_that_makes_them

test result: FAILED. 2 passed; 10 failed
```

The title one fails on exactly the split this fixes. The run *is* marked, and
the dispatcher disagrees:

```
---- daemon::setup::tests::enabling_titles_reaches_the_system_that_makes_them stdout ----
thread '...' panicked at crates/leviath-cli/src/daemon/setup.rs:2101:9:
and the dispatcher agrees, so the marker is acted on rather than dropped
```

(the assertion above it, that spawn marked the run `PendingTitle`, passes)

Two of the nine runtime tests pass against the unfixed code and are guards
rather than reproductions: `reconfiguring_with_the_same_limits_changes_nothing`
and `widening_cancels_a_shrink_that_has_not_landed` both assert that nothing
moves, which a no-op satisfies.

## Live check

`perf-tools/harness.sh` with a threaded stand-in for `mock.py` (the stock one is
a single-threaded `HTTPServer`, so it serialises every request and its peak
concurrency is always 1). Boot with `max_concurrent_inferences = 1` and titling
off, spawn six runs, edit `config.toml` in place, spawn six more. Nothing is
restarted, and the daemon pid is the same on both sides:

```json
{
  "daemon_pid_at_start": "76383",
  "daemon_pid_at_end": "76383",
  "before": {
    "max_concurrent_inferences": 1,
    "title_enabled": false,
    "peak_concurrent_completions": 1,
    "titles": [null, null, null, null, null, null],
    "unfinished": 0
  },
  "after": {
    "max_concurrent_inferences": 4,
    "title_enabled": true,
    "peak_concurrent_completions": 4,
    "titles": ["Mock Titled Run", "Mock Titled Run", "Mock Titled Run",
               "Mock Titled Run", "Mock Titled Run", "Mock Titled Run"],
    "unfinished": 0
  }
}
```

The pool width is measured at the provider, as the most completions it ever had
in flight at once, and the titles are read out of each run's `meta.json`.

## Gates

- `cargo fmt --all`
- `cargo clippy --all-targets --all-features` clean on `leviath-runtime`,
  `leviath-cli` and `leviath-core`
- `cargo xtask structure`: 429 files, none over 1200 lines
- `cargo xtask docs`: 40 pages, 3 schemas, no problems
- `cargo xtask coverage --package` at 100% for `leviath-runtime`, `leviath-cli`
  and `leviath-core`
- Full test suites green: 1659 runtime, 4150 cli, 922 core
- No `main.rs` touched
