### PR TITLE
feat: a config.toml that will not load is reported, not kept quiet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,12 @@ same list.
   A stage that is running keeps the snapshot it started on, and nothing the run has already spent
   or been granted is reset. The refusal a denied tool hands the model now says which setting lifts
   it and that resuming is enough.
+- The daemon re-read, re-parsed and re-warned about a broken `config.toml` on
+  every spawn and every `lev serve` request. The comment claimed the failing
+  mtime was kept to avoid exactly that; the code only recorded it on a
+  successful load. It is recorded either way now, so a broken file costs one
+  `stat` per call and produces one log line per save. Loading again is logged
+  too, which it never was.
 - The update check read the GitHub releases answer with no size cap, the one
   buffered remote read left after the daemon's caps landed. It now stops at
   the same 64 MiB as every other buffered body and reports the same
@@ -477,6 +483,24 @@ same list.
   unsigned console exe with no version block that talks to the network and
   spawns processes is the shape antivirus heuristics score worst, and an
   install Defender quarantines is not an install.
+- A `config.toml` that will not load is now something Leviath reports rather
+  than a fact it keeps to itself. The daemon has always kept serving the last
+  config that loaded when a save did not parse, which is right, but the only
+  sign of it was one line in `daemon.log` - so a typo made every later edit do
+  nothing, silently, and the file looked applied. It is now a state with a shape
+  and five places that show it: `lev run` prints one line before the run starts,
+  `lev ps` puts it under the run table, `lev doctor` fails its `config` check
+  with the position or the key, `lev dash` holds a warning across the top row
+  for as long as the file is broken, and `lev validate` says which of its checks
+  it had to skip. A syntax error carries a line and a column; a value that
+  parsed and was then refused carries the dotted key it belongs to. Everything
+  clears itself when the file parses again, with nothing restarted.
+- `GET /api/config` carries a `config_error` object with the kind, path,
+  one-line message, line and column or key, when it was first seen, and a note
+  saying the running config is the last one that loaded, plus `config_mtime` for
+  the config actually in force, so a client that just wrote the file can tell
+  whether the write was picked up. `/ws` sends a `config_health` frame on each
+  edge - broken, and loading again. Announced as the `config.health` capability.
 - `lev serve` holds at most 64 requests in flight and gives each 30 seconds; the
   65th is answered 503 at once and a request past its deadline 408, both in the
   usual `{"error": ...}` shape. `--max-concurrent-requests` and

--- a/crates/leviath-cli/src/commands/dashboard/construct.rs
+++ b/crates/leviath-cli/src/commands/dashboard/construct.rs
@@ -167,6 +167,13 @@ impl Dashboard {
             mcp_add_input: String::new(),
             mcp_rows: Vec::new(),
             mcp_selected: 0,
+            // Watches the file the MCP screen edits and the new-run screen
+            // reads, taken from the context so a test points it at its own
+            // tempdir along with everything else.
+            config_watch: crate::daemon::config_reload::ConfigWatch::new(
+                mcp_ctx.config_path.clone(),
+            ),
+            config_fault: None,
             mcp_ctx,
             mcp_cmd_tx,
             mcp_outcome_rx,

--- a/crates/leviath-cli/src/commands/dashboard/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/mod.rs
@@ -250,6 +250,10 @@ async fn run_dashboard_loop<B: ratatui::backend::Backend>(
         // …and whether those polls reached a daemon at all, and which one.
         dashboard.sync_daemon_link(control);
 
+        // …and whether the config file on disk still loads. One `stat` unless
+        // it has been saved since the last tick.
+        dashboard.sync_config_health();
+
         // Sync background runs from on-disk run-state dir (the daemon persists
         // meta/context/stages there).
         dashboard.sync_from_run_state();

--- a/crates/leviath-cli/src/commands/dashboard/render/mod.rs
+++ b/crates/leviath-cli/src/commands/dashboard/render/mod.rs
@@ -24,6 +24,59 @@ use super::state::Dashboard;
 use super::types::*;
 
 impl Dashboard {
+    /// Draw the config-health banner when `config.toml` will not load, and
+    /// hand back the area left for the screen under it.
+    ///
+    /// One row, full width, across every screen. It names the file, where in
+    /// it the problem is, and that runs are on the last config that loaded -
+    /// the third of those being the part a user cannot work out for
+    /// themselves, since a broken config is otherwise indistinguishable from
+    /// an edit that was never saved.
+    ///
+    /// Nothing is drawn, and the whole frame handed back, when the file loads
+    /// or when the terminal has no row to spare.
+    fn draw_config_banner(&self, frame: &mut Frame) -> ratatui::layout::Rect {
+        use crate::commands::dashboard::theme::{C_DIM, C_WARN};
+        use ratatui::style::{Modifier, Style};
+        use ratatui::text::{Line, Span};
+        use ratatui::widgets::Paragraph;
+
+        let full = frame.area();
+        let Some(fault) = &self.config_fault else {
+            return full;
+        };
+        // Two rows is the floor: taking the only row a screen has leaves
+        // nothing for the banner to be in aid of.
+        if full.height < 2 {
+            return full;
+        }
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Length(1), Constraint::Min(1)])
+            .split(full);
+
+        // `!` is this dashboard's warning icon, as on a warning toast.
+        let parts = vec![
+            "! ".to_string(),
+            fault.path.display().to_string(),
+            format!(" {}", fault.summary()),
+            " · runs are on the last config that loaded".to_string(),
+        ];
+        // The path shrinks first: there is only one config file and the user
+        // is looking at it, so it is the least surprising thing to lose. The
+        // reassurance goes next, and the error itself is cut last.
+        let parts = super::helpers::fit_parts(&parts, full.width as usize, &[1, 3, 2]);
+        let warn = Style::default().fg(C_WARN);
+        let spans = vec![
+            Span::styled(parts[0].clone(), warn.add_modifier(Modifier::BOLD)),
+            Span::styled(parts[1].clone(), warn.add_modifier(Modifier::BOLD)),
+            Span::styled(parts[2].clone(), warn),
+            Span::styled(parts[3].clone(), Style::default().fg(C_DIM)),
+        ];
+        frame.render_widget(Paragraph::new(Line::from(spans)), chunks[0]);
+        chunks[1]
+    }
+
     pub(super) fn draw(&mut self, frame: &mut Frame) {
         // The whole frame accepts mouse selection, exactly like native
         // terminal selection; re-registered per frame so a resize (the one
@@ -38,8 +91,15 @@ impl Dashboard {
         // over from a previous layout is a click on the wrong thing.
         self.click_targets.clear();
 
+        // A `config.toml` that will not load takes the top row of every
+        // screen, for as long as it will not load. It has to be a banner
+        // rather than a toast: the condition persists until somebody edits the
+        // file, and a message that faded three seconds after the save cannot
+        // explain why the run started two minutes later ignored the edit.
+        let area = self.draw_config_banner(frame);
+
         if self.agent_builder.is_some() {
-            self.draw_agents_screen(frame, frame.area());
+            self.draw_agents_screen(frame, area);
             self.apply_selection_overlay(frame);
             self.draw_toasts(frame);
             if self.show_help {
@@ -53,7 +113,7 @@ impl Dashboard {
             return;
         }
         if self.mcp_screen {
-            self.draw_mcp_screen(frame, frame.area());
+            self.draw_mcp_screen(frame, area);
             self.apply_selection_overlay(frame);
             self.draw_toasts(frame);
             if self.show_help {
@@ -66,7 +126,7 @@ impl Dashboard {
             return;
         }
         if self.new_run_screen {
-            self.draw_new_run_screen(frame, frame.area());
+            self.draw_new_run_screen(frame, area);
             self.apply_selection_overlay(frame);
             self.draw_toasts(frame);
             // This screen types text, so `?` is a question mark here and F1 is
@@ -85,7 +145,7 @@ impl Dashboard {
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([Constraint::Min(1), Constraint::Length(1)])
-                .split(frame.area());
+                .split(area);
             self.draw_detail_panel(frame, chunks[0]);
             self.draw_help_bar(frame, chunks[1]);
         } else {
@@ -97,7 +157,7 @@ impl Dashboard {
                     Constraint::Percentage(44),
                     Constraint::Length(1),
                 ])
-                .split(frame.area());
+                .split(area);
             self.draw_agent_table(frame, chunks[0]);
             self.draw_log_panel(frame, chunks[1]);
             self.draw_help_bar(frame, chunks[2]);
@@ -1027,5 +1087,146 @@ mod tests {
             crate::commands::dashboard::test_support::rendered_buffer(&terminal)
                 .contains("Run unattended?")
         );
+    }
+
+    /// A dashboard watching `path` for its config health.
+    fn dash_watching(path: &std::path::Path) -> Dashboard {
+        let mut dash = make_test_dashboard();
+        dash.config_watch = crate::daemon::config_reload::ConfigWatch::new(path.to_path_buf());
+        dash
+    }
+
+    /// Write a config with an mtime strictly newer than the last write, so the
+    /// watch sees a save even inside one clock tick.
+    fn save_config(path: &std::path::Path, body: &str) {
+        std::fs::write(path, body).unwrap();
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(5))
+            .unwrap();
+    }
+
+    /// The top row of a rendered frame, which is where the banner is.
+    ///
+    /// Read as a row rather than out of the flattened screen on purpose: a
+    /// warning toast carries much the same words, so an assertion over the
+    /// whole buffer would pass on the toast alone and prove nothing about the
+    /// banner that has to outlive it.
+    fn top_row(terminal: &Terminal<TestBackend>) -> String {
+        let buf = terminal.backend().buffer();
+        (0..buf.area.width)
+            .map(|x| buf.cell((x, 0)).expect("in the buffer").symbol())
+            .collect()
+    }
+
+    /// The banner is the whole point of this layer: a broken config used to
+    /// change nothing on screen at all.
+    #[test]
+    fn a_broken_config_raises_a_banner_that_clears_when_the_file_is_fixed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save_config(&path, "default_provider = \"anthropic\"\n");
+        let mut dash = dash_watching(&path);
+        // Wide enough that nothing has to be cut: the fitting is the narrow
+        // terminal's test, and this one is about what the banner says.
+        let mut terminal = Terminal::new(TestBackend::new(200, 20)).unwrap();
+
+        dash.sync_config_health();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        // Bound before the assert, not passed as a lazy format argument: an
+        // argument only evaluates when the assert fails, and the 100% gate
+        // counts it as a region nothing reached.
+        let row = top_row(&terminal);
+        assert!(
+            !row.starts_with('!'),
+            "a file that loads raises nothing: {row:?}"
+        );
+
+        save_config(&path, "default_provider = \"anthropic\"\nbroken : :\n");
+        dash.sync_config_health();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let row = top_row(&terminal);
+        assert!(row.starts_with("! "), "{row:?}");
+        assert!(row.contains("config.toml"), "{row:?}");
+        assert!(
+            row.contains("line 2, column 8"),
+            "the banner points at the spot: {row:?}"
+        );
+        assert!(
+            row.contains("runs are on the last config that loaded"),
+            "{row:?}"
+        );
+
+        // Fixed, with nothing restarted and no key pressed.
+        save_config(&path, "default_provider = \"openai\"\n");
+        dash.sync_config_health();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let row = top_row(&terminal);
+        assert!(
+            !row.starts_with('!'),
+            "the banner clears by itself: {row:?}"
+        );
+    }
+
+    /// A refused value names the key rather than a position, and the banner
+    /// says so rather than showing nothing.
+    #[test]
+    fn a_refused_value_names_its_key_in_the_banner() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save_config(&path, "default_provider = \"anthropic\"\n");
+        let mut dash = dash_watching(&path);
+
+        save_config(
+            &path,
+            "[model_providers.local]\nkind = \"openai-compatible\"\n",
+        );
+        dash.sync_config_health();
+        let mut terminal = Terminal::new(TestBackend::new(110, 20)).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let row = top_row(&terminal);
+        assert!(row.contains("model_providers.local"), "{row:?}");
+    }
+
+    /// Narrow terminals are the case a fixed-width banner gets wrong. The row
+    /// is fitted by column, so it never wraps and never pushes the screen off.
+    #[test]
+    fn the_banner_fits_a_narrow_terminal_and_still_leaves_the_screen_its_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save_config(&path, "default_provider = \"anthropic\"\n");
+        let mut dash = dash_watching(&path);
+        save_config(&path, "broken : :");
+        dash.sync_config_health();
+
+        for width in [40u16, 60, 200] {
+            let mut terminal = Terminal::new(TestBackend::new(width, 12)).unwrap();
+            terminal.draw(|f| dash.draw(f)).unwrap();
+            let row = top_row(&terminal);
+            assert!(row.starts_with('!'), "width {width}: {row:?}");
+            // The screen still got its rows: the run table's border is under
+            // the banner rather than pushed off the bottom.
+            let rest: String = rendered_buffer(&terminal)
+                .chars()
+                .skip(width as usize)
+                .collect();
+            assert!(rest.contains('┌') || rest.contains('│'), "width {width}");
+        }
+    }
+
+    /// One row is all there is on a terminal a single row tall, and a banner
+    /// that took it would leave nothing to be a banner about.
+    #[test]
+    fn a_one_row_terminal_keeps_its_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save_config(&path, "default_provider = \"anthropic\"\n");
+        let mut dash = dash_watching(&path);
+        save_config(&path, "broken : :");
+        dash.sync_config_health();
+
+        let mut terminal = Terminal::new(TestBackend::new(80, 1)).unwrap();
+        terminal.draw(|f| dash.draw(f)).unwrap();
+        let row = top_row(&terminal);
+        assert!(!row.starts_with('!'), "{row:?}");
     }
 }

--- a/crates/leviath-cli/src/commands/dashboard/state.rs
+++ b/crates/leviath-cli/src/commands/dashboard/state.rs
@@ -295,6 +295,16 @@ pub(crate) struct Dashboard {
         mpsc::UnboundedReceiver<McpCommand>,
         mpsc::UnboundedSender<McpOutcome>,
     )>,
+    /// Watches `config.toml`, so the header can say when it stopped loading.
+    ///
+    /// The dashboard reads the config on two screens and swallowed a broken
+    /// file whole on one of them (`unwrap_or_default()` on the new-run
+    /// screen), which is how a typo turned into an empty agent list with
+    /// nothing said. mtime-gated, so asking on every tick costs one `stat`.
+    pub(super) config_watch: crate::daemon::config_reload::ConfigWatch,
+    /// Why `config.toml` does not load, as of this tick. Held beside the watch
+    /// so the renderer, which has only `&self`, can draw it.
+    pub(super) config_fault: Option<crate::config::ConfigFault>,
 }
 
 mod sync;
