### PR TITLE
fix(daemon): a resumed run re-reads the permissions it is stuck on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,16 @@ same list.
   read a fresh config, so the run was marked for a title, and the part that
   makes titles read the boot-time setting, saw titling switched off, and dropped
   the marker in silence. Both halves read the same file now.
+- A run re-reads `[tool_permissions]`, `[safe_commands]`, `[security] read_paths` and the write
+  ceilings when it resumes, so a run stopped on a tool it may not call, a path it may not read, or
+  a ceiling it has hit can be freed by editing `config.toml` and running `lev resume`. Those were
+  resolved once when the agent spawned, so the only way out was to cancel the run and start it
+  again, losing everything it had done, and the file you were told to edit did nothing until you
+  did. Resuming counts three ways: `lev resume`, answering an approval prompt (whoever answers may
+  equally have changed the permission it was about), and the daemon paging a run back in from disk.
+  A stage that is running keeps the snapshot it started on, and nothing the run has already spent
+  or been granted is reset. The refusal a denied tool hands the model now says which setting lifts
+  it and that resuming is enough.
 - The update check read the GitHub releases answer with no size cap, the one
   buffered remote read left after the daemon's caps landed. It now stops at
   the same 64 MiB as every other buffered body and reports the same

--- a/crates/leviath-cli/src/daemon/setup.rs
+++ b/crates/leviath-cli/src/daemon/setup.rs
@@ -243,6 +243,35 @@ fn make_reaper(
     })
 }
 
+/// The resume hook installed on the host: re-reads the config layers an agent
+/// resolved at spawn, against `config.toml` as it stands now.
+///
+/// Which is the whole point of the hook. A run parked on a tool it is not
+/// permitted to call, on a path it may not read, or against a write ceiling it
+/// has hit could not be freed by editing the file those come from: the answer
+/// was resolved once at spawn, so the only way out was to cancel the run and
+/// start it again, losing everything it had done. With an unanswered approval
+/// prompt waiting for ever by default, that stall never ends on its own.
+///
+/// A run that is not paused and not being paged in never reaches here, so a
+/// stage under way keeps the snapshot it started on.
+///
+/// Factored out (rather than an inline closure) so its body is exercised by a
+/// unit test - the daemon only ever fires it from the private `serve()` loop.
+fn make_resumer(
+    tool_service: Arc<CliToolService>,
+    reloader: Arc<crate::daemon::config_reload::ConfigReloader>,
+) -> leviath_runtime::host::Resumer {
+    Box::new(move |_world, entity| {
+        let Some(state) = tool_service.state_for(entity) else {
+            // Not every resumed entity has tool state: a fan-out parent that
+            // has been paged back in registers its workers as it goes.
+            return;
+        };
+        state.reread_config(&reloader.current());
+    })
+}
+
 /// Everything the daemon hands its world host at construction.
 ///
 /// A struct rather than eight positional parameters because these are not
@@ -497,6 +526,13 @@ pub fn build_host(parts: HostParts) -> WorldHost {
     // state was never released). Factored into `make_reaper` so the closure body
     // is unit-testable - the daemon only ever drives it from `serve()`.
     host.set_reaper(make_reaper(tool_service.clone(), parts.mcp_pool.clone()));
+
+    // Resume hook: a run that starts moving again re-reads the config layers a
+    // person edits to unblock it. A run parked on a denied tool used to have
+    // no way out but a cancel, because its permissions were resolved once at
+    // spawn - and with an unanswered prompt waiting for ever by default, that
+    // stall is permanent.
+    host.set_resumer(make_resumer(tool_service.clone(), reloader.clone()));
 
     // Preprocessor: before the sync spawner runs, connect the blueprint's declared
     // MCP servers into the shared pool (lazy, deduped) so they're warm to advertise -
@@ -829,6 +865,58 @@ mod tests {
         let mut config = Config::default();
         config.providers.anthropic_api_key = Some("test-key".to_string());
         config
+    }
+
+    /// The resume hook the daemon installs, driven the way `serve()` drives
+    /// it. Both arms in one test: an entity with no tool state (a fan-out
+    /// parent paged back in before its workers register) is a no-op, and one
+    /// with state has its config layers re-read.
+    #[tokio::test]
+    async fn make_resumer_rereads_the_config_of_a_registered_agent() {
+        let tool_service = Arc::new(CliToolService::new());
+        let mut world = PipelineWorld::new(
+            ProviderRegistry::new(),
+            tool_service.clone(),
+            leviath_runtime::inference_pool::InferencePoolConfig::new(),
+            1,
+            None,
+            Handle::current(),
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, toml::to_string(&Config::default()).unwrap()).unwrap();
+        let reloader = Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+            config_path.clone(),
+            Config::default(),
+        ));
+        let mut resumer = make_resumer(tool_service.clone(), reloader);
+
+        let entity = bevy_ecs::entity::Entity::from_raw_u32(1)
+            .expect("a small literal index is always a valid entity id");
+        // No state registered: nothing to re-read, and nothing panics.
+        resumer(&mut world, entity);
+
+        // With state, the layers follow the file. `lev resume` is what makes
+        // the daemon read it again.
+        let state = crate::daemon::tool_service::test_state_for_resume(dir.path());
+        tool_service.register(entity, state.clone());
+        assert!(!state.blueprint_may_loosen());
+        let mut edited = Config::default();
+        edited.security.allow_blueprint_permissions = true;
+        std::fs::write(&config_path, toml::to_string(&edited).unwrap()).unwrap();
+        let later = std::time::SystemTime::now() + std::time::Duration::from_secs(5);
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&config_path)
+            .unwrap()
+            .set_modified(later)
+            .unwrap();
+
+        resumer(&mut world, entity);
+        assert!(
+            state.blueprint_may_loosen(),
+            "the resume reads config.toml as it stands now, not as the spawn read it"
+        );
     }
 
     #[tokio::test]

--- a/crates/leviath-cli/src/daemon/spawn/mod.rs
+++ b/crates/leviath-cli/src/daemon/spawn/mod.rs
@@ -45,7 +45,7 @@ pub(crate) use policy::*;
 mod scripts;
 pub(crate) use scripts::*;
 mod seeds;
-use seeds::*;
+pub(crate) use seeds::*;
 mod tool_state;
 use tool_state::*;
 
