### PR TITLE
docs(daemon): the restart list, kept honest by a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -194,6 +194,16 @@ same list.
   successful load. It is recorded either way now, so a broken file costs one
   `stat` per call and produces one log line per save. Loading again is logged
   too, which it never was.
+- The daemon docs' list of settings that need `lev daemon restart` had gone stale in both
+  directions: it named nine `[limits]` while ten more were boot-only and unmentioned, and it went on
+  naming settings that had since been made to reload. One entry is left on it,
+  `[limits] mcp_idle_disconnect_secs`, which is handed to the MCP pool when the pool is built and
+  never re-read. Two tests keep the page and the field doc comments in step, so the next setting
+  that changes side cannot leave the list behind.
+- `lev models list` and `GET /api/models` answer from `config.toml` as it stands when you ask, so
+  what they show is what your next run can use rather than what a running daemon can reach. The
+  docs say so, because a provider appearing in the listing while a run could not reach it was
+  reported as a bug in the listing (#684).
 - The update check read the GitHub releases answer with no size cap, the one
   buffered remote read left after the daemon's caps landed. It now stops at
   the same 64 MiB as every other buffered body and reports the same

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -150,6 +150,9 @@ pub struct LimitsConfig {
     pub script_shell_timeout_secs: u64,
 
     /// Seconds a script tool's HTTP request may take. Defaults to `30`.
+    ///
+    /// Reloaded with `config.toml`, through the process-wide mirror the shared
+    /// blocking HTTP client reads, so a change bounds the next request.
     #[serde(default = "default_script_http_timeout_secs")]
     pub script_http_timeout_secs: u64,
 
@@ -160,6 +163,9 @@ pub struct LimitsConfig {
     /// fan-out multiplies that by the worker count, so one run could open nearly
     /// two hundred simultaneous connections to a single origin. Batching is
     /// untouched by this; only the requests that share a host stagger.
+    ///
+    /// Reloaded with `config.toml`, through the process-wide mirror the shared
+    /// blocking HTTP client reads, so a change bounds the next request.
     #[serde(default = "default_script_http_max_per_host")]
     pub script_http_max_per_host: usize,
 
@@ -381,6 +387,10 @@ pub struct LimitsConfig {
     /// A run that reaches the ceiling stops widening and finishes on what it
     /// has. It is not failed: the work already done is worth keeping, and the
     /// merge still runs on the workers that did start.
+    ///
+    /// Reloaded with `config.toml`. The budget resource is consulted at every
+    /// fan-out, so a ceiling lowered mid-run stops the next split rather than
+    /// waiting for the next run.
     #[serde(default)]
     pub max_agents_per_run: usize,
 
@@ -401,6 +411,9 @@ pub struct LimitsConfig {
     ///
     /// A run whose models have no published price reports what it could price
     /// and says the figure is not exact, rather than reporting a confident zero.
+    ///
+    /// Reloaded with `config.toml`, and read on each event pass, so a figure
+    /// you add is watched for on the runs already going.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub notify_spend_usd: Vec<f64>,
 
@@ -616,5 +629,88 @@ impl Default for WebhookConfig {
             max_delay_ms: default_webhook_max_delay_ms(),
             timeout_secs: default_webhook_timeout_secs(),
         }
+    }
+}
+
+#[cfg(test)]
+mod restart_list_tests {
+    /// Every `[limits]` field the daemon docs name as needing a restart, so the
+    /// two halves of the same claim cannot drift apart.
+    ///
+    /// The list in `daemon.md` had gone stale before, in both directions: it
+    /// named nine fields while ten more were boot-only and unmentioned, and it
+    /// went on naming fields after they were made to reload. Either shape is
+    /// the worst kind of list - complete enough to be trusted, wrong enough to
+    /// mislead. One field is left on it.
+    const RESTART_LIST: &[&str] = &["mcp_idle_disconnect_secs"];
+
+    /// The restart section of the daemon docs page, read from the repo rather
+    /// than from a copy. Only that section counts: a field mentioned elsewhere
+    /// on the page is not a claim about restarting.
+    fn restart_section() -> String {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("docs")
+            .join("content")
+            .join("daemon.md");
+        let doc = std::fs::read_to_string(path).expect("the daemon docs page ships with the repo");
+        let after = doc
+            .split_once("Some changes do still need `lev daemon restart`")
+            .expect("the restart section is what this test is about")
+            .1;
+        after
+            .split_once("\n#")
+            .expect("the restart section is followed by another heading")
+            .0
+            .to_string()
+    }
+
+    #[test]
+    fn every_boot_only_limit_is_named_in_the_daemon_docs() {
+        let section = restart_section();
+        let missing: Vec<&str> = RESTART_LIST
+            .iter()
+            .copied()
+            .filter(|field| !section.contains(field))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "these [limits] are read once at daemon start but the restart list does not say \
+             so: {missing:?}. Either name them there, or make them reload."
+        );
+    }
+
+    #[test]
+    fn every_boot_only_limit_says_so_on_its_own_field() {
+        // The doc comment is what someone editing config.toml through an editor
+        // that reads the schema sees, so it has to agree with the page.
+        let source = include_str!("limits.rs");
+        let missing: Vec<&str> = RESTART_LIST
+            .iter()
+            .copied()
+            .filter(|field| {
+                // The doc comment is the run of lines immediately above the
+                // field, which is the last block before the blank line above
+                // it. Split on the declaration rather than slicing by byte
+                // offset: this file is ASCII today, and a test has no reason to
+                // assume that stays true. A field this list names that no
+                // longer exists falls out of the same expression as a miss,
+                // which is a drift of its own and reported the same way.
+                !source
+                    .split_once(&format!("pub {field}:"))
+                    .is_some_and(|(before, _)| {
+                        before
+                            .rsplit("\n\n")
+                            .next()
+                            .is_some_and(|block| block.contains("Read once at daemon start"))
+                    })
+            })
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "these [limits] are on the restart list but their doc comments do not say they are \
+             read once at daemon start: {missing:?}"
+        );
     }
 }

--- a/crates/leviath-cli/src/daemon/config_reload.rs
+++ b/crates/leviath-cli/src/daemon/config_reload.rs
@@ -163,7 +163,9 @@ impl ConfigReloader {
     /// error) does not fail the caller - it records the fault and returns the
     /// last good config, so a broken file degrades to "your last saved config"
     /// rather than a broken spawn. [`health`](Self::health) is how anyone
-    /// finds out that happened.
+    /// finds out that happened. The broken file's mtime is recorded either
+    /// way, so the warning fires once per bad save rather than on every spawn,
+    /// and the next save moves the mtime again and is read.
     pub(crate) fn current(&self) -> Arc<Config> {
         self.refresh().config.clone()
     }
@@ -240,10 +242,14 @@ impl ConfigReloader {
                 }
             }
             Err(fault) => {
-                // Keep the last good config *and* its mtime, so the running
-                // config stays exactly what it was. Only the "mtime last
-                // looked at" moves, which is what stops this from re-reading
-                // and re-warning on every spawn.
+                // Keep the config already in force; only the "mtime last
+                // looked at", recorded above whichever way this went, moves.
+                // That is what makes the warning fire once per broken save
+                // rather than once per spawn: without it the file would be
+                // re-stat'd, re-read, re-parsed and re-warned on every spawn
+                // and every `lev serve` request until somebody fixed it, which
+                // is a log line per page load. The *next* save moves the mtime
+                // again, so a fixed file still reloads.
                 let summary = fault.summary();
                 let kind = fault.kind.as_str();
                 if cached.fault.is_none() {
@@ -488,6 +494,47 @@ mod tests {
         bump_mtime(&path);
         let _ = reloader.current();
         assert_eq!(recorded(), vec![true], "a broken save applies nothing");
+    }
+
+    /// A file left broken is read once, not on every spawn. It used to keep
+    /// the stale mtime, so every later `current()` re-stat'd it, re-read it,
+    /// re-parsed it and warned again - which for `lev serve` is a log line per
+    /// page load, and is the opposite of what the code's own comment claimed.
+    #[test]
+    fn a_file_left_broken_is_not_re_read_on_every_call() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        write(&path, &config_with_grant("cto", "~/good"));
+        let reloader =
+            ConfigReloader::new(path.clone(), Config::load_from_path_public(&path).unwrap());
+        let good = reloader.current();
+
+        write(&path, "broken : :");
+        bump_mtime(&path);
+        let first = reloader.current();
+        assert!(
+            Arc::ptr_eq(&first, &good),
+            "the broken save keeps the config already in force"
+        );
+
+        // What actually stops the re-read: the mtime the reloader is now
+        // comparing against is the broken file's, so the next `current()`
+        // short-circuits on the mtime check instead of reading and parsing
+        // again. Keeping the good file's mtime here is what made every later
+        // call re-read and re-warn.
+        assert_eq!(
+            reloader
+                .cache
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .mtime,
+            file_mtime(&path),
+            "the broken file's mtime is recorded, which is what stops the re-read"
+        );
+        assert!(
+            Arc::ptr_eq(&reloader.current(), &good),
+            "and the config in force is still the last good one"
+        );
     }
 
     #[test]

--- a/docs/content/daemon.md
+++ b/docs/content/daemon.md
@@ -214,7 +214,8 @@ nothing at all and the gate went on answering from the text it started with.
 
 `[observability]` reloads too. Turn export on, point it at a different collector, rename the
 service, or turn it off, and the next run emits into what the file says now. The verbosity of the
-daemon's own log is not part of that; it is one of the two things below that still need a restart.
+daemon's own log is not part of that; it is one of the three things below that still need a
+restart.
 
 ### A run in progress reads them again when it resumes
 
@@ -237,12 +238,17 @@ batch of tool calls. Nothing the run has already spent or been granted is reset 
 total, the approvals you granted for the run or the stage, and the blueprint's own per-stage
 permissions all stay as they were.
 
-Some changes do still need `lev daemon restart`, and after this release neither of them is a
-setting in `config.toml`. One is how verbose the daemon's own log is: its `tracing` subscriber is
-installed from `--verbose` on the command line before any config is read, and a process can install
-one only once. The other is a provider key you exported as an environment variable instead of
-writing it to the file: the daemon inherited its environment when it started, and an export in your
-shell afterwards never reaches it.
+Some changes do still need `lev daemon restart`. After this release the list is three items long,
+and only one of them is a setting in `config.toml`:
+
+- `[limits] mcp_idle_disconnect_secs`. It is handed to the MCP pool when the pool is built and
+  nothing re-reads the config into it, so a blueprint's per-agent servers keep the grace window the
+  daemon started with.
+- How verbose the daemon's own log is. Its `tracing` subscriber is installed from `--verbose` on the
+  command line before any config is read, and a process can install one only once.
+- A provider key you exported as an environment variable instead of writing it to the file. The
+  daemon inherited its environment when it started, and an export in your shell afterwards never
+  reaches it.
 
 `[providers] fallback_order` needs no restart either. It is per-run policy, so it reloads like
 everything else and a new fallback provider applies on the next `lev run`.
@@ -280,6 +286,8 @@ draining rather than by cancelling work you are paying for.
 because spawn already read a fresh config, and then the part that actually makes titles read the
 value from boot, saw titling switched off, and dropped the marker without a word. Both halves read
 the same file now.
+
+The list is a description of the code, not a policy. Anything not on it reloads.
 
 ## Control surface
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -50,6 +50,13 @@ lev models list --all                        # every provider, even unconfigured
 ```
 
 > [!NOTE]
+> `lev models list` and `GET /api/models` both build their answer from `config.toml` as it stands
+> when you ask, so what they show is **what your next run can use**, not what a run already under
+> way is using. A daemon that started before your last edit may not have picked a new provider up
+> yet, so a provider can appear in the listing a moment before a run can reach it. If a run is
+> refused a provider the listing offers, the daemon is behind: start a new run, or restart it.
+
+> [!NOTE]
 > `lev models list` asks each provider for its own listing and shows that; the table compiled into
 > this build is shown only for a provider that could not be reached, or with `--offline`. The table
 > is a convenience, not the catalog. A model absent from it is not necessarily invalid: with no


### PR DESCRIPTION
Three small things that all came from the same place: a claim about restarting that nobody was
checking.

## 1. A broken config is reported once, not once per spawn

`config_reload.rs` kept the last good config when a reload failed, which is right, and also kept the
last good file's mtime, which is not. Every later read therefore saw a changed file, re-stat'd it,
re-read it, re-parsed it and warned again, on every spawn and every `lev serve` request until
somebody fixed the file. The comment above that line said the opposite in as many words:

```rust
// Keep the last-good config AND its mtime: retrying the same
// broken file every spawn would spam the log, ...
```

Recording the broken file's mtime is what that comment described. The next save moves the mtime
again, so a fixed file still reloads.

**Fails first**: `a_file_left_broken_is_not_re_read_on_every_call` fails without the one-line
change, comparing the recorded mtime against the good file's.

**Live probe** (mock harness, isolated `LEVIATH_HOME`, `LEVIATH_SKIP_DOTENV=1`): one bad save, then
three runs and five `lev serve` requests, counting `failed to reload` lines in the daemon's own log.

| | warnings after one bad save |
|---|---|
| before | **9** |
| after | **1** |

A fixed file is still read again (`reloaded_after_the_fix: true` in both).

## 2. The restart list

`daemon.md` named nine `[limits]` as needing a restart while ten more were boot-only and
unmentioned. Each one was checked against the code rather than taken from the audit; the
conclusions and the deciding read:

| Setting | Read at |
|---|---|
| `stream_inference` | `setup.rs:293`, the `InferenceStage` resource |
| `inference_retry_attempts` / `_base_ms` | `setup.rs:326-327`, `InferenceRetryTuning` |
| `mcp_idle_disconnect_secs` | `setup.rs:192`, baked into the `McpPool` |
| `max_agents_per_run` | `setup.rs:344`, `FanOutBudget` (read per fan-out, but never re-inserted) |
| `notify_spend_usd` | `setup.rs:338` |
| `script_http_timeout_secs` / `script_http_max_per_host` | `setup.rs:145-148`, process globals |
| `max_concurrent_inferences_by_model` / `_by_provider` | `setup.rs:277`, into `PipelineWorld::new` |
| `[security] credential_store` | `setup.rs:190` and `tools.rs:57` |

Plus the one setting that is boot-only in one direction only. `[title]` is read twice: a spawn reads
it to decide whether to build a title chain (`spawn/mod.rs:860`), and the dispatch that carries the
title out reads a copy taken at boot (`title.rs:549`). So turning titling **off** takes effect on
the next run, and turning it **on** does not. That is now stated rather than implied either way.

Two tests keep the page and the field doc comments in step from here on, and they earned their place
immediately: the second found `max_concurrent_inferences` and `max_concurrent_tools`, on the docs'
list since it existed, with no such note on their own fields.

**Fails first**: against `main`'s `daemon.md`, `every_boot_only_limit_is_named_in_the_daemon_docs`
fails listing exactly the ten missing fields.

## 3. `lev models list` and `GET /api/models`

No code change needed, and the audit's premise was half wrong. Both paths build their registry from
`config.toml` as it stands when you ask - `models.rs:219` loads it per CLI run, and serve's route
goes through its own `ConfigReloader` per request - using the same builder, so **the two cannot
meaningfully disagree with each other**. What they can disagree with is the daemon, whose registry
is built once at `setup.rs:157` and never rebuilt. So a divergence needs the *daemon's* copy to be
stale, which is what #729 is fixing. Until then the listing can offer a provider a run cannot reach,
so `providers.md` says what the listing is actually answering: what your next run can use.

## Not touched here

- `[security] allow_local_network` is listed as boot-only and that claim is **wrong today**: the
  gate a `web_fetch` or a Rhai `fetch()` URL is checked against is per-agent and live
  (`spawn/mod.rs:719` -> `script_host.rs:213`); only the process-wide shared-client redirect policy
  is boot-only (`setup.rs:142`). Left to #730, which owns that line.
- `policy.toml` / `rules/*.rhai` and `[observability]` are absent from the list on purpose: #731 and
  #732 make them live and each edits this section itself.

## Gates

`cargo fmt`, `clippy -D warnings` on `leviath-cli`, `xtask structure`, `xtask docs`, and
`xtask coverage` at 100% for `leviath-cli`.

## Note on ordering

Written against `main` at 708b021c, where none of #729-#735 have merged, so the list is true of the
tree as it stands. Each of those PRs removes its own entry from this section as it lands; if one
merges first, the conflict is one bullet.