@@ -620,6 +630,46 @@ impl Dashboard {
         if toasts.len() > 4 {
             toasts.remove(0);
         }
+    }
+
+    /// Notice whether `config.toml` still loads, and say so once each way.
+    ///
+    /// A toast is not enough on its own here: the condition persists until
+    /// somebody edits the file, and a message that has already faded cannot
+    /// explain why the run they start two minutes later ignored their edit.
+    /// So the toast announces the change and [`config_fault`] holds the banner
+    /// up for as long as it is true.
+    ///
+    /// [`config_fault`]: Self::config_fault
+    pub(super) fn sync_config_health(&mut self) {
+        let fault = self.config_watch.poll().cloned();
+        if fault == self.config_fault {
+            return;
+        }
+        match &fault {
+            Some(fault) => {
+                let file = fault.path.display();
+                self.add_log(format!("{file} no longer loads: {}", fault.summary()));
+                Self::push_toast(
+                    &mut self.toasts,
+                    format!("config.toml: {}", fault.summary()),
+                    ToastLevel::Warning,
+                    50,
+                );
+            }
+            // The only way here is from a fault to none: an unchanged answer
+            // returned above, so `None` means it was `Some` a tick ago.
+            None => {
+                self.add_log("config.toml parses again.".to_string());
+                Self::push_toast(
+                    &mut self.toasts,
+                    "config.toml loads again",
+                    ToastLevel::Info,
+                    30,
+                );
+            }
+        }
+        self.config_fault = fault;
     }
 
     pub(super) fn tick_toasts(&mut self) {

--- a/crates/leviath-cli/src/commands/doctor.rs
+++ b/crates/leviath-cli/src/commands/doctor.rs
@@ -401,6 +401,26 @@ fn config_check(config: &Config, registry: &ProviderRegistry) -> Check {
     )
 }
 
+/// The `config` check for a file that will not load.
+///
+/// It says three things, and the third is the one nothing said before: where
+/// in the file the problem is, that the file is not being read, and that a
+/// daemon already running is *still serving the last config that loaded* - so
+/// runs keep working on settings that are not the ones on disk, which is
+/// exactly why a broken config went unnoticed for as long as it did.
+fn broken_config_check(fault: &crate::config::ConfigFault) -> Check {
+    Check::fail(
+        "config",
+        format!(
+            "{} does not load ({}). Fix the file: a running daemon keeps serving the last \
+             config that loaded, so runs still work and your edits do not - and it picks the \
+             file up on the next spawn, with no restart",
+            fault.path.display(),
+            fault.summary()
+        ),
+    )
+}
+
 // ─── Check 2: resolve ─────────────────────────────────────────────────────────
 
 /// What check 2 settled on, when it settled on something usable. The handle is