@@ -804,6 +804,9 @@ fn build_agent_inner(
     // Taken here for the same reason: the tool state is built after the
     // blueprint has been handed to the world, and this list cannot change.
     let blueprint_safe = blueprint.safe_commands.clone();
+    // And this one, so a resume can recompile the read-path grants against the
+    // config as it stands then.
+    let blueprint_read_paths = blueprint.read_paths.clone();
 
     // 6. Spawn the agent.
     let entity = spawn_agent_seeded(
@@ -924,6 +927,8 @@ fn build_agent_inner(
         dynamic,
         unattended: args.yolo,
         blueprint_safe: blueprint_safe.as_ref(),
+        blueprint_read_paths: blueprint_read_paths.as_ref(),
+        workdir: std::path::PathBuf::from(&args.workdir),
     });
     deps.tool_service.register(entity, state);
 

--- a/crates/leviath-cli/src/daemon/spawn/seeds.rs
+++ b/crates/leviath-cli/src/daemon/spawn/seeds.rs
@@ -351,18 +351,33 @@ pub(super) fn build_read_path_policy(
     config: &crate::config::Config,
     workdir: &std::path::Path,
 ) -> Result<(leviath_core::ReadPathPolicy, Option<String>), String> {
-    let Some(rp) = blueprint
-        .read_paths
-        .as_ref()
-        .filter(|rp| !rp.allow.is_empty())
-    else {
+    compile_read_path_policy(
+        &blueprint.name,
+        blueprint.read_paths.as_ref(),
+        config,
+        workdir,
+    )
+}
+
+/// The same resolution over its parts rather than a whole [`Blueprint`], so a
+/// run that has already spawned can redo it: [`AgentToolState::reread_config`]
+/// keeps only the blueprint half on the run, not the manifest.
+///
+/// [`AgentToolState::reread_config`]: crate::daemon::tool_service::AgentToolState::reread_config
+pub(crate) fn compile_read_path_policy(
+    agent_name: &str,
+    declared: Option<&leviath_core::blueprint::ReadPathsConfig>,
+    config: &crate::config::Config,
+    workdir: &std::path::Path,
+) -> Result<(leviath_core::ReadPathPolicy, Option<String>), String> {
+    let Some(rp) = declared.filter(|rp| !rp.allow.is_empty()) else {
         return Ok((leviath_core::ReadPathPolicy::inactive(), None));
     };
     let home = leviath_core::home_dir();
     let declared =
         leviath_core::ReadPathSet::compile(&rp.allow, workdir, home.as_deref(), cfg!(windows))
-            .map_err(|e| format!("agent '{}' [read_paths]: {e}", blueprint.name))?;
-    let grant_entries = config.read_path_grants_for_agent(&blueprint.name);
+            .map_err(|e| format!("agent '{agent_name}' [read_paths]: {e}"))?;
+    let grant_entries = config.read_path_grants_for_agent(agent_name);
     let grants =
         leviath_core::ReadPathSet::compile(&grant_entries, workdir, home.as_deref(), cfg!(windows))
             .map_err(|e| format!("read_paths grant in your config.toml: {e}"))?;
@@ -379,18 +394,51 @@ pub(super) fn build_read_path_policy(
              the workdir will be refused. To grant them, add to your config.toml either:\n\
              [security]\nallow_blueprint_read_paths = true\n\
              or the specific paths:\n[agent_read_paths.{name}]\nallow = [{entries}]",
-            name = blueprint.name,
+            name = agent_name,
         )
     });
     Ok((
         leviath_core::ReadPathPolicy {
-            agent: blueprint.name.clone(),
+            agent: agent_name.to_string(),
             blueprint: declared,
             grants,
             allow_blueprint,
         },
         warning,
     ))
+}
+
+/// The policy a resuming run should enforce, or `None` when the entries no
+/// longer compile.
+///
+/// A resume has nowhere to report a bad entry to: the run is already going and
+/// the person is watching it, not a spawn. Refusing loudly at spawn and keeping
+/// the working policy at resume is the same posture the config reloader takes
+/// with a half-saved file, and it fails in the safe direction - a run keeps the
+/// grants it had rather than losing them to a typo.
+pub(crate) fn read_path_policy_for(
+    agent_name: &str,
+    declared: Option<&leviath_core::blueprint::ReadPathsConfig>,
+    config: &crate::config::Config,
+    workdir: &std::path::Path,
+) -> Option<leviath_core::ReadPathPolicy> {
+    match compile_read_path_policy(agent_name, declared, config, workdir) {
+        Ok((policy, _warning)) => Some(policy),
+        Err(error) => {
+            // Pre-bound rather than left as lazy `%` fields: a method call or a
+            // borrow inside a structured field only runs when the callsite is
+            // enabled, and tracing caches that interest process-wide, so under
+            // a coverage run the region can be unreachable.
+            let agent = agent_name;
+            let reason = error;
+            tracing::warn!(
+                agent = %agent,
+                error = %reason,
+                "the [read_paths] in config.toml would not compile; the run keeps the ones it had"
+            );
+            None
+        }
+    }
 }
 
 /// How many of a blueprint's `[read_paths]` entries the config grants, for the

--- a/crates/leviath-cli/src/daemon/spawn/tool_state.rs
+++ b/crates/leviath-cli/src/daemon/spawn/tool_state.rs
@@ -63,6 +63,10 @@ pub(super) struct ToolStateParts<'a> {
     pub(super) unattended: bool,
     /// `[safe_commands]` the blueprint declares, if the user opted in.
     pub(super) blueprint_safe: Option<&'a leviath_core::blueprint::SafeCommandsConfig>,
