### PR TITLE
docs: what reloads now, on every page that said it did not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -396,6 +396,16 @@ same list.
   `FnPtr::new` no longer accepts a name starting with an underscore. The chunk
   sink is `leviath_emit_chunk`; scripts are unaffected, they call
   `on_chunk.call(...)` (#677).
+- The docs no longer tell you to restart the daemon for things that now reload.
+  The config schema's `[limits]` description, the `mcp_idle_disconnect_secs`
+  field doc, the tool-lane advice in troubleshooting, and the interaction
+  deadline all said the daemon reads them once at start-up. `tools.md` said a
+  parked agent holds a lane slot until a restart, when it hands the slot back
+  and comes back parked. The pages that never mentioned what changed now do:
+  provider keys, `rules/*.rhai`, pool and lane resizing, the taint gate on
+  `submit_output`, and a run that waits for a person with no timer. The
+  glossary gained gateways and deny-with-feedback, and the API reference says
+  that every route can answer 401 and lists the two MCP write routes.
 
 ### Changed
 

--- a/crates/leviath-cli/src/config/limits.rs
+++ b/crates/leviath-cli/src/config/limits.rs
@@ -221,8 +221,11 @@ pub struct LimitsConfig {
     /// child process). Long enough that back-to-back runs of a blueprint reuse
     /// the warm connection; the next run that declares the server reconnects
     /// lazily. `0` keeps every server connected for the daemon's life, which
-    /// was the old behaviour. Global `[[mcp_servers]]` from config.toml are
-    /// never disconnected regardless.
+    /// was the old behaviour. A global `[[mcp_servers]]` entry is never
+    /// disconnected for idleness, because nothing leases one; take it out of
+    /// `config.toml` and this is how long it stays connected before
+    /// `daemon::mcp_reload` tears it down, so a stage part-way through a call
+    /// keeps the tool it was given.
     ///
     /// Read once at daemon start, so a change needs a daemon restart.
     #[serde(default = "default_mcp_idle_disconnect_secs")]

--- a/crates/leviath-cli/src/daemon/config_reload.rs
+++ b/crates/leviath-cli/src/daemon/config_reload.rs
@@ -23,9 +23,11 @@
 //! process-wide network policy, which is mirrored into atomics the shared
 //! blocking HTTP client reads (`script_host::mirror_process_policy`).
 //!
-//! What is still established once at boot is MCP connections: those hold live
-//! connections, and adding an MCP server still needs a daemon restart; see
-//! `daemon.md`.
+//! The global `[[mcp_servers]]` are reconciled against the reloaded config by
+//! the `mcp_reload` module beside this one, so a server added, edited or
+//! removed here reaches the next run too. What still comes from the config the
+//! daemon booted with is `[limits] mcp_idle_disconnect_secs`, which the MCP
+//! pool is built with; see `daemon.md`.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, PoisonError};

--- a/crates/leviath-runtime/src/interaction_hub.rs
+++ b/crates/leviath-runtime/src/interaction_hub.rs
@@ -54,8 +54,10 @@ pub struct InteractionHub {
     wake: Arc<OnceLock<Arc<Notify>>>,
     /// How long an open request may go unanswered before the hub resolves it
     /// itself, in seconds. `0` (the default) waits indefinitely: it is how
-    /// [`set_timeout_secs`](Self::set_timeout_secs) stores `None`. Set once at
-    /// daemon start from `[limits] interaction_timeout_secs`.
+    /// [`set_timeout_secs`](Self::set_timeout_secs) stores `None`. Written
+    /// from `[limits] interaction_timeout_secs` on every config reload, and
+    /// read when a request opens, so one already waiting keeps the deadline it
+    /// opened with.
     timeout_secs: Arc<AtomicU64>,
 }
 

--- a/docs/content/api.md
+++ b/docs/content/api.md
@@ -197,6 +197,10 @@ sequenceDiagram
 
 Base path `/api`; all JSON unless noted.
 
+Every route below can answer `401` when the bearer token is missing or wrong, so a client has to
+handle that on all of them rather than on a few. The body is a line of plain text, not JSON.
+`GET /`, the fixed status page, is the only route that does not check a token.
+
 | Method · Path | Purpose |
 |---|---|
 | `GET /api/runs` · `DELETE /api/runs` | List runs: paginated, sortable, searchable · prune many at once. See [below](#listing-and-searching-runs) |
@@ -218,7 +222,7 @@ Base path `/api`; all JSON unless noted.
 | `POST /api/models/probe` *(admin)* | Ask an OpenAI-compatible server what it serves before writing a gateway for it: `{"base_url", "api_key"?, "headers"?}` → `{"models": [ids]}`, or 502 carrying the server's own error text. See [below](#gateways) |
 | `GET /api/tools?agent=` | What an agent here can actually call. See [below](#tools-and-scripts) |
 | `GET /api/scripts?agent=` · `GET/PUT/DELETE /api/scripts/{kind}/{name}` · `POST /api/scripts/validate` | Read and write the machine's Rhai: the agent's tools, hooks and validators, and the global model providers. Writes need admin. See [below](#tools-and-scripts) |
-| `GET /api/mcp/servers` · `GET /{name}/status` · `POST /{name}/login` *(admin)* · `POST /{name}/test` *(admin)* | MCP servers. Add, remove, login and test need admin: each connects to a server, opens a browser, or spawns a command |
+| `GET /api/mcp/servers` · `POST …` *(admin)* · `DELETE …/{name}` *(admin)* · `GET …/{name}/status` · `POST …/{name}/login` *(admin)* · `POST …/{name}/test` *(admin)* | List, add, remove, check, log in, test. The writes need admin. A server added or removed here reaches the next run, with no daemon restart |
 | `GET /api/doctor` · `POST /api/doctor/live` *(admin)* | The checks `lev doctor` runs, as data. `GET` is `lev doctor --offline`: config, search and resolve, nothing billed. `POST .../live` runs the whole chain (two billed calls and a throwaway run) and answers 409 while one is already going. A failing check is `ok: false` inside a 200, never an HTTP error |
 | `GET /api/update` | Whether anything newer exists, how this copy was installed, and the command that upgrades it. See [below](#asking-how-to-upgrade) |
 | `POST /api/update` *(admin)* · `GET /api/update/jobs/{id}` | Carry that plan out, and read where it got to. See [below](#pressing-the-button) |

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -193,7 +193,12 @@ cerebras = 1                     # every model this provider serves, together
 | `notify_spend_usd` | empty | Dollar figures to be told about while a run is still going. See below |
 | `max_agents_per_run` | `0` | Most agents one run may create, sub-agents included. `0` is no ceiling. See below |
 
-Eleven of those need more than a table cell.
+The daemon applies this whole section when `config.toml` changes, so a new number is in force for
+the next run with no restart, and most of them reach a run already going. The exception is
+`mcp_idle_disconnect_secs`: the MCP pool is built with it at start-up. See
+[the daemon](/docs/daemon#config-changes-take-effect-on-the-next-run) for which is which.
+
+Some of these need more than a table cell.
 
 **`stream_inference`** asks a model that can stream to stream. It changes nothing an agent sees:
 the chunks are folded back into one finished turn before anything reads it, because half a sentence
@@ -945,7 +950,8 @@ model    = "claude-haiku-4-5-20251001"
 ```
 
 `enabled` defaults to `true`. `provider` and `model` fall back to the run's own first-stage
-provider and model.
+provider and model. The section reloads with the rest of the file, so turning titles on or off
+reaches the next run with no daemon restart.
 
 ## `[webhook]`
 

--- a/docs/content/dashboard.md
+++ b/docs/content/dashboard.md
@@ -174,8 +174,9 @@ along its top does.
 
 `Ctrl-Y` warns every time you turn it on (turning it off never asks), and the warning is worth
 reading: an unattended run approves its own file edits and shell commands, but it does **not** skip
-a checkpoint the blueprint asks a person for. Those still stop, and one nobody answers ends the run
-when the interaction timeout expires. The setting is off again every time the screen opens.
+a checkpoint the blueprint asks a person for. Those still stop, and by default one nobody answers
+waits for as long as it takes. `[limits] interaction_timeout_secs` is how you bound that wait. The
+setting is off again every time the screen opens.
 
 ### Detail view
 

--- a/docs/content/engine.md
+++ b/docs/content/engine.md
@@ -341,6 +341,11 @@ spend: capping one provider at 1 leaves every other provider's pool untouched, w
 global number cannot do. A provider that is not named there has no pool of its own - the global
 fallback is a per-model number and is not applied a second time per provider.
 
+Pool sizes reload with `config.toml`, so a new number applies to the next request that asks for a
+slot and no daemon restart is involved. Raising a cap is immediate: the extra slots go to whoever is
+already waiting on that pool. Lowering one takes back only the slots nobody is holding, so the pool
+narrows as requests finish and nothing in flight is interrupted.
+
 The smallest a pool can be is 1. A configured `0` is read as `1`, since a pool of nothing would
 park every request on it forever under the backpressure rule below - which is exactly the shape
 nothing ever reports.
@@ -361,7 +366,8 @@ sees every model pool with room in it.
 ## The tool lane
 
 Tools have a pool of their own: `[limits] max_concurrent_tools` (8 by default) caps how many
-agents' tool batches run at once across the whole daemon.
+agents' tool batches run at once across the whole daemon. It resizes on a config reload under the
+same rule as the inference pools: wider at once, narrower as the batches in flight finish.
 
 The interesting part is waiting. Some things a batch can wait for have no time limit at all: a
 tool-approval prompt, an `ask_user`, a `wait_for_agent` that only ends when another run finishes.

--- a/docs/content/glossary.md
+++ b/docs/content/glossary.md
@@ -56,6 +56,11 @@ never fails or reroutes a stage. See [nudging](/docs/stages#nudging).
 **Interaction point**: a place in a blueprint where the run stops and asks a person something. Some
 older text calls these checkpoints. See [Human-in-the-loop](/docs/interaction).
 
+**Deny with feedback**: refusing a tool call and saying what the model should do instead. The text
+reaches the model inside the refused call's tool result, so its next turn is a redirect rather than
+a guess. The dashboard offers it on an approval prompt, `lev respond` takes `--feedback`, and the
+API takes `feedback`. See [Human-in-the-loop](/docs/interaction).
+
 **Seed command**: a shell command that fills a context region before the run starts.
 
 **Spawn**: starting a run. Also used for the moment it starts, as in "resolved at spawn", meaning
@@ -131,6 +136,12 @@ in order to offer its tools to agents.
 
 **Provider**: a model backend such as Anthropic, OpenAI, or Ollama. See
 [Providers](/docs/providers).
+
+**Gateway**: a server that speaks OpenAI's chat API in front of whatever models it holds, such as
+llama.cpp, LM Studio, or vLLM. You add one as a `[model_providers.<name>]` entry with
+`kind = "openai-compatible"` and a `base_url`. It is a route to models rather than a model family,
+so Leviath asks it what it serves. See
+[custom OpenAI-compatible providers](/docs/providers#custom-openai-compatible-providers).
 
 ## Safety
 

--- a/docs/content/interaction.md
+++ b/docs/content/interaction.md
@@ -91,13 +91,14 @@ way). When a deadline passes, the prompt resolves exactly as cancelling it would
 | Tool approval | Denied. A timeout is never read as consent. |
 | Taint gate | Denied. |
 | `ask_user_*` | The model is told no answer came, and carries on. |
-| Interaction point | Proceeds with no user text, as a cancelled checkpoint does. See below. |
+| Interaction point | Proceeds with no user text, unless it declared `unattended = "ask"`. See below. |
 
 An interaction point that declared `unattended = "ask"` behaves differently on a timeout: the run
 **stops with an error**, rather than approving a checkpoint nobody made.
 
-The deadline is read once when the daemon starts, so changing it needs a daemon restart. Neither
-`lev setup` nor any bundled agent sets one for you.
+The deadline is read from `config.toml` every time it reloads, so setting one or clearing it needs
+no daemon restart. It is read when a prompt opens, so a prompt already waiting keeps the deadline it
+opened with. Neither `lev setup` nor any bundled agent sets one for you.
 
 ## Tool approval
 

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -293,6 +293,17 @@ catch an agent that was supposed to write something and did not.
 A submitted answer clears it. A researcher, a reviewer, or a router produces its answer and nothing
 else, and reporting those runs as empty was wrong.
 
+## Taint tracking gates the submission
+
+With [taint tracking](/docs/security#taint-tracking-experimental) on, `submit_output` counts as a
+way off the machine, the same as `shell` or `web_fetch`. The answer is what `lev serve` hands to
+anyone who reads `GET /api/agents/{id}/result`, and what the dashboard shows.
+
+So a stage that read a Private region and then submits it meets the gate before the answer is
+recorded. Your policy decides what happens: allow, deny, or ask. A run with nobody watching is
+blocked rather than asked. Taint tracking is off unless you turn it on, so this changes nothing for
+an install that leaves it alone.
+
 ## Large results
 
 An answer is one model response. That is a hard ceiling, not a policy. `submit_output` takes its

--- a/docs/content/outputs.md
+++ b/docs/content/outputs.md
@@ -300,9 +300,9 @@ way off the machine, the same as `shell` or `web_fetch`. The answer is what `lev
 anyone who reads `GET /api/agents/{id}/result`, and what the dashboard shows.
 
 So a stage that read a Private region and then submits it meets the gate before the answer is
-recorded. Your policy decides what happens: allow, deny, or ask. A run with nobody watching is
-blocked rather than asked. Taint tracking is off unless you turn it on, so this changes nothing for
-an install that leaves it alone.
+recorded. Your policy decides what happens: allow it, deny it, or ask. A blocked submission is not
+recorded as the run's answer, and the model is told, so the stage can submit something else. Taint
+tracking is off unless you turn it on, so this changes nothing for an install that leaves it alone.
 
 ## Large results
 

--- a/docs/content/providers.md
+++ b/docs/content/providers.md
@@ -379,6 +379,18 @@ lev auth migrate --to-file      # move them back to config.toml
 lev auth migrate --dry-run      # preview without moving anything
 ```
 
+A key you add, replace, or remove is in force for the next run you start. The daemon watches
+`config.toml` and rebuilds its provider registry when the credentials in it change, so no restart is
+involved, and it makes no difference whether the write came from `lev setup`, `PUT /api/config`, or
+an editor. A run already under way keeps calling the provider its current stage started on. A
+provider whose key changed also has its circuit-breaker record cleared, so a replaced key is tried
+at once rather than sitting out the old key's cooldown.
+
+The exception is a key you export as an environment variable instead of writing it to the file. The
+daemon inherited its environment when it started, so an `export` in your shell afterwards never
+reaches it. Write the key to `config.toml`, or run `lev daemon restart` from the shell that exports
+it.
+
 ## Rate limits
 
 Optional per-provider client-side rate limits, enforced before each call:

--- a/docs/content/rhai-tools.md
+++ b/docs/content/rhai-tools.md
@@ -152,6 +152,10 @@ context.tool == "send_email"
     && context.taint_level == "internal"
 ```
 
+Rules are re-read when they change. Add a file, edit one, or delete it, and the next run is gated
+against what the directory holds now, with no daemon restart. `policy.toml` beside it reloads the
+same way. A run already going keeps the rules it started under.
+
 A script that errors or does not evaluate to a boolean is treated as no match, so a broken rule can
 never accidentally open the gate. Inspect and dry-run rules with the CLI:
 

--- a/docs/content/scripting.md
+++ b/docs/content/scripting.md
@@ -84,5 +84,8 @@ Provider scripts are recompiled when the file's mtime changes, so an edit takes 
 run with no daemon restart. Region scripts are read and compile-checked once, at spawn, so an edit
 applies to the next run rather than an in-flight one.
 
+Policy rules reload as well. The daemon stats `policy.toml` and every `rules/*.rhai` beside it, so a
+rule you add, edit, or delete gates the next run. Nothing is restarted for that either.
+
 Neither is scanned or executed until something actually references it, so dropping a file into a
 directory does not by itself run it.

--- a/docs/content/tools.md
+++ b/docs/content/tools.md
@@ -153,7 +153,9 @@ Present work to the user for approval or direct editing.
 
 Every tool in the two tables above does the same thing: it opens a prompt and waits. That is fine
 when you are watching the run. When nobody is, the wait has no end. The agent sits in
-`WaitingInput`, holding a concurrency slot, until the daemon restarts.
+`WaitingInput` until somebody answers or you cancel the run. It hands its
+[tool-lane](/docs/engine#the-tool-lane) slot back while it waits, and a daemon restart does not free
+it either: the open prompt is written to disk, and the run comes back still parked on it.
 
 So an unattended run does not get them. A run launched with `--yolo` (and every sub-agent and
 fan-out worker under it) has these five tools removed from the set advertised to the model, per

--- a/docs/content/troubleshooting.md
+++ b/docs/content/troubleshooting.md
@@ -279,7 +279,8 @@ and not one run moved. `parked` is not part of the problem: a batch waiting on a
 another run holds no capacity. `busy` with a `queued` figure that never falls is.
 
 The usual cause is too little tool capacity for the shape of the workload. Raise
-`[limits] max_concurrent_tools` and restart the daemon.
+`[limits] max_concurrent_tools` and save the file. The daemon picks the new width up on its own,
+and a raised lane is usable at once, so nothing needs restarting.
 
 Left alone, the daemon widens the lane itself after `[limits] dead_cycles_before_relief` cycles, 10
 by default, and logs it at `error` level. It never cancels anything, and it stops after granting one

--- a/docs/content/work-queues.md
+++ b/docs/content/work-queues.md
@@ -78,6 +78,22 @@ In the third row, `updated_at` tells you when it ended, and `status` and `error`
 `finished` and `not_running` never overlap, so a run appears exactly once and you cannot close the
 same work item twice.
 
+## A run waiting on a person waits indefinitely
+
+A prompt that needs a person waits until somebody answers it, with no timer on it by default. The
+run stays in `runs` with status `Waiting`, and your queue keeps its slot busy for as long as that
+takes. `lev ps` says what each run is waiting on.
+
+That is the right default for somebody at a keyboard and the wrong one for a queue. Two ways to
+bound it:
+
+- Start the run unattended: `--yolo` on `lev run`, or `"yolo": true` on the API spawn. The tools
+  that wait for a person are never offered to the model.
+- Set `[limits] interaction_timeout_secs`. A prompt nobody answers within that resolves the way
+  cancelling it would, so a tool approval and a taint gate are denied.
+
+See [when nobody answers](/docs/interaction#when-nobody-answers).
+
 ## When the daemon does not answer
 
 If `daemon_reachable` is false, act on nothing at all.

--- a/docs/schema/config.schema.json
+++ b/docs/schema/config.schema.json
@@ -104,7 +104,7 @@
     },
     "limits": {
       "type": "object",
-      "description": "The daemon reads these once at startup, so a change needs `lev daemon restart`.",
+      "description": "Reloaded with config.toml, so a new value is in force for the next run with no daemon restart, and most of these reach a run already going. `mcp_idle_disconnect_secs` is the exception: the MCP pool is built with it at start-up.",
       "additionalProperties": false,
       "properties": {
         "max_concurrent_inferences": {
@@ -136,7 +136,7 @@
           "type": "integer",
           "minimum": 0,
           "default": 60,
-          "description": "Disconnect an MCP server no agent has used for this long. It reconnects on next use."
+          "description": "Disconnect a per-agent MCP server no run has leased for this long. It reconnects on next use. A global [[mcp_servers]] entry is never disconnected for idleness; take one out of config.toml and this is how long it stays up before the daemon tears it down. Read once at daemon start."
         },
         "stall_timeout_secs": {
           "type": "integer",


### PR DESCRIPTION
## What this is

The reload round shipped 21 PRs and left the documentation describing the daemon
that came before it. This makes the pages true again, and fills in the things
that shipped with no page mentioning them at all.

Every claim below was re-checked against main at 45c1c15c before it was written.

## Brief items that were already fixed, and left alone

The docs audit brief was written before the last seven PRs landed. These four
were already correct on main and this PR does not touch them:

- `docs/content/daemon.md:241` restart list. It is three items now
  (`mcp_idle_disconnect_secs`, the daemon's own log verbosity, an exported
  provider key), and `config/limits.rs:645` holds it to that with a test.
- `crates/leviath-cli/src/daemon/config_reload.rs` module doc, for the provider
  registry, the network policy and the telemetry sink. Its last paragraph was
  still stale about MCP, which this PR fixes; see below.
- `docs/content/configuration.md:20` reload NOTE. Already one sentence naming
  what is live.
- The CHANGELOG structure. One `### Fixed`, no duplicated entries, the reload
  entries filed together.

The brief also asked for a drift test for `docs/schema/openapi.json`'s
hand-maintained `version` against `CARGO_PKG_VERSION`. **That test already
exists** and passes: `the_api_version_matches_the_spec_it_names` in
`crates/leviath-cli/src/commands/serve/mod.rs:721` asserts
`spec.info.version == types::API_VERSION`, and `API_VERSION` is
`env!("CARGO_PKG_VERSION")` (`serve/config_types.rs:103`). `cargo xtask version
set` also rewrites the spec's `info.version` alongside the thirteen manifest
lines (`xtask/src/version.rs:55`, `:575`), so the 0.5.6 bump keeps them
together. Nothing was added here.

## Wrong, now corrected

| Where | Was | Checked against |
|---|---|---|
| `docs/schema/config.schema.json` `[limits]` | "read once at startup, so a change needs `lev daemon restart`" | `daemon/live_limits.rs:83` applies the whole section on reload |
| `docs/schema/config.schema.json` `mcp_idle_disconnect_secs` | silent on global servers | `daemon/mcp_reload.rs:113` |
| `crates/leviath-cli/src/config/limits.rs:225` | "Global `[[mcp_servers]]` are never disconnected regardless" | `mcp_reload.rs:113` retires a removed global entry through the same grace timer |
| `docs/content/troubleshooting.md:282` | raise `max_concurrent_tools` "and restart the daemon" | `live_limits.rs:97` calls `set_tool_concurrency` on reload |
| `docs/content/tools.md:156` | a parked agent holds a slot "until the daemon restarts" | `tool_bridge.rs:133` hands the permit back on a park; the prompt is persisted and comes back parked |
| `docs/content/interaction.md:99` | the deadline is read once at daemon start | `live_limits.rs:134` writes it on every reload |
| `docs/content/interaction.md` table row | said an interaction point proceeds, the sentence under it said it errors | `interaction_points.rs:326`: it errors only when the point declared `unattended = "ask"` |
| `docs/content/dashboard.md:178` | an unanswered checkpoint "ends the run when the interaction timeout expires" | the timeout is unset by default (`limits.rs:303`) |
| `crates/leviath-runtime/src/interaction_hub.rs:57` | "Set once at daemon start" | same, `live_limits.rs:134` |
| `crates/leviath-cli/src/daemon/config_reload.rs:26` | "adding an MCP server still needs a daemon restart" | `daemon/mcp_reload.rs`, whole module |

The `mcp_idle_disconnect_secs` field doc keeps its "Read once at daemon start"
line, because that half is still true and `every_boot_only_limit_says_so_on_its_own_field`
asserts it. What changed is the claim about global servers: one stays connected
while it is in the file (nothing leases it, so it is never idle-disconnected),
and removing it from the file starts this same window before the teardown.

## Never mentioned anywhere, now written down

- `providers.md`: a key you add, replace or remove reaches the next run, the
  breaker record is cleared for a replaced key, and the environment-variable
  exception (`provider_reload.rs`, and the daemon's inherited environment).
- `outputs.md`: with taint tracking on, `submit_output` is an outbound channel
  and the gate runs before the answer is recorded (`pipeline/tools.rs`,
  `leviath-core/src/taint.rs`). `security.md` already said this; the page a
  reader of outputs would look at did not.
- `rhai-tools.md` and `scripting.md`: `policy.toml` and `rules/*.rhai` are
  re-read when they change (`daemon/policy_reload.rs`).
- `engine.md`: inference pools and the tool lane resize on reload, raising is
  immediate and lowering takes back only idle slots
  (`inference_pool.rs:186-192`, `tool_bridge.rs:251-272`: `forget_permits` only
  ever takes available permits).
- `work-queues.md`: a new section. A run waiting on a person has no timer by
  default, sits in `runs` as `Waiting`, and holds the queue's slot. The two ways
  to bound it are `--yolo` and `interaction_timeout_secs`.
- `configuration.md`: `[limits]` and `[title]` say they are live.
- `api.md`: a blanket line that every route can answer 401, with `GET /` named
  as the exception (`serve/mod.rs:502` layers `require_auth` over everything,
  and the status page is merged after it at `:517`). The 401 body is plain text
  (`auth.rs:87`).
- `glossary.md`: gateways (`kind = "openai-compatible"`) and deny-with-feedback.

## Confusing, now not

- `configuration.md:186` said "Eleven of those need more than a table cell". The
  section has eleven paragraphs covering fourteen keys, and any edit moves both
  numbers. It no longer counts.
- `api.md:221` MCP row now lists `POST /api/mcp/servers` and
  `DELETE /api/mcp/servers/{name}` (`serve/mod.rs:461-462`), which the
  `--allow-admin` table above already referred to.

## Also checked, no change needed

Everything new in the round is already documented where a reader would look:
deny-with-feedback in `interaction.md:155` and `cli.md:470`, config-health
reporting in `troubleshooting.md:20` and `api.md:896`, the serve request limits
in `api.md:74`, the read caps in `security.md:245`, the price table in
`costs.md:149`. `README.md` still describes the product accurately.

## No behaviour change

Documentation and doc comments only. Three `.rs` files are touched and all three
edits are comments.

Gates: `cargo xtask docs`, `cargo xtask structure`, `cargo fmt --all`,
`cargo clippy --all-targets --all-features -p leviath-cli -- -D warnings`, and
the drift tests that read these files
(`restart_list_tests`, `the_api_version_matches_the_spec_it_names`,
`the_example_config_satisfies_the_published_schema_and_deserializes`).