@@ -875,10 +895,10 @@ pub(crate) async fn run_checks_with(
 
     // A config that will not parse is itself a finding, and the most common
     // one there is - reporting it as `config FAIL` beats the bare load error.
-    let config = match Config::load() {
+    let config = match Config::load_faulted() {
         Ok(config) => config,
-        Err(e) => {
-            checks.push(Check::fail("config", e.to_string()));
+        Err(fault) => {
+            checks.push(broken_config_check(&fault));
             return checks;
         }
     };

--- a/crates/leviath-cli/src/commands/doctor/tests.rs
+++ b/crates/leviath-cli/src/commands/doctor/tests.rs
@@ -1121,6 +1121,39 @@ async fn run_checks_reports_a_config_that_will_not_parse() {
     assert_eq!(checks.len(), 1, "nothing runs after a broken config");
     assert_eq!(checks[0].name, "config");
     assert_eq!(checks[0].status, CheckStatus::Fail);
+    // Where in the file, and what a running daemon is doing meanwhile. The
+    // check used to be the loader's paragraph pasted into one column.
+    let detail = &checks[0].detail;
+    assert!(detail.contains("does not load"), "{detail}");
+    assert!(detail.contains("line 1, column"), "{detail}");
+    assert!(
+        detail.contains("last config that loaded"),
+        "it says runs are not stopped, which is the surprising part: {detail}"
+    );
+    assert!(detail.contains("no restart"), "and the fix: {detail}");
+    assert!(!detail.contains('\n'), "one line for one row: {detail}");
+}
+
+/// A value that parses and is then refused names the key, which is what the
+/// user has to go and edit.
+#[tokio::test]
+async fn run_checks_names_the_key_a_refused_value_belongs_to() {
+    let checks = with_env(|root| async move {
+        std::fs::write(
+            root.join("config.toml"),
+            "[model_providers.local]\nkind = \"openai-compatible\"\n",
+        )
+        .expect("write");
+        let build = always(ProviderRegistry::new());
+        run_checks(&DoctorArgs::default(), &build, DaemonTarget::Skip).await
+    })
+    .await;
+    assert_eq!(checks[0].status, CheckStatus::Fail);
+    assert!(
+        checks[0].detail.contains("model_providers.local"),
+        "{}",
+        checks[0].detail
+    );
 }
 
 #[tokio::test]

--- a/crates/leviath-cli/src/commands/ps.rs
+++ b/crates/leviath-cli/src/commands/ps.rs
@@ -616,18 +616,40 @@ fn annotated(runs: &[RunListEntry], now: i64) -> Vec<serde_json::Value> {
         .collect()
 }
 
+/// Everything one `lev ps` invocation has to print.
+///
+/// A struct rather than six parameters: the list grew to the point where a
+/// caller could transpose two of them without the compiler noticing, and the
+/// `bool` in the middle was the one most likely to be got wrong.
+struct Listing<'a> {
+    /// The runs the daemon is hosting.
+    runs: &'a [RunListEntry],
+    /// The ones it has finished with and is still holding.
+    finished: &'a [RunListEntry],
+    /// What the daemon says about itself.
+    health: &'a DaemonHealth,
+    /// The runs on disk nothing is hosting, under `--all`.
+    offline: Option<&'a [OfflineRun]>,
+    /// Whether the daemon answered at all.
+    daemon_reachable: bool,
+    /// The config file to report on. Passed in rather than read here so a test
+    /// can point it at a file of its own instead of the developer's real
+    /// `~/.leviath`.
+    config_path: &'a std::path::Path,
+}
+
 /// Print the live listing, optionally followed by the runs on disk the daemon is
 /// not hosting. Pure formatting/serialization, so the shape is testable without
 /// a daemon.
-fn print_listing(
-    runs: &[RunListEntry],
-    finished: &[RunListEntry],
-    health: &DaemonHealth,
-    offline: Option<&[OfflineRun]>,
-    daemon_reachable: bool,
-    args: &PsArgs,
-    now: i64,
-) {
+fn print_listing(listing: Listing<'_>, args: &PsArgs, now: i64) {
+    let Listing {
+        runs,
+        finished,
+        health,
+        offline,
+        daemon_reachable,
+        config_path,
+    } = listing;
     if args.json {
         let mut body = serde_json::json!({
             "runs": annotated(runs, now),
@@ -655,6 +677,29 @@ fn print_listing(
     if let Some(block) = offline.and_then(|o| format_offline(o, now)) {
         println!("\n{block}");
     }
+    // Last, under everything else, because it is about the machine rather than
+    // any run in the table. It belongs here at all because every run listed
+    // above may be running on settings the user edited and believes are in
+    // force: the daemon keeps the last config that loaded, silently.
+    //
+    // The path is passed in rather than read here so a test can point it at a
+    // file of its own instead of the developer's real `~/.leviath`.
+    if let Some(line) = broken_config_footer(config_path) {
+        println!("\n{line}");
+    }
+}
+
+/// One line saying the config file does not load, for under the run table.
+/// `None` while it loads, and pure so the wording is testable without a daemon
+/// or a real `~/.leviath`.
+fn broken_config_footer(path: &std::path::Path) -> Option<String> {
+    let fault = crate::config::ConfigFault::check(path)?;
+    Some(format!(
+        "{} does not load ({}); these runs are on the last config that did - `lev doctor` \
+         has the detail",
+        path.display(),
+        fault.summary()
+    ))
 }
 
 /// Query the daemon for its runs and print the listing.
@@ -687,11 +732,14 @@ pub async fn send_list(client: &ControlClient, args: &PsArgs) -> anyhow::Result<
                 .collect();
             let offline = all.then(|| offline_runs(runstate::list_runs(), Some(&shown), now));
             print_listing(
-                &runs,
-                &finished,
-                &health,
-                offline.as_deref(),
-                true,
+                Listing {
+                    runs: &runs,
+                    finished: &finished,
+                    health: &health,
+                    offline: offline.as_deref(),
+                    daemon_reachable: true,
+                    config_path: &crate::config::Config::config_path(),
+                },
                 args,
                 now,
             );
@@ -701,11 +749,14 @@ pub async fn send_list(client: &ControlClient, args: &PsArgs) -> anyhow::Result<
         (Err(_), true) => {
             let offline = offline_runs(runstate::list_runs(), None, now);
             print_listing(
-                &[],
-                &[],
-                &DaemonHealth::default(),
-                Some(&offline),
-                false,
+                Listing {
+                    runs: &[],
+                    finished: &[],
+                    health: &DaemonHealth::default(),
+                    offline: Some(&offline),
+                    daemon_reachable: false,
+                    config_path: &crate::config::Config::config_path(),
+                },
                 args,
                 now,
             );

--- a/crates/leviath-cli/src/commands/ps/tests.rs
+++ b/crates/leviath-cli/src/commands/ps/tests.rs
@@ -1003,3 +1003,55 @@ fn the_title_column_shows_a_generated_title() {
         "an untitled run leaves the cell empty rather than borrowing one: {out}"
     );
 }
+
+/// `lev ps` is where a person looks when a run is not doing what they expect,
+/// so it is where a config that stopped loading has to be visible. It goes
+/// under the table, with the other advisory footers.
+#[test]
+fn a_config_that_does_not_load_gets_a_line_under_the_table() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("config.toml");
+
+    std::fs::write(&path, "default_provider = \"anthropic\"\n").unwrap();
+    assert!(
+        broken_config_footer(&path).is_none(),
+        "a file that loads says nothing"
+    );
+    assert!(
+        broken_config_footer(&dir.path().join("absent.toml")).is_none(),
+        "no config file means defaults, not a broken one"
+    );
+
+    std::fs::write(&path, "default_provider = \"anthropic\"\nbroken : :\n").unwrap();
+    let line = broken_config_footer(&path).expect("a broken file gets a line");
+    assert!(line.contains("does not load"), "{line}");
+    assert!(line.contains("line 2, column 8"), "{line}");
+    assert!(
+        line.contains("last config that did"),
+        "the runs above are not on the file on disk: {line}"
+    );
+    assert!(
+        line.contains("lev doctor"),
+        "and where the detail is: {line}"
+    );
+
+    // …and it reaches the printed listing, under everything else. Printed both
+    // ways round, because the listing must be unchanged when the file loads.
+    let listing = |config_path: &std::path::Path| {
+        print_listing(
+            Listing {
+                runs: &[entry("a", AgentStatus::Active)],
+                finished: &[],
+                health: &healthy_daemon(),
+                offline: None,
+                daemon_reachable: true,
+                config_path,
+            },
+            &PsArgs::default(),
+            0,
+        );
+    };
+    listing(&path);
+    std::fs::write(&path, "default_provider = \"anthropic\"\n").unwrap();
+    listing(&path);
+}

--- a/crates/leviath-cli/src/commands/serve/config.rs
+++ b/crates/leviath-cli/src/commands/serve/config.rs
@@ -41,8 +41,20 @@ fn gateways_of(c: &Config) -> Vec<GatewayInfo> {
 /// Redacted view of a config: booleans for keys, never their values.
 /// `requests` is what this server resolved at start-up, which no config
 /// file alone can say once a flag is involved.
-fn redact(c: &Config, requests: &super::request_limits::RequestLimits) -> RedactedConfig {
+///
+/// `health` is the file behind `c`, which on a broken save is not the file on
+/// disk. Every other field here describes the config in force; without this
+/// one a client had no way to tell "your edit is applied" from "your edit did
+/// not parse and is being ignored".
+fn redact(
+    c: &Config,
+    requests: &super::request_limits::RequestLimits,
+    health: &crate::daemon::config_reload::ConfigHealth,
+) -> RedactedConfig {
+    let (config_error, config_mtime) = super::config_health::report(health);
     RedactedConfig {
+        config_error,
+        config_mtime,
         default_provider: c.default_provider.clone(),
         has_anthropic_key: c.providers.anthropic_api_key.is_some(),
         has_openai_key: c.providers.openai_api_key.is_some(),
@@ -62,10 +74,13 @@ fn redact(c: &Config, requests: &super::request_limits::RequestLimits) -> Redact
 /// made through [`put_config`] - or by anything else on the machine - is
 /// visible to the very next request (issue #532).
 pub(super) async fn get_config(State(state): State<AppState>) -> Json<RedactedConfig> {
-    Json(redact(
-        &state.current_config(),
-        &state.limits.request_limits,
-    ))
+    // One `health()` call rather than a `current_config()` beside it: health
+    // re-checks the file itself and hands back the config in force with its
+    // verdict, so the two halves of one answer cannot disagree about whether a
+    // save has been seen.
+    let health = state.config.health();
+    let config = health.config.clone();
+    Json(redact(&config, &state.limits.request_limits, &health))
 }
 
 /// `PUT /api/config` (admin-only). Loads the on-disk config, applies every
@@ -165,7 +180,13 @@ pub(super) async fn put_config(
             format!("failed to write config: {e}"),
         )
     })?;
-    Ok(Json(redact(&config, &state.limits.request_limits)))
+    // Health read *after* the write, so the answer describes the file this
+    // request just left behind. A write this route made always parses - it
+    // serializes a `Config` and the refusals above ran first - so this is
+    // normally healthy; it is not assumed, because the file could equally have
+    // been broken by hand a moment ago and rewritten by something else.
+    let health = state.config.health();
+    Ok(Json(redact(&config, &state.limits.request_limits, &health)))
 }
 
 /// `POST /api/models/probe` (admin-only): what an OpenAI-compatible server
@@ -449,6 +470,13 @@ mod tests {
     use crate::commands::serve::events::ServerEvent;
     use crate::config::Config;
 
+    /// The health of a reloader with no file to watch: loading, because there
+    /// is nothing that could fail to. For the tests about the *other* fields
+    /// `redact` fills in.
+    fn healthy() -> crate::daemon::config_reload::ConfigHealth {
+        crate::daemon::config_reload::ConfigReloader::fixed(Config::default()).health()
+    }
+
     /// A default config whose ollama endpoint cannot answer.
     ///
     /// Ollama is always registered, so on a machine running `ollama serve` its
@@ -553,6 +581,81 @@ mod tests {
         assert!(!config.has_openai_key);
         assert!(!config.has_openrouter_key);
         assert!(config.ollama_base_url.is_none());
+    }
+
+    /// A broken save is the one thing this route could not previously say. It
+    /// kept answering with the last good config, which reads exactly like an
+    /// edit that was never made.
+    #[tokio::test]
+    async fn get_config_reports_a_broken_file_and_keeps_serving_the_last_good_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let good = crate::config::Config {
+            default_provider: "google".to_string(),
+            ..Default::default()
+        };
+        write_config(&path, &toml::to_string(&good).unwrap());
+        let state = crate::commands::serve::testutil::state_with_config_at(&path);
+
+        // While it loads: no error, and an mtime for the config in force.
+        let config = fetch_config(&state).await;
+        assert!(config.config_error.is_none());
+        let good_mtime = config.config_mtime;
+        assert!(good_mtime.is_some());
+
+        write_config(&path, "default_provider = \"google\"\nbroken : :\n");
+        let config = fetch_config(&state).await;
+
+        let error = config.config_error.expect("the file no longer loads");
+        assert_eq!(error.kind, "parse");
+        assert_eq!(error.line, Some(2));
+        assert_eq!(error.column, Some(8));
+        assert_eq!(error.path, path.display().to_string());
+        assert!(
+            error.note.contains("last one that loaded"),
+            "{}",
+            error.note
+        );
+        assert_eq!(
+            config.config_mtime, good_mtime,
+            "the mtime is the config in force, not the file that failed"
+        );
+        assert_eq!(
+            config.default_provider, "google",
+            "the last good config is still what is served"
+        );
+
+        // Fixed: the error goes away by itself, with no restart.
+        write_config(&path, "default_provider = \"openai\"\n");
+        let config = fetch_config(&state).await;
+        assert!(config.config_error.is_none());
+        assert_eq!(config.default_provider, "openai");
+    }
+
+    /// Write a config file with an mtime strictly newer than the last write,
+    /// so the reloader sees a save even inside one clock tick.
+    fn write_config(path: &std::path::Path, body: &str) {
+        std::fs::write(path, body).unwrap();
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(5))
+            .unwrap();
+    }
+
+    /// `GET /api/config` against `state`, parsed.
+    async fn fetch_config(state: &AppState) -> RedactedConfig {
+        let app = Router::new()
+            .route("/api/config", get(get_config))
+            .with_state(state.clone());
+        let req = Request::builder()
+            .uri("/api/config")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), axum::http::StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&body).unwrap()
     }
 
     /// The console used to feature-detect by calling a route and reading a 404
@@ -828,6 +931,8 @@ mod tests {
             api_version: API_VERSION.to_string(),
             capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
             limits: ApiLimits::current(&Default::default()),
+            config_error: None,
+            config_mtime: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         // Must NOT contain actual key values
@@ -852,6 +957,8 @@ mod tests {
             api_version: API_VERSION.to_string(),
             capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
             limits: ApiLimits::current(&Default::default()),
+            config_error: None,
+            config_mtime: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("\"ollama_base_url\":\"http://localhost:11434\""));
@@ -1229,6 +1336,34 @@ mod tests {
         assert!(!saved.model_providers["groq"].is_endpoint());
     }
 
+    /// A refused write leaves the file byte for byte as it was.
+    ///
+    /// The test above proves the refused entry is absent, which a partial
+    /// write could still satisfy. This is the stronger claim, and the one that
+    /// matters: a request that answers 400 must not be able to leave the
+    /// machine's config in a state nobody asked for.
+    #[tokio::test]
+    async fn a_refused_put_writes_nothing_at_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to_path_public(&path).unwrap();
+        let before = std::fs::read(&path).unwrap();
+
+        // One request that both edits something valid and asks for something
+        // refused: the valid half must not survive the refusal.
+        let resp = put_config_request(
+            state_with_config_path(path.clone()),
+            r#"{"default_provider":"openai","gateways":[{"name":"bare","kind":"openai-compatible"}]}"#,
+        )
+        .await;
+        assert_eq!(resp.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            before,
+            "a refused write must not touch the file"
+        );
+    }
+
     async fn probe(body: serde_json::Value) -> (axum::http::StatusCode, serde_json::Value) {
         let app = Router::new().route("/api/models/probe", axum::routing::post(probe_models));
         let req = Request::builder()
@@ -1402,7 +1537,7 @@ mod tests {
             },
         );
 
-        let redacted = redact(&config, &Default::default());
+        let redacted = redact(&config, &Default::default(), &healthy());
         let gateway = &redacted.gateways[0];
         assert_eq!(gateway.name, "groq");
         assert_eq!(gateway.kind, "script");

--- a/crates/leviath-cli/src/commands/serve/config_health.rs
+++ b/crates/leviath-cli/src/commands/serve/config_health.rs
@@ -1,0 +1,300 @@
+//! Reporting whether `config.toml` loads, over HTTP and over the websocket.
+//!
+//! The daemon's [`ConfigReloader`](crate::daemon::config_reload::ConfigReloader)
+//! has always kept the last good config when a save did not parse, and this
+//! server holds the same kind of reloader over the same file. What neither of
+//! them did was say so: a user with a typo saw their edits stop taking effect
+//! and had nothing to read that explained it.
+//!
+//! Two shapes come out of here. `GET /api/config` carries the answer as a
+//! field on the config it returns, because the fact a client needs is "the
+//! config you are reading is not the file on disk" and that belongs beside the
+//! config. The websocket carries the *edges*, because a client that has drawn
+//! a banner needs to be told when to take it down, and polling a config
+//! endpoint to find out is the thing this exists to avoid.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use super::config_types::ConfigErrorInfo;
+use super::events::ServerEvent;
+use super::types::AppState;
+use crate::config::ConfigFault;
+use crate::daemon::config_reload::ConfigHealth;
+
+/// How often the watcher re-checks the file.
+///
+/// A `stat` per interval, and nothing more while the mtime is unchanged. Two
+/// seconds because this is a person editing a file in another window: fast
+/// enough that the banner appears while they are still looking at the
+/// terminal, slow enough to be free.
+pub(super) const WATCH_INTERVAL: Duration = Duration::from_secs(2);
+
+/// What a person is told is happening while the file will not load.
+///
+/// Written once, here, so the API, the dashboard and the CLI cannot end up
+/// describing the same situation three slightly different ways.
+pub(crate) const LAST_GOOD_NOTE: &str = "The running config is the last one that loaded; edits to this file take effect only \
+     once it parses again.";
+
+/// The API's view of a health snapshot: the error object, and the mtime of the
+/// config actually in force.
+pub(super) fn report(health: &ConfigHealth) -> (Option<ConfigErrorInfo>, Option<i64>) {
+    let error = health.fault.as_ref().map(|fault| ConfigErrorInfo {
+        kind: fault.kind.as_str().to_string(),
+        path: fault.path.display().to_string(),
+        message: fault.message.clone(),
+        line: fault.line,
+        column: fault.column,
+        key: fault.key.clone(),
+        since: health.since.map(unix_secs).unwrap_or_default(),
+        note: LAST_GOOD_NOTE.to_string(),
+    });
+    (error, health.loaded_mtime.map(unix_secs))
+}
+
+/// The websocket frame for a health snapshot.
+pub(super) fn event(health: &ConfigHealth) -> ServerEvent {
+    let (error, config_mtime) = report(health);
+    ServerEvent::ConfigHealth {
+        healthy: health.is_healthy(),
+        path: health.path.display().to_string(),
+        error,
+        config_mtime,
+    }
+}
+
+/// A `SystemTime` as unix seconds, the way every other timestamp on this API
+/// is spelled. A time before the epoch, which a filesystem can report for a
+/// file with a nonsense mtime, reads as 0 rather than failing the request.
+fn unix_secs(t: SystemTime) -> i64 {
+    t.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or_default()
+}
+
+/// Watch the config file and broadcast a frame whenever its health changes.
+///
+/// Edge-triggered, never on a timer: a client holds a banner up from one frame
+/// and takes it down on the next, and a subscriber that never sees one is
+/// looking at a machine whose config has loaded the whole time it has been
+/// connected. `GET /api/config` is what a client that connected mid-outage
+/// asks.
+///
+/// Never returns; held behind the same abort-on-drop guard as the event loop.
+pub(super) async fn watch_loop(state: AppState, interval: Duration) {
+    let mut reported = state.config.health().fault;
+    loop {
+        tokio::time::sleep(interval).await;
+        reported = broadcast_change(&state, &reported);
+    }
+}
+
+/// One check: broadcast a frame if the answer is not what was last sent, and
+/// return the answer now.
+///
+/// The comparison is on the whole fault rather than on "is it broken", because
+/// a user fixing a syntax error and landing on a refused value never leaves the
+/// broken state - and a client holding a banner would go on showing the line
+/// and column of a problem that no longer exists.
+///
+/// Separate from the loop so the rule can be tested without a clock. Driving it
+/// through the loop means racing the spawn against the first edit, and a test
+/// that has to sleep to be right is a test that eventually is not.
+fn broadcast_change(state: &AppState, reported: &Option<ConfigFault>) -> Option<ConfigFault> {
+    let health = state.config.health();
+    if &health.fault != reported {
+        let _ = state.event_tx.send(event(&health));
+    }
+    health.fault
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::daemon::config_reload::ConfigReloader;
+    use std::sync::Arc;
+
+    /// Write `body` to `path` with an mtime strictly newer than any previous
+    /// write, so a reload is observable even inside one clock tick.
+    fn save(path: &std::path::Path, body: &str) {
+        std::fs::write(path, body).unwrap();
+        let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        f.set_modified(SystemTime::now() + Duration::from_secs(5))
+            .unwrap();
+    }
+
+    fn empty_config() -> String {
+        toml::to_string(&Config::default()).unwrap()
+    }
+
+    /// A reloader over a real file, seeded the way boot seeds it.
+    fn reloader(path: &std::path::Path) -> Arc<ConfigReloader> {
+        Arc::new(ConfigReloader::new(
+            path.to_path_buf(),
+            Config::load_from_path_public(path).unwrap(),
+        ))
+    }
+
+    #[test]
+    fn a_healthy_config_reports_no_error_and_the_mtime_in_force() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save(&path, &empty_config());
+        let health = reloader(&path).health();
+
+        let (error, mtime) = report(&health);
+        assert!(error.is_none());
+        assert!(mtime.is_some(), "a config that loaded has an mtime");
+    }
+
+    #[test]
+    fn a_syntax_error_is_reported_with_its_place_and_the_last_good_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save(&path, &empty_config());
+        let reloader = reloader(&path);
+        let (_, good_mtime) = report(&reloader.health());
+
+        save(&path, "default_provider = \"anthropic\"\nbroken : :\n");
+        let (error, mtime) = report(&reloader.health());
+
+        let error = error.expect("a file that will not parse is an error");
+        assert_eq!(error.kind, "parse");
+        assert_eq!(error.line, Some(2));
+        assert_eq!(error.column, Some(8));
+        assert!(error.key.is_none());
+        assert_eq!(error.path, path.display().to_string());
+        assert!(error.since > 0, "the moment it broke is reported");
+        assert_eq!(error.note, LAST_GOOD_NOTE);
+        assert_eq!(
+            mtime, good_mtime,
+            "the mtime reported is the config in force, not the broken file"
+        );
+    }
+
+    #[test]
+    fn a_refused_value_is_reported_with_the_key_and_no_position() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save(&path, &empty_config());
+        let reloader = reloader(&path);
+
+        save(
+            &path,
+            "[model_providers.local]\nkind = \"openai-compatible\"\n",
+        );
+        let (error, _) = report(&reloader.health());
+
+        let error = error.expect("an endpoint with no address is an error");
+        assert_eq!(error.kind, "validation");
+        assert_eq!(error.key.as_deref(), Some("model_providers.local"));
+        assert!(error.line.is_none() && error.column.is_none());
+    }
+
+    #[test]
+    fn the_frame_carries_the_health_and_names_no_run() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save(&path, &empty_config());
+        let reloader = reloader(&path);
+
+        let frame = event(&reloader.health());
+        let json = serde_json::to_value(&frame).unwrap();
+        assert_eq!(json["type"], "config_health");
+        assert_eq!(json["healthy"], true);
+        assert!(json.get("error").is_none(), "no error when it loads");
+        assert_eq!(frame.run_id(), "", "it is about the machine, not a run");
+        assert!(
+            !frame.is_for_run("run-1"),
+            "a per-run subscription is not the place for it"
+        );
+
+        save(&path, "broken : :");
+        let frame = event(&reloader.health());
+        let json = serde_json::to_value(&frame).unwrap();
+        assert_eq!(json["healthy"], false);
+        assert_eq!(json["error"]["kind"], "parse");
+        assert_eq!(json["path"], path.display().to_string());
+    }
+
+    /// An mtime before the epoch is nonsense a filesystem can still hand back;
+    /// it reports as 0 rather than taking the request down.
+    #[test]
+    fn a_time_before_the_epoch_reads_as_zero() {
+        assert_eq!(unix_secs(UNIX_EPOCH - Duration::from_secs(5)), 0);
+        assert_eq!(unix_secs(UNIX_EPOCH + Duration::from_secs(7)), 7);
+    }
+
+    #[test]
+    fn a_frame_goes_out_on_each_edge_and_on_neither_steady_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save(&path, &empty_config());
+        let state = super::super::testutil::state_with_config_at(&path);
+        let mut rx = state.event_tx.subscribe();
+
+        // Steady and loading: nothing to say.
+        let reported = broadcast_change(&state, &None);
+        assert!(reported.is_none());
+        assert!(rx.try_recv().is_err(), "no frame while nothing changed");
+
+        save(&path, "broken : :");
+        let reported = broadcast_change(&state, &reported);
+        assert!(reported.is_some(), "the file stopped loading");
+        let frame = serde_json::to_value(rx.try_recv().expect("a frame on the edge")).unwrap();
+        assert_eq!(frame["type"], "config_health");
+        assert_eq!(frame["healthy"], false);
+        assert_eq!(frame["error"]["kind"], "parse");
+
+        // Still broken, in the same way, and already announced.
+        let reported = broadcast_change(&state, &reported);
+        assert!(rx.try_recv().is_err(), "a held state repeats no frame");
+
+        // Still broken, for a different reason: a client holding a banner has
+        // to be told, or it goes on showing a position that no longer exists.
+        save(
+            &path,
+            "[model_providers.local]\nkind = \"openai-compatible\"\n",
+        );
+        let reported = broadcast_change(&state, &reported);
+        let frame = serde_json::to_value(rx.try_recv().expect("a new reason is an edge")).unwrap();
+        assert_eq!(frame["healthy"], false);
+        assert_eq!(frame["error"]["kind"], "validation");
+        assert_eq!(frame["error"]["key"], "model_providers.local");
+
+        save(&path, &empty_config());
+        let reported = broadcast_change(&state, &reported);
+        assert!(reported.is_none(), "it loads again");
+        let frame = serde_json::to_value(rx.try_recv().expect("recovery is an edge too")).unwrap();
+        assert_eq!(frame["healthy"], true);
+        assert!(frame.get("error").is_none());
+    }
+
+    /// The loop itself: it polls on its interval and puts a frame on the
+    /// channel when the file changes under it. The *rule* it applies is tested
+    /// above, without a clock; this is the wiring.
+    #[tokio::test]
+    async fn the_watch_loop_notices_the_file_changing_under_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        save(&path, &empty_config());
+        let state = super::super::testutil::state_with_config_at(&path);
+        let mut rx = state.event_tx.subscribe();
+
+        let watcher = tokio::spawn(watch_loop(state, Duration::from_millis(5)));
+        // Let the task reach its first `sleep`, which is past the baseline
+        // read: break the file before that and there is no edge to see. The
+        // test runtime is single-threaded, so one yield is enough.
+        tokio::task::yield_now().await;
+        save(&path, "broken : :");
+
+        let frame = tokio::time::timeout(Duration::from_secs(10), rx.recv())
+            .await
+            .expect("the watcher sends a frame")
+            .expect("the channel stays open");
+        let json = serde_json::to_value(&frame).unwrap();
+        assert_eq!(json["type"], "config_health");
+        watcher.abort();
+    }
+}