+    /// `[read_paths]` the blueprint declares, if any.
+    pub(super) blueprint_read_paths: Option<&'a leviath_core::blueprint::ReadPathsConfig>,
+    /// The run's workdir, which read-path entries compile relative to.
+    pub(super) workdir: std::path::PathBuf,
 }
 
 pub(super) fn build_tool_state(parts: ToolStateParts<'_>) -> Arc<AgentToolState> {
@@ -84,7 +88,7 @@ pub(super) fn build_tool_state(parts: ToolStateParts<'_>) -> Arc<AgentToolState>
         mcp: parts.mcp,
         builtin_names: parts.builtin_names,
         launch_overrides: Arc::new(parts.launch_overrides),
-        safe_keys: Arc::new(
+        safe_keys: crate::daemon::tool_service::Live::new(
             parts
                 .config
                 .safe_keys_for_agent(parts.agent_name, parts.blueprint_safe)
@@ -99,12 +103,16 @@ pub(super) fn build_tool_state(parts: ToolStateParts<'_>) -> Arc<AgentToolState>
         stage_required: Arc::new(StdMutex::new(entry_required)),
         stage_required_by_index: Arc::new(parts.stage_required_by_index),
         agent_perms: Arc::new(parts.agent_perms),
-        blueprint_may_loosen: parts.config.security.allow_blueprint_permissions,
+        blueprint_may_loosen: Arc::new(std::sync::atomic::AtomicBool::new(
+            parts.config.security.allow_blueprint_permissions,
+        )),
         // The ceiling a blueprint may tighten but not loosen: the user's global
         // `[tool_permissions]` plus any `[agent_tool_permissions.<name>]` grant
-        // they made for this specific agent. Resolved once here so every later
-        // `resolve_policy` reads one flat map.
-        global_perms: Arc::new(parts.config.permissions_for_agent(parts.agent_name)),
+        // they made for this specific agent. Flattened here so every later
+        // `resolve_policy` reads one map, and re-flattened on resume.
+        global_perms: crate::daemon::tool_service::Live::new(
+            parts.config.permissions_for_agent(parts.agent_name),
+        ),
         interaction: parts.hub.backend_for(parts.run_id),
         unattended: parts.unattended,
         stage_name: Arc::new(StdMutex::new(parts.entry_stage.to_string())),
@@ -114,5 +122,13 @@ pub(super) fn build_tool_state(parts: ToolStateParts<'_>) -> Arc<AgentToolState>
         script_tool_names: Arc::new(StdMutex::new(parts.script_tool_names)),
         script_host: parts.script_host,
         dynamic: parts.dynamic,
+        // Everything a resume needs to redo this resolution against the config
+        // as it stands then, rather than the copy this spawn read.
+        config_source: Arc::new(crate::daemon::tool_service::ConfigSource {
+            agent_name: parts.agent_name.to_string(),
+            blueprint_safe: parts.blueprint_safe.cloned(),
+            blueprint_read_paths: parts.blueprint_read_paths.cloned(),
+            workdir: parts.workdir,
+        }),
     })
 }

--- a/crates/leviath-cli/src/daemon/tool_service.rs
+++ b/crates/leviath-cli/src/daemon/tool_service.rs
@@ -27,6 +27,8 @@ use leviath_runtime::dynamic_interaction::{
 };
 use leviath_runtime::interaction_hub::HubInteractionBackend;
 use leviath_runtime::pipeline::{ToolProgress, ToolService};
+
+use crate::config::Config;
 use leviath_runtime::tool_bridge::BoxedToolExec;
 use tokio::sync::Mutex;
 
@@ -46,7 +48,10 @@ use crate::tools::resolve_policy;
 /// tracking per-path deltas, which a command writing to a path Leviath cannot
 /// name defeats anyway.
 pub(crate) struct WriteBudget {
-    limits: leviath_core::write_limits::WriteLimits,
+    /// Behind a lock because a run re-reads `[limits]` when it resumes, and a
+    /// run parked against a ceiling the user has since raised is the case that
+    /// matters. Read once per check, never held across I/O.
+    limits: StdMutex<leviath_core::write_limits::WriteLimits>,
     written: std::sync::atomic::AtomicU64,
     /// The filesystem probe, injected so a test can drive the disk-full arm
     /// without one. `fn` rather than a closure: one coverage instance.
@@ -65,10 +70,23 @@ impl WriteBudget {
         available: fn(&std::path::Path) -> Option<u64>,
     ) -> Self {
         Self {
-            limits,
+            limits: StdMutex::new(limits),
             written: std::sync::atomic::AtomicU64::new(0),
             available,
         }
+    }
+
+    /// Raise or lower the ceilings without forgetting what has been spent.
+    ///
+    /// A run resumes against the `[limits]` the file names now, and the
+    /// running total is the whole point of a per-run budget, so it survives.
+    pub(crate) fn set_limits(&self, limits: leviath_core::write_limits::WriteLimits) {
+        *self.limits.lock().unwrap_or_else(PoisonError::into_inner) = limits;
+    }
+
+    /// The ceilings in force right now.
+    fn limits(&self) -> leviath_core::write_limits::WriteLimits {
+        *self.limits.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
     /// Whether a write of `bytes` into `workdir` may proceed.
@@ -81,7 +99,7 @@ impl WriteBudget {
         bytes: u64,
     ) -> leviath_core::write_limits::WriteVerdict {
         leviath_core::write_limits::check_write(
-            self.limits,
+            self.limits(),
             self.written.load(std::sync::atomic::Ordering::Relaxed),
             bytes,
             (self.available)(workdir),
@@ -123,13 +141,14 @@ pub(crate) struct AgentToolState {
     /// `--yolo` / `--allow` / `--ask` / `--deny` launch overrides.
     pub launch_overrides: Arc<HashMap<String, ToolPolicy>>,
     /// Keys that need no prompt at all: the shipped safe list plus whatever the
-    /// user's `[safe_commands]` adds. Resolved once at spawn and never mutated,
-    /// so reading it needs no lock.
+    /// user's `[safe_commands]` adds. Re-resolved when the run resumes, so a
+    /// command the person adds to `[safe_commands]` after watching it prompt
+    /// stops prompting in the run that prompted.
     ///
     /// Unlike a grant, a safe entry matches by program as well as exactly:
     /// naming `cat` covers `cat notes.md`, because otherwise it would cover
     /// nothing anybody runs. See [`crate::shell_keys::program_of`].
-    pub safe_keys: Arc<HashSet<String>>,
+    pub safe_keys: Arc<Live<HashSet<String>>>,
     /// Grant keys the user allowed for the rest of the run.
     pub run_allows: Arc<Mutex<HashSet<String>>>,
     /// Grant keys the user allowed for the current stage only, cleared by
@@ -160,12 +179,13 @@ pub(crate) struct AgentToolState {
     pub stage_required_by_index: Arc<Vec<HashSet<String>>>,
     /// Blueprint-level `[tool_permissions]`.
     pub agent_perms: Arc<HashMap<String, String>>,
-    /// Config-level tool permissions.
-    pub global_perms: Arc<HashMap<String, ToolPolicy>>,
+    /// Config-level tool permissions, re-resolved when the run resumes.
+    pub global_perms: Arc<Live<HashMap<String, ToolPolicy>>>,
     /// `[security] allow_blueprint_permissions`: whether this manifest's
     /// `[tool_permissions]` may exceed the built-in default for a tool the user
     /// has not configured. See `BLUEPRINT_LOOSENABLE` in `crate::tools`.
-    pub blueprint_may_loosen: bool,
+    /// Re-read when the run resumes, like the permission maps beside it.
+    pub blueprint_may_loosen: Arc<std::sync::atomic::AtomicBool>,
     /// The agent's interaction backend (ask_user + tool approvals).
     pub interaction: HubInteractionBackend,
     /// `--yolo`: nobody is watching this run, so the tools that block on a
@@ -197,6 +217,68 @@ pub(crate) struct AgentToolState {
     /// Present only for `dynamic_tools` agents: everything needed to re-discover
     /// and re-advertise this agent's tools mid-run.
     pub dynamic: Option<Arc<DynamicToolCtx>>,
+    /// What [`AgentToolState::reread_config`] needs to resolve the config
+    /// layers again: which agent this is, and the blueprint halves of the two
+    /// settings that are a blueprint-plus-config decision.
+    pub config_source: Arc<ConfigSource>,
+}
+
+/// A config-derived layer that is re-read when a run resumes.
+///
+/// A lock around an `Arc` rather than the `Arc` alone: a reader takes a clone
+/// and lets go, so a swap never waits on a tool call and a tool call never
+/// sees half of one.
+pub(crate) struct Live<T>(StdMutex<Arc<T>>);
+
+impl<T> Live<T> {
+    /// Hold `value` until something replaces it.
+    pub(crate) fn new(value: T) -> Arc<Self> {
+        Arc::new(Self(StdMutex::new(Arc::new(value))))
+    }
+
+    /// The value in force right now.
+    pub(crate) fn get(&self) -> Arc<T> {
+        self.0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Replace it. An in-flight reader keeps the copy it took.
+    pub(crate) fn set(&self, value: T) {
+        *self.0.lock().unwrap_or_else(PoisonError::into_inner) = Arc::new(value);
+    }
+}
+
+/// The parts of a spawn a later config re-read has to resolve against.
+///
+/// Two of these layers are not the config alone: `[safe_commands]` merges with
+/// the blueprint's own list, and `[read_paths]` grants mean nothing without the
+/// blueprint's declarations and the run's workdir. Keeping them here is what
+/// lets a resume redo the resolution the spawn did rather than an
+/// approximation of it.
+pub(crate) struct ConfigSource {
+    /// The blueprint's name, which the per-agent config tables are keyed by.
+    pub agent_name: String,
+    /// The blueprint's `[safe_commands]`, when it declares any.
+    pub blueprint_safe: Option<leviath_core::blueprint::SafeCommandsConfig>,
+    /// The blueprint's `[read_paths]`, when it declares any.
+    pub blueprint_read_paths: Option<leviath_core::blueprint::ReadPathsConfig>,
+    /// The run's workdir, which read-path entries compile relative to.
+    pub workdir: std::path::PathBuf,
+}
+
+/// A minimal [`AgentToolState`] over `workdir`, for the daemon-level test of
+/// the resume hook. Lives here rather than in `setup`'s test module because
+/// the struct's fields are private to this one.
+#[cfg(test)]
+pub(crate) fn test_state_for_resume(workdir: &std::path::Path) -> Arc<AgentToolState> {
+    tests::budgeted_state(
+        &leviath_runtime::interaction_hub::InteractionHub::new(),
+        workdir,
+        WriteBudget::new(Default::default()),
+        HashMap::new(),
+    )
 }
 
 /// The tool result for an approval prompt that resolved with no answer: the
@@ -235,6 +317,56 @@ fn declined_result(tool: &str, feedback: Option<&str>) -> String {
 }
 
 impl AgentToolState {
+    /// Whether this manifest's `[tool_permissions]` may exceed the built-in
+    /// default for a tool the user has not configured.
+    pub(crate) fn blueprint_may_loosen(&self) -> bool {
+        self.blueprint_may_loosen
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Re-resolve every layer that comes from `config.toml` against `config`.
+    ///
+    /// Called when a run resumes: from a pause, after an approval prompt is
+    /// answered, or when the recovery path pages the run back in. A stage that
+    /// is running keeps the snapshot it started on, so nothing under way is
+    /// re-judged halfway through a batch.
+    ///
+    /// The four layers are the ones a person actually edits to unblock a
+    /// stuck run: `[tool_permissions]` (with the per-agent overlay),
+    /// `[safe_commands]`, `[security] read_paths`, and the write ceilings.
+    /// What it deliberately does not touch is what the run has already spent
+    /// or been granted: the write total, the run and stage grants, and the
+    /// stage's own `tool_permissions` from the blueprint, none of which are
+    /// config.
+    pub(crate) fn reread_config(&self, config: &Config) {
+        let source = &self.config_source;
+        self.safe_keys.set(
+            config
+                .safe_keys_for_agent(&source.agent_name, source.blueprint_safe.as_ref())
+                .into_keys()
+                .collect(),
+        );
+        self.global_perms
+            .set(config.permissions_for_agent(&source.agent_name));
+        self.blueprint_may_loosen.store(
+            config.security.allow_blueprint_permissions,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        self.writes.set_limits(config.limits.write_limits());
+        // The read-path set is the one layer here that can fail to compile, and
+        // dropping the grants the run already had over a typo would tighten it
+        // rather than widen it, which is the wrong direction for a file people
+        // edit to get unstuck. A set that will not compile is left alone.
+        if let Some(policy) = crate::daemon::spawn::read_path_policy_for(
+            &source.agent_name,
+            source.blueprint_read_paths.as_ref(),
+            config,
+            &source.workdir,
+        ) {
+            self.builtins.set_read_paths(policy);
+        }
+    }
+
     /// Whether every key this call needs is already covered, by the safe list or
     /// by a grant.
     ///
@@ -248,7 +380,8 @@ impl AgentToolState {
             .unwrap_or_else(PoisonError::into_inner)
             .clone();
         let run = self.run_allows.lock().await;
-        crate::shell_keys::all_covered(keys, &|k| self.safe_keys.contains(k), &|k| {
+        let safe = self.safe_keys.get();
+        crate::shell_keys::all_covered(keys, &|k| safe.contains(k), &|k| {
             staged.contains(k) || run.contains(k)
         })
     }
@@ -524,8 +657,8 @@ pub(crate) async fn dispatch_tools(
             &state.launch_overrides,
             &stage_snap,
             &state.agent_perms,
-            &state.global_perms,
-            state.blueprint_may_loosen,
+            &state.global_perms.get(),
+            state.blueprint_may_loosen(),
         );
         // A shell redirect writes a file, and no tool name says so. Clamping by
         // the write tool's own policy is what stops `echo x > f` being a
@@ -537,8 +670,8 @@ pub(crate) async fn dispatch_tools(
                 &state.launch_overrides,
                 &stage_snap,
                 &state.agent_perms,
-                &state.global_perms,
-                state.blueprint_may_loosen,
+                &state.global_perms.get(),
+                state.blueprint_may_loosen(),
             )
         });
         // A grant can only ever collapse `Ask` into `Allow`. It never reaches
@@ -551,7 +684,16 @@ pub(crate) async fn dispatch_tools(
 
         match policy {
             ToolPolicy::Deny => {
-                let result = format!("[denied] Tool '{}' is not permitted.", tc.name);
+                // Says what actually lifts it. The answer used to be "cancel
+                // the run and start it again", because the permission was
+                // resolved once at spawn; now the run re-reads it when it
+                // resumes, and the message has to say the thing that is true.
+                let result = format!(
+                    "[denied] Tool '{}' is not permitted. To allow it, set it to \"allow\" or \
+                     \"ask\" under [tool_permissions] in config.toml and resume this run \
+                     (`lev resume`); the run re-reads them and does not need restarting.",
+                    tc.name
+                );
                 progress(&tc.id, &result);
                 slots.push((tc.id.clone(), Some(result)));
             }
@@ -658,6 +800,16 @@ impl CliToolService {
             .lock()
             .unwrap_or_else(PoisonError::into_inner)
             .insert(entity, state);
+    }
+
+    /// An agent's tool state, for a caller that wants to act on it without
+    /// taking it away. The resume hook's read.
+    pub(crate) fn state_for(&self, entity: Entity) -> Option<Arc<AgentToolState>> {
+        self.states
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .get(&entity)
+            .cloned()
     }
 
     /// Drop an agent's tool state.
@@ -843,6 +995,17 @@ mod tests {
     use leviath_runtime::interaction_hub::InteractionHub;
     use leviath_runtime::pipeline::noop_progress;
 
+    /// What a hand-built state re-resolves against: an agent named `tester`
+    /// with no blueprint-side declarations, over a workdir nothing reads.
+    fn test_config_source() -> Arc<ConfigSource> {
+        Arc::new(ConfigSource {
+            agent_name: "tester".to_string(),
+            blueprint_safe: None,
+            blueprint_read_paths: None,
+            workdir: std::env::temp_dir(),
+        })
+    }
+
     /// The three script-tool fields of [`AgentToolState`], as a tuple.
     type ScriptFields = (
         Arc<StdMutex<leviath_scripting::ScriptToolSet>>,
@@ -873,7 +1036,7 @@ mod tests {
 
     /// [`state_with_writes`] with the policies and the interaction hub chosen,
     /// for the tests where the budget and the policy layer meet.
-    fn budgeted_state(
+    pub(super) fn budgeted_state(
         hub: &InteractionHub,
         workdir: &std::path::Path,
         budget: WriteBudget,
@@ -890,7 +1053,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -899,8 +1062,8 @@ mod tests {
             stage_required: Arc::new(StdMutex::new(HashSet::new())),
             stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(global),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(global),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("agent-a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -910,6 +1073,7 @@ mod tests {
             script_tool_names,
             script_host,
             dynamic: None,
+            config_source: test_config_source(),
         })
     }
 
@@ -950,7 +1114,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(mcp)),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -959,8 +1123,8 @@ mod tests {
             stage_required: Arc::new(StdMutex::new(HashSet::new())),
             stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(global),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(global),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("agent-a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -970,6 +1134,7 @@ mod tests {
             script_tool_names,
             script_host,
             dynamic: None,
+            config_source: test_config_source(),
         })
     }
 
@@ -1032,7 +1197,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -1041,8 +1206,8 @@ mod tests {
             stage_required: Arc::new(StdMutex::new(HashSet::new())),
             stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(global),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(global),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("agent-a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -1052,6 +1217,7 @@ mod tests {
             script_tool_names: Arc::new(StdMutex::new(script_tool_names)),
             script_host: host,
             dynamic: None,
+            config_source: test_config_source(),
         });
         (state, dir)
     }
@@ -1077,6 +1243,232 @@ mod tests {
         .await;
         assert_eq!(out[0].0, "c1");
         assert_eq!(out[0].1, "HI");
+    }
+
+    // ── re-reading the config when a run resumes ──
+
+    /// A config naming one policy for `read_file`, and nothing else.
+    fn config_with(tool: &str, policy: ToolPolicy) -> Config {
+        let mut config = Config::default();
+        config.tool_permissions.insert(tool.to_string(), policy);
+        config
+    }
+
+    /// A state over `workdir` whose only permission layer is the config one,
+    /// so a test about re-reading is not also a test about stage policy.
+    fn state_over(
+        workdir: &std::path::Path,
+        global: HashMap<String, ToolPolicy>,
+    ) -> Arc<AgentToolState> {
+        budgeted_state(
+            &InteractionHub::new(),
+            workdir,
+            WriteBudget::new(Default::default()),
+            global,
+        )
+    }
+
+    /// The bug, at the seam it lives at: a run parked on a denied tool could
+    /// not be freed by permitting the tool, because the answer was resolved
+    /// once at spawn. Cancelling and re-running was the only way out, and with
+    /// an unanswered prompt waiting for ever (#728) it is the only way out for
+    /// good.
+    #[tokio::test]
+    async fn a_denied_tool_runs_after_the_permission_is_broadened_and_the_run_resumes() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("notes.md"), "hello").unwrap();
+        let mut denied = HashMap::new();
+        denied.insert("read_file".to_string(), ToolPolicy::Deny);
+        let state = state_over(dir.path(), denied);
+
+        let before = dispatch_tools(
+            state.clone(),
+            vec![call(
+                "c1",
+                "read_file",
+                serde_json::json!({"path": "notes.md"}),
+            )],
+            noop_progress(),
+        )
+        .await;
+        let refusal = before[0].1.clone();
+        assert!(refusal.contains("[denied]"), "got: {refusal}");
+        assert!(
+            refusal.contains("resume"),
+            "the refusal has to name what actually lifts it: {refusal}"
+        );
+
+        // What the person does: permit the tool, and resume the run.
+        state.reread_config(&config_with("read_file", ToolPolicy::Allow));
+
+        let after = dispatch_tools(
+            state,
+            vec![call(
+                "c2",
+                "read_file",
+                serde_json::json!({"path": "notes.md"}),
+            )],
+            noop_progress(),
+        )
+        .await;
+        let allowed = after[0].1.clone();
+        assert!(
+            allowed.contains("hello"),
+            "the tool the user just permitted has to run in the run that was refused: {allowed}"
+        );
+    }
+
+    /// The other direction, because a re-read that only ever loosened would be
+    /// a way to keep a permission the user has taken away.
+    #[tokio::test]
+    async fn a_narrowed_permission_takes_effect_on_the_same_resume() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("notes.md"), "hello").unwrap();
+        let mut allowed = HashMap::new();
+        allowed.insert("read_file".to_string(), ToolPolicy::Allow);
+        let state = state_over(dir.path(), allowed);
+
+        state.reread_config(&config_with("read_file", ToolPolicy::Deny));
+        let after = dispatch_tools(
+            state,
+            vec![call(
+                "c1",
+                "read_file",
+                serde_json::json!({"path": "notes.md"}),
+            )],
+            noop_progress(),
+        )
+        .await;
+        let narrowed = after[0].1.clone();
+        assert!(narrowed.contains("[denied]"), "got: {narrowed}");
+    }
+
+    #[test]
+    fn a_reread_picks_up_safe_commands_and_the_blueprint_override() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_over(dir.path(), HashMap::new());
+        assert!(!state.safe_keys.get().contains("mytool"));
+        assert!(!state.blueprint_may_loosen());
+
+        let mut config = Config::default();
+        config.safe_commands.tools = vec!["mytool".to_string()];
+        config.security.allow_blueprint_permissions = true;
+        state.reread_config(&config);
+
+        assert!(
+            state.safe_keys.get().contains("mytool"),
+            "a command added to [safe_commands] stops prompting in the run that prompted"
+        );
+        assert!(state.blueprint_may_loosen());
+    }
+
+    #[test]
+    fn a_reread_raises_the_write_ceiling_without_forgetting_what_was_spent() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = state_over(dir.path(), HashMap::new());
+        state.writes.record(600);
+
+        let mut config = Config::default();
+        config.limits.max_run_write_bytes = Some(500);
+        state.reread_config(&config);
+        assert_ne!(
+            state.writes.check(dir.path(), 1),
+            leviath_core::write_limits::WriteVerdict::Allow,
+            "the run is over the ceiling the user just set"
+        );
+
+        config.limits.max_run_write_bytes = Some(5_000);
+        state.reread_config(&config);
+        assert_eq!(
+            state.writes.check(dir.path(), 1),
+            leviath_core::write_limits::WriteVerdict::Allow,
+            "raising it frees the run"
+        );
+        assert_eq!(
+            state.writes.written(),
+            600,
+            "and what the run already spent is still spent"
+        );
+    }
+
+    /// `[security] read_paths` is the fourth layer, and the only one that is a
+    /// blueprint-plus-config decision the resume has to redo rather than
+    /// re-copy.
+    #[tokio::test]
+    async fn a_reread_applies_a_read_path_grant_the_user_just_added() {
+        let outside = tempfile::tempdir().unwrap();
+        let secret = outside.path().join("shared.txt");
+        std::fs::write(&secret, "from outside").unwrap();
+        let workdir = tempfile::tempdir().unwrap();
+
+        let mut allow = HashMap::new();
+        allow.insert("read_file".to_string(), ToolPolicy::Allow);
+        let state = Arc::new(AgentToolState {
+            config_source: Arc::new(ConfigSource {
+                agent_name: "tester".to_string(),
+                blueprint_safe: None,
+                blueprint_read_paths: Some(leviath_core::blueprint::ReadPathsConfig {
+                    allow: vec![outside.path().to_string_lossy().to_string()],
+                }),
+                workdir: workdir.path().to_path_buf(),
+            }),
+            ..(*state_over(workdir.path(), allow)).clone()
+        });
+
+        let path = secret.to_string_lossy().to_string();
+        let before = dispatch_tools(
+            state.clone(),
+            vec![call(
+                "c1",
+                "read_file",
+                serde_json::json!({"path": path.clone()}),
+            )],
+            noop_progress(),
+        )
+        .await;
+        let refused = before[0].1.clone();
+        assert!(
+            !refused.contains("from outside"),
+            "nothing grants the declaration yet: {refused}"
+        );
+
+        // What the person does after reading that refusal.
+        let mut config = Config::default();
+        config.security.allow_blueprint_read_paths = true;
+        state.reread_config(&config);
+
+        let after = dispatch_tools(
+            state,
+            vec![call("c2", "read_file", serde_json::json!({"path": path}))],
+            noop_progress(),
+        )
+        .await;
+        let granted = after[0].1.clone();
+        assert!(
+            granted.contains("from outside"),
+            "the grant the user just added has to reach the run that was refused: {granted}"
+        );
+    }
+
+    #[test]
+    fn a_read_path_entry_that_will_not_compile_leaves_the_run_with_what_it_had() {
+        let workdir = tempfile::tempdir().unwrap();
+        let state = Arc::new(AgentToolState {
+            config_source: Arc::new(ConfigSource {
+                agent_name: "tester".to_string(),
+                blueprint_safe: None,
+                blueprint_read_paths: Some(leviath_core::blueprint::ReadPathsConfig {
+                    // An empty entry is refused by the compiler, which is the
+                    // arm a resume has to survive.
+                    allow: vec![String::new()],
+                }),
+                workdir: workdir.path().to_path_buf(),
+            }),
+            ..(*state_over(workdir.path(), HashMap::new())).clone()
+        });
+        // The declaration itself will not compile, so the resolution fails and
+        // the run keeps the policy it was spawned with rather than losing it.
+        state.reread_config(&Config::default());
     }
 
     // ── dynamic_tools (issue #97) ──
@@ -1133,7 +1525,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -1142,8 +1534,8 @@ mod tests {
             stage_required: Arc::new(StdMutex::new(HashSet::new())),
             stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(allow),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(allow),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -1161,6 +1553,7 @@ mod tests {
                 unattended,
                 dirty: Arc::new(AtomicBool::new(false)),
             })),
+            config_source: test_config_source(),
         })
     }
 
@@ -1389,7 +1782,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -1398,8 +1791,8 @@ mod tests {
             stage_required: Arc::new(StdMutex::new(HashSet::new())),
             stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(allow),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(allow),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -1409,6 +1802,7 @@ mod tests {
             script_tool_names,
             script_host,
             dynamic: None,
+            config_source: test_config_source(),
         });
         // Must not panic (the mark_dirty early-return path).
         let out = dispatch_tools(
@@ -1763,7 +2157,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -1772,8 +2166,8 @@ mod tests {
             stage_required: Arc::new(StdMutex::new(HashSet::new())),
             stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(global),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(global),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("agent-a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -1783,6 +2177,7 @@ mod tests {
             script_tool_names,
             script_host,
             dynamic: None,
+            config_source: test_config_source(),
         });
         let out = dispatch_tools(
             state,
@@ -1831,7 +2226,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -1840,8 +2235,8 @@ mod tests {
             stage_required: Arc::new(StdMutex::new(HashSet::new())),
             stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(global),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(global),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("agent-a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -1851,6 +2246,7 @@ mod tests {
             script_tool_names,
             script_host,
             dynamic: None,
+            config_source: test_config_source(),
         });
 
         let out = dispatch_tools(
@@ -2250,7 +2646,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -2262,8 +2658,8 @@ mod tests {
                 HashSet::from(["ask_user_text".to_string()]),
             ]),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(HashMap::new()),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(HashMap::new()),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -2273,6 +2669,7 @@ mod tests {
             script_tool_names,
             script_host,
             dynamic: None,
+            config_source: test_config_source(),
         });
         service.register(e, state.clone());
 
@@ -2822,7 +3219,7 @@ mod tests {
             mcp: Arc::new(Mutex::new(leviath_mcp::ToolExecutor::new())),
             builtin_names,
             launch_overrides: Arc::new(HashMap::new()),
-            safe_keys: Arc::new(HashSet::new()),
+            safe_keys: Live::new(HashSet::new()),
             run_allows: Arc::new(Mutex::new(HashSet::new())),
             stage_allows: Arc::new(StdMutex::new(HashSet::new())),
             stage_allows_index: Arc::new(StdMutex::new(None)),
@@ -2831,8 +3228,8 @@ mod tests {
             stage_required: Arc::new(StdMutex::new(HashSet::new())),
             stage_required_by_index: Arc::new(Vec::new()),
             agent_perms: Arc::new(HashMap::new()),
-            global_perms: Arc::new(HashMap::new()),
-            blueprint_may_loosen: false,
+            global_perms: Live::new(HashMap::new()),
+            blueprint_may_loosen: Arc::new(AtomicBool::new(false)),
             interaction: hub.backend_for("agent-a"),
             unattended: false,
             stage_name: Arc::new(StdMutex::new("main".to_string())),
@@ -2842,6 +3239,7 @@ mod tests {
             script_tool_names,
             script_host,
             dynamic: None,
+            config_source: test_config_source(),
         });
         let out = dispatch_tools(
             state,

--- a/crates/leviath-runtime/src/host/mod.rs
+++ b/crates/leviath-runtime/src/host/mod.rs
@@ -49,6 +49,7 @@ pub struct WorldHost {
     reloader: Option<Reloader>,
     force_terminator: Option<ForceTerminator>,
     reaper: Option<Reaper>,
+    resumer: Option<Resumer>,
     events: broadcast::Sender<WorldEvent>,
     emitted: HashMap<String, Emitted>,
     /// The `[limits]` settings the host itself runs on: relief threshold,
@@ -174,6 +175,7 @@ impl WorldHost {
             reloader: None,
             force_terminator: None,
             reaper: None,
+            resumer: None,
             events,
             emitted: HashMap::new(),
             settings: HostSettings::default(),
@@ -369,6 +371,25 @@ impl WorldHost {
         self.reaper = Some(reaper);
     }
 
+    /// Install the hook run when a run starts moving again, so the daemon can
+    /// re-read the config layers a person edits to unblock it. Without one,
+    /// resuming is only un-pausing (the prior behavior).
+    pub fn set_resumer(&mut self, resumer: Resumer) {
+        self.resumer = Some(resumer);
+    }
+
+    /// Run the resume hook for `entity`, if one is installed.
+    ///
+    /// The hook is moved out for the call so it does not borrow `self` while
+    /// the world does, and put straight back - the same shape the reaper uses.
+    pub(super) fn on_resumed(&mut self, entity: Entity) {
+        let mut resumer = self.resumer.take();
+        if let Some(resume) = resumer.as_mut() {
+            resume(&mut self.world, entity);
+        }
+        self.resumer = resumer;
+    }
+
     /// Resolve a run id to a live entity, paging it in from disk if it has been
     /// unloaded (and a reloader is installed). Returns `None` if the run is
     /// neither live nor resumable from disk. Newly-reloaded runs are registered.
@@ -540,7 +561,17 @@ impl WorldHost {
                 let _ = reply.send(self.interactions.pending());
             }
             ControlOp::AnswerInteraction { response, reply } => {
-                let _ = reply.send(self.interactions.answer(response));
+                // Answering a prompt is one of the points a run resumes at: the
+                // person who just said "no, and here is why" may equally have
+                // gone and changed the permission the prompt was about, and
+                // this is where that reaches the run (issue #728 makes an
+                // unanswered prompt wait for ever, so a run stuck behind one
+                // has no other way out but a cancel).
+                let agent = self.interactions.answer_for(response);
+                if let Some(entity) = agent.as_deref().and_then(|id| self.live_entity(id)) {
+                    self.on_resumed(entity.entity());
+                }
+                let _ = reply.send(agent.is_some());
             }
             ControlOp::CancelInteraction { request_id, reply } => {
                 let _ = reply.send(self.interactions.cancel(&request_id));

--- a/crates/leviath-runtime/src/host/subagents.rs
+++ b/crates/leviath-runtime/src/host/subagents.rs
@@ -247,6 +247,10 @@ impl WorldHost {
             if let Some(mut fan_out) = self.world.world_mut().get_mut::<FanOutWaiting>(e) {
                 acted |= fan_out.set_paused(false);
             }
+            // Every agent in the tree, not just the one that was named: a
+            // fan-out worker is as capable of being stuck on a permission as
+            // its parent, and the pause stopped all of them.
+            self.on_resumed(e);
         }
         acted
     }

--- a/crates/leviath-runtime/src/host/types.rs
+++ b/crates/leviath-runtime/src/host/types.rs
@@ -331,6 +331,19 @@ pub(crate) type ForceTerminator = Box<dyn FnMut(&str) -> bool + Send>;
 /// Installed with [`super::WorldHost::set_reaper`]; a no-op when none is set.
 pub type Reaper = Box<dyn FnMut(&mut PipelineWorld, Entity) + Send>;
 
+/// The daemon-installed hook run when a run starts moving again: a `Resume`
+/// control op, an answered approval prompt, or a run paged back in from disk.
+/// It receives the world and the agent's entity.
+///
+/// The runtime has no opinion about what resuming means beyond un-pausing. The
+/// daemon's is that a run re-reads the parts of `config.toml` a person edits to
+/// unblock it - tool permissions, safe commands, read-path grants, write
+/// ceilings - so a run stuck on one of them can be freed without cancelling it
+/// and starting again. A stage that is already running keeps the snapshot it
+/// started on; this fires only at the boundary. Installed with
+/// [`super::WorldHost::set_resumer`]; a no-op when none is set.
+pub type Resumer = Box<dyn FnMut(&mut PipelineWorld, Entity) + Send>;
+
 /// An async hook the host awaits *before* servicing a top-level `Spawn` control
 /// op, so the daemon can do async preparation the sync spawner can't - e.g.
 /// lazily connecting the blueprint's MCP servers into the shared pool so

--- a/crates/leviath-runtime/src/host_tests.rs
+++ b/crates/leviath-runtime/src/host_tests.rs
@@ -2220,6 +2220,145 @@ async fn unregistered_world_agents_are_adopted_and_become_cancellable() {
     );
 }
 
+/// The three ways a run starts moving again all reach the resume hook, which
+/// is what lets the daemon re-read the permissions a person edits to unblock a
+/// run instead of making them cancel it. Recorded per entity, because a
+/// fan-out worker is as capable of being stuck as its parent.
+#[tokio::test]
+async fn the_resume_hook_fires_for_a_resume_and_for_an_answered_prompt() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static RESUMED: AtomicUsize = AtomicUsize::new(0);
+    RESUMED.store(0, Ordering::SeqCst);
+
+    let mut host = host_with(vec![]);
+    host.set_resumer(Box::new(|world, entity| {
+        // Branch-free, so one firing covers the body; the entity has to still
+        // be live or the daemon could not reach its tool state.
+        let live = world.world().get::<AgentState>(entity).is_some();
+        RESUMED.fetch_add(live as usize, Ordering::SeqCst);
+    }));
+    spawn(&mut host, "run-a", "agent-a");
+
+    // Nothing has resumed yet.
+    assert!(
+        ask(&mut host, |reply| ControlOp::Pause {
+            run_id: "run-a".to_string(),
+            reply
+        })
+        .await
+    );
+    assert_eq!(RESUMED.load(Ordering::SeqCst), 0);
+
+    // 1. `lev resume`.
+    assert!(
+        ask(&mut host, |reply| ControlOp::Resume {
+            run_id: "run-a".to_string(),
+            reply
+        })
+        .await
+    );
+    assert_eq!(RESUMED.load(Ordering::SeqCst), 1);
+
+    // 2. An answered prompt. The run is the one that asked, so the hook sees
+    //    the same entity.
+    let backend = host.interactions().backend_for("run-a");
+    let asking = tokio::spawn(async move {
+        backend
+            .ask(leviath_core::interaction::InteractionRequest::free_text(
+                "q-perm", "may I?", "stage", true,
+            ))
+            .await
+    });
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        ask(&mut host, |reply| ControlOp::AnswerInteraction {
+            response: leviath_core::interaction::InteractionResponse::text("q-perm", "yes"),
+            reply,
+        })
+        .await
+    );
+    assert_eq!(asking.await.unwrap().value.as_deref(), Some("yes"));
+    assert_eq!(
+        RESUMED.load(Ordering::SeqCst),
+        2,
+        "answering the prompt is a resume: the person may have changed the permission it was about"
+    );
+
+    // An answer to a request nobody is waiting on resumes nothing, and still
+    // reports the miss.
+    assert!(
+        !ask(&mut host, |reply| ControlOp::AnswerInteraction {
+            response: leviath_core::interaction::InteractionResponse::text("gone", "x"),
+            reply,
+        })
+        .await
+    );
+    assert_eq!(RESUMED.load(Ordering::SeqCst), 2);
+}
+
+/// An answer for an agent the world no longer holds must not look up an entity
+/// that is not there. The reply still says the request was answered - the
+/// waiting `submit` may be a sub-agent the host does not register by run id.
+#[tokio::test]
+async fn an_answer_for_an_unregistered_agent_resumes_nothing() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static RESUMED_ORPHAN: AtomicUsize = AtomicUsize::new(0);
+    RESUMED_ORPHAN.store(0, Ordering::SeqCst);
+
+    let mut host = host_with(vec![]);
+    host.set_resumer(Box::new(|_world, _entity| {
+        RESUMED_ORPHAN.fetch_add(1, Ordering::SeqCst);
+    }));
+    let backend = host.interactions().backend_for("nobody");
+    let asking = tokio::spawn(async move {
+        backend
+            .ask(leviath_core::interaction::InteractionRequest::free_text(
+                "q-orphan", "p", "s", true,
+            ))
+            .await
+    });
+    for _ in 0..8 {
+        tokio::task::yield_now().await;
+    }
+    assert!(
+        ask(&mut host, |reply| ControlOp::AnswerInteraction {
+            response: leviath_core::interaction::InteractionResponse::text("q-orphan", "hi"),
+            reply,
+        })
+        .await
+    );
+    assert_eq!(asking.await.unwrap().value.as_deref(), Some("hi"));
+    assert_eq!(RESUMED_ORPHAN.load(Ordering::SeqCst), 0);
+}
+
+/// With no hook installed, resuming is only un-pausing - the behaviour every
+/// embedder that does not install one keeps.
+#[tokio::test]
+async fn resuming_without_a_hook_is_just_unpausing() {
+    let mut host = host_with(vec![]);
+    spawn(&mut host, "run-a", "agent-a");
+    assert!(
+        ask(&mut host, |reply| ControlOp::Pause {
+            run_id: "run-a".to_string(),
+            reply
+        })
+        .await
+    );
+    assert!(
+        ask(&mut host, |reply| ControlOp::Resume {
+            run_id: "run-a".to_string(),
+            reply
+        })
+        .await
+    );
+    assert_eq!(
+        host.world.agent_status(host.by_run_id["run-a"]),
+        Some(AgentStatus::Active)
+    );
+}
+
 #[tokio::test]
 async fn interaction_ops_list_answer_and_cancel() {
     let mut host = host_with(vec![]);

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -189,19 +189,24 @@ impl InteractionHub {
     /// Answer an open request. Returns `false` if no request with that id is
     /// open (already answered, cancelled, or never existed).
     pub fn answer(&self, response: InteractionResponse) -> bool {
+        self.answer_for(response).is_some()
+    }
+
+    /// [`answer`](Self::answer), reporting *whose* request it was.
+    ///
+    /// The host needs the agent id because answering a prompt is one of the
+    /// points a run resumes at, and what a resume does is per-agent.
+    pub(crate) fn answer_for(&self, response: InteractionResponse) -> Option<String> {
         let entry = leviath_core::sync::lock(&self.pending).remove(&response.request_id);
-        match entry {
-            Some(entry) => {
-                // The awaiting `submit` may have gone away (agent despawned); a
-                // failed send is harmless.
-                let _ = entry.responder.send(response);
-                // Wake the driver so it reflects the now-cleared request back
-                // into the agent's status (Waiting → Active).
-                self.nudge();
-                true
-            }
-            None => false,
-        }
+        let entry = entry?;
+        let agent_id = entry.agent_id.clone();
+        // The awaiting `submit` may have gone away (agent despawned); a
+        // failed send is harmless.
+        let _ = entry.responder.send(response);
+        // Wake the driver so it reflects the now-cleared request back
+        // into the agent's status (Waiting → Active).
+        self.nudge();
+        Some(agent_id)
     }
 
     /// Cancel an open request (its `submit` returns the neutral response).

--- a/crates/leviath-tools/src/context.rs
+++ b/crates/leviath-tools/src/context.rs
@@ -11,7 +11,12 @@ pub struct ToolContext {
     /// blueprint declares them and the user's config grants them. Inactive by
     /// default, and never consulted by `write_file`/`edit_file` - writes are
     /// confined to `workdir` unconditionally.
-    pub(crate) read_paths: leviath_core::ReadPathPolicy,
+    ///
+    /// Behind a lock because a run re-reads its grants when it resumes: a
+    /// person who answers a refused read by granting the path in `config.toml`
+    /// has to be able to resume the run rather than start it again. Read once
+    /// per resolve, so the lock is never held across any I/O.
+    read_paths: Mutex<leviath_core::ReadPathPolicy>,
     /// Per-path advisory locks serializing concurrent mutating file operations
     /// (`write_file`/`edit_file`) on the *same* file. Fan-out sub-agent workers
     /// share one process and one workdir, so an in-process lock map keyed by
@@ -81,7 +86,7 @@ impl ToolContext {
         let workdir = std::fs::canonicalize(&workdir).unwrap_or(workdir);
         Self {
             workdir,
-            read_paths: leviath_core::ReadPathPolicy::inactive(),
+            read_paths: Mutex::new(leviath_core::ReadPathPolicy::inactive()),
             file_locks: Arc::new(Mutex::new(HashMap::new())),
             shell_env: ShellEnvPolicy::default(),
         }
@@ -89,9 +94,29 @@ impl ToolContext {
 
     /// Attach a `[read_paths]` policy resolved at spawn. Builder-style, like
     /// [`BuiltinTools::with_shell_executor`].
-    pub fn with_read_paths(mut self, policy: leviath_core::ReadPathPolicy) -> Self {
-        self.read_paths = policy;
+    pub fn with_read_paths(self, policy: leviath_core::ReadPathPolicy) -> Self {
+        self.set_read_paths(policy);
         self
+    }
+
+    /// Replace the `[read_paths]` policy on a context already in service.
+    ///
+    /// What a resume calls: the grants are resolved from `config.toml`, which
+    /// the daemon re-reads, and a run parked on a refused read is exactly the
+    /// case where the person has just gone and granted the path.
+    pub fn set_read_paths(&self, policy: leviath_core::ReadPathPolicy) {
+        *self
+            .read_paths
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) = policy;
+    }
+
+    /// The `[read_paths]` policy in force right now.
+    pub(crate) fn read_paths(&self) -> leviath_core::ReadPathPolicy {
+        self.read_paths
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
     }
 
     /// Attach the `[security] shell_env` decision resolved at spawn.

--- a/crates/leviath-tools/src/exec.rs
+++ b/crates/leviath-tools/src/exec.rs
@@ -229,13 +229,14 @@ impl BuiltinTools {
         match resolve_within(requested, &self.ctx.workdir, resolves_within) {
             Ok(path) => Ok(path),
             Err(workdir_err) => {
-                if !self.ctx.read_paths.is_active() {
+                let read_paths = self.ctx.read_paths();
+                if !read_paths.is_active() {
                     return Err(workdir_err);
                 }
                 Self::resolve_outside(
                     requested,
                     &self.ctx.workdir,
-                    &self.ctx.read_paths,
+                    &read_paths,
                     leviath_core::canonicalize_for_match,
                 )
             }

--- a/crates/leviath-tools/src/lib.rs
+++ b/crates/leviath-tools/src/lib.rs
@@ -57,6 +57,16 @@ impl BuiltinTools {
         }
     }
 
+    /// Replace the `[read_paths]` policy these tools resolve reads against.
+    ///
+    /// Takes `&self` because the executor is shared behind an `Arc` for the
+    /// life of a run: the daemon calls this when a run resumes, so a grant the
+    /// person added to `config.toml` after watching a read be refused applies
+    /// to the run that was refused rather than only to a new one.
+    pub fn set_read_paths(&self, policy: leviath_core::ReadPathPolicy) {
+        self.ctx.set_read_paths(policy);
+    }
+
     /// The directory every path these tools resolve is confined to, already
     /// canonicalized.
     ///
@@ -642,6 +652,43 @@ mod tests {
             .await;
         assert!(out.contains("inside contents"), "got: {out}");
         assert!(out.contains("outside contents"), "got: {out}");
+    }
+
+    /// A grant added after these tools were built reaches them. The daemon
+    /// calls this when a run resumes, so someone who watches a read be refused
+    /// and then grants the path gets the run they were watching rather than a
+    /// new one.
+    #[tokio::test]
+    async fn a_policy_installed_after_construction_governs_the_next_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        fs::write(outside.path().join("doc.md"), "outside contents").unwrap();
+        let entry = outside.path().to_str().unwrap();
+        // Declared, granted by nothing: refused.
+        let tools = make_tools_with_read_paths(dir.path(), &[entry], &[], false);
+        let target = outside.path().join("doc.md");
+        let target = target.to_str().unwrap();
+        assert!(
+            tools
+                .read_file(&json!({ "path": target }))
+                .await
+                .contains("[error]"),
+            "nothing grants it yet"
+        );
+
+        let raw = vec![entry.to_string()];
+        let compiled = leviath_core::ReadPathSet::compile(&raw, dir.path(), None, false).unwrap();
+        tools.set_read_paths(leviath_core::ReadPathPolicy {
+            agent: "tester".into(),
+            blueprint: compiled.clone(),
+            grants: compiled,
+            allow_blueprint: false,
+        });
+        assert_eq!(
+            tools.read_file(&json!({ "path": target })).await,
+            "outside contents",
+            "the grant the person just made has to reach the tools already in service"
+        );
     }
 
     /// `[read_paths]` grants reads and nothing else: the same fully granted

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -197,6 +197,27 @@ nothing at all and the gate went on answering from the text it started with.
 service, or turn it off, and the next run emits into what the file says now. The verbosity of the
 daemon's own log is not part of that; it is one of the two things below that still need a restart.
 
+### A run in progress reads them again when it resumes
+
+An agent resolves its permissions when it spawns, so an edit made while it is running does not
+reach the run that is already going. That mattered most in exactly the case you would want it to
+work: a run stopped on a tool it is not permitted to call, a path it may not read, or a write
+ceiling it has hit, with the fix sitting in a file the run was never going to read again.
+
+So a run re-reads four things when it starts moving again: `[tool_permissions]` (including the
+per-agent overlay), `[safe_commands]`, `[security] read_paths`, and the write ceilings. Three
+moments count as starting again:
+
+- `lev resume` on a paused run.
+- Answering an approval prompt, since the person answering may equally have gone and changed the
+  permission the prompt was about.
+- The daemon paging a run back in from disk to act on it.
+
+A stage that is running keeps the snapshot it started on, so nothing is re-judged halfway through a
+batch of tool calls. Nothing the run has already spent or been granted is reset either: the write
+total, the approvals you granted for the run or the stage, and the blueprint's own per-stage
+permissions all stay as they were.
+
 Some changes do still need `lev daemon restart`, and after this release neither of them is a
 setting in `config.toml`. One is how verbose the daemon's own log is: its `tracing` subscriber is
 installed from `--verbose` on the command line before any config is read, and a process can install

--- a/docs/content/security.md
+++ b/docs/content/security.md
@@ -170,8 +170,9 @@ last: an individual read is still matched against the real, symlink-resolved pat
 
 You do not need to restart the daemon after editing the grant: it reloads `config.toml` on
 change, so the **next `lev run` picks up the new grant automatically** (see
-[the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run)). An agent that just
-failed on a refused read succeeds the next time you run it, once you have added the grant.
+[the daemon docs](/docs/daemon#config-changes-take-effect-on-the-next-run)). The run that was
+refused picks it up too, once you `lev resume` it, so a long run does not have to be thrown away
+over a path you had not granted yet.
 
 The rules that keep this safe:
 


### PR DESCRIPTION
## What

A run re-reads `[tool_permissions]`, `[safe_commands]`, `[security] read_paths` and the write
ceilings when it resumes, so a run stopped on one of them can be freed by editing `config.toml` and
running `lev resume`, instead of being cancelled and started again.

## Why

An agent's config was resolved once, at spawn, into `AgentToolState` (`daemon/spawn/tool_state.rs`).
A run stopped on a tool it may not call, a path it may not read, or a ceiling it has hit was never
going to read that file again, so editing it did nothing and the only way out was to throw the run
away. With #728 making an unanswered approval prompt wait for ever by default, that stall never ends
on its own.

## What counts as resuming

Three moments, as agreed:

- `lev resume` on a paused run (every agent in the tree, not only the one named).
- Answering an approval prompt, since whoever answers may equally have gone and changed the
  permission the prompt was about.
- The daemon paging a run back in from disk.

A stage that is already running keeps the snapshot it started on, so nothing is re-judged halfway
through a batch of tool calls.

## How

- `leviath-runtime` gains a `Resumer` hook beside `Reaper`, fired from `resume_tree` and from
  `AnswerInteraction`. With none installed, resuming is only un-pausing, as before.
- The daemon installs one (`make_resumer`) that re-resolves the four layers against the config
  reloader's current copy.
- Those layers move behind interior mutability: two `Live<T>` cells, an `AtomicBool`, a lock around
  the write ceilings, and a lock around `ToolContext`'s read-path policy. A reader takes a clone and
  lets go, so an in-flight tool call keeps what it took and a swap never waits on one.

What a re-read does **not** touch is what the run has already spent or been granted: the write
total, the run and stage approvals, and the blueprint's own per-stage permissions, none of which come
from the config. A read-path set that no longer compiles leaves the run with the grants it had, so a
typo cannot tighten a run in the one place people edit to widen it.

The refusal a denied tool hands the model said only that the tool was not permitted. It now names
the setting that lifts it and says resuming is enough, which is the part that was not true before.

## Tests

**Fails first.** With `reread_config` stubbed to a no-op (the behaviour on `main`), five of the new
tests fail:

```
a_denied_tool_runs_after_the_permission_is_broadened_and_the_run_resumes
a_narrowed_permission_takes_effect_on_the_same_resume
a_reread_picks_up_safe_commands_and_the_blueprint_override
a_reread_raises_the_write_ceiling_without_forgetting_what_was_spent
a_reread_applies_a_read_path_grant_the_user_just_added
```

Also new: the runtime's hook firing for a resume and an answered prompt (and not for an answer to a
request nobody is waiting on, nor when no hook is installed), the daemon's `make_resumer` reading
`config.toml` as it stands rather than as the spawn read it, a read-path policy installed after
`BuiltinTools` was built governing the next read, and the narrowing direction, because a re-read
that only ever loosened would be a way to keep a permission the user has taken away.

**Live probe** (mock harness, isolated `LEVIATH_HOME`, `LEVIATH_SKIP_DOTENV=1`). A real daemon,
`shell` denied in `config.toml`, and a mock that asks the agent to run `touch shell-ran.txt` - the
marker is a side effect rather than text, because the requested command appears in the journal
whether or not it ran. Run 1 is refused. Run 2 is paused, `shell` is set to `allow`, and the run is
resumed:

```
first_run_denied:         true
refusal_mentions_resume:  true
first_run_ran_shell:      false
pause_worked:             true
resume_worked:            true
second_run_ran_shell:     true      <- the point
pid_unchanged:            true
```

The same probe against a build whose `reread_config` is stubbed out reports `second_run_ran_shell:
false`, so the probe discriminates rather than passing on both.

## Gates

`cargo fmt`, `clippy -D warnings` on `leviath-cli`, `leviath-runtime` and `leviath-tools`,
`xtask structure`, `xtask docs`, and `xtask coverage` at 100% for all three.

## Notes

Touches `daemon/setup.rs` near the hooks #729, #731 and #732 also touch, so expect a small conflict
with each.