--- a/crates/leviath-cli/src/commands/serve/config_types.rs
+++ b/crates/leviath-cli/src/commands/serve/config_types.rs
@@ -37,6 +37,49 @@ pub(super) struct RedactedConfig {
     /// and one round trip per feature.
     pub(super) capabilities: Vec<String>,
     pub(super) limits: ApiLimits,
+    /// Why the config file on disk is not the config being served, when it is
+    /// not. Absent while `config.toml` loads.
+    ///
+    /// Every other field here describes the config *in force*, which on a
+    /// broken file is the last one that loaded. Without this, a client had no
+    /// way to tell the two apart: an edit that did not parse simply did not
+    /// show up, and looked identical to an edit that was never saved.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) config_error: Option<ConfigErrorInfo>,
+    /// The mtime of the config actually in force, in unix seconds.
+    ///
+    /// Always present, not only under an error: it is how a client that just
+    /// wrote the file confirms the write was picked up. While
+    /// `config_error` is set this is the *last good* save rather than what is
+    /// on disk now. `null` when there is no config file, which means defaults.
+    pub(super) config_mtime: Option<i64>,
+}
+
+/// A config file that will not load, as the API reports it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ConfigErrorInfo {
+    /// Which step refused it: `parse`, `validation` or `read`.
+    pub(crate) kind: String,
+    /// The file, as this server resolved it.
+    pub(crate) path: String,
+    /// One line: what is wrong, with no caret art in it.
+    pub(crate) message: String,
+    /// 1-based position of a parse failure. Absent for a validation failure,
+    /// which names a `key` instead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) line: Option<usize>,
+    /// 1-based column, alongside `line`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) column: Option<usize>,
+    /// The dotted config key a validation failure is about, such as
+    /// `model_providers.local`. Absent for a parse failure.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) key: Option<String>,
+    /// When this server first saw the file in this state, in unix seconds.
+    pub(crate) since: i64,
+    /// Said in words, because a client that only renders strings should still
+    /// be able to tell somebody what is happening.
+    pub(crate) note: String,
 }
 
 /// The API contract version: this build's own version, and nothing to keep in
@@ -218,6 +261,13 @@ pub(super) const API_CAPABILITIES: &[&str] = &[
     // without a word: a console that offered the box against one would send
     // the person's redirect nowhere.
     "interaction.feedback",
+    // `config_error` and `config_mtime` on `GET /api/config`, and the
+    // `config_health` websocket frame. Announced because the absence of
+    // `config_error` has to be readable as "this file loads" rather than as
+    // "this daemon would not tell me": a console that cannot tell the two
+    // apart has to keep showing the config as authoritative while the user's
+    // edits are quietly going nowhere.
+    "config.health",
 ];
 
 /// The server's numeric limits.

--- a/crates/leviath-cli/src/commands/serve/events.rs
+++ b/crates/leviath-cli/src/commands/serve/events.rs
@@ -278,12 +278,41 @@ pub(crate) enum ServerEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         restart_advised: Option<String>,
     },
+
+    /// Whether `config.toml` on disk loads has changed.
+    ///
+    /// About the machine rather than a run, like
+    /// [`DaemonLink`](Self::DaemonLink), and sent for much the same reason: it
+    /// is the frame that explains why something appears to have had no effect.
+    /// A save that does not parse leaves the last good config in force and
+    /// changes nothing else a client can observe, so without this the only
+    /// symptom is `GET /api/config` quietly answering with the old values.
+    ///
+    /// Sent on each edge rather than on a timer: it stopped loading, it loads
+    /// again, or it is still broken for a different reason than the frame
+    /// before said. That third case matters - a person fixing a syntax error
+    /// and landing on a refused value never leaves the broken state, and a
+    /// client holding a banner would go on showing a line and column that no
+    /// longer exists.
+    ConfigHealth {
+        /// Whether the file on disk loads right now.
+        healthy: bool,
+        /// The file this is about.
+        path: String,
+        /// Why it does not load. Absent when `healthy`.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<super::config_types::ConfigErrorInfo>,
+        /// The mtime of the config in force, in unix seconds. While unhealthy
+        /// this is the last good save, not what is on disk.
+        config_mtime: Option<i64>,
+    },
 }
 
 impl ServerEvent {
     /// The run id this event belongs to, for per-run subscription filtering.
-    /// Every event names one except the three about the machine rather than a
-    /// run - [`DaemonLink`](Self::DaemonLink), and the two an update sends.
+    /// Every event names one except the four about the machine rather than a
+    /// run - [`DaemonLink`](Self::DaemonLink),
+    /// [`ConfigHealth`](Self::ConfigHealth), and the two an update sends.
     pub(crate) fn run_id(&self) -> &str {
         match self {
             ServerEvent::AgentStatus { run_id, .. }
@@ -300,18 +329,21 @@ impl ServerEvent {
             | ServerEvent::AgentSpend { run_id, .. } => run_id,
             ServerEvent::DaemonLink { .. }
             | ServerEvent::UpdateProgress { .. }
-            | ServerEvent::UpdateFinished { .. } => "",
+            | ServerEvent::UpdateFinished { .. }
+            | ServerEvent::ConfigHealth { .. } => "",
         }
     }
 
     /// Whether a subscription filtered to `run_id` should receive this event:
     /// its own run's events, and the ones about no run at all.
     ///
-    /// The update frames are deliberately not in that second group. A link
-    /// event explains why a run's events stopped arriving, which is something
-    /// a per-run subscriber has to know; an update happening on the machine is
-    /// not about the run it is watching, and `/ws` is where a console watches
-    /// for it.
+    /// The update frames are deliberately not in that second group, and
+    /// neither is [`ConfigHealth`](Self::ConfigHealth). A link event explains
+    /// why a run's events stopped arriving, which is something a per-run
+    /// subscriber has to know; an update happening on the machine is not about
+    /// the run it is watching, and neither is the config file being edited -
+    /// the run in front of it keeps going on the config it started with either
+    /// way. `/ws` is where a console watches for both.
     pub(crate) fn is_for_run(&self, run_id: &str) -> bool {
         matches!(self, ServerEvent::DaemonLink { .. }) || self.run_id() == run_id
     }

--- a/crates/leviath-cli/src/commands/serve/mod.rs
+++ b/crates/leviath-cli/src/commands/serve/mod.rs
@@ -7,6 +7,7 @@ mod agents;
 mod auth;
 mod blueprints;
 mod config;
+mod config_health;
 mod config_types;
 mod cursor;
 mod doctor;
@@ -392,6 +393,17 @@ async fn execute_with_shutdown(
     let _event_guard = AbortOnDrop(tokio::spawn(polling::event_loop(
         event_state,
         polling::RECONNECT_BACKOFF,
+    )));
+
+    // Config-health watcher, behind the same kind of guard for the same
+    // reason. Separate from the event loop above because it watches a file on
+    // this machine rather than the daemon's stream: a broken `config.toml` is
+    // not something the daemon pushes, and this server holds its own reloader
+    // over the same file.
+    let health_state = state.clone();
+    let _config_health_guard = AbortOnDrop(tokio::spawn(config_health::watch_loop(
+        health_state,
+        config_health::WATCH_INTERVAL,
     )));
 
     // No `--cors` at all: no CORS layer. Programmatic clients are not subject to

--- a/crates/leviath-cli/src/commands/serve/testutil.rs
+++ b/crates/leviath-cli/src/commands/serve/testutil.rs
@@ -57,6 +57,25 @@ pub(super) fn state_with_agent_paths(paths: Vec<std::path::PathBuf>) -> super::t
     }
 }
 
+/// An `AppState` watching the real file at `path`, so a test can edit it and
+/// see the server notice. The counterpart to [`state_with_agent_paths`], whose
+/// config is fixed and watches nothing.
+pub(super) fn state_with_config_at(path: &std::path::Path) -> super::types::AppState {
+    let (event_tx, _) = tokio::sync::broadcast::channel(64);
+    super::types::AppState {
+        update_check: Default::default(),
+        update_jobs: Default::default(),
+        config: Arc::new(crate::daemon::config_reload::ConfigReloader::new(
+            path.to_path_buf(),
+            crate::config::Config::load_from_path_public(path).expect("a config that loads"),
+        )),
+        event_tx,
+        control: no_daemon_client(),
+        mcp: super::mcp::McpAdmin::default(),
+        limits: Default::default(),
+    }
+}
+
 /// A control client pointing at an address with no daemon - used by tests that
 /// never exercise agent actions (read/websocket/polling/config paths).
 pub(super) fn no_daemon_client() -> ControlClient {

--- a/crates/leviath-cli/src/commands/serve/types.rs
+++ b/crates/leviath-cli/src/commands/serve/types.rs
@@ -1292,6 +1292,8 @@ mod tests {
             api_version: API_VERSION.to_string(),
             capabilities: API_CAPABILITIES.iter().map(|c| c.to_string()).collect(),
             limits: ApiLimits::current(&Default::default()),
+            config_error: None,
+            config_mtime: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         let parsed: RedactedConfig = serde_json::from_str(&json).unwrap();

--- a/crates/leviath-cli/src/commands/validate.rs
+++ b/crates/leviath-cli/src/commands/validate.rs
@@ -842,9 +842,42 @@ async fn primed_registry_with(
 /// rather than silently changing which model the output names.
 const VALIDATE_PRIME_TIMEOUT_SECS: u64 = 5;
 
+/// What `lev validate` says about a config file that will not load.
+///
+/// Not a failure: the blueprint is what was asked about, and it checks out or
+/// does not on its own. But the provider and read-path checks below need a
+/// config, and running them against no config at all while saying nothing is
+/// how `validate` came to report a clean blueprint that the daemon then
+/// refused.
+fn broken_config_note(fault: &crate::config::ConfigFault) -> Vec<String> {
+    vec![
+        format!(
+            "warning: {} does not load ({})",
+            fault.path.display(),
+            fault.summary()
+        ),
+        "  the blueprint is still checked; the model and read-path checks that need a config \
+         are skipped"
+            .to_string(),
+    ]
+}
+
 /// Run `lev validate`: check a blueprint and print what is wrong with it.
 pub(crate) async fn execute(args: ValidateArgs) -> anyhow::Result<()> {
-    let config = crate::config::Config::load().ok();
+    // A config that will not load used to be swallowed whole here: `.ok()`
+    // turned it into `None`, and the checks that need a config - which models
+    // an install would use, which read paths are granted - quietly stopped
+    // running. The blueprint still validates without one, so this stays a
+    // warning rather than a refusal, but it is said out loud now.
+    let config = match crate::config::Config::load_faulted() {
+        Ok(config) => Some(config),
+        Err(fault) => {
+            for line in broken_config_note(&fault) {
+                eprintln!("{line}");
+            }
+            None
+        }
+    };
     // Appended to a load failure, and only when the file is an installed copy
     // of a bundled agent this build ships a different version of. Then the
     // answer is "reinstall it", not "debug your graph".
@@ -2195,5 +2228,50 @@ brain = { kind = "custom", script = "hooks/brain.rhai", max_tokens = 1000 }
         // Pass the *file* path directly, not the directory.
         let checked = check_manifest(&manifest_path).unwrap();
         assert_eq!(checked.blueprint.name, "ok-agent");
+    }
+
+    /// The blueprint is still validated when the config file will not load,
+    /// and the warning goes out on the way past.
+    #[tokio::test]
+    async fn execute_warns_about_a_broken_config_and_still_checks_the_blueprint() {
+        crate::config::with_isolated_config_path_async(
+            "validate-broken-config",
+            |dir| async move {
+                std::fs::write(
+                    dir.join("config.toml"),
+                    "default_provider = \"anthropic\"\nbroken : :\n",
+                )
+                .unwrap();
+                let manifest_dir = tempfile::tempdir().unwrap();
+                write_test_agent(manifest_dir.path(), CLEAN_MANIFEST);
+                assert!(
+                    execute(args_for(manifest_dir.path())).await.is_ok(),
+                    "a blueprint is checked whether or not the config loads"
+                );
+            },
+        )
+        .await;
+    }
+
+    /// `lev validate` used to swallow a config that would not load: `.ok()`
+    /// made it `None`, the model and read-path checks silently stopped
+    /// running, and the command reported a clean blueprint the daemon would
+    /// then refuse to run the way it described.
+    #[test]
+    fn a_config_that_does_not_load_is_said_out_loud_rather_than_swallowed() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "default_provider = \"anthropic\"\nbroken : :\n").unwrap();
+        let fault = crate::config::ConfigFault::check(&path).expect("it does not load");
+
+        let joined = broken_config_note(&fault).join("\n");
+        assert!(joined.starts_with("warning: "), "{joined}");
+        assert!(joined.contains("does not load"), "{joined}");
+        assert!(joined.contains("line 2, column 8"), "{joined}");
+        assert!(
+            joined.contains("blueprint is still checked"),
+            "it says what still ran: {joined}"
+        );
+        assert!(joined.contains("skipped"), "and what did not: {joined}");
     }
 }

--- a/crates/leviath-cli/src/config/fault.rs
+++ b/crates/leviath-cli/src/config/fault.rs
@@ -1,0 +1,307 @@
+//! Why `config.toml` would not load, in enough detail to point at the spot.
+//!
+//! Loading a config used to fail as an `anyhow::Error` carrying one flattened
+//! string. That is fine for a command about to exit and print it, and useless
+//! everywhere else: the daemon keeps running on its last good config, and the
+//! surfaces that then have to *explain* that - a JSON field, a dashboard
+//! banner two lines tall, a doctor check - each need the file, the one-line
+//! reason, and where in the file it is, separately.
+//!
+//! So the loader produces a [`ConfigFault`] and the string is derived from it
+//! rather than the other way round. `Display` is still the sentence the CLI
+//! printed before, so nothing that only wanted the string had to change.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Which step of loading refused the file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FaultKind {
+    /// The file exists and could not be read.
+    Read,
+    /// The bytes are not TOML this build can parse, or a value has the wrong
+    /// type for the field it was given to.
+    Parse,
+    /// It parsed, and then one of its values was refused: an endpoint with no
+    /// address, an MCP server with no command.
+    Validation,
+}
+
+impl FaultKind {
+    /// The word the API and the log use for this kind.
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Read => "read",
+            Self::Parse => "parse",
+            Self::Validation => "validation",
+        }
+    }
+}
+
+/// A config file that will not load, and everything a surface needs to say so.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfigFault {
+    /// Which step refused it.
+    pub(crate) kind: FaultKind,
+    /// The file. Carried on the fault rather than assumed by each reader,
+    /// because `LEVIATH_CONFIG_PATH` and `LEVIATH_HOME` both move it.
+    pub(crate) path: PathBuf,
+    /// One line, no caret art: what a banner, a JSON field or a status line
+    /// shows.
+    pub(crate) message: String,
+    /// 1-based line, when the failure has a place in the file. A validation
+    /// failure has none: it is about a value, not a byte offset.
+    pub(crate) line: Option<usize>,
+    /// 1-based column, alongside [`line`](Self::line).
+    pub(crate) column: Option<usize>,
+    /// The config key a validation failure is about, dotted
+    /// (`model_providers.local`). `None` for a parse failure, which has a
+    /// position instead.
+    pub(crate) key: Option<String>,
+    /// The full rendering, including the caret art `toml` draws under the
+    /// offending line. What the log and `lev validate` print when there is
+    /// room for more than one line.
+    pub(crate) detail: String,
+}
+
+impl ConfigFault {
+    /// The file is there and could not be read.
+    pub(crate) fn read(path: &Path, e: &std::io::Error) -> Self {
+        Self {
+            kind: FaultKind::Read,
+            path: path.to_path_buf(),
+            message: e.to_string(),
+            line: None,
+            column: None,
+            key: None,
+            detail: format!("Failed to read config from '{}': {e}", path.display()),
+        }
+    }
+
+    /// The bytes did not parse. `content` is what was parsed, and is what
+    /// turns the error's byte span into a line and a column.
+    pub(crate) fn parse(path: &Path, content: &str, e: &toml::de::Error) -> Self {
+        // `unzip` rather than a match on the option: an error with no span is
+        // rare enough that a branch for it would be a region no test reaches,
+        // and "both or neither" is exactly what the two fields mean.
+        let (line, column) = e
+            .span()
+            .map(|span| line_and_column(content, span.start))
+            .unzip();
+        Self {
+            kind: FaultKind::Parse,
+            path: path.to_path_buf(),
+            message: one_line(e.message()),
+            line,
+            column,
+            key: None,
+            detail: format!("Failed to parse config: {e}"),
+        }
+    }
+
+    /// It parsed and a value was refused. `key` is the dotted config key the
+    /// refusal is about, which is the thing the user has to go and edit.
+    pub(crate) fn validation(path: &Path, key: &str, message: &str) -> Self {
+        Self {
+            kind: FaultKind::Validation,
+            path: path.to_path_buf(),
+            message: one_line(message),
+            line: None,
+            column: None,
+            key: Some(key.to_string()),
+            detail: message.to_string(),
+        }
+    }
+
+    /// Read `path` only to find out whether it loads, without keeping the
+    /// config it produces.
+    ///
+    /// For the surfaces that report rather than serve: the dashboard header
+    /// and `lev doctor` both want the answer and neither has any use for the
+    /// `Config`. A missing file is not a fault - no config means defaults.
+    pub(crate) fn check(path: &Path) -> Option<Self> {
+        super::Config::read_file(path).err().map(|boxed| *boxed)
+    }
+
+    /// Where in the file, in words, when that is known.
+    ///
+    /// A parse failure has a position and a validation failure has a key, and
+    /// a reader wants whichever there is without asking which kind it holds.
+    pub(crate) fn location(&self) -> Option<String> {
+        if let (Some(line), Some(column)) = (self.line, self.column) {
+            return Some(format!("line {line}, column {column}"));
+        }
+        self.key.clone()
+    }
+
+    /// The whole fault on one line: where, then what.
+    ///
+    /// This is what fits in a banner, a spawn warning and a doctor check, so
+    /// it is written once here rather than assembled slightly differently at
+    /// each of them.
+    pub(crate) fn summary(&self) -> String {
+        match self.location() {
+            Some(place) => format!("{place}: {}", self.message),
+            None => self.message.clone(),
+        }
+    }
+}
+
+impl fmt::Display for ConfigFault {
+    /// The sentence the CLI printed before any of this existed, so a caller
+    /// that only ever wanted a string keeps getting the same one.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.detail)
+    }
+}
+
+impl std::error::Error for ConfigFault {}
+
+/// Collapse a message onto one line, so a banner or a JSON field never gets a
+/// newline it has no way to draw.
+fn one_line(message: &str) -> String {
+    message.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// The 1-based line and column of a byte offset in `content`.
+///
+/// The column counts characters rather than bytes, matching how `toml` renders
+/// its own position and how an editor counts: a comment in Japanese above the
+/// broken line should not push the caret off the end of it.
+fn line_and_column(content: &str, offset: usize) -> (usize, usize) {
+    let mut line = 1;
+    let mut column = 1;
+    for (idx, ch) in content.char_indices() {
+        // Stop at the character the offset lands in, rather than past it: a
+        // span that names a byte in the middle of one should point at that
+        // character, and an offset past the end simply consumes everything.
+        if idx + ch.len_utf8() > offset {
+            break;
+        }
+        match ch {
+            '\n' => {
+                line += 1;
+                column = 1;
+            }
+            _ => column += 1,
+        }
+    }
+    (line, column)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A syntax error keeps the place it happened, so a banner can point at it.
+    #[test]
+    fn a_syntax_error_carries_a_line_and_a_column() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "default_provider = \"anthropic\"\nbroken : :\n").unwrap();
+
+        let fault = ConfigFault::check(&path).expect("a syntax error is a fault");
+        assert_eq!(fault.kind, FaultKind::Parse);
+        assert_eq!(fault.line, Some(2), "{fault:?}");
+        assert_eq!(fault.column, Some(8), "{fault:?}");
+        assert_eq!(fault.path, path);
+        assert!(fault.key.is_none());
+        // Bound first: a lazy format argument only evaluates on failure, and
+        // the 100% gate counts it as a region nothing reached.
+        let summary = fault.summary();
+        assert!(summary.starts_with("line 2, column 8: "), "{summary}");
+    }
+
+    /// A refused value keeps the key it is about, which is what the user edits.
+    #[test]
+    fn a_validation_failure_carries_the_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[model_providers.local]\nkind = \"openai-compatible\"\n",
+        )
+        .unwrap();
+
+        let fault = ConfigFault::check(&path).expect("an endpoint with no base_url is a fault");
+        assert_eq!(fault.kind, FaultKind::Validation);
+        assert_eq!(fault.key.as_deref(), Some("model_providers.local"));
+        assert!(fault.line.is_none());
+        let summary = fault.summary();
+        assert!(summary.starts_with("model_providers.local: "), "{summary}");
+    }
+
+    /// A file that loads is no fault, and neither is one that is not there.
+    #[test]
+    fn a_good_file_and_a_missing_file_are_both_healthy() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        assert!(
+            ConfigFault::check(&path).is_none(),
+            "no file means defaults"
+        );
+
+        std::fs::write(&path, "default_provider = \"anthropic\"\n").unwrap();
+        assert!(ConfigFault::check(&path).is_none());
+    }
+
+    /// A directory is not readable as a file, and says so without a position.
+    #[test]
+    fn an_unreadable_path_is_a_read_fault() {
+        let dir = tempfile::tempdir().unwrap();
+        let fault = ConfigFault::check(dir.path()).expect("a directory is not a config file");
+        assert_eq!(fault.kind, FaultKind::Read);
+        assert_eq!(fault.kind.as_str(), "read");
+        assert!(fault.location().is_none());
+        assert_eq!(fault.summary(), fault.message);
+        assert!(fault.to_string().contains("Failed to read config from"));
+    }
+
+    /// The other two kinds name themselves for the API and the log.
+    #[test]
+    fn every_kind_has_a_word() {
+        assert_eq!(FaultKind::Parse.as_str(), "parse");
+        assert_eq!(FaultKind::Validation.as_str(), "validation");
+    }
+
+    /// A multi-byte character before the fault moves the column by one per
+    /// character, not one per byte.
+    #[test]
+    fn the_column_counts_characters_rather_than_bytes() {
+        assert_eq!(line_and_column("# ありがとう\nx", 0), (1, 1));
+        // The `x` sits on line 2, whatever the comment above it cost in bytes.
+        let content = "# ありがとう\nx";
+        let offset = content.find('x').unwrap();
+        assert_eq!(line_and_column(content, offset), (2, 1));
+    }
+
+    /// An offset that lands inside a character, or past the end, answers
+    /// rather than panicking.
+    #[test]
+    fn an_offset_off_a_boundary_still_answers() {
+        // Byte 3 is inside the second character of "あい".
+        assert_eq!(line_and_column("あい", 4), (1, 2));
+        assert_eq!(line_and_column("ab", 99), (1, 3));
+    }
+
+    /// A value of the wrong type is a parse failure too, and points at the
+    /// value rather than at the key.
+    #[test]
+    fn a_wrongly_typed_value_points_at_the_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(&path, "default_provider = 7\n").unwrap();
+
+        let fault = ConfigFault::check(&path).expect("a number is not a provider name");
+        assert_eq!(fault.kind, FaultKind::Parse);
+        assert_eq!(fault.line, Some(1), "{fault:?}");
+        assert_eq!(fault.column, Some(20), "{fault:?}");
+    }
+
+    /// Whitespace and newlines are squeezed out of a message before it reaches
+    /// a one-line surface.
+    #[test]
+    fn a_message_is_flattened_onto_one_line() {
+        assert_eq!(one_line("two\nlines   here"), "two lines here");
+    }
+}

--- a/crates/leviath-cli/src/config/mod.rs
+++ b/crates/leviath-cli/src/config/mod.rs
@@ -20,6 +20,12 @@ pub(crate) use security::*;
 mod serve;
 pub(crate) use serve::*;
 
+// Why a config file would not load, kept structured rather than flattened into
+// a string, so the surfaces that have to explain a broken file can point at
+// the line or the key instead of pasting a paragraph.
+mod fault;
+pub(crate) use fault::ConfigFault;
+
 // Two helpers with no `[table]` of their own: reading a repository's `.env`,
 // and hardening the config file's permissions. Private to this module; the
 // tests below reach them through the imports here.
@@ -420,6 +426,16 @@ impl Config {
     /// After loading from file (or using defaults), environment variables are
     /// checked as fallbacks. Env vars override config file values if set.
     pub fn load() -> anyhow::Result<Self> {
+        Ok(Self::load_faulted()?)
+    }
+
+    /// [`load`](Self::load) keeping the structure of a failure, for the
+    /// callers that report one instead of exiting on it.
+    ///
+    /// `lev doctor` is why: it turns a config that will not load into a check,
+    /// and a check that can point at the line beats one that pastes the
+    /// loader's paragraph.
+    pub(crate) fn load_faulted() -> Result<Self, Box<ConfigFault>> {
         // In the crate's own test build, refuse to read the *real* environment.
         //
         // `Config::load()` reads process-wide state, and `cargo test` runs tests
@@ -478,7 +494,7 @@ impl Config {
             load_dotenv_filtered(".env");
         }
 
-        let config = Self::load_from_path(&Self::config_path())?;
+        let config = Self::load_from_path_faulted(&Self::config_path())?;
 
         // Check config file permissions on Unix
         check_permissions();
@@ -612,40 +628,73 @@ impl Config {
         unknown
     }
 
+    /// The file half of loading: read, parse, validate. Everything that can
+    /// blame the file lives here, and it fails with a [`ConfigFault`] rather
+    /// than a flattened string so a caller can say *where*.
+    ///
+    /// Split out of [`load_from_path`](Self::load_from_path) because the
+    /// health surfaces - the dashboard banner, `lev doctor`, `GET
+    /// /api/config` - want exactly this question answered and have no use for
+    /// the environment fallbacks or the keychain lookup that follow it.
+    /// [`ConfigFault::check`] is the no-config-wanted form.
+    pub(crate) fn read_file(path: &std::path::Path) -> Result<Self, Box<ConfigFault>> {
+        if !path.exists() {
+            let path_display = path.display();
+            tracing::debug!("No config file found at {}, using defaults", path_display);
+            return Ok(Self::default());
+        }
+        let content =
+            std::fs::read_to_string(path).map_err(|e| Box::new(ConfigFault::read(path, &e)))?;
+
+        let c: Self = toml::from_str(&content)
+            .map_err(|e| Box::new(ConfigFault::parse(path, &content, &e)))?;
+
+        Self::warn_unknown_config_keys(&content);
+        c.warn_qualified_default_model();
+
+        // Catch a malformed MCP server entry here, at load, rather than at
+        // the first tool call: a typo that drops a server's tools should
+        // fail loudly and immediately.
+        for server in &c.mcp_servers {
+            server.validate().map_err(|e| {
+                Box::new(ConfigFault::validation(
+                    path,
+                    &format!("mcp_servers.{}", server.name),
+                    &e.to_string(),
+                ))
+            })?;
+        }
+        // An endpoint with no address is the same kind of mistake, and is
+        // named against its table for the same reason.
+        for (name, provider) in &c.model_providers {
+            provider.validate(name).map_err(|e| {
+                Box::new(ConfigFault::validation(
+                    path,
+                    &format!("model_providers.{name}"),
+                    &e.to_string(),
+                ))
+            })?;
+        }
+
+        let path_display = path.display();
+        tracing::debug!("Loaded config from {}", path_display);
+        Ok(c)
+    }
+
     /// Core of `load()`, parameterized by path so it can be exercised in
     /// tests against a tempfile instead of the real `~/.leviath/config.toml`.
     fn load_from_path(path: &std::path::Path) -> anyhow::Result<Self> {
-        let mut config = if !path.exists() {
-            let path_display = path.display();
-            tracing::debug!("No config file found at {}, using defaults", path_display);
-            Self::default()
-        } else {
-            let content = std::fs::read_to_string(path).map_err(|e| {
-                anyhow::anyhow!("Failed to read config from '{}': {}", path.display(), e)
-            })?;
+        Ok(Self::load_from_path_faulted(path)?)
+    }
 
-            let c: Self = toml::from_str(&content)
-                .map_err(|e| anyhow::anyhow!("Failed to parse config: {}", e))?;
-
-            Self::warn_unknown_config_keys(&content);
-            c.warn_qualified_default_model();
-
-            // Catch a malformed MCP server entry here, at load, rather than at
-            // the first tool call: a typo that drops a server's tools should
-            // fail loudly and immediately.
-            for server in &c.mcp_servers {
-                server.validate()?;
-            }
-            // An endpoint with no address is the same kind of mistake, and is
-            // named against its table for the same reason.
-            for (name, provider) in &c.model_providers {
-                provider.validate(name)?;
-            }
-
-            let path_display = path.display();
-            tracing::debug!("Loaded config from {}", path_display);
-            c
-        };
+    /// [`load_from_path`](Self::load_from_path) keeping the structure of a
+    /// failure, for the callers that report one rather than exit on it.
+    ///
+    /// The daemon's reloader is the reason this exists: it keeps serving the
+    /// last good config and has to be able to *say* what is wrong with the
+    /// new one, down to the line.
+    pub(crate) fn load_from_path_faulted(path: &std::path::Path) -> Result<Self, Box<ConfigFault>> {
+        let mut config = Self::read_file(path)?;
 
         // Env var fallbacks (env vars override config file if set)
         if config.providers.anthropic_api_key.is_none() {

--- a/crates/leviath-cli/src/daemon/client.rs
+++ b/crates/leviath-cli/src/daemon/client.rs
@@ -265,6 +265,35 @@ fn spawn_warning_lines(
     lines
 }
 
+/// Say, before the run starts, that the config file on disk does not load.
+///
+/// This is the one warning here that is not about the blueprint. The daemon
+/// keeps serving the last config that loaded, so the run *works* - on settings
+/// the user may have edited an hour ago and believes are in force. Every other
+/// warning on this path exists because the daemon only said it in its own log;
+/// this one existed nowhere at all.
+fn warn_broken_config() {
+    for line in broken_config_warning(&crate::config::Config::config_path()) {
+        eprintln!("{line}");
+    }
+}
+
+/// The warning for a config file at `path`. Empty when it loads, which is why
+/// this is pure: the wording is worth a test and a real `~/.leviath` is not.
+fn broken_config_warning(path: &std::path::Path) -> Vec<String> {
+    let Some(fault) = crate::config::ConfigFault::check(path) else {
+        return Vec::new();
+    };
+    vec![
+        format!(
+            "warning: '{}' does not load ({}); this run uses the last config that did",
+            path.display(),
+            fault.summary()
+        ),
+        "  fix the file and the next run picks it up; nothing needs restarting".to_string(),
+    ]
+}
+
 /// Say, before the run starts, that `--yolo` will still stop for a person.
 ///
 /// `--yolo` means "run without me", so a run that stops anyway reads as a hang.
@@ -379,6 +408,7 @@ pub(crate) async fn send_spawn(
     spawn_args: SpawnArgs,
     json: bool,
 ) -> anyhow::Result<()> {
+    warn_broken_config();
     warn_ungranted_read_paths(&spawn_args);
     warn_held_checkpoints(&spawn_args);
     let spawned = spawn_once(client, spawn_args).await?;
@@ -410,7 +440,9 @@ pub async fn send_spawn_batch(
     if count == 1 {
         return send_spawn(client, spawn_args, json).await;
     }
-    // The warnings describe the blueprint, not the individual run: once.
+    // The warnings describe the blueprint and the machine, not the individual
+    // run: once.
+    warn_broken_config();
     warn_ungranted_read_paths(&spawn_args);
     warn_held_checkpoints(&spawn_args);
     let mut spawned = Vec::with_capacity(count);
@@ -1200,6 +1232,54 @@ allow = ["/data/runs"]
         assert!(joined.contains("agent 'cto'"), "{joined}");
         assert!(joined.contains("[agent_read_paths.cto]"), "{joined}");
         assert!(joined.contains(r#"allow = ["/data/runs"]"#), "{joined}");
+    }
+
+    /// A run started against a broken config file works, on settings that are
+    /// not the ones on disk. Nothing said so before this.
+    #[test]
+    fn a_config_that_does_not_load_warns_once_before_the_run_starts() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        std::fs::write(&path, "default_provider = \"anthropic\"\n").unwrap();
+        assert!(
+            broken_config_warning(&path).is_empty(),
+            "a file that loads says nothing"
+        );
+        assert!(
+            broken_config_warning(&dir.path().join("absent.toml")).is_empty(),
+            "no config file means defaults, not a broken one"
+        );
+
+        std::fs::write(&path, "default_provider = \"anthropic\"\nbroken : :\n").unwrap();
+        let joined = broken_config_warning(&path).join("\n");
+        assert!(joined.starts_with("warning: "), "{joined}");
+        assert!(joined.contains("does not load"), "{joined}");
+        assert!(joined.contains("line 2, column 8"), "{joined}");
+        assert!(
+            joined.contains("last config that did"),
+            "it says which config the run is actually on: {joined}"
+        );
+        assert!(
+            joined.contains("nothing needs restarting"),
+            "and what to do about it: {joined}"
+        );
+    }
+
+    /// The wrapper the spawn path actually calls, driven against an isolated
+    /// config so it never reads the developer's real `~/.leviath`.
+    #[test]
+    fn the_spawn_path_warning_reads_the_configured_path() {
+        crate::config::with_isolated_config_path("client-broken-config", |dir| {
+            std::fs::write(dir.join("config.toml"), "broken : :").unwrap();
+            // Prints to stderr; the wording is asserted above, and this is
+            // about the wrapper reaching the right file.
+            warn_broken_config();
+            assert!(
+                !broken_config_warning(&crate::config::Config::config_path()).is_empty(),
+                "the isolated config is what it read"
+            );
+        });
     }
 
     #[test]

--- a/crates/leviath-cli/src/daemon/config_reload.rs
+++ b/crates/leviath-cli/src/daemon/config_reload.rs
@@ -31,15 +31,61 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};
 use std::time::SystemTime;
 
-use crate::config::Config;
+use crate::config::{Config, ConfigFault};
 
 /// The config as of a given file mtime.
 struct Cached {
-    /// The file mtime this config was loaded from. `None` means the file did
-    /// not exist at load time (defaults in use); it reloads if the file later
+    /// The mtime this reloader last *looked at*, good or bad. `None` means the
+    /// file did not exist then (defaults in use); it reloads if the file later
     /// appears.
+    ///
+    /// Advanced on a failed load as well as a successful one, which is what
+    /// makes a broken file cost one stat per spawn instead of a stat, a read,
+    /// a parse and a log line. The comment here used to claim that already;
+    /// the code only did it in the `Ok` arm.
     mtime: Option<SystemTime>,
+    /// The mtime of the config actually in force. Differs from
+    /// [`mtime`](Self::mtime) exactly while the file on disk is broken, and is
+    /// what "the last good config" means as a fact a client can check.
+    loaded_mtime: Option<SystemTime>,
     config: Arc<Config>,
+    /// Why the file on disk does not load, while it does not.
+    fault: Option<ConfigFault>,
+    /// When [`fault`](Self::fault) was first seen, so a surface can say how
+    /// long the config has been broken rather than only that it is.
+    since: Option<SystemTime>,
+}
+
+/// Whether `config.toml` loads, and what is running while it does not.
+///
+/// The reloader has always kept the last good config when a save did not
+/// parse. What it did not do was tell anyone: the single `tracing::warn!` went
+/// to the daemon log, so a user with a typo watched their edits do nothing and
+/// had no way to find out why. This is that fact, in a shape the API, the
+/// dashboard and the CLI can each render.
+#[derive(Debug, Clone)]
+pub(crate) struct ConfigHealth {
+    /// The file being watched.
+    pub(crate) path: PathBuf,
+    /// `None` while the file on disk loads.
+    pub(crate) fault: Option<ConfigFault>,
+    /// When the fault was first seen.
+    pub(crate) since: Option<SystemTime>,
+    /// The mtime of the config in force. While `fault` is set this is the last
+    /// good save, not what is on disk.
+    pub(crate) loaded_mtime: Option<SystemTime>,
+    /// The config in force, handed back with the health rather than fetched
+    /// beside it: a caller that asked both questions separately could catch a
+    /// save landing between the two and answer with a config and a verdict
+    /// that disagree about whether it had been seen.
+    pub(crate) config: Arc<Config>,
+}
+
+impl ConfigHealth {
+    /// Whether the file on disk loads.
+    pub(crate) fn is_healthy(&self) -> bool {
+        self.fault.is_none()
+    }
 }
 
 /// What to re-apply when `config.toml` reloads, for settings that live
@@ -73,7 +119,10 @@ impl ConfigReloader {
             path: Some(path),
             cache: Mutex::new(Cached {
                 mtime,
+                loaded_mtime: mtime,
                 config: Arc::new(initial),
+                fault: None,
+                since: None,
             }),
             on_reload: None,
         }
@@ -98,7 +147,10 @@ impl ConfigReloader {
             path: None,
             cache: Mutex::new(Cached {
                 mtime: None,
+                loaded_mtime: None,
                 config: Arc::new(config),
+                fault: None,
+                since: None,
             }),
             on_reload: None,
         }
@@ -108,24 +160,48 @@ impl ConfigReloader {
     /// unchanged, or a freshly loaded one when its mtime moved.
     ///
     /// A reload that fails to parse (an edit saved half-written, a syntax
-    /// error) does not fail the caller - it logs a warning and returns the
+    /// error) does not fail the caller - it records the fault and returns the
     /// last good config, so a broken file degrades to "your last saved config"
-    /// rather than a broken spawn. The stale mtime is retained, so the next
-    /// successful save is picked up.
+    /// rather than a broken spawn. [`health`](Self::health) is how anyone
+    /// finds out that happened.
     pub(crate) fn current(&self) -> Arc<Config> {
+        self.refresh().config.clone()
+    }
+
+    /// Whether the file on disk loads, and what is running while it does not.
+    ///
+    /// Re-checks the file first, exactly as [`current`](Self::current) does,
+    /// so a caller polling only this still notices a save. Costs one `stat`
+    /// when nothing changed.
+    pub(crate) fn health(&self) -> ConfigHealth {
+        let cached = self.refresh();
+        ConfigHealth {
+            // A fixed reloader watches no file and can never be unhealthy; the
+            // empty path says "there is nothing being watched here".
+            path: self.path.clone().unwrap_or_default(),
+            fault: cached.fault.clone(),
+            since: cached.since,
+            loaded_mtime: cached.loaded_mtime,
+            config: cached.config.clone(),
+        }
+    }
+
+    /// Re-read the file if its mtime moved, and hand back the cache to read.
+    ///
+    /// The whole state machine lives here so `current` and `health` cannot
+    /// disagree about whether a save has been seen.
+    fn refresh(&self) -> std::sync::MutexGuard<'_, Cached> {
+        let mut cached = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
         let Some(path) = &self.path else {
             // A fixed reloader: nothing to watch.
-            return self
-                .cache
-                .lock()
-                .unwrap_or_else(PoisonError::into_inner)
-                .config
-                .clone();
+            return cached;
         };
         let mtime = file_mtime(path);
-        let mut cached = self.cache.lock().unwrap_or_else(PoisonError::into_inner);
         if mtime == cached.mtime {
-            return cached.config.clone();
+            // Includes the broken case: the failing mtime is recorded below,
+            // so a file that will not parse is stat'd once per call and read,
+            // parsed and logged exactly once per save.
+            return cached;
         }
         // Bind the displayed path in a plain statement rather than as a lazy
         // `%path.display()` tracing field: the method-call region inside a
@@ -134,10 +210,11 @@ impl ConfigReloader {
         // unreachable under a coverage run whose other tests hit it with no
         // subscriber. A pre-bound value sidesteps that.
         let displayed = path.display();
-        match Config::load_from_path_public(path) {
+        cached.mtime = mtime;
+        match Config::load_from_path_faulted(path) {
             Ok(config) => {
                 let config = Arc::new(config);
-                cached.mtime = mtime;
+                cached.loaded_mtime = mtime;
                 cached.config = config.clone();
                 // Under the cache lock on purpose: the hook re-applies settings
                 // that have been copied elsewhere, and two threads reloading at
@@ -146,21 +223,88 @@ impl ConfigReloader {
                 if let Some(hook) = &self.on_reload {
                     hook(&config);
                 }
-                tracing::info!(path = %displayed, "reloaded config after an on-disk change");
-                config
+                // Recovery is news in its own right: the operator wants to
+                // know their fix took, and a client watching health needs the
+                // edge to clear its banner.
+                match cached.fault.take() {
+                    Some(_) => {
+                        cached.since = None;
+                        tracing::info!(
+                            path = %displayed,
+                            "config parses again; reloaded and back on the file on disk"
+                        );
+                    }
+                    None => {
+                        tracing::info!(path = %displayed, "reloaded config after an on-disk change")
+                    }
+                }
             }
-            Err(e) => {
-                // Keep the last-good config AND its mtime: retrying the same
-                // broken file every spawn would spam the log, and we want the
-                // *next* good save (a new mtime) to reload.
+            Err(fault) => {
+                // Keep the last good config *and* its mtime, so the running
+                // config stays exactly what it was. Only the "mtime last
+                // looked at" moves, which is what stops this from re-reading
+                // and re-warning on every spawn.
+                let summary = fault.summary();
+                let kind = fault.kind.as_str();
+                if cached.fault.is_none() {
+                    cached.since = Some(SystemTime::now());
+                }
+                cached.fault = Some(*fault);
                 tracing::warn!(
                     path = %displayed,
-                    error = %e,
-                    "config changed on disk but failed to reload; keeping the last good config"
+                    kind,
+                    error = %summary,
+                    "config changed on disk but failed to load; keeping the last good config"
                 );
-                cached.config.clone()
             }
         }
+        cached
+    }
+}
+
+/// Watches `config.toml` only to report whether it loads.
+///
+/// The read-only half of [`ConfigReloader`], for the surfaces that have to
+/// *say* the file is broken without serving anything from it: the dashboard
+/// header, redrawn ten times a second, and `lev doctor`. It keeps no config
+/// and logs nothing, which is what makes it safe to poll from inside a draw
+/// loop.
+///
+/// mtime-gated like the reloader, for the same reason: a poll on a file that
+/// has not been saved is one `stat`, so a tick can afford to ask every time.
+pub(crate) struct ConfigWatch {
+    path: PathBuf,
+    /// The mtime last judged. `None` before the first poll, which is why
+    /// [`checked`](Self::checked) exists rather than treating `None` as "no
+    /// file".
+    mtime: Option<SystemTime>,
+    checked: bool,
+    fault: Option<ConfigFault>,
+}
+
+impl ConfigWatch {
+    /// Watch `path`, without reading it yet. The first
+    /// [`poll`](Self::poll) does that.
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            mtime: None,
+            checked: false,
+            fault: None,
+        }
+    }
+
+    /// Why the file does not load, re-reading it only if it has been saved
+    /// since the last call.
+    pub(crate) fn poll(&mut self) -> Option<&ConfigFault> {
+        let mtime = file_mtime(&self.path);
+        if self.checked && mtime == self.mtime {
+            return self.fault.as_ref();
+        }
+        self.checked = true;
+        self.mtime = mtime;
+        self.fault = ConfigFault::check(&self.path);
+        self.fault.as_ref()
     }
 }
 
@@ -184,8 +328,14 @@ mod tests {
     /// hot-reload test helper).
     fn bump_mtime(path: &std::path::Path) {
         let later = SystemTime::now() + Duration::from_secs(5);
+        set_mtime(path, later);
+    }
+
+    /// Pin a file's mtime to an exact instant, so a test can rewrite the
+    /// contents *without* the reloader seeing a new save.
+    fn set_mtime(path: &std::path::Path, at: SystemTime) {
         let f = std::fs::OpenOptions::new().write(true).open(path).unwrap();
-        f.set_modified(later).unwrap();
+        f.set_modified(at).unwrap();
     }
 
     /// A complete, valid config TOML (several top-level fields have no serde
@@ -360,5 +510,184 @@ mod tests {
             reloader.current().read_path_grants_for_agent("cto"),
             vec!["~/fixed".to_string()]
         );
+    }
+
+    /// A reloader seeded from a file that already loads, as boot does.
+    fn seeded(path: &std::path::Path) -> ConfigReloader {
+        ConfigReloader::new(
+            path.to_path_buf(),
+            Config::load_from_path_public(path).unwrap(),
+        )
+    }
+
+    #[test]
+    fn health_goes_unhealthy_on_a_bad_save_and_healthy_again_on_a_good_one() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &config_with_grant("cto", "~/good"));
+        let reloader = seeded(&path);
+        let good_mtime = file_mtime(&path);
+
+        let health = reloader.health();
+        assert!(health.is_healthy(), "{health:?}");
+        assert_eq!(health.path, path);
+        assert!(health.since.is_none());
+
+        write(&path, "broken : :");
+        bump_mtime(&path);
+
+        let health = reloader.health();
+        assert!(
+            !health.is_healthy(),
+            "a file that will not parse is not healthy"
+        );
+        assert!(health.since.is_some(), "the moment it broke is recorded");
+        assert_eq!(
+            health.loaded_mtime, good_mtime,
+            "the config in force is still the one that loaded"
+        );
+
+        // The user fixes it.
+        write(&path, &config_with_grant("cto", "~/fixed"));
+        bump_mtime(&path);
+
+        let health = reloader.health();
+        assert!(health.is_healthy(), "{health:?}");
+        assert!(health.since.is_none(), "recovery clears when it broke");
+        assert_ne!(
+            health.loaded_mtime, good_mtime,
+            "a newer config is in force"
+        );
+    }
+
+    #[test]
+    fn a_syntax_error_reports_a_line_and_column_and_a_bad_value_its_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &empty_config());
+        let reloader = seeded(&path);
+
+        write(&path, "default_provider = \"anthropic\"\nbroken : :\n");
+        bump_mtime(&path);
+        let fault = reloader.health().fault.expect("a syntax error is a fault");
+        assert_eq!(fault.line, Some(2), "{fault:?}");
+        assert_eq!(fault.column, Some(8), "{fault:?}");
+
+        write(
+            &path,
+            "[model_providers.local]\nkind = \"openai-compatible\"\n",
+        );
+        bump_mtime(&path);
+        let fault = reloader
+            .health()
+            .fault
+            .expect("an endpoint with no address is a fault");
+        assert_eq!(fault.key.as_deref(), Some("model_providers.local"));
+    }
+
+    /// The reloader must read and complain about a broken file once per save,
+    /// not once per spawn.
+    ///
+    /// Probed by rewriting the file to something valid while pinning its mtime
+    /// back to the failing save's: a reloader that re-reads on every call
+    /// would see the good content and go healthy, and one that remembers the
+    /// mtime it already judged cannot. Before this change the failing mtime
+    /// was never recorded, so every `current()` re-read, re-parsed and
+    /// re-warned - which is what the log spam was.
+    #[test]
+    fn a_broken_file_is_read_once_per_failing_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &config_with_grant("cto", "~/good"));
+        let reloader = seeded(&path);
+
+        write(&path, "broken : :");
+        bump_mtime(&path);
+        let broken_mtime = file_mtime(&path).expect("the file is there");
+        assert!(!reloader.health().is_healthy());
+
+        // Same mtime, different bytes: nothing has "saved", so nothing is read.
+        write(&path, &config_with_grant("cto", "~/sneaked"));
+        set_mtime(&path, broken_mtime);
+        assert!(
+            !reloader.health().is_healthy(),
+            "a file already judged at this mtime must not be read again"
+        );
+        assert_eq!(
+            reloader.current().read_path_grants_for_agent("cto"),
+            vec!["~/good".to_string()],
+            "and the config in force is still the last good one"
+        );
+
+        // A real save is a new mtime, and is picked up.
+        bump_mtime(&path);
+        assert!(reloader.health().is_healthy());
+        assert_eq!(
+            reloader.current().read_path_grants_for_agent("cto"),
+            vec!["~/sneaked".to_string()]
+        );
+    }
+
+    #[test]
+    fn two_bad_saves_in_a_row_keep_the_moment_the_config_first_broke() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &empty_config());
+        let reloader = seeded(&path);
+
+        write(&path, "broken : :");
+        bump_mtime(&path);
+        let first = reloader.health().since.expect("it broke");
+
+        write(&path, "still broken : :");
+        bump_mtime(&path);
+        assert_eq!(
+            reloader.health().since,
+            Some(first),
+            "a second failed save does not restart the clock"
+        );
+    }
+
+    #[test]
+    fn the_watch_reports_a_break_and_a_fix_and_re_reads_only_on_a_save() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut watch = ConfigWatch::new(path.clone());
+
+        // No file at all is not a fault: no config means defaults.
+        assert!(watch.poll().is_none());
+
+        write(&path, &empty_config());
+        bump_mtime(&path);
+        assert!(watch.poll().is_none());
+
+        write(&path, "default_provider = \"anthropic\"\nbroken : :\n");
+        bump_mtime(&path);
+        let fault = watch.poll().expect("a syntax error is a fault").clone();
+        assert_eq!(fault.line, Some(2));
+        assert_eq!(fault.column, Some(8));
+
+        // Same mtime, different bytes: nothing was saved, so nothing is read.
+        let broken_mtime = file_mtime(&path).expect("the file is there");
+        write(&path, &empty_config());
+        set_mtime(&path, broken_mtime);
+        assert_eq!(
+            watch.poll(),
+            Some(&fault),
+            "a file already judged at this mtime is not read again"
+        );
+
+        // A real save clears it.
+        bump_mtime(&path);
+        assert!(watch.poll().is_none());
+    }
+
+    #[test]
+    fn a_reloader_with_no_file_to_watch_is_always_healthy() {
+        let reloader = ConfigReloader::fixed(Config::default());
+        let health = reloader.health();
+        assert!(health.is_healthy());
+        assert_eq!(health.path, std::path::PathBuf::new());
+        assert!(health.loaded_mtime.is_none());
     }
 }

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -886,6 +886,51 @@ without an `agent`, since the answer is the same either way.
 Each listed provider carries a `provider` object with what its leading `// @` comments declare:
 `description`, `default_model`, `max_context_tokens`, `max_output_tokens` and `supports_streaming`.
 
+## When the config file will not load
+
+`GET /api/config` describes the config **in force**, which is not always the file on disk. A save
+that does not parse, or that sets a value Leviath refuses, leaves the last config that loaded in
+force: runs keep starting on it, and nothing about them changes. Without a way to say so, that
+looked exactly like an edit nobody had made.
+
+`config_error` is how the server says so. It is absent while the file loads, and present with the
+whole story while it does not:
+
+```json
+{
+  "default_provider": "anthropic",
+  "config_mtime": 1756000000,
+  "config_error": {
+    "kind": "parse",
+    "path": "/Users/you/.leviath/config.toml",
+    "message": "expected `.`, `=`",
+    "line": 12,
+    "column": 8,
+    "since": 1756000420,
+    "note": "The running config is the last one that loaded; edits to this file take effect only once it parses again."
+  }
+}
+```
+
+`kind` is `parse` for a syntax error or a value of the wrong type, `validation` for a value that
+parsed and was then refused, and `read` for a file that could not be read at all. A parse failure
+carries `line` and `column`, both 1-based; a validation failure carries `key` instead, the dotted
+config key it is about, such as `model_providers.local`. `message` is one line with no caret art in
+it, ready to put in a banner. `since` is when this server first saw the file in this state, in unix
+seconds.
+
+`config_mtime` is always there, error or not: it is the mtime of the config in force, so a client
+that just wrote the file can tell whether the write was picked up. While `config_error` is set it
+names the last good save rather than the file on disk.
+
+Nothing has to be restarted. Fix the file, and the next request answers with no `config_error` and
+the new values. Announced as the `config.health` capability; a server that does not announce it
+omits the field whether or not the file loads, so its absence proves nothing there.
+
+`PUT /api/config` is checked before it writes, with the same rules the loader applies, so this API
+cannot be the thing that breaks the file: a body that would produce a config this build refuses to
+read back answers **400** and the file is left byte for byte as it was.
+
 ## Gateways
 
 `gateways` on `GET /api/config` lists every `[model_providers.<name>]` entry, name-sorted, and
@@ -999,6 +1044,7 @@ than that feature, not broken.
 | `models.probe` | `POST /api/models/probe`, which asks an OpenAI-compatible server what it serves before a gateway for it is written; admin only |
 | `fs.mkdir` | `POST /api/fs/dirs`, so a folder picker can offer "New Folder" rather than one that 404s |
 | `interaction.feedback` | `feedback` beside `approved: false` on `POST /api/agents/{id}/interaction`, and the "Deny with feedback" option on a tool approval. An older daemon drops the field without a word, so a console should only offer the box where this is announced. See [answering a question](#answering-a-question) |
+| `config.health` | `config_error` and `config_mtime` on `GET /api/config`, and the `config_health` frame on the socket. Without it a missing `config_error` means nothing, so a console cannot tell a file that loads from a daemon that would not say. See [when the config file will not load](#when-the-config-file-will-not-load) |
 
 ## Live updates over WebSocket
 
@@ -1021,8 +1067,11 @@ sequenceDiagram
 
 ### The frames
 
-Every frame is a JSON object with a `type`, and every frame except `daemon_link` carries a
-`run_id`, which is what `/ws/agents/{id}` filters on.
+Every frame is a JSON object with a `type`. Every frame except `daemon_link` and `config_health`
+carries a `run_id`, which is what `/ws/agents/{id}` filters on. `daemon_link` reaches every
+subscription including a per-run one, because it explains why a run's frames stopped;
+`config_health` reaches only `/ws`, because a run in flight keeps going on the config it started
+with either way.
 
 | `type` | Sent when | Beyond `agent_id` and `run_id` |
 | --- | --- | --- |
@@ -1039,6 +1088,7 @@ Every frame is a JSON object with a `type`, and every frame except `daemon_link`
 | `interaction_needed` | The run is blocked on a person | `request` |
 | `agent_completed` | The run reaches a terminal status | `status`, `result` (its error), `final_output` |
 | `daemon_link` | This server's link to the daemon changes | `connected`, `daemon`, `restarted`, `restart_advised` |
+| `config_health` | `config.toml` stops loading, loads again, or breaks for a different reason | `healthy`, `path`, `error`, `config_mtime` |
 
 `agent_spend` arrives while the run is still going, which is the point: a run that quietly spends
 far more than intended looks, from the outside, exactly like one making ordinary progress. Each

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -654,6 +654,39 @@ This shapes request *rate*. `[limits] max_concurrent_inferences` and
 configure their rate limit under `[model_providers.<name>.rate_limit]` instead; their concurrency
 cap goes in `[limits.max_concurrent_inferences_by_provider]` with everyone else's.
 
+## When the file will not load
+
+A key Leviath does not recognize is a warning. A file it cannot *parse* is different: there is no
+config to read at all, so nothing can be applied.
+
+Leviath never falls back to defaults there, and never stops. **The last version of the file that
+loaded stays in force**, so runs in flight keep going and new ones still start. What changes is that
+your edits are not being read - and that is the part that used to be silent, which is what made a
+single typo cost an afternoon.
+
+Every surface now says so, and each one clears itself when the file parses again. Nothing has to be
+restarted:
+
+| Where | What you see |
+|---|---|
+| `lev run` | One line before the run starts: the file, where in it the problem is, and that this run is on the last config that loaded |
+| `lev ps` | The same fact under the run table |
+| `lev doctor` | The `config` check fails, with the line and column, or with the key |
+| `lev dash` | A warning across the top of the screen for as long as the file is broken |
+| `lev validate` | A warning that the model and read-path checks were skipped; the blueprint is still checked |
+| `GET /api/config` | A `config_error` object, and a `config_health` frame on `/ws`. See [the API reference](/docs/api#when-the-config-file-will-not-load) |
+
+Two kinds of problem are reported differently, because they are found differently:
+
+- A **syntax error**, or a value of the wrong type for its key, has a place in the file: it is
+  reported with a line and a column.
+- A **refused value** parsed fine and was then turned down - an `openai-compatible` gateway with no
+  `base_url`, an `[[mcp_servers]]` entry with neither a `command` nor a `url`. There is no position
+  to point at, so it is reported with the dotted key it is about, such as `model_providers.local`.
+
+The file is read once per save. A broken file nobody has touched since costs one `stat`, not a
+re-read and a fresh warning on every command.
+
 ## Keys nothing reads
 
 A key Leviath does not recognize is named at start-up rather than ignored, wherever it sits:

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -157,6 +157,25 @@ If a save leaves the file briefly unparseable, which happens while you are halfw
 edit, the daemon keeps serving the last version that worked. It reloads on your next clean save, so
 an in-progress edit never breaks a spawn.
 
+That is the right behaviour and it used to be invisible, which made it the wrong experience: a typo
+you did not spot meant every edit after it silently did nothing, and the only record was one line in
+`daemon.log`. So a config that will not load is now a state Leviath reports rather than a fact it
+keeps to itself:
+
+- `lev run` prints one line before the run starts, naming the file, where in it the problem is, and
+  that this run is on the last config that loaded.
+- `lev ps` puts the same fact under the run table.
+- `lev doctor` fails its `config` check with the line and column, or with the key for a value that
+  parsed and was then refused.
+- `lev dash` keeps a warning across the top of the screen for as long as the file is broken. It
+  clears itself when the file parses again.
+- `GET /api/config` carries a `config_error` object, and `/ws` sends a `config_health` frame each
+  time the answer changes. See [the API reference](/docs/api#when-the-config-file-will-not-load).
+
+The file is re-read once per save, not once per run: a broken file that nobody has touched since
+costs one `stat` and produces one log line, rather than a re-read and a fresh warning on every
+spawn. Fix the file and everything above clears on its own, with nothing restarted.
+
 `[model_providers.<name>]` reloads too, as of this release. A script provider's own `.rhai` file
 has always been re-read on each use, so a table beside it that needed a restart made two halves of
 one feature disagree in silence - setting a `base_url` and watching it do nothing looked exactly

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -57,6 +57,14 @@ panel and answer. `lev respond` does the same from the shell.
   daemon stops answering and again when it is back. While the daemon is unreachable, or came back
   on a different build than this dashboard, the run list wears a chip beside the sort chip. The
   second case is the one that asks something of you: restart `lev dash` so both run the same code.
+- **The config banner**: when `~/.leviath/config.toml` stops loading, a warning takes the top row of
+  every screen and stays there. It names the file, where in it the problem is - a line and column
+  for a syntax error, the key for a value that was refused - and says that runs are on the last
+  config that loaded, which is the part a broken file otherwise hides. It is a banner rather than a
+  toast because the condition lasts until somebody edits the file, and a message that faded three
+  seconds after the save cannot explain the run you start two minutes later. Fix the file and it
+  clears itself, with nothing restarted. On a narrow terminal the path gives way first, then the
+  reassurance; the error itself is the last thing cut.
 
 ## Keys
 

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -17,6 +17,36 @@ resolution, one real inference, and the daemon handoff, in that order, and repor
 check that fails tells you which section below you need. In particular it separates "my keys are
 wrong" from "the daemon is stuck", which look identical from the outside.
 
+## I edited config.toml and nothing changed
+
+The daemon picks up `~/.leviath/config.toml` on its own, so an edit that does nothing almost always
+means the file no longer parses. When that happens Leviath keeps serving **the last version of the
+file that loaded**: runs still start and still work, on the settings from before your edit. That is
+deliberate - a half-typed save should not break a spawn - and it is why the symptom is "nothing
+changed" rather than an error.
+
+Any of these will tell you:
+
+```bash
+lev doctor        # the `config` check fails, with the line and column, or the key
+lev ps            # a line under the run table
+lev run ...       # one line before the run starts
+lev dash          # a warning across the top of the screen, for as long as it lasts
+```
+
+The message names the file and where in it the problem is. A syntax error, or a value of the wrong
+type, comes with a line and a column. A value that parsed and was then refused - an
+`openai-compatible` gateway with no `base_url`, an `[[mcp_servers]]` entry with neither a `command`
+nor a `url` - comes with the key instead, such as `model_providers.local`.
+
+Fix the file and save it. Everything above clears on its own and the next run uses the new config;
+nothing needs restarting. If you would rather see it over HTTP, `GET /api/config` carries the same
+thing as a `config_error` object, and `/ws` sends a `config_health` frame each time the answer
+changes.
+
+A key Leviath simply does not recognize is a *different* problem: the file still loads, and the key
+is reported as one nothing reads. See [keys nothing reads](/docs/configuration#keys-nothing-reads).
+
 ## The install worked, but `lev` is not found
 
 The installer finished, and `lev --version` says `command not found`. Almost always the shell just

--- a/docs/schema/openapi.json
+++ b/docs/schema/openapi.json
@@ -1714,14 +1714,15 @@
           "503": {
             "$ref": "#/components/responses/Overloaded"
           }
-        }
+        },
+        "description": "Describes the config in force. When `config.toml` on disk does not load, the server keeps serving the last config that did and reports why here: `config_error` carries `kind` (`parse`, `validation` or `read`), `path`, a one-line `message`, `line` and `column` for a syntax error, `key` for a refused value, `since` in unix seconds, and a `note` saying the running config is the last good one. `config_mtime` is the mtime of that config, so a client can tell whether its own write was picked up. `config_error` is absent while the file loads. Announced as the `config.health` capability."
       },
       "put": {
         "tags": [
           "config"
         ],
         "summary": "Replace the configuration",
-        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed.",
+        "description": "Admin only. Mounted only when `lev serve --allow-admin` is passed. The body is validated with the same checks the loader makes, before anything is written, so a request that would produce a config this build refuses to read back answers 400 and leaves the file byte for byte as it was.",
         "responses": {
           "200": {
             "description": "The configuration as written, redacted.",
@@ -1840,7 +1841,7 @@
           "events"
         ],
         "summary": "Event stream for every run",
-        "description": "A WebSocket upgrade, not a JSON response. Authenticate with `?token=` since a browser cannot set a header on the handshake. Each frame is a ServerEvent.",
+        "description": "A WebSocket upgrade, not a JSON response. Authenticate with `?token=` since a browser cannot set a header on the handshake. Each frame is a ServerEvent. Frames about the machine rather than a run - `daemon_link` and `config_health` - arrive here. `config_health` is sent when `config.toml` stops loading, when it loads again, and when it is still broken for a different reason than the last frame gave, carrying the same error shape `GET /api/config` reports.",
         "parameters": [
           {
             "name": "token",


### PR DESCRIPTION
A bad config errors, is reported everywhere a person is looking, and is not loaded in.

## The state today

`crates/leviath-cli/src/daemon/config_reload.rs` is a lazy mtime-polled reloader
with no filesystem watcher. On a parse failure it already does the right thing
structurally, keeping the last good config, and the **only** signal is one
`tracing::warn!("config changed on disk but failed to reload; keeping the last
good config")` in the daemon log. Nothing reached the HTTP API, the dashboard or
the CLI, so a user with a typo in `config.toml` watched their edits silently do
nothing and had no way to find out why.

Two things were measured and turned out differently than the brief suggested:

- The reloader's own comment claimed it kept the failing mtime to avoid log
  spam. It did not: `cached.mtime` was only advanced in the `Ok` arm, so a
  broken file was re-stat'd, re-read, re-parsed and re-warned on **every** spawn
  and every `lev serve` request. Fixed here, with a test that fails against the
  old behaviour.
- The brief said "`lev validate` already validates a config file". It does not -
  it validates a *blueprint*, and it did `Config::load().ok()`, so a broken
  config became `None` and the checks that need one (which models an install
  would use, which read paths are granted) quietly stopped running. That is now
  a warning rather than silence.

## The four layers

**1. Daemon** (`ff9c083e`). `ConfigFault` carries the file, a one-line message,
the line and column of a syntax error or the dotted key of a refused value, and
the full rendering for a surface with room for it. `Config::read_file` and
`load_from_path_faulted` produce it; `load_from_path` still flattens it into the
same `anyhow` sentence, so nothing that only wanted the string changed.
`ConfigReloader::health()` reports the fault, the mtime of the config in force,
and when the fault was first seen, and hands the config back with the verdict so
two separate questions cannot answer inconsistently. The failing mtime is now
recorded, so a broken file costs one `stat` per call and one log line per save;
loading again is logged, which it never was. The last good config keeps being
served throughout, unchanged.

**2. HTTP API** (`7c3bb6ff`). `GET /api/config` gains `config_error` (`kind`,
`path`, `message`, `line`/`column` or `key`, `since`, and a `note` stating in
words that the running config is the last good one) and `config_mtime`, which is
always present so a client that just wrote the file can tell whether the write
landed. Put on that route rather than a separate `/api/config/health` because
the fact a client needs is "the config you are reading is not the file on disk",
and that belongs beside the config. A `config_health` frame goes out on `/ws` on
each edge: broken, loading again, **and** still broken for a different reason -
that last one because somebody fixing a syntax error and landing on a refused
value never leaves the broken state, and a console holding a banner would go on
showing a position that no longer exists. Announced as the `config.health`
capability. `docs/schema/openapi.json` and `docs/content/api.md` updated,
including the `400` on `PUT /api/config`.

No `WorldEvent` variant was added, and `to_server_event` is untouched. `lev
serve` holds its own `ConfigReloader` over the same file, so it observes the
break directly; routing it through the daemon's event stream would duplicate a
fact this process already has. Said here because the brief asked for the
`to_server_event` route.

`PUT /api/config` was already correct: it runs the loader's own checks before
writing and answers 400 with nothing written. A test now holds the file byte for
byte across a refused request, which a partial write could otherwise satisfy.

**3. TUI** (`daa965be`). `ConfigWatch` is the read-only half of the reloader:
reports whether the file loads, keeps no config, logs nothing, re-reads only on
a new mtime, so the 100ms tick can ask for the price of a `stat`. A banner takes
the top row of every screen for as long as the file is broken - a banner and not
only a toast, because the condition lasts until somebody edits the file and a
message that faded three seconds after the save cannot explain the run started
two minutes later. Fitted with `fit_parts`: the path gives way first, then the
reassurance, and the error is cut last. A one-row terminal keeps its row.

**4. CLI** (`c1c07d1d`). `lev run` prints one line on stderr beside the existing
read-path and checkpoint warnings. `lev ps` puts it under the run table with the
other advisory footers (that file's convention is footers, not headers).
`lev doctor` keeps failing its `config` check and now says where in the file and
that a running daemon is still serving the last good config. `lev validate`
warns and names the checks it had to skip. `print_listing` took its arguments as
a `Listing` struct on the way past - the list had grown to where two could be
transposed silently, and the config path is now passed in so a test can point it
somewhere other than the developer's real `~/.leviath`.

## Tests that fail first

Each was run against the unfixed behaviour before being kept.

**Only one read (and so one log line) per failing mtime.** Probed by rewriting
the file to something valid while pinning its mtime back to the failing save's:
a reloader that re-reads on every call goes healthy, one that remembers the
mtime it already judged cannot. With `cached.mtime = mtime` moved back into the
`Ok` arm (the old code):

```
test daemon::config_reload::tests::a_broken_file_is_read_once_per_failing_mtime ... FAILED
panicked at crates/leviath-cli/src/daemon/config_reload.rs:468:9:
a file already judged at this mtime must not be read again
```

**The API reports it.** With `redact` handing back `(None, None)` instead of the
health:

```
test commands::serve::config::tests::get_config_reports_a_broken_file_and_keeps_serving_the_last_good_one ... FAILED
panicked at crates/leviath-cli/src/commands/serve/config.rs:609:9:
assertion failed: good_mtime.is_some()
```

**The dashboard renders the banner.** With `draw_config_banner` returning the
whole frame unconditionally:

```
test commands::dashboard::render::tests::a_broken_config_raises_a_banner_that_clears_when_the_file_is_fixed ... FAILED
panicked at crates/leviath-cli/src/commands/dashboard/render/mod.rs:1137:9:
╭ Agent Runs ─── … ! config.toml: line 2, column 8: key … │
```

That failure also caught a probe that would have proved nothing: the warning
toast carries much the same words, so an assertion over the flattened screen
passes on the toast alone. The banner tests read row 0 specifically now.

The rest, all green and all asserting on behaviour the old code did not have:
health goes unhealthy on a bad save and healthy again on a good one; `since`
survives a second bad save and clears on recovery; a syntax error carries line
and column and a refused value carries its key, at every layer; a frame goes out
on each of the three edges and on neither steady state; the dashboard banner
fits 40, 60 and 200 columns and clears itself; `lev run`, `lev ps`,
`lev doctor` and `lev validate` each say it. No `#[cfg(unix)]`-only tests.

## Live check

`perf-tools/harness.sh` with a short `LEVIATH_HOME`, `LEVIATH_SKIP_DOTENV=1`,
`start_new_session=True`, the mock provider, a real daemon and `lev serve`. The
probe saves atomically (write beside, rename), because truncating in place
leaves a moment where the file is empty and *parses* - which the reloader then
correctly treats as a good config, as the first run of this probe demonstrated.

```
== 1. healthy: daemon and serve up, config.toml loads
{ "config_error": null, "config_mtime": 1788075865, "default_provider": "openai",
  "config.health advertised": true }
a baseline run: probe-1788075864-c7985e07bfa5 -> complete
  config  OK  default_provider=openai; registered: openai (script providers resolve by name)
$ lev dash (top row over a pty)
  ╭ Agent Runs ──────────────────────────────────────────── sort: started ▾ ╮

== 2. a syntax error is saved into config.toml
GET /api/config:
  "config_error": {
    "kind": "parse",
    "path": "/tmp/lv9/.leviath/config.toml",
    "message": "string values must be quoted, expected literal string",
    "line": 4, "column": 18, "since": 1788075868,
    "note": "The running config is the last one that loaded; edits to this file take effect only once it parses again."
  },
  "config_mtime": 1788075865,          <- the LAST GOOD save, not the broken file
  "default_provider": "openai"         <- still serving it

$ lev ps
/tmp/lv9/.leviath/config.toml does not load (line 4, column 18: string values must be
quoted, expected literal string); these runs are on the last config that did -
`lev doctor` has the detail

$ lev doctor --offline
  config  FAIL  /tmp/lv9/.leviath/config.toml does not load (line 4, column 18: string
  values must be quoted, expected literal string). Fix the file: a running daemon keeps
  serving the last config that loaded, so runs still work and your edits do not - and it
  picks the file up on the next spawn, with no restart

$ lev dash (top row over a pty)
  ! /tmp/lv9/.leviath/config.toml line 4, column 18: string values must be quoted,
    expected literal string · runs are on the last config that loaded

/ws config_health frames since the last step:
  healthy=False path=/tmp/lv9/.leviath/config.toml error=parse/4:18 config_mtime=1788075865

a run started while the file is broken: probe-1788075871-42327e121e2a -> complete
$ lev run (spawn-time warning, on stderr)
  warning: '/tmp/lv9/.leviath/config.toml' does not load (line 4, column 18: string values
  must be quoted, expected literal string); this run uses the last config that did

== 3. an invalid value is saved instead
  "config_error": {
    "kind": "validation",
    "message": "[model_providers.local] has kind = \"openai-compatible\" but no base_url;
                set base_url to where the server listens, such as \"http://localhost:8080/v1\"",
    "key": "model_providers.local",
    "since": 1788075868
  },
  "config_mtime": 1788075865, "default_provider": "openai"

$ lev dash (top row over a pty)
  ! /tmp/lv…model_providers.local: [model_providers.local] has kind = "openai-compatible"
    but no base_url; set base_url to where the server listens, such as "http://localhos…· runs …

/ws config_health frames since the last step:
  healthy=False path=/tmp/lv9/.leviath/config.toml error=validation/None:None/model_providers.local
  config_mtime=1788075865

== 4. the file is fixed; nothing is restarted
{ "config_error": null, "config_mtime": 1788075877, "default_provider": "openai" }
  config  OK  default_provider=openai; registered: openai …
$ lev dash (top row over a pty)
  ╭ Agent Runs ──────────────────────────────────────────── sort: started ▾ ╮
/ws config_health frames since the last step:
  healthy=True path=/tmp/lv9/.leviath/config.toml error=None/None:None config_mtime=1788075877

a run started after the fix: probe-1788075879-3dd59e5bc89c -> complete
```

Note the narrow-terminal fitting in step 3: the path is cut to `/tmp/lv…` and
the trailing note to `· runs …`, keeping the key and the reason, which is the
shrink order the banner declares.

## Docs

`configuration.md` (a section of its own, beside the keys-nothing-reads one it
gets confused with), `daemon.md`, `api.md`, `dashboard.md`, `troubleshooting.md`
(under the question people actually type: "I edited config.toml and nothing
changed"), plus `docs/schema/openapi.json`. CHANGELOG under Added and Fixed.

## Gates

`cargo fmt --all`; `cargo clippy --all-targets --all-features -p leviath-cli --
-D warnings`; `cargo test -p leviath-cli --lib` (4172 pass);
`cargo xtask structure` (429 files, none over 1200); `cargo xtask docs` (40
pages, 3 schemas); `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`;
`cargo xtask coverage --package leviath-cli` green at 100% after a
`rm -rf target/llvm-cov-target`. One cargo at a time throughout. No `main.rs`
touched. Rebased onto `origin/main` at `708b021c`.

The five commits are review units, one per layer plus docs; the branch head is
what the gates were run against.
